### PR TITLE
Remove phrase "invalid URL" of datasource error messages.

### DIFF
--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -162,7 +162,7 @@ var fetchMetadataTests = []struct {
 	about:         "error: stream file not found",
 	stream:        "no-such",
 	jujuVersion:   "2.0.0",
-	expectedError: `error fetching simplestreams metadata: cannot read product data, "test:/streams/v1/com.canonical.streams-no-such-gui.json" not found`,
+	expectedError: `error fetching simplestreams metadata: cannot read product data: "test:/streams/v1/com.canonical.streams-no-such-gui.json" not found`,
 }}
 
 func (s *simplestreamsSuite) TestFetchMetadata(c *gc.C) {

--- a/environs/gui/simplestreams_test.go
+++ b/environs/gui/simplestreams_test.go
@@ -162,7 +162,7 @@ var fetchMetadataTests = []struct {
 	about:         "error: stream file not found",
 	stream:        "no-such",
 	jujuVersion:   "2.0.0",
-	expectedError: `error fetching simplestreams metadata: cannot read product data, invalid URL "test:/streams/v1/com.canonical.streams-no-such-gui.json" not found`,
+	expectedError: `error fetching simplestreams metadata: cannot read product data, "test:/streams/v1/com.canonical.streams-no-such-gui.json" not found`,
 }}
 
 func (s *simplestreamsSuite) TestFetchMetadata(c *gc.C) {

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -166,7 +166,7 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 	resp, err := client.Get(dataURL)
 	if err != nil {
 		logger.Tracef("Got error requesting %q: %v", dataURL, err)
-		return nil, dataURL, errors.NotFoundf("invalid URL %q", dataURL)
+		return nil, dataURL, errors.NotFoundf("%q", dataURL)
 	}
 	if resp.StatusCode != http.StatusOK {
 		_ = resp.Body.Close()

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -165,14 +165,19 @@ func (h *urlDataSource) Fetch(path string) (io.ReadCloser, string, error) {
 	dataURL = utils.MakeFileURL(dataURL)
 	resp, err := client.Get(dataURL)
 	if err != nil {
-		logger.Tracef("Got error requesting %q: %v", dataURL, err)
-		return nil, dataURL, errors.NotFoundf("%q", dataURL)
+		if !errors.IsNotFound(err) {
+			// Callers of this mask the actual error.  Therefore warn here.
+			// This is called multiple times when a machine is created, we
+			// only need one success for images and one for tools.
+			logger.Warningf("Got error requesting %q: %v", dataURL, err)
+		}
+		return nil, dataURL, errors.NewNotFound(err, fmt.Sprintf("%q", dataURL))
 	}
 	if resp.StatusCode != http.StatusOK {
 		_ = resp.Body.Close()
 		switch resp.StatusCode {
 		case http.StatusNotFound:
-			return nil, dataURL, errors.NotFoundf("cannot find URL %q", dataURL)
+			return nil, dataURL, errors.NotFoundf("%q", dataURL)
 		case http.StatusUnauthorized:
 			return nil, dataURL, errors.Unauthorizedf("unauthorised access to URL %q", dataURL)
 		}

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -73,7 +74,7 @@ func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
 	reader, _, err := ds.Fetch("bar")
 	// The underlying failure is a x509: certificate signed by unknown authority
 	// However, the urlDataSource abstraction hides that as a simple NotFound
-	c.Assert(err, gc.ErrorMatches, "\".*/bar\" not found")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Check(reader, gc.IsNil)
 }
 

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -73,7 +73,7 @@ func (s *datasourceHTTPSSuite) TestNormalClientFails(c *gc.C) {
 	reader, _, err := ds.Fetch("bar")
 	// The underlying failure is a x509: certificate signed by unknown authority
 	// However, the urlDataSource abstraction hides that as a simple NotFound
-	c.Assert(err, gc.ErrorMatches, "invalid URL \".*/bar\" not found")
+	c.Assert(err, gc.ErrorMatches, "\".*/bar\" not found")
 	c.Check(reader, gc.IsNil)
 }
 

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -436,7 +436,7 @@ func getMaybeSignedMetadata(source DataSource, params GetMetadataParams, signed 
 	logger.Tracef("looking for data index using URL %s", indexURL)
 	if errors.IsNotFound(err) || errors.IsUnauthorized(err) {
 		legacyIndexPath := makeIndexPath(defaultLegacyIndexPath)
-		logger.Tracef("%s not accessed, actual error: %v", indexPath, err)
+		logger.Tracef("%s not accessed, actual error: %v", indexPath, errors.Details(err))
 		logger.Tracef("%s not accessed, trying legacy index path: %s", indexPath, legacyIndexPath)
 		indexPath = legacyIndexPath
 		indexRef, indexURL, err = fetchIndex(
@@ -488,7 +488,7 @@ func fetchData(source DataSource, path string, requireSigned bool) (data []byte,
 	rc, dataURL, err := source.Fetch(path)
 	if err != nil {
 		logger.Tracef("fetchData failed for %q: %v", dataURL, err)
-		return nil, dataURL, errors.NotFoundf("%q", dataURL)
+		return nil, dataURL, err
 	}
 	defer func() { _ = rc.Close() }()
 	if requireSigned {
@@ -963,7 +963,7 @@ func (indexRef *IndexReference) GetCloudMetadataWithFormat(cons LookupConstraint
 	data, url, err := fetchData(indexRef.Source, productFilesPath, requireSigned)
 	if err != nil {
 		logger.Tracef("can't read product data: %v", err)
-		return nil, fmt.Errorf("cannot read product data, %v", err)
+		return nil, errors.Annotate(err, "cannot read product data")
 	}
 	return ParseCloudMetadata(data, format, url, indexRef.valueParams.ValueTemplate)
 }


### PR DESCRIPTION
## Description of change

It can be misleading to put a blanket "invalid URL" message on any error from the http client, remove.  Sometimes a not found can be an invalid URL, however other errors can be surface this way such as Forbidden.

Drive by: remove unused function arg and fix code for IDE warning that error from method is ignored.

## QA steps

```console
$ microstack.openstack service create --name product-stream  product-streams
$ microstack.openstack endpoint create --region RegionOne product-streams public http://some.bad.url.com/simplestreams
$ juju bootstrap microstack testme --debug --show-log

# output should include:
DEBUG juju.environs.bootstrap bootstrap.go:896 ignoring image metadata in keystone catalog: "http://some.bad.url.com/simplestreams/streams/v1/index.json" not found
# not:
DEBUG juju.environs.bootstrap bootstrap.go:877 ignoring image metadata in keystone catalog: invalid URL "http://some.bad.url.com/simplestreams/streams/v1/index.json" not found

# when finished, remove the endpoint, or your microstack cloud might not bootstrap again.
```

## Bug

Addresses confusion in: https://bugs.launchpad.net/juju/+bug/1885145 but does not fix it.