### PR TITLE
Update find command to the new find API

### DIFF
--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -109,13 +109,15 @@ func getInfoResponse() InfoResponse {
 }
 
 func getFindResponses() []FindResponse {
-	//_, entity, defaultChannelMap := getChannelMapResponse()
 	return []FindResponse{{
-		Name: "wordpress",
-		Type: "object",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		//Entity:         entity,
-		//DefaultRelease: defaultChannelMap,
+		Name:      "wordpress",
+		Type:      "object",
+		ID:        "charmCHARMcharmCHARMcharmCHARM01",
+		Publisher: "Wordress Charmers",
+		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Version:   "1.0.3",
+		Series:    []string{"bionic"},
+		StoreURL:  "https://someurl.com/wordpress",
 	}}
 }
 
@@ -147,8 +149,11 @@ func assertFindResponsesSameContents(c *gc.C, obtained, expected []FindResponse)
 	c.Assert(want.Type, gc.Equals, got.Type)
 	c.Assert(want.ID, gc.Equals, got.ID)
 	c.Assert(want.Name, gc.Equals, got.Name)
-	//assertEntitySameContents(c, want.Entity, got.Entity)
-	c.Assert(want.DefaultRelease, gc.DeepEquals, got.DefaultRelease)
+	c.Assert(want.Publisher, gc.Equals, got.Publisher)
+	c.Assert(want.Summary, gc.Equals, got.Summary)
+	c.Assert(want.Version, gc.Equals, got.Version)
+	c.Assert(want.Series, gc.DeepEquals, got.Series)
+	c.Assert(want.StoreURL, gc.Equals, got.StoreURL)
 }
 
 func getParamsInfoResponse() params.InfoResponse {
@@ -196,12 +201,14 @@ func getParamsInfoResponse() params.InfoResponse {
 }
 
 func getParamsFindResponses() []params.FindResponse {
-	//_, entity, defaultChannelMap := getParamsChannelMapResponse()
 	return []params.FindResponse{{
-		Name: "wordpress",
-		Type: "object",
-		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		//Entity:         entity,
-		//DefaultRelease: defaultChannelMap,
+		Type:      "object",
+		ID:        "charmCHARMcharmCHARMcharmCHARM01",
+		Name:      "wordpress",
+		Publisher: "Wordress Charmers",
+		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Version:   "1.0.3",
+		Series:    []string{"bionic"},
+		StoreURL:  "https://someurl.com/wordpress",
 	}}
 }

--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -43,13 +43,16 @@ func convertCharmFindResults(responses []params.FindResponse) []FindResponse {
 	return results
 }
 
-func convertCharmFindResult(info params.FindResponse) FindResponse {
+func convertCharmFindResult(resp params.FindResponse) FindResponse {
 	return FindResponse{
-		Type: info.Type,
-		ID:   info.ID,
-		Name: info.Name,
-		//Entity:         convertEntity(info.Entity),
-		//DefaultRelease: convertOneChannelMap(info.DefaultRelease),
+		Type:      resp.Type,
+		ID:        resp.ID,
+		Name:      resp.Name,
+		Publisher: resp.Publisher,
+		Summary:   resp.Summary,
+		Version:   resp.Version,
+		Series:    resp.Series,
+		StoreURL:  resp.StoreURL,
 	}
 }
 
@@ -118,16 +121,14 @@ type InfoResponse struct {
 }
 
 type FindResponse struct {
-	Type           string     `json:"type"`
-	ID             string     `json:"id"`
-	Name           string     `json:"name"`
-	Entity         Entity     `json:"entity"`
-	DefaultRelease ChannelMap `json:"default-release,omitempty"`
-}
-
-type ChannelMap struct {
-	Channel Channel `json:"channel,omitempty"`
-	//Revision Revision `json:"revision,omitempty"`
+	Type      string   `json:"type"`
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Publisher string   `json:"publisher"`
+	Summary   string   `json:"summary"`
+	Version   string   `json:"version"`
+	Series    []string `json:"series"`
+	StoreURL  string   `json:"store-url"`
 }
 
 type Channel struct {
@@ -137,16 +138,6 @@ type Channel struct {
 	Revision   int    `json:"revision"`
 	Size       int    `json:"size"`
 	Version    string `json:"version"`
-}
-
-type Entity struct {
-	//Categories  []Category        `json:"categories"`
-	Description string `json:"description"`
-	License     string `json:"license"`
-	//Media       []Media           `json:"media"`
-	Publisher map[string]string `json:"publisher"`
-	Summary   string            `json:"summary"`
-	UsedBy    []string          `json:"used-by"` // bundles which use the charm
 }
 
 // Charm matches a params.CharmHubCharm

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -21,6 +21,7 @@ var logger = loggo.GetLogger("juju.apiserver.charmhub")
 
 // Client represents a charmhub Client for making queries to the charmhub API.
 type Client interface {
+	URL() string
 	Info(ctx context.Context, name string) (transport.InfoResponse, error)
 	Find(ctx context.Context, query string) ([]transport.FindResponse, error)
 }
@@ -63,7 +64,7 @@ func (api *CharmHubAPI) Info(arg params.Entity) (params.CharmHubEntityInfoResult
 	if err != nil {
 		return params.CharmHubEntityInfoResult{}, errors.Trace(err)
 	}
-	return params.CharmHubEntityInfoResult{Result: convertCharmInfoResult(info)}, nil
+	return params.CharmHubEntityInfoResult{Result: convertCharmInfoResult(info, api.client.URL())}, nil
 }
 
 // Find queries the charmhub API with a given entity ID.
@@ -75,5 +76,5 @@ func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubEntityFindResult,
 	if err != nil {
 		return params.CharmHubEntityFindResult{}, errors.Trace(err)
 	}
-	return params.CharmHubEntityFindResult{Results: convertCharmFindResults(results)}, nil
+	return params.CharmHubEntityFindResult{Results: convertCharmFindResults(results, api.client.URL())}, nil
 }

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -220,7 +220,7 @@ func getParamsInfoResponse() params.InfoResponse {
 		Publisher:   "Wordress Charmers",
 		Summary:     "WordPress is a full featured web blogging tool, this charm deploys it.",
 		Tracks:      []string{"latest"},
-		Series:      []string{"bionic"},
+		Series:      []string{"bionic", "xenial"},
 		StoreURL:    "https://someurl.com/wordpress",
 		Tags:        []string{"blog"},
 		Channels: map[string]params.Channel{
@@ -263,7 +263,7 @@ func getParamsFindResponse() params.FindResponse {
 		Publisher: "Wordress Charmers",
 		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
 		Version:   "1.0.3",
-		Series:    []string{"bionic"},
+		Series:    []string{"bionic", "xenial"},
 		StoreURL:  "https://someurl.com/wordpress",
 	}
 }

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -89,17 +89,9 @@ func transformStoreURL(clientURL, name string) string {
 // transformSeries returns a slice of supported series for that revision.
 func transformSeries(channel transport.ChannelMap) []string {
 	if meta := unmarshalCharmMetadata(channel.Revision.MetadataYAML); meta != nil {
-		return uniqueStrings(meta.Series)
+		return meta.Series
 	}
 	return nil
-}
-
-func uniqueStrings(strings []string) []string {
-	series := set.NewStrings()
-	for _, s := range strings {
-		series.Add(s)
-	}
-	return series.SortedValues()
 }
 
 // transformChannelMap returns channel map data in a format that facilitates
@@ -136,9 +128,7 @@ func convertCharm(info transport.InfoResponse) (*params.CharmHubCharm, []string)
 	if meta := unmarshalCharmMetadata(info.DefaultRelease.Revision.MetadataYAML); meta != nil {
 		charmHubCharm.Subordinate = meta.Subordinate
 		charmHubCharm.Relations = transformRelations(meta.Requires, meta.Provides)
-
-		// Ensure the series is outputted correctly.
-		series = uniqueStrings(meta.Series)
+		series = meta.Series
 	}
 	if cfg := unmarshalCharmConfig(info.DefaultRelease.Revision.ConfigYAML); cfg != nil {
 		charmHubCharm.Config = params.ToCharmOptionMap(cfg)

--- a/apiserver/facades/client/charmhub/mocks/package_mock.go
+++ b/apiserver/facades/client/charmhub/mocks/package_mock.go
@@ -63,3 +63,17 @@ func (mr *MockClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockClient)(nil).Info), arg0, arg1)
 }
+
+// URL mocks base method
+func (m *MockClient) URL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// URL indicates an expected call of URL
+func (mr *MockClientMockRecorder) URL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockClient)(nil).URL))
+}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9606,6 +9606,12 @@
                                 }
                             }
                         },
+                        "series": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "subordinate": {
                             "type": "boolean"
                         },
@@ -9621,7 +9627,8 @@
                         "config",
                         "relations",
                         "subordinate",
-                        "used-by"
+                        "used-by",
+                        "series"
                     ]
                 },
                 "CharmHubEntityFindResult": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9606,12 +9606,6 @@
                                 }
                             }
                         },
-                        "series": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "subordinate": {
                             "type": "boolean"
                         },
@@ -9627,8 +9621,7 @@
                         "config",
                         "relations",
                         "subordinate",
-                        "used-by",
-                        "series"
+                        "used-by"
                     ]
                 },
                 "CharmHubEntityFindResult": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9567,15 +9567,6 @@
                         "version"
                     ]
                 },
-                "ChannelMap": {
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "$ref": "#/definitions/Channel"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "CharmHubBundle": {
                     "type": "object",
                     "properties": {
@@ -9630,42 +9621,6 @@
                         "config",
                         "relations",
                         "subordinate",
-                        "used-by"
-                    ]
-                },
-                "CharmHubEntity": {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "type": "string"
-                        },
-                        "license": {
-                            "type": "string"
-                        },
-                        "publisher": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "summary": {
-                            "type": "string"
-                        },
-                        "used-by": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "description",
-                        "license",
-                        "publisher",
-                        "summary",
                         "used-by"
                     ]
                 },
@@ -9766,19 +9721,31 @@
                 "FindResponse": {
                     "type": "object",
                     "properties": {
-                        "default-release": {
-                            "$ref": "#/definitions/ChannelMap"
-                        },
-                        "entity": {
-                            "$ref": "#/definitions/CharmHubEntity"
-                        },
                         "id": {
                             "type": "string"
                         },
                         "name": {
                             "type": "string"
                         },
+                        "publisher": {
+                            "type": "string"
+                        },
+                        "series": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "store-url": {
+                            "type": "string"
+                        },
+                        "summary": {
+                            "type": "string"
+                        },
                         "type": {
+                            "type": "string"
+                        },
+                        "version": {
                             "type": "string"
                         }
                     },
@@ -9787,7 +9754,11 @@
                         "type",
                         "id",
                         "name",
-                        "entity"
+                        "publisher",
+                        "summary",
+                        "version",
+                        "series",
+                        "store-url"
                     ]
                 },
                 "InfoResponse": {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -60,7 +60,6 @@ type CharmHubCharm struct {
 	Relations   map[string]map[string]string `json:"relations"`
 	Subordinate bool                         `json:"subordinate"`
 	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
-	Series      []string                     `json:"series"`
 }
 
 type CharmHubBundle struct {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -55,21 +55,12 @@ type Channel struct {
 	Version    string `json:"version"`
 }
 
-type CharmHubEntity struct {
-	//Categories  []Category        `json:"categories"`
-	Description string `json:"description"`
-	License     string `json:"license"`
-	//Media       []Media           `json:"media"`
-	Publisher map[string]string `json:"publisher"`
-	Summary   string            `json:"summary"`
-	UsedBy    []string          `json:"used-by"` // bundles which use the charm
-}
-
 type CharmHubCharm struct {
 	Config      map[string]CharmOption       `json:"config"`
 	Relations   map[string]map[string]string `json:"relations"`
 	Subordinate bool                         `json:"subordinate"`
 	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
+	Series      []string                     `json:"series"`
 }
 
 type CharmHubBundle struct {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -36,16 +36,14 @@ type CharmHubEntityFindResult struct {
 }
 
 type FindResponse struct {
-	Type           string         `json:"type"`
-	ID             string         `json:"id"`
-	Name           string         `json:"name"`
-	Entity         CharmHubEntity `json:"entity"`
-	DefaultRelease ChannelMap     `json:"default-release,omitempty"`
-}
-
-type ChannelMap struct {
-	Channel Channel `json:"channel,omitempty"`
-	//Revision Revision `json:"revision,omitempty"`
+	Type      string   `json:"type"`
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Publisher string   `json:"publisher"`
+	Summary   string   `json:"summary"`
+	Version   string   `json:"version"`
+	Series    []string `json:"series"`
+	StoreURL  string   `json:"store-url"`
 }
 
 type Channel struct {

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -81,6 +81,7 @@ func (c Config) BasePath() (charmhubpath.Path, error) {
 
 // Client represents the client side of a charm store.
 type Client struct {
+	url        string
 	infoClient *InfoClient
 	findClient *FindClient
 }
@@ -107,9 +108,15 @@ func NewClient(config Config) (*Client, error) {
 	restClient := NewHTTPRESTClient(apiRequester)
 
 	return &Client{
+		url:        base.String(),
 		infoClient: NewInfoClient(infoPath, restClient),
 		findClient: NewFindClient(findPath, restClient),
 	}, nil
+}
+
+// URL returns the underlying store URL.
+func (c *Client) URL() string {
+	return c.url
 }
 
 // Info returns charm info on the provided charm name from charmhub.

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -4,6 +4,8 @@
 package charmhub
 
 import (
+	"bytes"
+
 	"github.com/juju/juju/api/charmhub"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -20,63 +22,40 @@ func (s *printFindSuite) TestCharmPrintFind(c *gc.C) {
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
-	//	obtained := ctx.Stdout.(*bytes.Buffer).String()
-	//	expected := `
-	//Name       Bundle  Version   Publisher           Summary
-	//wordpress  -       1.0.3     Wordpress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
-	//osm        Y       31.12.33  charmed-osm         Single instance OSM bundle.
-	//
-	//`[1:]
-	//	c.Assert(obtained, gc.Equals, expected)
+	obtained := ctx.Stdout.(*bytes.Buffer).String()
+	expected := `
+Name       Bundle  Version  Supports              Publisher          Summary
+wordpress  -       1.0.3    bionic                Wordress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
+osm        Y       3.2.3    bionic,xenial,trusty  charmed-osm        Single instance OSM bundle.
+
+`[1:]
+	c.Assert(obtained, gc.Equals, expected)
 }
 
 func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 	fr := getCharmFindResponse()
-	fr[0].Entity.Summary = ""
-	fr[0].Entity.Publisher = make(map[string]string)
-	fr[0].DefaultRelease = charmhub.ChannelMap{}
+	fr[0].Version = ""
+	fr[0].Series = make([]string, 0)
+	fr[0].Summary = ""
 
 	ctx := commandContextForTest(c)
 	fw := makeFindWriter(ctx, fr)
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
-	//	obtained := ctx.Stdout.(*bytes.Buffer).String()
-	//	expected := `
-	//Name       Bundle  Version   Publisher    Summary
-	//wordpress  -
-	//osm        Y       31.12.33  charmed-osm  Single instance OSM bundle.
-	//
-	//`[1:]
-	//	c.Assert(obtained, gc.Equals, expected)
-}
+	obtained := ctx.Stdout.(*bytes.Buffer).String()
+	expected := `
+Name       Bundle  Version  Supports              Publisher          Summary
+wordpress  -                                      Wordress Charmers  
+osm        Y       3.2.3    bionic,xenial,trusty  charmed-osm        Single instance OSM bundle.
 
-func (s *printFindSuite) TestPublisher(c *gc.C) {
-	entity := getCharmEntity()
-	fw := findWriter{}
-	publisher := fw.publisher(entity)
-
-	obtained := publisher
-	expected := "Wordpress Charmers"
-	c.Assert(obtained, gc.Equals, expected)
-}
-
-func (s *printFindSuite) TestPublisherEmpty(c *gc.C) {
-	entity := getCharmEntity()
-	entity.Publisher = make(map[string]string)
-
-	fw := findWriter{}
-	publisher := fw.publisher(entity)
-
-	obtained := publisher
-	expected := ""
+`[1:]
 	c.Assert(obtained, gc.Equals, expected)
 }
 
 func (s *printFindSuite) TestSummary(c *gc.C) {
-	entity := getCharmEntity()
-	fw := findWriter{}
-	summary := fw.summary(entity)
+	summary, err := oneLine("WordPress is a full featured web blogging tool, this charm deploys it.\nSome addition data\nMore Lines")
+	c.Assert(err, jc.ErrorIsNil)
 
 	obtained := summary
 	expected := "WordPress is a full featured web blogging tool, this charm deploys it."
@@ -84,11 +63,8 @@ func (s *printFindSuite) TestSummary(c *gc.C) {
 }
 
 func (s *printFindSuite) TestSummaryEmpty(c *gc.C) {
-	entity := getCharmEntity()
-	entity.Summary = ""
-
-	fw := findWriter{}
-	summary := fw.summary(entity)
+	summary, err := oneLine("")
+	c.Assert(err, jc.ErrorIsNil)
 
 	obtained := summary
 	expected := ""
@@ -97,88 +73,22 @@ func (s *printFindSuite) TestSummaryEmpty(c *gc.C) {
 
 func getCharmFindResponse() []charmhub.FindResponse {
 	return []charmhub.FindResponse{{
-		Name:           "wordpress",
-		Type:           "charm",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		Entity:         getCharmEntity(),
-		DefaultRelease: charmhub.ChannelMap{
-			//Channel: charmhub.Channel{
-			//	Name: "latest/stable",
-			//	Platform: charmhub.Platform{
-			//		Architecture: "all",
-			//		OS:           "ubuntu",
-			//		Series:       "bionic",
-			//	},
-			//	ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			//},
-			//Revision: charmhub.Revision{
-			//	ConfigYAML: config,
-			//	CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-			//	Download: charmhub.Download{
-			//		HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-			//		Size:       12042240,
-			//		URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-			//	},
-			//	MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
-			//	Revision:     16,
-			//	Version:      "1.0.3",
-			//},
-		},
+		Name:      "wordpress",
+		Type:      "charm",
+		ID:        "charmCHARMcharmCHARMcharmCHARM01",
+		Publisher: "Wordress Charmers",
+		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Version:   "1.0.3",
+		Series:    []string{"bionic"},
+		StoreURL:  "https://someurl.com/wordpress",
 	}, {
-		Name:           "osm",
-		Type:           "bundle",
-		ID:             "bundleBUNDLEbundleBUNDLEbundleBUNDLE01",
-		Entity:         getBundleEntity(),
-		DefaultRelease: charmhub.ChannelMap{
-			//Channel: charmhub.Channel{
-			//	Name: "latest/stable",
-			//	Platform: charmhub.Platform{
-			//		Architecture: "all",
-			//		OS:           "ubuntu",
-			//		Series:       "bionic",
-			//	},
-			//	ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-			//},
-			//Revision: charmhub.Revision{
-			//	ConfigYAML: config,
-			//	CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-			//	Download: charmhub.Download{
-			//		HashSHA265: "4a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab492a8b825ed1108ab64863b19e544a908ec83c4",
-			//		Size:       32042240,
-			//		URL:        "https://api.snapcraft.io/api/v1/snaps/download/LfVfcQLnTZiPFnmfIKB2vB60Gcig5ZY7_16.snap",
-			//	},
-			//	MetadataYAML: "name: myname\nversion: 1.0.3\nsubordinate: false\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\ntags: [app, seven]\nseries: [bionic, xenial]\n",
-			//	Revision:     12,
-			//	Version:      "31.12.33",
-			//},
-		},
+		Name:      "osm",
+		Type:      "bundle",
+		ID:        "bundleBUNDLEbundleBUNDLEbundleBUNDLE01",
+		Publisher: "charmed-osm",
+		Summary:   "Single instance OSM bundle.",
+		Version:   "3.2.3",
+		Series:    []string{"bionic", "xenial", "trusty"},
+		StoreURL:  "https://someurl.com/osm",
 	}}
-}
-
-func getCharmEntity() charmhub.Entity {
-	return charmhub.Entity{
-		//Categories: []charmhub.Category{{
-		//	Featured: true,
-		//	Name:     "blog",
-		//}},
-		Description: "This will install and setup WordPress optimized to run in the cloud. By default it will place Ngnix and php-fpm configured to scale horizontally with Nginx's reverse proxy.",
-		Publisher: map[string]string{
-			"display-name": "Wordpress Charmers",
-		},
-		Summary: "WordPress is a full featured web blogging tool, this charm deploys it.\nFor blogging.",
-	}
-}
-
-func getBundleEntity() charmhub.Entity {
-	return charmhub.Entity{
-		//Categories: []charmhub.Category{{
-		//	Featured: true,
-		//	Name:     "blog",
-		//}},
-		Description: "Charmed OSM is an OSM distribution, developed and maintained by Canonical, which uses Juju charms to simplify its deployments and operations.",
-		Publisher: map[string]string{
-			"display-name": "charmed-osm",
-		},
-		Summary: "Single instance OSM bundle.",
-	}
 }


### PR DESCRIPTION
## Description of change

Pushing the charmhub client API into the API server and reducing how
much the client has to do to show the find/info data for a charm/bundle
makes the client much, much more simpler.

The code changes are really simple, but are laborious, which generally
means it's right. One code becomes complicated you have to wonder if
it's the right implementation.

## QA steps

```sh
juju bootstrap lxd test
juju find wordpress
```

Expected output:

```sh
$ juju find wordpress
Name       Bundle  Version  Supports       Publisher          Summary
wordpress  -       1.0.3    bionic,trusty  Wordress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
osm        Y       1.0.3    bionic,trusty  charmed-osm        A bundle by charmed-osm.
```