### PR TITLE
[2.7] Backport cleanup script changes

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -76,7 +76,11 @@ for path_to_unit in $(ls /etc/systemd/system/juju*); do
   systemctl stop "$unit"
   systemctl disable "$unit"
   systemctl daemon-reload
+  rm -f "$path_to_unit"
 done
+
+echo "removing /var/lib/juju/tools/*"
+rm -rf /var/lib/juju/tools/*
 
 echo "removing /var/lib/juju/db/*"
 rm -rf /var/lib/juju/db/*


### PR DESCRIPTION
## Description of change

This PR back-ports a set of improvements to the manually provisioned machine clean up script. More specifically:
- systemd units are also deleted (if present)
- the /var/lib/juju/tools folder contents are also removed.

The second change was not included in the back-ported fix but was added to this PR to address a problem (lingering symlinks in the tools folder) that got discovered while doing the bootstrap/cleanup dance several times. This one-line change will also need to be forward-ported to 2.8+

## QA steps

Acquire an instance that you can use as a manual machine. Repeat the following set of
steps 3-4 times to ensure that the machine gets properly cleaned up and provisioned
each time:

```console
$ juju bootstrap manual/ubuntu@$instance_ip --no-gui
$ juju kill-controller -y manual

# SSH into the instance and run the cleanup script
$ sudo /sbin/remove-juju-services
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1884331