### PR TITLE
Merge 2.8 into develop

### DIFF
--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -684,6 +684,9 @@ func (st *mockState) Export() (description.Model, error) {
 
 func (st *mockState) ExportPartial(cfg state.ExportConfig) (description.Model, error) {
 	st.MethodCall(st, "ExportPartial", cfg)
+	if !cfg.IgnoreIncompleteModel {
+		return nil, errors.New("expected IgnoreIncompleteModel=true")
+	}
 	return st.Export()
 }
 

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -722,7 +722,7 @@ func (m *ModelManagerAPI) dumpModel(args params.Entity, simplified bool) ([]byte
 	}
 	defer release()
 
-	var exportConfig state.ExportConfig
+	exportConfig := state.ExportConfig{IgnoreIncompleteModel: true}
 	if simplified {
 		exportConfig.SkipActions = true
 		exportConfig.SkipAnnotations = true

--- a/apiserver/facades/controller/instancepoller/package_mock_test.go
+++ b/apiserver/facades/controller/instancepoller/package_mock_test.go
@@ -7,6 +7,7 @@ package instancepoller
 import (
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
+	state "github.com/juju/juju/state"
 	txn "gopkg.in/mgo.v2/txn"
 	reflect "reflect"
 )
@@ -32,6 +33,20 @@ func NewMockLinkLayerDevice(ctrl *gomock.Controller) *MockLinkLayerDevice {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 	return m.recorder
+}
+
+// ID mocks base method
+func (m *MockLinkLayerDevice) ID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ID indicates an expected call of ID
+func (mr *MockLinkLayerDeviceMockRecorder) ID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockLinkLayerDevice)(nil).ID))
 }
 
 // MACAddress mocks base method
@@ -62,6 +77,20 @@ func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
+// ParentID mocks base method
+func (m *MockLinkLayerDevice) ParentID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ParentID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ParentID indicates an expected call of ParentID
+func (mr *MockLinkLayerDeviceMockRecorder) ParentID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentID", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentID))
+}
+
 // ProviderID mocks base method
 func (m *MockLinkLayerDevice) ProviderID() network.Id {
 	m.ctrl.T.Helper()
@@ -74,6 +103,20 @@ func (m *MockLinkLayerDevice) ProviderID() network.Id {
 func (mr *MockLinkLayerDeviceMockRecorder) ProviderID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderID", reflect.TypeOf((*MockLinkLayerDevice)(nil).ProviderID))
+}
+
+// RemoveOps mocks base method
+func (m *MockLinkLayerDevice) RemoveOps() []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOps")
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// RemoveOps indicates an expected call of RemoveOps
+func (mr *MockLinkLayerDeviceMockRecorder) RemoveOps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).RemoveOps))
 }
 
 // SetProviderIDOps mocks base method
@@ -89,6 +132,20 @@ func (m *MockLinkLayerDevice) SetProviderIDOps(arg0 network.Id) ([]txn.Op, error
 func (mr *MockLinkLayerDeviceMockRecorder) SetProviderIDOps(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderIDOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).SetProviderIDOps), arg0)
+}
+
+// UpdateOps mocks base method
+func (m *MockLinkLayerDevice) UpdateOps(arg0 state.LinkLayerDeviceArgs) []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateOps", arg0)
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// UpdateOps indicates an expected call of UpdateOps
+func (mr *MockLinkLayerDeviceMockRecorder) UpdateOps(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).UpdateOps), arg0)
 }
 
 // MockLinkLayerAddress is a mock of LinkLayerAddress interface
@@ -140,6 +197,20 @@ func (m *MockLinkLayerAddress) Origin() network.Origin {
 func (mr *MockLinkLayerAddressMockRecorder) Origin() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Origin", reflect.TypeOf((*MockLinkLayerAddress)(nil).Origin))
+}
+
+// RemoveOps mocks base method
+func (m *MockLinkLayerAddress) RemoveOps() []txn.Op {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOps")
+	ret0, _ := ret[0].([]txn.Op)
+	return ret0
+}
+
+// RemoveOps indicates an expected call of RemoveOps
+func (mr *MockLinkLayerAddressMockRecorder) RemoveOps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOps", reflect.TypeOf((*MockLinkLayerAddress)(nil).RemoveOps))
 }
 
 // SetOriginOps mocks base method

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -16,7 +16,6 @@ type StateMachine interface {
 	state.Entity
 	networkingcommon.LinkLayerMachine
 
-	Id() string
 	InstanceId() (instance.Id, error)
 	ProviderAddresses() network.SpaceAddresses
 	SetProviderAddresses(...network.SpaceAddress) error

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -396,6 +396,7 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 	if err != nil {
 		return err
 	}
+
 	if len(c.keys) == 1 {
 		logger.Infof("format %v is ignored", c.out.Name())
 		key := c.keys[0]
@@ -408,13 +409,9 @@ func (c *configCommand) getConfig(client applicationAPI, ctx *cmd.Context) error
 		}
 		v, ok := info["value"]
 		if !ok || v == nil {
-			// Note that unlike the output with a non-nil and non-empty value below, this
-			// output should never have a newline.
-			return nil
+			v = ""
 		}
-		// TODO (anastasiamac 2018-08-29) We want to have a new line after here (fmt.Fprintln).
-		// However, it will break all existing scripts and should be done as part of Juju 3.x work.
-		_, err := fmt.Fprint(ctx.Stdout, v)
+		_, err = fmt.Fprintln(ctx.Stdout, v)
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -196,7 +196,7 @@ func (s *configCommandSuite) TestGetCharmConfigKey(c *gc.C) {
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "title"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Nearly There")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "Nearly There\n")
 }
 
 func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
@@ -204,7 +204,7 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValue(c *gc.C) {
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
 func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
@@ -212,7 +212,7 @@ func (s *configCommandSuite) TestGetCharmConfigKeyMultilineValueJSON(c *gc.C) {
 	code := cmd.Main(application.NewConfigCommandForTest(s.fake, s.store), ctx, []string{"dummy-application", "multiline-value", "--format", "json"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" ")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "The quick brown fox jumps over the lazy dog. \"The quick brown fox jumps over the lazy dog\" \"The quick brown fox jumps over the lazy dog\" \n")
 }
 
 func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
@@ -221,7 +221,7 @@ func (s *configCommandSuite) TestGetAppConfigKey(c *gc.C) {
 		s.fake, s.store), ctx, []string{"dummy-application", "juju-external-hostname"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "ext-host\n")
 }
 
 func (s *configCommandSuite) TestGetConfigKeyNotFound(c *gc.C) {

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 
@@ -34,15 +35,25 @@ func (f *ConfigFlag) SetPreserveStringValue(val bool) {
 }
 
 // Set implements gnuflag.Value.Set.
+// TODO (stickupkid): Clean this up to correctly handle stdin. Additionally the
+// method is confusing and cryptic, we should improve this at some point!
 func (f *ConfigFlag) Set(s string) error {
 	if s == "" {
 		return errors.NotValidf("empty string")
 	}
+
+	// Attempt to work out if we're dealing with key value pairs or a string
+	// for a file.
+	// If the key value pairs don't contain a `=` sign, then it's assumed it's
+	// a file, so append that and bail out.
 	fields := strings.SplitN(s, "=", 2)
 	if len(fields) == 1 {
 		f.files = append(f.files, fields[0])
 		return nil
 	}
+
+	// It's assumed that we have a set of key value pairs. So attempt to extract
+	// the key value pairs accordingly.
 	var value interface{}
 	if fields[1] == "" || f.preserveStringValue {
 		value = fields[1]
@@ -58,8 +69,32 @@ func (f *ConfigFlag) Set(s string) error {
 	return nil
 }
 
+// SetAttrsFromReader sets the attributes from a slice of bytes. The bytes are
+// expected to be YAML parsable and align to the attrs type of
+// map[string]interface{}.
+// This will over write any attributes that already exist if found in the YAML
+// configuration.
+func (f *ConfigFlag) SetAttrsFromReader(reader io.Reader) error {
+	if reader == nil {
+		return errors.NotValidf("empty reader")
+	}
+	attrs := make(map[string]interface{})
+	if err := yaml.NewDecoder(reader).Decode(&attrs); err != nil {
+		return errors.Trace(err)
+	}
+	if f.attrs == nil {
+		f.attrs = make(map[string]interface{})
+	}
+	for k, attr := range attrs {
+		f.attrs[k] = attr
+	}
+	return nil
+}
+
 // ReadAttrs reads attributes from the specified files, and then overlays
 // the results with the k=v attributes.
+// TODO (stickupkid): This should only know about io.Readers and correctly
+// handle the various path ways from that abstraction.
 func (f *ConfigFlag) ReadAttrs(ctx *cmd.Context) (map[string]interface{}, error) {
 	attrs := make(map[string]interface{})
 	for _, f := range f.files {

--- a/cmd/juju/model/configcommand.go
+++ b/cmd/juju/model/configcommand.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/api/modelconfig"
@@ -33,7 +34,8 @@ are displayed.
 
 Supplying one key name returns only the value for the key. Supplying key=value
 will set the supplied key to the supplied value, this can be repeated for
-multiple keys. You can also specify a yaml file containing key values.
+multiple keys. You can also specify a yaml file containing key values, that can
+be used for the input for the command.
 `
 	modelConfigHelpDocKeys = `
 The following keys are available:
@@ -63,6 +65,70 @@ func NewConfigCommand() cmd.Command {
 
 type attributes map[string]interface{}
 
+// CoerceFormat attempts to convert the attributes values from the complex type
+// to the more simple type. This is because the output of this command outputs
+// in the following format:
+//
+//     resource-name:
+//        value: foo
+//        source: default
+//
+// Where the consuming side of the command expects it in the following format:
+//
+//     resource-name: foo
+//
+// CoerceFormat attempts to diagnose this and attempt to do this correctly.
+func (a attributes) CoerceFormat() (attributes, error) {
+	coerced := make(map[string]interface{})
+
+	fields := schema.FieldMap(schema.Fields{
+		"value":  schema.Any(),
+		"source": schema.String(),
+	}, nil)
+
+	for k, v := range a {
+		out, err := fields.Coerce(v, []string{})
+		if err != nil {
+			// Fallback to the old format and just pass through the value.
+			coerced[k] = v
+			continue
+		}
+
+		m := out.(map[string]interface{})
+		v = m["value"]
+
+		// Resource tags in the new output format is a map[string]interface{},
+		// but it should be of the format `foo=bar baz=boo`.
+		if k == "resource-tags" {
+			tags, err := coerceResourceTags(v)
+			if err != nil {
+				return nil, errors.Annotate(err, "unable to read resource-tags")
+			}
+			v = tags
+		}
+
+		coerced[k] = v
+	}
+
+	return coerced, nil
+}
+
+func coerceResourceTags(resourceTags interface{}) (string, error) {
+	tags := schema.StringMap(schema.Any())
+	out, err := tags.Coerce(resourceTags, []string{})
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	m := out.(map[string]interface{})
+	result := make([]string, 0, len(m))
+	for k, v := range m {
+		result = append(result, fmt.Sprintf("%s=%v", k, v))
+	}
+
+	return strings.Join(result, " "), nil
+}
+
 // configCommand is the simplified command for accessing and setting
 // attributes related to model configuration.
 type configCommand struct {
@@ -70,11 +136,12 @@ type configCommand struct {
 	modelcmd.ModelCommandBase
 	out cmd.Output
 
-	action     func(configCommandAPI, *cmd.Context) error // The action which we want to handle, set in cmd.Init.
-	keys       []string
-	reset      []string // Holds the keys to be reset until parsed.
-	resetKeys  []string // Holds the keys to be reset once parsed.
-	setOptions common.ConfigFlag
+	action             func(configCommandAPI, *cmd.Context) error // The action which we want to handle, set in cmd.Init.
+	keys               []string
+	reset              []string // Holds the keys to be reset until parsed.
+	resetKeys          []string // Holds the keys to be reset once parsed.
+	setOptions         common.ConfigFlag
+	ignoreAgentVersion bool
 }
 
 // configCommandAPI defines an API interface to be used during testing.
@@ -119,6 +186,7 @@ func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 		"yaml":    cmd.FormatYaml,
 	})
 	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys")
+	f.BoolVar(&c.ignoreAgentVersion, "ignore-agent-version", false, "Skip the error when passing in the agent version configuration")
 }
 
 // Init implements part of the cmd.Command interface.
@@ -153,9 +221,18 @@ func (c *configCommand) handleZeroArgs() error {
 
 // handleOneArg handles the case where there is one positional arg.
 func (c *configCommand) handleOneArg(arg string) error {
+	if arg == "-" {
+		// If we can't read the stdin, then continue onwards to fall back to the
+		// previous logic.
+		if err := c.parseStdin(); err == nil {
+			return nil
+		}
+	}
+
 	// We may have a single config.yaml file
-	_, err := os.Stat(arg)
-	if err == nil || strings.Contains(arg, "=") {
+	if _, err := os.Stat(arg); err == nil {
+		return c.parseYAMLFile(arg)
+	} else if strings.Contains(arg, "=") {
 		return c.parseSetKeys([]string{arg})
 	}
 	// If we are not setting a value, then we are retrieving one so we need to
@@ -181,6 +258,24 @@ func (c *configCommand) handleArgs(args []string) error {
 			return errors.New("can only retrieve a single value, or all values")
 		}
 	}
+	return nil
+}
+
+// parseStdin ensures that we handle stdin correctly.
+func (c *configCommand) parseStdin() error {
+	if err := c.setOptions.SetAttrsFromReader(os.Stdin); err != nil {
+		return errors.Trace(err)
+	}
+	c.action = c.setConfig
+	return nil
+}
+
+// parseYAMLFile ensures that we handle the YAML file passed in.
+func (c *configCommand) parseYAMLFile(file string) error {
+	if err := c.setOptions.Set(file); err != nil {
+		return errors.Trace(err)
+	}
+	c.action = c.setConfig
 	return nil
 }
 
@@ -260,7 +355,7 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 	return c.action(client, ctx)
 }
 
-// reset unsets the keys provided to the command.
+// resetConfig unsets the keys provided to the command.
 func (c *configCommand) resetConfig(client configCommandAPI, ctx *cmd.Context) error {
 	// ctx unused in this method
 	if err := c.verifyKnownKeys(client, c.resetKeys); err != nil {
@@ -270,7 +365,7 @@ func (c *configCommand) resetConfig(client configCommandAPI, ctx *cmd.Context) e
 	return block.ProcessBlockedError(client.ModelUnset(c.resetKeys...), block.BlockChange)
 }
 
-// set sets the provided key/value pairs on the model.
+// setConfig sets the provided key/value pairs on the model.
 func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) error {
 	attrs, err := c.setOptions.ReadAttrs(ctx)
 	if err != nil {
@@ -280,14 +375,23 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 	values := make(attributes)
 	for k, v := range attrs {
 		if k == config.AgentVersionKey {
+			if c.ignoreAgentVersion {
+				continue
+			}
 			return errors.Errorf(`"agent-version"" must be set via "upgrade-model"`)
 		}
+
 		values[k] = v
 		keys = append(keys, k)
 	}
 
+	coerced, err := values.CoerceFormat()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	for _, k := range c.resetKeys {
-		if _, ok := values[k]; ok {
+		if _, ok := coerced[k]; ok {
 			return errors.Errorf(
 				"key %q cannot be both set and reset in the same command", k)
 		}
@@ -296,7 +400,8 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 	if err := c.verifyKnownKeys(client, keys); err != nil {
 		return errors.Trace(err)
 	}
-	return block.ProcessBlockedError(client.ModelSet(values), block.BlockChange)
+
+	return block.ProcessBlockedError(client.ModelSet(coerced), block.BlockChange)
 }
 
 // get writes the value of a single key or the full output for the model to the cmd.Context.

--- a/cmd/juju/model/configcommand_test.go
+++ b/cmd/juju/model/configcommand_test.go
@@ -239,6 +239,24 @@ func (s *ConfigCommandSuite) TestSetFromFile(c *gc.C) {
 	c.Assert(s.fake.values, jc.DeepEquals, expected)
 }
 
+func (s *ConfigCommandSuite) TestSetFromFileUsingYAML(c *gc.C) {
+	tmpdir := c.MkDir()
+	configFile := filepath.Join(tmpdir, "config.yaml")
+	err := ioutil.WriteFile(configFile, []byte(`
+special:
+  value: extra
+  source: default
+`), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.run(c, configFile)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := map[string]interface{}{
+		"special": "extra",
+	}
+	c.Assert(s.fake.values, jc.DeepEquals, expected)
+}
+
 func (s *ConfigCommandSuite) TestSetFromFileCombined(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -109,6 +109,31 @@ func (*nicSuite) TestCIDRAddress(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
 }
 
+func (*nicSuite) TestInterfaceInfoValidate(c *gc.C) {
+	dev := network.InterfaceInfo{InterfaceName: ""}
+	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)
+
+	dev = network.InterfaceInfo{MACAddress: "do you even MAC bro?"}
+	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)
+
+	dev = network.InterfaceInfo{
+		InterfaceName: "eth0",
+		MACAddress:    network.GenerateVirtualMACAddress(),
+		InterfaceType: "invalid",
+	}
+	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)
+
+	dev = network.InterfaceInfo{
+		InterfaceName: "not#valid",
+		InterfaceType: "bond",
+	}
+	c.Check(dev.Validate(), jc.ErrorIsNil)
+}
+
+func (*nicSuite) TestInterfaceInfosValidate(c *gc.C) {
+	c.Check(getInterFaceInfos().Validate(), jc.ErrorIsNil)
+}
+
 func (*nicSuite) TestInterfaceInfosChildren(c *gc.C) {
 	interfaces := getInterFaceInfos()
 
@@ -183,25 +208,30 @@ func getInterFaceInfos() network.InterfaceInfos {
 		{
 			DeviceIndex:   0,
 			InterfaceName: "br-bond0",
+			InterfaceType: network.BondInterface,
 		},
 		{
 			DeviceIndex:   1,
 			InterfaceName: "eth2",
+			InterfaceType: network.EthernetInterface,
 		},
 		{
 			DeviceIndex:         2,
 			InterfaceName:       "bond0",
 			ParentInterfaceName: "br-bond0",
+			InterfaceType:       network.BondInterface,
 		},
 		{
 			DeviceIndex:         3,
 			InterfaceName:       "eth0",
 			ParentInterfaceName: "bond0",
+			InterfaceType:       network.BondInterface,
 		},
 		{
 			DeviceIndex:         4,
 			InterfaceName:       "eth1",
 			ParentInterfaceName: "bond0",
+			InterfaceType:       network.BondInterface,
 		},
 	}
 }

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -143,12 +143,12 @@ func (s *ApplicationConfigSuite) TestConfigNoValueSingleSetting(c *gc.C) {
 	// use 'juju config foo' to see values
 	for option := range charm.Config().Options {
 		output := s.configCommandOutput(c, appName, option)
-		c.Assert(output, gc.Equals, "")
+		c.Assert(output, gc.Equals, "\n")
 	}
 	// set value to be something so that we can check newline added
 	s.configCommandOutput(c, appName, "stremptydefault=a")
 	output := s.configCommandOutput(c, appName, "stremptydefault")
-	c.Assert(output, gc.Equals, "a")
+	c.Assert(output, gc.Equals, "a\n")
 }
 
 func (s *ApplicationConfigSuite) assertSameConfigOutput(c *gc.C, expectedValues settingsMap) {

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/juju/rpcreflect v0.0.0-20200416001309-bb46e9ba1476
 	github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989
 	github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae
-	github.com/juju/testing v0.0.0-20200608005635-e4eedbc6f7aa
+	github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd
 	github.com/juju/txn v0.0.0-20190416045819-5f348e78887d
 	github.com/juju/usso v0.0.0-20160401104424-68a59c96c178 // indirect
 	github.com/juju/utils v0.0.0-20200604140309-9d78121a29e0
@@ -107,7 +107,7 @@ require (
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
 	golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,8 @@ github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b h1:Rrp0ByJXEjhREMPGTt
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20200608005635-e4eedbc6f7aa h1:v1ZEHRVaUgTIkxzYaT78fJ+3bV3vjxj9jfNJcYzi9pY=
 github.com/juju/testing v0.0.0-20200608005635-e4eedbc6f7aa/go.mod h1:hpGvhGHPVbNBraRLZEhoQwFLMrjK8PSlO4D3nDjKYXo=
+github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd h1:4MRI5TGW0cRgovUipCGLF4uF+31Fo8VzkV2753OAfEE=
+github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd/go.mod h1:hpGvhGHPVbNBraRLZEhoQwFLMrjK8PSlO4D3nDjKYXo=
 github.com/juju/txn v0.0.0-20190416045819-5f348e78887d h1:8I8WXDHbmcN+HJP4y1O42f2eYuN8U3CeP/y3LVboZZI=
 github.com/juju/txn v0.0.0-20190416045819-5f348e78887d/go.mod h1:ZgVptALKKa9UUv7ItEJVQjFWNG/0bs+tAu0ad0O8DAE=
 github.com/juju/usso v0.0.0-20160401104424-68a59c96c178 h1:+Hw/cvdgko8DzBM+qI+HsEphk08NyNM0ONPFDg5cGis=
@@ -674,8 +676,8 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjut
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd h1:QPwSajcTUrFriMF1nJ3XzgoqakqQEsnZf9LdXdi2nkI=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
-golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -116,8 +116,12 @@ func (c *Client) FindFolder(ctx context.Context, folderPath string) (vmFolder *o
 		return dcfolders.VmFolder, nil
 	}
 
+	// We either have a folder that is a relative path or an absolute path.
+	// We'll accept an absolute path as is. Relative paths will use the DC vm folder as a parent.
 	folderPath = strings.TrimPrefix(folderPath, "./")
-	if !strings.HasPrefix(folderPath, dcfolders.VmFolder.InventoryPath) {
+	if strings.HasPrefix(folderPath, "/") {
+		c.logger.Debugf("using absolute folder path %q", folderPath)
+	} else if !strings.HasPrefix(folderPath, dcfolders.VmFolder.InventoryPath) {
 		c.logger.Debugf("relative folderPath %q found, join with DC vm folder %q now", folderPath, dcfolders.VmFolder.InventoryPath)
 		folderPath = path.Join(dcfolders.VmFolder.InventoryPath, folderPath)
 	}

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -660,6 +660,37 @@ func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 	})
 }
 
+func (s *clientSuite) TestFindFolder(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	folder, err := client.FindFolder(context.Background(), "foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(folder, gc.NotNil)
+	c.Assert(folder.InventoryPath, gc.Equals, "/dc0/vm/foo/bar")
+}
+
+func (s *clientSuite) TestFindFolderRelativePath(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	folder, err := client.FindFolder(context.Background(), "./foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(folder, gc.NotNil)
+	c.Assert(folder.InventoryPath, gc.Equals, "/dc0/vm/foo/bar")
+}
+
+func (s *clientSuite) TestFindFolderAbsolutePath(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.FindFolder(context.Background(), "/foo/bar")
+	// mock not set up to have a /foo/bar folder
+	c.Assert(err, gc.ErrorMatches, `folder path "/foo/bar" not found`)
+}
+
+func (s *clientSuite) TestFindFolderSubPath(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	folder, err := client.FindFolder(context.Background(), "/dc0/vm/foo/bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(folder, gc.NotNil)
+	c.Assert(folder.InventoryPath, gc.Equals, "/dc0/vm/foo/bar")
+}
+
 func (s *clientSuite) TestMoveVMFolderInto(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	err := client.MoveVMFolderInto(context.Background(), "foo", "foo/bar")

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -611,23 +611,3 @@ func baseCisp() types.OvfCreateImportSpecParams {
 func newBool(v bool) *bool {
 	return &v
 }
-
-func findStubCall(c *gc.C, calls []testing.StubCall, name string) testing.StubCall {
-	c.Logf("finding stub \"%s\"", name)
-	for i, call := range calls {
-		c.Logf("stub %d: %s(%v)", i, call.FuncName, call.Args)
-		if call.FuncName == name {
-			return call
-		}
-	}
-	c.Fatalf("failed to find call %q", name)
-	panic("unreachable")
-}
-
-func assertNoCall(c *gc.C, calls []testing.StubCall, name string) {
-	for _, call := range calls {
-		if call.FuncName == name {
-			c.Fatalf("found call %q", name)
-		}
-	}
-}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3905,8 +3905,8 @@ func (s *ApplicationSuite) TestUnitStatusesWithUnits(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 
 	check := jc.NewMultiChecker()
-	check.AddRegex(`\[.*\]\.Since`, jc.Ignore)
-	check.AddRegex(`\[.*\]\.Data`, jc.Ignore)
+	check.AddExpr(`_[_].Since`, jc.Ignore)
+	check.AddExpr(`_[_].Data`, jc.Ignore)
 	c.Assert(statuses, check, map[string]status.StatusInfo{
 		"mysql/0": {
 			Status: status.Maintenance,

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -72,10 +72,15 @@ func newLinkLayerDevice(st *State, doc linkLayerDeviceDoc) *LinkLayerDevice {
 	return &LinkLayerDevice{st: st, doc: doc}
 }
 
-// DocID returns the globally unique ID of the link-layer device, including the
-// model UUID as prefix.
+// DocID returns the globally unique ID of the link-layer device,
+// including the model UUID as prefix.
 func (dev *LinkLayerDevice) DocID() string {
 	return dev.st.docID(dev.doc.DocID)
+}
+
+// ID returns the unique ID of this device within the model.
+func (dev *LinkLayerDevice) ID() string {
+	return dev.st.localID(dev.doc.DocID)
 }
 
 // Name returns the name of the device, as it appears on the machine.
@@ -143,21 +148,19 @@ func (dev *LinkLayerDevice) VirtualPortType() network.VirtualPortType {
 	return dev.doc.VirtualPortType
 }
 
-// ParentID uses the rules for ParentName (above) to return the global ID of
-// this device's parent if it has one.
+// ParentID uses the rules for ParentName (above) to return
+// the ID of this device's parent if it has one.
 func (dev *LinkLayerDevice) ParentID() string {
 	parent := dev.doc.ParentName
 	if parent == "" {
 		return ""
 	}
 
-	prefix := dev.doc.ModelUUID + ":"
 	if strings.Contains(parent, "#") {
-		return prefix + parent
+		return parent
 	}
 
-	prefix = prefix + "m"
-	return strings.Join([]string{prefix, dev.doc.MachineID, "d", dev.doc.ParentName}, "#")
+	return strings.Join([]string{"m", dev.doc.MachineID, "d", dev.doc.ParentName}, "#")
 }
 
 // ParentDevice returns the LinkLayerDevice corresponding to the parent device
@@ -243,6 +246,32 @@ func (dev *LinkLayerDevice) RemoveOps() []txn.Op {
 	}
 
 	return ops
+}
+
+// UpdateOps returns the transaction operations required to update the device
+// so that it reflects the incoming arguments.
+// This method is intended for updating a device based on args gleaned from the
+// host/container directly. As such it does not update provider IDs.
+// There are separate methods for generating those operations.
+func (dev *LinkLayerDevice) UpdateOps(args LinkLayerDeviceArgs) []txn.Op {
+	newDoc := &linkLayerDeviceDoc{
+		DocID:           dev.doc.DocID,
+		Name:            args.Name,
+		ModelUUID:       dev.doc.ModelUUID,
+		MTU:             args.MTU,
+		MachineID:       dev.doc.MachineID,
+		Type:            args.Type,
+		MACAddress:      args.MACAddress,
+		IsAutoStart:     args.IsAutoStart,
+		IsUp:            args.IsUp,
+		ParentName:      args.ParentName,
+		VirtualPortType: args.VirtualPortType,
+	}
+
+	if op, hasUpdates := updateLinkLayerDeviceDocOp(&dev.doc, newDoc); hasUpdates {
+		return []txn.Op{op}
+	}
+	return nil
 }
 
 // Remove removes the device, if it exists. No error is returned when the device
@@ -340,9 +369,7 @@ func removeLinkLayerDeviceOps(st *State, linkLayerDeviceDocID, parentDeviceDocID
 
 	var ops []txn.Op
 	if parentDeviceDocID != "" {
-		localID, _ := st.strictLocalID(parentDeviceDocID)
-		ops = append(ops, decrementDeviceNumChildrenOp(localID))
-		//ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
+		ops = append(ops, decrementDeviceNumChildrenOp(parentDeviceDocID))
 	}
 
 	addressesQuery := findAddressesQuery(machineID, deviceName)
@@ -459,10 +486,6 @@ func (dev *LinkLayerDevice) String() string {
 	return fmt.Sprintf("%s device %q on machine %q", dev.doc.Type, dev.doc.Name, dev.doc.MachineID)
 }
 
-func (dev *LinkLayerDevice) globalKey() string {
-	return linkLayerDeviceGlobalKey(dev.doc.MachineID, dev.doc.Name)
-}
-
 func linkLayerDeviceGlobalKey(machineID, deviceName string) string {
 	if machineID == "" || deviceName == "" {
 		return ""
@@ -516,14 +539,16 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(name string) (LinkLayerDevic
 	if !dev.isBridge() {
 		return LinkLayerDeviceArgs{}, errors.Errorf("device must be a Bridge Device, receiver has type %q", dev.Type())
 	}
+
 	return LinkLayerDeviceArgs{
-		Name:        name,
-		Type:        network.EthernetDevice,
-		MACAddress:  network.GenerateVirtualMACAddress(),
-		MTU:         dev.MTU(),
-		IsUp:        true,
-		IsAutoStart: true,
-		ParentName:  dev.globalKey(),
+		Name:            name,
+		Type:            network.EthernetDevice,
+		MACAddress:      network.GenerateVirtualMACAddress(),
+		MTU:             dev.MTU(),
+		IsUp:            true,
+		IsAutoStart:     true,
+		ParentName:      dev.ID(),
+		VirtualPortType: dev.VirtualPortType(),
 	}, nil
 }
 

--- a/state/linklayerdevices_internal_test.go
+++ b/state/linklayerdevices_internal_test.go
@@ -73,18 +73,6 @@ func (s *linkLayerDevicesInternalSuite) TestLinkLayerDeviceGlobalKeyHelper(c *gc
 	c.Assert(result, gc.Equals, "")
 }
 
-func (s *linkLayerDevicesInternalSuite) TestGlobalKeyMethod(c *gc.C) {
-	doc := linkLayerDeviceDoc{
-		MachineID: "42",
-		Name:      "foo",
-	}
-	config := s.newLinkLayerDeviceWithDummyState(doc)
-	c.Check(config.globalKey(), gc.Equals, "m#42#d#foo")
-
-	config = s.newLinkLayerDeviceWithDummyState(linkLayerDeviceDoc{})
-	c.Check(config.globalKey(), gc.Equals, "")
-}
-
 func (s *linkLayerDevicesInternalSuite) TestParseLinkLayerParentNameAsGlobalKey(c *gc.C) {
 	for i, test := range []struct {
 		about              string

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -699,6 +699,30 @@ func (s *linkLayerDevicesStateSuite) TestRemoveOps(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *linkLayerDevicesStateSuite) TestUpdateOps(c *gc.C) {
+	dev := s.addNamedDevice(c, "eth0")
+
+	ops := dev.UpdateOps(state.LinkLayerDeviceArgs{
+		Name: "eth0",
+		Type: corenetwork.EthernetDevice,
+	})
+	c.Check(ops, gc.HasLen, 0)
+
+	mac := corenetwork.GenerateVirtualMACAddress()
+	ops = dev.UpdateOps(state.LinkLayerDeviceArgs{
+		Name:       "eth0",
+		Type:       corenetwork.EthernetDevice,
+		MACAddress: mac,
+	})
+	c.Assert(ops, gc.HasLen, 1)
+
+	state.RunTransaction(c, s.State, ops)
+
+	dev, err := s.machine.LinkLayerDevice("eth0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(dev.MACAddress(), gc.Equals, mac)
+}
+
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
 	s.createSpaceAndSubnetWithProviderID(c, spaceName, CIDR, "")
 }

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -162,7 +162,7 @@ while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
         export BOOTSTRAP_REUSE_LOCAL="${OPTARG}"
         export BOOTSTRAP_REUSE="true"
         CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
-        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}')
+        PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}' | head -n 1)
         export BOOTSTRAP_PROVIDER="${PROVIDER}"
         ;;
     p)

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -1,0 +1,45 @@
+run_model_config_isomorphic() {
+  echo
+
+  FILE=$(mktemp)
+
+  juju model-config --format=yaml | juju model-config --ignore-agent-version -
+}
+
+run_model_config_cloudinit_userdata() {
+  echo
+
+  FILE=$(mktemp)
+
+  cat << EOF > "${FILE}"
+cloudinit-userdata: |
+  packages:
+    - jq
+    - shellcheck
+EOF
+
+  juju model-config "${FILE}"
+  juju model-config cloudinit-userdata | grep -q "shellcheck"
+
+  # cloudinit-userdata is not present from the default tabluar output
+  ! juju model-config cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
+
+  # cloudinit-userdata is hidden in the normal output
+  juju model-config | grep -q "<value set, see juju model-config cloudinit-userdata>"
+}
+
+test_model_config() {
+  if [ "$(skip 'test_model_config')" ]; then
+    echo "==> TEST SKIPPED: model config"
+    return
+  fi
+
+  (
+    set_verbosity
+
+    cd .. || exit
+
+    run "run_model_config_isomorphic"
+    run "run_model_config_cloudinit_userdata"
+  )
+}

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -15,6 +15,7 @@ test_cli() {
 
     test_display_clouds
     test_local_charms
+    test_model_config
 
     destroy_controller "test-cli"
 }

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -57,7 +57,7 @@ func (s *ServerSession) RunHook(hookName, charmDir string, env []string, hookRun
 		return errors.Trace(err)
 	}
 	defer func() { _ = os.RemoveAll(debugDir) }()
-	help := buildRunHookCmd(hookName, hookRunner)
+	help := buildRunHookCmd(hookName, hookRunner, charmDir)
 	if err := s.writeDebugFiles(debugDir, help, hookRunner); err != nil {
 		return errors.Trace(err)
 	}
@@ -88,11 +88,15 @@ func (s *ServerSession) RunHook(hookName, charmDir string, env []string, hookRun
 	return cmd.Wait()
 }
 
-func buildRunHookCmd(hookName, hookRunner string) string {
+func buildRunHookCmd(hookName, hookRunner, charmDir string) string {
 	if hookName == filepath.Base(hookRunner) {
 		return "./$JUJU_DISPATCH_PATH"
 	}
-	return "./" + hookRunner
+	relPath, err := filepath.Rel(charmDir, hookRunner)
+	if err == nil {
+		return "./" + relPath
+	}
+	return hookRunner
 }
 
 func (s *ServerSession) writeDebugFiles(debugDir, help, hookRunner string) error {

--- a/worker/uniter/runner/debug/server_test.go
+++ b/worker/uniter/runner/debug/server_test.go
@@ -349,3 +349,46 @@ echo "$@" >&2
 `), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+// DebugSuite is for tests of methods/functions that don't need complex setup.
+type DebugSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&DebugSuite{})
+
+func checkBuildRunHookCommand(c *gc.C, expected, hookName, hookRunner, charmDir string) {
+	c.Check(expected, gc.Equals, buildRunHookCmd(hookName, hookRunner, charmDir))
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_legacy(c *gc.C) {
+	checkBuildRunHookCommand(c, "./$JUJU_DISPATCH_PATH", "install",
+		"hooks/install",
+		"/var/lib/juju")
+	checkBuildRunHookCommand(c, "./$JUJU_DISPATCH_PATH", "install",
+		"/var/lib/juju/charm/hooks/install",
+		"/var/lib/juju/charm")
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_dispatch_subdir(c *gc.C) {
+	checkBuildRunHookCommand(c, "./dispatch", "install",
+		"/var/lib/juju/charm/dispatch",
+		"/var/lib/juju/charm/")
+	checkBuildRunHookCommand(c, "./hooks/foo", "install",
+		"/var/lib/juju/charm/hooks/foo",
+		"/var/lib/juju/charm/")
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_dispatch_neigbor(c *gc.C) {
+	checkBuildRunHookCommand(c, "./../../not-charm/dispatch",
+		"install",
+		"/var/lib/juju/not-charm/dispatch",
+		"/var/lib/juju/charm/dispatch")
+}
+
+func (s *DebugSuite) Test_buildRunHookCmd_dispatch_relative(c *gc.C) {
+	checkBuildRunHookCommand(c, "./dispatch",
+		"install",
+		"./dispatch",
+		"/var/lib/juju/not-charm/dispatch")
+}


### PR DESCRIPTION
Merge from 2.8 to bring forward:
- #11807 from manadart/2.8-machiner-lld
- #11802 from hpidcock/update-testing-dep
- #11806 from wallyworld/dump-model-partial
- #11805 from jameinel/2.8-dispatch-relative-1885543
- #11796 from SimonRichardson/model-config-input
- #11804 from achilleasa/2.8-manual-provisioning-on-non-amd64-instances-backport
- #11800 from wallyworld/vsphere-absolute-vmfolder
- #11786 from SimonRichardson/juju-config-new-line