### PR TITLE
Use different registered app for azure credentials; allow use of custom resource groups

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -749,9 +749,6 @@ func (cfg *BootstrapConfig) VerifyConfig() (err error) {
 	if cfg.BootstrapMachineInstanceId == "" {
 		return errors.New("missing bootstrap machine instance ID")
 	}
-	if len(cfg.HostedModelConfig) == 0 {
-		return errors.New("missing hosted model config")
-	}
 	return nil
 }
 

--- a/cmd/juju/cloud/detectcredentials_test.go
+++ b/cmd/juju/cloud/detectcredentials_test.go
@@ -159,7 +159,7 @@ func (s *detectCredentialsSuite) assertDetectCredential(c *gc.C, t detectCredent
 	s.aCredential = jujucloud.CloudCredential{
 		DefaultRegion: "default region",
 		AuthCredentials: map[string]jujucloud.Credential{
-			"test": s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential")},
+			"test cred": s.credentialWithLabel(jujucloud.AccessKeyAuthType, "credential")},
 	}
 	clouds := map[string]jujucloud.Cloud{
 		"test-cloud": {
@@ -194,7 +194,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialOverwrites(c *gc.C) {
 	s.store.Credentials = map[string]jujucloud.CloudCredential{
 		"test-cloud": {
 			AuthCredentials: map[string]jujucloud.Credential{
-				"test": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+				"test_cred": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
 			},
 		},
 	}
@@ -206,7 +206,7 @@ func (s *detectCredentialsSuite) TestDetectCredentialKeepsExistingRegion(c *gc.C
 		"test-cloud": {
 			DefaultRegion: "west",
 			AuthCredentials: map[string]jujucloud.Credential{
-				"test": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
+				"test_cred": jujucloud.NewCredential(jujucloud.AccessKeyAuthType, nil),
 			},
 		},
 	}

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -68,6 +68,14 @@ func (s *configSuite) TestValidateModelNameLength(c *gc.C) {
 Please choose a model name of no more than 32 characters.`)
 }
 
+func (s *configSuite) TestValidateResourceGroupNameLength(c *gc.C) {
+	s.assertConfigInvalid(
+		c, testing.Attrs{"resource-group-name": "someextremelyoverlylongishresourcegroupname-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+		`resource group name "someextremelyoverlylongishresourcegroupname-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" is too long
+
+Please choose a name of no more than 80 characters.`)
+}
+
 func (s *configSuite) TestValidateStorageAccountTypeCantChange(c *gc.C) {
 	cfgOld := makeTestModelConfig(c, testing.Attrs{"storage-account-type": "Standard_LRS"})
 	_, err := s.provider.Validate(cfgOld, cfgOld)
@@ -89,6 +97,16 @@ func (s *configSuite) TestValidateLoadBalancerSkuNameCanChange(c *gc.C) {
 
 	_, err = s.provider.Validate(cfgOld, cfgNew)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *configSuite) TestValidateResourceGroupNameCantChange(c *gc.C) {
+	cfgOld := makeTestModelConfig(c, testing.Attrs{"resource-group-name": "foo"})
+	_, err := s.provider.Validate(cfgOld, cfgOld)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfgNew := makeTestModelConfig(c, testing.Attrs{"resource-group-name": "bar"})
+	_, err = s.provider.Validate(cfgNew, cfgOld)
+	c.Assert(err, gc.ErrorMatches, `cannot change immutable "resource-group-name" config \(foo -> bar\)`)
 }
 
 func (s *configSuite) assertConfigValid(c *gc.C, attrs testing.Attrs) {

--- a/provider/azure/credentials.go
+++ b/provider/azure/credentials.go
@@ -21,7 +21,6 @@ import (
 const (
 	credAttrAppId          = "application-id"
 	credAttrSubscriptionId = "subscription-id"
-	credAttrTenantId       = "tenant-id"
 	credAttrAppPassword    = "application-password"
 
 	// clientCredentialsAuthType is the auth-type for the
@@ -116,7 +115,7 @@ func (c environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 	}
 	var defaultCredential string
 	authCredentials := make(map[string]cloud.Credential)
-	for i, acc := range accounts {
+	for _, acc := range accounts {
 		cloudInfo, ok := cloudMap[acc.CloudName]
 		if !ok {
 			continue
@@ -124,13 +123,6 @@ func (c environProviderCredentials) DetectCredentials() (*cloud.CloudCredential,
 		cred, err := c.accountCredential(acc, cloudInfo)
 		if err != nil {
 			logger.Debugf("cannot get credential for %s: %s", acc.Name, err)
-			if i == 0 {
-				// Assume that if this fails the first
-				// time then it will always fail and
-				// don't attempt to create any further
-				// credentials.
-				return nil, errors.NotFoundf("credentials")
-			}
 			continue
 		}
 		cred.Label = fmt.Sprintf("%s subscription %s", cloudInfo.Name, acc.Name)

--- a/provider/azure/internal/azureauth/serviceprincipal.go
+++ b/provider/azure/internal/azureauth/serviceprincipal.go
@@ -36,7 +36,7 @@ const (
 	// for interactive authentication. When the user logs in, a service
 	// principal will be created in their Active Directory tenant for
 	// the application.
-	jujuApplicationId = "cbb548f1-5039-4836-af0b-727e8571f6a9"
+	jujuApplicationId = "60a04dc9-1857-425f-8076-5ba81ca53d66"
 
 	// passwordExpiryDuration is how long the application password we
 	// set will remain valid.
@@ -163,12 +163,12 @@ func (c *ServicePrincipalCreator) InteractiveCreate(sdkCtx context.Context, stde
 	fmt.Fprintln(stderr, "Initiating interactive authentication.")
 	fmt.Fprintln(stderr)
 	clientId := jujuApplicationId
-	deviceCode, err := adal.InitiateDeviceAuth(&client, *oauthConfig, clientId, params.ResourceManagerResourceId)
+	deviceCode, err := adal.InitiateDeviceAuthWithContext(sdkCtx, &client, *oauthConfig, clientId, params.ResourceManagerResourceId)
 	if err != nil {
 		return "", "", errors.Annotate(err, "initiating interactive authentication")
 	}
 	fmt.Fprintln(stderr, to.String(deviceCode.Message)+"\n")
-	token, err := adal.WaitForUserCompletion(&client, deviceCode)
+	token, err := adal.WaitForUserCompletionWithContext(sdkCtx, &client, deviceCode)
 	if err != nil {
 		return "", "", errors.Annotate(err, "waiting for interactive authentication to completed")
 	}

--- a/provider/azure/internal/azureauth/serviceprincipal_test.go
+++ b/provider/azure/internal/azureauth/serviceprincipal_test.go
@@ -79,7 +79,7 @@ func currentUserSender() autorest.Sender {
 
 func createServicePrincipalSender() autorest.Sender {
 	return azuretesting.NewSenderWithValue(graphrbac.ServicePrincipal{
-		AppID:    to.StringPtr("cbb548f1-5039-4836-af0b-727e8571f6a9"),
+		AppID:    to.StringPtr("60a04dc9-1857-425f-8076-5ba81ca53d66"),
 		ObjectID: to.StringPtr("sp-object-id"),
 	})
 }
@@ -115,7 +115,7 @@ func createServicePrincipalNotReferenceSender() autorest.Sender {
 func servicePrincipalListSender() autorest.Sender {
 	return azuretesting.NewSenderWithValue(graphrbac.ServicePrincipalListResult{
 		Value: &[]graphrbac.ServicePrincipal{{
-			AppID:    to.StringPtr("cbb548f1-5039-4836-af0b-727e8571f6a9"),
+			AppID:    to.StringPtr("60a04dc9-1857-425f-8076-5ba81ca53d66"),
 			ObjectID: to.StringPtr("sp-object-id"),
 		}},
 	})
@@ -203,7 +203,7 @@ func (s *InteractiveSuite) TestInteractive(c *gc.C) {
 		SubscriptionId:            subscriptionId,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(appId, gc.Equals, "cbb548f1-5039-4836-af0b-727e8571f6a9")
+	c.Assert(appId, gc.Equals, "60a04dc9-1857-425f-8076-5ba81ca53d66")
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
 	c.Assert(stderr.String(), gc.Equals, `
 Initiating interactive authentication.


### PR DESCRIPTION
## Description of change

There's some issues bootstrapping to Azure.
The first is that the "Juju CLI" app in the canonical.com AD appears to have been setup as single tenant only. This means that depending on your subscription tenant, you could not bootstrap since it was not possible to create a service principal off this app. In my case, I could bootstrap but autoload-credentials failed.

The fix is to create a new "Juju" app in the canonical.com AD and have it be multi-tenant. The Juju change is to update the app id which is used to create the user's service principal. A drive by fix autoload-credentials was done to replace " " in detected credential names with "_".

The second issue is that for some accounts, resource groups cannot be created by policy. So we add a new Azure specific model config "resource-group-name". This will use an existing resource group. To make it work, Juju cannot be allowed to create a "default" model at bootstrap or else the same resource group will be used for both. So a new --no-default-model arg was added to bootstrap. We want to get rid of the default model eventually anyway.

There's a problem though - since we cannot tag these "read only" resource groups, destroy-controller cannot see them, so any models which use a custom group name will not have resources cleaned up. This is not easily fixed. It will be a known issue if this type of deployment is used. The user will need to destroy all models and then the controller.

## QA steps

install the az cli tool (this will be there anyway if azure used previously)
az logout
az login
juju autoload-credentials
(choose interactive method)

There should be a credential created allowing you to juju bootstrap to azure.

To test the resource group, set up a resource group "juju-test" via the azure dashboard, then

juju bootstrap azure -config resource-group-name=juju-test --no-default-model

The juju-test group should have the controller machine etc in it.
Create a new group juju-test2. Add a model

juju add-model test --config resource-group-name=juju-test2
juju add-machine

The juju-test2 group should have machine and some network items.

juju destroy-model test

The juju-test2 group will have everything deleted but the group will remain behind

## Bug reference

https://bugs.launchpad.net/bugs/1885557
https://bugs.launchpad.net/bugs/1869939
