### PR TITLE
info output for Tags from info response entity []category

### DIFF
--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -73,6 +73,7 @@ func getInfoResponse() InfoResponse {
 		Tracks:      []string{"latest"},
 		Series:      []string{"bionic", "xenial"},
 		StoreURL:    "https://someurl.com/wordpress",
+		Tags:        []string{"app", "seven"},
 		Channels: map[string]Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
@@ -95,7 +96,6 @@ func getInfoResponse() InfoResponse {
 					"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
 				},
 			},
-			Tags: []string{"app", "seven"},
 			Relations: map[string]map[string]string{
 				"provides": {"source": "dummy-token"},
 				"requires": {"sink": "dummy-token"}},
@@ -126,6 +126,7 @@ func assertInfoResponseSameContents(c *gc.C, obtained, expected InfoResponse) {
 	c.Assert(obtained.Description, gc.Equals, expected.Description)
 	c.Assert(obtained.Publisher, jc.DeepEquals, expected.Publisher)
 	c.Assert(obtained.Summary, gc.Equals, expected.Summary)
+	c.Assert(obtained.Tags, gc.DeepEquals, expected.Tags)
 	c.Assert(obtained.Channels, jc.DeepEquals, expected.Channels)
 	c.Assert(obtained.Tracks, jc.SameContents, expected.Tracks)
 	assertCharmSameContents(c, obtained.Charm, expected.Charm)
@@ -136,13 +137,11 @@ func assertCharmSameContents(c *gc.C, obtained, expected *Charm) {
 	c.Assert(obtained.Relations, jc.DeepEquals, expected.Relations)
 	c.Assert(obtained.Subordinate, gc.Equals, expected.Subordinate)
 	c.Assert(obtained.UsedBy, gc.DeepEquals, expected.UsedBy)
-	c.Assert(obtained.Tags, gc.DeepEquals, expected.Tags)
 }
 
 func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse) {
 	c.Assert(obtained, gc.HasLen, 1)
 	c.Assert(expected, gc.HasLen, 1)
-
 	want := obtained[0]
 	got := expected[0]
 	c.Assert(want.Type, gc.Equals, got.Type)
@@ -163,6 +162,7 @@ func getParamsInfoResponse() params.InfoResponse {
 		Tracks:      []string{"latest"},
 		Series:      []string{"bionic", "xenial"},
 		StoreURL:    "https://someurl.com/wordpress",
+		Tags:        []string{"app", "seven"},
 		Channels: map[string]params.Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
@@ -183,7 +183,6 @@ func getParamsInfoResponse() params.InfoResponse {
 				"skill-level":        {Type: "int", Description: "A number indicating skill."},
 				"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
 			},
-			Tags: []string{"app", "seven"},
 			Relations: map[string]map[string]string{
 				"provides": {"source": "dummy-token"},
 				"requires": {"sink": "dummy-token"}},

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -22,6 +22,7 @@ func convertCharmInfoResult(info params.InfoResponse) InfoResponse {
 		Summary:     info.Summary,
 		Series:      info.Series,
 		StoreURL:    info.StoreURL,
+		Tags:        info.Tags,
 		Channels:    convertChannels(info.Channels),
 		Tracks:      info.Tracks,
 	}
@@ -85,7 +86,6 @@ func convertCharm(in interface{}) *Charm {
 		Config:      params.FromCharmOptionMap(inC.Config),
 		Relations:   inC.Relations,
 		Subordinate: inC.Subordinate,
-		Tags:        inC.Tags,
 		UsedBy:      inC.UsedBy,
 	}
 }
@@ -110,6 +110,7 @@ type InfoResponse struct {
 	Summary     string             `json:"summary"`
 	Series      []string           `json:"series"`
 	StoreURL    string             `json:"store-url"`
+	Tags        []string           `json:"tags"`
 	Charm       *Charm             `json:"charm,omitempty"`
 	Bundle      *Bundle            `json:"bundle,omitempty"`
 	Channels    map[string]Channel `json:"channel-map"`
@@ -153,7 +154,6 @@ type Charm struct {
 	Config      *charm.Config                `json:"config"`
 	Relations   map[string]map[string]string `json:"relations"`
 	Subordinate bool                         `json:"subordinate"`
-	Tags        []string                     `json:"tags"`
 	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
 }
 

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -78,6 +78,7 @@ func assertInfoResponseSameContents(c *gc.C, obtained, expected params.InfoRespo
 	c.Assert(obtained.Summary, gc.Equals, expected.Summary)
 	c.Assert(obtained.Channels, jc.DeepEquals, expected.Channels)
 	c.Assert(obtained.Tracks, jc.SameContents, expected.Tracks)
+	c.Assert(obtained.Tags, gc.DeepEquals, expected.Tags)
 	assertCharmSameContents(c, obtained.Charm, expected.Charm)
 }
 
@@ -94,7 +95,6 @@ func assertCharmSameContents(c *gc.C, obtained, expected *params.CharmHubCharm) 
 	c.Assert(obtained.Relations, jc.DeepEquals, expected.Relations)
 	c.Assert(obtained.Subordinate, gc.Equals, expected.Subordinate)
 	c.Assert(obtained.UsedBy, gc.DeepEquals, expected.UsedBy)
-	c.Assert(obtained.Tags, gc.DeepEquals, expected.Tags)
 }
 
 func getCharmHubFindResponses() []transport.FindResponse {
@@ -222,6 +222,7 @@ func getParamsInfoResponse() params.InfoResponse {
 		Tracks:      []string{"latest"},
 		Series:      []string{"bionic", "xenial"},
 		StoreURL:    "https://someurl.com/wordpress",
+		Tags:        []string{"blog"},
 		Channels: map[string]params.Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
@@ -242,7 +243,6 @@ func getParamsInfoResponse() params.InfoResponse {
 				"skill-level":        {Type: "int", Description: "A number indicating skill."},
 				"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
 			},
-			Tags: []string{"app", "seven"},
 			Relations: map[string]map[string]string{
 				"provides": {"source": "dummy-token"},
 				"requires": {"sink": "dummy-token"}},
@@ -264,7 +264,6 @@ description: |
   This will install and setup services optimized to run in the cloud.
   By default it will place Ngnix configured to scale horizontally
   with Nginx's reverse proxy.
-tags: [app, seven]
 series: [bionic, xenial]
 provides:
   source:

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -22,6 +22,7 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 		Description: info.Entity.Description,
 		Publisher:   publisher(info.Entity),
 		Summary:     info.Entity.Summary,
+		Tags:        categories(info.Entity.Categories),
 	}
 	switch ir.Type {
 	case "bundle":
@@ -31,6 +32,17 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 	}
 	ir.Tracks, ir.Channels = transformChannelMap(info.ChannelMap)
 	return ir
+}
+
+func categories(cats []transport.Category) []string {
+	if len(cats) == 0 {
+		return nil
+	}
+	result := make([]string, len(cats))
+	for i, v := range cats {
+		result[i] = v.Name
+	}
+	return result
 }
 
 func convertCharmFindResults(responses []transport.FindResponse) []params.FindResponse {
@@ -100,7 +112,6 @@ func convertCharm(info transport.InfoResponse) *params.CharmHubCharm {
 	}
 	if meta := unmarshalCharmMetadata(info.DefaultRelease.Revision.MetadataYAML); meta != nil {
 		charmHubCharm.Subordinate = meta.Subordinate
-		charmHubCharm.Tags = meta.Tags
 		charmHubCharm.Relations = transformRelations(meta.Requires, meta.Provides)
 	}
 	if cfg := unmarshalCharmConfig(info.DefaultRelease.Revision.ConfigYAML); cfg != nil {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9618,12 +9618,6 @@
                         "subordinate": {
                             "type": "boolean"
                         },
-                        "tags": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "used-by": {
                             "type": "array",
                             "items": {
@@ -9636,7 +9630,6 @@
                         "config",
                         "relations",
                         "subordinate",
-                        "tags",
                         "used-by"
                     ]
                 },
@@ -9838,6 +9831,12 @@
                         "summary": {
                             "type": "string"
                         },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "tracks": {
                             "type": "array",
                             "items": {
@@ -9858,6 +9857,7 @@
                         "summary",
                         "series",
                         "store-url",
+                        "tags",
                         "channel-map",
                         "tracks"
                     ]

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -23,6 +23,7 @@ type InfoResponse struct {
 	Summary     string             `json:"summary"`
 	Series      []string           `json:"series"`
 	StoreURL    string             `json:"store-url"`
+	Tags        []string           `json:"tags"`
 	Charm       *CharmHubCharm     `json:"charm,omitempty"`
 	Bundle      *CharmHubBundle    `json:"bundle,omitempty"`
 	Channels    map[string]Channel `json:"channel-map"`
@@ -70,7 +71,6 @@ type CharmHubCharm struct {
 	Config      map[string]CharmOption       `json:"config"`
 	Relations   map[string]map[string]string `json:"relations"`
 	Subordinate bool                         `json:"subordinate"`
-	Tags        []string                     `json:"tags"`
 	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
 }
 

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -131,6 +131,7 @@ func (b bundleInfoWriter) Print() error {
 		Summary:     b.in.Summary,
 		Publisher:   b.in.Publisher,
 		Description: b.in.Description,
+		Tags:        strings.Join(b.in.Tags, ", "),
 		Channels:    b.channels(),
 	}
 	return b.print(out)
@@ -169,9 +170,9 @@ func (c charmInfoWriter) Print() error {
 		Supports:    strings.Join(c.in.Series, ", "),
 		Description: c.in.Description,
 		Channels:    c.channels(),
+		Tags:        strings.Join(c.in.Tags, ", "),
 	}
 	if c.in.Charm != nil {
-		out.Tags = strings.Join(c.in.Charm.Tags, ", ")
 		out.Subordinate = c.in.Charm.Subordinate
 	}
 	if rels, err := c.relations(); err == nil {

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -34,6 +34,12 @@ description: |-
   This will install and setup WordPress optimized to run in the cloud.
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
+relations:
+  provides:
+    one: two
+    three: four
+  requires:
+    five: six
 channels: |
   latest/stable:     1.0.3  2019-12-16  (16)  12MB
   latest/candidate:  1.0.3  2019-12-16  (17)  12MB
@@ -147,6 +153,15 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 		Tags:        []string{"app", "seven"},
 		Charm: &charmhub.Charm{
 			Subordinate: true,
+			Relations: map[string]map[string]string{
+				"provides": {
+					"one":   "two",
+					"three": "four",
+				},
+				"requires": {
+					"five": "six",
+				},
+			},
 		},
 		Channels: map[string]charmhub.Channel{
 			"latest/stable": {

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -29,7 +29,7 @@ summary: WordPress is a full featured web blogging tool, this charm deploys it.
 publisher: Wordress Charmers
 supports: bionic, xenial
 tags: app, seven
-subordinate: false
+subordinate: true
 description: |-
   This will install and setup WordPress optimized to run in the cloud.
   By default it will place Ngnix and php-fpm configured to scale horizontally with
@@ -77,6 +77,7 @@ func (s *printInfoSuite) TestBundlePrintInfo(c *gc.C) {
 bundle-id: bundleBUNDLEbundleBUNDLEbundle01
 summary: A bundle by charmed-osm.
 publisher: charmed-osm
+tags: networking
 description: Single instance OSM bundle.
 channels: |
   latest/stable:     1.0.3  2019-12-16  (16)  12MB
@@ -95,6 +96,7 @@ func getBundleInfoResponse() charmhub.InfoResponse {
 		Description: "Single instance OSM bundle.",
 		Publisher:   "charmed-osm",
 		Summary:     "A bundle by charmed-osm.",
+		Tags:        []string{"networking"},
 		Bundle:      nil,
 		Channels: map[string]charmhub.Channel{
 			"latest/stable": {
@@ -142,8 +144,9 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 		Publisher:   "Wordress Charmers",
 		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix and php-fpm configured to scale horizontally with\nNginx's reverse proxy.",
 		Series:      []string{"bionic", "xenial"},
+		Tags:        []string{"app", "seven"},
 		Charm: &charmhub.Charm{
-			Tags: []string{"app", "seven"},
+			Subordinate: true,
 		},
 		Channels: map[string]charmhub.Channel{
 			"latest/stable": {


### PR DESCRIPTION

## Description of change

New information about where to find tags data for juju info output has been provided.  Rather than in the charm metadata, check the entity for category in the response data.  This is a good change as bundles do not have metadata.
## QA steps
```console
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju bootstrap localhost --build-agent
$ juju info wordpress | grep tags
tags: blog, applications

# bundles look slightly different
$ juju info osm | grep tags
tags: networking
```


