### PR TITLE
Normalise InterfaceInfos

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -122,7 +122,7 @@ func NewMachineLinkLayerOp(machine LinkLayerMachine, incoming network.InterfaceI
 
 	return &MachineLinkLayerOp{
 		machine:   machine,
-		incoming:  incoming,
+		incoming:  incoming.Normalise(),
 		processed: set.NewStrings(),
 	}
 }

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -990,16 +990,28 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 		Args: []params.ProviderNetworkConfig{
 			{
 				Tag: "machine-1",
-				Configs: []params.NetworkConfig{{
-					// This should still be matched based on hardware address.
-					InterfaceName:     "some-provider-esoteria",
-					MACAddress:        "00:00:00:00:00:00",
-					ProviderId:        "p-dev",
-					ProviderAddressId: "p-addr",
-					ProviderNetworkId: "p-net",
-					ProviderSubnetId:  "p-sub",
-					Addresses:         []params.Address{{Value: "10.0.0.42"}},
-				}},
+				Configs: []params.NetworkConfig{
+					{
+						// This should still be matched based on hardware address.
+						InterfaceName:     "some-provider-esoteria",
+						MACAddress:        "00:00:00:00:00:00",
+						ProviderId:        "p-dev",
+						ProviderAddressId: "p-addr",
+						ProviderNetworkId: "p-net",
+						ProviderSubnetId:  "p-sub",
+						Addresses:         []params.Address{{Value: "10.0.0.42"}},
+					},
+					{
+						// A duplicate (MAC and addresses) should make no difference.
+						InterfaceName:     "more-provider-esoteria",
+						MACAddress:        "00:00:00:00:00:00",
+						ProviderId:        "p-dev",
+						ProviderAddressId: "p-addr",
+						ProviderNetworkId: "p-net",
+						ProviderSubnetId:  "p-sub",
+						Addresses:         []params.Address{{Value: "10.0.0.42"}},
+					},
+				},
 			},
 		},
 	})

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -298,16 +298,16 @@ func (s InterfaceInfos) Children(parentName string) InterfaceInfos {
 	return children
 }
 
-// GetByHardwareAddress returns a reference to the interface with the input
-// hardware address (such as a MAC address) if it exists in the collection,
-// otherwise nil is returned.
-func (s InterfaceInfos) GetByHardwareAddress(hwAddr string) *InterfaceInfo {
+// GetByHardwareAddress returns a new collection containing any interfaces
+// with the input hardware (MAC) address.
+func (s InterfaceInfos) GetByHardwareAddress(hwAddr string) InterfaceInfos {
+	var res InterfaceInfos
 	for _, dev := range s {
 		if dev.MACAddress == hwAddr {
-			return &dev
+			res = append(res, dev)
 		}
 	}
-	return nil
+	return res
 }
 
 // ProviderInterfaceInfo holds enough information to identify an

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -159,11 +159,17 @@ func (*nicSuite) TestInterfaceInfosIterHierarchy(c *gc.C) {
 }
 
 func (s *nicSuite) TestInterfaceInfosGetByHardwareAddress(c *gc.C) {
-	dev := s.info.GetByHardwareAddress("not-there")
-	c.Assert(dev, gc.IsNil)
+	devs := s.info.GetByHardwareAddress("not-there")
+	c.Assert(devs, gc.IsNil)
 
-	dev = s.info.GetByHardwareAddress("00:16:3e:aa:bb:cc")
-	c.Assert(dev.InterfaceName, gc.Equals, "eth0")
+	hwAddr := "00:16:3e:aa:bb:cc"
+
+	devs = s.info.GetByHardwareAddress(hwAddr)
+	c.Assert(devs, gc.HasLen, 1)
+	c.Assert(devs[0].InterfaceName, gc.Equals, "eth0")
+
+	devs = append(s.info, network.InterfaceInfo{MACAddress: hwAddr}).GetByHardwareAddress(hwAddr)
+	c.Assert(devs, gc.HasLen, 2)
 }
 
 func getInterFaceInfos() network.InterfaceInfos {

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -172,6 +172,86 @@ func (s *nicSuite) TestInterfaceInfosGetByHardwareAddress(c *gc.C) {
 	c.Assert(devs, gc.HasLen, 2)
 }
 
+func (s *nicSuite) TestInterfaceInfosSanitise(c *gc.C) {
+	sameMAC := network.GenerateVirtualMACAddress()
+	uniqueMAC := network.GenerateVirtualMACAddress()
+
+	devs := network.InterfaceInfos{
+		{
+			MACAddress: sameMAC,
+			CIDR:       "10.0.0.0/24",
+			ConfigType: network.ConfigStatic,
+			Addresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+			},
+		},
+		{
+			MACAddress: sameMAC,
+			CIDR:       "20.0.0.0/24",
+			ConfigType: network.ConfigDHCP,
+			Addresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("20.0.0.1", network.ScopeCloudLocal),
+			},
+		},
+		// Wholesale duplicated address should not be present in result.
+		{
+			MACAddress: sameMAC,
+			CIDR:       "20.0.0.0/24",
+			ConfigType: network.ConfigDHCP,
+			Addresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("20.0.0.1", network.ScopeCloudLocal),
+			},
+		},
+		{
+			MACAddress: uniqueMAC,
+			CIDR:       "20.0.0.0/24",
+			ConfigType: network.ConfigDHCP,
+			Addresses: network.ProviderAddresses{
+				network.NewScopedProviderAddress("20.0.0.2", network.ScopeCloudLocal),
+			},
+		},
+	}.Normalise()
+
+	c.Assert(devs, gc.HasLen, 2)
+
+	same := devs.GetByHardwareAddress(sameMAC)
+	c.Assert(same, gc.HasLen, 1)
+	c.Assert(same[0].Addresses, jc.SameContents, network.ProviderAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value:      "10.0.0.1",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+				CIDR:       "10.0.0.0/24",
+				ConfigType: network.ConfigStatic,
+			},
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value:      "20.0.0.1",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+				CIDR:       "20.0.0.0/24",
+				ConfigType: network.ConfigDHCP,
+			},
+		},
+	})
+
+	unique := devs.GetByHardwareAddress(uniqueMAC)
+	c.Assert(unique, gc.HasLen, 1)
+	c.Assert(unique[0].Addresses, jc.SameContents, network.ProviderAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value:      "20.0.0.2",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+				CIDR:       "20.0.0.0/24",
+				ConfigType: network.ConfigDHCP,
+			},
+		},
+	})
+}
+
 func getInterFaceInfos() network.InterfaceInfos {
 	return network.InterfaceInfos{
 		{


### PR DESCRIPTION
## Description of change

This patch adds a `Normalise` method to `network.InterfaceInfos` that will turn duplicated interfaces with different addresses into a single interface with multiple addresses. In particular it handles the format for link-layer data supplied by the machine agent.

It is only effectively applied to the instance-poller in this patch, but the rework for machine-sourced link-layer data will follow.

This is a temporary solution in lieu of having upstream suppliers of this data populate the new fields for `CIDR` and `ConfigType` on member addresses. The ultimate solution should consist of the following:
- The fields mentioned above are populated on addresses and removed from `InterfaceInfo`, so that devices are never duplicated.
- This change is reflected in the DTO and in the to/from transformations. This may require waiting for Juju 3 to break prior version compatibility.
- This new method is no longer required the therefore removed.

## QA steps

Same steps as #11683 are suitable for regression testing.

## Documentation changes

None.

## Bug reference

N/A
