### PR TITLE
Allow dump-model to work with incomplete model data

### DIFF
--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -684,6 +684,9 @@ func (st *mockState) Export() (description.Model, error) {
 
 func (st *mockState) ExportPartial(cfg state.ExportConfig) (description.Model, error) {
 	st.MethodCall(st, "ExportPartial", cfg)
+	if !cfg.IgnoreIncompleteModel {
+		return nil, errors.New("expected IgnoreIncompleteModel=true")
+	}
 	return st.Export()
 }
 

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -722,7 +722,7 @@ func (m *ModelManagerAPI) dumpModel(args params.Entity, simplified bool) ([]byte
 	}
 	defer release()
 
-	var exportConfig state.ExportConfig
+	exportConfig := state.ExportConfig{IgnoreIncompleteModel: true}
 	if simplified {
 		exportConfig.SkipActions = true
 		exportConfig.SkipAnnotations = true

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -53,6 +53,7 @@ const maxStatusHistoryEntries = 20
 // during the export. The intent of this is to be able to get a partial
 // export to support other API calls, like status.
 type ExportConfig struct {
+	IgnoreIncompleteModel    bool
 	SkipActions              bool
 	SkipAnnotations          bool
 	SkipCloudImageMetadata   bool
@@ -478,25 +479,27 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 	// some instance data.
 	if !e.cfg.SkipInstanceData {
 		instData, found := instances[machine.doc.Id]
-		if !found {
+		if !found && !e.cfg.IgnoreIncompleteModel {
 			return nil, errors.NotValidf("missing instance data for machine %s", machine.Id())
 		}
-		exMachine.SetInstance(e.newCloudInstanceArgs(instData))
-		instance := exMachine.Instance()
-		instanceKey := machine.globalInstanceKey()
-		statusArgs, err := e.statusArgs(instanceKey)
-		if err != nil {
-			return nil, errors.Annotatef(err, "status for machine instance %s", machine.Id())
+		if found {
+			exMachine.SetInstance(e.newCloudInstanceArgs(instData))
+			instance := exMachine.Instance()
+			instanceKey := machine.globalInstanceKey()
+			statusArgs, err := e.statusArgs(instanceKey)
+			if err != nil {
+				return nil, errors.Annotatef(err, "status for machine instance %s", machine.Id())
+			}
+			instance.SetStatus(statusArgs)
+			instance.SetStatusHistory(e.statusHistoryArgs(instanceKey))
+			// Extract the modification status from the status dataset
+			modificationInstanceKey := machine.globalModificationKey()
+			modificationStatusArgs, err := e.statusArgs(modificationInstanceKey)
+			if err != nil {
+				return nil, errors.Annotatef(err, "modification status for machine instance %s", machine.Id())
+			}
+			instance.SetModificationStatus(modificationStatusArgs)
 		}
-		instance.SetStatus(statusArgs)
-		instance.SetStatusHistory(e.statusHistoryArgs(instanceKey))
-		// Extract the modification status from the status dataset
-		modificationInstanceKey := machine.globalModificationKey()
-		modificationStatusArgs, err := e.statusArgs(modificationInstanceKey)
-		if err != nil {
-			return nil, errors.Annotatef(err, "modification status for machine instance %s", machine.Id())
-		}
-		instance.SetModificationStatus(modificationStatusArgs)
 	}
 
 	// We don't rely on devices being there. If they aren't, we get an empty slice,
@@ -528,17 +531,18 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 
 	if !e.cfg.SkipMachineAgentBinaries {
 		tools, err := machine.AgentTools()
-		if err != nil {
+		if err != nil && !e.cfg.IgnoreIncompleteModel {
 			// This means the tools aren't set, but they should be.
 			return nil, errors.Trace(err)
 		}
-
-		exMachine.SetTools(description.AgentToolsArgs{
-			Version: tools.Version,
-			URL:     tools.URL,
-			SHA256:  tools.SHA256,
-			Size:    tools.Size,
-		})
+		if err == nil {
+			exMachine.SetTools(description.AgentToolsArgs{
+				Version: tools.Version,
+				URL:     tools.URL,
+				SHA256:  tools.SHA256,
+				Size:    tools.Size,
+			})
+		}
 	}
 
 	for _, args := range e.openedPortsArgsForMachine(machine.Id(), portsData) {
@@ -785,19 +789,33 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	leadershipKey := leadershipSettingsKey(appName)
 	storageConstraintsKey := application.storageConstraintsKey()
 
+	var charmConfig map[string]interface{}
 	applicationCharmSettingsDoc, found := e.modelSettings[charmConfigKey]
-	if !found && !e.cfg.SkipSettings {
+	if !found && !e.cfg.SkipSettings && !e.cfg.IgnoreIncompleteModel {
 		return errors.Errorf("missing charm settings for application %q", appName)
 	}
+	if found {
+		charmConfig = applicationCharmSettingsDoc.Settings
+	}
 	delete(e.modelSettings, charmConfigKey)
+
+	var applicationConfig map[string]interface{}
 	applicationConfigDoc, found := e.modelSettings[appConfigKey]
-	if !found && !e.cfg.SkipSettings {
+	if !found && !e.cfg.SkipSettings && !e.cfg.IgnoreIncompleteModel {
 		return errors.Errorf("missing config for application %q", appName)
 	}
+	if found {
+		applicationConfig = applicationConfigDoc.Settings
+	}
 	delete(e.modelSettings, appConfigKey)
+
+	var leadershipSettings map[string]interface{}
 	leadershipSettingsDoc, found := e.modelSettings[leadershipKey]
-	if !found && !e.cfg.SkipSettings {
+	if !found && !e.cfg.SkipSettings && !e.cfg.IgnoreIncompleteModel {
 		return errors.Errorf("missing leadership settings for application %q", appName)
+	}
+	if found {
+		leadershipSettings = leadershipSettingsDoc.Settings
 	}
 	delete(e.modelSettings, leadershipKey)
 
@@ -817,10 +835,10 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		DesiredScale:         application.doc.DesiredScale,
 		MinUnits:             application.doc.MinUnits,
 		EndpointBindings:     map[string]string(ctx.endpoingBindings[globalKey]),
-		ApplicationConfig:    applicationConfigDoc.Settings,
-		CharmConfig:          applicationCharmSettingsDoc.Settings,
+		ApplicationConfig:    applicationConfig,
+		CharmConfig:          charmConfig,
 		Leader:               ctx.leader,
-		LeadershipSettings:   leadershipSettingsDoc.Settings,
+		LeadershipSettings:   leadershipSettings,
 		MetricsCredentials:   application.doc.MetricCredentials,
 		PodSpec:              ctx.podSpecs[application.globalKey()],
 	}
@@ -974,16 +992,18 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 
 		if e.dbModel.Type() != ModelTypeCAAS && !e.cfg.SkipUnitAgentBinaries {
 			tools, err := unit.AgentTools()
-			if err != nil {
+			if err != nil && !e.cfg.IgnoreIncompleteModel {
 				// This means the tools aren't set, but they should be.
 				return errors.Trace(err)
 			}
-			exUnit.SetTools(description.AgentToolsArgs{
-				Version: tools.Version,
-				URL:     tools.URL,
-				SHA256:  tools.SHA256,
-				Size:    tools.Size,
-			})
+			if err == nil {
+				exUnit.SetTools(description.AgentToolsArgs{
+					Version: tools.Version,
+					URL:     tools.URL,
+					SHA256:  tools.SHA256,
+					Size:    tools.Size,
+				})
+			}
 		} else {
 			// TODO(caas) - Actually use the exported cloud container details and status history.
 			// Currently these are only grabbed to make the MigrationExportSuite tests happy.
@@ -1185,11 +1205,11 @@ func (e *exporter) relations() error {
 					continue
 				}
 				key := ru.key()
-				if !e.cfg.SkipRelationData && !relationScopes.Contains(key) {
+				if !e.cfg.SkipRelationData && !relationScopes.Contains(key) && !e.cfg.IgnoreIncompleteModel {
 					return errors.Errorf("missing relation scope for %s and %s", relation, unit.Name())
 				}
 				settingsDoc, found := e.modelSettings[key]
-				if !found && !e.cfg.SkipSettings && !e.cfg.SkipRelationData {
+				if !found && !e.cfg.SkipSettings && !e.cfg.SkipRelationData && !e.cfg.IgnoreIncompleteModel {
 					return errors.Errorf("missing relation settings for %s and %s", relation, unit.Name())
 				}
 				delete(e.modelSettings, key)
@@ -2062,6 +2082,10 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 }
 
 func (e *exporter) checkUnexportedValues() error {
+	if e.cfg.IgnoreIncompleteModel {
+		return nil
+	}
+
 	var missing []string
 
 	// As annotations are saved into the model, they are removed from the

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1217,8 +1217,26 @@ func (s *MigrationExportSuite) TestInstanceDataSkipped(c *gc.C) {
 
 	listMachines := model.Machines()
 
-	instance := listMachines[0].Instance()
-	c.Assert(instance, gc.Equals, nil)
+	instData := listMachines[0].Instance()
+	c.Assert(instData, gc.Equals, nil)
+}
+
+func (s *MigrationExportSuite) TestMissingInstanceDataIgnored(c *gc.C) {
+	_, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "bionic",
+		Jobs:   []state.MachineJob{state.JobManageModel},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		IgnoreIncompleteModel: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	listMachines := model.Machines()
+
+	instData := listMachines[0].Instance()
+	c.Assert(instData, gc.Equals, nil)
 }
 
 func (s *MigrationBaseSuite) TestMachineAgentBinariesSkipped(c *gc.C) {
@@ -1228,6 +1246,23 @@ func (s *MigrationBaseSuite) TestMachineAgentBinariesSkipped(c *gc.C) {
 
 	model, err := s.State.ExportPartial(state.ExportConfig{
 		SkipMachineAgentBinaries: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	listMachines := model.Machines()
+	tools := listMachines[0].Tools()
+	c.Assert(tools, gc.Equals, nil)
+}
+
+func (s *MigrationBaseSuite) TestMissingMachineAgentBinariesIgnored(c *gc.C) {
+	_, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "bionic",
+		Jobs:   []state.MachineJob{state.JobManageModel},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		IgnoreIncompleteModel: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1253,6 +1288,23 @@ func (s *MigrationBaseSuite) TestUnitAgentBinariesSkipped(c *gc.C) {
 	c.Assert(unit[0].Tools(), gc.Equals, nil)
 }
 
+func (s *MigrationBaseSuite) TestMissingUnitAgentBinariesIgnored(c *gc.C) {
+	dummyCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "dummy"})
+	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "dummy", Charm: dummyCharm})
+
+	_, err := application.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		IgnoreIncompleteModel: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	listApplications := model.Applications()
+	unit := listApplications[0].Units()
+	c.Assert(unit[0].Tools(), gc.Equals, nil)
+}
+
 func (s *MigrationBaseSuite) TestRelationScopeSkipped(c *gc.C) {
 	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
 	mysql := state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
@@ -1266,6 +1318,25 @@ func (s *MigrationBaseSuite) TestRelationScopeSkipped(c *gc.C) {
 
 	model, err := s.State.ExportPartial(state.ExportConfig{
 		SkipRelationData: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(model.Relations(), gc.HasLen, 1)
+}
+
+func (s *MigrationBaseSuite) TestMissingRelationScopeIgnored(c *gc.C) {
+	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	mysql := state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
+	// InferEndpoints will always return provider, requirer
+	eps, err := s.State.InferEndpoints("mysql", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		IgnoreIncompleteModel: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
## Description of change

juju dump-model errors out if run just after adding a machine or relation, since the machine is still pending and there's no instance data yet, or the relation units are not yet in scope and so relation data is missing.

This PR adds a new IgnoreIncompleteModel bool to export config so that we still get a dumped model output if there's missing data. This is what we want as we only care about complete model data when doing migrations.

## QA steps

juju add-machine && juju dump-model
juju deploy foo && juju deploy bar && juju relate foo bar && juju dump-model

## Bug reference

https://bugs.launchpad.net/bugs/1849746
https://bugs.launchpad.net/bugs/1886369
