### PR TITLE
Merge 2.8 into develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,9 @@ rebuild-schema:
 ## rebuild-schema: Rebuild the schema for clients with the latest facades
 	@echo "Generating facade schema..."
 ifdef SCHEMA_PATH
-	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen "$(SCHEMA_PATH)"
+	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
 else
-	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen \
+	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
 		./apiserver/facades/schema.json
 endif
 

--- a/acceptancetests/assess_user_grant_revoke.py
+++ b/acceptancetests/assess_user_grant_revoke.py
@@ -218,9 +218,9 @@ def assert_change_password(client, user, password):
     try:
         child = client.expect('change-user-password', (user.name,),
                               include_e=False)
-        child.expect('(?i)password')
+        child.expect(u'(?i)password')
         child.sendline(password)
-        child.expect('(?i)password')
+        child.expect(u'(?i)password')
         child.sendline(password)
         client._end_pexpect_session(child)
     except pexpect.TIMEOUT:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -2077,7 +2077,7 @@ class ModelClient:
             child = self.expect(self.login_user_command,
                                 (username, '-c', self.env.controller.name),
                                 include_e=False)
-            child.expect('(?i)password')
+            child.expect(u'(?i)password')
             child.sendline(password)
             self._end_pexpect_session(child)
         except pexpect.TIMEOUT:
@@ -2175,11 +2175,11 @@ class ModelClient:
         child = self.expect('add-cloud', include_e=False)
         try:
             child.logfile = sys.stdout
-            child.expect('Select cloud type:')
+            child.expect(u'Select cloud type:')
             child.sendline(cloud['type'])
             match = child.expect([
-                'Enter a name for your .* cloud:',
-                'Select cloud type:'
+                u'Enter a name for your .* cloud:',
+                u'Select cloud type:'
             ])
             if match == 1:
                 raise TypeNotAccepted('Cloud type not accepted.')
@@ -2192,7 +2192,7 @@ class ModelClient:
                 self.handle_openstack(child, cloud)
             if cloud['type'] == 'vsphere':
                 self.handle_vsphere(child, cloud)
-            match = child.expect(["Do you ONLY want to add cloud", "Can't validate endpoint", pexpect.EOF])
+            match = child.expect([u'Do you ONLY want to add cloud', u'Can\'t validate endpoint', pexpect.EOF])
             if match == 0:
                 child.sendline("y")
             if match == 1:
@@ -2201,7 +2201,7 @@ class ModelClient:
                 # The endpoint was validated and there isn't a controller to
                 # ask about.
                 return
-            child.expect([pexpect.EOF, "Can't validate endpoint"])
+            child.expect([pexpect.EOF, u'Can\'t validate endpoint'])
             if child.match != pexpect.EOF:
                 if child.match.group(0) == "Can't validate endpoint":
                     raise InvalidEndpoint()
@@ -2211,8 +2211,8 @@ class ModelClient:
 
     def handle_maas(self, child, cloud):
         match = child.expect([
-            'Enter the API endpoint url:',
-            'Enter a name for your .* cloud:',
+            u'Enter the API endpoint url:',
+            u'Enter a name for your .* cloud:',
         ])
         if match == 1:
             raise NameNotAccepted('Cloud name not accepted.')
@@ -2220,9 +2220,9 @@ class ModelClient:
 
     def handle_manual(self, child, cloud):
         match = child.expect([
-            "Enter a name for your .* cloud:",
-            "Enter the ssh connection string for controller",
-            "Enter the controller's hostname or IP address:",
+            u"Enter a name for your .* cloud:",
+            u"Enter the ssh connection string for controller",
+            u"Enter the controller's hostname or IP address:",
             pexpect.EOF
         ])
         if match == 0:
@@ -2232,26 +2232,26 @@ class ModelClient:
 
     def handle_openstack(self, child, cloud):
         match = child.expect([
-            'Enter the API endpoint url for the cloud',
-            "Enter a name for your .* cloud:"
+            u'Enter the API endpoint url for the cloud',
+            u'Enter a name for your .* cloud:'
         ])
         if match == 1:
             raise NameNotAccepted('Cloud name not accepted.')
         child.sendline(cloud['endpoint'])
         match = child.expect([
-            "Enter a path to the CA certificate for your cloud if one is required to access it",
-            "Can't validate endpoint:",
+            u'Enter a path to the CA certificate for your cloud if one is required to access it',
+            u'Can\'t validate endpoint:',
         ])
         if match == 1:
             raise InvalidEndpoint()
         child.sendline("")
-        match = child.expect("Select one or more auth types separated by commas:")
+        match = child.expect(u"Select one or more auth types separated by commas:")
         if match == 0:
             child.sendline(','.join(cloud['auth-types']))
         for num, (name, values) in enumerate(cloud['regions'].items()):
             match = child.expect([
-                'Enter region name:',
-                'Select one or more auth types separated by commas:',
+                u'Enter region name:',
+                u'Select one or more auth types separated by commas:',
             ])
             if match == 1:
                 raise AuthNotAccepted('Auth was not compatible.')
@@ -2259,8 +2259,8 @@ class ModelClient:
             child.expect(self.REGION_ENDPOINT_PROMPT)
             child.sendline(values['endpoint'])
             match = child.expect([
-                "Enter another region\? \([yY]/[nN]\):",
-                "Can't validate endpoint"
+                u"Enter another region\? \([yY]/[nN]\):",
+                u"Can't validate endpoint"
             ])
             if match == 1:
                 raise InvalidEndpoint()
@@ -2270,8 +2270,8 @@ class ModelClient:
                 child.sendline('n')
 
     def handle_vsphere(self, child, cloud):
-        match = child.expect(["Enter a name for your .* cloud:",
-                              'Enter the (vCenter address or URL|API endpoint url for the cloud \[\]):'])
+        match = child.expect([u"Enter a name for your .* cloud:",
+                              u'Enter the (vCenter address or URL|API endpoint url for the cloud \[\]):'])
         if match == 0:
             raise NameNotAccepted('Cloud name not accepted.')
         if match == 1:
@@ -2279,15 +2279,15 @@ class ModelClient:
 
         for num, (name, values) in enumerate(cloud['regions'].items()):
             match = child.expect([
-                "Enter datacenter name",
-                "Enter region name",
-                "Can't validate endpoint"
+                u"Enter datacenter name",
+                u"Enter region name",
+                u"Can't validate endpoint"
             ])
             if match == 2:
                 raise InvalidEndpoint()
             child.sendline(name)
             child.expect(
-                'Enter another (datacenter|region)\? \([yY]/[nN]\):')
+                u'Enter another (datacenter|region)\? \([yY]/[nN]\):')
             if num + 1 < len(cloud['regions']):
                 child.sendline('y')
             else:

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -164,3 +164,8 @@ func (o *MachineLinkLayerOp) MarkProcessed(dev LinkLayerDevice) {
 func (o *MachineLinkLayerOp) IsProcessed(dev network.InterfaceInfo) bool {
 	return o.processed.Contains(dev.MACAddress)
 }
+
+// Done (state.ModelOperation) returns the result of running the operation.
+func (o *MachineLinkLayerOp) Done(err error) error {
+	return err
+}

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -9,6 +9,44 @@ import (
 	"github.com/juju/juju/state"
 )
 
+// machineShim wraps a state.Machine reference in order to
+// implement the LinkLayerMachine indirection.
+type machineShim struct {
+	*state.Machine
+}
+
+// AllLinkLayerDevices returns all layer-2 devices for the machine
+// as a slice of the LinkLayerDevice indirection.
+func (s machineShim) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
+	devList, err := s.Machine.AllLinkLayerDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]LinkLayerDevice, len(devList))
+	for i, dev := range devList {
+		out[i] = dev
+	}
+
+	return out, nil
+}
+
+// AllLinkLayerDevices returns all layer-3 addresses for the machine
+// as a slice of the LinkLayerAddress indirection.
+func (s machineShim) AllAddresses() ([]LinkLayerAddress, error) {
+	addrList, err := s.Machine.AllAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]LinkLayerAddress, len(addrList))
+	for i, addr := range addrList {
+		out[i] = addr
+	}
+
+	return out, nil
+}
+
 // NOTE: All of the following code is only tested with a feature test.
 
 // NewSubnetShim creates new subnet shim to be used by subnets and spaces Facades.

--- a/apiserver/facades/agent/upgrader/upgrader.go
+++ b/apiserver/facades/agent/upgrader/upgrader.go
@@ -39,7 +39,7 @@ func NewUpgraderFacade(st *state.State, resources facade.Resources, auth facade.
 		return nil, common.ErrPerm
 	}
 	switch tag.(type) {
-	case names.MachineTag, names.ControllerAgentTag, names.ApplicationTag:
+	case names.MachineTag, names.ControllerAgentTag, names.ApplicationTag, names.ModelTag:
 		return NewUpgraderAPI(st, resources, auth)
 	case names.UnitTag:
 		return NewUnitUpgraderAPI(st, resources, auth)
@@ -72,7 +72,7 @@ func NewUpgraderAPI(
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*UpgraderAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthApplicationAgent() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthApplicationAgent() && !authorizer.AuthModelAgent() {
 		return nil, common.ErrPerm
 	}
 	getCanReadWrite := func() (common.AuthFunc, error) {

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
-	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/state/stateenvirons"
 )
 
@@ -43,7 +42,9 @@ func NewCAASOperatorUpgraderAPI(
 	authorizer facade.Authorizer,
 	broker caas.Upgrader,
 ) (*API, error) {
-	if !authorizer.AuthController() && !authorizer.AuthApplicationAgent() {
+	if !authorizer.AuthController() &&
+		!authorizer.AuthApplicationAgent() &&
+		!authorizer.AuthModelAgent() {
 		return nil, common.ErrPerm
 	}
 	return &API{
@@ -64,14 +65,9 @@ func (api *API) UpgradeOperator(arg params.KubernetesUpgradeArg) (params.ErrorRe
 	if !api.auth.AuthOwner(tag) {
 		return serverErr(common.ErrPerm), nil
 	}
-	appName := tag.Id()
 
-	// Nodes representing controllers really mean the controller operator.
-	if tag.Kind() == names.MachineTagKind || tag.Kind() == names.ControllerAgentTagKind {
-		appName = bootstrap.ControllerModelName
-	}
-	logger.Debugf("upgrading caas app %v", appName)
-	err = api.broker.Upgrade(appName, arg.Version)
+	logger.Debugf("upgrading caas agent for %s", tag)
+	err = api.broker.Upgrade(arg.AgentTag, arg.Version)
 	if err != nil {
 		return serverErr(err), nil
 	}

--- a/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
+++ b/apiserver/facades/controller/caasoperatorupgrader/upgrader_test.go
@@ -55,7 +55,7 @@ func (s *CAASProvisionerSuite) TestUpgradeOperator(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	s.broker.CheckCall(c, 0, "Upgrade", "app", vers)
+	s.broker.CheckCall(c, 0, "Upgrade", s.authorizer.Tag.String(), vers)
 }
 
 func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
@@ -74,7 +74,7 @@ func (s *CAASProvisionerSuite) assertUpgradeController(c *gc.C, tag names.Tag) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	s.broker.CheckCall(c, 0, "Upgrade", "controller", vers)
+	s.broker.CheckCall(c, 0, "Upgrade", tag.String(), vers)
 }
 
 func (s *CAASProvisionerSuite) TestUpgradeLegacyController(c *gc.C) {

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -914,8 +914,10 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigRelinquishUnseen(c *gc
 
 	// Hardware address not matched.
 	dev := instancepoller.NewMockLinkLayerDevice(ctrl)
-	dev.EXPECT().MACAddress().Return("01:01:01:01:01:01")
-	dev.EXPECT().Name().Return("eth0")
+	dExp := dev.EXPECT()
+	dExp.MACAddress().Return("01:01:01:01:01:01")
+	dExp.Name().Return("eth0")
+	dExp.SetProviderIDOps(network.Id("")).Return([]txn.Op{{C: "dev-provider-id"}}, nil)
 
 	// Address should be set back to machine origin.
 	addr := instancepoller.NewMockLinkLayerAddress(ctrl)
@@ -947,6 +949,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigRelinquishUnseen(c *gc
 			buildCalled = true
 			c.Check(call.Args, gc.DeepEquals, []interface{}{[]txn.Op{
 				{C: "machine-alive"},
+				{C: "dev-provider-id"},
 				{C: "address-origin-manual"},
 			}})
 		}
@@ -960,7 +963,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 
 	s.setDefaultSpaceInfo()
 
-	// Hardware address will match; prover ID will be set.
+	// Hardware address will match; provider ID will be set.
 	dev := instancepoller.NewMockLinkLayerDevice(ctrl)
 	dExp := dev.EXPECT()
 	dExp.MACAddress().Return("00:00:00:00:00:00").Times(2)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -849,6 +849,267 @@
         }
     },
     {
+        "Name": "Admin",
+        "Description": "admin is the only object that unlogged-in clients can access. It holds any\nmethods that are needed to log in.",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Login": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/LoginRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LoginResult"
+                        }
+                    },
+                    "description": "Login logs in with the provided credentials.  All subsequent requests on the\nconnection will act as the authenticated user."
+                },
+                "RedirectInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/RedirectInfoResult"
+                        }
+                    },
+                    "description": "RedirectInfo returns redirected host information for the model.\nIn Juju it always returns an error because the Juju controller\ndoes not multiplex controllers."
+                }
+            },
+            "definitions": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "AuthUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "controller-access": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "identity": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model-access": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "display-name",
+                        "identity",
+                        "controller-access",
+                        "model-access"
+                    ]
+                },
+                "FacadeVersions": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "versions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "versions"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "LoginRequest": {
+                    "type": "object",
+                    "properties": {
+                        "auth-tag": {
+                            "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
+                        "cli-args": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "macaroons": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Macaroon"
+                                }
+                            }
+                        },
+                        "nonce": {
+                            "type": "string"
+                        },
+                        "user-data": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-tag",
+                        "credentials",
+                        "nonce",
+                        "macaroons",
+                        "user-data"
+                    ]
+                },
+                "LoginResult": {
+                    "type": "object",
+                    "properties": {
+                        "bakery-discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        },
+                        "discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "discharge-required-error": {
+                            "type": "string"
+                        },
+                        "facades": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FacadeVersions"
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "public-dns-name": {
+                            "type": "string"
+                        },
+                        "server-version": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        },
+                        "user-info": {
+                            "$ref": "#/definitions/AuthUserInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "RedirectInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers",
+                        "ca-cert"
+                    ]
+                }
+            }
+        }
+    },
+    {
         "Name": "Agent",
         "Description": "AgentAPIV2 implements the version 2 of the API provided to an agent.",
         "Version": 2,

--- a/caas/kubernetes/provider/controller_upgrade.go
+++ b/caas/kubernetes/provider/controller_upgrade.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/names/v4"
+	"github.com/juju/version"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/juju/juju/environs/bootstrap"
+)
+
+type upgradeCAASControllerBridge struct {
+	clientFn    func() kubernetes.Interface
+	namespaceFn func() string
+}
+
+// UpgradeCAASControllerBroker describes the interface needed for upgrading
+// Juju Kubernetes controllers
+type UpgradeCAASControllerBroker interface {
+	// Client returns a Kubernetes client associated with the current broker's
+	// cluster
+	Client() kubernetes.Interface
+
+	// Namespace returns the targeted Kubernetes namespace for this broker
+	Namespace() string
+}
+
+func (u *upgradeCAASControllerBridge) Client() kubernetes.Interface {
+	return u.clientFn()
+}
+
+func (u *upgradeCAASControllerBridge) Namespace() string {
+	return u.namespaceFn()
+}
+
+func controllerUpgrade(appName string, vers version.Number, broker UpgradeCAASControllerBroker) error {
+	return upgradeStatefulSet(appName, "", vers, broker.Client().AppsV1().StatefulSets(broker.Namespace()))
+}
+
+func (k *kubernetesClient) upgradeController(agentTag names.Tag, vers version.Number) error {
+	broker := &upgradeCAASControllerBridge{
+		clientFn:    k.client,
+		namespaceFn: k.GetCurrentNamespace,
+	}
+	return controllerUpgrade(bootstrap.ControllerModelName, vers, broker)
+}

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+// DummyUpgradeCAASController implements UpgradeCAASControllerBroker for the
+// purpose of testing.
+type dummyUpgradeCAASController struct {
+	client *fake.Clientset
+}
+
+type ControllerUpgraderSuite struct {
+	broker *dummyUpgradeCAASController
+}
+
+var _ = gc.Suite(&ControllerUpgraderSuite{})
+
+func (d *dummyUpgradeCAASController) Client() kubernetes.Interface {
+	return d.client
+}
+
+func (d *dummyUpgradeCAASController) Namespace() string {
+	return "test"
+}
+
+func (s *ControllerUpgraderSuite) SetUpTest(c *gc.C) {
+	s.broker = &dummyUpgradeCAASController{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
+	var (
+		appName      = JujuControllerStackName
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+	_, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).Create(
+		&apps.StatefulSet{
+			ObjectMeta: meta.ObjectMeta{
+				Name: appName,
+			},
+			Spec: apps.StatefulSetSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						Containers: []core.Container{
+							{
+								Name:  "jujud",
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
+
+	ss, err := s.broker.Client().AppsV1().StatefulSets(s.broker.Namespace()).
+		Get(appName, meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ss.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
+
+	c.Assert(ss.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Spec.Template.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+}
+
+func (s *ControllerUpgraderSuite) TestControllerDoesNotExist(c *gc.C) {
+	var (
+		appName = JujuControllerStackName
+	)
+	err := controllerUpgrade(appName, version.MustParse("9.9.9"), s.broker)
+	c.Assert(err, gc.NotNil)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}

--- a/caas/kubernetes/provider/modeloperator_upgrade.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/names/v4"
+	"github.com/juju/version"
+	"k8s.io/client-go/kubernetes"
+)
+
+type upgradeCAASModelOperatorBridge struct {
+	clientFn    func() kubernetes.Interface
+	namespaceFn func() string
+}
+
+type UpgradeCAASModelOperatorBroker interface {
+	// Client returns a Kubernetes client associated with the current broker's
+	// cluster
+	Client() kubernetes.Interface
+
+	// Namespace returns the targeted Kubernetes namespace for this broker
+	Namespace() string
+}
+
+func (u *upgradeCAASModelOperatorBridge) Client() kubernetes.Interface {
+	return u.clientFn()
+}
+
+func modelOperatorUpgrade(
+	operatorName string,
+	vers version.Number,
+	broker UpgradeCAASModelOperatorBroker) error {
+	return upgradeDeployment(operatorName, "", vers,
+		broker.Client().AppsV1().Deployments(broker.Namespace()))
+}
+
+func (u *upgradeCAASModelOperatorBridge) Namespace() string {
+	return u.namespaceFn()
+}
+
+func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version.Number) error {
+	broker := &upgradeCAASModelOperatorBridge{
+		clientFn:    k.client,
+		namespaceFn: k.GetCurrentNamespace,
+	}
+	return modelOperatorUpgrade(modelOperatorName, vers, broker)
+}

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+type dummyUpgradeCAASModel struct {
+	client *fake.Clientset
+}
+
+type modelUpgraderSuite struct {
+	broker *dummyUpgradeCAASModel
+}
+
+var _ = gc.Suite(&modelUpgraderSuite{})
+
+func (d *dummyUpgradeCAASModel) Client() kubernetes.Interface {
+	return d.client
+}
+
+func (d *dummyUpgradeCAASModel) Namespace() string {
+	return "test"
+}
+
+func (s *modelUpgraderSuite) SetUpTest(c *gc.C) {
+	s.broker = &dummyUpgradeCAASModel{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
+	var (
+		operatorName = modelOperatorName
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).Create(
+		&apps.Deployment{
+			ObjectMeta: meta.ObjectMeta{
+				Name: operatorName,
+			},
+			Spec: apps.DeploymentSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						Containers: []core.Container{
+							{
+								Name:  "jujud",
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(modelOperatorUpgrade(operatorName, version.MustParse("9.9.9"), s.broker), jc.ErrorIsNil)
+	de, err := s.broker.Client().AppsV1().Deployments(s.broker.Namespace()).
+		Get(operatorName, meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(de.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
+
+	c.Assert(de.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Spec.Template.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+}

--- a/caas/kubernetes/provider/operator_upgrade.go
+++ b/caas/kubernetes/provider/operator_upgrade.go
@@ -1,0 +1,224 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/version"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+type upgradeCAASOperatorBridge struct {
+	clientFn         func() kubernetes.Interface
+	clockFn          func() clock.Clock
+	deploymentNameFn func(string, bool) string
+	namespaceFn      func() string
+	operatorFn       func(string) (*caas.Operator, error)
+	operatorNameFn   func(string) string
+}
+
+type UpgradeCAASOperatorBroker interface {
+	// Clock provides the clock to use with this broker for time operations
+	Clock() clock.Clock
+
+	// Client returns a Kubernetes client associated with the current broker's
+	// cluster
+	Client() kubernetes.Interface
+
+	// Returns the deployment name use for the given application name, supports
+	// finding legacy deployment names if set to True.
+	DeploymentName(string, bool) string
+
+	Namespace() string
+
+	// Operator returns an Operator with current status and life details.
+	Operator(string) (*caas.Operator, error)
+
+	// OperatorName returns the operator name used for the operator deployment
+	// for the supplied application.
+	OperatorName(string) string
+}
+
+const applicationUpgradeTimeoutSeconds = time.Second * 30
+
+func (u *upgradeCAASOperatorBridge) Client() kubernetes.Interface {
+	return u.clientFn()
+}
+
+func (u *upgradeCAASOperatorBridge) Clock() clock.Clock {
+	return u.clockFn()
+}
+
+func (u *upgradeCAASOperatorBridge) DeploymentName(n string, l bool) string {
+	return u.deploymentNameFn(n, l)
+}
+
+func (u *upgradeCAASOperatorBridge) Operator(n string) (*caas.Operator, error) {
+	return u.operatorFn(n)
+}
+
+func (u *upgradeCAASOperatorBridge) OperatorName(n string) string {
+	return u.operatorNameFn(n)
+}
+
+func (u *upgradeCAASOperatorBridge) Namespace() string {
+	return u.namespaceFn()
+}
+
+func operatorInitUpgrade(appName, imagePath string, broker UpgradeCAASOperatorBroker) (func() (bool, error), error) {
+	deploymentName := broker.DeploymentName(appName, true)
+
+	var data []byte
+	var selector labels.Set
+	podChecker := func(appName string,
+		labelSet labels.Set,
+		broker UpgradeCAASOperatorBroker) func() (bool, error) {
+
+		return func() (done bool, err error) {
+			labelSelector := labelSetToSelector(labelSet).String()
+			podList, err := broker.Client().CoreV1().Pods(broker.Namespace()).
+				List(meta.ListOptions{
+					LabelSelector: labelSelector,
+				})
+			if k8serrors.IsNotFound(err) {
+				// Not found means not ready.
+				logger.Tracef("listing pod %q, not found yet", selector.String())
+				return false, nil
+			} else if err != nil {
+				return false, errors.Trace(err)
+			}
+			pod := podList.Items[0]
+			if pod.Status.Phase != core.PodRunning {
+				logger.Debugf(
+					"init container %q is still upgrade, current status -> %q",
+					appName, pod.Status.Phase)
+				return false, nil
+			}
+
+			index, found := findJujudContainer(pod.Spec.InitContainers)
+			if !found {
+				logger.Debugf("init container for app %q not found", appName)
+				return false, nil
+			}
+
+			return pod.Spec.InitContainers[index].Image == imagePath, nil
+		}
+	}
+
+	ssInterface := broker.Client().AppsV1().StatefulSets(broker.Namespace())
+	sResource, err := ssInterface.Get(deploymentName, meta.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, errors.Annotatef(err, "getting statefulset %q", deploymentName)
+	} else if err == nil {
+		selector = sResource.Spec.Selector.MatchLabels
+		if err := ensureJujuInitContainer(&sResource.Spec.Template.Spec, imagePath); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data, err = json.Marshal(apps.StatefulSet{Spec: sResource.Spec}); err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = ssInterface.Patch(sResource.GetName(), types.StrategicMergePatchType, data)
+		return podChecker(deploymentName, selector, broker), errors.Trace(err)
+	}
+
+	deInterface := broker.Client().AppsV1().Deployments(broker.Namespace())
+	deResource, err := deInterface.Get(deploymentName, meta.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	} else if err == nil {
+		selector = deResource.Spec.Selector.MatchLabels
+		if err := ensureJujuInitContainer(&deResource.Spec.Template.Spec, imagePath); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data, err = json.Marshal(apps.Deployment{Spec: deResource.Spec}); err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = deInterface.Patch(deResource.GetName(), types.StrategicMergePatchType, data)
+		return podChecker(deploymentName, selector, broker), errors.Trace(err)
+	}
+
+	dsInterface := broker.Client().AppsV1().DaemonSets(broker.Namespace())
+	dsResource, err := dsInterface.Get(deploymentName, meta.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	} else if err == nil {
+		selector = dsResource.Spec.Selector.MatchLabels
+		if err := ensureJujuInitContainer(&dsResource.Spec.Template.Spec, imagePath); err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data, err = json.Marshal(apps.DaemonSet{Spec: dsResource.Spec}); err != nil {
+			return nil, errors.Trace(err)
+		}
+		_, err = dsInterface.Patch(dsResource.GetName(), types.StrategicMergePatchType, data)
+		return podChecker(deploymentName, selector, broker), errors.Trace(err)
+	}
+
+	return nil, errors.NotFoundf("deployment %q init containers", deploymentName)
+}
+
+func operatorUpgrade(appName string, vers version.Number, broker UpgradeCAASOperatorBroker) error {
+	operator, err := broker.Operator(appName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	operatorImagePath := podcfg.RebuildOldOperatorImagePath(operator.Config.OperatorImagePath, vers)
+	if len(operatorImagePath) == 0 {
+		// This should never happen.
+		return errors.NotValidf("no resource is upgradable for application %q", appName)
+	}
+
+	podChecker, err := operatorInitUpgrade(appName, operatorImagePath, broker)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	timeout := broker.Clock().After(applicationUpgradeTimeoutSeconds)
+	for {
+		select {
+		case <-timeout:
+			return errors.Timeoutf("timeout while waiting for the upgraded operator of %q ready", appName)
+		case <-broker.Clock().After(time.Second):
+			// TODO(caas): change to use k8s watcher to trigger the polling.
+			ready, err := podChecker()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if ready {
+				logger.Infof("init container has been upgraded to %q, now the operator for %q starts to upgrade", operatorImagePath, appName)
+				return errors.Trace(upgradeStatefulSet(
+					broker.OperatorName(appName),
+					operatorImagePath,
+					vers,
+					broker.Client().AppsV1().StatefulSets(broker.Namespace())))
+			}
+		}
+	}
+}
+
+func (k *kubernetesClient) upgradeOperator(agentTag names.Tag, vers version.Number) error {
+	broker := &upgradeCAASOperatorBridge{
+		clientFn:         k.client,
+		clockFn:          func() clock.Clock { return k.clock },
+		deploymentNameFn: k.deploymentName,
+		namespaceFn:      k.GetCurrentNamespace,
+		operatorFn:       k.Operator,
+		operatorNameFn:   k.operatorName,
+	}
+	return operatorUpgrade(agentTag.Id(), vers, broker)
+}

--- a/caas/kubernetes/provider/operator_upgrade_test.go
+++ b/caas/kubernetes/provider/operator_upgrade_test.go
@@ -1,0 +1,340 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/cloudconfig/podcfg"
+)
+
+type DummyUpgradeCAASOperator struct {
+	client     *fake.Clientset
+	OperatorFn func(string) (*caas.Operator, error)
+}
+
+type OperatorUpgraderSuite struct {
+	broker *DummyUpgradeCAASOperator
+}
+
+var _ = gc.Suite(&OperatorUpgraderSuite{})
+
+func (d *DummyUpgradeCAASOperator) Client() kubernetes.Interface {
+	return d.client
+}
+
+func (d *DummyUpgradeCAASOperator) Clock() clock.Clock {
+	return testclock.NewClock(time.Time{})
+}
+
+func (d *DummyUpgradeCAASOperator) DeploymentName(n string, _ bool) string {
+	return n
+}
+
+func (d *DummyUpgradeCAASOperator) Namespace() string {
+	return "test"
+}
+
+func (d *DummyUpgradeCAASOperator) Operator(n string) (*caas.Operator, error) {
+	if d.OperatorFn == nil {
+		return nil, errors.NotImplementedf("Operator()")
+	}
+	return d.OperatorFn(n)
+}
+
+func (d *DummyUpgradeCAASOperator) OperatorName(n string) string {
+	return n
+}
+
+func (o *OperatorUpgraderSuite) SetUpTest(c *gc.C) {
+	o.broker = &DummyUpgradeCAASOperator{
+		client: fake.NewSimpleClientset(),
+	}
+}
+
+func (o *OperatorUpgraderSuite) TestStatefulSetInitUpgrade(c *gc.C) {
+	var (
+		appName      = "testinitss"
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := o.broker.Client().AppsV1().StatefulSets(o.broker.Namespace()).Create(
+		&apps.StatefulSet{
+			ObjectMeta: meta.ObjectMeta{
+				Name: o.broker.DeploymentName(appName, true),
+			},
+			Spec: apps.StatefulSetSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						InitContainers: []core.Container{
+							{
+								Name:  caas.InitContainerName,
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	podChecker, err := operatorInitUpgrade(appName, newImagePath, o.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ss, err := o.broker.Client().AppsV1().StatefulSets(o.broker.Namespace()).
+		Get(o.broker.DeploymentName(appName, true), meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ss.Spec.Template.Spec.InitContainers[0].Image, gc.Equals, newImagePath)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Create(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodPending,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err := podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsFalse)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Update(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodRunning,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err = podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsTrue)
+}
+
+func (o *OperatorUpgraderSuite) TestDaemonSetInitUpgrade(c *gc.C) {
+	var (
+		appName      = "testinitds"
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := o.broker.Client().AppsV1().DaemonSets(o.broker.Namespace()).Create(
+		&apps.DaemonSet{
+			ObjectMeta: meta.ObjectMeta{
+				Name: o.broker.DeploymentName(appName, true),
+			},
+			Spec: apps.DaemonSetSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						InitContainers: []core.Container{
+							{
+								Name:  caas.InitContainerName,
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	podChecker, err := operatorInitUpgrade(appName, newImagePath, o.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ds, err := o.broker.Client().AppsV1().DaemonSets(o.broker.Namespace()).
+		Get(o.broker.DeploymentName(appName, true), meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ds.Spec.Template.Spec.InitContainers[0].Image, gc.Equals, newImagePath)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Create(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodPending,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err := podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsFalse)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Update(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodRunning,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err = podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsTrue)
+}
+
+func (o *OperatorUpgraderSuite) TestDeploymentInitUpgrade(c *gc.C) {
+	var (
+		appName      = "testinitds"
+		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
+	)
+
+	_, err := o.broker.Client().AppsV1().Deployments(o.broker.Namespace()).Create(
+		&apps.Deployment{
+			ObjectMeta: meta.ObjectMeta{
+				Name: o.broker.DeploymentName(appName, true),
+			},
+			Spec: apps.DeploymentSpec{
+				Selector: &meta.LabelSelector{
+					MatchLabels: map[string]string{
+						"match-label": "true",
+					},
+				},
+				Template: core.PodTemplateSpec{
+					Spec: core.PodSpec{
+						InitContainers: []core.Container{
+							{
+								Name:  caas.InitContainerName,
+								Image: oldImagePath,
+							},
+						},
+					},
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	podChecker, err := operatorInitUpgrade(appName, newImagePath, o.broker)
+	c.Assert(err, jc.ErrorIsNil)
+
+	de, err := o.broker.Client().AppsV1().Deployments(o.broker.Namespace()).
+		Get(o.broker.DeploymentName(appName, true), meta.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(de.Spec.Template.Spec.InitContainers[0].Image, gc.Equals, newImagePath)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Create(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodPending,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err := podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsFalse)
+
+	_, err = o.broker.Client().CoreV1().Pods(o.broker.Namespace()).Update(&core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pod1",
+			Labels: map[string]string{
+				"match-label": "true",
+			},
+		},
+		Spec: core.PodSpec{
+			InitContainers: []core.Container{
+				{
+					Name:  caas.InitContainerName,
+					Image: newImagePath,
+				},
+			},
+		},
+		Status: core.PodStatus{
+			Phase: core.PodRunning,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ready, err = podChecker()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ready, jc.IsTrue)
+}

--- a/caas/kubernetes/provider/specs/container_env.go
+++ b/caas/kubernetes/provider/specs/container_env.go
@@ -235,6 +235,10 @@ func (cv configValue) to(name string) (envVars []core.EnvVar, envFromSources []c
 
 // JSON Unmarshal types - https://golang.org/pkg/encoding/json/#Unmarshal
 func stringify(i interface{}) (string, error) {
+	type stringer interface {
+		String() string
+	}
+
 	switch v := i.(type) {
 	case string:
 		return v, nil
@@ -243,6 +247,8 @@ func stringify(i interface{}) (string, error) {
 	case float64:
 		// All the numbers are float64 - https://golang.org/pkg/encoding/json/#Number
 		return fmt.Sprintf("%g", v), nil
+	case stringer:
+		return v.(stringer).String(), nil
 	default:
 		return "", errors.NotSupportedf("%v with type %T", i, i)
 	}

--- a/caas/kubernetes/provider/specs/decode.go
+++ b/caas/kubernetes/provider/specs/decode.go
@@ -82,6 +82,7 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	}
 	logger.Debugf("decoding stream as JSON")
 	decoder := json.NewDecoder(d.r)
+	decoder.UseNumber()
 	if d.strict {
 		decoder.DisallowUnknownFields()
 	}

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -5,6 +5,7 @@ package specs_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -75,6 +76,7 @@ containers:
       restricted: "yes"
       switch: on
       special: p@ssword's
+      number: 5242880
       my-resource-limit:
         resource:
           container-name: container1
@@ -421,6 +423,7 @@ echo "do some stuff here for gitlab container"
 					"switch":     true,
 					"brackets":   `["hello", "world"]`,
 					"special":    "p@ssword's",
+					"number":     json.Number("5242880"),
 					"my-resource-limit": map[string]interface{}{
 						"resource": map[string]interface{}{
 							"container-name": "container1",

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -4,222 +4,136 @@
 package provider
 
 import (
-	"encoding/json"
-	"fmt"
-	"time"
-
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 	"github.com/juju/version"
-	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
-	k8stypes "k8s.io/apimachinery/pkg/types"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	"github.com/juju/juju/cloudconfig/podcfg"
 	k8sannotations "github.com/juju/juju/core/annotations"
-	"github.com/juju/juju/core/status"
 )
 
-const applicationUpgradeTimeoutSeconds = 30
-
-// Upgrade sets the OCI image for the app's operator to the specified version.
-func (k *kubernetesClient) Upgrade(appName string, vers version.Number) error {
-
-	isController := appName == JujuControllerStackName
-	if isController {
-		// Upgrade the controller pod.
-		return errors.Trace(k.upgradeControllerOrOperator(appName, vers, ""))
-	}
-
-	operator, err := k.Operator(appName)
+func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
+	tag, err := names.ParseTag(agentTag)
 	if err != nil {
-		return errors.Trace(err)
-	}
-	operatorImagePath := podcfg.RebuildOldOperatorImagePath(operator.Config.OperatorImagePath, vers)
-	if len(operatorImagePath) == 0 {
-		// This should never happen.
-		return errors.NotValidf("no resource is upgradable for application %q", appName)
+		return errors.Annotate(err, "parsing agent tag to upgrade")
 	}
 
-	// To upgrade an application, we upgrade the Juju init container in the workload pod first then operator pod.
-	podChecker, err := k.upgradeJujuInitContainer(appName, operatorImagePath)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	logger.Infof("handling upgrade request for tag %q", tag)
 
-	timeout := k.clock.After(applicationUpgradeTimeoutSeconds * time.Second)
-	for {
-		select {
-		case <-timeout:
-			return errors.Timeoutf("timeout while waiting for the upgraded operator of %q ready", appName)
-		case <-k.clock.After(1 * time.Second):
-			// TODO(caas): change to use k8s watcher to trigger the polling.
-			ready, err := podChecker()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if ready {
-				logger.Infof("init container has been upgraded to %q, now the operator for %q starts to upgrade", operatorImagePath, appName)
-				return errors.Trace(k.upgradeControllerOrOperator(k.operatorName(appName), vers, operatorImagePath))
-			}
-		}
+	switch tag.Kind() {
+	case names.MachineTagKind:
+	case names.ControllerAgentTagKind:
+		return k.upgradeController(tag, vers)
+	case names.ApplicationTagKind:
+		return k.upgradeOperator(tag, vers)
+	case names.ModelTagKind:
+		return k.upgradeModelOperator(tag, vers)
 	}
+	return errors.NotImplementedf("k8s upgrade for agent tag %q", agentTag)
 }
 
-func upgradeContainer(existingContainers []core.Container, imagePath string) {
-	index := findJujudContainer(existingContainers)
-	if index >= 0 {
-		c := existingContainers[index]
-		if imagePath != c.Image {
-			logger.Infof("upgrading from %q to %q", c.Image, imagePath)
-			c.Image = imagePath
-			existingContainers[index] = c
-		}
-	}
-}
-
-func findJujudContainer(containers []core.Container) (index int) {
-	index = -1
-	for i, c := range containers {
-		if podcfg.IsJujuOCIImage(c.Image) {
-			return i
-		}
-	}
-	return index
-}
-
-func (k *kubernetesClient) upgradeControllerOrOperator(name string, vers version.Number, imagePath string) error {
-	logger.Debugf("Upgrading %q", name)
-
-	api := k.client().AppsV1().StatefulSets(k.namespace)
-	existingStatefulSet, err := api.Get(name, v1.GetOptions{})
+func upgradeDeployment(name, imagePath string, vers version.Number, broker appstyped.DeploymentInterface) error {
+	de, err := broker.Get(name, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		// We always expect that the controller or operator statefulset resource exist.
-		// So this should never happen unless it was deleted accidentally.
-		return errors.Annotatef(err, "getting the existing statefulset %q to upgrade", name)
+		return errors.NotFoundf(
+			"deployment %q", name)
+	} else if err != nil {
+		return errors.Annotatef(err,
+			"getting deployment to upgrade for name %q", name)
 	}
+
+	updatedTemplateSpec, err := upgradePodTemplateSpec(&de.Spec.Template, imagePath, vers)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotatef(err, "deployment %q", name)
 	}
-
-	if len(imagePath) == 0 {
-		jujudContainerIdx := findJujudContainer(existingStatefulSet.Spec.Template.Spec.Containers)
-		if jujudContainerIdx < 0 {
-			return errors.NotFoundf("jujud container in statefulset %q", existingStatefulSet.GetName())
-		}
-		imagePath = existingStatefulSet.Spec.Template.Spec.Containers[jujudContainerIdx].Image
-	}
-
-	upgradeContainer(existingStatefulSet.Spec.Template.Spec.Containers, imagePath)
+	de.Spec.Template = *updatedTemplateSpec
 
 	// update juju-version annotation.
 	// TODO(caas): consider how to upgrade to current annotations format safely.
 	// just ensure juju-version to current version for now.
-	existingStatefulSet.SetAnnotations(
-		k8sannotations.New(existingStatefulSet.GetAnnotations()).
+	de.SetAnnotations(
+		k8sannotations.New(de.GetAnnotations()).
 			Add(labelVersion, vers.String()).ToMap(),
 	)
-	existingStatefulSet.Spec.Template.SetAnnotations(
-		k8sannotations.New(existingStatefulSet.Spec.Template.GetAnnotations()).
+	de.Spec.Template.SetAnnotations(
+		k8sannotations.New(de.Spec.Template.GetAnnotations()).
 			Add(labelVersion, vers.String()).ToMap(),
 	)
 
-	_, err = api.Update(existingStatefulSet)
-	return errors.Trace(err)
+	if _, err := broker.Update(de); err != nil {
+		return errors.Annotatef(err, "updating deployment %q to %s",
+			name, vers)
+	}
+	return nil
 }
 
-func (k *kubernetesClient) selectPod(labelSet k8slabels.Set) (*core.Pod, error) {
-	labelSelector := labelSetToSelector(labelSet).String()
-	podList, err := k.client().CoreV1().Pods(k.namespace).List(v1.ListOptions{
-		LabelSelector: labelSelector,
-	})
+func upgradeStatefulSet(name, imagePath string, vers version.Number, broker appstyped.StatefulSetInterface) error {
+	ss, err := broker.Get(name, meta.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NotFoundf(
+			"statefulset %q", name)
+	} else if err != nil {
+		return errors.Annotatef(err,
+			"getting statefulset to upgrade for name %q", name)
+	}
+
+	updatedTemplateSpec, err := upgradePodTemplateSpec(&ss.Spec.Template, imagePath, vers)
 	if err != nil {
-		return nil, errors.Annotatef(err, "selecting pod with label %q", labelSelector)
+		return errors.Annotatef(err, "statefulset %q", name)
 	}
-	if len(podList.Items) == 0 {
-		return nil, errors.NotFoundf("pod for selector %q", labelSet)
+	ss.Spec.Template = *updatedTemplateSpec
+
+	// update juju-version annotation.
+	// TODO(caas): consider how to upgrade to current annotations format safely.
+	// just ensure juju-version to current version for now.
+	ss.SetAnnotations(
+		k8sannotations.New(ss.GetAnnotations()).
+			Add(labelVersion, vers.String()).ToMap(),
+	)
+	ss.Spec.Template.SetAnnotations(
+		k8sannotations.New(ss.Spec.Template.GetAnnotations()).
+			Add(labelVersion, vers.String()).ToMap(),
+	)
+
+	if _, err := broker.Update(ss); err != nil {
+		return errors.Annotatef(err, "updating statefulset %q to %s",
+			name, vers)
 	}
-	return &podList.Items[0], nil
+	return nil
 }
 
-func (k *kubernetesClient) upgradeJujuInitContainer(appName string, imagePath string) (podChecker func() (bool, error), err error) {
-	deploymentName := k.deploymentName(appName, true)
-
-	var data []byte
-	var selector k8slabels.Set
-	defer func() {
-		podChecker = func() (done bool, err error) {
-			pod, err := k.selectPod(selector)
-			if errors.IsNotFound(err) {
-				// Not found means not ready.
-				logger.Tracef("listing pod %q, not found yet", selector.String())
-				return false, nil
-			} else if err != nil {
-				return false, errors.Trace(err)
-			}
-			_, opStatus, _, err := k.getPODStatus(*pod, k.clock.Now())
-			if err != nil {
-				return false, errors.Trace(err)
-			}
-			index := findJujudContainer(pod.Spec.InitContainers)
-			msg := fmt.Sprintf("init container of %q is still upgrading, current status -> %q", appName, opStatus)
-			if index >= 0 {
-				msg += " | version -> " + pod.Spec.InitContainers[index].Image
-			}
-			defer func() {
-				if !done {
-					logger.Debugf(msg)
-				}
-			}()
-			return opStatus == status.Running && index >= 0 && pod.Spec.InitContainers[index].Image == imagePath, nil
-		}
-	}()
-	sResource, err := k.getStatefulSet(deploymentName)
-	if err != nil && !errors.IsNotFound(err) {
-		return podChecker, errors.Trace(err)
-	} else if err == nil {
-		selector = sResource.Spec.Selector.MatchLabels
-		if err := ensureJujuInitContainer(&sResource.Spec.Template.Spec, imagePath); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		if data, err = json.Marshal(apps.StatefulSet{Spec: sResource.Spec}); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		_, err = k.client().AppsV1().StatefulSets(k.namespace).Patch(sResource.GetName(), k8stypes.StrategicMergePatchType, data)
-		return podChecker, errors.Trace(err)
+func upgradePodTemplateSpec(
+	podTemplate *core.PodTemplateSpec,
+	imagePath string,
+	vers version.Number,
+) (*core.PodTemplateSpec, error) {
+	jujudContainerIdx, found := findJujudContainer(podTemplate.Spec.Containers)
+	if !found {
+		return nil, errors.NotFoundf("jujud container in pod spec")
 	}
 
-	deResource, err := k.getDeployment(deploymentName)
-	if err != nil && !errors.IsNotFound(err) {
-		return podChecker, errors.Trace(err)
-	} else if err == nil {
-		selector = deResource.Spec.Selector.MatchLabels
-		if err := ensureJujuInitContainer(&deResource.Spec.Template.Spec, imagePath); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		if data, err = json.Marshal(apps.Deployment{Spec: deResource.Spec}); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		_, err = k.client().AppsV1().Deployments(k.namespace).Patch(deResource.GetName(), k8stypes.StrategicMergePatchType, data)
-		return podChecker, errors.Trace(err)
+	if imagePath == "" {
+		imagePath = podcfg.RebuildOldOperatorImagePath(
+			podTemplate.Spec.Containers[jujudContainerIdx].Image, vers)
 	}
 
-	daResource, err := k.getDaemonSet(deploymentName)
-	if err != nil && !errors.IsNotFound(err) {
-		return podChecker, errors.Trace(err)
-	} else if err == nil {
-		selector = daResource.Spec.Selector.MatchLabels
-		if err := ensureJujuInitContainer(&daResource.Spec.Template.Spec, imagePath); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		if data, err = json.Marshal(apps.DaemonSet{Spec: daResource.Spec}); err != nil {
-			return podChecker, errors.Trace(err)
-		}
-		_, err = k.client().AppsV1().DaemonSets(k.namespace).Patch(daResource.GetName(), k8stypes.StrategicMergePatchType, data)
-		return podChecker, errors.Trace(err)
+	upgradedTemp := podTemplate.DeepCopy()
+
+	if upgradedTemp.Spec.Containers[jujudContainerIdx].Image != imagePath {
+		upgradedTemp.Spec.Containers[jujudContainerIdx].Image = imagePath
 	}
-	// TODO(caas): check here should error or not(operator charm does not have any workload. So it's probably ok if there is no init containers to upgrade).
-	return podChecker, nil
+	return upgradedTemp, nil
+}
+
+func findJujudContainer(containers []core.Container) (int, bool) {
+	for i, c := range containers {
+		if podcfg.IsJujuOCIImage(c.Image) {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/caas/kubernetes/provider/upgrade_test.go
+++ b/caas/kubernetes/provider/upgrade_test.go
@@ -1,390 +1,57 @@
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package provider_test
+package provider
 
 import (
-	"encoding/json"
-	"time"
+	"fmt"
 
-	"github.com/golang/mock/gomock"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
-	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/cloudconfig/podcfg"
 )
 
-func (s *K8sBrokerSuite) TestUpgradeController(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
+type UpgraderSuite struct {
+}
 
-	ss := apps.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "controller",
-			Annotations: map[string]string{
-				"juju-version": "1.1.1",
-			},
-			Labels: map[string]string{"juju-operator": "controller"},
-		},
-		Spec: apps.StatefulSetSpec{
-			RevisionHistoryLimit: int32Ptr(0),
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						"juju-version": "1.1.1",
-					},
-				},
+var _ = gc.Suite(&UpgraderSuite{})
+
+func (u *UpgraderSuite) TestUpgradePodTemplateSpec(c *gc.C) {
+	tests := []struct {
+		ExpectedPodTemplateSpec core.PodTemplateSpec
+		PodTemplateSpec         core.PodTemplateSpec
+		ImagePath               string
+		Version                 version.Number
+	}{
+		{
+			ExpectedPodTemplateSpec: core.PodTemplateSpec{
 				Spec: core.PodSpec{
 					Containers: []core.Container{
-						{Image: "foo"},
-						{Image: "jujud-operator:1.1.1"},
+						{
+							Image: fmt.Sprintf("%s/%s:2.6.7", podcfg.JujudOCINamespace, podcfg.JujudOCIName),
+						},
 					},
 				},
 			},
-		},
-	}
-	updated := ss
-	updated.Annotations["juju-version"] = "6.6.6"
-	updated.Spec.Template.Annotations["juju-version"] = "6.6.6"
-	updated.Spec.Template.Spec.Containers[1].Image = "jujud-operator:6.6.6"
-	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{}).
-			Return(&ss, nil),
-		s.mockStatefulSets.EXPECT().Update(&updated).
-			Return(nil, nil),
-	)
-
-	err := s.broker.Upgrade("controller", version.MustParse("6.6.6"))
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *K8sBrokerSuite) assertUpgradeApplication(c *gc.C, shouldTimeout bool, adjustClock func(), assertCalls ...*gomock.Call) {
-	operatorSS := apps.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "app-name-operator",
-			Annotations: map[string]string{
-				"juju-version":       "1.1.1",
-				"juju.io/controller": testing.ControllerTag.Id(),
-			},
-			Labels: map[string]string{"juju-app": "app-name"},
-		},
-		Spec: apps.StatefulSetSpec{
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						"juju-version": "1.1.1",
-					},
-				},
+			PodTemplateSpec: core.PodTemplateSpec{
 				Spec: core.PodSpec{
 					Containers: []core.Container{
-						{Image: "foo"},
-						{Name: "juju-operator", Image: "jujud-operator:1.1.1"},
+						{
+							Image: fmt.Sprintf("%s/%s:2.6.6", podcfg.JujudOCINamespace, podcfg.JujudOCIName),
+						},
 					},
 				},
 			},
+			Version: version.MustParse("2.6.7"),
 		},
 	}
 
-	opPodRuning := core.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name: "test-operator",
-		},
-		Spec: core.PodSpec{
-			Containers: []core.Container{
-				{Image: "foo"},
-				{Name: "juju-operator", Image: "jujud-operator:1.1.1"},
-			},
-		},
-		Status: core.PodStatus{
-			Phase:   core.PodRunning,
-			Message: "test message.",
-		},
-	}
-	opCm := core.ConfigMap{
-		Data: map[string]string{
-			"test-agent.conf": "agent-conf-data",
-			"operator.yaml":   "operator-info-data",
-		},
-	}
-
-	updatedOperatorSS := operatorSS
-	updatedOperatorSS.Annotations["juju-version"] = "6.6.6"
-	updatedOperatorSS.Spec.Template.Annotations["juju-version"] = "6.6.6"
-	updatedOperatorSS.Spec.Template.Spec.Containers[1].Image = "jujud-operator:6.6.6"
-
-	expectedAssertCalls := []*gomock.Call{
-		// check operator status.
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockStatefulSets.EXPECT().Get("app-name-operator", v1.GetOptions{}).
-			Return(&updatedOperatorSS, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-operator=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{opPodRuning}}, nil),
-		s.mockConfigMaps.EXPECT().Get("app-name-operator-config", v1.GetOptions{}).
-			Return(&opCm, nil),
-
-		// handle legacy operator name.
-		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-	}
-	expectedAssertCalls = append(expectedAssertCalls, assertCalls...)
-	if !shouldTimeout {
-		expectedAssertCalls = append(expectedAssertCalls,
-			// handle legacy operator name.
-			s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
-				Return(nil, s.k8sNotFoundError()),
-			s.mockStatefulSets.EXPECT().Get("app-name-operator", v1.GetOptions{}).
-				Return(&operatorSS, nil),
-			// Upgrade operator.
-			s.mockStatefulSets.EXPECT().Update(&updatedOperatorSS).
-				DoAndReturn(func(in *apps.StatefulSet) (*apps.StatefulSet, error) {
-					return in, nil
-				}),
-		)
-	}
-	gomock.InOrder(
-		expectedAssertCalls...,
-	)
-
-	errChan := make(chan error)
-	go func() {
-		errChan <- s.broker.Upgrade("app-name", version.MustParse("6.6.6"))
-	}()
-
-	adjustClock()
-	select {
-	case err := <-errChan:
-		if shouldTimeout {
-			c.Assert(err, jc.Satisfies, errors.IsTimeout)
-		} else {
-			c.Assert(err, jc.ErrorIsNil)
-		}
-	case <-time.After(testing.LongWait):
-		c.Fatalf("timed out waiting for Upgrade return")
-	}
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationTimeoutFailed(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
-		Name:      "database-appuuid",
-		MountPath: "path/to/here",
-	})
-	workloadStatefulSet := unitStatefulSetArg(2, "workload-storage", podSpec)
-	expectedPatchSS := apps.StatefulSet{Spec: unitStatefulSetArg(2, "workload-storage", podSpec).Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchSS.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchSSData, err := json.Marshal(expectedPatchSS)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, true,
-		func() {
-			err := s.clock.WaitAdvance(30*time.Second, testing.ShortWait, 2)
-			c.Assert(err, jc.ErrorIsNil)
-		},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadStatefulSet, nil),
-		s.mockStatefulSets.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchSSData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{}}, nil),
-	)
-}
-
-var appPodRuning = core.Pod{
-	ObjectMeta: v1.ObjectMeta{
-		Name:   "app-name",
-		Labels: map[string]string{"juju-app": "app-name"},
-	},
-	Spec: core.PodSpec{
-		InitContainers: []core.Container{
-			{Name: "juju-operator", Image: "jujud-operator:6.6.6"},
-		},
-	},
-	Status: core.PodStatus{
-		Phase:   core.PodRunning,
-		Message: "test message.",
-	},
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationForStatefulApp(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
-		Name:      "database-appuuid",
-		MountPath: "path/to/here",
-	})
-	workloadStatefulSet := unitStatefulSetArg(2, "workload-storage", podSpec)
-	expectedPatchSS := apps.StatefulSet{Spec: unitStatefulSetArg(2, "workload-storage", podSpec).Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchSS.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchSSData, err := json.Marshal(expectedPatchSS)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, false, func() {
-		err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
+	for _, test := range tests {
+		podTempl, err := upgradePodTemplateSpec(&test.PodTemplateSpec, test.ImagePath, test.Version)
 		c.Assert(err, jc.ErrorIsNil)
-	},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadStatefulSet, nil),
-		s.mockStatefulSets.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchSSData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{appPodRuning}}, nil),
-	)
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationForStatelessApp(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-
-	workloadDeployment := &apps.Deployment{
-		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
-			}},
-		Spec: apps.DeploymentSpec{
-			Replicas: int32Ptr(1),
-			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
-			},
-			RevisionHistoryLimit: int32Ptr(0),
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{
-						"juju-app": "app-name",
-					},
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
-					},
-				},
-				Spec: podSpec,
-			},
-		},
+		c.Assert(test.ExpectedPodTemplateSpec.Spec.Containers[0].Image, gc.Equals, podTempl.Spec.Containers[0].Image)
 	}
-	expectedPatchDeployment := apps.Deployment{Spec: workloadDeployment.Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchDeployment.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchDeploymentData, err := json.Marshal(expectedPatchDeployment)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, false, func() {
-		err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
-		c.Assert(err, jc.ErrorIsNil)
-	},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadDeployment, nil),
-		s.mockDeployments.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchDeploymentData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{appPodRuning}}, nil),
-	)
-}
-
-func (s *K8sBrokerSuite) TestUpgradeApplicationForDaemonApp(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
-	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
-
-	workloadDaemonSet := &apps.DaemonSet{
-		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
-			}},
-		Spec: apps.DaemonSetSpec{
-			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
-			},
-			RevisionHistoryLimit: int32Ptr(0),
-			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
-					GenerateName: "app-name-",
-					Labels:       map[string]string{"juju-app": "app-name"},
-					Annotations: map[string]string{
-						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
-						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-					},
-				},
-				Spec: podSpec,
-			},
-		},
-	}
-	expectedPatchDaemonSet := apps.DaemonSet{Spec: workloadDaemonSet.Spec}
-	upgradedInitContainer := initContainers()[0]
-	upgradedInitContainer.Image = "jujud-operator:6.6.6"
-	expectedPatchDaemonSet.Spec.Template.Spec.InitContainers = []core.Container{upgradedInitContainer}
-	expectedPatchDaemonSetData, err := json.Marshal(expectedPatchDaemonSet)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertUpgradeApplication(c, false, func() {
-		err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
-		c.Assert(err, jc.ErrorIsNil)
-	},
-		s.mockStatefulSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDeployments.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-		s.mockDaemonSets.EXPECT().Get("app-name", v1.GetOptions{}).
-			Return(workloadDaemonSet, nil),
-		s.mockDaemonSets.EXPECT().Patch("app-name", k8stypes.StrategicMergePatchType, expectedPatchDaemonSetData).
-			Return(nil, nil),
-		s.mockPods.EXPECT().List(v1.ListOptions{LabelSelector: "juju-app=app-name"}).
-			Return(&core.PodList{Items: []core.Pod{appPodRuning}}, nil),
-	)
-}
-
-func (s *K8sBrokerSuite) TestUpgradeNothingToUpgrade(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockStatefulSets.EXPECT().Get("controller", v1.GetOptions{}).
-			Return(nil, s.k8sNotFoundError()),
-	)
-
-	err := s.broker.Upgrade("controller", version.MustParse("6.6.6"))
-	c.Assert(err, gc.ErrorMatches, `getting the existing statefulset "controller" to upgrade:  "test" not found`)
 }

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -92,6 +92,12 @@ var cloudinitDataVerifyTests = []cloudinitDataVerifyTest{
 		result:          expectedResult,
 	},
 	{
+		description:     "centos8 on centos8",
+		machineSeries:   "centos8",
+		containerSeries: "centos8",
+		result:          expectedResult,
+	},
+	{
 		description:     "win2012 on win2012",
 		machineSeries:   "win2012",
 		containerSeries: "win2012",

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	jujudOCINamespace = "jujusolutions"
-	jujudOCIName      = "jujud-operator"
-	jujudbOCIName     = "juju-db"
+	JujudOCINamespace = "jujusolutions"
+	JujudOCIName      = "jujud-operator"
+	JujudbOCIName     = "juju-db"
 )
 
 // GetControllerImagePath returns oci image path of jujud for a controller.
@@ -27,15 +27,15 @@ func (cfg *ControllerPodConfig) GetControllerImagePath() string {
 func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() string {
 	imageRepo := cfg.Controller.Config.CAASImageRepo()
 	if imageRepo == "" {
-		imageRepo = jujudOCINamespace
+		imageRepo = JujudOCINamespace
 	}
 	v := jujudbVersion
-	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, jujudbOCIName, v.Major, v.Minor)
+	return fmt.Sprintf("%s/%s:%d.%d", imageRepo, JujudbOCIName, v.Major, v.Minor)
 }
 
 // IsJujuOCIImage returns true if the image path is for a Juju operator.
 func IsJujuOCIImage(imagePath string) bool {
-	return strings.Contains(imagePath, jujudOCIName+":")
+	return strings.Contains(imagePath, JujudOCIName+":")
 }
 
 // GetJujuOCIImagePath returns the jujud oci image path.
@@ -78,8 +78,8 @@ func tagImagePath(path string, ver version.Number) string {
 
 func imageRepoToPath(imageRepo string, ver version.Number) string {
 	if imageRepo == "" {
-		imageRepo = jujudOCINamespace
+		imageRepo = JujudOCINamespace
 	}
-	path := fmt.Sprintf("%s/%s", imageRepo, jujudOCIName)
+	path := fmt.Sprintf("%s/%s", imageRepo, JujudOCIName)
 	return tagImagePath(path, ver)
 }

--- a/cmd/juju/action/list.go
+++ b/cmd/juju/action/list.go
@@ -4,6 +4,8 @@
 package action
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -182,7 +184,18 @@ func (c *listCommand) printTabular(writer io.Writer, value interface{}) error {
 	tw := output.TabWriter(writer)
 	fmt.Fprintf(tw, "%s\t%s\n", "Action", "Description")
 	for _, value := range list {
-		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.TrimSpace(value.description))
+		scanner := bufio.NewScanner(bytes.NewBufferString(strings.TrimSpace(value.description)))
+		scanner.Split(bufio.ScanLines)
+
+		var lines []string
+		for scanner.Scan() {
+			var prefix string
+			if len(lines) > 0 {
+				prefix = "\t"
+			}
+			lines = append(lines, fmt.Sprintf("%s%s", prefix, scanner.Text()))
+		}
+		fmt.Fprintf(tw, "%s\t%s\n", value.action, strings.Join(lines, "\n"))
 	}
 	tw.Flush()
 	return nil

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -145,7 +145,7 @@ func (c *removeUnitCommand) validateCAASRemoval() error {
 	if names.IsValidUnit(c.EntityNames[0]) {
 		msg := `
 k8s models do not support removing named units.
-Instead specify an application with --num-units (defaults to 1).
+Instead specify an application with --num-units.
 `[1:]
 		return errors.Errorf(msg)
 	}
@@ -156,9 +156,8 @@ Instead specify an application with --num-units (defaults to 1).
 		return errors.NotValidf("application name %q", c.EntityNames[0])
 	}
 	if c.NumUnits <= 0 {
-		return errors.NotValidf("removing %d units", c.NumUnits)
+		return errors.New("specify the number of units (> 0) to remove using --num-units")
 	}
-
 	return nil
 }
 

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -194,7 +194,7 @@ func (s *RemoveUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	s.store.Models["arthur"].Models["king/sword"] = m
 
 	_, err := s.runRemoveUnit(c, "some-application-name")
-	c.Assert(err, gc.ErrorMatches, "removing 0 units not valid")
+	c.Assert(err, gc.ErrorMatches, `specify the number of units \(> 0\) to remove using --num-units`)
 
 	_, err = s.runRemoveUnit(c, "some-application-name", "--destroy-storage")
 	c.Assert(err, gc.ErrorMatches, "k8s models only support --num-units")

--- a/cmd/juju/application/setseries.go
+++ b/cmd/juju/application/setseries.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
-	"github.com/juju/utils/series"
+	"github.com/juju/os/series"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"

--- a/cmd/juju/caas/gke_test.go
+++ b/cmd/juju/caas/gke_test.go
@@ -274,5 +274,5 @@ func (s *gkeSuite) TestEnsureExecutableGcloudNotFound(c *gc.C) {
 			}, nil),
 	)
 	err := gke.ensureExecutable()
-	c.Assert(err, gc.ErrorMatches, "gcloud command not found, please 'snap install gcloud' then try again: ")
+	c.Assert(err, gc.ErrorMatches, "gcloud command not found, please 'snap install google-cloud-sdk --classic' then try again: ")
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4984,6 +4984,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 	for _, s := range steps {
 		s.step(c, ctx)
 	}
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 	return ctx
 }
 

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	jujuos "github.com/juju/os"
 	"github.com/juju/os/series"
 	"github.com/juju/utils/arch"
 	"github.com/juju/utils/ssh"
@@ -532,11 +534,20 @@ func (c *BootstrapCommand) populateTools(st *state.State, env environs.Bootstrap
 		if err != nil {
 			return errors.Trace(err)
 		}
-		osSeries := series.OSSupportedSeries(opSys)
-		for _, s := range osSeries {
-			toolsVersion := agentTools.Version
-			toolsVersion.Series = s
-			toolsVersions = append(toolsVersions, toolsVersion)
+		osTypes := set.NewInts(int(opSys))
+		// If a Linux OS, we'll include all Linux OS's.
+		if opSys.IsLinux() {
+			for _, osType := range []jujuos.OSType{jujuos.Ubuntu, jujuos.CentOS, jujuos.GenericLinux, jujuos.OpenSUSE} {
+				osTypes.Add(int(osType))
+			}
+		}
+		for _, osType := range osTypes.SortedValues() {
+			osSeries := series.OSSupportedSeries(jujuos.OSType(osType))
+			for _, s := range osSeries {
+				toolsVersion := agentTools.Version
+				toolsVersion.Series = s
+				toolsVersions = append(toolsVersions, toolsVersion)
+			}
 		}
 	} else {
 		// Tools were downloaded from an external source: don't clone.

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -713,7 +713,7 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 			c.Assert(err, jc.ErrorIsNil)
 			hostos, err := series.GetOSFromSeries(series.MustHostSeries())
 			c.Assert(err, jc.ErrorIsNil)
-			if os == hostos {
+			if os == hostos || os.IsLinux() && hostos.IsLinux() {
 				expectedSeries.Add(ser)
 			}
 		}

--- a/cmd/plugins/juju-metadata/toolsmetadata.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/utils"
 
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
@@ -24,13 +23,12 @@ import (
 )
 
 func newToolsMetadataCommand() cmd.Command {
-	return modelcmd.Wrap(&toolsMetadataCommand{})
+	return &toolsMetadataCommand{}
 }
 
 // toolsMetadataCommand is used to generate simplestreams metadata for juju agents.
 type toolsMetadataCommand struct {
-	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
+	cmd.CommandBase
 	fetch       bool
 	metadataDir string
 	stream      string
@@ -44,8 +42,9 @@ generate-agents creates the simplestreams metadata for agents.
 This command works by scanning a directory for agent binary tarballs from which to generate
 simplestreams agent metadata. The working directory is specified using the -d argument
 (defaults to $JUJU_DATA or if not defined $XDG_DATA_HOME/juju or if that is not defined
-~/.local/share/juju). The working directory is expected to contain a named subdirectory
-containing agent binary tarballs, and is where the resulting metadata is written.
+~/.local/share/juju). The working directory path must contain a "tools" subdirectory.
+This "tools" directory is expected to contain a named subdirectory containing agent binary
+tarballs, and is where the resulting metadata is written.
 
 The stream for which metadata is generated is specified using the --stream parameter
 (default is "released"). Metadata can be generated for any supported stream - released,

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -121,9 +120,7 @@ var expectedOutputDirectoryTemplate = expectedOutputCommon + `
 `
 
 func newToolsMetadataCommandForTest() cmd.Command {
-	cmd := &toolsMetadataCommand{}
-	cmd.SetClientStore(jujuclienttesting.MinimalStore())
-	return modelcmd.Wrap(cmd)
+	return &toolsMetadataCommand{}
 }
 
 func (s *ToolsMetadataSuite) TestGenerateToDirectory(c *gc.C) {

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -8,13 +8,14 @@ import (
 	"path"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs"
+	jujuos "github.com/juju/os"
+	jujuseries "github.com/juju/os/series"
 	jujuarch "github.com/juju/utils/arch"
-	jujuos "github.com/juju/utils/os"
-	jujuseries "github.com/juju/utils/series"
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
+
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/environs"
 )
 
 // SourcedImage is the result of a successful image acquisition.
@@ -186,8 +187,15 @@ func seriesRemoteAliases(series, arch string) ([]string, error) {
 	case jujuos.Ubuntu:
 		return []string{path.Join(series, arch)}, nil
 	case jujuos.CentOS:
-		if series == "centos7" && arch == jujuarch.AMD64 {
-			return []string{"centos/7/amd64"}, nil
+		if arch == jujuarch.AMD64 {
+			switch series {
+			case "centos7":
+				return []string{"centos/7/amd64"}, nil
+			case "centos8":
+				return []string{"centos/8/amd64"}, nil
+			default:
+				return nil, errors.NotSupportedf("series %q", series)
+			}
 		}
 	case jujuos.OpenSUSE:
 		if series == "opensuseleap" && arch == jujuarch.AMD64 {

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -188,6 +188,9 @@ func (s *imageSuite) TestSeriesRemoteAliasesNotSupported(c *gc.C) {
 	_, err := lxd.SeriesRemoteAliases("centos7", "arm64")
 	c.Assert(err, gc.ErrorMatches, `series "centos7" not supported`)
 
+	_, err = lxd.SeriesRemoteAliases("centos8", "arm64")
+	c.Assert(err, gc.ErrorMatches, `series "centos8" not supported`)
+
 	_, err = lxd.SeriesRemoteAliases("opensuseleap", "s390x")
 	c.Assert(err, gc.ErrorMatches, `series "opensuseleap" not supported`)
 }

--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -6,8 +6,8 @@
 package lxd
 
 import (
+	"github.com/juju/os/series"
 	"github.com/juju/proxy"
-	"github.com/juju/utils/series"
 
 	"github.com/juju/juju/container"
 )

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/os/series"
 	"github.com/juju/packaging/manager"
 	"github.com/juju/proxy"
-	"github.com/juju/utils/series"
 	"github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/container"

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -6,8 +6,8 @@ package lxd
 import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/os"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/os"
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -850,7 +850,7 @@ func (s *AddressSuite) TestSpaceAddressesToProviderAddresses(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *AddressSuite) TestIPToCIDRNotation(c *gc.C) {
+func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 	type test struct {
 		IP   string
 		CIDR string
@@ -868,8 +868,8 @@ func (s *AddressSuite) TestIPToCIDRNotation(c *gc.C) {
 	}}
 
 	for i, t := range tests {
-		c.Logf("test %d: IPToCIDRNotation(%q, %q)", i, t.IP, t.CIDR)
-		got, err := network.IPToCIDRNotation(t.IP, t.CIDR)
+		c.Logf("test %d: ValueForCIDR(%q, %q)", i, t.IP, t.CIDR)
+		got, err := network.NewMachineAddress(t.IP).ValueForCIDR(t.CIDR)
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(got, gc.Equals, t.exp)
 	}

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -224,7 +224,9 @@ func (i *InterfaceInfo) IsVLAN() bool {
 	return i.VLANTag > 0
 }
 
-// CIDRAddress returns Address.Value combined with CIDR mask.
+// CIDRAddress returns Address.Value combined with subnet mask.
+// TODO (manadart 2020-07-02): Usage of this method should be phased out
+// in favour of calling ValueForCIDR on each member of the addresses slice.
 func (i *InterfaceInfo) CIDRAddress() (string, error) {
 	primaryAddr := i.PrimaryAddress()
 
@@ -232,18 +234,8 @@ func (i *InterfaceInfo) CIDRAddress() (string, error) {
 		return "", errors.NotFoundf("address and CIDR pair (%q, %q)", primaryAddr.Value, i.CIDR)
 	}
 
-	_, ipNet, err := net.ParseCIDR(i.CIDR)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	ip := primaryAddr.IP()
-	if ip == nil {
-		return "", errors.Errorf("cannot parse IP address %q", primaryAddr.Value)
-	}
-
-	ipNet.IP = ip
-	return ipNet.String(), nil
+	withMask, err := primaryAddr.ValueForCIDR(i.CIDR)
+	return withMask, errors.Trace(err)
 }
 
 // PrimaryAddress returns the primary address for the interface.

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -318,6 +318,7 @@ const (
 	Win81        SeriesName = "win81"
 	Win10        SeriesName = "win10"
 	Centos7      SeriesName = "centos7"
+	Centos8      SeriesName = "centos8"
 	OpenSUSELeap SeriesName = "opensuseleap"
 	GenericLinux SeriesName = "genericlinux"
 	Kubernetes   SeriesName = "kubernetes"
@@ -392,6 +393,11 @@ var nonUbuntuSeries = map[SeriesName]SeriesVersion{
 	Centos7: {
 		WorkloadType: OtherWorkloadType,
 		Version:      "centos7",
+		Supported:    true,
+	},
+	Centos8: {
+		WorkloadType: OtherWorkloadType,
+		Version:      "centos8",
 		Supported:    true,
 	},
 	OpenSUSELeap: {

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -41,7 +41,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -59,7 +59,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -77,7 +77,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -95,7 +95,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 
 	wrkSeries := info.WorkloadSeries()
 	sort.Strings(wrkSeries)
-	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, gc.DeepEquals, []string{"bionic", "centos7", "centos8", "eoan", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }
 
 func makeTempFile(c *gc.C, content string) (*os.File, func()) {

--- a/environs/imagemetadata_test.go
+++ b/environs/imagemetadata_test.go
@@ -65,7 +65,7 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNoConfigURL(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }
 
@@ -74,8 +74,8 @@ func (s *ImageMetadataSuite) TestImageMetadataURLs(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-image-metadata-url/", ""},
-		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"config-image-metadata-url/", "", false},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }
 
@@ -113,10 +113,10 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsRegisteredFuncs(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-image-metadata-url/", ""},
-		{"foobar/", ""},
-		{"betwixt/releases/", ""},
-		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"config-image-metadata-url/", "", false},
+		{"foobar/", "", false},
+		{"betwixt/releases/", "", false},
+		{"http://cloud-images.ubuntu.com/releases/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }
 
@@ -136,6 +136,6 @@ func (s *ImageMetadataSuite) TestImageMetadataURLsNonReleaseStream(c *gc.C) {
 	sources, err := environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey},
+		{"http://cloud-images.ubuntu.com/daily/", imagemetadata.SimplestreamsImagesPublicKey, true},
 	})
 }

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -652,8 +652,9 @@ func SignMetadata(fileName string, fileData []byte) (string, []byte, error) {
 
 // SourceDetails stored some details that need to be checked about data source.
 type SourceDetails struct {
-	URL string
-	Key string
+	URL           string
+	Key           string
+	RequireSigned bool
 }
 
 func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, dsDetails []SourceDetails) {
@@ -669,6 +670,7 @@ func AssertExpectedSources(c *gc.C, obtained []simplestreams.DataSource, dsDetai
 		expected := dsDetails[i]
 		c.Assert(url, gc.DeepEquals, expected.URL)
 		c.Assert(source.PublicSigningKey(), gc.DeepEquals, expected.Key)
+		c.Assert(source.RequireSigned(), gc.Equals, expected.RequireSigned)
 	}
 	c.Assert(obtained, gc.HasLen, len(dsDetails))
 }

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -43,12 +43,15 @@ const (
 
 	// IndexFileVersion is used to construct the streams index file.
 	IndexFileVersion = 2
+
+	// streamsAgentURL is the path to the default simplestreams agent metadata.
+	streamsAgentURL = "https://streams.canonical.com/juju/tools"
 )
 
 var currentStreamsVersion = StreamsVersionV1
 
 // This needs to be a var so we can override it for testing.
-var DefaultBaseURL = "https://streams.canonical.com/juju/tools"
+var DefaultBaseURL = streamsAgentURL
 
 const (
 	// Used to specify the released tools metadata.

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -109,7 +109,7 @@ func GetMetadataSources(env environs.BootstrapEnviron) ([]simplestreams.DataSour
 			PublicSigningKey:     keys.JujuPublicKey,
 			HostnameVerification: utils.VerifySSLHostnames,
 			Priority:             simplestreams.DEFAULT_CLOUD_DATA,
-			RequireSigned:        true,
+			RequireSigned:        DefaultBaseURL == streamsAgentURL,
 		}
 		if err := dataSourceConfig.Validate(); err != nil {
 			return nil, errors.Annotate(err, "simplestreams config validation failed")

--- a/environs/tools/urls_test.go
+++ b/environs/tools/urls_test.go
@@ -62,7 +62,7 @@ func (s *URLsSuite) TestToolsURLsNoConfigURL(c *gc.C) {
 	env := s.env(c, "")
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
-	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey}})
+	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey, true}})
 }
 
 func (s *URLsSuite) TestToolsSources(c *gc.C) {
@@ -70,8 +70,8 @@ func (s *URLsSuite) TestToolsSources(c *gc.C) {
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-tools-metadata-url/", keys.JujuPublicKey},
-		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey},
+		{"config-tools-metadata-url/", keys.JujuPublicKey, false},
+		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey, true},
 	})
 }
 
@@ -103,9 +103,9 @@ func (s *URLsSuite) TestToolsMetadataURLsRegisteredFuncs(c *gc.C) {
 	sources, err := tools.GetMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)
 	sstesting.AssertExpectedSources(c, sources, []sstesting.SourceDetails{
-		{"config-tools-metadata-url/", keys.JujuPublicKey},
-		{"betwixt/releases/", ""},
-		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey},
+		{"config-tools-metadata-url/", keys.JujuPublicKey, false},
+		{"betwixt/releases/", "", false},
+		{"https://streams.canonical.com/juju/tools/", keys.JujuPublicKey, true},
 	})
 }
 

--- a/featuretests/tools_test.go
+++ b/featuretests/tools_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/series"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"

--- a/generate/schemagen/gen/describeapi_mock.go
+++ b/generate/schemagen/gen/describeapi_mock.go
@@ -34,6 +34,20 @@ func (m *MockAPIServer) EXPECT() *MockAPIServerMockRecorder {
 	return m.recorder
 }
 
+// AdminFacadeDetails mocks base method
+func (m *MockAPIServer) AdminFacadeDetails() []facade.Details {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AdminFacadeDetails")
+	ret0, _ := ret[0].([]facade.Details)
+	return ret0
+}
+
+// AdminFacadeDetails indicates an expected call of AdminFacadeDetails
+func (mr *MockAPIServerMockRecorder) AdminFacadeDetails() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminFacadeDetails", reflect.TypeOf((*MockAPIServer)(nil).AdminFacadeDetails))
+}
+
 // AllFacades mocks base method
 func (m *MockAPIServer) AllFacades() Registry {
 	m.ctrl.T.Helper()

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/joyent/gosdc v0.0.0-20140524000815-2f11feadd2d9
 	github.com/joyent/gosign v0.0.0-20140524000734-0da0d5f13420
 	github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf
-	github.com/juju/bundlechanges v0.0.0-20200625095418-8b1912834d29
+	github.com/juju/bundlechanges v1.0.0
 	github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815
 	github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
@@ -59,7 +59,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200424054733-9a8294627524
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20200323101341-8e16ce76f45e
+	github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
@@ -114,7 +114,7 @@ require (
 	google.golang.org/api v0.4.0
 	gopkg.in/amz.v3 v3.0.0-20191122063134-7ba11a47c789
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
-	gopkg.in/goose.v2 v2.0.0-20200403131220-0c829f62c42a
+	gopkg.in/goose.v2 v2.0.1
 	gopkg.in/httprequest.v1 v1.2.0
 	gopkg.in/ini.v1 v1.10.1
 	gopkg.in/juju/blobstore.v2 v2.0.0-20160125023703-51fa6e26128d

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN76APTgBEdHkR/PSbpeY4I8cWeEA=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges v0.0.0-20200625095418-8b1912834d29 h1:S4124f9P1GL47R++sAYPC9KCmmy4TsINvjNY3TjyUl8=
-github.com/juju/bundlechanges v0.0.0-20200625095418-8b1912834d29/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
+github.com/juju/bundlechanges v1.0.0 h1:MWHsdeas7iy5uJJlgqKCNmgUCr3aTgV4Vn+Sz5L3UJg=
+github.com/juju/bundlechanges v1.0.0/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596 h1:HxkKL4WZ8j/2q63vngE6poi5p1I6KzsxC0v93bvpDBM=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596/go.mod h1:/Hb24f6NaHMuxV/XeKR9v1QY8qCc0NanWAXQuv6+Ob0=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85 h1:YgEB2tnlAwVftOnPUKTN4i6NDYZy0ztR5l/HdUuHS2Y=
@@ -354,8 +354,8 @@ github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdG
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
-github.com/juju/os v0.0.0-20200323101341-8e16ce76f45e h1:atxWn8Xx0oEjyYxd6RmV0O2vA+imhCfDvNHKkFAcnzM=
-github.com/juju/os v0.0.0-20200323101341-8e16ce76f45e/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
+github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
+github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=
@@ -411,6 +411,7 @@ github.com/juju/usso v0.0.0-20160401104424-68a59c96c178/go.mod h1:sHjHrlB/5phHrK
 github.com/juju/utils v0.0.0-20160526025251-ffea6ead0c37/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20161003233226-28c01ec2ad93/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
+github.com/juju/utils v0.0.0-20180517015153-d2ddf8edc7dc/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180619112806-c746c6e86f4f/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180808125547-9dfc6dbfb02b/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
@@ -700,6 +701,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -778,8 +780,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gobwas/glob.v0 v0.2.3 h1:uLMy+ys6BqRCutdUNyWLlmEnd7VULqh1nsxxV1kj0qQ=
 gopkg.in/gobwas/glob.v0 v0.2.3/go.mod h1:JgYsZg6HmXzPbMVcSQwXigfIbVWt5ysj8n78j6LiwQY=
 gopkg.in/goose.v2 v2.0.0-20180816040309-cf9b64132d71/go.mod h1:X3PYCIEMHdiiAiEpk6rdBgT6ACN+bfZWQ6y1G6qGJ+c=
-gopkg.in/goose.v2 v2.0.0-20200403131220-0c829f62c42a h1:OF1DchDAItBHvthfsCpOI9GQPubALPq0NHDCVTrY+oQ=
-gopkg.in/goose.v2 v2.0.0-20200403131220-0c829f62c42a/go.mod h1:X3PYCIEMHdiiAiEpk6rdBgT6ACN+bfZWQ6y1G6qGJ+c=
+gopkg.in/goose.v2 v2.0.1 h1:3UyAr+zpd9hA+WNPNsqG0EzYQ1yr/XFLW8ybkAgO7Lc=
+gopkg.in/goose.v2 v2.0.1/go.mod h1:X3PYCIEMHdiiAiEpk6rdBgT6ACN+bfZWQ6y1G6qGJ+c=
 gopkg.in/httprequest.v1 v1.0.0-20180319125457-3531529dedf0/go.mod h1:/CkavNL+g3qLOrpFHVrEx4NKepeqR4XTZWNj4sGGjz0=
 gopkg.in/httprequest.v1 v1.2.0 h1:YTGV1oXzaoKI6oPzQ0knoIPcrrVzeRG3amkoxoP7Xng=
 gopkg.in/httprequest.v1 v1.2.0/go.mod h1:T61ZUaJLpMnzvoJDO03ZD8yRXD4nZzBeDoW5e9sffjg=

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -20,7 +20,7 @@ type kvmDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep kvmDependency) PackageList(series string) ([]packaging.Package, error) {
-	if series == "centos7" || series == "opensuseleap" {
+	if series == "centos7" || series == "centos8" || series == "opensuseleap" {
 		return nil, errors.NotSupportedf("installing kvm on series %q", series)
 	}
 

--- a/packaging/dependency/lxd.go
+++ b/packaging/dependency/lxd.go
@@ -29,7 +29,7 @@ func (dep lxdDependency) PackageList(series string) ([]packaging.Package, error)
 	var pkg packaging.Package
 
 	switch series {
-	case "centos7", "opensuseleap", "precise":
+	case "centos7", "centos8", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("LXD containers on series %q", series)
 	case "trusty", "xenial", "bionic", blankSeries:
 		pkg.Name = "lxd"

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -38,7 +38,7 @@ func (dep mongoDependency) PackageList(series string) ([]packaging.Package, erro
 	}
 
 	switch series {
-	case "centos7", "opensuseleap", "precise":
+	case "centos7", "centos8", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("installing mongo on series %q", series)
 	case "trusty":
 		aptPkgList = append(aptPkgList, "juju-mongodb")

--- a/packaging/manager_test.go
+++ b/packaging/manager_test.go
@@ -21,15 +21,17 @@ func (s *DependencyManagerTestSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DependencyManagerTestSuite) TestInstallWithCentos(c *gc.C) {
-	s.assertInstallCallsCorrectBinary(c, assertParams{
-		series:       "centos7",
-		pkg:          "foo",
-		pm:           packaging.YumPackageManager,
-		expPkgBinary: "yum",
-		expArgs: []string{
-			"--assumeyes", "--debuglevel=1", "install", "foo",
-		},
-	})
+	for _, series := range []string{"centos7", "centos8"} {
+		s.assertInstallCallsCorrectBinary(c, assertParams{
+			series:       series,
+			pkg:          "foo",
+			pm:           packaging.YumPackageManager,
+			expPkgBinary: "yum",
+			expArgs: []string{
+				"--assumeyes", "--debuglevel=1", "install", "foo",
+			},
+		})
+	}
 }
 
 func (s *DependencyManagerTestSuite) TestInstallWithOpenSuse(c *gc.C) {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -713,13 +713,19 @@ func (s *environSuite) testStartInstanceWindows(
 }
 
 func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {
+	for _, series := range []string{"centos7", "centos8"} {
+		s.assertStartInstanceCentOS(c, series)
+	}
+}
+
+func (s *environSuite) assertStartInstanceCentOS(c *gc.C, series string) {
 	// Starting a CentOS VM, we should not expect an image query.
 	s.PatchValue(&s.ubuntuServerSKUs, nil)
 
 	env := s.openEnviron(c)
 	s.sender = s.startInstanceSenders(false)
 	s.requests = nil
-	args := makeStartInstanceParams(c, s.controllerUUID, "centos7")
+	args := makeStartInstanceParams(c, s.controllerUUID, series)
 	_, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -94,7 +94,7 @@ func SeriesImage(
 		publisher = centOSPublisher
 		offering = centOSOffering
 		switch series {
-		case "centos7":
+		case "centos7", "centos8":
 			sku = "7.3"
 		default:
 			return nil, errors.NotSupportedf("deploying %s", series)

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -86,7 +86,9 @@ func (s *imageutilsSuite) TestSeriesImageWindows(c *gc.C) {
 }
 
 func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
-	s.assertImageId(c, "centos7", "released", "OpenLogic:CentOS:7.3:latest")
+	for _, series := range []string{"centos7", "centos8"} {
+		s.assertImageId(c, series, "released", "OpenLogic:CentOS:7.3:latest")
+	}
 }
 
 func (s *imageutilsSuite) TestSeriesImageGenericLinux(c *gc.C) {

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -455,7 +455,7 @@ func (s *storageSuite) TestCreateVolumesLegacy(c *gc.C) {
 			Volume:  names.NewVolumeTag(volumeId),
 			Machine: names.NewMachineTag(machineId),
 			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
-				BusAddress: fmt.Sprintf("scsi@5:0.0.%d", lun),
+				DeviceLink: fmt.Sprintf("/dev/disk/azure/scsi1/lun%d", lun),
 			},
 		}
 	}

--- a/provider/common/disk_test.go
+++ b/provider/common/disk_test.go
@@ -21,6 +21,7 @@ func (s *DiskSuite) TestMinRootDiskSizeGiB(c *gc.C) {
 		{"trusty", 8},
 		{"win2012r2", 40},
 		{"centos7", 8},
+		{"centos8", 8},
 		{"opensuseleap", 8},
 		{"fake-series", 8},
 	}

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -29,9 +29,9 @@ func (*ErrorsSuite) TestWrapZoneIndependentError(c *gc.C) {
 
 	stack := errors.ErrorStack(wrapped)
 	c.Assert(stack, gc.Matches, `
-.*github.com/juju/juju/provider/common/errors_test.go:.*: foo
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/juju/juju/provider/common/errors_test.go:.*: foo
+.*/juju/juju/provider/common/errors_test.go:.*: bar
+.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
@@ -46,9 +46,9 @@ func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
 
 	stack := errors.ErrorStack(err)
 	c.Assert(stack, gc.Matches, `
-.*github.com/juju/juju/provider/common/errors_test.go:.*: foo
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar
-.*github.com/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/juju/juju/provider/common/errors_test.go:.*: foo
+.*/juju/juju/provider/common/errors_test.go:.*: bar
+.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialNew(c *gc.C) {

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -151,12 +151,12 @@ func (p environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 
 	remoteCertCredentials, err := p.detectRemoteCredentials(certPEM, keyPEM)
 	if err != nil {
-		logger.Errorf("unable to detect remote LXC credentials: %s", err)
+		logger.Debugf("unable to detect remote LXC credentials: %s", err)
 	}
 
 	localCertCredentials, err := p.detectLocalCredentials(certPEM, keyPEM)
 	if err != nil {
-		logger.Errorf("unable to detect local LXC credentials: %s", err)
+		logger.Debugf("unable to detect local LXC credentials: %s", err)
 	}
 
 	authCredentials := make(map[string]cloud.Credential)

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/os"
+	jujuseries "github.com/juju/os/series"
 	"github.com/juju/utils/arch"
-	"github.com/juju/utils/os"
-	jujuseries "github.com/juju/utils/series"
 	"github.com/juju/version"
 	"github.com/kr/pretty"
 

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -13,8 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	// jujuos "github.com/juju/utils/os"
-	"github.com/juju/utils/series"
+	"github.com/juju/os/series"
 
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
+	gooseerrors "gopkg.in/goose.v2/errors"
 	"gopkg.in/goose.v2/neutron"
 
 	"github.com/juju/juju/core/instance"
@@ -32,7 +34,7 @@ const (
 
 var extractControllerRe = regexp.MustCompile(GroupControllerPattern)
 
-//factory for obtaining firewaller object.
+// FirewallerFactory for obtaining firewaller object.
 type FirewallerFactory interface {
 	GetFirewaller(env environs.Environ) Firewaller
 }
@@ -75,20 +77,19 @@ type Firewaller interface {
 
 	// SetUpGroups sets up initial security groups, if any, and returns
 	// their names.
-	SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error)
+	SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string, apiPort int) ([]string, error)
 
 	// OpenInstancePorts opens the given port ranges for the specified  instance.
-	OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules []network.IngressRule) error
+	OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, rules []network.IngressRule) error
 
 	// CloseInstancePorts closes the given port ranges for the specified  instance.
-	CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules []network.IngressRule) error
+	CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, rules []network.IngressRule) error
 
 	// InstanceIngressRules returns the ingress rules applied to the specified  instance.
-	InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineId string) ([]network.IngressRule, error)
+	InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineID string) ([]network.IngressRule, error)
 }
 
-type firewallerFactory struct {
-}
+type firewallerFactory struct{}
 
 // GetFirewaller implements FirewallerFactory
 func (f *firewallerFactory) GetFirewaller(env environs.Environ) Firewaller {
@@ -114,7 +115,7 @@ func (c *firewallerBase) GetSecurityGroups(ctx context.ProviderCallContext, ids 
 			if inst == nil {
 				continue
 			}
-			serverId, err := instServerId(inst)
+			serverID, err := instServerID(inst)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -126,7 +127,7 @@ func (c *firewallerBase) GetSecurityGroups(ctx context.ProviderCallContext, ids 
 			for _, group := range groups {
 				// We only include the group specifically tied to the instance, not
 				// any group global to the model itself.
-				suffix := fmt.Sprintf("%s-%s", c.environ.Config().UUID(), serverId)
+				suffix := fmt.Sprintf("%s-%s", c.environ.Config().UUID(), serverID)
 				if strings.HasSuffix(group.Name, suffix) {
 					securityGroupNames = append(securityGroupNames, group.Name)
 				}
@@ -136,14 +137,13 @@ func (c *firewallerBase) GetSecurityGroups(ctx context.ProviderCallContext, ids 
 	return securityGroupNames, nil
 }
 
-func instServerId(inst instances.Instance) (string, error) {
+func instServerID(inst instances.Instance) (string, error) {
 	openstackName := inst.(*openstackInstance).getServerDetail().Name
 	lastDashPos := strings.LastIndex(openstackName, "-")
 	if lastDashPos == -1 {
 		return "", errors.Errorf("cannot identify machine ID in openstack server name %q", openstackName)
 	}
-	serverId := openstackName[lastDashPos+1:]
-	return serverId, nil
+	return openstackName[lastDashPos+1:], nil
 }
 
 func deleteSecurityGroupsMatchingName(
@@ -185,14 +185,17 @@ func deleteSecurityGroupsOneOfNames(
 // of the groups is tried multiple times.
 func deleteSecurityGroup(
 	ctx context.ProviderCallContext,
-	deleteSecurityGroupById func(string) error,
+	deleteSecurityGroupByID func(string) error,
 	name, id string,
 	clock clock.Clock,
 ) {
 	logger.Debugf("deleting security group %q", name)
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
-			if err := deleteSecurityGroupById(id); err != nil {
+			if err := deleteSecurityGroupByID(id); err != nil {
+				if gooseerrors.IsNotFound(err) {
+					return nil
+				}
 				handleCredentialError(err, ctx)
 				return errors.Trace(err)
 			}
@@ -262,37 +265,37 @@ func (c *firewallerBase) ingressRules(
 func (c *firewallerBase) openInstancePorts(
 	ctx context.ProviderCallContext,
 	openPortsInGroup func(context.ProviderCallContext, string, []network.IngressRule) error,
-	machineId string,
+	machineID string,
 	rules []network.IngressRule,
 ) error {
-	nameRegexp := c.machineGroupRegexp(machineId)
+	nameRegexp := c.machineGroupRegexp(machineID)
 	if err := openPortsInGroup(ctx, nameRegexp, rules); err != nil {
 		return errors.Trace(err)
 	}
-	logger.Infof("opened ports in security group %s-%s: %v", c.environ.Config().UUID(), machineId, rules)
+	logger.Infof("opened ports in security group %s-%s: %v", c.environ.Config().UUID(), machineID, rules)
 	return nil
 }
 
 func (c *firewallerBase) closeInstancePorts(
 	ctx context.ProviderCallContext,
 	closePortsInGroup func(context.ProviderCallContext, string, []network.IngressRule) error,
-	machineId string,
+	machineID string,
 	rules []network.IngressRule,
 ) error {
-	nameRegexp := c.machineGroupRegexp(machineId)
+	nameRegexp := c.machineGroupRegexp(machineID)
 	if err := closePortsInGroup(ctx, nameRegexp, rules); err != nil {
 		return errors.Trace(err)
 	}
-	logger.Infof("closed ports in security group %s-%s: %v", c.environ.Config().UUID(), machineId, rules)
+	logger.Infof("closed ports in security group %s-%s: %v", c.environ.Config().UUID(), machineID, rules)
 	return nil
 }
 
 func (c *firewallerBase) instanceIngressRules(
 	ctx context.ProviderCallContext,
 	ingressRulesInGroup func(context.ProviderCallContext, string) ([]network.IngressRule, error),
-	machineId string,
+	machineID string,
 ) ([]network.IngressRule, error) {
-	nameRegexp := c.machineGroupRegexp(machineId)
+	nameRegexp := c.machineGroupRegexp(machineID)
 	portRanges, err := ingressRulesInGroup(ctx, nameRegexp)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -304,8 +307,8 @@ func (c *firewallerBase) globalGroupName(controllerUUID string) string {
 	return fmt.Sprintf("%s-global", c.jujuGroupName(controllerUUID))
 }
 
-func (c *firewallerBase) machineGroupName(controllerUUID, machineId string) string {
-	return fmt.Sprintf("%s-%s", c.jujuGroupName(controllerUUID), machineId)
+func (c *firewallerBase) machineGroupName(controllerUUID, machineID string) string {
+	return fmt.Sprintf("%s-%s", c.jujuGroupName(controllerUUID), machineID)
 }
 
 func (c *firewallerBase) jujuGroupName(controllerUUID string) string {
@@ -326,9 +329,9 @@ func (c *firewallerBase) globalGroupRegexp() string {
 	return fmt.Sprintf("%s-global", c.jujuGroupRegexp())
 }
 
-func (c *firewallerBase) machineGroupRegexp(machineId string) string {
+func (c *firewallerBase) machineGroupRegexp(machineID string) string {
 	// we are only looking to match 1 machine
-	return fmt.Sprintf("%s-%s$", c.jujuGroupRegexp(), machineId)
+	return fmt.Sprintf("%s-%s$", c.jujuGroupRegexp(), machineID)
 }
 
 type neutronFirewaller struct {
@@ -346,7 +349,7 @@ type neutronFirewaller struct {
 // Note: ideally we'd have a better way to determine group membership so that 2
 // people that happen to share an openstack account and name their environment
 // "openstack" don't end up destroying each other's machines.
-func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error) {
+func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineID string, apiPort int) ([]string, error) {
 	jujuGroup, err := c.setUpGlobalGroup(c.jujuGroupName(controllerUUID), apiPort)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -354,7 +357,7 @@ func (c *neutronFirewaller) SetUpGroups(ctx context.ProviderCallContext, control
 	var machineGroup neutron.SecurityGroupV2
 	switch c.environ.Config().FirewallMode() {
 	case config.FwInstance:
-		machineGroup, err = c.ensureGroup(c.machineGroupName(controllerUUID, machineId), nil)
+		machineGroup, err = c.ensureGroup(c.machineGroupName(controllerUUID, machineID), nil)
 	case config.FwGlobal:
 		machineGroup, err = c.ensureGroup(c.globalGroupName(controllerUUID), nil)
 	}
@@ -447,14 +450,17 @@ var zeroGroup neutron.SecurityGroupV2
 // If a group with name does not exist, one will be created.
 // If it exists, its permissions are set to rules.
 func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2) (neutron.SecurityGroupV2, error) {
-	neutronClient := c.environ.neutron()
-	var group neutron.SecurityGroupV2
-
 	// Due to parallelization of the provisioner, it's possible that we try
 	// to create the model security group a second time before the first time
 	// is complete causing failures.
+	// TODO (stickupkid): This can block forever (API timeouts). We should allow
+	// a mutex to timeout and fail with an error.
 	c.ensureGroupMutex.Lock()
 	defer c.ensureGroupMutex.Unlock()
+
+	neutronClient := c.environ.neutron()
+	var group neutron.SecurityGroupV2
+
 	// First attempt to look up an existing group by name.
 	groupsFound, err := neutronClient.SecurityGroupByNameV2(name)
 	// a list is returned, but there should be only one
@@ -480,16 +486,20 @@ func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2)
 
 	// Find rules we want to delete, that we have but don't want, and
 	// delete them.
-	remove := make(ruleInfoSet)
+	// Define a removal set to ensure that we only ever delete a ruleID once.
+	remove := set.NewStrings()
 	for k := range have {
 		// Neutron creates 2 egress rules with any new Security Group.
 		// Keep them.
 		if _, ok := want[k]; !ok && k.Direction != "egress" {
-			remove[k] = have[k]
+			remove.Add(have[k])
 		}
 	}
-	for _, ruleId := range remove {
-		if err = neutronClient.DeleteSecurityGroupRuleV2(ruleId); err != nil {
+	for _, ruleID := range remove.SortedValues() {
+		if err = neutronClient.DeleteSecurityGroupRuleV2(ruleID); err != nil {
+			if gooseerrors.IsNotFound(err) {
+				continue
+			}
 			return zeroGroup, err
 		}
 	}
@@ -691,7 +701,7 @@ func (c *neutronFirewaller) IngressRules(ctx context.ProviderCallContext) ([]net
 }
 
 // OpenInstancePorts implements Firewaller interface.
-func (c *neutronFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, ports []network.IngressRule) error {
+func (c *neutronFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, ports []network.IngressRule) error {
 	if c.environ.Config().FirewallMode() != config.FwInstance {
 		return errors.Errorf("invalid firewall mode %q for opening ports on instance",
 			c.environ.Config().FirewallMode())
@@ -703,7 +713,7 @@ func (c *neutronFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, i
 	if securityGroups := inst.(*openstackInstance).getServerDetail().Groups; securityGroups == nil {
 		return nil
 	}
-	err := c.openInstancePorts(ctx, c.openPortsInGroup, machineId, ports)
+	err := c.openInstancePorts(ctx, c.openPortsInGroup, machineID, ports)
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
@@ -712,7 +722,7 @@ func (c *neutronFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, i
 }
 
 // CloseInstancePorts implements Firewaller interface.
-func (c *neutronFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, ports []network.IngressRule) error {
+func (c *neutronFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineID string, ports []network.IngressRule) error {
 	if c.environ.Config().FirewallMode() != config.FwInstance {
 		return errors.Errorf("invalid firewall mode %q for closing ports on instance",
 			c.environ.Config().FirewallMode())
@@ -724,7 +734,7 @@ func (c *neutronFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, 
 	if securityGroups := inst.(*openstackInstance).getServerDetail().Groups; securityGroups == nil {
 		return nil
 	}
-	err := c.closeInstancePorts(ctx, c.closePortsInGroup, machineId, ports)
+	err := c.closeInstancePorts(ctx, c.closePortsInGroup, machineID, ports)
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
@@ -733,7 +743,7 @@ func (c *neutronFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, 
 }
 
 // InstanceIngressRules implements Firewaller interface.
-func (c *neutronFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineId string) ([]network.IngressRule, error) {
+func (c *neutronFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineID string) ([]network.IngressRule, error) {
 	if c.environ.Config().FirewallMode() != config.FwInstance {
 		return nil, errors.Errorf("invalid firewall mode %q for retrieving ingress rules from instance",
 			c.environ.Config().FirewallMode())
@@ -745,7 +755,7 @@ func (c *neutronFirewaller) InstanceIngressRules(ctx context.ProviderCallContext
 	if securityGroups := inst.(*openstackInstance).getServerDetail().Groups; securityGroups == nil {
 		return []network.IngressRule{}, nil
 	}
-	rules, err := c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineId)
+	rules, err := c.instanceIngressRules(ctx, c.ingressRulesInGroup, machineID)
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return rules, errors.Trace(err)
@@ -841,8 +851,10 @@ func (c *neutronFirewaller) closePortsInGroup(ctx context.ProviderCallContext, n
 			if !secGroupMatchesIngressRule(p, rule) {
 				continue
 			}
-			err := neutronClient.DeleteSecurityGroupRuleV2(p.Id)
-			if err != nil {
+			if err := neutronClient.DeleteSecurityGroupRuleV2(p.Id); err != nil {
+				if gooseerrors.IsNotFound(err) {
+					break
+				}
 				handleCredentialError(err, ctx)
 				return errors.Trace(err)
 			}

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -132,6 +132,10 @@ var discoveryTests = []discoveryTest{{
 	series:   "centos7",
 	expected: service.InitSystemSystemd,
 }, {
+	os:       jujuos.CentOS,
+	series:   "centos8",
+	expected: service.InitSystemSystemd,
+}, {
 	os:       jujuos.OpenSUSE,
 	series:   "opensuseleap",
 	expected: service.InitSystemSystemd,

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -153,7 +153,7 @@ func (s *ipAddressesStateSuite) TestDeviceMethodReturnsNotFoundErrorWhenMissing(
 	result, err := addresses[0].Device()
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, `device "eth0" on machine "0" not found`)
+	c.Assert(err, gc.ErrorMatches, `device with ID .+ not found`)
 }
 
 func (s *ipAddressesStateSuite) TestSubnetMethodReturnsSubnet(c *gc.C) {

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
@@ -49,10 +50,10 @@ type linkLayerDeviceDoc struct {
 	// IsUp is true when the device is up (enabled).
 	IsUp bool `bson:"is-up"`
 
-	// ParentName is the name of the parent device, which may be empty. When set
-	// the parent device must be on the same machine, unless the current device
-	// is inside a container, in which case ParentName can be a global key of a
-	// BridgeDevice on the host machine of the container.
+	// ParentName is the name of the parent device, which may be empty.
+	// When set, the parent device must be on the same machine unless the
+	// current device is inside a container, in which case it can be a global
+	// key of a bridge device on the container host.
 	ParentName string `bson:"parent-name"`
 
 	// If this is device is part of a virtual switch, this field indicates
@@ -69,22 +70,6 @@ type LinkLayerDevice struct {
 
 func newLinkLayerDevice(st *State, doc linkLayerDeviceDoc) *LinkLayerDevice {
 	return &LinkLayerDevice{st: st, doc: doc}
-}
-
-// AllLinkLayerDevices returns all link layer devices in the model.
-func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
-	devicesCollection, closer := st.db().GetCollection(linkLayerDevicesC)
-	defer closer()
-
-	var sDocs []linkLayerDeviceDoc
-	err = devicesCollection.Find(nil).All(&sDocs)
-	if err != nil {
-		return nil, errors.Errorf("cannot get all link layer devices")
-	}
-	for _, d := range sDocs {
-		devices = append(devices, newLinkLayerDevice(st, d))
-	}
-	return devices, nil
 }
 
 // DocID returns the globally unique ID of the link-layer device, including the
@@ -143,11 +128,11 @@ func (dev *LinkLayerDevice) IsUp() bool {
 	return dev.doc.IsUp
 }
 
-// ParentName returns the name of this device's parent device, if set. The
-// parent device is almost always on the same machine as the child device, but
-// as a special case a child device on a container machine can have a parent
-// BridgeDevice on the container's host machine. In the last case ParentName()
-// returns the global key of the parent device, not just its name.
+// ParentName returns the name of this device's parent device if set.
+// The parent device is almost always on the same machine as the child device,
+// but as a special case a child device on a container machine can have a
+// parent bridge device on the container's host machine.
+// In this case the global key of the parent device is returned.
 func (dev *LinkLayerDevice) ParentName() string {
 	return dev.doc.ParentName
 }
@@ -158,55 +143,65 @@ func (dev *LinkLayerDevice) VirtualPortType() network.VirtualPortType {
 	return dev.doc.VirtualPortType
 }
 
-func (dev *LinkLayerDevice) parentDeviceNameAndMachineID() (string, string) {
-	if dev.doc.ParentName == "" {
-		// No parent set, so no ID and name to return.
-		return "", ""
+// ParentID uses the rules for ParentName (above) to return the global ID of
+// this device's parent if it has one.
+func (dev *LinkLayerDevice) ParentID() string {
+	parent := dev.doc.ParentName
+	if parent == "" {
+		return ""
 	}
-	// In case ParentName is a global key, try getting the host machine ID from
-	// there first.
-	hostMachineID, parentDeviceName, err := parseLinkLayerDeviceParentNameAsGlobalKey(dev.doc.ParentName)
-	if err != nil {
-		// We validate the ParentName before setting it, so this case cannot
-		// happen and we're only logging the error.
-		logger.Errorf("%s has invalid parent: %v", dev, err)
-		return "", ""
+
+	prefix := dev.doc.ModelUUID + ":"
+	if strings.Contains(parent, "#") {
+		return prefix + parent
 	}
-	if hostMachineID == "" {
-		// Parent device is on the same machine and
-		// ParentName is not a global key.
-		return dev.doc.ParentName, dev.doc.MachineID
-	}
-	return parentDeviceName, hostMachineID
+
+	prefix = prefix + "m"
+	return strings.Join([]string{prefix, dev.doc.MachineID, "d", dev.doc.ParentName}, "#")
 }
 
 // ParentDevice returns the LinkLayerDevice corresponding to the parent device
 // of this device, if set. When no parent device name is set, it returns nil and
 // no error.
 func (dev *LinkLayerDevice) ParentDevice() (*LinkLayerDevice, error) {
-	if dev.doc.ParentName == "" {
+	if dev.ParentID() == "" {
 		return nil, nil
 	}
 
-	parentDeviceName, parentMachineID := dev.parentDeviceNameAndMachineID()
-	return dev.machineProxy(parentMachineID).LinkLayerDevice(parentDeviceName)
-}
-
-func (dev *LinkLayerDevice) parentDocID() string {
-	parentDeviceName, parentMachineID := dev.parentDeviceNameAndMachineID()
-	parentGlobalKey := linkLayerDeviceGlobalKey(parentMachineID, parentDeviceName)
-	if parentGlobalKey == "" {
-		return ""
-	}
-	return dev.st.docID(parentGlobalKey)
+	dev, err := dev.st.LinkLayerDevice(dev.ParentID())
+	return dev, errors.Trace(err)
 }
 
 // SetProviderIDOps returns the operations required to set the input
 // provider ID for the link-layer device.
 func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
-	// We only set the provider ID if it was previously empty.
-	if dev.doc.ProviderID != "" || id == "" || dev.doc.ProviderID == id.String() {
+	currentID := network.Id(dev.doc.ProviderID)
+
+	// If this provider ID is already set, we have nothing to do.
+	if id == currentID {
 		return nil, nil
+	}
+
+	// If the incoming provider ID is not empty, we will only set it on the
+	// device if it is currently empty.
+	// TODO (manadart 2020-06-30): This is a preservation of prior behaviour
+	// and probably bares re-evaluation.
+	if id != "" && currentID != "" {
+		return nil, nil
+	}
+
+	// If removing the provider ID from the device,
+	// also remove the ID from the global collection.
+	if id == "" {
+		return []txn.Op{
+			{
+				C:      linkLayerDevicesC,
+				Id:     dev.doc.DocID,
+				Assert: txn.DocExists,
+				Update: bson.M{"$unset": bson.M{"providerid": 1}},
+			},
+			dev.st.networkEntityGlobalKeyRemoveOp("linklayerdevice", currentID),
+		}, nil
 	}
 
 	// Since we assume that we are now setting the ID for the first time,
@@ -230,10 +225,24 @@ func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
 	}, nil
 }
 
-// machineProxy is a convenience wrapper for calling Machine.LinkLayerDevice()
-// or Machine.forEachLinkLayerDeviceDoc() from a *LinkLayerDevice and machineID.
-func (dev *LinkLayerDevice) machineProxy(machineID string) *Machine {
-	return &Machine{st: dev.st, doc: machineDoc{Id: machineID}}
+// RemoveOps returns transaction operations that will ensure that the
+// device is not present in the collection and that if set,
+// its provider ID is removed from the global register.
+// Note that this method eschews responsibility for removing device
+// addresses and for ensuring that this device has no children.
+// That responsibility lies with the caller.
+func (dev *LinkLayerDevice) RemoveOps() []txn.Op {
+	ops := []txn.Op{{
+		C:      linkLayerDevicesC,
+		Id:     dev.DocID(),
+		Remove: true,
+	}}
+
+	if dev.ProviderID() != "" {
+		ops = append(ops, dev.st.networkEntityGlobalKeyRemoveOp("linklayerdevice", dev.ProviderID()))
+	}
+
+	return ops
 }
 
 // Remove removes the device, if it exists. No error is returned when the device
@@ -248,7 +257,7 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 				return nil, err
 			}
 		}
-		ops, err := removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.parentDocID())
+		ops, err := removeLinkLayerDeviceOps(dev.st, dev.DocID(), dev.ParentID())
 		if err != nil {
 			return nil, err
 		}
@@ -262,13 +271,42 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 }
 
 func (dev *LinkLayerDevice) errNoOperationsIfMissing() error {
-	_, err := dev.machineProxy(dev.doc.MachineID).LinkLayerDevice(dev.doc.Name)
+	_, err := dev.st.LinkLayerDevice(dev.DocID())
 	if errors.IsNotFound(err) {
 		return jujutxn.ErrNoOperations
-	} else if err != nil {
-		return errors.Trace(err)
 	}
-	return nil
+	return errors.Trace(err)
+}
+
+// AllLinkLayerDevices returns all link layer devices in the model.
+func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
+	devicesCollection, closer := st.db().GetCollection(linkLayerDevicesC)
+	defer closer()
+
+	var sDocs []linkLayerDeviceDoc
+	err = devicesCollection.Find(nil).All(&sDocs)
+	if err != nil {
+		return nil, errors.Errorf("cannot get all link layer devices")
+	}
+	for _, d := range sDocs {
+		devices = append(devices, newLinkLayerDevice(st, d))
+	}
+	return devices, nil
+}
+
+func (st *State) LinkLayerDevice(id string) (*LinkLayerDevice, error) {
+	linkLayerDevices, closer := st.db().GetCollection(linkLayerDevicesC)
+	defer closer()
+
+	var doc linkLayerDeviceDoc
+	err := linkLayerDevices.FindId(id).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("device with ID %q", id)
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "retrieving %q", id)
+	}
+
+	return newLinkLayerDevice(st, doc), nil
 }
 
 // removeLinkLayerDeviceOps returns the list of operations needed to remove the
@@ -302,7 +340,9 @@ func removeLinkLayerDeviceOps(st *State, linkLayerDeviceDocID, parentDeviceDocID
 
 	var ops []txn.Op
 	if parentDeviceDocID != "" {
-		ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
+		localID, _ := st.strictLocalID(parentDeviceDocID)
+		ops = append(ops, decrementDeviceNumChildrenOp(localID))
+		//ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
 	}
 
 	addressesQuery := findAddressesQuery(machineID, deviceName)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -167,7 +167,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithMissingParentSam
 		Type:       corenetwork.EthernetDevice,
 		ParentName: "br-eth0",
 	}
-	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `ParentName not valid: device "br-eth0" on machine "0" not found`)
+	s.assertSetLinkLayerDevicesReturnsNotValidError(c, args, `ParentName not valid: device with ID .+ not found`)
 }
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesNoParentSuccess(c *gc.C) {
@@ -340,7 +340,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesRefusesToAddParentAn
 	c.Assert(err, gc.ErrorMatches, `cannot set link-layer devices to machine "0": `+
 		`invalid device "child1": `+
 		`ParentName not valid: `+
-		`device "parent1" on machine "0" not found`,
+		`device with ID .+ not found`,
 	)
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
@@ -439,7 +439,7 @@ func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsNotFoundEr
 	result, err := s.machine.LinkLayerDevice("missing")
 	c.Assert(result, gc.IsNil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(err, gc.ErrorMatches, `device "missing" on machine "0" not found`)
+	c.Assert(err, gc.ErrorMatches, "device with ID .+ not found")
 }
 
 func (s *linkLayerDevicesStateSuite) TestMachineLinkLayerDeviceReturnsLinkLayerDevice(c *gc.C) {
@@ -674,6 +674,29 @@ func (s *linkLayerDevicesStateSuite) TestSetProviderIDOps(c *gc.C) {
 	dev2 := s.addNamedDevice(c, "bar")
 	_, err = dev2.SetProviderIDOps("p1")
 	c.Assert(err, gc.ErrorMatches, "provider IDs not unique: p1")
+
+	// Unset the ID.
+	ops, err = dev1.SetProviderIDOps("")
+	c.Assert(err, jc.ErrorIsNil)
+	state.RunTransaction(c, s.State, ops)
+
+	dev1, err = s.machine.LinkLayerDevice("foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dev1.ProviderID().String(), gc.Equals, "")
+
+	// The global ID is unregistered, so we should be able to reset it.
+	ops, err = dev1.SetProviderIDOps("p1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.Not(gc.HasLen), 0)
+}
+
+func (s *linkLayerDevicesStateSuite) TestRemoveOps(c *gc.C) {
+	dev := s.addNamedDevice(c, "eth0")
+
+	state.RunTransaction(c, s.State, dev.RemoveOps())
+
+	_, err := s.State.LinkLayerDevice(dev.DocID())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -22,20 +22,8 @@ import (
 // error satisfying errors.IsNotFound() is returned when no such device exists
 // on the machine.
 func (m *Machine) LinkLayerDevice(name string) (*LinkLayerDevice, error) {
-	linkLayerDevices, closer := m.st.db().GetCollection(linkLayerDevicesC)
-	defer closer()
-
-	linkLayerDeviceDocID := m.linkLayerDeviceDocIDFromName(name)
-	deviceAsString := m.deviceAsStringFromName(name)
-
-	var doc linkLayerDeviceDoc
-	err := linkLayerDevices.FindId(linkLayerDeviceDocID).One(&doc)
-	if err == mgo.ErrNotFound {
-		return nil, errors.NotFoundf("%s", deviceAsString)
-	} else if err != nil {
-		return nil, errors.Annotatef(err, "cannot get %s", deviceAsString)
-	}
-	return newLinkLayerDevice(m.st, doc), nil
+	dev, err := m.st.LinkLayerDevice(m.linkLayerDeviceDocIDFromName(name))
+	return dev, errors.Trace(err)
 }
 
 func (m *Machine) linkLayerDeviceDocIDFromName(deviceName string) string {
@@ -44,10 +32,6 @@ func (m *Machine) linkLayerDeviceDocIDFromName(deviceName string) string {
 
 func (m *Machine) linkLayerDeviceGlobalKeyFromName(deviceName string) string {
 	return linkLayerDeviceGlobalKey(m.doc.Id, deviceName)
-}
-
-func (m *Machine) deviceAsStringFromName(deviceName string) string {
-	return fmt.Sprintf("device %q on machine %q", deviceName, m.doc.Id)
 }
 
 // AllLinkLayerDevices returns all exiting link-layer devices of the machine.

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	// HubWatcherIdleFunc allows tets to be able to get callbacks
+	// HubWatcherIdleFunc allows tests to be able to get callbacks
 	// when the hub watcher hasn't notified any watchers for a specified time.
 	HubWatcherIdleFunc func(string)
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -103,7 +103,7 @@ show_help() {
         # shellcheck disable=SC2086
         output="${output}\n    $(green ${test})|Runs the ${name} tests"
     done
-    echo "${output}" | column -t -s "|"
+    echo -e "${output}" | column -t -s "|"
 
     echo ""
     echo "Examples:"
@@ -124,7 +124,7 @@ show_help() {
     exit 1
 }
 
-while getopts "hH?:vVtAsaxrlpS" opt; do
+while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
     case "${opt}" in
     h|\?)
         show_help
@@ -134,52 +134,42 @@ while getopts "hH?:vVtAsaxrlpS" opt; do
         ;;
     v)
         VERBOSE=2
-        shift
         ;;
     V)
         VERBOSE=3
-        shift
         alias juju="juju --debug"
         ;;
     t)
         TEST_VERBOSE=3
-        shift
         alias juju="juju --debug"
         ;;
     A)
         RUN_ALL="true"
-        shift
         ;;
     s)
-        SKIP_LIST="${2}"
-        shift 2
+        SKIP_LIST="${OPTARG}"
         ;;
     a)
-        ARITFACT_FILE="${2}"
-        shift 2
+        ARITFACT_FILE="${OPTARG}"
         ;;
     x)
-        OUTPUT_FILE="${2}"
-        shift 2
+        OUTPUT_FILE="${OPTARG}"
         ;;
     r)
         export BOOTSTRAP_REUSE="true"
-        shift
         ;;
     l)
-        export BOOTSTRAP_REUSE_LOCAL="${2}"
+        export BOOTSTRAP_REUSE_LOCAL="${OPTARG}"
         export BOOTSTRAP_REUSE="true"
-        CLOUD=$(juju show-controller "${2}" --format=json | jq -r ".[\"${2}\"] | .details | .cloud")
-        export BOOTSTRAP_PROVIDER="${CLOUD}"
-        shift 2
+        CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
+        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}')
+        export BOOTSTRAP_PROVIDER="${PROVIDER}"
         ;;
     p)
-        export BOOTSTRAP_PROVIDER="${2}"
-        shift 2
+        export BOOTSTRAP_PROVIDER="${OPTARG}"
         ;;
     S)
-        export BOOTSTRAP_SERIES="${2}"
-        shift 2
+        export BOOTSTRAP_SERIES="${OPTARG}"
         ;;
     *)
         echo "Unexpected argument ${opt}" >&2
@@ -188,7 +178,6 @@ while getopts "hH?:vVtAsaxrlpS" opt; do
 done
 
 shift $((OPTIND-1))
-
 [ "${1:-}" = "--" ] && shift
 
 export VERBOSE="${VERBOSE}"

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -7,20 +7,19 @@ run_deploy_microk8s() {
   bootstrap microk8s "${name}"
 
   microk8s.config > "${TEST_DIR}"/kube.conf
+  export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 }
 
-test_deploy_admission() {
+test_controller_model_admission() {
   name=test-$(petname)
-
-  run_deploy_microk8s "${name}"
 
   namespace=controller-"${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 
-  kubectl --kubeconfig "${TEST_DIR}"/kube.conf apply -f - <<EOF
+  kubectl --kubeconfig "${KUBE_CONFIG}" apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: test
+  name: $name
   namespace: $namespace
   labels:
     juju-app: test-app
@@ -29,7 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: $namespace
-  name: test
+  name: $name
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -38,22 +37,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: role-grantor-binding
+  name: $name
   namespace: $namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: test
+  name: $name
 subjects:
   - kind: ServiceAccount
-    name: test
+    name: $name
     namespace: $namespace
 EOF
 
-  sa_secret=$(kubectl --kubeconfig "${TEST_DIR}"/kube.conf get sa -o json test -n "$namespace" | jq -r '.secrets[0].name')
-  bearer_token=$(kubectl --kubeconfig "${TEST_DIR}"/kube.conf get secret -o json "$sa_secret" -n "$namespace" | jq -r '.data.token' | base64 -d)
+  sa_secret=$(kubectl --kubeconfig "${KUBE_CONFIG}" get sa -o json "${name}" -n "$namespace" | jq -r '.secrets[0].name')
+  bearer_token=$(kubectl --kubeconfig "${KUBE_CONFIG}" get secret -o json "$sa_secret" -n "$namespace" | jq -r '.data.token' | base64 -d)
 
-  kubectl --kubeconfig "${TEST_DIR}"/kube.conf config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
+  kubectl --kubeconfig "${KUBE_CONFIG}" config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
 
 
   # Short sleep to let juju controller watchers catch up.
@@ -63,13 +62,79 @@ EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: test
+  name: $name
   namespace: $namespace
 data:
   test: test
 EOF
 
-juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" test -o=jsonpath='{.metadata.labels.juju-app}')
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
+  check_contains "${juju_app}" "test-app"
+
+  echo "$juju_app" | check test-app
+}
+
+test_new_model_admission() {
+  name=test-$(petname)
+
+  model_name=$(petname)
+  namespace=${model_name}
+
+  juju add-model "${model_name}"
+
+  kubectl --kubeconfig "${KUBE_CONFIG}" apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: $name
+  namespace: $namespace
+  labels:
+    juju-app: test-app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: $namespace
+  name: $name
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: $name
+  namespace: $namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: $name
+subjects:
+  - kind: ServiceAccount
+    name: $name
+    namespace: $namespace
+EOF
+
+  sa_secret=$(kubectl --kubeconfig "${KUBE_CONFIG}" get sa -o json "$name" -n "$namespace" | jq -r '.secrets[0].name')
+  bearer_token=$(kubectl --kubeconfig "${KUBE_CONFIG}" get secret -o json "$sa_secret" -n "$namespace" | jq -r '.data.token' | base64 -d)
+
+  kubectl --kubeconfig "${TEST_DIR}"/kube.conf config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
+
+  # Short sleep to let juju controller watchers catch up.
+  sleep 15
+
+ kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $name
+  namespace: $namespace
+data:
+  test: test
+EOF
+
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
   check_contains "${juju_app}" "test-app"
 
   echo "$juju_app" | check test-app

--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -9,5 +9,8 @@ test_caasadmission() {
     echo "==> Checking for dependencies"
     check_dependencies juju jq petname microk8s
 
-    test_deploy_admission
+    run_deploy_microk8s "$(petname)"
+
+    test_controller_model_admission
+    test_new_model_admission
 }

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -1,0 +1,55 @@
+run_relation_list_app() {
+    echo
+
+    model_name="test-relation-list-app"
+    file="${TEST_DIR}/${model_name}.log"
+
+    ensure "${model_name}" "${file}"
+
+    # Deploy 2 departer instances
+    juju deploy wordpress
+    juju deploy mysql
+    juju relate wordpress mysql
+    wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"
+    wait_for "mysql" "$(idle_condition "mysql" 0 0)"
+
+    # Figure out the right relation IDs to use for our hook tool invocations
+    db_rel_id=$(juju run --unit mysql/0 "relation-ids db" | cut -d':' -f2)
+    peer_rel_id=$(juju run --unit mysql/0 "relation-ids cluster" | cut -d':' -f2)
+
+    # Remove wordpress unit; the wordpress-mysql relation is still established
+    # but there are no units present in the wordpress side
+    juju remove-unit wordpress/0
+    sleep 5
+
+    got=$(juju run --unit mysql/0 "relation-list --app -r ${db_rel_id}")
+    if [ "${got}" != "wordpress" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected running 'relation-list --app' on mysql unit for non-peer relation to return 'wordpress'; got ${got}")
+      exit 1
+    fi
+
+    got=$(juju run --unit mysql/0 "relation-list --app -r ${peer_rel_id}")
+    if [ "${got}" != "mysql" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected running 'relation-list --app' on mysql unit for peer relation to return 'mysql'; got ${got}")
+      exit 1
+    fi
+
+    destroy_model "${model_name}"
+}
+
+test_relation_list_app() {
+    if [ "$(skip 'test_relation_list_app')" ]; then
+        echo "==> TEST SKIPPED: relation list app unit tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_relation_list_app"
+    )
+}

--- a/tests/suites/relations/task.sh
+++ b/tests/suites/relations/task.sh
@@ -15,6 +15,7 @@ test_relations() {
 
     test_relation_data_exchange
     test_relation_departing_unit
+    test_relation_list_app
 
     destroy_controller "test-relations"
 }

--- a/upgrades/steps_24.go
+++ b/upgrades/steps_24.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/series"
+	"github.com/juju/os/series"
 
 	"github.com/juju/juju/service"
 )

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -37,7 +37,7 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 			if s != "n/a" {
 				// There is no lsb_release command on CentOS.
 				if current_os == os.CentOS {
-					c.Check(s, gc.Matches, `centos7`)
+					c.Check(s, gc.Matches, `centos7|centos8`)
 				}
 			}
 		}

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -32,6 +33,13 @@ type Relation interface {
 
 	// Tag returns the relation tag.
 	Tag() names.RelationTag
+
+	// OtherApplication returns the name of the application on the other
+	// end of the relation (from this unit's perspective).
+	OtherApplication() string
+
+	// Life returns the relation's current life state.
+	Life() life.Value
 }
 
 type RelationUnit interface {
@@ -174,4 +182,15 @@ func (ctx *ContextRelation) Suspended() bool {
 // SetStatus sets the relation's status.
 func (ctx *ContextRelation) SetStatus(status relation.Status) error {
 	return errors.Trace(ctx.ru.Relation().SetStatus(status))
+}
+
+// RemoteApplicationName returns the application on the other end of this
+// relation from the perspective of this unit.
+func (ctx *ContextRelation) RemoteApplicationName() string {
+	return ctx.ru.Relation().OtherApplication()
+}
+
+// Life returns the relation's current life state.
+func (ctx *ContextRelation) Life() life.Value {
+	return ctx.ru.Relation().Life()
 }

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -211,6 +211,11 @@ func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
 	c.Assert(relStatus.Status, gc.Equals, status.Suspended)
 }
 
+func (s *ContextRelationSuite) TestRemoteApplicationName(c *gc.C) {
+	ctx := context.NewContextRelation(s.relUnit, nil)
+	c.Assert(ctx.RemoteApplicationName(), gc.Equals, "u")
+}
+
 type relUnitShim struct {
 	*apiuniter.RelationUnit
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/storage"
@@ -317,6 +318,13 @@ type ContextRelation interface {
 
 	// SetStatus sets the relation's status.
 	SetStatus(relation.Status) error
+
+	// RemoteApplicationName returns the application on the other end of
+	// the relation from the perspective of this unit.
+	RemoteApplicationName() string
+
+	// Life returns the relation's current life state.
+	Life() life.Value
 }
 
 // ContextStorageAttachment expresses the capabilities of a hook with

--- a/worker/uniter/runner/jujuc/context_mock_test.go
+++ b/worker/uniter/runner/jujuc/context_mock_test.go
@@ -7,6 +7,7 @@ package jujuc
 import (
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
+	life "github.com/juju/juju/core/life"
 	relation "github.com/juju/juju/core/relation"
 	reflect "reflect"
 )
@@ -77,6 +78,20 @@ func (mr *MockContextRelationMockRecorder) Id() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockContextRelation)(nil).Id))
 }
 
+// Life mocks base method
+func (m *MockContextRelation) Life() life.Value {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Life")
+	ret0, _ := ret[0].(life.Value)
+	return ret0
+}
+
+// Life indicates an expected call of Life
+func (mr *MockContextRelationMockRecorder) Life() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockContextRelation)(nil).Life))
+}
+
 // Name mocks base method
 func (m *MockContextRelation) Name() string {
 	m.ctrl.T.Helper()
@@ -119,6 +134,20 @@ func (m *MockContextRelation) ReadSettings(arg0 string) (params.Settings, error)
 func (mr *MockContextRelationMockRecorder) ReadSettings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadSettings), arg0)
+}
+
+// RemoteApplicationName mocks base method
+func (m *MockContextRelation) RemoteApplicationName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoteApplicationName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RemoteApplicationName indicates an expected call of RemoteApplicationName
+func (mr *MockContextRelationMockRecorder) RemoteApplicationName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplicationName", reflect.TypeOf((*MockContextRelation)(nil).RemoteApplicationName))
 }
 
 // SetStatus mocks base method

--- a/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -28,6 +29,10 @@ type Relation struct {
 	RemoteApplicationSettings Settings
 	// LocalApplicationSettings is data for jujuc.ContextRelation
 	LocalApplicationSettings Settings
+	// RemoteApplicationName is data for jujuc.ContextRelation
+	RemoteApplicationName string
+	// The current life value.
+	Life life.Value
 }
 
 // Reset clears the Relation's settings.
@@ -83,6 +88,14 @@ func (r *ContextRelation) FakeId() string {
 	r.stub.NextErr()
 
 	return fmt.Sprintf("%s:%d", r.info.Name, r.info.Id)
+}
+
+// Life implements jujuc.ContextRelation.
+func (r *ContextRelation) Life() life.Value {
+	r.stub.AddCall("Life")
+	r.stub.NextErr()
+
+	return r.info.Life
 }
 
 // Settings implements jujuc.ContextRelation.
@@ -154,4 +167,10 @@ func (r *ContextRelation) Suspended() bool {
 // SetStatus implements jujuc.ContextRelation.
 func (r *ContextRelation) SetStatus(status relation.Status) error {
 	return nil
+}
+
+// RemoteApplicationName implements jujuc.ContextRelation.
+func (r *ContextRelation) RemoteApplicationName() string {
+	r.stub.AddCall("RemoteApplicationName")
+	return r.info.RemoteApplicationName
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/relations.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -32,12 +33,17 @@ func (r *Relations) SetRelation(id int, relCtx jujuc.ContextRelation) {
 
 // SetNewRelation adds the relation to the set of known relations.
 func (r *Relations) SetNewRelation(id int, name string, stub *testing.Stub) *Relation {
+	return r.SetNewRelationWithLife(id, name, life.Alive, stub)
+}
+
+func (r *Relations) SetNewRelationWithLife(id int, name string, life life.Value, stub *testing.Stub) *Relation {
 	if name == "" {
 		name = fmt.Sprintf("relation-%d", id)
 	}
 	rel := &Relation{
 		Id:   id,
 		Name: name,
+		Life: life,
 	}
 	relCtx := &ContextRelation{info: rel}
 	relCtx.stub = stub

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -5,16 +5,15 @@
 package mocks
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
+	charm "github.com/juju/charm/v7"
 	params "github.com/juju/juju/apiserver/params"
 	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
+	time "time"
 )
 
 // MockContext is a mock of Context interface
@@ -172,10 +171,10 @@ func (mr *MockContextMockRecorder) Component(arg0 interface{}) *gomock.Call {
 }
 
 // ConfigSettings mocks base method
-func (m *MockContext) ConfigSettings() (charm_v6.Settings, error) {
+func (m *MockContext) ConfigSettings() (charm.Settings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigSettings")
-	ret0, _ := ret[0].(charm_v6.Settings)
+	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -609,7 +608,7 @@ func (mr *MockContextMockRecorder) SetUnitWorkloadVersion(arg0 interface{}) *gom
 }
 
 // Storage mocks base method
-func (m *MockContext) Storage(arg0 names_v3.StorageTag) (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) Storage(arg0 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Storage", arg0)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
@@ -624,10 +623,10 @@ func (mr *MockContextMockRecorder) Storage(arg0 interface{}) *gomock.Call {
 }
 
 // StorageTags mocks base method
-func (m *MockContext) StorageTags() ([]names_v3.StorageTag, error) {
+func (m *MockContext) StorageTags() ([]names.StorageTag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageTags")
-	ret0, _ := ret[0].([]names_v3.StorageTag)
+	ret0, _ := ret[0].([]names.StorageTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/uniter/runner/jujuc/relation-ids.go
+++ b/worker/uniter/runner/jujuc/relation-ids.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/life"
 )
 
 // RelationIdsCommand implements the relation-ids command.
@@ -73,7 +74,7 @@ func (c *RelationIdsCommand) Run(ctx *cmd.Context) error {
 	}
 	for _, id := range ids {
 		r, err := c.ctx.Relation(id)
-		if err == nil && r.Name() == c.Name {
+		if err == nil && r.Name() == c.Name && r.Life() != life.Dead {
 			result = append(result, r.FakeId())
 		} else if err != nil && !errors.IsNotFound(err) {
 			return errors.Trace(err)

--- a/worker/uniter/runner/jujuc/relation-list.go
+++ b/worker/uniter/runner/jujuc/relation-list.go
@@ -16,10 +16,11 @@ import (
 // RelationListCommand implements the relation-list command.
 type RelationListCommand struct {
 	cmd.CommandBase
-	ctx             Context
-	RelationId      int
-	relationIdProxy gnuflag.Value
-	out             cmd.Output
+	ctx                   Context
+	RelationId            int
+	relationIdProxy       gnuflag.Value
+	ListRemoteApplication bool
+	out                   cmd.Output
 }
 
 func NewRelationListCommand(ctx Context) (cmd.Command, error) {
@@ -49,8 +50,9 @@ func (c *RelationListCommand) Info() *cmd.Info {
 
 func (c *RelationListCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters.Formatters())
-	f.Var(c.relationIdProxy, "r", "specify a relation by id")
+	f.Var(c.relationIdProxy, "r", "Specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
+	f.BoolVar(&c.ListRemoteApplication, "app", false, "List remote application instead of participating units")
 }
 
 func (c *RelationListCommand) Init(args []string) (err error) {
@@ -65,6 +67,11 @@ func (c *RelationListCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	if c.ListRemoteApplication {
+		return c.out.Write(ctx, r.RemoteApplicationName())
+	}
+
 	unitNames := r.UnitNames()
 	if unitNames == nil {
 		unitNames = []string{}

--- a/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/worker/uniter/runner/jujuc/relation-list_test.go
@@ -25,6 +25,7 @@ var relationListTests = []struct {
 	summary            string
 	relid              int
 	members0, members1 []string
+	remoteAppName      string
 	args               []string
 	code               int
 	out                string
@@ -104,13 +105,20 @@ var relationListTests = []struct {
 		relid:    1,
 		args:     []string{"--format", "yaml"},
 		out:      "- bar\n- baz\n- foo",
+	}, {
+		summary:       "remote application for relation",
+		members1:      []string{}, // relation established but all units removed
+		relid:         1,
+		remoteAppName: "galaxy",
+		args:          []string{"--app"},
+		out:           "galaxy",
 	},
 }
 
 func (s *RelationListSuite) TestRelationList(c *gc.C) {
 	for i, t := range relationListTests {
 		c.Logf("test %d: %s", i, t.summary)
-		hctx, info := s.newHookContext(t.relid, "", "")
+		hctx, info := s.newHookContext(t.relid, "", t.remoteAppName)
 		info.setRelations(0, t.members0)
 		info.setRelations(1, t.members1)
 		c.Logf("%#v %#v", info.rels[t.relid], t.members1)
@@ -143,12 +151,14 @@ Summary:
 list relation units
 
 Options:
+--app  (= false)
+    List remote application instead of participating units
 --format  (= smart)
     Specify output format (json|smart|yaml)
 -o, --output (= "")
     Specify an output file
 -r, --relation  (= %s)
-    specify a relation by id
+    Specify a relation by id
 %s`[1:]
 
 	for relid, t := range map[int]struct {

--- a/worker/uniter/runner/jujuc/relation_test.go
+++ b/worker/uniter/runner/jujuc/relation_test.go
@@ -23,8 +23,8 @@ func (s *relationSuite) newHookContext(relid int, remote string, app string) (ju
 	settings := jujuctesting.Settings{
 		"private-address": "u-0.testing.invalid",
 	}
-	rInfo.setNextRelation("", s.Unit, settings) // peer0
-	rInfo.setNextRelation("", s.Unit, settings) // peer1
+	rInfo.setNextRelation("", s.Unit, app, settings) // peer0
+	rInfo.setNextRelation("", s.Unit, app, settings) // peer1
 	if relid >= 0 {
 		rInfo.SetAsRelationHook(relid, remote)
 		if app == "" {
@@ -52,7 +52,7 @@ func (ri *relationInfo) reset() {
 	ri.rels = nil
 }
 
-func (ri *relationInfo) setNextRelation(name, unit string, settings jujuctesting.Settings) int {
+func (ri *relationInfo) setNextRelation(name, unit, app string, settings jujuctesting.Settings) int {
 	if ri.rels == nil {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}
@@ -65,6 +65,7 @@ func (ri *relationInfo) setNextRelation(name, unit string, settings jujuctesting
 		relation.UnitName = unit
 		relation.SetRelated(unit, settings)
 	}
+	relation.RemoteApplicationName = app
 	ri.rels[id] = relation
 	return id
 }
@@ -74,7 +75,7 @@ func (ri *relationInfo) addRelatedApplications(relname string, count int) {
 		ri.rels = make(map[int]*jujuctesting.Relation)
 	}
 	for i := 0; i < count; i++ {
-		ri.setNextRelation(relname, "", nil)
+		ri.setNextRelation(relname, "", ri.RemoteApplicationName, nil)
 	}
 }
 


### PR DESCRIPTION
Merge from 2.8 to bring forward:
- #11794 from manadart/2.8-address-conversion-rework
- #11789 from SimonRichardson/actions-list-output
- #11693 from tlm/model-admission-upgrade
- #11785 from manadart/2.8-machiner-lld-prep
- #11790 from achilleasa/2.8-filter-non-live-relations-from-relation-ids-output
- #11792 from wallyworld/add-centos8
- #11791 from howbazaar/2.8-fix-intermittent-status-tests
- #11787 from hmlanigan/add-k8s-error-output
- #11780 from SimonRichardson/api-schema-admin
- #11773 from tlm/json-num
- #11783 from wallyworld/merge-2.7-20200701
- #11776 from ycliuhw/lp-1882149
- #11778 from manadart/2.8-instance-poller-dev-provider-id
- #11765 from achilleasa/2.8-enable-relation-list-to-show-remote-application
- #11768 from ycliuhw/fix/CAAS-CI-LB-GET
- #11770 from hmlanigan/unicode-vs-str
- #11769 from hmlanigan/unicode-vs-str
- #11766 from hmlanigan/autoload-cred-lxd
