### PR TITLE
[2.8] Manual provisioning on non-amd64 instances without extra constraints

### DIFF
--- a/environs/interface.go
+++ b/environs/interface.go
@@ -593,3 +593,14 @@ type DefaultConstraintsChecker interface {
 	// use default constraints
 	ShouldApplyControllerConstraints() bool
 }
+
+// HardwareCharacteristicsDetector is implemented by environments that can
+// provide advance information about the series and hardware for controller
+// instances that have not been provisioned yet.
+type HardwareCharacteristicsDetector interface {
+	// DetectSeries returns the series for the controller instance.
+	DetectSeries() (string, error)
+	// DetectHardware returns the hardware characteristics for the
+	// controller instance.
+	DetectHardware() (*instance.HardwareCharacteristics, error)
+}

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -44,7 +44,8 @@ const (
 )
 
 var (
-	logger = loggo.GetLogger("juju.provider.manual")
+	logger                                          = loggo.GetLogger("juju.provider.manual")
+	_      environs.HardwareCharacteristicsDetector = (*manualEnviron)(nil)
 )
 
 type manualEnviron struct {
@@ -383,4 +384,19 @@ func (*manualEnviron) Provider() environs.EnvironProvider {
 
 func isRunningController() bool {
 	return filepath.Base(os.Args[0]) == names.Jujud
+}
+
+// DetectSeries returns the series for the controller for this environment.
+// This method is part of the environs.HardwareCharacteristicsDetector interface.
+func (e *manualEnviron) DetectSeries() (string, error) {
+	_, series, err := e.seriesAndHardwareCharacteristics()
+	return series, err
+}
+
+// DetectHardware returns the hardware characteristics for the controller for
+// this environment. This method is part of the environs.HardwareCharacteristicsDetector
+// interface.
+func (e *manualEnviron) DetectHardware() (*instance.HardwareCharacteristics, error) {
+	hw, _, err := e.seriesAndHardwareCharacteristics()
+	return hw, err
 }


### PR DESCRIPTION
## Description of change

When no bootstrap/model constraints are provided when attempting to bootstrap, the current implementation would fallback to using the arch/series from the machine that the juju CLI executes on. This essentially prevents manually bootstrapping to non-amd64 machines without requiring the operator to explicitly provide additional constraints.

However, the manual provider will connect via ssh to the manual machine and detect both its arch and series. To make use of this information **before** juju attempts to locate the appropriate agent binaries for the bootstrap target, the PR defines a new interface (`HardwareCharacteristicsDetector`) in the `environs` package which is currently only implemented by the `manual` provider.

The bootstrap code has been modified to check whether the environment can provide advance (pre-bootstrap) information about the series/arch for the controller about to be bootstrapped and if so, inject bootstrap constraints for the series and arch **if and only if** the operator has not explicitly specified constraints for those fields.

## QA steps

To run these QA steps you need access to an arm64 and an amd64 instance. If you don't happen to have a rPI near you, you can provision them on AWS (use an `a1` instance for the arm machine) using the bionic AMI. However, before you can use the two machines with juju you need to perform the following additional steps:
- Install a suitable ssh key and make sure you can ssh into the boxes.
- Create a shared security group for the two boxes with the following rules:
   - Allow ALL TCP/UDP/ICMP4 where src is the security group
   - Allow TCP to 37017 from 0.0.0.0/0 (yuk!)

The last rule is required as juju will use the _public_ (shadow) IP instead of the internal IP when setting up the replica sets for mongo.

### ARM64 controller + AMD64 machine 

```console
# Bootstrap arm64 and add amd64 machine
$ juju bootstrap manual/ubuntu@arm-machine-IP --debug --agent-version=2.8.0
...
10:26:39 INFO  juju.cmd.juju.commands bootstrap.go:832 combined bootstrap constraints:
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:308 model "controller" supports application/machine networks: false
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:310 network management by juju enabled: true
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:336 auto-selecting bootstrap series "bionic" <--- look for this 
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:340 auto-selecting bootstrap arch "arm64"  <--- look for this

# Then add the amd machine and ensure that it comes up online as expected
$ juju add-machine ssh:ubuntu@amd-machine-IP --debug
```

### AMD64 controller + ARM64 machine 

Clean up the machines from the previous test by running `/sbin/remove-juju-services`. 
**You probably need to also run `rm -f /etc/systemd/system/juju*` to manually remove the systemd units**.

```console
# Bootstrap amd64 and add arm64 machine
$ juju bootstrap manual/ubuntu@amd-machine-IP --debug --agent-version=2.8.0
...
10:26:39 INFO  juju.cmd.juju.commands bootstrap.go:832 combined bootstrap constraints:
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:308 model "controller" supports application/machine networks: false
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:310 network management by juju enabled: true
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:336 auto-selecting bootstrap series "bionic" <--- look for this 
10:26:39 DEBUG juju.environs.bootstrap bootstrap.go:340 auto-selecting bootstrap arch "amd64"  <--- look for this

# Then add the arm machine and ensure that it comes up online as expected
$ juju add-machine ssh:ubuntu@arm-machine-IP --debug
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1880422
