### PR TITLE
Interface Info Address Extraction

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -170,6 +170,17 @@ func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.Inte
 	return nil
 }
 
+// MatchingIncomingAddrs finds all the primary addresses on devices matching
+// the hardware address of the input, and returns them as state args.
+// TODO (manadart 2020-07-15): We should investigate making an enhanced
+// core/network address type instead of this state type.
+// It would embed ProviderAddress and could be obtained directly via a method
+// or property of InterfaceInfos.
+func (o *MachineLinkLayerOp) MatchingIncomingAddrs(dev LinkLayerDevice) ([]state.LinkLayerDeviceAddress, error) {
+	addrs, err := networkAddressStateArgsForHWAddr(o.Incoming(), dev.MACAddress())
+	return addrs, errors.Trace(err)
+}
+
 // DeviceAddresses returns all currently known
 // IP addresses assigned to the input device.
 func (o *MachineLinkLayerOp) DeviceAddresses(dev LinkLayerDevice) []LinkLayerAddress {

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -181,9 +181,8 @@ func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.Inte
 // core/network address type instead of this state type.
 // It would embed ProviderAddress and could be obtained directly via a method
 // or property of InterfaceInfos.
-func (o *MachineLinkLayerOp) MatchingIncomingAddrs(dev LinkLayerDevice) ([]state.LinkLayerDeviceAddress, error) {
-	addrs, err := networkAddressStateArgsForHWAddr(o.Incoming(), dev.MACAddress())
-	return addrs, errors.Trace(err)
+func (o *MachineLinkLayerOp) MatchingIncomingAddrs(dev LinkLayerDevice) []state.LinkLayerDeviceAddress {
+	return networkAddressStateArgsForHWAddr(o.Incoming(), dev.MACAddress())
 }
 
 // DeviceAddresses returns all currently known

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -122,7 +122,7 @@ func NewMachineLinkLayerOp(machine LinkLayerMachine, incoming network.InterfaceI
 
 	return &MachineLinkLayerOp{
 		machine:   machine,
-		incoming:  incoming.Normalise(),
+		incoming:  incoming,
 		processed: set.NewStrings(),
 	}
 }
@@ -160,11 +160,9 @@ func (o *MachineLinkLayerOp) PopulateExistingAddresses() error {
 	return errors.Trace(err)
 }
 
-// MatchingIncoming returns the incoming interface info that
+// MatchingIncoming returns the first incoming interface that
 // matches the input known device, based on hardware address.
 // Nil is returned if there is no match.
-// The constructor normalises the incoming data, so we can safely assume that
-// there is at most one device with any given hardware address.
 func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.InterfaceInfo {
 	if matches := o.incoming.GetByHardwareAddress(dev.MACAddress()); len(matches) > 0 {
 		return &matches[0]

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -160,6 +160,18 @@ func (o *MachineLinkLayerOp) PopulateExistingAddresses() error {
 	return errors.Trace(err)
 }
 
+// MatchingIncoming returns the incoming interface info that
+// matches the input known device, based on hardware address.
+// Nil is returned if there is no match.
+// The constructor normalises the incoming data, so we can safely assume that
+// there is at most one device with any given hardware address.
+func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.InterfaceInfo {
+	if matches := o.incoming.GetByHardwareAddress(dev.MACAddress()); len(matches) > 0 {
+		return &matches[0]
+	}
+	return nil
+}
+
 // DeviceAddresses returns all currently known
 // IP addresses assigned to the input device.
 func (o *MachineLinkLayerOp) DeviceAddresses(dev LinkLayerDevice) []LinkLayerAddress {

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -211,20 +211,19 @@ func networkDeviceToStateArgs(dev corenetwork.InterfaceInfo) state.LinkLayerDevi
 // address.
 // This is a normalisation that returns state args for all primary addresses
 // of interfaces with the input hardware address.
-func networkAddressStateArgsForHWAddr(
-	devs corenetwork.InterfaceInfos, hwAddr string,
-) ([]state.LinkLayerDeviceAddress, error) {
+func networkAddressStateArgsForHWAddr(devs corenetwork.InterfaceInfos, hwAddr string) []state.LinkLayerDeviceAddress {
 	var res []state.LinkLayerDeviceAddress
 
 	for _, dev := range devs.GetByHardwareAddress(hwAddr) {
 		addr, err := networkAddressToStateArgs(dev, dev.PrimaryAddress())
 		if err != nil {
-			return nil, errors.Trace(err)
+			logger.Warningf("ignoring address for device %q: %v", dev.InterfaceName, err)
+			continue
 		}
 		res = append(res, addr)
 	}
 
-	return res, nil
+	return res
 }
 
 func networkAddressToStateArgs(

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -154,29 +154,29 @@ func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {
 
 // NetworkInterfacesToStateArgs splits the given interface list into a slice of
 // state.LinkLayerDeviceArgs and a slice of state.LinkLayerDeviceAddress.
-func NetworkInterfacesToStateArgs(ifaces corenetwork.InterfaceInfos) (
+func NetworkInterfacesToStateArgs(devs corenetwork.InterfaceInfos) (
 	[]state.LinkLayerDeviceArgs,
 	[]state.LinkLayerDeviceAddress,
 ) {
 	var devicesArgs []state.LinkLayerDeviceArgs
 	var devicesAddrs []state.LinkLayerDeviceAddress
 
-	logger.Tracef("transforming network interface list to state args: %+v", ifaces)
+	logger.Tracef("transforming network interface list to state args: %+v", devs)
 	seenDeviceNames := set.NewStrings()
-	for _, iface := range ifaces {
-		logger.Tracef("transforming device %q", iface.InterfaceName)
-		if !seenDeviceNames.Contains(iface.InterfaceName) {
+	for _, dev := range devs {
+		logger.Tracef("transforming device %q", dev.InterfaceName)
+		if !seenDeviceNames.Contains(dev.InterfaceName) {
 			// First time we see this, add it to devicesArgs.
-			seenDeviceNames.Add(iface.InterfaceName)
+			seenDeviceNames.Add(dev.InterfaceName)
 
-			args := networkDeviceToStateArgs(iface)
+			args := networkDeviceToStateArgs(dev)
 			logger.Tracef("state device args for device: %+v", args)
 			devicesArgs = append(devicesArgs, args)
 		}
 
-		addr, err := networkAddressToStateArgs(iface, iface.PrimaryAddress())
+		addr, err := networkAddressToStateArgs(dev, dev.PrimaryAddress())
 		if err != nil {
-			logger.Warningf("ignoring address for device %q: %v", iface.InterfaceName, err)
+			logger.Warningf("ignoring address for device %q: %v", dev.InterfaceName, err)
 			continue
 		}
 
@@ -204,6 +204,27 @@ func networkDeviceToStateArgs(dev corenetwork.InterfaceInfo) state.LinkLayerDevi
 		IsUp:        !dev.Disabled,
 		ParentName:  dev.ParentInterfaceName,
 	}
+}
+
+// NetworkAddressStateArgsForHWAddr accommodates the fact that network
+// configuration is sometimes supplied with a duplicated device for each
+// address.
+// This is a normalisation that returns state args for all primary addresses
+// of interfaces with the input hardware address.
+func NetworkAddressStateArgsForHWAddr(
+	devs corenetwork.InterfaceInfos, hwAddr string,
+) ([]state.LinkLayerDeviceAddress, error) {
+	var res []state.LinkLayerDeviceAddress
+
+	for _, dev := range devs.GetByHardwareAddress(hwAddr) {
+		addr, err := networkAddressToStateArgs(dev, dev.PrimaryAddress())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		res = append(res, addr)
+	}
+
+	return res, nil
 }
 
 func networkAddressToStateArgs(

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -206,12 +206,12 @@ func networkDeviceToStateArgs(dev corenetwork.InterfaceInfo) state.LinkLayerDevi
 	}
 }
 
-// NetworkAddressStateArgsForHWAddr accommodates the fact that network
+// networkAddressStateArgsForHWAddr accommodates the fact that network
 // configuration is sometimes supplied with a duplicated device for each
 // address.
 // This is a normalisation that returns state args for all primary addresses
 // of interfaces with the input hardware address.
-func NetworkAddressStateArgsForHWAddr(
+func networkAddressStateArgsForHWAddr(
 	devs corenetwork.InterfaceInfos, hwAddr string,
 ) ([]state.LinkLayerDeviceAddress, error) {
 	var res []state.LinkLayerDeviceAddress

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -1002,6 +1002,17 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 						CIDR:              "10.0.0.0/24",
 						Addresses:         []params.Address{{Value: "10.0.0.42"}},
 					},
+					{
+						// A duplicate (MAC and addresses) should make no difference.
+						InterfaceName:     "more-provider-esoteria",
+						MACAddress:        "00:00:00:00:00:00",
+						ProviderId:        "p-dev",
+						ProviderAddressId: "p-addr",
+						ProviderNetworkId: "p-net",
+						ProviderSubnetId:  "p-sub",
+						CIDR:              "10.0.0.0/24",
+						Addresses:         []params.Address{{Value: "10.0.0.42"}},
+					},
 				},
 			},
 		},

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -999,16 +999,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 						ProviderAddressId: "p-addr",
 						ProviderNetworkId: "p-net",
 						ProviderSubnetId:  "p-sub",
-						Addresses:         []params.Address{{Value: "10.0.0.42"}},
-					},
-					{
-						// A duplicate (MAC and addresses) should make no difference.
-						InterfaceName:     "more-provider-esoteria",
-						MACAddress:        "00:00:00:00:00:00",
-						ProviderId:        "p-dev",
-						ProviderAddressId: "p-addr",
-						ProviderNetworkId: "p-net",
-						ProviderSubnetId:  "p-sub",
+						CIDR:              "10.0.0.0/24",
 						Addresses:         []params.Address{{Value: "10.0.0.42"}},
 					},
 				},

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -915,7 +915,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigRelinquishUnseen(c *gc
 	// Hardware address not matched.
 	dev := instancepoller.NewMockLinkLayerDevice(ctrl)
 	dExp := dev.EXPECT()
-	dExp.MACAddress().Return("01:01:01:01:01:01")
+	dExp.MACAddress().Return("01:01:01:01:01:01").MinTimes(1)
 	dExp.Name().Return("eth0")
 	dExp.SetProviderIDOps(network.Id("")).Return([]txn.Op{{C: "dev-provider-id"}}, nil)
 
@@ -966,7 +966,7 @@ func (s *InstancePollerSuite) TestSetProviderNetworkClaimProviderOrigin(c *gc.C)
 	// Hardware address will match; provider ID will be set.
 	dev := instancepoller.NewMockLinkLayerDevice(ctrl)
 	dExp := dev.EXPECT()
-	dExp.MACAddress().Return("00:00:00:00:00:00").Times(2)
+	dExp.MACAddress().Return("00:00:00:00:00:00").MinTimes(1)
 	dExp.Name().Return("eth0")
 	dExp.ProviderID().Return(network.Id(""))
 	dExp.SetProviderIDOps(network.Id("p-dev")).Return([]txn.Op{{C: "dev-provider-id"}}, nil)

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -104,10 +104,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// TODO (manadart 2020-07-15): We also need to set shadow addresses.
 	// These are sent where appropriate by the provider,
 	// but we do not yet process them.
-	incomingAddrs, err := o.MatchingIncomingAddrs(dev)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	incomingAddrs := o.MatchingIncomingAddrs(dev)
 
 	for _, addr := range o.DeviceAddresses(dev) {
 		addrOps, err := o.processExistingDeviceAddress(addr, incomingAddrs)

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -69,7 +69,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// Match the incoming device by hardware address in order to
 	// identify addresses by device name.
 	// Not all providers (such as AWS) have names for NIC devices.
-	incomingDevs := o.Incoming().GetByHardwareAddress(dev.MACAddress())
+	incomingDev := o.MatchingIncoming(dev)
 
 	var ops []txn.Op
 	var err error
@@ -77,14 +77,10 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// If this device was not observed by the provider,
 	// ensure that responsibility for the addresses is relinquished
 	// to the machine agent.
-	if len(incomingDevs) == 0 {
+	if incomingDev == nil {
 		ops, err = o.opsForDeviceOriginRelinquishment(dev)
 		return ops, errors.Trace(err)
 	}
-
-	// The MachineLinkLayerOp constructor normalises the incoming interfaces.
-	// This means there is at most one interface with any given MAC address.
-	incomingDev := incomingDevs[0]
 
 	// Warn the user that we will not change a provider ID that is already set.
 	// TODO (manadart 2020-06-09): If this is seen in the wild, we should look
@@ -103,7 +99,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	}
 
 	for _, addr := range o.DeviceAddresses(dev) {
-		addrOps, err := o.processExistingDeviceAddress(addr, incomingDev)
+		addrOps, err := o.processExistingDeviceAddress(addr, *incomingDev)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -106,7 +106,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// We should at least log any that the machine is not aware of.
 	// We also need to set shadow addresses - these are sent where appropriate
 	// by the provider, but we do not yet process them.
-	incomingAddrs, err := networkingcommon.NetworkAddressStateArgsForHWAddr(o.Incoming(), incomingDev.MACAddress)
+	incomingAddrs, err := o.MatchingIncomingAddrs(dev)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

This patch is a follow-up to #11832 and a pre-cursor to comprehensive machine link-layer device update rework.

The `Normalise` method added in the patch above is insufficient for properly extracting state updates for link-layer data, as it does not accommodate DNS and gateway properties that apply to addresses.

As a temporary measure, normalisation of addresses out from `InterfaceInfos` is done by extracting the state address args, which have these properties.

We now also track which addresses have been processed by the update logic in addition to which devices. Where appropriate this logic resides in the base type for link-layer model operations so it can be used by both the machiner and instance-poller updaters.

## QA steps

No functional changes - unit tests are green.
A bootstrap is sufficient test for regression.

## Documentation changes

None.

## Bug reference

N/A
