### PR TITLE
Add startupProbe support;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2510,6 +2510,9 @@ func populateContainerDetails(deploymentName string, pod *core.PodSpec, podConta
 		if spec.ReadinessProbe != nil {
 			pc.ReadinessProbe = spec.ReadinessProbe
 		}
+		if spec.StartupProbe != nil {
+			pc.StartupProbe = spec.StartupProbe
+		}
 		if spec.SecurityContext != nil {
 			pc.SecurityContext = spec.SecurityContext
 		}

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -67,6 +67,12 @@ containers:
       httpGet:
         path: /pingReady
         port: www
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: liveness-port
+      failureThreshold: 30
+      periodSeconds: 10
     config:
       attr: foo=bar; name["fred"]="blogs";
       foo: bar
@@ -217,6 +223,19 @@ echo "do some stuff here for gitlab container"
 							HTTPGet: &core.HTTPGetAction{
 								Path: "/pingReady",
 								Port: intstr.IntOrString{StrVal: "www", Type: 1},
+							},
+						},
+					},
+					StartupProbe: &core.Probe{
+						PeriodSeconds:    10,
+						FailureThreshold: 30,
+						Handler: core.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.IntOrString{
+									Type:   intstr.String,
+									StrVal: "liveness-port",
+								},
 							},
 						},
 					},

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -70,6 +70,7 @@ func (c *k8sContainer) ToContainerSpec() specs.ContainerSpec {
 type K8sContainerSpec struct {
 	LivenessProbe   *core.Probe           `json:"livenessProbe,omitempty" yaml:"livenessProbe,omitempty"`
 	ReadinessProbe  *core.Probe           `json:"readinessProbe,omitempty" yaml:"readinessProbe,omitempty"`
+	StartupProbe    *core.Probe           `json:"startupProbe,omitempty" yaml:"startupProbe,omitempty"`
 	SecurityContext *core.SecurityContext `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 }
 

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -66,6 +66,12 @@ containers:
         httpGet:
           path: /pingReady
           port: www
+      startupProbe:
+        httpGet:
+          path: /healthz
+          port: liveness-port
+        failureThreshold: 30
+        periodSeconds: 10
     config:
       attr: foo=bar; name["fred"]="blogs";
       foo: bar
@@ -403,6 +409,19 @@ echo "do some stuff here for gitlab container"
 							HTTPGet: &core.HTTPGetAction{
 								Path: "/pingReady",
 								Port: intstr.IntOrString{StrVal: "www", Type: 1},
+							},
+						},
+					},
+					StartupProbe: &core.Probe{
+						PeriodSeconds:    10,
+						FailureThreshold: 30,
+						Handler: core.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.IntOrString{
+									Type:   intstr.String,
+									StrVal: "liveness-port",
+								},
 							},
 						},
 					},

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -69,6 +69,12 @@ containers:
         httpGet:
           path: /pingReady
           port: www
+      startupProbe:
+        httpGet:
+          path: /healthz
+          port: liveness-port
+        failureThreshold: 30
+        periodSeconds: 10
     envConfig:
       attr: foo=bar; name["fred"]="blogs";
       foo: bar
@@ -520,6 +526,19 @@ echo "do some stuff here for gitlab container"
 							HTTPGet: &core.HTTPGetAction{
 								Path: "/pingReady",
 								Port: intstr.IntOrString{StrVal: "www", Type: 1},
+							},
+						},
+					},
+					StartupProbe: &core.Probe{
+						PeriodSeconds:    10,
+						FailureThreshold: 30,
+						Handler: core.Handler{
+							HTTPGet: &core.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.IntOrString{
+									Type:   intstr.String,
+									StrVal: "liveness-port",
+								},
 							},
 						},
 					},


### PR DESCRIPTION

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

*Please replace with a description about why this change is needed, along with a description of what changed?*

## QA steps

Add startupProbe support;

```console
$ yml2json /tmp/charm-builds/mariadb-k8s/reactive/spec_template.yaml | jq '.containers[].kubernetes'
{
  "startupProbe": {
    "httpGet": {
      "path": "/healthz",
      "port": "liveness-port"
    },
    "failureThreshold": 30,
    "periodSeconds": 10
  }
}

$ mkubectl get -nt1 pod/mariadb-k8s-0 -o json | jq '.spec.containers[].startupProbe'
{
  "failureThreshold": 30,
  "httpGet": {
    "path": "/healthz",
    "port": "liveness-port",
    "scheme": "HTTP"
  },
  "periodSeconds": 10,
  "successThreshold": 1,
  "timeoutSeconds": 1
}

```

## Documentation changes

Yes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1887440
