### PR TITLE
Allow the user to specify formats

### DIFF
--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -111,9 +111,9 @@ type InfoResponse struct {
 	Description string             `json:"description"`
 	Publisher   string             `json:"publisher"`
 	Summary     string             `json:"summary"`
-	Series      []string           `json:"series"`
+	Series      []string           `json:"series,omitempty"`
 	StoreURL    string             `json:"store-url"`
-	Tags        []string           `json:"tags"`
+	Tags        []string           `json:"tags,omitempty"`
 	Charm       *Charm             `json:"charm,omitempty"`
 	Bundle      *Bundle            `json:"bundle,omitempty"`
 	Channels    map[string]Channel `json:"channel-map"`
@@ -127,7 +127,7 @@ type FindResponse struct {
 	Publisher string   `json:"publisher"`
 	Summary   string   `json:"summary"`
 	Version   string   `json:"version"`
-	Series    []string `json:"series"`
+	Series    []string `json:"series,omitempty"`
 	StoreURL  string   `json:"store-url"`
 }
 
@@ -142,14 +142,14 @@ type Channel struct {
 
 // Charm matches a params.CharmHubCharm
 type Charm struct {
-	Config      *charm.Config                `json:"config"`
-	Relations   map[string]map[string]string `json:"relations"`
-	Subordinate bool                         `json:"subordinate"`
-	UsedBy      []string                     `json:"used-by"` // bundles which use the charm
+	Config      *charm.Config                `json:"config,omitempty"`
+	Relations   map[string]map[string]string `json:"relations,omitempty"`
+	Subordinate bool                         `json:"subordinate,omitempty"`
+	UsedBy      []string                     `json:"used-by,omitempty"` // bundles which use the charm
 }
 
 type Bundle struct {
-	Charms []BundleCharm `json:"charms,"`
+	Charms []BundleCharm `json:"charms,omitempty"`
 }
 
 type BundleCharm struct {

--- a/cmd/juju/charmhub/data.go
+++ b/cmd/juju/charmhub/data.go
@@ -1,0 +1,150 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"github.com/juju/charm/v7"
+	"github.com/juju/errors"
+	"github.com/juju/juju/api/charmhub"
+)
+
+func convertCharmInfoResult(info charmhub.InfoResponse) (InfoResponse, error) {
+	ir := InfoResponse{
+		Type:        info.Type,
+		ID:          info.ID,
+		Name:        info.Name,
+		Description: info.Description,
+		Publisher:   info.Publisher,
+		Summary:     info.Summary,
+		Series:      info.Series,
+		StoreURL:    info.StoreURL,
+		Tags:        info.Tags,
+		Channels:    convertChannels(info.Channels),
+		Tracks:      info.Tracks,
+	}
+
+	var err error
+	switch ir.Type {
+	case "bundle":
+		ir.Bundle, err = convertBundle(info.Bundle)
+	case "charm":
+		ir.Charm, err = convertCharm(info.Charm)
+	}
+	return ir, errors.Trace(err)
+}
+
+func convertCharmFindResults(responses []charmhub.FindResponse) []FindResponse {
+	results := make([]FindResponse, len(responses))
+	for i, resp := range responses {
+		results[i] = convertCharmFindResult(resp)
+	}
+	return results
+}
+
+func convertCharmFindResult(resp charmhub.FindResponse) FindResponse {
+	return FindResponse{
+		Type:      resp.Type,
+		ID:        resp.ID,
+		Name:      resp.Name,
+		Publisher: resp.Publisher,
+		Summary:   resp.Summary,
+		Version:   resp.Version,
+		Series:    resp.Series,
+		StoreURL:  resp.StoreURL,
+	}
+}
+
+func convertBundle(in interface{}) (*Bundle, error) {
+	inB, ok := in.(*charmhub.Bundle)
+	if !ok {
+		return nil, errors.Errorf("unexpected: value is not a bundle")
+	}
+	if inB == nil {
+		return nil, errors.Errorf("bundle is nil")
+	}
+	out := Bundle{
+		Charms: make([]BundleCharm, len(inB.Charms)),
+	}
+	for i, c := range inB.Charms {
+		out.Charms[i] = BundleCharm(c)
+	}
+	return &out, nil
+}
+
+func convertCharm(in interface{}) (*Charm, error) {
+	inC, ok := in.(*charmhub.Charm)
+	if !ok {
+		return nil, errors.Errorf("unexpected: value is not a charm")
+	}
+	if inC == nil {
+		return nil, errors.Errorf("CharmHubCharm is nil")
+	}
+	return &Charm{
+		Config:      inC.Config,
+		Relations:   inC.Relations,
+		Subordinate: inC.Subordinate,
+		UsedBy:      inC.UsedBy,
+	}, nil
+}
+
+func convertChannels(in map[string]charmhub.Channel) map[string]Channel {
+	out := make(map[string]Channel, len(in))
+	for k, v := range in {
+		out[k] = Channel(v)
+	}
+	return out
+}
+
+type InfoResponse struct {
+	Type        string             `json:"type" yaml:"type"`
+	ID          string             `json:"id" yaml:"id"`
+	Name        string             `json:"name" yaml:"name"`
+	Description string             `json:"description" yaml:"description"`
+	Publisher   string             `json:"publisher" yaml:"publisher"`
+	Summary     string             `json:"summary" yaml:"summary"`
+	Series      []string           `json:"series,omitempty" yaml:"series,omitempty"`
+	StoreURL    string             `json:"store-url" yaml:"store-url"`
+	Tags        []string           `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Charm       *Charm             `json:"charm,omitempty" yaml:"charm,omitempty"`
+	Bundle      *Bundle            `json:"bundle,omitempty" yaml:"bundle,omitempty"`
+	Channels    map[string]Channel `json:"channel-map" yaml:"channel-map"`
+	Tracks      []string           `json:"tracks,omitempty" yaml:"tracks,omitempty"`
+}
+
+type FindResponse struct {
+	Type      string   `json:"type" yaml:"type"`
+	ID        string   `json:"id" yaml:"id"`
+	Name      string   `json:"name" yaml:"name"`
+	Publisher string   `json:"publisher" yaml:"publisher"`
+	Summary   string   `json:"summary" yaml:"summary"`
+	Version   string   `json:"version" yaml:"version"`
+	Series    []string `json:"series,omitempty" yaml:"series,omitempty"`
+	StoreURL  string   `json:"store-url" yaml:"store-url"`
+}
+
+type Channel struct {
+	ReleasedAt string `json:"released-at" yaml:"released-at"`
+	Track      string `json:"track" yaml:"track"`
+	Risk       string `json:"risk" yaml:"risk"`
+	Revision   int    `json:"revision" yaml:"revision"`
+	Size       int    `json:"size" yaml:"size"`
+	Version    string `json:"version" yaml:"version"`
+}
+
+// Charm matches a params.CharmHubCharm
+type Charm struct {
+	Config      *charm.Config                `json:"config,omitempty" yaml:"config,omitempty"`
+	Relations   map[string]map[string]string `json:"relations,omitempty" yaml:"relations,omitempty"`
+	Subordinate bool                         `json:"subordinate,omitempty" yaml:"subordinate,omitempty"`
+	UsedBy      []string                     `json:"used-by,omitempty" yaml:"used-by,omitempty"` // bundles which use the charm
+}
+
+type Bundle struct {
+	Charms []BundleCharm `json:"charms,omitempty" yaml:"charms,omitempty"`
+}
+
+type BundleCharm struct {
+	Name     string `json:"name" yaml:"name"`
+	Revision int    `json:"revision" yaml:"revision"`
+}

--- a/cmd/juju/charmhub/find.go
+++ b/cmd/juju/charmhub/find.go
@@ -61,10 +61,10 @@ func (c *findCommand) Info() *cmd.Info {
 // It implements part of the cmd.Command interface.
 func (c *findCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	c.out.AddFlags(f, "human", map[string]cmd.Formatter{
-		"yaml":  cmd.FormatYaml,
-		"json":  cmd.FormatJson,
-		"human": c.formatter,
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": c.formatter,
 	})
 	// TODO (stickupkid): add the following:
 	// --narrow
@@ -135,7 +135,8 @@ func (c *findCommand) output(ctx *cmd.Context, results []charmhub.FindResponse) 
 		}
 	}
 
-	if err := c.out.Write(ctx, results); err != nil {
+	view := convertCharmFindResults(results)
+	if err := c.out.Write(ctx, view); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -147,7 +148,7 @@ func (c *findCommand) output(ctx *cmd.Context, results []charmhub.FindResponse) 
 }
 
 func (c *findCommand) formatter(writer io.Writer, value interface{}) error {
-	results, ok := value.([]charmhub.FindResponse)
+	results, ok := value.([]FindResponse)
 	if !ok {
 		return errors.Errorf("unexpected results")
 	}

--- a/cmd/juju/charmhub/find_test.go
+++ b/cmd/juju/charmhub/find_test.go
@@ -71,7 +71,7 @@ func (s *findSuite) TestRunYAML(c *gc.C) {
   version: 1.0.3
   series:
   - bionic
-  storeurl: https://someurl.com/wordpress
+  store-url: https://someurl.com/wordpress
 `[1:])
 }
 

--- a/cmd/juju/charmhub/find_test.go
+++ b/cmd/juju/charmhub/find_test.go
@@ -5,6 +5,7 @@ package charmhub
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -35,9 +36,43 @@ func (s *findSuite) TestRun(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 	s.expectFind()
 	command := &findCommand{api: s.api, query: "test"}
+	cmdtesting.InitCommand(command, []string{})
 	ctx := commandContextForTest(c)
 	err := command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *findSuite) TestRunJSON(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+	s.expectFind()
+	command := &findCommand{api: s.api, query: "test"}
+	cmdtesting.InitCommand(command, []string{"--format", "json"})
+	ctx := commandContextForTest(c)
+	err := command.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"type":"object","id":"charmCHARMcharmCHARMcharmCHARM01","name":"wordpress","publisher":"Wordress Charmers","summary":"WordPress is a full featured web blogging tool, this charm deploys it.","version":"1.0.3","series":["bionic"],"store-url":"https://someurl.com/wordpress"}]
+`)
+}
+
+func (s *findSuite) TestRunYAML(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+	s.expectFind()
+	command := &findCommand{api: s.api, query: "test"}
+	cmdtesting.InitCommand(command, []string{"--format", "yaml"})
+	ctx := commandContextForTest(c)
+	err := command.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+- type: object
+  id: charmCHARMcharmCHARMcharmCHARM01
+  name: wordpress
+  publisher: Wordress Charmers
+  summary: WordPress is a full featured web blogging tool, this charm deploys it.
+  version: 1.0.3
+  series:
+  - bionic
+  storeurl: https://someurl.com/wordpress
+`[1:])
 }
 
 func (s *findSuite) setUpMocks(c *gc.C) *gomock.Controller {
@@ -48,5 +83,14 @@ func (s *findSuite) setUpMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *findSuite) expectFind() {
-	s.api.EXPECT().Find("test").Return([]charmhub.FindResponse{}, nil)
+	s.api.EXPECT().Find("test").Return([]charmhub.FindResponse{{
+		Name:      "wordpress",
+		Type:      "object",
+		ID:        "charmCHARMcharmCHARMcharmCHARM01",
+		Publisher: "Wordress Charmers",
+		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Version:   "1.0.3",
+		Series:    []string{"bionic"},
+		StoreURL:  "https://someurl.com/wordpress",
+	}}, nil)
 }

--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -10,17 +10,16 @@ import (
 	"io"
 	"strings"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/charmhub"
 	"github.com/juju/juju/cmd/output"
 )
 
-func makeFindWriter(ctx *cmd.Context, in []charmhub.FindResponse) Printer {
+func makeFindWriter(w io.Writer, warning Log, in []charmhub.FindResponse) Printer {
 	writer := findWriter{
-		w:        ctx.Stdout,
-		warningf: ctx.Warningf,
+		w:        w,
+		warningf: warning,
 		in:       in,
 	}
 	return writer

--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -12,11 +12,10 @@ import (
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/api/charmhub"
 	"github.com/juju/juju/cmd/output"
 )
 
-func makeFindWriter(w io.Writer, warning Log, in []charmhub.FindResponse) Printer {
+func makeFindWriter(w io.Writer, warning Log, in []FindResponse) Printer {
 	writer := findWriter{
 		w:        w,
 		warningf: warning,
@@ -28,7 +27,7 @@ func makeFindWriter(w io.Writer, warning Log, in []charmhub.FindResponse) Printe
 type findWriter struct {
 	warningf Log
 	w        io.Writer
-	in       []charmhub.FindResponse
+	in       []FindResponse
 }
 
 func (f findWriter) Print() error {
@@ -62,7 +61,7 @@ func (f findWriter) Print() error {
 	return err
 }
 
-func (f findWriter) bundle(result charmhub.FindResponse) string {
+func (f findWriter) bundle(result FindResponse) string {
 	if result.Type == "bundle" {
 		return "Y"
 	}

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -18,7 +18,7 @@ var _ = gc.Suite(&printFindSuite{})
 func (s *printFindSuite) TestCharmPrintFind(c *gc.C) {
 	fr := getCharmFindResponse()
 	ctx := commandContextForTest(c)
-	fw := makeFindWriter(ctx, fr)
+	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, fr)
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -39,7 +39,7 @@ func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 	fr[0].Summary = ""
 
 	ctx := commandContextForTest(c)
-	fw := makeFindWriter(ctx, fr)
+	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, fr)
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -6,7 +6,6 @@ package charmhub
 import (
 	"bytes"
 
-	"github.com/juju/juju/api/charmhub"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -71,8 +70,8 @@ func (s *printFindSuite) TestSummaryEmpty(c *gc.C) {
 	c.Assert(obtained, gc.Equals, expected)
 }
 
-func getCharmFindResponse() []charmhub.FindResponse {
-	return []charmhub.FindResponse{{
+func getCharmFindResponse() []FindResponse {
+	return []FindResponse{{
 		Name:      "wordpress",
 		Type:      "charm",
 		ID:        "charmCHARMcharmCHARMcharmCHARM01",

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -4,6 +4,8 @@
 package charmhub
 
 import (
+	"io"
+
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -35,6 +37,8 @@ func NewInfoCommand() cmd.Command {
 // about charm snaps.
 type infoCommand struct {
 	modelcmd.ModelCommandBase
+	out        cmd.Output
+	warningLog Log
 
 	api InfoCommandAPI
 
@@ -58,6 +62,11 @@ func (c *infoCommand) Info() *cmd.Info {
 // It implements part of the cmd.Command interface.
 func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	c.out.AddFlags(f, "human", map[string]cmd.Formatter{
+		"yaml":  cmd.FormatYaml,
+		"json":  cmd.FormatJson,
+		"human": c.formatter,
+	})
 	// TODO (hml)
 	// add --config
 }
@@ -89,7 +98,13 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	return makeInfoWriter(ctx, &info).Print()
+	// This is a side effect of the formatting code not wanting to error out
+	// when we get invalid data from the API.
+	// We store it on the command before attempting to output, so we can pick
+	// it up later.
+	c.warningLog = ctx.Warningf
+
+	return c.out.Write(ctx, &info)
 }
 
 func (c *infoCommand) validateCharmOrBundle(_ string) error {
@@ -111,4 +126,17 @@ func (c *infoCommand) getAPI() (InfoCommandAPI, error) {
 	}
 	client := charmhub.NewClient(api)
 	return client, nil
+}
+
+func (c *infoCommand) formatter(writer io.Writer, value interface{}) error {
+	results, ok := value.(*charmhub.InfoResponse)
+	if !ok {
+		return errors.Errorf("unexpected results")
+	}
+
+	if err := makeInfoWriter(writer, c.warningLog, results).Print(); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
 }

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -50,7 +50,7 @@ func (s *infoSuite) TestRunJSON(c *gc.C) {
 	ctx := commandContextForTest(c)
 	err := command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `{"type":"charm","id":"charmCHARMcharmCHARMcharmCHARM01","name":"wordpress","description":"This will install and setup WordPress optimized to run in the cloud.","publisher":"Wordress Charmers","summary":"WordPress is a full featured web blogging tool, this charm deploys it.","series":["bionic","xenial"],"store-url":"https://someurl.com/wordpress","tags":["app","seven"],"charm":{"config":{"Options":{"agility-ratio":{"Type":"float","Description":"A number from 0 to 1 indicating agility.","Default":null},"outlook":{"Type":"string","Description":"No default outlook.","Default":null},"reticulate-splines":{"Type":"boolean","Description":"Whether to reticulate splines on launch, or not.","Default":null},"skill-level":{"Type":"int","Description":"A number indicating skill.","Default":null},"subtitle":{"Type":"string","Description":"An optional subtitle used for the application.","Default":""},"title":{"Type":"string","Description":"A descriptive title used for the application.","Default":"My Title"},"username":{"Type":"string","Description":"The name of the initial account (given admin permissions).","Default":"admin001"}}},"relations":{"provides":{"source":"dummy-token"},"requires":{"sink":"dummy-token"}},"subordinate":false,"used-by":["wordpress-everlast","wordpress-jorge","wordpress-site"]},"channel-map":{"latest/stable":{"released-at":"2019-12-16T19:44:44.076943+00:00","track":"latest","risk":"stable","revision":16,"size":12042240,"version":"1.0.3"}},"tracks":["latest"]}
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `{"type":"charm","id":"charmCHARMcharmCHARMcharmCHARM01","name":"wordpress","description":"This will install and setup WordPress optimized to run in the cloud.","publisher":"Wordress Charmers","summary":"WordPress is a full featured web blogging tool, this charm deploys it.","series":["bionic","xenial"],"store-url":"https://someurl.com/wordpress","tags":["app","seven"],"charm":{"config":{"Options":{"agility-ratio":{"Type":"float","Description":"A number from 0 to 1 indicating agility.","Default":null},"outlook":{"Type":"string","Description":"No default outlook.","Default":null},"reticulate-splines":{"Type":"boolean","Description":"Whether to reticulate splines on launch, or not.","Default":null},"skill-level":{"Type":"int","Description":"A number indicating skill.","Default":null},"subtitle":{"Type":"string","Description":"An optional subtitle used for the application.","Default":""},"title":{"Type":"string","Description":"A descriptive title used for the application.","Default":"My Title"},"username":{"Type":"string","Description":"The name of the initial account (given admin permissions).","Default":"admin001"}}},"relations":{"provides":{"source":"dummy-token"},"requires":{"sink":"dummy-token"}},"used-by":["wordpress-everlast","wordpress-jorge","wordpress-site"]},"channel-map":{"latest/stable":{"released-at":"2019-12-16T19:44:44.076943+00:00","track":"latest","risk":"stable","revision":16,"size":12042240,"version":"1.0.3"}},"tracks":["latest"]}
 `)
 }
 
@@ -72,7 +72,7 @@ summary: WordPress is a full featured web blogging tool, this charm deploys it.
 series:
 - bionic
 - xenial
-storeurl: https://someurl.com/wordpress
+store-url: https://someurl.com/wordpress
 tags:
 - app
 - seven
@@ -108,15 +108,13 @@ charm:
       source: dummy-token
     requires:
       sink: dummy-token
-  subordinate: false
-  usedby:
+  used-by:
   - wordpress-everlast
   - wordpress-jorge
   - wordpress-site
-bundle: null
-channels:
+channel-map:
   latest/stable:
-    releasedat: "2019-12-16T19:44:44.076943+00:00"
+    released-at: "2019-12-16T19:44:44.076943+00:00"
     track: latest
     risk: stable
     revision: 16

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -5,6 +5,8 @@ package charmhub
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/charm/v7"
+	"github.com/juju/cmd/cmdtesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -34,9 +36,95 @@ func (s *infoSuite) TestRun(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 	s.expectInfo()
 	command := &infoCommand{api: s.api, charmOrBundle: "test"}
+	cmdtesting.InitCommand(command, []string{})
 	ctx := commandContextForTest(c)
 	err := command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *infoSuite) TestRunJSON(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+	s.expectInfo()
+	command := &infoCommand{api: s.api, charmOrBundle: "test"}
+	cmdtesting.InitCommand(command, []string{"--format", "json"})
+	ctx := commandContextForTest(c)
+	err := command.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `{"type":"charm","id":"charmCHARMcharmCHARMcharmCHARM01","name":"wordpress","description":"This will install and setup WordPress optimized to run in the cloud.","publisher":"Wordress Charmers","summary":"WordPress is a full featured web blogging tool, this charm deploys it.","series":["bionic","xenial"],"store-url":"https://someurl.com/wordpress","tags":["app","seven"],"charm":{"config":{"Options":{"agility-ratio":{"Type":"float","Description":"A number from 0 to 1 indicating agility.","Default":null},"outlook":{"Type":"string","Description":"No default outlook.","Default":null},"reticulate-splines":{"Type":"boolean","Description":"Whether to reticulate splines on launch, or not.","Default":null},"skill-level":{"Type":"int","Description":"A number indicating skill.","Default":null},"subtitle":{"Type":"string","Description":"An optional subtitle used for the application.","Default":""},"title":{"Type":"string","Description":"A descriptive title used for the application.","Default":"My Title"},"username":{"Type":"string","Description":"The name of the initial account (given admin permissions).","Default":"admin001"}}},"relations":{"provides":{"source":"dummy-token"},"requires":{"sink":"dummy-token"}},"subordinate":false,"used-by":["wordpress-everlast","wordpress-jorge","wordpress-site"]},"channel-map":{"latest/stable":{"released-at":"2019-12-16T19:44:44.076943+00:00","track":"latest","risk":"stable","revision":16,"size":12042240,"version":"1.0.3"}},"tracks":["latest"]}
+`)
+}
+
+func (s *infoSuite) TestRunYAML(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+	s.expectInfo()
+	command := &infoCommand{api: s.api, charmOrBundle: "test"}
+	cmdtesting.InitCommand(command, []string{"--format", "yaml"})
+	ctx := commandContextForTest(c)
+	err := command.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+type: charm
+id: charmCHARMcharmCHARMcharmCHARM01
+name: wordpress
+description: This will install and setup WordPress optimized to run in the cloud.
+publisher: Wordress Charmers
+summary: WordPress is a full featured web blogging tool, this charm deploys it.
+series:
+- bionic
+- xenial
+storeurl: https://someurl.com/wordpress
+tags:
+- app
+- seven
+charm:
+  config:
+    options:
+      agility-ratio:
+        type: float
+        description: A number from 0 to 1 indicating agility.
+      outlook:
+        type: string
+        description: No default outlook.
+      reticulate-splines:
+        type: boolean
+        description: Whether to reticulate splines on launch, or not.
+      skill-level:
+        type: int
+        description: A number indicating skill.
+      subtitle:
+        type: string
+        description: An optional subtitle used for the application.
+        default: ""
+      title:
+        type: string
+        description: A descriptive title used for the application.
+        default: My Title
+      username:
+        type: string
+        description: The name of the initial account (given admin permissions).
+        default: admin001
+  relations:
+    provides:
+      source: dummy-token
+    requires:
+      sink: dummy-token
+  subordinate: false
+  usedby:
+  - wordpress-everlast
+  - wordpress-jorge
+  - wordpress-site
+bundle: null
+channels:
+  latest/stable:
+    releasedat: "2019-12-16T19:44:44.076943+00:00"
+    track: latest
+    risk: stable
+    revision: 16
+    size: 12042240
+    version: 1.0.3
+tracks:
+- latest
+`[1:])
 }
 
 func (s *infoSuite) setUpMocks(c *gc.C) *gomock.Controller {
@@ -47,5 +135,47 @@ func (s *infoSuite) setUpMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *infoSuite) expectInfo() {
-	s.api.EXPECT().Info("test").Return(charmhub.InfoResponse{}, nil)
+	s.api.EXPECT().Info("test").Return(charmhub.InfoResponse{
+		Name:        "wordpress",
+		Type:        "charm",
+		ID:          "charmCHARMcharmCHARMcharmCHARM01",
+		Description: "This will install and setup WordPress optimized to run in the cloud.",
+		Publisher:   "Wordress Charmers",
+		Summary:     "WordPress is a full featured web blogging tool, this charm deploys it.",
+		Tracks:      []string{"latest"},
+		Series:      []string{"bionic", "xenial"},
+		StoreURL:    "https://someurl.com/wordpress",
+		Tags:        []string{"app", "seven"},
+		Channels: map[string]charmhub.Channel{
+			"latest/stable": {
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Track:      "latest",
+				Risk:       "stable",
+				Size:       12042240,
+				Revision:   16,
+				Version:    "1.0.3",
+			}},
+		Charm: &charmhub.Charm{
+			Subordinate: false,
+			Config: &charm.Config{
+				Options: map[string]charm.Option{
+					"reticulate-splines": {Type: "boolean", Description: "Whether to reticulate splines on launch, or not."},
+					"title":              {Type: "string", Description: "A descriptive title used for the application.", Default: "My Title"},
+					"subtitle":           {Type: "string", Description: "An optional subtitle used for the application.", Default: ""},
+					"outlook":            {Type: "string", Description: "No default outlook."},
+					"username":           {Type: "string", Description: "The name of the initial account (given admin permissions).", Default: "admin001"},
+					"skill-level":        {Type: "int", Description: "A number indicating skill."},
+					"agility-ratio":      {Type: "float", Description: "A number from 0 to 1 indicating agility."},
+				},
+			},
+			Relations: map[string]map[string]string{
+				"provides": {"source": "dummy-token"},
+				"requires": {"sink": "dummy-token"}},
+			UsedBy: []string{
+				"wordpress-everlast",
+				"wordpress-jorge",
+				"wordpress-site",
+			},
+		},
+	}, nil)
 }

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/api/charmhub"
 	"github.com/juju/juju/cmd/output"
 )
 
@@ -24,7 +23,7 @@ import (
 // There are exceptions, slices of strings and tables.  These
 // are transformed into strings.
 
-func makeInfoWriter(w io.Writer, warningLog Log, in *charmhub.InfoResponse) Printer {
+func makeInfoWriter(w io.Writer, warningLog Log, in *InfoResponse) Printer {
 	iw := infoWriter{
 		w:        w,
 		warningf: warningLog,
@@ -39,7 +38,7 @@ func makeInfoWriter(w io.Writer, warningLog Log, in *charmhub.InfoResponse) Prin
 type infoWriter struct {
 	warningf Log
 	w        io.Writer
-	in       *charmhub.InfoResponse
+	in       *InfoResponse
 }
 
 func (iw infoWriter) print(info interface{}) error {
@@ -77,7 +76,7 @@ func (iw infoWriter) channels() string {
 	return buffer.String()
 }
 
-func (iw infoWriter) writeOpenChanneltoBuffer(w output.Wrapper, channel charmhub.Channel) {
+func (iw infoWriter) writeOpenChanneltoBuffer(w output.Wrapper, channel Channel) {
 	w.Printf("%s/%s:", channel.Track, channel.Risk)
 	w.Print(channel.Version)
 	releasedAt, err := time.Parse(time.RFC3339, channel.ReleasedAt)

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
@@ -25,10 +24,10 @@ import (
 // There are exceptions, slices of strings and tables.  These
 // are transformed into strings.
 
-func makeInfoWriter(ctx *cmd.Context, in *charmhub.InfoResponse) Printer {
+func makeInfoWriter(w io.Writer, warningLog Log, in *charmhub.InfoResponse) Printer {
 	iw := infoWriter{
-		w:        ctx.Stdout,
-		warningf: ctx.Warningf,
+		w:        w,
+		warningf: warningLog,
 		in:       in,
 	}
 	if iw.in.Type == "charm" {

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -18,7 +18,7 @@ var _ = gc.Suite(&printInfoSuite{})
 func (s *printInfoSuite) TestCharmPrintInfo(c *gc.C) {
 	ir := getCharmInfoResponse()
 	ctx := commandContextForTest(c)
-	iw := makeInfoWriter(ctx, &ir)
+	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, &ir)
 	err := iw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -52,7 +52,7 @@ channels: |
 func (s *printInfoSuite) TestBundleChannelClosed(c *gc.C) {
 	ir := getBundleInfoClosedTrack()
 	ctx := commandContextForTest(c)
-	iw := makeInfoWriter(ctx, &ir)
+	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, &ir)
 	err := iw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -74,7 +74,7 @@ channels: |
 func (s *printInfoSuite) TestBundlePrintInfo(c *gc.C) {
 	ir := getBundleInfoResponse()
 	ctx := commandContextForTest(c)
-	iw := makeInfoWriter(ctx, &ir)
+	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, &ir)
 	err := iw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -6,7 +6,6 @@ package charmhub
 import (
 	"bytes"
 
-	"github.com/juju/juju/api/charmhub"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -94,8 +93,8 @@ channels: |
 	c.Assert(obtained, gc.Equals, expected)
 }
 
-func getBundleInfoResponse() charmhub.InfoResponse {
-	return charmhub.InfoResponse{
+func getBundleInfoResponse() InfoResponse {
+	return InfoResponse{
 		Type:        "Bundle",
 		ID:          "bundleBUNDLEbundleBUNDLEbundle01",
 		Name:        "osm",
@@ -104,7 +103,7 @@ func getBundleInfoResponse() charmhub.InfoResponse {
 		Summary:     "A bundle by charmed-osm.",
 		Tags:        []string{"networking"},
 		Bundle:      nil,
-		Channels: map[string]charmhub.Channel{
+		Channels: map[string]Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Track:      "latest",
@@ -141,8 +140,8 @@ func getBundleInfoResponse() charmhub.InfoResponse {
 	}
 }
 
-func getCharmInfoResponse() charmhub.InfoResponse {
-	return charmhub.InfoResponse{
+func getCharmInfoResponse() InfoResponse {
+	return InfoResponse{
 		Type:        "charm",
 		ID:          "charmCHARMcharmCHARMcharmCHARM01",
 		Name:        "wordpress",
@@ -151,7 +150,7 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 		Description: "This will install and setup WordPress optimized to run in the cloud.\nBy default it will place Ngnix and php-fpm configured to scale horizontally with\nNginx's reverse proxy.",
 		Series:      []string{"bionic", "xenial"},
 		Tags:        []string{"app", "seven"},
-		Charm: &charmhub.Charm{
+		Charm: &Charm{
 			Subordinate: true,
 			Relations: map[string]map[string]string{
 				"provides": {
@@ -163,7 +162,7 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 				},
 			},
 		},
-		Channels: map[string]charmhub.Channel{
+		Channels: map[string]Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Track:      "latest",
@@ -200,11 +199,11 @@ func getCharmInfoResponse() charmhub.InfoResponse {
 	}
 }
 
-func getBundleInfoClosedTrack() charmhub.InfoResponse {
-	return charmhub.InfoResponse{
+func getBundleInfoClosedTrack() InfoResponse {
+	return InfoResponse{
 		Name: "osm",
 		Type: "bundle",
-		Channels: map[string]charmhub.Channel{
+		Channels: map[string]Channel{
 			"latest/stable": {
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Track:      "latest",


### PR DESCRIPTION
## Description of change

Juju has a strong pattern of outputting different formats from each
command to allow the user to script against the CLI. The following
updates both find and info to allow this to happen.

The controversial thing about this change is naming the default output,
as for info the output is some sort of hybrid yaml that isn't yaml and
the default format for find is tabular. To be consistent I've named the
human (naming is hard).

The code is easy other than the warning logger to enable the commands to
output a warning if the result from the API isn't parsable. This can
happen if the charm creator fat fingers something and we don't want to
bring down the find/info commands to the user because of this. We'll
ignore the error (log it out) and present what we have to the user.

## QA steps

```sh
juju bootstrap lxd test
juju find wordpress
juju find --format=json wordpress
juju find --format=yaml wordpress
```
