### PR TITLE
Fix operator image path when build number is 0

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -37,7 +37,7 @@ operator_image_release_path() {
     echo "${DOCKER_USERNAME}/jujud-operator:$(_operator_image_version)"
 }
 operator_image_path() {
-    if [ -z "${JUJU_BUILD_NUMBER}" ]; then
+    if [ -z "${JUJU_BUILD_NUMBER}" ] || [ ${JUJU_BUILD_NUMBER} -eq 0 ]; then
         operator_image_release_path
     else
         echo "${DOCKER_USERNAME}/jujud-operator:$(_operator_image_version).${JUJU_BUILD_NUMBER}"


### PR DESCRIPTION
## Description of change

Fix operator image path when build number is 0

## QA steps

```
$ source make_functions.sh
$ operator_image_path
jujusolutions/jujud-operator:2.8.1
$ JUJU_BUILD_NUMBER=0
$ operator_image_path
jujusolutions/jujud-operator:2.8.1
$ JUJU_BUILD_NUMBER=1
$ operator_image_path
jujusolutions/jujud-operator:2.8.1.1
```

## Documentation changes

N/A

## Bug reference

N/A