### PR TITLE
Non-functional link-layer device refactoring

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -6,16 +6,16 @@ package networkingcommon
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/juju/state"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/state"
 )
 
 // LinkLayerDevice describes a single layer-2 network device.
 type LinkLayerDevice interface {
-	// DocID returns the globally unique identifier for the device.
-	DocID() string
+	// ID returns the unique identifier for the device.
+	ID() string
 
 	// MACAddress is the hardware address of the device.
 	MACAddress() string

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -25,6 +25,10 @@ type LinkLayerDevice interface {
 	// SetProviderIDOps returns the operations required to set the input
 	// provider ID for the link-layer device.
 	SetProviderIDOps(id network.Id) ([]txn.Op, error)
+
+	// RemoveOps returns the transaction operations required to remove this
+	// device and if required, its provider ID.
+	RemoveOps() []txn.Op
 }
 
 // LinkLayerAddress describes a single layer-3 network address
@@ -50,6 +54,10 @@ type LinkLayerAddress interface {
 	// SetProviderNetIDsOps returns the transaction operations required to ensure
 	// that the input provider IDs are set against the address.
 	SetProviderNetIDsOps(networkID, subnetID network.Id) []txn.Op
+
+	// RemoveOps returns the transaction operations required to remove this
+	// address and if required, its provider ID.
+	RemoveOps() []txn.Op
 }
 
 // LinkLayerAccessor describes an entity that can

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -77,6 +77,9 @@ type LinkLayerAccessor interface {
 type LinkLayerMachine interface {
 	LinkLayerAccessor
 
+	// Id returns the ID for the machine.
+	Id() string
+
 	// AssertAliveOp returns a transaction operation for asserting
 	// that the machine is currently alive.
 	AssertAliveOp() txn.Op
@@ -103,6 +106,8 @@ type MachineLinkLayerOp struct {
 // NewMachineLinkLayerOp returns a reference that can be embedded in a model
 // operation for updating the input machine's link layer data.
 func NewMachineLinkLayerOp(machine LinkLayerMachine, incoming network.InterfaceInfos) *MachineLinkLayerOp {
+	logger.Debugf("processing link-layer devices for machine %q", machine.Id())
+
 	return &MachineLinkLayerOp{
 		machine:   machine,
 		incoming:  incoming,

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -13,6 +13,9 @@ import (
 
 // LinkLayerDevice describes a single layer-2 network device.
 type LinkLayerDevice interface {
+	// DocID returns the globally unique identifier for the device.
+	DocID() string
+
 	// MACAddress is the hardware address of the device.
 	MACAddress() string
 
@@ -25,6 +28,10 @@ type LinkLayerDevice interface {
 	// SetProviderIDOps returns the operations required to set the input
 	// provider ID for the link-layer device.
 	SetProviderIDOps(id network.Id) ([]txn.Op, error)
+
+	// ParentID returns the globally unique identifier
+	// for this device's parent if it has one.
+	ParentID() string
 
 	// RemoveOps returns the transaction operations required to remove this
 	// device and if required, its provider ID.

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -6,6 +6,7 @@ package networkingcommon
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/juju/state"
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/network"
@@ -36,6 +37,10 @@ type LinkLayerDevice interface {
 	// RemoveOps returns the transaction operations required to remove this
 	// device and if required, its provider ID.
 	RemoveOps() []txn.Op
+
+	// UpdateOps returns the transaction operations required to update the
+	// device so that it reflects the incoming arguments.
+	UpdateOps(args state.LinkLayerDeviceArgs) []txn.Op
 }
 
 // LinkLayerAddress describes a single layer-3 network address

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -99,7 +99,7 @@ type BackingSpace interface {
 }
 
 // NetworkBacking defines the methods needed by the API facade to store and
-// retrieve information from the underlying persistency layer (state
+// retrieve information from the underlying persistence layer (state
 // DB).
 type NetworkBacking interface {
 	environs.EnvironConfigGetter
@@ -168,20 +168,8 @@ func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 		if !seenDeviceNames.Contains(iface.InterfaceName) {
 			// First time we see this, add it to devicesArgs.
 			seenDeviceNames.Add(iface.InterfaceName)
-			var mtu uint
-			if iface.MTU >= 0 {
-				mtu = uint(iface.MTU)
-			}
-			args := state.LinkLayerDeviceArgs{
-				Name:        iface.InterfaceName,
-				MTU:         mtu,
-				ProviderID:  iface.ProviderId,
-				Type:        corenetwork.LinkLayerDeviceType(iface.InterfaceType),
-				MACAddress:  iface.MACAddress,
-				IsAutoStart: !iface.NoAutoStart,
-				IsUp:        !iface.Disabled,
-				ParentName:  iface.ParentInterfaceName,
-			}
+
+			args := networkDeviceToStateArgs(iface)
 			logger.Tracef("state device args for device: %+v", args)
 			devicesArgs = append(devicesArgs, args)
 		}
@@ -198,6 +186,24 @@ func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
 	logger.Tracef("seen devices: %+v", seenDeviceNames.SortedValues())
 	logger.Tracef("network interface list transformed to state args:\n%+v\n%+v", devicesArgs, devicesAddrs)
 	return devicesArgs, devicesAddrs
+}
+
+func networkDeviceToStateArgs(dev corenetwork.InterfaceInfo) state.LinkLayerDeviceArgs {
+	var mtu uint
+	if dev.MTU >= 0 {
+		mtu = uint(dev.MTU)
+	}
+
+	return state.LinkLayerDeviceArgs{
+		Name:        dev.InterfaceName,
+		MTU:         mtu,
+		ProviderID:  dev.ProviderId,
+		Type:        corenetwork.LinkLayerDeviceType(dev.InterfaceType),
+		MACAddress:  dev.MACAddress,
+		IsAutoStart: !dev.NoAutoStart,
+		IsUp:        !dev.Disabled,
+		ParentName:  dev.ParentInterfaceName,
+	}
 }
 
 func networkAddressToStateArgs(
@@ -278,9 +284,9 @@ func MachineNetworkInfoResultToNetworkInfoResult(inResult state.MachineNetworkIn
 }
 
 func FanConfigToFanConfigResult(config network.FanConfig) params.FanConfigResult {
-	result := params.FanConfigResult{make([]params.FanConfigEntry, len(config))}
+	result := params.FanConfigResult{Fans: make([]params.FanConfigEntry, len(config))}
 	for i, entry := range config {
-		result.Fans[i] = params.FanConfigEntry{entry.Underlay.String(), entry.Overlay.String()}
+		result.Fans[i] = params.FanConfigEntry{Underlay: entry.Underlay.String(), Overlay: entry.Overlay.String()}
 	}
 	return result
 }
@@ -288,16 +294,16 @@ func FanConfigToFanConfigResult(config network.FanConfig) params.FanConfigResult
 func FanConfigResultToFanConfig(config params.FanConfigResult) (network.FanConfig, error) {
 	rv := make(network.FanConfig, len(config.Fans))
 	for i, entry := range config.Fans {
-		_, ipnet, err := net.ParseCIDR(entry.Underlay)
+		_, ipNet, err := net.ParseCIDR(entry.Underlay)
 		if err != nil {
 			return nil, err
 		}
-		rv[i].Underlay = ipnet
-		_, ipnet, err = net.ParseCIDR(entry.Overlay)
+		rv[i].Underlay = ipNet
+		_, ipNet, err = net.ParseCIDR(entry.Overlay)
 		if err != nil {
 			return nil, err
 		}
-		rv[i].Overlay = ipnet
+		rv[i].Overlay = ipNet
 	}
 	return rv, nil
 }

--- a/apiserver/facades/controller/instancepoller/package_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/package_mock_test.go
@@ -35,18 +35,18 @@ func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 	return m.recorder
 }
 
-// DocID mocks base method
-func (m *MockLinkLayerDevice) DocID() string {
+// ID mocks base method
+func (m *MockLinkLayerDevice) ID() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DocID")
+	ret := m.ctrl.Call(m, "ID")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// DocID indicates an expected call of DocID
-func (mr *MockLinkLayerDeviceMockRecorder) DocID() *gomock.Call {
+// ID indicates an expected call of ID
+func (mr *MockLinkLayerDeviceMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockLinkLayerDevice)(nil).DocID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockLinkLayerDevice)(nil).ID))
 }
 
 // MACAddress mocks base method

--- a/apiserver/facades/controller/instancepoller/package_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/package_mock_test.go
@@ -76,6 +76,20 @@ func (mr *MockLinkLayerDeviceMockRecorder) ProviderID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderID", reflect.TypeOf((*MockLinkLayerDevice)(nil).ProviderID))
 }
 
+// RemoveOps mocks base method
+func (m *MockLinkLayerDevice) RemoveOps() []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOps")
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// RemoveOps indicates an expected call of RemoveOps
+func (mr *MockLinkLayerDeviceMockRecorder) RemoveOps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).RemoveOps))
+}
+
 // SetProviderIDOps mocks base method
 func (m *MockLinkLayerDevice) SetProviderIDOps(arg0 network.Id) ([]txn.Op, error) {
 	m.ctrl.T.Helper()
@@ -140,6 +154,20 @@ func (m *MockLinkLayerAddress) Origin() network.Origin {
 func (mr *MockLinkLayerAddressMockRecorder) Origin() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Origin", reflect.TypeOf((*MockLinkLayerAddress)(nil).Origin))
+}
+
+// RemoveOps mocks base method
+func (m *MockLinkLayerAddress) RemoveOps() []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOps")
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// RemoveOps indicates an expected call of RemoveOps
+func (mr *MockLinkLayerAddressMockRecorder) RemoveOps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOps", reflect.TypeOf((*MockLinkLayerAddress)(nil).RemoveOps))
 }
 
 // SetOriginOps mocks base method

--- a/apiserver/facades/controller/instancepoller/package_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/package_mock_test.go
@@ -34,6 +34,20 @@ func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 	return m.recorder
 }
 
+// DocID mocks base method
+func (m *MockLinkLayerDevice) DocID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DocID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// DocID indicates an expected call of DocID
+func (mr *MockLinkLayerDeviceMockRecorder) DocID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockLinkLayerDevice)(nil).DocID))
+}
+
 // MACAddress mocks base method
 func (m *MockLinkLayerDevice) MACAddress() string {
 	m.ctrl.T.Helper()
@@ -60,6 +74,20 @@ func (m *MockLinkLayerDevice) Name() string {
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
+}
+
+// ParentID mocks base method
+func (m *MockLinkLayerDevice) ParentID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ParentID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ParentID indicates an expected call of ParentID
+func (mr *MockLinkLayerDeviceMockRecorder) ParentID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentID", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentID))
 }
 
 // ProviderID mocks base method

--- a/apiserver/facades/controller/instancepoller/package_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/package_mock_test.go
@@ -7,6 +7,7 @@ package instancepoller
 import (
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
+	state "github.com/juju/juju/state"
 	txn "gopkg.in/mgo.v2/txn"
 	reflect "reflect"
 )
@@ -131,6 +132,20 @@ func (m *MockLinkLayerDevice) SetProviderIDOps(arg0 network.Id) ([]txn.Op, error
 func (mr *MockLinkLayerDeviceMockRecorder) SetProviderIDOps(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderIDOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).SetProviderIDOps), arg0)
+}
+
+// UpdateOps mocks base method
+func (m *MockLinkLayerDevice) UpdateOps(arg0 state.LinkLayerDeviceArgs) []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateOps", arg0)
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// UpdateOps indicates an expected call of UpdateOps
+func (mr *MockLinkLayerDeviceMockRecorder) UpdateOps(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).UpdateOps), arg0)
 }
 
 // MockLinkLayerAddress is a mock of LinkLayerAddress interface

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -16,7 +16,6 @@ type StateMachine interface {
 	state.Entity
 	networkingcommon.LinkLayerMachine
 
-	Id() string
 	InstanceId() (instance.Id, error)
 	ProviderAddresses() network.SpaceAddresses
 	SetProviderAddresses(...network.SpaceAddress) error

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -210,6 +210,32 @@ func (i *InterfaceInfo) IsVLAN() bool {
 	return i.VLANTag > 0
 }
 
+// Validate checks that the receiver looks like a real interface.
+// An error is returned if invalid members are detected.
+func (i *InterfaceInfo) Validate() error {
+	if i.MACAddress != "" {
+		if _, err := net.ParseMAC(i.MACAddress); err != nil {
+			return errors.NotValidf("link-layer device hardware address %q", i.MACAddress)
+		}
+	}
+
+	if i.InterfaceName == "" {
+		return errors.NotValidf("link-layer device %q, empty name", i.MACAddress)
+	}
+
+	if !IsValidLinkLayerDeviceName(i.InterfaceName) {
+		// TODO (manadart 2020-07-07): This preserves prior behaviour.
+		// If we are waving invalid names through, I'm not sure of the value.
+		logger.Warningf("link-layer device %q has an invalid name, %q", i.MACAddress, i.InterfaceName)
+	}
+
+	if !IsValidLinkLayerDeviceType(string(i.InterfaceType)) {
+		return errors.NotValidf("link-layer device %q, type %q", i.InterfaceName, i.InterfaceType)
+	}
+
+	return nil
+}
+
 // CIDRAddress returns Address.Value combined with subnet mask.
 // TODO (manadart 2020-07-02): Usage of this method should be phased out
 // in favour of calling ValueForCIDR on each member of the addresses slice.
@@ -241,6 +267,16 @@ func (i *InterfaceInfo) PrimaryAddress() ProviderAddress {
 // InterfaceInfos is a slice of InterfaceInfo
 // for a single host/machine/container.
 type InterfaceInfos []InterfaceInfo
+
+// Validate validates each interface, returning an error if any are invalid
+func (s InterfaceInfos) Validate() error {
+	for _, dev := range s {
+		if err := dev.Validate(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
 
 // IterHierarchy runs the input function for every interface by processing each
 // device hierarchy, ensuring that no child device is processed before its

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -105,6 +105,31 @@ func (*nicSuite) TestCIDRAddress(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
 }
 
+func (*nicSuite) TestInterfaceInfoValidate(c *gc.C) {
+	dev := network.InterfaceInfo{InterfaceName: ""}
+	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)
+
+	dev = network.InterfaceInfo{MACAddress: "do you even MAC bro?"}
+	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)
+
+	dev = network.InterfaceInfo{
+		InterfaceName: "eth0",
+		MACAddress:    network.GenerateVirtualMACAddress(),
+		InterfaceType: "invalid",
+	}
+	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)
+
+	dev = network.InterfaceInfo{
+		InterfaceName: "not#valid",
+		InterfaceType: "bond",
+	}
+	c.Check(dev.Validate(), jc.ErrorIsNil)
+}
+
+func (*nicSuite) TestInterfaceInfosValidate(c *gc.C) {
+	c.Check(getInterFaceInfos().Validate(), jc.ErrorIsNil)
+}
+
 func (*nicSuite) TestInterfaceInfosChildren(c *gc.C) {
 	interfaces := getInterFaceInfos()
 
@@ -146,25 +171,30 @@ func getInterFaceInfos() network.InterfaceInfos {
 		{
 			DeviceIndex:   0,
 			InterfaceName: "br-bond0",
+			InterfaceType: network.BondInterface,
 		},
 		{
 			DeviceIndex:   1,
 			InterfaceName: "eth2",
+			InterfaceType: network.EthernetInterface,
 		},
 		{
 			DeviceIndex:         2,
 			InterfaceName:       "bond0",
 			ParentInterfaceName: "br-bond0",
+			InterfaceType:       network.BondInterface,
 		},
 		{
 			DeviceIndex:         3,
 			InterfaceName:       "eth0",
 			ParentInterfaceName: "bond0",
+			InterfaceType:       network.BondInterface,
 		},
 		{
 			DeviceIndex:         4,
 			InterfaceName:       "eth1",
 			ParentInterfaceName: "bond0",
+			InterfaceType:       network.BondInterface,
 		},
 	}
 }

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -235,6 +235,31 @@ func (dev *LinkLayerDevice) RemoveOps() []txn.Op {
 	return ops
 }
 
+// UpdateOps returns the transaction operations required to update the device
+// so that it reflects the incoming arguments.
+// This method is intended for updating a device based on args gleaned from the
+// host/container directly. As such it does not update provider IDs.
+// There are separate methods for generating those operations.
+func (dev *LinkLayerDevice) UpdateOps(args LinkLayerDeviceArgs) []txn.Op {
+	newDoc := &linkLayerDeviceDoc{
+		DocID:       dev.doc.DocID,
+		Name:        args.Name,
+		ModelUUID:   dev.doc.ModelUUID,
+		MTU:         args.MTU,
+		MachineID:   dev.doc.MachineID,
+		Type:        args.Type,
+		MACAddress:  args.MACAddress,
+		IsAutoStart: args.IsAutoStart,
+		IsUp:        args.IsUp,
+		ParentName:  args.ParentName,
+	}
+
+	if op, hasUpdates := updateLinkLayerDeviceDocOp(&dev.doc, newDoc); hasUpdates {
+		return []txn.Op{op}
+	}
+	return nil
+}
+
 // Remove removes the device, if it exists. No error is returned when the device
 // was already removed. ErrParentDeviceHasChildren is returned if this device is
 // a parent to one or more existing devices and therefore cannot be removed.

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -446,10 +446,6 @@ func (dev *LinkLayerDevice) String() string {
 	return fmt.Sprintf("%s device %q on machine %q", dev.doc.Type, dev.doc.Name, dev.doc.MachineID)
 }
 
-func (dev *LinkLayerDevice) globalKey() string {
-	return linkLayerDeviceGlobalKey(dev.doc.MachineID, dev.doc.Name)
-}
-
 func linkLayerDeviceGlobalKey(machineID, deviceName string) string {
 	if machineID == "" || deviceName == "" {
 		return ""
@@ -503,6 +499,12 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(name string) (LinkLayerDevic
 	if dev.Type() != network.BridgeDevice {
 		return LinkLayerDeviceArgs{}, errors.Errorf("device must be a Bridge Device, receiver has type %q", dev.Type())
 	}
+
+	parentName, err := dev.st.strictLocalID(dev.DocID())
+	if err != nil {
+		return LinkLayerDeviceArgs{}, errors.Trace(err)
+	}
+
 	return LinkLayerDeviceArgs{
 		Name:        name,
 		Type:        network.EthernetDevice,
@@ -510,6 +512,6 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(name string) (LinkLayerDevic
 		MTU:         dev.MTU(),
 		IsUp:        true,
 		IsAutoStart: true,
-		ParentName:  dev.globalKey(),
+		ParentName:  parentName,
 	}, nil
 }

--- a/state/linklayerdevices_internal_test.go
+++ b/state/linklayerdevices_internal_test.go
@@ -73,18 +73,6 @@ func (s *linkLayerDevicesInternalSuite) TestLinkLayerDeviceGlobalKeyHelper(c *gc
 	c.Assert(result, gc.Equals, "")
 }
 
-func (s *linkLayerDevicesInternalSuite) TestGlobalKeyMethod(c *gc.C) {
-	doc := linkLayerDeviceDoc{
-		MachineID: "42",
-		Name:      "foo",
-	}
-	config := s.newLinkLayerDeviceWithDummyState(doc)
-	c.Check(config.globalKey(), gc.Equals, "m#42#d#foo")
-
-	config = s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{})
-	c.Check(config.globalKey(), gc.Equals, "")
-}
-
 func (s *linkLayerDevicesInternalSuite) TestParseLinkLayerParentNameAsGlobalKey(c *gc.C) {
 	for i, test := range []struct {
 		about              string

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -684,6 +684,30 @@ func (s *linkLayerDevicesStateSuite) TestRemoveOps(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *linkLayerDevicesStateSuite) TestUpdateOps(c *gc.C) {
+	dev := s.addNamedDevice(c, "eth0")
+
+	ops := dev.UpdateOps(state.LinkLayerDeviceArgs{
+		Name: "eth0",
+		Type: corenetwork.EthernetDevice,
+	})
+	c.Check(ops, gc.HasLen, 0)
+
+	mac := corenetwork.GenerateVirtualMACAddress()
+	ops = dev.UpdateOps(state.LinkLayerDeviceArgs{
+		Name:       "eth0",
+		Type:       corenetwork.EthernetDevice,
+		MACAddress: mac,
+	})
+	c.Assert(ops, gc.HasLen, 1)
+
+	state.RunTransaction(c, s.State, ops)
+
+	dev, err := s.machine.LinkLayerDevice("eth0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(dev.MACAddress(), gc.Equals, mac)
+}
+
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
 	s.createSpaceAndSubnetWithProviderID(c, spaceName, CIDR, "")
 }


### PR DESCRIPTION
## Description of change

This patch contains preparatory work for updating link-layer device information:
- Validation directly on `network.InterfaceInfo`.
- Addition of `UpdateOps` for link-layer devices.
- Extension of interfaces and corresponding mock regeneration.
- Some other modularisation.

## QA steps

These changes are not yet realised; unit tests remain green.

A bootstrap/add-machine without error covers regressions.

## Documentation changes

None.

## Bug reference

N/A
