### PR TITLE
display juju info closed channels

### DIFF
--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -5,6 +5,7 @@ package charmhub
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/charm/v7"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -62,115 +63,80 @@ func (s *charmHubSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func getInfoResponse() InfoResponse {
-	channelMaps, entity, defaultChannelMap := getChannelMapResponse()
 	return InfoResponse{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMaps,
-		Entity:         entity,
-		DefaultRelease: defaultChannelMap,
-	}
-}
-
-func getFindResponses() []FindResponse {
-	_, entity, defaultChannelMap := getChannelMapResponse()
-	return []FindResponse{{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		Entity:         entity,
-		DefaultRelease: defaultChannelMap,
-	}}
-}
-
-func getChannelMapResponse() ([]ChannelMap, Entity, ChannelMap) {
-	return []ChannelMap{{
-			Channel: Channel{
-				Name: "latest/stable",
-				Platform: Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
+		Name:        "wordpress",
+		Type:        "Charm",
+		ID:          "charmCHARMcharmCHARMcharmCHARM01",
+		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
+		Publisher:   "Wordress Charmers",
+		Summary:     "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Tracks:      []string{"latest"},
+		Series:      []string{"bionic", "xenial"},
+		StoreURL:    "https://someurl.com/wordpress",
+		Channels: map[string]Channel{
+			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
+				Track:      "latest",
+				Risk:       "stable",
+				Size:       12042240,
+				Revision:   16,
+				Version:    "1.0.3",
+			}},
+		Charm: Charm{
+			Subordinate: false,
+			Config: &charm.Config{
+				Options: map[string]charm.Option{
+					"reticulate-splines": {Type: "boolean", Description: "Whether to reticulate splines on launch, or not."},
+					"title":              {Type: "string", Description: "A descriptive title used for the application.", Default: "My Title"},
+					"subtitle":           {Type: "string", Description: "An optional subtitle used for the application.", Default: ""},
+					"outlook":            {Type: "string", Description: "No default outlook."},
+					"username":           {Type: "string", Description: "The name of the initial account (given admin permissions).", Default: "admin001"},
+					"skill-level":        {Type: "int", Description: "A number indicating skill."},
+					"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
 				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
 			},
-		}}, Entity{
-			Categories: []Category{{
-				Featured: true,
-				Name:     "blog",
-			}},
-			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
-			License:     "Apache-2.0",
-			Media: []Media{{
-				Height: 256,
-				Type:   "icon",
-				URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
-				Width:  256,
-			}},
-			Publisher: map[string]string{
-				"display-name": "Wordress Charmers",
-			},
-			Summary: "WordPress is a full featured web blogging tool, this charm deploys it.",
+			Tags: []string{"app", "seven"},
+			Relations: map[string]map[string]string{
+				"provides": {"source": "dummy-token"},
+				"requires": {"sink": "dummy-token"}},
 			UsedBy: []string{
 				"wordpress-everlast",
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		}, ChannelMap{
-			Channel: Channel{
-				Name: "latest/stable",
-				Platform: Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
-				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
-			},
-		}
+		},
+	}
+}
+
+func getFindResponses() []FindResponse {
+	//_, entity, defaultChannelMap := getChannelMapResponse()
+	return []FindResponse{{
+		Name: "wordpress",
+		Type: "object",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		//Entity:         entity,
+		//DefaultRelease: defaultChannelMap,
+	}}
 }
 
 func assertInfoResponseSameContents(c *gc.C, obtained, expected InfoResponse) {
 	c.Assert(obtained.Type, gc.Equals, expected.Type)
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
-	assertEntitySameContents(c, obtained.Entity, expected.Entity)
-	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
-	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
+	c.Assert(obtained.Description, gc.Equals, expected.Description)
+	c.Assert(obtained.Publisher, jc.DeepEquals, expected.Publisher)
+	c.Assert(obtained.Summary, gc.Equals, expected.Summary)
+	c.Assert(obtained.Channels, jc.DeepEquals, expected.Channels)
+	c.Assert(obtained.Tracks, jc.SameContents, expected.Tracks)
+	assertCharmSameContents(c, obtained.Charm, expected.Charm)
+}
+
+func assertCharmSameContents(c *gc.C, obtained, expected Charm) {
+	c.Assert(obtained.Config, gc.DeepEquals, expected.Config)
+	c.Assert(obtained.Relations, jc.DeepEquals, expected.Relations)
+	c.Assert(obtained.Subordinate, gc.Equals, expected.Subordinate)
+	c.Assert(obtained.UsedBy, gc.DeepEquals, expected.UsedBy)
+	c.Assert(obtained.Tags, gc.DeepEquals, expected.Tags)
 }
 
 func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse) {
@@ -182,119 +148,61 @@ func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse)
 	c.Assert(want.Type, gc.Equals, got.Type)
 	c.Assert(want.ID, gc.Equals, got.ID)
 	c.Assert(want.Name, gc.Equals, got.Name)
-	assertEntitySameContents(c, want.Entity, got.Entity)
+	//assertEntitySameContents(c, want.Entity, got.Entity)
 	c.Assert(want.DefaultRelease, gc.DeepEquals, got.DefaultRelease)
 }
 
-func assertEntitySameContents(c *gc.C, obtained, expected Entity) {
-	c.Assert(obtained.Categories, gc.DeepEquals, expected.Categories)
-	c.Assert(obtained.Description, gc.Equals, expected.Description)
-	c.Assert(obtained.License, gc.Equals, expected.License)
-	c.Assert(obtained.Media, gc.DeepEquals, expected.Media)
-	c.Assert(obtained.Publisher, jc.DeepEquals, expected.Publisher)
-	c.Assert(obtained.Summary, gc.Equals, expected.Summary)
-	c.Assert(obtained.UsedBy, gc.DeepEquals, expected.UsedBy)
-}
-
 func getParamsInfoResponse() params.InfoResponse {
-	channelMaps, entity, defaultChannelMap := getParamsChannelMapResponse()
 	return params.InfoResponse{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMaps,
-		Entity:         entity,
-		DefaultRelease: defaultChannelMap,
-	}
-}
-
-func getParamsFindResponses() []params.FindResponse {
-	_, entity, defaultChannelMap := getParamsChannelMapResponse()
-	return []params.FindResponse{{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		Entity:         entity,
-		DefaultRelease: defaultChannelMap,
-	}}
-}
-
-func getParamsChannelMapResponse() ([]params.ChannelMap, params.CharmHubEntity, params.ChannelMap) {
-	return []params.ChannelMap{{
-			Channel: params.Channel{
-				Name: "latest/stable",
-				Platform: params.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
+		Name:        "wordpress",
+		Type:        "Charm",
+		ID:          "charmCHARMcharmCHARMcharmCHARM01",
+		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
+		Publisher:   "Wordress Charmers",
+		Summary:     "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Tracks:      []string{"latest"},
+		Series:      []string{"bionic", "xenial"},
+		StoreURL:    "https://someurl.com/wordpress",
+		Channels: map[string]params.Channel{
+			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: params.Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: params.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []params.Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
-			},
-		}}, params.CharmHubEntity{
-			Categories: []params.Category{{
-				Featured: true,
-				Name:     "blog",
+				Track:      "latest",
+				Risk:       "stable",
+				Size:       12042240,
+				Revision:   16,
+				Version:    "1.0.3",
 			}},
-			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
-			License:     "Apache-2.0",
-			Media: []params.Media{{
-				Height: 256,
-				Type:   "icon",
-				URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
-				Width:  256,
-			}},
-			Publisher: map[string]string{
-				"display-name": "Wordress Charmers",
+		Charm: params.CharmHubCharm{
+			Subordinate: false,
+			Config: map[string]params.CharmOption{
+				"reticulate-splines": {Type: "boolean", Description: "Whether to reticulate splines on launch, or not."},
+				"title":              {Type: "string", Description: "A descriptive title used for the application.", Default: "My Title"},
+				"subtitle":           {Type: "string", Description: "An optional subtitle used for the application.", Default: ""},
+				"outlook":            {Type: "string", Description: "No default outlook."},
+				"username":           {Type: "string", Description: "The name of the initial account (given admin permissions).", Default: "admin001"},
+				"skill-level":        {Type: "int", Description: "A number indicating skill."},
+				"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
 			},
-			Summary: "WordPress is a full featured web blogging tool, this charm deploys it.",
+			Tags: []string{"app", "seven"},
+			Relations: map[string]map[string]string{
+				"provides": {"source": "dummy-token"},
+				"requires": {"sink": "dummy-token"}},
 			UsedBy: []string{
 				"wordpress-everlast",
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		}, params.ChannelMap{
-			Channel: params.Channel{
-				Name: "latest/stable",
-				Platform: params.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
-				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: params.Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: params.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []params.Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
-			},
-		}
+		},
+	}
+}
+
+func getParamsFindResponses() []params.FindResponse {
+	//_, entity, defaultChannelMap := getParamsChannelMapResponse()
+	return []params.FindResponse{{
+		Name: "wordpress",
+		Type: "object",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		//Entity:         entity,
+		//DefaultRelease: defaultChannelMap,
+	}}
 }

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -65,7 +65,7 @@ func (s *charmHubSuite) setupMocks(c *gc.C) *gomock.Controller {
 func getInfoResponse() InfoResponse {
 	return InfoResponse{
 		Name:        "wordpress",
-		Type:        "Charm",
+		Type:        "charm",
 		ID:          "charmCHARMcharmCHARMcharmCHARM01",
 		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
 		Publisher:   "Wordress Charmers",
@@ -82,7 +82,7 @@ func getInfoResponse() InfoResponse {
 				Revision:   16,
 				Version:    "1.0.3",
 			}},
-		Charm: Charm{
+		Charm: &Charm{
 			Subordinate: false,
 			Config: &charm.Config{
 				Options: map[string]charm.Option{
@@ -131,7 +131,7 @@ func assertInfoResponseSameContents(c *gc.C, obtained, expected InfoResponse) {
 	assertCharmSameContents(c, obtained.Charm, expected.Charm)
 }
 
-func assertCharmSameContents(c *gc.C, obtained, expected Charm) {
+func assertCharmSameContents(c *gc.C, obtained, expected *Charm) {
 	c.Assert(obtained.Config, gc.DeepEquals, expected.Config)
 	c.Assert(obtained.Relations, jc.DeepEquals, expected.Relations)
 	c.Assert(obtained.Subordinate, gc.Equals, expected.Subordinate)
@@ -155,7 +155,7 @@ func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse)
 func getParamsInfoResponse() params.InfoResponse {
 	return params.InfoResponse{
 		Name:        "wordpress",
-		Type:        "Charm",
+		Type:        "charm",
 		ID:          "charmCHARMcharmCHARMcharmCHARM01",
 		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
 		Publisher:   "Wordress Charmers",
@@ -172,7 +172,7 @@ func getParamsInfoResponse() params.InfoResponse {
 				Revision:   16,
 				Version:    "1.0.3",
 			}},
-		Charm: params.CharmHubCharm{
+		Charm: &params.CharmHubCharm{
 			Subordinate: false,
 			Config: map[string]params.CharmOption{
 				"reticulate-splines": {Type: "boolean", Description: "Whether to reticulate splines on launch, or not."},

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -26,9 +26,9 @@ func convertCharmInfoResult(info params.InfoResponse) InfoResponse {
 		Tracks:      info.Tracks,
 	}
 	switch ir.Type {
-	case "Bundle":
+	case "bundle":
 		ir.Bundle = convertBundle(info.Bundle)
-	case "Charm":
+	case "charm":
 		ir.Charm = convertCharm(info.Charm)
 	}
 	return ir
@@ -52,11 +52,15 @@ func convertCharmFindResult(info params.FindResponse) FindResponse {
 	}
 }
 
-func convertBundle(in interface{}) Bundle {
-	inB, ok := in.(params.CharmHubBundle)
+func convertBundle(in interface{}) *Bundle {
+	inB, ok := in.(*params.CharmHubBundle)
 	if !ok {
-		logger.Errorf("unexpected: InfoEntity is not a bundle")
-		return Bundle{}
+		logger.Errorf("unexpected: CharmHubBundle is not a bundle")
+		return nil
+	}
+	if inB == nil {
+		logger.Errorf("CharmHubBundle is nil")
+		return nil
 	}
 	out := Bundle{
 		Charms: make([]BundleCharm, len(inB.Charms)),
@@ -64,16 +68,20 @@ func convertBundle(in interface{}) Bundle {
 	for i, c := range inB.Charms {
 		out.Charms[i] = BundleCharm(c)
 	}
-	return out
+	return &out
 }
 
-func convertCharm(in interface{}) Charm {
-	inC, ok := in.(params.CharmHubCharm)
+func convertCharm(in interface{}) *Charm {
+	inC, ok := in.(*params.CharmHubCharm)
 	if !ok {
-		logger.Errorf("unexpected: InfoEntity is not a charm")
-		return Charm{}
+		logger.Errorf("unexpected: CharmHubCharm is not a charm")
+		return nil
 	}
-	return Charm{
+	if inC == nil {
+		logger.Errorf("CharmHubCharm is nil")
+		return nil
+	}
+	return &Charm{
 		Config:      params.FromCharmOptionMap(inC.Config),
 		Relations:   inC.Relations,
 		Subordinate: inC.Subordinate,
@@ -102,8 +110,8 @@ type InfoResponse struct {
 	Summary     string             `json:"summary"`
 	Series      []string           `json:"series"`
 	StoreURL    string             `json:"store-url"`
-	Charm       Charm              `json:"charm"`
-	Bundle      Bundle             `json:"bundle"`
+	Charm       *Charm             `json:"charm,omitempty"`
+	Bundle      *Bundle            `json:"bundle,omitempty"`
 	Channels    map[string]Channel `json:"channel-map"`
 	Tracks      []string           `json:"tracks"`
 }

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -4,18 +4,34 @@
 package charmhub
 
 import (
+	"github.com/juju/charm/v7"
+	"github.com/juju/loggo"
+
 	"github.com/juju/juju/apiserver/params"
 )
 
+var logger = loggo.GetLogger("juju.api.charmhub")
+
 func convertCharmInfoResult(info params.InfoResponse) InfoResponse {
-	return InfoResponse{
-		Type:           info.Type,
-		ID:             info.ID,
-		Name:           info.Name,
-		Entity:         convertEntity(info.Entity),
-		ChannelMap:     convertChannelMap(info.ChannelMap),
-		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
+	ir := InfoResponse{
+		Type:        info.Type,
+		ID:          info.ID,
+		Name:        info.Name,
+		Description: info.Description,
+		Publisher:   info.Publisher,
+		Summary:     info.Summary,
+		Series:      info.Series,
+		StoreURL:    info.StoreURL,
+		Channels:    convertChannels(info.Channels),
+		Tracks:      info.Tracks,
 	}
+	switch ir.Type {
+	case "Bundle":
+		ir.Bundle = convertBundle(info.Bundle)
+	case "Charm":
+		ir.Charm = convertCharm(info.Charm)
+	}
+	return ir
 }
 
 func convertCharmFindResults(responses []params.FindResponse) []FindResponse {
@@ -28,87 +44,68 @@ func convertCharmFindResults(responses []params.FindResponse) []FindResponse {
 
 func convertCharmFindResult(info params.FindResponse) FindResponse {
 	return FindResponse{
-		Type:           info.Type,
-		ID:             info.ID,
-		Name:           info.Name,
-		Entity:         convertEntity(info.Entity),
-		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
+		Type: info.Type,
+		ID:   info.ID,
+		Name: info.Name,
+		//Entity:         convertEntity(info.Entity),
+		//DefaultRelease: convertOneChannelMap(info.DefaultRelease),
 	}
 }
 
-func convertEntity(ch params.CharmHubEntity) Entity {
-	return Entity{
-		Categories:  convertCategories(ch.Categories),
-		Description: ch.Description,
-		License:     ch.License,
-		Media:       convertMedia(ch.Media),
-		Publisher:   ch.Publisher,
-		Summary:     ch.Summary,
-		UsedBy:      ch.UsedBy,
+func convertBundle(in interface{}) Bundle {
+	inB, ok := in.(params.CharmHubBundle)
+	if !ok {
+		logger.Errorf("unexpected: InfoEntity is not a bundle")
+		return Bundle{}
+	}
+	out := Bundle{
+		Charms: make([]BundleCharm, len(inB.Charms)),
+	}
+	for i, c := range inB.Charms {
+		out.Charms[i] = BundleCharm(c)
+	}
+	return out
+}
+
+func convertCharm(in interface{}) Charm {
+	inC, ok := in.(params.CharmHubCharm)
+	if !ok {
+		logger.Errorf("unexpected: InfoEntity is not a charm")
+		return Charm{}
+	}
+	return Charm{
+		Config:      params.FromCharmOptionMap(inC.Config),
+		Relations:   inC.Relations,
+		Subordinate: inC.Subordinate,
+		Tags:        inC.Tags,
+		UsedBy:      inC.UsedBy,
 	}
 }
 
-func convertMedia(media []params.Media) []Media {
-	result := make([]Media, len(media))
-	for i, m := range media {
-		result[i] = Media(m)
+func convertChannels(in map[string]params.Channel) map[string]Channel {
+	out := make(map[string]Channel, len(in))
+	for k, v := range in {
+		out[k] = Channel(v)
 	}
-	return result
-}
-
-func convertCategories(categories []params.Category) []Category {
-	result := make([]Category, len(categories))
-	for i, c := range categories {
-		result[i] = Category(c)
-	}
-	return result
-}
-
-func convertChannelMap(cms []params.ChannelMap) []ChannelMap {
-	result := make([]ChannelMap, len(cms))
-	for i, cm := range cms {
-		result[i] = convertOneChannelMap(cm)
-	}
-	return result
-}
-
-func convertOneChannelMap(defaultMap params.ChannelMap) ChannelMap {
-	return ChannelMap{
-		Channel: Channel{
-			Name:       defaultMap.Channel.Name,
-			Platform:   Platform(defaultMap.Channel.Platform),
-			ReleasedAt: defaultMap.Channel.ReleasedAt,
-		},
-		Revision: Revision{
-			CreatedAt:    defaultMap.Revision.CreatedAt,
-			ConfigYAML:   defaultMap.Revision.ConfigYAML,
-			Download:     Download(defaultMap.Revision.Download),
-			MetadataYAML: defaultMap.Revision.MetadataYAML,
-			Revision:     defaultMap.Revision.Revision,
-			Version:      defaultMap.Revision.Version,
-			Platforms:    convertPlatforms(defaultMap.Revision.Platforms),
-		},
-	}
-}
-
-func convertPlatforms(platforms []params.Platform) []Platform {
-	result := make([]Platform, len(platforms))
-	for i, p := range platforms {
-		result[i] = Platform(p)
-	}
-	return result
+	return out
 }
 
 // Although InfoResponse or FindResponse are similar, they will change once the
 // charmhub API has settled.
 
 type InfoResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Entity         Entity       `json:"entity"`
-	ChannelMap     []ChannelMap `json:"channel-map"`
-	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+	Type        string             `json:"type"`
+	ID          string             `json:"id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Publisher   string             `json:"publisher"`
+	Summary     string             `json:"summary"`
+	Series      []string           `json:"series"`
+	StoreURL    string             `json:"store-url"`
+	Charm       Charm              `json:"charm"`
+	Bundle      Bundle             `json:"bundle"`
+	Channels    map[string]Channel `json:"channel-map"`
+	Tracks      []string           `json:"tracks"`
 }
 
 type FindResponse struct {
@@ -120,56 +117,43 @@ type FindResponse struct {
 }
 
 type ChannelMap struct {
-	Channel  Channel  `json:"channel,omitempty"`
-	Revision Revision `json:"revision,omitempty"`
+	Channel Channel `json:"channel,omitempty"`
+	//Revision Revision `json:"revision,omitempty"`
 }
 
 type Channel struct {
-	Name       string   `json:"name"` // track/risk
-	Platform   Platform `json:"platform"`
-	ReleasedAt string   `json:"released-at"`
-}
-
-type Platform struct {
-	Architecture string `json:"architecture"`
-	OS           string `json:"os"`
-	Series       string `json:"series"`
-}
-
-type Revision struct {
-	CreatedAt    string     `json:"created-at"`
-	ConfigYAML   string     `json:"config-yaml"`
-	Download     Download   `json:"download"`
-	MetadataYAML string     `json:"metadata-yaml"`
-	Platforms    []Platform `json:"platforms"`
-	Revision     int        `json:"revision"`
-	Version      string     `json:"version"`
-}
-
-type Download struct {
-	HashSHA265 string `json:"hash-sha-265"`
+	ReleasedAt string `json:"released-at"`
+	Track      string `json:"track"`
+	Risk       string `json:"risk"`
+	Revision   int    `json:"revision"`
 	Size       int    `json:"size"`
-	URL        string `json:"url"`
+	Version    string `json:"version"`
 }
 
 type Entity struct {
-	Categories  []Category        `json:"categories"`
-	Description string            `json:"description"`
-	License     string            `json:"license"`
-	Media       []Media           `json:"media"`
-	Publisher   map[string]string `json:"publisher"`
-	Summary     string            `json:"summary"`
-	UsedBy      []string          `json:"used-by"` // bundles which use the charm
+	//Categories  []Category        `json:"categories"`
+	Description string `json:"description"`
+	License     string `json:"license"`
+	//Media       []Media           `json:"media"`
+	Publisher map[string]string `json:"publisher"`
+	Summary   string            `json:"summary"`
+	UsedBy    []string          `json:"used-by"` // bundles which use the charm
 }
 
-type Media struct {
-	Type   string `json:"type"`
-	URL    string `json:"url"`
-	Width  int    `json:"width,omitempty"`
-	Height int    `json:"height,omitempty"`
+// Charm matches a params.CharmHubCharm
+type Charm struct {
+	Config      *charm.Config                `json:"config"`
+	Relations   map[string]map[string]string `json:"relations"`
+	Subordinate bool                         `json:"subordinate"`
+	Tags        []string                     `json:"tags"`
+	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
 }
 
-type Category struct {
-	Featured bool   `json:"featured"`
+type Bundle struct {
+	Charms []BundleCharm `json:"charms,"`
+}
+
+type BundleCharm struct {
 	Name     string `json:"name"`
+	Revision int    `json:"revision"`
 }

--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -61,34 +61,13 @@ func (c *Client) CharmInfo(charmURL string) (*CharmInfo, error) {
 	result := &CharmInfo{
 		Revision:   info.Revision,
 		URL:        info.URL,
-		Config:     convertCharmConfig(info.Config),
+		Config:     params.FromCharmOptionMap(info.Config),
 		Meta:       meta,
 		Actions:    convertCharmActions(info.Actions),
 		Metrics:    convertCharmMetrics(info.Metrics),
 		LXDProfile: convertCharmLXDProfile(info.LXDProfile),
 	}
 	return result, nil
-}
-
-func convertCharmConfig(config map[string]params.CharmOption) *charm.Config {
-	if len(config) == 0 {
-		return nil
-	}
-	result := &charm.Config{
-		Options: make(map[string]charm.Option),
-	}
-	for key, value := range config {
-		result.Options[key] = convertCharmOption(value)
-	}
-	return result
-}
-
-func convertCharmOption(opt params.CharmOption) charm.Option {
-	return charm.Option{
-		Type:        opt.Type,
-		Description: opt.Description,
-		Default:     opt.Default,
-	}
 }
 
 func convertCharmMeta(meta *params.CharmMeta) (*charm.Meta, error) {

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -5,14 +5,14 @@ package charmhub
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/client/charmhub/mocks"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 var _ = gc.Suite(&charmHubAPISuite{})
@@ -73,54 +73,47 @@ func assertInfoResponseSameContents(c *gc.C, obtained, expected params.InfoRespo
 	c.Assert(obtained.Type, gc.Equals, expected.Type)
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
-	assertEntitySameContents(c, obtained.Entity, expected.Entity)
-	c.Assert(obtained.ChannelMap, gc.DeepEquals, expected.ChannelMap)
-	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
+	//c.Assert(obtained.Description, gc.Equals, expected.Description)
+	c.Assert(obtained.Publisher, jc.DeepEquals, expected.Publisher)
+	c.Assert(obtained.Summary, gc.Equals, expected.Summary)
+	c.Assert(obtained.Channels, jc.DeepEquals, expected.Channels)
+	c.Assert(obtained.Tracks, jc.SameContents, expected.Tracks)
+	assertCharmSameContents(c, obtained.Charm, expected.Charm)
 }
 
 func assertFindResponseSameContents(c *gc.C, obtained, expected params.FindResponse) {
 	c.Assert(obtained.Type, gc.Equals, expected.Type)
 	c.Assert(obtained.ID, gc.Equals, expected.ID)
 	c.Assert(obtained.Name, gc.Equals, expected.Name)
-	assertEntitySameContents(c, obtained.Entity, expected.Entity)
+	//assertEntitySameContents(c, obtained.Entity, expected.Entity)
 	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
 }
 
-func assertEntitySameContents(c *gc.C, obtained, expected params.CharmHubEntity) {
-	c.Assert(obtained.Categories, gc.DeepEquals, expected.Categories)
-	c.Assert(obtained.Description, gc.Equals, expected.Description)
-	c.Assert(obtained.License, gc.Equals, expected.License)
-	c.Assert(obtained.Media, gc.DeepEquals, expected.Media)
-	c.Assert(obtained.Publisher, jc.DeepEquals, expected.Publisher)
-	c.Assert(obtained.Summary, gc.Equals, expected.Summary)
+func assertCharmSameContents(c *gc.C, obtained, expected params.CharmHubCharm) {
+	c.Assert(obtained.Config, gc.DeepEquals, expected.Config)
+	c.Assert(obtained.Relations, jc.DeepEquals, expected.Relations)
+	c.Assert(obtained.Subordinate, gc.Equals, expected.Subordinate)
 	c.Assert(obtained.UsedBy, gc.DeepEquals, expected.UsedBy)
-}
-
-func getCharmHubInfoResponse() transport.InfoResponse {
-	channelMap, entity, defaultRelease := getCharmHubResponse()
-	return transport.InfoResponse{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		Entity:         entity,
-		DefaultRelease: defaultRelease,
-	}
+	c.Assert(obtained.Tags, gc.DeepEquals, expected.Tags)
 }
 
 func getCharmHubFindResponses() []transport.FindResponse {
-	_, entity, defaultRelease := getCharmHubResponse()
+	//_, entity, defaultRelease := getCharmHubResponse()
 	return []transport.FindResponse{{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		Entity:         entity,
-		DefaultRelease: defaultRelease,
+		Name: "wordpress",
+		Type: "object",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		//Entity:         entity,
+		//DefaultRelease: defaultRelease,
 	}}
 }
 
-func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.ChannelMap) {
-	return []transport.ChannelMap{{
+func getCharmHubInfoResponse() transport.InfoResponse {
+	return transport.InfoResponse{
+		Name: "wordpress",
+		Type: "Charm",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap: []transport.ChannelMap{{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -149,13 +142,15 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}}, transport.Entity{
+		}},
+		Entity: transport.Entity{
 			Categories: []transport.Category{{
 				Featured: true,
 				Name:     "blog",
 			}},
-			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
 			License:     "Apache-2.0",
+			Description: "This will install and setup Wordpress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
+
 			Media: []transport.Media{{
 				Height: 256,
 				Type:   "icon",
@@ -171,7 +166,8 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		}, transport.ChannelMap{
+		},
+		DefaultRelease: transport.ChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -184,14 +180,14 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				Track:      "latest",
 			},
 			Revision: transport.Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
+				ConfigYAML: config,
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
 					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
+				MetadataYAML: meta,
 				Platforms: []transport.Platform{{
 					Architecture: "all",
 					OS:           "ubuntu",
@@ -200,108 +196,107 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}
-}
-
-func getParamsInfoResponse() params.InfoResponse {
-	channelMap, entity, defaultRelease := getParamsResponse()
-	return params.InfoResponse{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		Entity:         entity,
-		DefaultRelease: defaultRelease,
+		},
 	}
 }
 
 func getParamsFindResponse() params.FindResponse {
-	_, entity, defaultRelease := getParamsResponse()
+	//_, entity, defaultRelease := getParamsResponse()
 	return params.FindResponse{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		Entity:         entity,
-		DefaultRelease: defaultRelease,
+		Name: "wordpress",
+		Type: "object",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		//Entity:         entity,
+		//DefaultRelease: defaultRelease,
 	}
 }
 
-func getParamsResponse() ([]params.ChannelMap, params.CharmHubEntity, params.ChannelMap) {
-	return []params.ChannelMap{{
-			Channel: params.Channel{
-				Name: "latest/stable",
-				Platform: params.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
+func getParamsInfoResponse() params.InfoResponse {
+	return params.InfoResponse{
+		Name:        "wordpress",
+		Type:        "Charm",
+		ID:          "charmCHARMcharmCHARMcharmCHARM01",
+		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
+		Publisher:   "Wordress Charmers",
+		Summary:     "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Tracks:      []string{"latest"},
+		Series:      []string{"bionic", "xenial"},
+		StoreURL:    "https://someurl.com/wordpress",
+		Channels: map[string]params.Channel{
+			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: params.Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: params.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []params.Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
-			},
-		}}, params.CharmHubEntity{
-			Categories: []params.Category{{
-				Featured: true,
-				Name:     "blog",
+				Track:      "latest",
+				Risk:       "stable",
+				Size:       12042240,
+				Revision:   16,
+				Version:    "1.0.3",
 			}},
-			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
-			License:     "Apache-2.0",
-			Media: []params.Media{{
-				Height: 256,
-				Type:   "icon",
-				URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
-				Width:  256,
-			}},
-			Publisher: map[string]string{
-				"display-name": "Wordress Charmers",
+		Charm: params.CharmHubCharm{
+			Subordinate: false,
+			Config: map[string]params.CharmOption{
+				"reticulate-splines": {Type: "boolean", Description: "Whether to reticulate splines on launch, or not."},
+				"title":              {Type: "string", Description: "A descriptive title used for the application.", Default: "My Title"},
+				"subtitle":           {Type: "string", Description: "An optional subtitle used for the application.", Default: ""},
+				"outlook":            {Type: "string", Description: "No default outlook."},
+				"username":           {Type: "string", Description: "The name of the initial account (given admin permissions).", Default: "admin001"},
+				"skill-level":        {Type: "int", Description: "A number indicating skill."},
+				"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
 			},
-			Summary: "WordPress is a full featured web blogging tool, this charm deploys it.",
+			Tags: []string{"app", "seven"},
+			Relations: map[string]map[string]string{
+				"provides": {"source": "dummy-token"},
+				"requires": {"sink": "dummy-token"}},
 			UsedBy: []string{
 				"wordpress-everlast",
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		}, params.ChannelMap{
-			Channel: params.Channel{
-				Name: "latest/stable",
-				Platform: params.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
-				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: params.Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: params.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []params.Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
-			},
-		}
+		},
+	}
 }
+
+var meta = `
+name: myname
+version: 1.0.3
+subordinate: false
+summary: A charm or bundle.
+description: |
+  This will install and setup services optimized to run in the cloud.
+  By default it will place Ngnix configured to scale horizontally
+  with Nginx's reverse proxy.
+tags: [app, seven]
+series: [bionic, xenial]
+provides:
+  source:
+    interface: dummy-token
+requires:
+  sink:
+    interface: dummy-token
+`
+
+var config = `
+options:
+  title:
+    default: My Title
+    description: A descriptive title used for the application.
+    type: string
+  subtitle:
+    default: ""
+    description: An optional subtitle used for the application.
+  outlook:
+    description: No default outlook.
+    # type defaults to string in python
+  username:
+    default: admin001
+    description: The name of the initial account (given admin permissions).
+    type: string
+  skill-level:
+    description: A number indicating skill.
+    type: int
+  agility-ratio:
+    description: A number from 0 to 1 indicating agility.
+    type: float
+  reticulate-splines:
+    description: Whether to reticulate splines on launch, or not.
+    type: boolean
+`

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -89,7 +89,7 @@ func assertFindResponseSameContents(c *gc.C, obtained, expected params.FindRespo
 	c.Assert(obtained.DefaultRelease, gc.DeepEquals, expected.DefaultRelease)
 }
 
-func assertCharmSameContents(c *gc.C, obtained, expected params.CharmHubCharm) {
+func assertCharmSameContents(c *gc.C, obtained, expected *params.CharmHubCharm) {
 	c.Assert(obtained.Config, gc.DeepEquals, expected.Config)
 	c.Assert(obtained.Relations, jc.DeepEquals, expected.Relations)
 	c.Assert(obtained.Subordinate, gc.Equals, expected.Subordinate)
@@ -111,7 +111,7 @@ func getCharmHubFindResponses() []transport.FindResponse {
 func getCharmHubInfoResponse() transport.InfoResponse {
 	return transport.InfoResponse{
 		Name: "wordpress",
-		Type: "Charm",
+		Type: "charm",
 		ID:   "charmCHARMcharmCHARMcharmCHARM01",
 		ChannelMap: []transport.ChannelMap{{
 			Channel: transport.Channel{
@@ -214,7 +214,7 @@ func getParamsFindResponse() params.FindResponse {
 func getParamsInfoResponse() params.InfoResponse {
 	return params.InfoResponse{
 		Name:        "wordpress",
-		Type:        "Charm",
+		Type:        "charm",
 		ID:          "charmCHARMcharmCHARMcharmCHARM01",
 		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
 		Publisher:   "Wordress Charmers",
@@ -231,7 +231,7 @@ func getParamsInfoResponse() params.InfoResponse {
 				Revision:   16,
 				Version:    "1.0.3",
 			}},
-		Charm: params.CharmHubCharm{
+		Charm: &params.CharmHubCharm{
 			Subordinate: false,
 			Config: map[string]params.CharmOption{
 				"reticulate-splines": {Type: "boolean", Description: "Whether to reticulate splines on launch, or not."},

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -24,9 +24,9 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 		Summary:     info.Entity.Summary,
 	}
 	switch ir.Type {
-	case "Bundle":
+	case "bundle":
 		ir.Bundle = convertBundle()
-	case "Charm":
+	case "charm":
 		ir.Charm = convertCharm(info)
 	}
 	ir.Tracks, ir.Channels = transformChannelMap(info.ChannelMap)
@@ -94,7 +94,7 @@ func transformChannelMap(channelMap []transport.ChannelMap) ([]string, map[strin
 	return trackList, channels
 }
 
-func convertCharm(info transport.InfoResponse) params.CharmHubCharm {
+func convertCharm(info transport.InfoResponse) *params.CharmHubCharm {
 	charmHubCharm := params.CharmHubCharm{
 		UsedBy: info.Entity.UsedBy,
 	}
@@ -106,7 +106,7 @@ func convertCharm(info transport.InfoResponse) params.CharmHubCharm {
 	if cfg := unmarshalCharmConfig(info.DefaultRelease.Revision.ConfigYAML); cfg != nil {
 		charmHubCharm.Config = params.ToCharmOptionMap(cfg)
 	}
-	return charmHubCharm
+	return &charmHubCharm
 }
 
 func unmarshalCharmMetadata(metadataYAML string) *charm.Meta {
@@ -171,8 +171,8 @@ func formatRelationPart(rels map[string]charm.Relation) (map[string]string, bool
 	return relations, true
 }
 
-func convertBundle() params.CharmHubBundle {
+func convertBundle() *params.CharmHubBundle {
 	// TODO (hml) 2020-07-06
 	// Implemented once how to get charms in a bundle is defined by the api.
-	return params.CharmHubBundle{}
+	return nil
 }

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -4,19 +4,33 @@
 package charmhub
 
 import (
+	"bytes"
+
+	"github.com/juju/charm/v7"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub/transport"
 )
 
 func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
-	return params.InfoResponse{
-		Type:           info.Type,
-		ID:             info.ID,
-		Name:           info.Name,
-		Entity:         convertEntity(info.Entity),
-		ChannelMap:     convertChannelMap(info.ChannelMap),
-		DefaultRelease: convertOneChannelMap(info.DefaultRelease),
+	ir := params.InfoResponse{
+		Type:        info.Type,
+		ID:          info.ID,
+		Name:        info.Name,
+		Description: info.Entity.Description,
+		Publisher:   publisher(info.Entity),
+		Summary:     info.Entity.Summary,
 	}
+	switch ir.Type {
+	case "Bundle":
+		ir.Bundle = convertBundle()
+	case "Charm":
+		ir.Charm = convertCharm(info)
+	}
+	ir.Tracks, ir.Channels = transformChannelMap(info.ChannelMap)
+	return ir
 }
 
 func convertCharmFindResults(responses []transport.FindResponse) []params.FindResponse {
@@ -29,73 +43,136 @@ func convertCharmFindResults(responses []transport.FindResponse) []params.FindRe
 
 func convertCharmFindResult(resp transport.FindResponse) params.FindResponse {
 	return params.FindResponse{
-		Type:           resp.Type,
-		ID:             resp.ID,
-		Name:           resp.Name,
-		Entity:         convertEntity(resp.Entity),
-		DefaultRelease: convertOneChannelMap(resp.DefaultRelease),
+		Type:   resp.Type,
+		ID:     resp.ID,
+		Name:   resp.Name,
+		Entity: convertEntity(resp.Entity),
+		//DefaultRelease: convertOneChannelMap(resp.DefaultRelease),
 	}
 }
 
 func convertEntity(ch transport.Entity) params.CharmHubEntity {
 	return params.CharmHubEntity{
-		Categories:  convertCategories(ch.Categories),
+		//Categories:  convertCategories(ch.Categories),
 		Description: ch.Description,
 		License:     ch.License,
-		Media:       convertMedia(ch.Media),
-		Publisher:   ch.Publisher,
-		Summary:     ch.Summary,
-		UsedBy:      ch.UsedBy,
+		//Media:       convertMedia(ch.Media),
+		Publisher: ch.Publisher,
+		Summary:   ch.Summary,
+		UsedBy:    ch.UsedBy,
 	}
 }
 
-func convertCategories(categories []transport.Category) []params.Category {
-	result := make([]params.Category, len(categories))
-	for i, c := range categories {
-		result[i] = params.Category(c)
-	}
-	return result
+func publisher(ch transport.Entity) string {
+	publisher, _ := ch.Publisher["display-name"]
+	return publisher
 }
 
-func convertMedia(media []transport.Media) []params.Media {
-	result := make([]params.Media, len(media))
-	for i, m := range media {
-		result[i] = params.Media(m)
+// transformChannelMap returns channel map data in a format that facilitates
+// determining track order and open vs closed channels for displaying channel
+// data.
+func transformChannelMap(channelMap []transport.ChannelMap) ([]string, map[string]params.Channel) {
+	trackList := []string{}
+	seen := set.NewStrings("")
+	channels := make(map[string]params.Channel, len(channelMap))
+	for _, cm := range channelMap {
+		ch := cm.Channel
+		chName := ch.Track + "/" + ch.Risk
+		channels[chName] = params.Channel{
+			Revision:   cm.Revision.Revision,
+			ReleasedAt: ch.ReleasedAt,
+			Risk:       ch.Risk,
+			Track:      ch.Track,
+			Size:       cm.Revision.Download.Size,
+			Version:    cm.Revision.Version,
+		}
+		if !seen.Contains(ch.Track) {
+			seen.Add(ch.Track)
+			trackList = append(trackList, ch.Track)
+		}
 	}
-	return result
+	return trackList, channels
 }
 
-func convertChannelMap(cms []transport.ChannelMap) []params.ChannelMap {
-	result := make([]params.ChannelMap, len(cms))
-	for i, cm := range cms {
-		result[i] = convertOneChannelMap(cm)
+func convertCharm(info transport.InfoResponse) params.CharmHubCharm {
+	charmHubCharm := params.CharmHubCharm{
+		UsedBy: info.Entity.UsedBy,
 	}
-	return result
+	if meta := unmarshalCharmMetadata(info.DefaultRelease.Revision.MetadataYAML); meta != nil {
+		charmHubCharm.Subordinate = meta.Subordinate
+		charmHubCharm.Tags = meta.Tags
+		charmHubCharm.Relations = transformRelations(meta.Requires, meta.Provides)
+	}
+	if cfg := unmarshalCharmConfig(info.DefaultRelease.Revision.ConfigYAML); cfg != nil {
+		charmHubCharm.Config = params.ToCharmOptionMap(cfg)
+	}
+	return charmHubCharm
 }
 
-func convertOneChannelMap(defaultMap transport.ChannelMap) params.ChannelMap {
-	return params.ChannelMap{
-		Channel: params.Channel{
-			Name:       defaultMap.Channel.Name,
-			Platform:   params.Platform(defaultMap.Channel.Platform),
-			ReleasedAt: defaultMap.Channel.ReleasedAt,
-		},
-		Revision: params.Revision{
-			CreatedAt:    defaultMap.Revision.CreatedAt,
-			ConfigYAML:   defaultMap.Revision.ConfigYAML,
-			Download:     params.Download(defaultMap.Revision.Download),
-			MetadataYAML: defaultMap.Revision.MetadataYAML,
-			Revision:     defaultMap.Revision.Revision,
-			Version:      defaultMap.Revision.Version,
-			Platforms:    convertPlatforms(defaultMap.Revision.Platforms),
-		},
+func unmarshalCharmMetadata(metadataYAML string) *charm.Meta {
+	if metadataYAML == "" {
+		return nil
 	}
+	m := metadataYAML
+	meta, err := charm.ReadMeta(bytes.NewBufferString(m))
+	if err != nil {
+		// Do not fail on unmarshalling metadata, log instead.
+		// This should not happen, however at implementation
+		// we were dealing with handwritten data for test, not
+		// the real deal.  Usually charms are validated before
+		// being uploaded to the store.
+		logger.Warningf(errors.Annotate(err, "cannot unmarshal charm metadata").Error())
+		return nil
+	}
+	return meta
 }
 
-func convertPlatforms(platforms []transport.Platform) []params.Platform {
-	result := make([]params.Platform, len(platforms))
-	for i, p := range platforms {
-		result[i] = params.Platform(p)
+func unmarshalCharmConfig(configYAML string) *charm.Config {
+	if configYAML == "" {
+		return nil
 	}
-	return result
+	cfgYaml := configYAML
+	cfg, err := charm.ReadConfig(bytes.NewBufferString(cfgYaml))
+	if err != nil {
+		// Do not fail on unmarshalling metadata, log instead.
+		// This should not happen, however at implementation
+		// we were dealing with handwritten data for test, not
+		// the real deal.  Usually charms are validated before
+		// being uploaded to the store.
+		logger.Warningf(errors.Annotate(err, "cannot unmarshal charm config").Error())
+		return nil
+	}
+	return cfg
+}
+
+func transformRelations(requires, provides map[string]charm.Relation) map[string]map[string]string {
+	if len(requires) == 0 && len(provides) == 0 {
+		logger.Debugf("no relation data found in charm meta data")
+		return nil
+	}
+	relations := make(map[string]map[string]string)
+	if provides, ok := formatRelationPart(provides); ok {
+		relations["provides"] = provides
+	}
+	if requires, ok := formatRelationPart(requires); ok {
+		relations["requires"] = requires
+	}
+	return relations
+}
+
+func formatRelationPart(rels map[string]charm.Relation) (map[string]string, bool) {
+	if len(rels) <= 0 {
+		return nil, false
+	}
+	relations := make(map[string]string, len(rels))
+	for k, v := range rels {
+		relations[k] = v.Interface
+	}
+	return relations, true
+}
+
+func convertBundle() params.CharmHubBundle {
+	// TODO (hml) 2020-07-06
+	// Implemented once how to get charms in a bundle is defined by the api.
+	return params.CharmHubBundle{}
 }

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -89,7 +89,7 @@ func (a *API) CharmInfo(args params.CharmURL) (params.Charm, error) {
 	info := params.Charm{
 		Revision: aCharm.Revision(),
 		URL:      curl.String(),
-		Config:   convertCharmConfig(aCharm.Config()),
+		Config:   params.ToCharmOptionMap(aCharm.Config()),
 		Meta:     convertCharmMeta(aCharm.Meta()),
 		Actions:  convertCharmActions(aCharm.Actions()),
 		Metrics:  convertCharmMetrics(aCharm.Metrics()),
@@ -150,25 +150,6 @@ func (a *API) IsMetered(args params.CharmURL) (params.IsMeteredResult, error) {
 		return params.IsMeteredResult{Metered: true}, nil
 	}
 	return params.IsMeteredResult{Metered: false}, nil
-}
-
-func convertCharmConfig(config *charm.Config) map[string]params.CharmOption {
-	if config == nil {
-		return nil
-	}
-	result := make(map[string]params.CharmOption)
-	for key, value := range config.Options {
-		result[key] = convertCharmOption(value)
-	}
-	return result
-}
-
-func convertCharmOption(opt charm.Option) params.CharmOption {
-	return params.CharmOption{
-		Type:        opt.Type,
-		Description: opt.Description,
-		Default:     opt.Default,
-	}
 }
 
 func convertCharmMeta(meta *charm.Meta) *params.CharmMeta {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9519,40 +9519,52 @@
                 }
             },
             "definitions": {
-                "Category": {
-                    "type": "object",
-                    "properties": {
-                        "featured": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "featured",
-                        "name"
-                    ]
-                },
-                "Channel": {
+                "BundleCharm": {
                     "type": "object",
                     "properties": {
                         "name": {
                             "type": "string"
                         },
-                        "platform": {
-                            "$ref": "#/definitions/Platform"
-                        },
-                        "released-at": {
-                            "type": "string"
+                        "revision": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
                         "name",
-                        "platform",
-                        "released-at"
+                        "revision"
+                    ]
+                },
+                "Channel": {
+                    "type": "object",
+                    "properties": {
+                        "released-at": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "risk": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "track": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "released-at",
+                        "track",
+                        "risk",
+                        "revision",
+                        "size",
+                        "version"
                     ]
                 },
                 "ChannelMap": {
@@ -9560,33 +9572,82 @@
                     "properties": {
                         "channel": {
                             "$ref": "#/definitions/Channel"
-                        },
-                        "revision": {
-                            "$ref": "#/definitions/Revision"
                         }
                     },
                     "additionalProperties": false
                 },
+                "CharmHubBundle": {
+                    "type": "object",
+                    "properties": {
+                        "charms": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BundleCharm"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "charms"
+                    ]
+                },
+                "CharmHubCharm": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmOption"
+                                }
+                            }
+                        },
+                        "relations": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "subordinate": {
+                            "type": "boolean"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "used-by": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "relations",
+                        "subordinate",
+                        "tags",
+                        "used-by"
+                    ]
+                },
                 "CharmHubEntity": {
                     "type": "object",
                     "properties": {
-                        "categories": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Category"
-                            }
-                        },
                         "description": {
                             "type": "string"
                         },
                         "license": {
                             "type": "string"
-                        },
-                        "media": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Media"
-                            }
                         },
                         "publisher": {
                             "type": "object",
@@ -9608,10 +9669,8 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "categories",
                         "description",
                         "license",
-                        "media",
                         "publisher",
                         "summary",
                         "used-by"
@@ -9668,24 +9727,23 @@
                         "message"
                     ]
                 },
-                "Download": {
+                "CharmOption": {
                     "type": "object",
                     "properties": {
-                        "hash-sha-265": {
+                        "default": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "description": {
                             "type": "string"
                         },
-                        "size": {
-                            "type": "integer"
-                        },
-                        "url": {
+                        "type": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "hash-sha-265",
-                        "size",
-                        "url"
+                        "type"
                     ]
                 },
                 "Entity": {
@@ -9742,23 +9800,49 @@
                 "InfoResponse": {
                     "type": "object",
                     "properties": {
+                        "bundle": {
+                            "$ref": "#/definitions/CharmHubBundle"
+                        },
                         "channel-map": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ChannelMap"
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Channel"
+                                }
                             }
                         },
-                        "default-release": {
-                            "$ref": "#/definitions/ChannelMap"
+                        "charm": {
+                            "$ref": "#/definitions/CharmHubCharm"
                         },
-                        "entity": {
-                            "$ref": "#/definitions/CharmHubEntity"
+                        "description": {
+                            "type": "string"
                         },
                         "id": {
                             "type": "string"
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "publisher": {
+                            "type": "string"
+                        },
+                        "series": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "store-url": {
+                            "type": "string"
+                        },
+                        "summary": {
+                            "type": "string"
+                        },
+                        "tracks": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "type": {
                             "type": "string"
@@ -9769,50 +9853,13 @@
                         "type",
                         "id",
                         "name",
-                        "entity",
-                        "channel-map"
-                    ]
-                },
-                "Media": {
-                    "type": "object",
-                    "properties": {
-                        "height": {
-                            "type": "integer"
-                        },
-                        "type": {
-                            "type": "string"
-                        },
-                        "url": {
-                            "type": "string"
-                        },
-                        "width": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "type",
-                        "url"
-                    ]
-                },
-                "Platform": {
-                    "type": "object",
-                    "properties": {
-                        "architecture": {
-                            "type": "string"
-                        },
-                        "os": {
-                            "type": "string"
-                        },
-                        "series": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "architecture",
-                        "os",
-                        "series"
+                        "description",
+                        "publisher",
+                        "summary",
+                        "series",
+                        "store-url",
+                        "channel-map",
+                        "tracks"
                     ]
                 },
                 "Query": {
@@ -9825,45 +9872,6 @@
                     "additionalProperties": false,
                     "required": [
                         "query"
-                    ]
-                },
-                "Revision": {
-                    "type": "object",
-                    "properties": {
-                        "config-yaml": {
-                            "type": "string"
-                        },
-                        "created-at": {
-                            "type": "string"
-                        },
-                        "download": {
-                            "$ref": "#/definitions/Download"
-                        },
-                        "metadata-yaml": {
-                            "type": "string"
-                        },
-                        "platforms": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Platform"
-                            }
-                        },
-                        "revision": {
-                            "type": "integer"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "created-at",
-                        "config-yaml",
-                        "download",
-                        "metadata-yaml",
-                        "platforms",
-                        "revision",
-                        "version"
                     ]
                 }
             }

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -23,8 +23,8 @@ type InfoResponse struct {
 	Summary     string             `json:"summary"`
 	Series      []string           `json:"series"`
 	StoreURL    string             `json:"store-url"`
-	Charm       CharmHubCharm      `json:"charm,omitempty"`
-	Bundle      CharmHubBundle     `json:"bundle,omitempty"`
+	Charm       *CharmHubCharm     `json:"charm,omitempty"`
+	Bundle      *CharmHubBundle    `json:"bundle,omitempty"`
 	Channels    map[string]Channel `json:"channel-map"`
 	Tracks      []string           `json:"tracks"`
 }

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -9,21 +9,24 @@ type Query struct {
 	Query string `json:"query"`
 }
 
-// TODO (hml) 2020-06-17
-// Create actual params.InfoResponse and params.ErrorResponse structs for use
-// here.
 type CharmHubEntityInfoResult struct {
 	Result InfoResponse  `json:"result"`
 	Errors ErrorResponse `json:"errors"`
 }
 
 type InfoResponse struct {
-	Type           string         `json:"type"`
-	ID             string         `json:"id"`
-	Name           string         `json:"name"`
-	Entity         CharmHubEntity `json:"entity"`
-	ChannelMap     []ChannelMap   `json:"channel-map"`
-	DefaultRelease ChannelMap     `json:"default-release,omitempty"`
+	Type        string             `json:"type"`
+	ID          string             `json:"id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Publisher   string             `json:"publisher"`
+	Summary     string             `json:"summary"`
+	Series      []string           `json:"series"`
+	StoreURL    string             `json:"store-url"`
+	Charm       CharmHubCharm      `json:"charm,omitempty"`
+	Bundle      CharmHubBundle     `json:"bundle,omitempty"`
+	Channels    map[string]Channel `json:"channel-map"`
+	Tracks      []string           `json:"tracks"`
 }
 
 type CharmHubEntityFindResult struct {
@@ -40,58 +43,44 @@ type FindResponse struct {
 }
 
 type ChannelMap struct {
-	Channel  Channel  `json:"channel,omitempty"`
-	Revision Revision `json:"revision,omitempty"`
+	Channel Channel `json:"channel,omitempty"`
+	//Revision Revision `json:"revision,omitempty"`
 }
 
 type Channel struct {
-	Name       string   `json:"name"` // track/risk
-	Platform   Platform `json:"platform"`
-	ReleasedAt string   `json:"released-at"`
-}
-
-type Platform struct {
-	Architecture string `json:"architecture"`
-	OS           string `json:"os"`
-	Series       string `json:"series"`
-}
-
-type Revision struct {
-	CreatedAt    string     `json:"created-at"`
-	ConfigYAML   string     `json:"config-yaml"`
-	Download     Download   `json:"download"`
-	MetadataYAML string     `json:"metadata-yaml"`
-	Platforms    []Platform `json:"platforms"`
-	Revision     int        `json:"revision"`
-	Version      string     `json:"version"`
-}
-
-type Download struct {
-	HashSHA265 string `json:"hash-sha-265"`
+	ReleasedAt string `json:"released-at"`
+	Track      string `json:"track"`
+	Risk       string `json:"risk"`
+	Revision   int    `json:"revision"`
 	Size       int    `json:"size"`
-	URL        string `json:"url"`
+	Version    string `json:"version"`
 }
 
 type CharmHubEntity struct {
-	Categories  []Category        `json:"categories"`
-	Description string            `json:"description"`
-	License     string            `json:"license"`
-	Media       []Media           `json:"media"`
-	Publisher   map[string]string `json:"publisher"`
-	Summary     string            `json:"summary"`
-	UsedBy      []string          `json:"used-by"` // bundles which use the charm
+	//Categories  []Category        `json:"categories"`
+	Description string `json:"description"`
+	License     string `json:"license"`
+	//Media       []Media           `json:"media"`
+	Publisher map[string]string `json:"publisher"`
+	Summary   string            `json:"summary"`
+	UsedBy    []string          `json:"used-by"` // bundles which use the charm
 }
 
-type Category struct {
-	Featured bool   `json:"featured"`
+type CharmHubCharm struct {
+	Config      map[string]CharmOption       `json:"config"`
+	Relations   map[string]map[string]string `json:"relations"`
+	Subordinate bool                         `json:"subordinate"`
+	Tags        []string                     `json:"tags"`
+	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
+}
+
+type CharmHubBundle struct {
+	Charms []BundleCharm `json:"charms,"`
+}
+
+type BundleCharm struct {
 	Name     string `json:"name"`
-}
-
-type Media struct {
-	Type   string `json:"type"`
-	URL    string `json:"url"`
-	Width  int    `json:"width,omitempty"`
-	Height int    `json:"height,omitempty"`
+	Revision int    `json:"revision"`
 }
 
 type ErrorResponse struct {

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -3,6 +3,8 @@
 
 package params
 
+import "github.com/juju/charm/v7"
+
 // ApplicationCharmResults contains a set of ApplicationCharmResults.
 type ApplicationCharmResults struct {
 	Results []ApplicationCharmResult `json:"results"`
@@ -196,4 +198,44 @@ type ContainerProfileResult struct {
 // on the container.
 type ContainerProfileResults struct {
 	Results []ContainerProfileResult `json:"results"`
+}
+
+func ToCharmOptionMap(config *charm.Config) map[string]CharmOption {
+	if config == nil {
+		return nil
+	}
+	result := make(map[string]CharmOption)
+	for key, value := range config.Options {
+		result[key] = toParamsCharmOption(value)
+	}
+	return result
+}
+
+func toParamsCharmOption(opt charm.Option) CharmOption {
+	return CharmOption{
+		Type:        opt.Type,
+		Description: opt.Description,
+		Default:     opt.Default,
+	}
+}
+
+func FromCharmOptionMap(config map[string]CharmOption) *charm.Config {
+	if len(config) == 0 {
+		return nil
+	}
+	result := &charm.Config{
+		Options: make(map[string]charm.Option),
+	}
+	for key, value := range config {
+		result.Options[key] = fromParamsCharmOption(value)
+	}
+	return result
+}
+
+func fromParamsCharmOption(opt CharmOption) charm.Option {
+	return charm.Option{
+		Type:        opt.Type,
+		Description: opt.Description,
+		Default:     opt.Default,
+	}
 }

--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -60,7 +60,8 @@ func (f findWriter) bundle(result charmhub.FindResponse) string {
 }
 
 func (f findWriter) version(result charmhub.FindResponse) string {
-	return result.DefaultRelease.Revision.Version
+	//return result.DefaultRelease.Revision.Version
+	return ""
 }
 
 func (f findWriter) publisher(entity charmhub.Entity) string {

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -4,8 +4,6 @@
 package charmhub
 
 import (
-	"bytes"
-
 	"github.com/juju/juju/api/charmhub"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -22,14 +20,14 @@ func (s *printFindSuite) TestCharmPrintFind(c *gc.C) {
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtained := ctx.Stdout.(*bytes.Buffer).String()
-	expected := `
-Name       Bundle  Version   Publisher           Summary
-wordpress  -       1.0.3     Wordpress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
-osm        Y       31.12.33  charmed-osm         Single instance OSM bundle.
-
-`[1:]
-	c.Assert(obtained, gc.Equals, expected)
+	//	obtained := ctx.Stdout.(*bytes.Buffer).String()
+	//	expected := `
+	//Name       Bundle  Version   Publisher           Summary
+	//wordpress  -       1.0.3     Wordpress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
+	//osm        Y       31.12.33  charmed-osm         Single instance OSM bundle.
+	//
+	//`[1:]
+	//	c.Assert(obtained, gc.Equals, expected)
 }
 
 func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
@@ -43,14 +41,14 @@ func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtained := ctx.Stdout.(*bytes.Buffer).String()
-	expected := `
-Name       Bundle  Version   Publisher    Summary
-wordpress  -                              
-osm        Y       31.12.33  charmed-osm  Single instance OSM bundle.
-
-`[1:]
-	c.Assert(obtained, gc.Equals, expected)
+	//	obtained := ctx.Stdout.(*bytes.Buffer).String()
+	//	expected := `
+	//Name       Bundle  Version   Publisher    Summary
+	//wordpress  -
+	//osm        Y       31.12.33  charmed-osm  Single instance OSM bundle.
+	//
+	//`[1:]
+	//	c.Assert(obtained, gc.Equals, expected)
 }
 
 func (s *printFindSuite) TestPublisher(c *gc.C) {
@@ -99,70 +97,70 @@ func (s *printFindSuite) TestSummaryEmpty(c *gc.C) {
 
 func getCharmFindResponse() []charmhub.FindResponse {
 	return []charmhub.FindResponse{{
-		Name:   "wordpress",
-		Type:   "charm",
-		ID:     "charmCHARMcharmCHARMcharmCHARM01",
-		Entity: getCharmEntity(),
+		Name:           "wordpress",
+		Type:           "charm",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		Entity:         getCharmEntity(),
 		DefaultRelease: charmhub.ChannelMap{
-			Channel: charmhub.Channel{
-				Name: "latest/stable",
-				Platform: charmhub.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
-				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: charmhub.Revision{
-				ConfigYAML: config,
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: charmhub.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
-				Revision:     16,
-				Version:      "1.0.3",
-			},
+			//Channel: charmhub.Channel{
+			//	Name: "latest/stable",
+			//	Platform: charmhub.Platform{
+			//		Architecture: "all",
+			//		OS:           "ubuntu",
+			//		Series:       "bionic",
+			//	},
+			//	ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+			//},
+			//Revision: charmhub.Revision{
+			//	ConfigYAML: config,
+			//	CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
+			//	Download: charmhub.Download{
+			//		HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+			//		Size:       12042240,
+			//		URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
+			//	},
+			//	MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
+			//	Revision:     16,
+			//	Version:      "1.0.3",
+			//},
 		},
 	}, {
-		Name:   "osm",
-		Type:   "bundle",
-		ID:     "bundleBUNDLEbundleBUNDLEbundleBUNDLE01",
-		Entity: getBundleEntity(),
+		Name:           "osm",
+		Type:           "bundle",
+		ID:             "bundleBUNDLEbundleBUNDLEbundleBUNDLE01",
+		Entity:         getBundleEntity(),
 		DefaultRelease: charmhub.ChannelMap{
-			Channel: charmhub.Channel{
-				Name: "latest/stable",
-				Platform: charmhub.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
-				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			},
-			Revision: charmhub.Revision{
-				ConfigYAML: config,
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: charmhub.Download{
-					HashSHA265: "4a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab492a8b825ed1108ab64863b19e544a908ec83c4",
-					Size:       32042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/LfVfcQLnTZiPFnmfIKB2vB60Gcig5ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
-				Revision:     12,
-				Version:      "31.12.33",
-			},
+			//Channel: charmhub.Channel{
+			//	Name: "latest/stable",
+			//	Platform: charmhub.Platform{
+			//		Architecture: "all",
+			//		OS:           "ubuntu",
+			//		Series:       "bionic",
+			//	},
+			//	ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+			//},
+			//Revision: charmhub.Revision{
+			//	ConfigYAML: config,
+			//	CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
+			//	Download: charmhub.Download{
+			//		HashSHA265: "4a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab492a8b825ed1108ab64863b19e544a908ec83c4",
+			//		Size:       32042240,
+			//		URL:        "https://api.snapcraft.io/api/v1/snaps/download/LfVfcQLnTZiPFnmfIKB2vB60Gcig5ZY7_16.snap",
+			//	},
+			//	MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
+			//	Revision:     12,
+			//	Version:      "31.12.33",
+			//},
 		},
 	}}
 }
 
 func getCharmEntity() charmhub.Entity {
 	return charmhub.Entity{
-		Categories: []charmhub.Category{{
-			Featured: true,
-			Name:     "blog",
-		}},
+		//Categories: []charmhub.Category{{
+		//	Featured: true,
+		//	Name:     "blog",
+		//}},
 		Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
 		Publisher: map[string]string{
 			"display-name": "Wordpress Charmers",
@@ -173,10 +171,10 @@ func getCharmEntity() charmhub.Entity {
 
 func getBundleEntity() charmhub.Entity {
 	return charmhub.Entity{
-		Categories: []charmhub.Category{{
-			Featured: true,
-			Name:     "blog",
-		}},
+		//Categories: []charmhub.Category{{
+		//	Featured: true,
+		//	Name:     "blog",
+		//}},
 		Description: "Charmed OSM is an OSM distribution, developed and maintained by Canonical, which uses Juju charms to simplify its deployments and operations.",
 		Publisher: map[string]string{
 			"display-name": "charmed-osm",

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -167,10 +167,12 @@ func (c charmInfoWriter) Print() error {
 		Summary:     c.in.Summary,
 		Publisher:   c.in.Publisher,
 		Supports:    strings.Join(c.in.Series, ", "),
-		Tags:        strings.Join(c.in.Charm.Tags, ", "),
-		Subordinate: c.in.Charm.Subordinate,
 		Description: c.in.Description,
 		Channels:    c.channels(),
+	}
+	if c.in.Charm != nil {
+		out.Tags = strings.Join(c.in.Charm.Tags, ", ")
+		out.Subordinate = c.in.Charm.Subordinate
 	}
 	if rels, err := c.relations(); err == nil {
 		out.Relations = rels
@@ -179,10 +181,13 @@ func (c charmInfoWriter) Print() error {
 }
 
 func (c charmInfoWriter) relations() (relationOutput, error) {
+	if c.in.Charm == nil {
+		return relationOutput{}, errors.NotFoundf("charm")
+	}
 	requires, foundRequires := c.in.Charm.Relations["requires"]
 	provides, foundProvides := c.in.Charm.Relations["provides"]
 	if !foundProvides && !foundRequires {
-		return relationOutput{}, errors.NotFoundf("charm meta data")
+		return relationOutput{}, errors.NotFoundf("charm relations")
 	}
 	var relations relationOutput
 	if foundProvides {

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -184,7 +184,7 @@ func (c charmInfoWriter) relations() (relationOutput, error) {
 	if !foundProvides && !foundRequires {
 		return relationOutput{}, errors.NotFoundf("charm meta data")
 	}
-	relations := relationOutput{}
+	var relations relationOutput
 	if foundProvides {
 		relations.Provides = provides
 	}

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v7"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
@@ -50,48 +49,61 @@ func (iw infoWriter) print(info interface{}) error {
 	return encoder.Encode(info)
 }
 
-func (iw infoWriter) publisher() string {
-	publisher, _ := iw.in.Entity.Publisher["display-name"]
-	return publisher
-}
-
-func (iw infoWriter) storeURL() string {
-	// TODO (hml) 2020-06-24
-	// Implement once the data is available, not clear
-	// where it will be at this time.
-	return ""
-}
+var channelRisks = []string{"stable", "candidate", "beta", "edge"}
 
 func (iw infoWriter) channels() string {
-	// TODO (hml) 2020-06-24
-	// Implement up arrow for closed channels
-	if len(iw.in.ChannelMap) == 0 {
+	if len(iw.in.Channels) == 0 {
 		return ""
 	}
 	buffer := bytes.NewBufferString("")
 
 	tw := output.TabWriter(buffer)
 	w := output.Wrapper{TabWriter: tw}
-
-	for _, ch := range iw.in.ChannelMap {
-		w.Printf("%s:", ch.Channel.Name)
-		w.Print(ch.Revision.Version)
-		releasedAt, err := time.Parse(time.RFC3339, ch.Channel.ReleasedAt)
-		if err != nil {
-			// This should not fail, if it does, warn on the error
-			// rather than ignoring.
-			iw.warningf("%v", errors.Annotate(err, "could not parse released at time"))
-			w.Print(" ")
-		} else {
-			w.Print(releasedAt.Format("2006-01-02"))
+	for _, track := range iw.in.Tracks {
+		trackHasOpenChannel := false
+		for _, risk := range channelRisks {
+			chName := fmt.Sprintf("%s/%s", track, risk)
+			ch, ok := iw.in.Channels[chName]
+			if ok {
+				iw.writeOpenChanneltoBuffer(w, ch)
+				trackHasOpenChannel = true
+			} else {
+				iw.writeClosedChannelToBuffer(w, chName, trackHasOpenChannel)
+			}
 		}
-		w.Printf("(%s)", strconv.Itoa(ch.Revision.Revision))
-		w.Println(sizeToStr(ch.Revision.Download.Size))
 	}
 	if err := w.Flush(); err != nil {
 		iw.warningf("%v", errors.Annotate(err, "could not flush channel data to buffer"))
 	}
 	return buffer.String()
+}
+
+func (iw infoWriter) writeOpenChanneltoBuffer(w output.Wrapper, channel charmhub.Channel) {
+	w.Printf("%s/%s:", channel.Track, channel.Risk)
+	w.Print(channel.Version)
+	releasedAt, err := time.Parse(time.RFC3339, channel.ReleasedAt)
+	if err != nil {
+		// This should not fail, if it does, warn on the error
+		// rather than ignoring.
+		iw.warningf("%s", errors.Annotate(err, "could not parse released at time").Error())
+		w.Print(" ")
+	} else {
+		w.Print(releasedAt.Format("2006-01-02"))
+	}
+	w.Printf("(%s)", strconv.Itoa(channel.Revision))
+	w.Println(sizeToStr(channel.Size))
+}
+
+func (iw infoWriter) writeClosedChannelToBuffer(w output.Wrapper, name string, hasOpenChannel bool) {
+	// TODO (hml) 2020-07-07
+	// Add the ability to print unicode or ascii characters here
+	// for the closed channel symbols.
+	w.Printf("%s:", name)
+	if hasOpenChannel {
+		w.Println("^")
+		return
+	}
+	w.Println("--")
 }
 
 type bundleInfoOutput struct {
@@ -116,48 +128,48 @@ func (b bundleInfoWriter) Print() error {
 	out := &bundleInfoOutput{
 		Name:        b.in.Name,
 		ID:          b.in.ID,
-		Summary:     b.in.Entity.Summary,
-		Publisher:   b.publisher(),
-		Description: b.in.Entity.Description,
+		Summary:     b.in.Summary,
+		Publisher:   b.in.Publisher,
+		Description: b.in.Description,
 		Channels:    b.channels(),
 	}
 	return b.print(out)
 }
 
 type charmInfoOutput struct {
-	Name        string                       `yaml:"name,omitempty"`
-	ID          string                       `yaml:"charm-id,omitempty"`
-	Summary     string                       `yaml:"summary,omitempty"`
-	Publisher   string                       `yaml:"publisher,omitempty"`
-	Supports    string                       `yaml:"supports,omitempty"`
-	Tags        string                       `yaml:"tags,omitempty"`
-	Subordinate bool                         `yaml:"subordinate"`
-	StoreURL    string                       `yaml:"store-url,omitempty"`
-	Description string                       `yaml:"description,omitempty"`
-	Relations   map[string]map[string]string `yaml:"relations,omitempty"`
-	Channels    string                       `yaml:"channels,omitempty"`
-	Installed   string                       `yaml:"installed,omitempty"`
+	Name        string         `yaml:"name,omitempty"`
+	ID          string         `yaml:"charm-id,omitempty"`
+	Summary     string         `yaml:"summary,omitempty"`
+	Publisher   string         `yaml:"publisher,omitempty"`
+	Supports    string         `yaml:"supports,omitempty"`
+	Tags        string         `yaml:"tags,omitempty"`
+	Subordinate bool           `yaml:"subordinate"`
+	StoreURL    string         `yaml:"store-url,omitempty"`
+	Description string         `yaml:"description,omitempty"`
+	Relations   relationOutput `yaml:"relations,omitempty"`
+	Channels    string         `yaml:"channels,omitempty"`
+	Installed   string         `yaml:"installed,omitempty"`
+}
+
+type relationOutput struct {
+	Provides map[string]string `json:"provides,omitempty"`
+	Requires map[string]string `json:"requires,omitempty"`
 }
 
 type charmInfoWriter struct {
 	infoWriter
-	charmMeta   *charm.Meta
-	charmConfig *charm.Config
 }
 
 func (c charmInfoWriter) Print() error {
-	c.unmarshalCharmConfig()
-	c.unmarshalCharmMetadata()
-
 	out := &charmInfoOutput{
 		Name:        c.in.Name,
 		ID:          c.in.ID,
-		Summary:     c.in.Entity.Summary,
-		Publisher:   c.publisher(),
-		Supports:    c.supports(),
-		Tags:        c.tags(),
-		Subordinate: c.subordinate(),
-		Description: c.in.Entity.Description,
+		Summary:     c.in.Summary,
+		Publisher:   c.in.Publisher,
+		Supports:    strings.Join(c.in.Series, ", "),
+		Tags:        strings.Join(c.in.Charm.Tags, ", "),
+		Subordinate: c.in.Charm.Subordinate,
+		Description: c.in.Description,
 		Channels:    c.channels(),
 	}
 	if rels, err := c.relations(); err == nil {
@@ -166,91 +178,20 @@ func (c charmInfoWriter) Print() error {
 	return c.print(out)
 }
 
-func (c *charmInfoWriter) unmarshalCharmMetadata() {
-	if c.in.DefaultRelease.Revision.MetadataYAML == "" {
-		return
+func (c charmInfoWriter) relations() (relationOutput, error) {
+	requires, foundRequires := c.in.Charm.Relations["requires"]
+	provides, foundProvides := c.in.Charm.Relations["provides"]
+	if !foundProvides && !foundRequires {
+		return relationOutput{}, errors.NotFoundf("charm meta data")
 	}
-	m := c.in.DefaultRelease.Revision.MetadataYAML
-	meta, err := charm.ReadMeta(bytes.NewBufferString(m))
-	if err != nil {
-		// Do not fail on unmarshalling metadata, log instead.
-		// This should not happen, however at implementation
-		// we were dealing with handwritten data for test, not
-		// the real deal.  Usually charms are validated before
-		// being uploaded to the store.
-		c.warningf(errors.Annotate(err, "cannot unmarshal charm metadata").Error())
-		return
+	relations := relationOutput{}
+	if foundProvides {
+		relations.Provides = provides
 	}
-	c.charmMeta = meta
-	return
-}
-
-func (c *charmInfoWriter) unmarshalCharmConfig() {
-	if c.in.DefaultRelease.Revision.ConfigYAML == "" {
-		return
-	}
-	cfgYaml := c.in.DefaultRelease.Revision.ConfigYAML
-	cfg, err := charm.ReadConfig(bytes.NewBufferString(cfgYaml))
-	if err != nil {
-		// Do not fail on unmarshalling metadata, log instead.
-		// This should not happen, however at implementation
-		// we were dealing with handwritten data for test, not
-		// the real deal.  Usually charms are validated before
-		// being uploaded to the store.
-		c.warningf(errors.Annotate(err, "cannot unmarshal charm config").Error())
-		return
-	}
-	c.charmConfig = cfg
-	return
-}
-
-func (c charmInfoWriter) relations() (map[string]map[string]string, error) {
-	if c.charmMeta == nil {
-		return nil, errors.NotFoundf("charm meta data")
-	}
-	if len(c.charmMeta.Requires) == 0 && len(c.charmMeta.Provides) == 0 {
-		return nil, errors.NotFoundf("charm meta data")
-	}
-	relations := make(map[string]map[string]string)
-	if provides, ok := formatRelationPart(c.charmMeta.Provides); ok {
-		relations["provides"] = provides
-	}
-	if requires, ok := formatRelationPart(c.charmMeta.Requires); ok {
-		relations["requires"] = requires
+	if foundRequires {
+		relations.Requires = requires
 	}
 	return relations, nil
-}
-
-func formatRelationPart(rels map[string]charm.Relation) (map[string]string, bool) {
-	if len(rels) <= 0 {
-		return nil, false
-	}
-	relations := make(map[string]string, len(rels))
-	for k, v := range rels {
-		relations[k] = v.Name
-	}
-	return relations, true
-}
-
-func (c charmInfoWriter) subordinate() bool {
-	if c.charmMeta == nil {
-		return false
-	}
-	return c.charmMeta.Subordinate
-}
-
-func (c charmInfoWriter) supports() string {
-	if c.charmMeta == nil || len(c.charmMeta.Series) == 0 {
-		return ""
-	}
-	return strings.Join(c.charmMeta.Series, ", ")
-}
-
-func (c charmInfoWriter) tags() string {
-	if c.charmMeta == nil || len(c.charmMeta.Tags) == 0 {
-		return ""
-	}
-	return strings.Join(c.charmMeta.Tags, ", ")
 }
 
 func sizeToStr(size int) string {

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -89,13 +89,13 @@ channels: |
 
 func getBundleInfoResponse() charmhub.InfoResponse {
 	return charmhub.InfoResponse{
-		Type:        "bundle",
+		Type:        "Bundle",
 		ID:          "bundleBUNDLEbundleBUNDLEbundle01",
 		Name:        "osm",
 		Description: "Single instance OSM bundle.",
 		Publisher:   "charmed-osm",
 		Summary:     "A bundle by charmed-osm.",
-		Bundle:      charmhub.Bundle{},
+		Bundle:      nil,
 		Channels: map[string]charmhub.Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
@@ -142,7 +142,7 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 		Publisher:   "Wordress Charmers",
 		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix and php-fpm configured to scale horizontally with\nNginx's reverse proxy.",
 		Series:      []string{"bionic", "xenial"},
-		Charm: charmhub.Charm{
+		Charm: &charmhub.Charm{
 			Tags: []string{"app", "seven"},
 		},
 		Channels: map[string]charmhub.Channel{

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -30,7 +30,8 @@ publisher: Wordress Charmers
 supports: bionic, xenial
 tags: app, seven
 subordinate: false
-description: This will install and setup WordPress optimized to run in the cloud.
+description: |-
+  This will install and setup WordPress optimized to run in the cloud.
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
 channels: |
@@ -38,6 +39,28 @@ channels: |
   latest/candidate:  1.0.3  2019-12-16  (17)  12MB
   latest/beta:       1.0.3  2019-12-16  (17)  12MB
   latest/edge:       1.0.3  2019-12-16  (18)  12MB
+`
+	c.Assert(obtained, gc.Equals, expected)
+}
+
+func (s *printInfoSuite) TestBundleChannelClosed(c *gc.C) {
+	ir := getBundleInfoClosedTrack()
+	ctx := commandContextForTest(c)
+	iw := makeInfoWriter(ctx, &ir)
+	err := iw.Print()
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained := ctx.Stdout.(*bytes.Buffer).String()
+	expected := `name: osm
+channels: |
+  latest/stable:     1.0.3  2019-12-16  (15)  12MB
+  latest/candidate:  1.0.3  2019-12-16  (16)  12MB
+  latest/beta:       1.0.3  2019-12-16  (17)  12MB
+  latest/edge:       1.0.3  2019-12-16  (18)  12MB
+  2.8/stable:        --
+  2.8/candidate:     1.0.3  2019-12-13  (56)  12MB
+  2.8/beta:          ^
+  2.8/edge:          1.0.3  2019-12-17  (60)  12MB
 `
 	c.Assert(obtained, gc.Equals, expected)
 }
@@ -66,243 +89,152 @@ channels: |
 
 func getBundleInfoResponse() charmhub.InfoResponse {
 	return charmhub.InfoResponse{
-		Name: "osm",
-		Type: "bundle",
-		ID:   "bundleBUNDLEbundleBUNDLEbundle01",
-		ChannelMap: []charmhub.ChannelMap{
-			{
-				Channel: charmhub.Channel{
-					Name:       "latest/stable",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					CreatedAt: "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					Revision: 16,
-					Version:  "1.0.3",
-				},
-			}, {
-				Channel: charmhub.Channel{
-					Name:       "latest/candidate",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					ConfigYAML: config,
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Revision:     17,
-					Version:      "1.0.3",
-				},
-			}, {
-				Channel: charmhub.Channel{
-					Name:       "latest/beta",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					CreatedAt: "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					Revision: 17,
-					Version:  "1.0.3",
-				},
-			}, {
-				Channel: charmhub.Channel{
-					Name:       "latest/edge",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					CreatedAt: "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					Revision: 18,
-					Version:  "1.0.3",
-				},
-			}},
-		Entity: charmhub.Entity{
-			Categories: []charmhub.Category{{
-				Featured: true,
-				Name:     "blog",
-			}},
-			Summary: "A bundle by charmed-osm.",
-			Publisher: map[string]string{
-				"display-name": "charmed-osm",
-			},
-			Description: "Single instance OSM bundle.",
-		},
-		DefaultRelease: charmhub.ChannelMap{
-			Channel: charmhub.Channel{
-				Name: "latest/stable",
-				Platform: charmhub.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
+		Type:        "bundle",
+		ID:          "bundleBUNDLEbundleBUNDLEbundle01",
+		Name:        "osm",
+		Description: "Single instance OSM bundle.",
+		Publisher:   "charmed-osm",
+		Summary:     "A bundle by charmed-osm.",
+		Bundle:      charmhub.Bundle{},
+		Channels: map[string]charmhub.Channel{
+			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "stable",
+				Revision:   16,
+				Size:       12042240,
+				Version:    "1.0.3",
 			},
-			Revision: charmhub.Revision{
-				CreatedAt: "2019-12-16T19:20:26.673192+00:00",
-				Download: charmhub.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				Revision: 16,
-				Version:  "1.0.3",
+			"latest/beta": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "beta",
+				Revision:   17,
+				Size:       12042240,
+				Version:    "1.0.3",
 			},
-		},
+			"latest/candidate": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "candidate",
+				Revision:   17,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"latest/edge": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "edge",
+				Revision:   18,
+				Size:       12042240,
+				Version:    "1.0.3",
+			}},
+		Tracks: []string{"latest"},
 	}
 }
 
 func getCharmInfoResponse() charmhub.InfoResponse {
 	return charmhub.InfoResponse{
-		Name: "wordpress",
-		Type: "charm",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []charmhub.ChannelMap{
-			{
-				Channel: charmhub.Channel{
-					Name:       "latest/stable",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					ConfigYAML: config,
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Revision:     16,
-					Version:      "1.0.3",
-				},
-			}, {
-				Channel: charmhub.Channel{
-					Name:       "latest/candidate",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					ConfigYAML: config,
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Revision:     17,
-					Version:      "1.0.3",
-				},
-			}, {
-				Channel: charmhub.Channel{
-					Name:       "latest/beta",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					ConfigYAML: config,
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Revision:     17,
-					Version:      "1.0.3",
-				},
-			}, {
-				Channel: charmhub.Channel{
-					Name:       "latest/edge",
-					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				},
-				Revision: charmhub.Revision{
-					ConfigYAML: config,
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-					Download: charmhub.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-						Size:       12042240,
-						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-					Revision:     18,
-					Version:      "1.0.3",
-				},
-			}},
-		Entity: charmhub.Entity{
-			Categories: []charmhub.Category{{
-				Featured: true,
-				Name:     "blog",
-			}},
-			Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
-			Publisher: map[string]string{
-				"display-name": "Wordress Charmers",
-			},
-			Summary: "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Type:        "charm",
+		ID:          "charmCHARMcharmCHARMcharmCHARM01",
+		Name:        "wordpress",
+		Summary:     "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Publisher:   "Wordress Charmers",
+		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix and php-fpm configured to scale horizontally with\nNginx's reverse proxy.",
+		Series:      []string{"bionic", "xenial"},
+		Charm: charmhub.Charm{
+			Tags: []string{"app", "seven"},
 		},
-		DefaultRelease: charmhub.ChannelMap{
-			Channel: charmhub.Channel{
-				Name: "latest/stable",
-				Platform: charmhub.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
+		Channels: map[string]charmhub.Channel{
+			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "stable",
+				Revision:   16,
+				Size:       12042240,
+				Version:    "1.0.3",
 			},
-			Revision: charmhub.Revision{
-				ConfigYAML: config,
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: charmhub.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
-				Revision:     16,
-				Version:      "1.0.3",
+			"latest/beta": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "beta",
+				Revision:   17,
+				Size:       12042240,
+				Version:    "1.0.3",
 			},
-		},
+			"latest/candidate": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "candidate",
+				Revision:   17,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"latest/edge": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "edge",
+				Revision:   18,
+				Size:       12042240,
+				Version:    "1.0.3",
+			}},
+		Tracks: []string{"latest"},
 	}
 }
 
-var config = `
-options:
-  title:
-    default: My Title
-    description: A descriptive title used for the application.
-    type: string
-  subtitle:
-    default: ""
-    description: An optional subtitle used for the application.
-  outlook:
-    description: No default outlook.
-    # type defaults to string in python
-  username:
-    default: admin001
-    description: The name of the initial account (given admin permissions).
-    type: string
-  skill-level:
-    description: A number indicating skill.
-    type: int
-  agility-ratio:
-    description: A number from 0 to 1 indicating agility.
-    type: float
-  reticulate-splines:
-    description: Whether to reticulate splines on launch, or not.
-    type: boolean
-`
+func getBundleInfoClosedTrack() charmhub.InfoResponse {
+	return charmhub.InfoResponse{
+		Name: "osm",
+		Type: "bundle",
+		Channels: map[string]charmhub.Channel{
+			"latest/stable": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "stable",
+				Revision:   15,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"latest/beta": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "beta",
+				Revision:   17,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"latest/candidate": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "candidate",
+				Revision:   16,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"latest/edge": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "edge",
+				Revision:   18,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"2.8/candidate": {
+				ReleasedAt: "2019-12-13T19:44:44.076943+00:00",
+				Track:      "2.8",
+				Risk:       "candidate",
+				Revision:   56,
+				Size:       12042240,
+				Version:    "1.0.3",
+			},
+			"2.8/edge": {
+				ReleasedAt: "2019-12-17T19:44:44.076943+00:00",
+				Track:      "2.8",
+				Risk:       "edge",
+				Revision:   60,
+				Size:       12042240,
+				Version:    "1.0.3",
+			}},
+		Tracks: []string{"latest", "2.8"},
+	}
+}


### PR DESCRIPTION

## Description of change

Update juju info output to display closed channels.  There is no useable data at this time, therefore all testing done in unit test.

Move transformation of the data over the wire from the charm hub api into something easily useable by juju info from the command into the facade.  

## QA steps

Same QA steps as for juju info in #11761 
