### PR TITLE
Use rsync to copy acceptancetests *.py to exclude gitignored local fi…

### DIFF
--- a/tests/suites/static_analysis/lint_python.sh
+++ b/tests/suites/static_analysis/lint_python.sh
@@ -1,5 +1,5 @@
 run_compileall() {
-  cp -R acceptancetests "${TEST_DIR}/"
+  rsync -r --exclude-from=acceptancetests/.gitignore acceptancetests "${TEST_DIR}/"
   cp -R scripts "${TEST_DIR}/"
 
   CURRENT_DIRECTORY=$(pwd)


### PR DESCRIPTION
## Description of change

Exclude git ignored local files for *.py listing in acceptancetests folder;
