### PR TITLE
Allow absolute vmfolder paths

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -116,8 +116,12 @@ func (c *Client) FindFolder(ctx context.Context, folderPath string) (vmFolder *o
 		return dcfolders.VmFolder, nil
 	}
 
+	// We either have a folder that is a relative path or an absolute path.
+	// We'll accept an absolute path as is. Relative paths will use the DC vm folder as a parent.
 	folderPath = strings.TrimPrefix(folderPath, "./")
-	if !strings.HasPrefix(folderPath, dcfolders.VmFolder.InventoryPath) {
+	if strings.HasPrefix(folderPath, "/") {
+		c.logger.Debugf("using absolute folder path %q", folderPath)
+	} else if !strings.HasPrefix(folderPath, dcfolders.VmFolder.InventoryPath) {
 		c.logger.Debugf("relative folderPath %q found, join with DC vm folder %q now", folderPath, dcfolders.VmFolder.InventoryPath)
 		folderPath = path.Join(dcfolders.VmFolder.InventoryPath, folderPath)
 	}

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -660,6 +660,37 @@ func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 	})
 }
 
+func (s *clientSuite) TestFindFolder(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	folder, err := client.FindFolder(context.Background(), "foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(folder, gc.NotNil)
+	c.Assert(folder.InventoryPath, gc.Equals, "/dc0/vm/foo/bar")
+}
+
+func (s *clientSuite) TestFindFolderRelativePath(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	folder, err := client.FindFolder(context.Background(), "./foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(folder, gc.NotNil)
+	c.Assert(folder.InventoryPath, gc.Equals, "/dc0/vm/foo/bar")
+}
+
+func (s *clientSuite) TestFindFolderAbsolutePath(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.FindFolder(context.Background(), "/foo/bar")
+	// mock not set up to have a /foo/bar folder
+	c.Assert(err, gc.ErrorMatches, `folder path "/foo/bar" not found`)
+}
+
+func (s *clientSuite) TestFindFolderSubPath(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	folder, err := client.FindFolder(context.Background(), "/dc0/vm/foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(folder, gc.NotNil)
+	c.Assert(folder.InventoryPath, gc.Equals, "/dc0/vm/foo/bar")
+}
+
 func (s *clientSuite) TestMoveVMFolderInto(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	err := client.MoveVMFolderInto(context.Background(), "foo", "foo/bar")

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -611,23 +611,3 @@ func baseCisp() types.OvfCreateImportSpecParams {
 func newBool(v bool) *bool {
 	return &v
 }
-
-func findStubCall(c *gc.C, calls []testing.StubCall, name string) testing.StubCall {
-	c.Logf("finding stub \"%s\"", name)
-	for i, call := range calls {
-		c.Logf("stub %d: %s(%v)", i, call.FuncName, call.Args)
-		if call.FuncName == name {
-			return call
-		}
-	}
-	c.Fatalf("failed to find call %q", name)
-	panic("unreachable")
-}
-
-func assertNoCall(c *gc.C, calls []testing.StubCall, name string) {
-	for _, call := range calls {
-		if call.FuncName == name {
-			c.Fatalf("found call %q", name)
-		}
-	}
-}


### PR DESCRIPTION
## Description of change

The vSphere vmfolder was not able to be set as an absolute path - it was always being interpreted as a subfolder of the DC folder. We now allow absolute paths to be handled.

## QA steps

A version of the fix was tested on site.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1884490
