### PR TITLE
Handle dispatch path better in debug-hooks.

### DIFF
--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -57,7 +57,7 @@ func (s *ServerSession) RunHook(hookName, charmDir string, env []string, hookRun
 		return errors.Trace(err)
 	}
 	defer func() { _ = os.RemoveAll(debugDir) }()
-	help := buildRunHookCmd(hookName, hookRunner)
+	help := buildRunHookCmd(hookName, hookRunner, charmDir)
 	if err := s.writeDebugFiles(debugDir, help, hookRunner); err != nil {
 		return errors.Trace(err)
 	}
@@ -88,11 +88,15 @@ func (s *ServerSession) RunHook(hookName, charmDir string, env []string, hookRun
 	return cmd.Wait()
 }
 
-func buildRunHookCmd(hookName, hookRunner string) string {
+func buildRunHookCmd(hookName, hookRunner, charmDir string) string {
 	if hookName == filepath.Base(hookRunner) {
 		return "./$JUJU_DISPATCH_PATH"
 	}
-	return "./" + hookRunner
+	relPath, err := filepath.Rel(charmDir, hookRunner)
+	if err == nil {
+		return "./" + relPath
+	}
+	return hookRunner
 }
 
 func (s *ServerSession) writeDebugFiles(debugDir, help, hookRunner string) error {

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -349,3 +349,47 @@ echo "$@" >&2
 `), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+
+// DebugSuite is for tests of methods/functions that don't need complex setup.
+type DebugSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&DebugSuite{})
+
+func checkBuildRunHookCommand(c *gc.C, expected, hookName, hookRunner, charmDir string) {
+	c.Check(expected, gc.Equals, buildRunHookCmd(hookName, hookRunner, charmDir))
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_legacy(c *gc.C) {
+	checkBuildRunHookCommand(c, "./$JUJU_DISPATCH_PATH", "install",
+		"hooks/install",
+		"/var/lib/juju")
+	checkBuildRunHookCommand(c, "./$JUJU_DISPATCH_PATH", "install",
+		"/var/lib/juju/charm/hooks/install",
+		"/var/lib/juju/charm")
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_dispatch_subdir(c *gc.C) {
+	checkBuildRunHookCommand(c, "./dispatch", "install",
+		"/var/lib/juju/charm/dispatch",
+		"/var/lib/juju/charm/")
+	checkBuildRunHookCommand(c, "./hooks/foo", "install",
+		"/var/lib/juju/charm/hooks/foo",
+		"/var/lib/juju/charm/")
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_dispatch_neigbor(c *gc.C) {
+	checkBuildRunHookCommand(c, "./../../not-charm/dispatch",
+		"install",
+		"/var/lib/juju/not-charm/dispatch",
+		"/var/lib/juju/charm/dispatch")
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_dispatch_relative(c *gc.C) {
+	checkBuildRunHookCommand(c, "./dispatch",
+		"install",
+		"./dispatch",
+		"/var/lib/juju/not-charm/dispatch")
+}

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -350,7 +350,6 @@ echo "$@" >&2
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-
 // DebugSuite is for tests of methods/functions that don't need complex setup.
 type DebugSuite struct {
 	testing.BaseSuite


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

We were printing the full abspath to the hook runner, but it was quite
ugly. This cleans it up so that when we can, we use a relative path.

## QA steps

```sh

$ juju deploy charm-with-dispatch
$ juju debug-hooks
```

Without this patch, when it intercepts a hook, it will tell you:
```
...
3. To run an action or hook and end the debugging session avoiding processing any more events manually, use:

.//var/lib/juju/agents/unit-uo-0/charm/dispatch
...
```
With this patch it changes to:
```
...
3. To run an action or hook and end the debugging session avoiding processing any more events manually, use:

./dispatch
...
```
## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/2.8/+bug/1885543