### PR TITLE
Consume yaml for model-config

### DIFF
--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -58,6 +58,28 @@ func (f *ConfigFlag) Set(s string) error {
 	return nil
 }
 
+// SetAttrsFromYAML sets the attributes from a slice of bytes. The bytes are
+// expected to be YAML parsable and align to the attrs type of
+// map[string]interface{}.
+// This will over write any attributes that already exist if found in the YAML
+// configuration.
+func (f *ConfigFlag) SetAttrsFromYAML(input []byte) error {
+	if len(input) == 0 {
+		return errors.NotValidf("empty yaml")
+	}
+	attrs := make(map[string]interface{})
+	if err := yaml.Unmarshal(input, &attrs); err != nil {
+		return errors.Trace(err)
+	}
+	if f.attrs == nil {
+		f.attrs = make(map[string]interface{})
+	}
+	for k, attr := range attrs {
+		f.attrs[k] = attr
+	}
+	return nil
+}
+
 // ReadAttrs reads attributes from the specified files, and then overlays
 // the results with the k=v attributes.
 func (f *ConfigFlag) ReadAttrs(ctx *cmd.Context) (map[string]interface{}, error) {

--- a/cmd/juju/common/flags_test.go
+++ b/cmd/juju/common/flags_test.go
@@ -53,6 +53,30 @@ func (*FlagsSuite) TestConfigFlagSetErrors(c *gc.C) {
 	c.Assert(f.Set("x=%"), gc.ErrorMatches, "yaml: could not find expected directive name")
 }
 
+func (*FlagsSuite) TestConfigFlagSetAttrsFromYAML(c *gc.C) {
+	yaml := `
+foo: 1
+bar: 2
+`[1:]
+
+	var f ConfigFlag
+	c.Assert(f.SetAttrsFromYAML([]byte(yaml)), jc.ErrorIsNil)
+	assertConfigFlag(c, f, nil, map[string]interface{}{"foo": 1, "bar": 2})
+
+	yaml = `
+foo: 3
+baz: 4
+`[1:]
+	c.Assert(f.SetAttrsFromYAML([]byte(yaml)), jc.ErrorIsNil)
+	assertConfigFlag(c, f, nil, map[string]interface{}{"foo": 3, "bar": 2, "baz": 4})
+}
+
+func (*FlagsSuite) TestConfigFlagSetAttrsFromYAMLErrors(c *gc.C) {
+	var f ConfigFlag
+	c.Assert(f.SetAttrsFromYAML([]byte{}), gc.ErrorMatches, "empty yaml not valid")
+	c.Assert(f.SetAttrsFromYAML([]byte("!?@>£")), gc.ErrorMatches, "yaml: did not find expected whitespace or line break")
+}
+
 func (*FlagsSuite) TestConfigFlagString(c *gc.C) {
 	var f ConfigFlag
 	c.Assert(f.String(), gc.Equals, "")

--- a/cmd/juju/common/flags_test.go
+++ b/cmd/juju/common/flags_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -53,28 +54,28 @@ func (*FlagsSuite) TestConfigFlagSetErrors(c *gc.C) {
 	c.Assert(f.Set("x=%"), gc.ErrorMatches, "yaml: could not find expected directive name")
 }
 
-func (*FlagsSuite) TestConfigFlagSetAttrsFromYAML(c *gc.C) {
+func (*FlagsSuite) TestConfigFlagSetAttrsFromReader(c *gc.C) {
 	yaml := `
 foo: 1
 bar: 2
 `[1:]
 
 	var f ConfigFlag
-	c.Assert(f.SetAttrsFromYAML([]byte(yaml)), jc.ErrorIsNil)
+	c.Assert(f.SetAttrsFromReader(bytes.NewBufferString(yaml)), jc.ErrorIsNil)
 	assertConfigFlag(c, f, nil, map[string]interface{}{"foo": 1, "bar": 2})
 
 	yaml = `
 foo: 3
 baz: 4
 `[1:]
-	c.Assert(f.SetAttrsFromYAML([]byte(yaml)), jc.ErrorIsNil)
+	c.Assert(f.SetAttrsFromReader(bytes.NewBufferString(yaml)), jc.ErrorIsNil)
 	assertConfigFlag(c, f, nil, map[string]interface{}{"foo": 3, "bar": 2, "baz": 4})
 }
 
-func (*FlagsSuite) TestConfigFlagSetAttrsFromYAMLErrors(c *gc.C) {
+func (*FlagsSuite) TestConfigFlagSetAttrsFromReaderErrors(c *gc.C) {
 	var f ConfigFlag
-	c.Assert(f.SetAttrsFromYAML([]byte{}), gc.ErrorMatches, "empty yaml not valid")
-	c.Assert(f.SetAttrsFromYAML([]byte("!?@>£")), gc.ErrorMatches, "yaml: did not find expected whitespace or line break")
+	c.Assert(f.SetAttrsFromReader(nil), gc.ErrorMatches, "empty reader not valid")
+	c.Assert(f.SetAttrsFromReader(bytes.NewBufferString("!?@>£")), gc.ErrorMatches, "yaml: did not find expected whitespace or line break")
 }
 
 func (*FlagsSuite) TestConfigFlagString(c *gc.C) {

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -3,7 +3,6 @@
 package model
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -264,18 +263,7 @@ func (c *configCommand) handleArgs(args []string) error {
 
 // parseStdin ensures that we handle stdin correctly.
 func (c *configCommand) parseStdin() error {
-	reader := bufio.NewReader(os.Stdin)
-
-	var input []byte
-	for {
-		b, err := reader.ReadByte()
-		if err != nil && err == io.EOF {
-			break
-		}
-		input = append(input, b)
-	}
-
-	if err := c.setOptions.SetAttrsFromYAML(input); err != nil {
+	if err := c.setOptions.SetAttrsFromReader(os.Stdin); err != nil {
 		return errors.Trace(err)
 	}
 	c.action = c.setConfig

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -239,6 +239,24 @@ func (s *ConfigCommandSuite) TestSetFromFile(c *gc.C) {
 	c.Assert(s.fake.values, jc.DeepEquals, expected)
 }
 
+func (s *ConfigCommandSuite) TestSetFromFileUsingYAML(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+	err := ioutil.WriteFile(configFile, []byte(`
+special:
+  value: extra
+  source: default
+`), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, configFile)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := map[string]interface{}{
+		"special": "extra",
+	}
+	c.Assert(s.fake.values, jc.DeepEquals, expected)
+}
+
 func (s *ConfigCommandSuite) TestSetFromFileCombined(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -162,7 +162,7 @@ while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
         export BOOTSTRAP_REUSE_LOCAL="${OPTARG}"
         export BOOTSTRAP_REUSE="true"
         CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
-        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}')
+        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}' | head -n 1)
         export BOOTSTRAP_PROVIDER="${PROVIDER}"
         ;;
     p)

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -3,9 +3,7 @@ run_model_config_isomorphic() {
 
   FILE=$(mktemp)
 
-  juju model-config --format=yaml > "${FILE}" && \
-    sed -i '/^agent\-version/,/source\: .*/d' "${FILE}" && \
-    juju model-config "${FILE}"
+  juju model-config --format=yaml | juju model-config --ignore-agent-version -
 }
 
 run_model_config_cloudinit_userdata() {

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -1,0 +1,47 @@
+run_model_config_isomorphic() {
+  echo
+
+  FILE=$(mktemp)
+
+  juju model-config --format=yaml > "${FILE}" && \
+    sed -i '/^agent\-version/,/source\: .*/d' "${FILE}" && \
+    juju model-config "${FILE}"
+}
+
+run_model_config_cloudinit_userdata() {
+  echo
+
+  FILE=$(mktemp)
+
+  cat << EOF > "${FILE}"
+cloudinit-userdata: |
+  packages:
+    - jq
+    - shellcheck
+EOF
+
+  juju model-config "${FILE}"
+  juju model-config cloudinit-userdata | grep -q "shellcheck"
+
+  # cloudinit-userdata is not present from the default tabluar output
+  ! juju model-config cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
+
+  # cloudinit-userdata is hidden in the normal output
+  juju model-config | grep -q "<value set, see juju model-config cloudinit-userdata>"
+}
+
+test_model_config() {
+  if [ "$(skip 'test_model_config')" ]; then
+    echo "==> TEST SKIPPED: model config"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    run "run_model_config_isomorphic"
+    run "run_model_config_cloudinit_userdata"
+  )
+}

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -15,6 +15,7 @@ test_cli() {
 
     test_display_clouds
     test_local_charms
+    test_model_config
 
     destroy_controller "test-cli"
 }


### PR DESCRIPTION
## Description of change

The following changes are a different approach than #11784, whereby
that PR attempted to put out a better yaml file for consuming. This PR
attempts to consume the existing yaml. That way we can work with all
sorts of older model-config commands, without having to get operators to
mess about with the various yamls they might have.

The nice thing about this way is that it uses feature detection of the
schema package to detect if a type matches a given format. If that is so
then coerce it into what we expect. This has been employed for the
description package for upgrades and migrations with great success. So

## QA steps

Unfortunately, we have to drop the agent-version as you can't use that
 during a model-config change.

```sh
$ juju model-config --format=yaml | juju model-config --ignore-agent-version -
```

## Bug reference

Fixes: https://bugs.launchpad.net/juju/+bug/1879972
