### PR TITLE
[2.8] Make manual machine cleanup script a bit more robust

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -78,6 +78,9 @@ for path_to_unit in $(ls /etc/systemd/system/juju*); do
   rm -f "$path_to_unit"
 done
 
+echo "removing /var/lib/juju/tools/*"
+rm -rf /var/lib/juju/tools/*
+
 echo "removing /var/lib/juju/db/*"
 rm -rf /var/lib/juju/db/*
 


### PR DESCRIPTION
## Description of change

Forward ports a tiny fix from #11827 to avoid lingering symlinks in /var/lib/juju/tools which might prevent the machine from being re-provisioned after running /sbin/remove-juju-services.

## QA steps

Same as #11827 