### PR TITLE
Fix UpgradeSeriesAPI.GetMachine() where we ignored an error

### DIFF
--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -173,11 +173,11 @@ func (u *UpgradeSeriesAPI) GetMachine(tag names.Tag) (UpgradeSeriesMachine, erro
 	case names.UnitTagKind:
 		unit, err := u.backend.Unit(tag.Id())
 		if err != nil {
-
+			return nil, errors.Trace(err)
 		}
 		id, err = unit.AssignedMachineId()
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
 	default:
 	}


### PR DESCRIPTION
## Description of change

There was a customer outage due to a nil pointer deference. Turns out we were ignoring an error, which would be a "not found" error for a unit. The unit agent would normally restart and then terminate if its unit is not longer there, but instead due to the nil pointer the controller got wedged as the api call never returned and the controller workers got stuck.

## QA steps

just a simple bootstrap and deploy 

## Bug reference

https://bugs.launchpad.net/juju/+bug/1887327
