### PR TITLE
Remove nbd from lxd profile tests

### DIFF
--- a/tests/suites/deploy/charms/lxd-profile/lxd-profile.yaml
+++ b/tests/suites/deploy/charms/lxd-profile/lxd-profile.yaml
@@ -3,6 +3,6 @@ description: lxd profile for testing
 config:
   security.nesting: "true"
   security.privileged: "true"
-  linux.kernel_modules: nbd,ip_tables,ip6_tables
+  linux.kernel_modules: ip_tables,ip6_tables
   environment.http_proxy: ""
 


### PR DESCRIPTION
## Description of change

As our CI machines are not homogeneous we have issues where some of our
tests will work on some machines, but not on others. The very fact that
we have non-homogeneous machines is both an asset and a curse. If they
were all the same, we could ensure that our tests wouldn't be that
flakey. Except that we should be testing the cases where they're not.

In this instance, we're testing LXD profiles and so we need to test the
lowest common denominator and that means removing kernel support from
lxd profiles that we can never meet.

It does beg the question though, how an owner of a charm is expected to
code against this, other than stating that each kernel module is a hard
dependency. This might have been better with feature testing if a module
was available and attempting to use that...


## QA steps

Wait till it lands and see the CI run.
