### PR TITLE
Relocate gateway module from network to core/network

### DIFF
--- a/api/common/network.go
+++ b/api/common/network.go
@@ -60,7 +60,7 @@ func (n *netPackageConfigSource) InterfaceAddresses(name string) ([]net.Addr, er
 
 // DefaultRoute implements NetworkConfigSource.
 func (n *netPackageConfigSource) DefaultRoute() (net.IP, string, error) {
-	return network.GetDefaultRoute()
+	return corenetwork.GetDefaultRoute()
 }
 
 // DefaultNetworkConfigSource returns a NetworkConfigSource backed by the net

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -192,7 +192,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigInterfaceAddressesError(c *gc
 	s.stubConfigSource.SetErrors(
 		nil,                        // Interfaces
 		nil,                        // DefaultRoute
-		errors.New("no addresses"), // InterfaceAddressses
+		errors.New("no addresses"), // InterfaceAddresses
 	)
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
@@ -217,7 +217,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigNoInterfaceAddresses(c *gc.C)
 		InterfaceName: "br-eth1",
 		InterfaceType: "bridge",
 		ConfigType:    "manual",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -238,7 +238,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigLoopbackInferred(c *gc.C) {
 		InterfaceName: "lo",
 		InterfaceType: "loopback", // inferred from the flags.
 		ConfigType:    "loopback", // since it is a loopback
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:   1,
 		CIDR:          "::1/128",
@@ -247,7 +247,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigLoopbackInferred(c *gc.C) {
 		InterfaceName: "lo",
 		InterfaceType: "loopback",
 		ConfigType:    "loopback",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -273,7 +273,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 		InterfaceName: "eth0.100",
 		InterfaceType: "802.1q",
 		ConfigType:    "manual", // the IPv6 address treated as empty.
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:   13,
 		CIDR:          "10.100.19.0/24",
@@ -283,7 +283,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 		InterfaceName: "eth0.100",
 		InterfaceType: "802.1q",
 		ConfigType:    "static",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -303,7 +303,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigEthernetInfrerred(c *gc.C) {
 		InterfaceName: "eth0",
 		InterfaceType: "ethernet",
 		ConfigType:    "manual", // the IPv6 address treated as empty.
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -329,7 +329,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceType:       "ethernet",
 		ParentInterfaceName: "br-eth0",
 		ConfigType:          "manual",
-		NetworkOrigin:       params.NetworkOrigin("machine"),
+		NetworkOrigin:       "machine",
 	}, {
 		DeviceIndex:   10,
 		CIDR:          "10.20.19.0/24",
@@ -339,7 +339,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth0",
 		InterfaceType: "bridge",
 		ConfigType:    "static",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:   10,
 		CIDR:          "10.20.19.0/24",
@@ -349,7 +349,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth0",
 		InterfaceType: "bridge",
 		ConfigType:    "static",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:   10,
 		MACAddress:    "aa:bb:cc:dd:ee:f0",
@@ -357,7 +357,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth0",
 		InterfaceType: "bridge",
 		ConfigType:    "manual",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:   11,
 		CIDR:          "10.20.19.0/24",
@@ -367,7 +367,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth1",
 		InterfaceType: "bridge",
 		ConfigType:    "static",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:   11,
 		MACAddress:    "aa:bb:cc:dd:ee:f1",
@@ -375,7 +375,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		InterfaceName: "br-eth1",
 		InterfaceType: "bridge",
 		ConfigType:    "manual",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}, {
 		DeviceIndex:         3,
 		MACAddress:          "aa:bb:cc:dd:ee:f1",
@@ -386,7 +386,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *g
 		ConfigType:          "manual",
 		GatewayAddress:      "1.2.3.4",
 		IsDefaultGateway:    true,
-		NetworkOrigin:       params.NetworkOrigin("machine"),
+		NetworkOrigin:       "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c,
@@ -423,7 +423,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 		InterfaceName: "eth0",
 		InterfaceType: "ethernet",
 		ConfigType:    "static",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -446,7 +446,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigEmptyAddressValue(c *gc.C) {
 		InterfaceName: "eth0",
 		InterfaceType: "ethernet",
 		ConfigType:    "manual",
-		NetworkOrigin: params.NetworkOrigin("machine"),
+		NetworkOrigin: "machine",
 	}})
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")

--- a/core/network/gateway_test.go
+++ b/core/network/gateway_test.go
@@ -6,16 +6,16 @@ package network_test
 import (
 	"fmt"
 	"net"
+	"os/exec"
 	"runtime"
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/network"
-	"github.com/juju/juju/testing"
+	"github.com/juju/juju/core/network"
 )
 
 type GatewaySuite struct {
-	testing.BaseSuite
+	network.BaseSuite
 }
 
 var _ = gc.Suite(&GatewaySuite{})
@@ -24,14 +24,24 @@ func (s *GatewaySuite) TestDefaultRouteOnMachine(c *gc.C) {
 	if runtime.GOOS != "linux" {
 		c.Skip("skipping default route on-machine test on non-linux")
 	}
-	s.PatchValue(network.LaunchIpRouteShow, network.LaunchIpRouteShowReal)
+
+	// This just runs "ip" from /sbin directly, as IsolationSuite
+	// causes it not to be found in PATH.
+	s.PatchRunIPRouteShow(func() (string, error) {
+		output, err := exec.Command("/sbin/ip", "route", "show").CombinedOutput()
+		if err != nil {
+			return "", err
+		}
+		return string(output), nil
+	})
+
 	_, _, err := network.GetDefaultRoute()
 	c.Check(err, gc.IsNil)
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxSimple(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "default via 10.0.0.1 dev wlp2s0 proto static\n" +
 			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n", nil
 	})
@@ -42,8 +52,8 @@ func (s *GatewaySuite) TestDefaultRouteLinuxSimple(c *gc.C) {
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxTwoRoutes(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
 			"default via 10.100.1.10 dev lxdbr0 metric 700\n" +
 			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
@@ -56,8 +66,8 @@ func (s *GatewaySuite) TestDefaultRouteLinuxTwoRoutes(c *gc.C) {
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxNoMetric(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
 			"default via 10.100.1.10 dev lxdbr0\n" +
 			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
@@ -70,8 +80,8 @@ func (s *GatewaySuite) TestDefaultRouteLinuxNoMetric(c *gc.C) {
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxNoGW(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
 			"default dev lxdbr0\n" +
 			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
@@ -84,8 +94,8 @@ func (s *GatewaySuite) TestDefaultRouteLinuxNoGW(c *gc.C) {
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxNoDev(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "default via 10.0.0.1 dev wlp2s0 proto static metric 800\n" +
 			"default via 10.100.1.10 metric 500\n" +
 			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
@@ -98,8 +108,8 @@ func (s *GatewaySuite) TestDefaultRouteLinuxNoDev(c *gc.C) {
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxError(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "", fmt.Errorf("no can do")
 	})
 	ip, dev, err := network.GetDefaultRoute()
@@ -109,8 +119,8 @@ func (s *GatewaySuite) TestDefaultRouteLinuxError(c *gc.C) {
 }
 
 func (s *GatewaySuite) TestDefaultRouteLinuxWrongOutput(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "linux")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
+	s.PatchGOOS("linux")
+	s.PatchRunIPRouteShow(func() (string, error) {
 		return "default via 10.0.0.1 dev wlp2s0 proto static metric chewbacca\n" +
 			"default dev lxdbr0\n" +
 			"10.0.0.0/24 dev wlp2s0 proto kernel scope link src 10.0.0.66 metric 600\n" +
@@ -122,11 +132,11 @@ func (s *GatewaySuite) TestDefaultRouteLinuxWrongOutput(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, ".*chewbacca.*")
 }
 
-// We don't return 'not supported' error, we simply give no output
+// We don't return 'not supported' error, we simply give no output.
 func (s *GatewaySuite) TestDefaultRouteWindowsEmpty(c *gc.C) {
-	s.PatchValue(network.SimulatedOS, "windows")
-	s.PatchValue(network.LaunchIpRouteShow, func() (string, error) {
-		return "", fmt.Errorf("why someone calls me?")
+	s.PatchGOOS("windows")
+	s.PatchRunIPRouteShow(func() (string, error) {
+		return "", fmt.Errorf("blam")
 	})
 	ip, dev, err := network.GetDefaultRoute()
 	c.Check(ip, gc.IsNil)

--- a/core/network/import_test.go
+++ b/core/network/import_test.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+type ImportSuite struct{}
+
+var _ = gc.Suite(&ImportSuite{})
+
+func (*ImportSuite) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/network")
+	// This package only brings in other core packages.
+	c.Assert(found, jc.SameContents, []string{})
+}

--- a/core/network/package_test.go
+++ b/core/network/package_test.go
@@ -1,14 +1,12 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package network_test
+package network
 
 import (
 	"testing"
 
-	jc "github.com/juju/testing/checkers"
-
-	coretesting "github.com/juju/juju/testing"
+	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 )
 
@@ -16,13 +14,19 @@ func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }
 
-type ImportSuite struct{}
+// BaseSuite exposes base testing functionality to the network tests,
+// including patching package-private functions/variables.
+type BaseSuite struct {
+	jujutesting.IsolationSuite
+}
 
-var _ = gc.Suite(&ImportSuite{})
+// PatchGOOS allows us to simulate the running OS.
+func (s *BaseSuite) PatchGOOS(os string) {
+	s.PatchValue(&goos, func() string { return os })
+}
 
-func (*ImportSuite) TestImports(c *gc.C) {
-	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/network")
-
-	// This package only brings in other core packages.
-	c.Assert(found, jc.SameContents, []string{})
+// PatchUnIPRouteShow allows us to simulate the return from running
+// "ip route show" on the host.
+func (s *BaseSuite) PatchRunIPRouteShow(run func() (string, error)) {
+	s.PatchValue(&runIPRouteShow, run)
 }

--- a/network/export_test.go
+++ b/network/export_test.go
@@ -7,7 +7,4 @@ var (
 	NetListen                      = &netListen
 	RunCommand                     = runCommand
 	NewEtcNetworkInterfacesBridger = newEtcNetworkInterfacesBridger
-	SimulatedOS                    = &simulatedOS
-	LaunchIpRouteShow              = &launchIpRouteShow
-	LaunchIpRouteShowReal          = launchIpRouteShowReal
 )


### PR DESCRIPTION
## Description of change

Progresses the phasing out of `network` in favour of `core/network` by relocating the gateway module.

## QA steps

Mechanical only; unit tests pass
