### PR TITLE
Reflect series-upgrade status in machine instance status

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -109,7 +109,7 @@ var facadeVersions = map[string]int{
 	"UnitAssigner":                 1,
 	"Uniter":                       16,
 	"Upgrader":                     1,
-	"UpgradeSeries":                2,
+	"UpgradeSeries":                3,
 	"UpgradeSteps":                 2,
 	"UserManager":                  2,
 	"VolumeAttachmentsWatcher":     2,

--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
 )
 
 const upgradeSeriesFacade = "UpgradeSeries"

--- a/api/upgradeseries/upgradeseries.go
+++ b/api/upgradeseries/upgradeseries.go
@@ -232,8 +232,8 @@ func (s *Client) FinishUpgradeSeries(hostSeries string) error {
 	return nil
 }
 
-// SetStatus sets the machine status in remote state.
-func (s *Client) SetStatus(sts model.UpgradeSeriesStatus, msg string) error {
+// SetInstanceStatus sets the machine status in remote state.
+func (s *Client) SetInstanceStatus(sts model.UpgradeSeriesStatus, msg string) error {
 	var results params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
@@ -243,7 +243,7 @@ func (s *Client) SetStatus(sts model.UpgradeSeriesStatus, msg string) error {
 		}},
 	}
 
-	err := s.facade.FacadeCall("SetStatus", args, &results)
+	err := s.facade.FacadeCall("SetInstanceStatus", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/upgradeseries/upgradeseries_test.go
+++ b/api/upgradeseries/upgradeseries_test.go
@@ -237,9 +237,9 @@ func (s *upgradeSeriesSuite) TestSetStatus(c *gc.C) {
 		},
 	}
 	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}}}
-	fCaller.EXPECT().FacadeCall("SetStatus", args, gomock.Any()).SetArg(2, resultSource)
+	fCaller.EXPECT().FacadeCall("SetInstanceStatus", args, gomock.Any()).SetArg(2, resultSource)
 
 	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
-	err := api.SetStatus(model.UpgradeSeriesCompleteStarted, "waiting for something")
+	err := api.SetInstanceStatus(model.UpgradeSeriesCompleteStarted, "waiting for something")
 	c.Assert(err, gc.IsNil)
 }

--- a/api/upgradeseries/upgradeseries_test.go
+++ b/api/upgradeseries/upgradeseries_test.go
@@ -6,7 +6,9 @@ package upgradeseries_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/names/v4"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,11 +16,10 @@ import (
 	"github.com/juju/juju/api/upgradeseries"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/model"
-	jujutesting "github.com/juju/juju/testing"
 )
 
 type upgradeSeriesSuite struct {
-	jujutesting.BaseSuite
+	testing.IsolationSuite
 
 	tag                                  names.Tag
 	args                                 params.Entities
@@ -33,7 +34,7 @@ func (s *upgradeSeriesSuite) SetUpTest(c *gc.C) {
 	s.upgradeSeriesStartUnitCompletionArgs = params.UpgradeSeriesStartUnitCompletionParam{
 		Entities: []params.Entity{{Tag: s.tag.String()}},
 	}
-	s.BaseSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
 }
 
 func (s *upgradeSeriesSuite) TestMachineStatus(c *gc.C) {
@@ -217,5 +218,28 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeries(c *gc.C) {
 
 	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
 	err := api.FinishUpgradeSeries("xenial")
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *upgradeSeriesSuite) TestSetStatus(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	fCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	args := params.SetStatus{
+		Entities: []params.EntityStatusArgs{
+			{
+				Tag:    s.tag.String(),
+				Status: status.Running.String(),
+				Info:   "series upgrade complete started: waiting for something",
+			},
+		},
+	}
+	resultSource := params.ErrorResults{Results: []params.ErrorResult{{}}}
+	fCaller.EXPECT().FacadeCall("SetStatus", args, gomock.Any()).SetArg(2, resultSource)
+
+	api := upgradeseries.NewStateFromCaller(fCaller, s.tag)
+	err := api.SetStatus(model.UpgradeSeriesCompleteStarted, "waiting for something")
 	c.Assert(err, gc.IsNil)
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -345,7 +345,8 @@ func AllFacades() *facade.Registry {
 	reg("Upgrader", 1, upgrader.NewUpgraderFacade)
 
 	reg("UpgradeSeries", 1, upgradeseries.NewAPIv1)
-	reg("UpgradeSeries", 2, upgradeseries.NewAPI) // Adds CurrentSeries.
+	reg("UpgradeSeries", 2, upgradeseries.NewAPIv2) // Adds CurrentSeries.
+	reg("UpgradeSeries", 3, upgradeseries.NewAPI)   // Adds SetStatus.
 
 	reg("UpgradeSteps", 1, upgradesteps.NewFacadeV1)
 	reg("UpgradeSteps", 2, upgradesteps.NewFacadeV2)

--- a/apiserver/common/mocks/authorizer_mock.go
+++ b/apiserver/common/mocks/authorizer_mock.go
@@ -5,10 +5,9 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockAuthorizer is a mock of Authorizer interface
@@ -63,10 +62,10 @@ func (mr *MockAuthorizerMockRecorder) AuthMachineAgent() *gomock.Call {
 }
 
 // GetAuthTag mocks base method
-func (m *MockAuthorizer) GetAuthTag() names_v3.Tag {
+func (m *MockAuthorizer) GetAuthTag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthTag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 

--- a/apiserver/common/mocks/upgradeseries.go
+++ b/apiserver/common/mocks/upgradeseries.go
@@ -5,13 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/juju/juju/apiserver/common"
 	model "github.com/juju/juju/core/model"
+	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockUpgradeSeriesBackend is a mock of UpgradeSeriesBackend interface
@@ -116,6 +116,20 @@ func (m *MockUpgradeSeriesMachine) Series() string {
 func (mr *MockUpgradeSeriesMachineMockRecorder) Series() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Series))
+}
+
+// SetStatus mocks base method
+func (m *MockUpgradeSeriesMachine) SetStatus(arg0 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetStatus", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetStatus indicates an expected call of SetStatus
+func (mr *MockUpgradeSeriesMachineMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetStatus), arg0)
 }
 
 // SetUpgradeSeriesStatus mocks base method
@@ -288,10 +302,10 @@ func (mr *MockUpgradeSeriesUnitMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 i
 }
 
 // Tag mocks base method
-func (m *MockUpgradeSeriesUnit) Tag() names_v3.Tag {
+func (m *MockUpgradeSeriesUnit) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 

--- a/apiserver/common/mocks/upgradeseries.go
+++ b/apiserver/common/mocks/upgradeseries.go
@@ -118,18 +118,18 @@ func (mr *MockUpgradeSeriesMachineMockRecorder) Series() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Series))
 }
 
-// SetStatus mocks base method
-func (m *MockUpgradeSeriesMachine) SetStatus(arg0 status.StatusInfo) error {
+// SetInstanceStatus mocks base method
+func (m *MockUpgradeSeriesMachine) SetInstanceStatus(arg0 status.StatusInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0)
+	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetStatus indicates an expected call of SetStatus
-func (mr *MockUpgradeSeriesMachineMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
+// SetInstanceStatus indicates an expected call of SetInstanceStatus
+func (mr *MockUpgradeSeriesMachineMockRecorder) SetInstanceStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetInstanceStatus), arg0)
 }
 
 // SetUpgradeSeriesStatus mocks base method

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -35,7 +35,7 @@ type UpgradeSeriesMachine interface {
 	UpgradeSeriesTarget() (string, error)
 	Series() string
 	UpdateMachineSeries(series string, force bool) error
-	SetStatus(status.StatusInfo) error
+	SetInstanceStatus(status.StatusInfo) error
 }
 
 // UpgradeSeriesUnit describes unit-receiver state methods

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -5,13 +5,13 @@ package common
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
 

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -34,6 +35,7 @@ type UpgradeSeriesMachine interface {
 	UpgradeSeriesTarget() (string, error)
 	Series() string
 	UpdateMachineSeries(series string, force bool) error
+	SetStatus(status.StatusInfo) error
 }
 
 // UpgradeSeriesUnit describes unit-receiver state methods

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -97,7 +97,6 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 }
 
 // SetMachineStatus sets the current upgrade-series status of a machine.
-// The addition of SetStatus to this API makes this method poorly named.
 func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{}
 
@@ -324,8 +323,8 @@ func (a *API) UnpinMachineApplications() (params.PinApplicationsResults, error) 
 	return a.leadership.UnpinApplicationLeaders()
 }
 
-// SetStatus sets the status of the machine.
-func (a *API) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+// SetInstanceStatus sets the status of the machine.
+func (a *API) SetInstanceStatus(args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{}
 
 	canAccess, err := a.AccessMachine()
@@ -341,7 +340,7 @@ func (a *API) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
 			continue
 		}
 
-		if err := machine.SetStatus(status.StatusInfo{
+		if err := machine.SetInstanceStatus(status.StatusInfo{
 			Status:  status.Status(entity.Status),
 			Message: entity.Info,
 		}); err != nil {

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -365,8 +365,8 @@ type APIv2 struct {
 	*API
 }
 
-// SetStatus was not available on version 2 of the API.
-func (api *APIv2) SetStatus(_, _ struct{}) {}
+// SetInstanceStatus was not available on version 2 of the API.
+func (api *APIv2) SetInstanceStatus(_, _ struct{}) {}
 
 // NewAPIv1 is a wrapper that creates a V1 upgrade-series API.
 func NewAPIv1(ctx facade.Context) (*APIv1, error) {

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -5,6 +5,7 @@ package upgradeseries
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -78,7 +79,7 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 
 	results := make([]params.UpgradeSeriesStatusResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndGetMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity.Tag, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -96,6 +97,7 @@ func (a *API) MachineStatus(args params.Entities) (params.UpgradeSeriesStatusRes
 }
 
 // SetMachineStatus sets the current upgrade-series status of a machine.
+// The addition of SetStatus to this API makes this method poorly named.
 func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{}
 
@@ -106,7 +108,7 @@ func (a *API) SetMachineStatus(args params.UpgradeSeriesStatusParams) (params.Er
 
 	results := make([]params.ErrorResult, len(args.Params))
 	for i, param := range args.Params {
-		machine, err := a.authAndGetMachine(param.Entity, canAccess)
+		machine, err := a.authAndGetMachine(param.Entity.Tag, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -135,7 +137,7 @@ func (a *API) CurrentSeries(args params.Entities) (params.StringResults, error) 
 
 	results := make([]params.StringResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndGetMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity.Tag, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -159,7 +161,7 @@ func (a *API) TargetSeries(args params.Entities) (params.StringResults, error) {
 
 	results := make([]params.StringResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndGetMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity.Tag, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -186,7 +188,7 @@ func (a *API) StartUnitCompletion(args params.UpgradeSeriesStartUnitCompletionPa
 		return params.ErrorResults{}, err
 	}
 	for i, entity := range args.Entities {
-		machine, err := a.authAndGetMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity.Tag, canAccess)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -213,7 +215,7 @@ func (a *API) FinishUpgradeSeries(args params.UpdateSeriesArgs) (params.ErrorRes
 		return params.ErrorResults{}, err
 	}
 	for i, arg := range args.Args {
-		machine, err := a.authAndGetMachine(arg.Entity, canAccess)
+		machine, err := a.authAndGetMachine(arg.Entity.Tag, canAccess)
 		if err != nil {
 			result.Results[i].Error = common.ServerError(err)
 			continue
@@ -268,7 +270,7 @@ func (a *API) unitsInState(args params.Entities, status model.UpgradeSeriesStatu
 
 	results := make([]params.EntitiesResult, len(args.Entities))
 	for i, entity := range args.Entities {
-		machine, err := a.authAndGetMachine(entity, canAccess)
+		machine, err := a.authAndGetMachine(entity.Tag, canAccess)
 		if err != nil {
 			results[i].Error = common.ServerError(err)
 			continue
@@ -293,8 +295,8 @@ func (a *API) unitsInState(args params.Entities, status model.UpgradeSeriesStatu
 	return result, nil
 }
 
-func (a *API) authAndGetMachine(e params.Entity, canAccess common.AuthFunc) (common.UpgradeSeriesMachine, error) {
-	tag, err := names.ParseMachineTag(e.Tag)
+func (a *API) authAndGetMachine(entityTag string, canAccess common.AuthFunc) (common.UpgradeSeriesMachine, error) {
+	tag, err := names.ParseMachineTag(entityTag)
 	if err != nil {
 		return nil, err
 	}
@@ -322,19 +324,65 @@ func (a *API) UnpinMachineApplications() (params.PinApplicationsResults, error) 
 	return a.leadership.UnpinApplicationLeaders()
 }
 
+// SetStatus sets the status of the machine.
+func (a *API) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+	result := params.ErrorResults{}
+
+	canAccess, err := a.AccessMachine()
+	if err != nil {
+		return result, err
+	}
+
+	results := make([]params.ErrorResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		machine, err := a.authAndGetMachine(entity.Tag, canAccess)
+		if err != nil {
+			results[i].Error = common.ServerError(err)
+			continue
+		}
+
+		if err := machine.SetStatus(status.StatusInfo{
+			Status:  status.Status(entity.Status),
+			Message: entity.Info,
+		}); err != nil {
+			results[i].Error = common.ServerError(err)
+		}
+	}
+
+	result.Results = results
+	return result, nil
+}
+
 // APIv1 provides the upgrade-series API facade for version 1.
 type APIv1 struct {
-	*API
+	*APIv2
 }
 
 // CurrentSeries was not available on version 1 of the API.
 func (api *APIv1) CurrentSeries(_, _ struct{}) {}
 
+// APIv2 provides the upgrade-series API facade for version 2.
+type APIv2 struct {
+	*API
+}
+
+// SetStatus was not available on version 2 of the API.
+func (api *APIv2) SetStatus(_, _ struct{}) {}
+
 // NewAPIv1 is a wrapper that creates a V1 upgrade-series API.
 func NewAPIv1(ctx facade.Context) (*APIv1, error) {
-	api, err := NewAPI(ctx)
+	api, err := NewAPIv2(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &APIv1{api}, nil
+}
+
+// NewAPIv2 is a wrapper that creates a V2 upgrade-series API.
+func NewAPIv2(ctx facade.Context) (*APIv2, error) {
+	api, err := NewAPI(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv2{api}, nil
 }

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -5,7 +5,6 @@ package upgradeseries
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.upgradeseries")

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -5,6 +5,7 @@ package upgradeseries_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/juju/core/status"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -184,6 +185,32 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeriesNotUpgraded(c *gc.C) {
 	}
 
 	results, err := s.api.FinishUpgradeSeries(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+
+func (s *upgradeSeriesSuite) TestSetStatus(c *gc.C) {
+	defer s.arrangeTest(c).Finish()
+
+	msg := "series upgrade: " + string(model.UpgradeSeriesPrepareStarted)
+
+	exp := s.machine.EXPECT()
+	exp.SetStatus(status.StatusInfo{
+		Status:  status.Running,
+		Message: msg,
+	}).Return(nil)
+
+	results, err := s.api.SetStatus(params.SetStatus{
+		Entities: []params.EntityStatusArgs{
+			{
+				Tag:    s.machineTag.String(),
+				Status: status.Running.String(),
+				Info:   msg,
+			},
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}},

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -197,12 +197,12 @@ func (s *upgradeSeriesSuite) TestSetStatus(c *gc.C) {
 	msg := "series upgrade: " + string(model.UpgradeSeriesPrepareStarted)
 
 	exp := s.machine.EXPECT()
-	exp.SetStatus(status.StatusInfo{
+	exp.SetInstanceStatus(status.StatusInfo{
 		Status:  status.Running,
 		Message: msg,
 	}).Return(nil)
 
-	results, err := s.api.SetStatus(params.SetStatus{
+	results, err := s.api.SetInstanceStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{
 				Tag:    s.machineTag.String(),

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -41158,7 +41158,7 @@
     {
         "Name": "UpgradeSeries",
         "Description": "API serves methods required by the machine agent upgrade-series worker.",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -41221,6 +41221,18 @@
                         }
                     },
                     "description": "PinnedLeadership returns all pinned applications and the entities that\nrequire their pinned behaviour, for leadership in the current model."
+                },
+                "SetInstanceStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetInstanceStatus sets the status of the machine."
                 },
                 "SetMachineStatus": {
                     "type": "object",
@@ -41389,6 +41401,36 @@
                         "tag"
                     ]
                 },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
                 "Error": {
                     "type": "object",
                     "properties": {
@@ -41514,6 +41556,21 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
                 },
                 "StringResult": {
                     "type": "object",

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -118,10 +118,10 @@ Prepare machine 3 for upgrade to series "bionic"":
 
 	juju upgrade-series 3 prepare bionic
 
-Prepare machine 4 for upgrade to series "cosmic" even if there are applications
+Prepare machine 4 for upgrade to series "focal" even if there are applications
 running units that do not support the target series:
 
-	juju upgrade-series 4 prepare cosmic --force
+	juju upgrade-series 4 prepare focal --force
 
 Complete upgrade of machine 5, indicating that all automatic and any
 necessary manual upgrade steps have completed successfully:

--- a/state/machine_upgradeseries_test.go
+++ b/state/machine_upgradeseries_test.go
@@ -8,7 +8,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
 
@@ -36,11 +35,6 @@ func (s *MachineSuite) TestCreateUpgradeSeriesLock(c *gc.C) {
 		i++
 	}
 	c.Assert(lockedUnitsIds, jc.SameContents, unitIds)
-
-	sts, err := mach.InstanceStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(sts.Status, gc.Equals, status.Running)
-	c.Check(sts.Message, gc.Equals, "Series upgrade: prepare started")
 }
 
 func (s *MachineSuite) TestIsParentLockedForSeriesUpgrade(c *gc.C) {
@@ -188,24 +182,6 @@ func (s *MachineSuite) TestCompleteSeriesUpgradeShouldSetCompleteStatusOfMachine
 	sts, err := s.machine.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sts, gc.Equals, model.UpgradeSeriesCompleteStarted)
-
-	iStatus, err := s.machine.InstanceStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(iStatus.Status, gc.Equals, status.Running)
-	c.Check(iStatus.Message, gc.Equals, "Series upgrade: complete started")
-}
-
-func (s *MachineSuite) TestUpgradeSeriesCompletedResetsInstanceStatus(c *gc.C) {
-	err := s.machine.CreateUpgradeSeriesLock([]string{}, "cosmic")
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.machine.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, "")
-	c.Assert(err, jc.ErrorIsNil)
-
-	iStatus, err := s.machine.InstanceStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(iStatus.Status, gc.Equals, status.Running)
-	c.Check(iStatus.Message, gc.Equals, "Running")
 }
 
 func (s *MachineSuite) TestCompleteSeriesUpgradeShouldFailIfAlreadyInCompleteState(c *gc.C) {

--- a/worker/upgradeseries/mocks/package_mock.go
+++ b/worker/upgradeseries/mocks/package_mock.go
@@ -95,6 +95,20 @@ func (mr *MockFacadeMockRecorder) PinMachineApplications() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinMachineApplications", reflect.TypeOf((*MockFacade)(nil).PinMachineApplications))
 }
 
+// SetInstanceStatus mocks base method
+func (m *MockFacade) SetInstanceStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetInstanceStatus indicates an expected call of SetInstanceStatus
+func (mr *MockFacadeMockRecorder) SetInstanceStatus(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockFacade)(nil).SetInstanceStatus), arg0, arg1)
+}
+
 // SetMachineStatus mocks base method
 func (m *MockFacade) SetMachineStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/worker/upgradeseries/shim.go
+++ b/worker/upgradeseries/shim.go
@@ -28,6 +28,7 @@ type Facade interface {
 	FinishUpgradeSeries(string) error
 	PinMachineApplications() (map[string]error, error)
 	UnpinMachineApplications() (map[string]error, error)
+	SetInstanceStatus(model.UpgradeSeriesStatus, string) error
 }
 
 // NewFacade creates a new upgrade-series client and returns its

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -166,6 +166,10 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 	case model.UpgradeSeriesCompleted:
 		err = w.handleCompleted()
 	}
+
+	if err != nil {
+		_ = w.SetInstanceStatus(model.UpgradeSeriesError, err.Error())
+	}
 	return errors.Trace(err)
 }
 
@@ -173,6 +177,10 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 // lock status of "UpgradeSeriesPrepareStarted"
 func (w *upgradeSeriesWorker) handlePrepareStarted() error {
 	var err error
+	if err = w.SetInstanceStatus(model.UpgradeSeriesPrepareStarted, "preparing units"); err != nil {
+		return errors.Trace(err)
+	}
+
 	if !w.leadersPinned {
 		if err = w.pinLeaders(); err != nil {
 			return errors.Trace(err)
@@ -202,6 +210,10 @@ func (w *upgradeSeriesWorker) handlePrepareStarted() error {
 // on this machine so that they are compatible with the init system of the
 // series upgrade target.
 func (w *upgradeSeriesWorker) transitionPrepareComplete() error {
+	if err := w.SetInstanceStatus(model.UpgradeSeriesPrepareStarted, "completing preparation"); err != nil {
+		return errors.Trace(err)
+	}
+
 	w.logger.Infof("preparing service units for series upgrade")
 	currentSeries, err := w.CurrentSeries()
 	if err != nil {
@@ -221,10 +233,18 @@ func (w *upgradeSeriesWorker) transitionPrepareComplete() error {
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(w.SetMachineStatus(model.UpgradeSeriesPrepareCompleted, "binaries and service files written"))
+	if err := w.SetMachineStatus(model.UpgradeSeriesPrepareCompleted, "binaries and service files written"); err != nil {
+		return errors.Trace(err)
+	}
+
+	return errors.Trace(w.SetInstanceStatus(model.UpgradeSeriesPrepareCompleted, "waiting for completion command"))
 }
 
 func (w *upgradeSeriesWorker) handleCompleteStarted() error {
+	if err := w.SetInstanceStatus(model.UpgradeSeriesCompleteStarted, "waiting for units"); err != nil {
+		return errors.Trace(err)
+	}
+
 	var err error
 	if w.preparedUnits, err = w.UnitsPrepared(); err != nil {
 		return errors.Trace(err)
@@ -271,6 +291,10 @@ func (w *upgradeSeriesWorker) handleCompleteStarted() error {
 func (w *upgradeSeriesWorker) transitionUnitsStarted(unitServices map[string]string) error {
 	w.logger.Infof("ensuring units are up after series upgrade")
 
+	if err := w.SetInstanceStatus(model.UpgradeSeriesCompleteStarted, "starting unit agents"); err != nil {
+		return errors.Trace(err)
+	}
+
 	for unit, serviceName := range unitServices {
 		svc, err := w.service.DiscoverService(serviceName)
 		if err != nil {
@@ -294,6 +318,10 @@ func (w *upgradeSeriesWorker) transitionUnitsStarted(unitServices map[string]str
 // handleCompleted notifies the server that it has completed the upgrade
 // workflow, then unpins leadership for applications running on the machine.
 func (w *upgradeSeriesWorker) handleCompleted() error {
+	if err := w.SetInstanceStatus(model.UpgradeSeriesCompleted, "finalising upgrade"); err != nil {
+		return errors.Trace(err)
+	}
+
 	s, err := hostSeries()
 	if err != nil {
 		return errors.Trace(err)
@@ -301,7 +329,11 @@ func (w *upgradeSeriesWorker) handleCompleted() error {
 	if err = w.FinishUpgradeSeries(s); err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(w.unpinLeaders())
+	if err = w.unpinLeaders(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return errors.Trace(w.SetInstanceStatus(model.UpgradeSeriesCompleted, "success"))
 }
 
 // compareUnitsAgentServices filters the services running on the local machine

--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -168,7 +168,9 @@ func (w *upgradeSeriesWorker) handleUpgradeSeriesChange() error {
 	}
 
 	if err != nil {
-		_ = w.SetInstanceStatus(model.UpgradeSeriesError, err.Error())
+		if err := w.SetInstanceStatus(model.UpgradeSeriesError, err.Error()); err != nil {
+			w.logger.Errorf("failed to set series upgrade error status: %s", err.Error())
+		}
 	}
 	return errors.Trace(err)
 }


### PR DESCRIPTION
## Description of change

This patch removes side-effect setting of instance status from series-upgrade state logic, opting instead to set this status explicitly from the worker.

`SetInstanceStatus` is added for this purpose to a new version of the series-upgrade agent API facade.

## QA steps

- Bootstrap to LXD.
- `juju deploy postegresql --series xenial` and wait for quiescence.
- Start a separate terminal watch of `juju status`.
- `juju upgrade series prepare 0 bionic -y` and watch the status transitions.
- Once complete, `juju upgrade series 0 complete`, watch the transition to a final success message.

## Documentation changes

Not at this time.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1882796
