### PR TITLE
Add CIDR and config method to Address type

### DIFF
--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -314,7 +314,7 @@ func (st *State) prepareOrGetContainerInterfaceInfo(
 			InterfaceType:       corenetwork.InterfaceType(cfg.InterfaceType),
 			Disabled:            cfg.Disabled,
 			NoAutoStart:         cfg.NoAutoStart,
-			ConfigType:          corenetwork.InterfaceConfigType(cfg.ConfigType),
+			ConfigType:          corenetwork.AddressConfigType(cfg.ConfigType),
 			Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(cfg.Address)},
 			DNSServers:          corenetwork.NewProviderAddresses(cfg.DNSServers...),
 			DNSSearchDomains:    cfg.DNSSearchDomains,

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -143,7 +143,7 @@ type NetworkConfig struct {
 	NoAutoStart bool `json:"no-auto-start,omitempty"`
 
 	// ConfigType, if set, defines what type of configuration to use.
-	// See network.InterfaceConfigType for more info. If not set, for
+	// See network.AddressConfigType for more info. If not set, for
 	// backwards-compatibility, "dhcp" is assumed.
 	ConfigType string `json:"config-type,omitempty"`
 
@@ -282,7 +282,7 @@ func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) network.InterfaceIn
 			InterfaceType:       network.InterfaceType(v.InterfaceType),
 			Disabled:            v.Disabled,
 			NoAutoStart:         v.NoAutoStart,
-			ConfigType:          network.InterfaceConfigType(v.ConfigType),
+			ConfigType:          network.AddressConfigType(v.ConfigType),
 			Addresses:           ToProviderAddresses(v.Addresses...),
 			ShadowAddresses:     ToProviderAddresses(v.ShadowAddresses...),
 			DNSServers:          network.NewProviderAddresses(v.DNSServers...),

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -98,6 +98,9 @@ type Address interface {
 
 	// AddressCIDR returns the subnet CIDR of the address.
 	AddressCIDR() string
+
+	// AddressConfigType returns the configuration method of the address.
+	AddressConfigType() AddressConfigType
 }
 
 // ScopeMatchFunc is an alias for a function that accepts an Address,
@@ -133,6 +136,9 @@ type MachineAddress struct {
 	// CIDR is used for IP addresses to indicate
 	// the subnet that they are part of.
 	CIDR string
+
+	// ConfigType denotes how this address was configured.
+	ConfigType AddressConfigType
 }
 
 // Host returns the value for the host-name/IP address.
@@ -153,6 +159,11 @@ func (a MachineAddress) AddressScope() Scope {
 // AddressCIDR returns the subnet CIDR of the address.
 func (a MachineAddress) AddressCIDR() string {
 	return a.CIDR
+}
+
+// AddressConfigType returns the configuration method of the address.
+func (a MachineAddress) AddressConfigType() AddressConfigType {
+	return a.ConfigType
 }
 
 // GoString implements fmt.GoStringer.

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -468,13 +468,6 @@ func (a SpaceAddress) GoString() string {
 	return a.String()
 }
 
-// Converts the space address to a net.IP address assuming the space address is
-// either v4 or v6. If the SpaceAddress value is not a valid ip address nil is
-// returned
-func (a SpaceAddress) IP() net.IP {
-	return net.ParseIP(a.Value)
-}
-
 // String returns a string representation of the address, in the form:
 // `<scope>:<address-value>@space:<space-id>`; for example:
 //

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -33,6 +33,18 @@ func mustParseCIDR(s string) *net.IPNet {
 	return ipNet
 }
 
+// AddressConfigType defines valid network link configuration types.
+// See interfaces(5) for details.
+type AddressConfigType string
+
+const (
+	ConfigUnknown  AddressConfigType = ""
+	ConfigDHCP     AddressConfigType = "dhcp"
+	ConfigStatic   AddressConfigType = "static"
+	ConfigManual   AddressConfigType = "manual"
+	ConfigLoopback AddressConfigType = "loopback"
+)
+
 // AddressType represents the possible ways of specifying a machine location by
 // either a hostname resolvable by dns lookup, or IPv4 or IPv6 address.
 type AddressType string

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -10,18 +10,6 @@ import (
 	"github.com/juju/errors"
 )
 
-// InterfaceConfigType defines valid network interface configuration
-// types. See interfaces(5) for details
-type InterfaceConfigType string
-
-const (
-	ConfigUnknown  InterfaceConfigType = ""
-	ConfigDHCP     InterfaceConfigType = "dhcp"
-	ConfigStatic   InterfaceConfigType = "static"
-	ConfigManual   InterfaceConfigType = "manual"
-	ConfigLoopback InterfaceConfigType = "loopback"
-)
-
 // InterfaceType defines valid network interface types.
 type InterfaceType string
 
@@ -143,7 +131,7 @@ type InterfaceInfo struct {
 	// ConfigType determines whether the interface should be
 	// configured via DHCP, statically, manually, etc. See
 	// interfaces(5) for more information.
-	ConfigType InterfaceConfigType
+	ConfigType AddressConfigType
 
 	// Addresses contains an optional list of static IP address to
 	// configure for this network interface. The subnet mask to set will be

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -441,7 +441,7 @@ func parseInterfaces(jsonBytes []byte) ([]maasInterface, error) {
 	return interfaces, nil
 }
 
-func maasLinkToInterfaceConfigType(mode string) corenetwork.InterfaceConfigType {
+func maasLinkToInterfaceConfigType(mode string) corenetwork.AddressConfigType {
 	switch maasLinkMode(mode) {
 	case modeUnknown:
 		return corenetwork.ConfigUnknown


### PR DESCRIPTION
## Description of change

This patch adds new members and corresponding accessors to `network.Address`. These are not yet recruited or reflected in DTOs, but will be used in forthcoming refactoring around usage of `InterfaceInfo`.

`InterfaceConfigType` is renamed to `AddressConfigType` as it applies to links and not the interface they are on.

## QA steps

None required.

## Documentation changes

None.

## Bug reference

N/A
