### PR TITLE
Allows concat json specs to be decoded

### DIFF
--- a/caas/kubernetes/provider/specs/decode.go
+++ b/caas/kubernetes/provider/specs/decode.go
@@ -86,5 +86,12 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	if d.strict {
 		decoder.DisallowUnknownFields()
 	}
-	return d.processError(decoder.Decode(into), decoder)
+
+	for decoder.More() {
+		if err := decoder.Decode(into); err != nil {
+			return d.processError(err, decoder)
+		}
+	}
+
+	return nil
 }

--- a/caas/kubernetes/provider/specs/decode_test.go
+++ b/caas/kubernetes/provider/specs/decode_test.go
@@ -97,4 +97,45 @@ unknownkey: ops`
 		Foo: "foo1",
 		Bar: "bar1",
 	})
+
+	in = `
+{
+    "foo": "foo1"
+}
+{
+    "bar": "bar1"
+}`
+	// decode JSON in strict mode - good.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), true)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+	// decode JSON in non-strict mode - good.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), false)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
+
+	in = `
+{
+    "foo": "foo1"
+}
+{
+	"bar": "bar1",
+	"unknownkey": "ops"
+}`
+	// decode JSON in strict mode - bad.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), true)
+	c.Assert(decoder.Decode(&out), gc.ErrorMatches, `json: unknown field "unknownkey"`)
+	// decode JSON in non-strict mode - unknown field ignored.
+	decoder = k8sspces.NewYAMLOrJSONDecoder(strings.NewReader(in), len(in), false)
+	c.Assert(decoder.Decode(&out), jc.ErrorIsNil)
+	c.Assert(out, gc.DeepEquals, tS{
+		Foo: "foo1",
+		Bar: "bar1",
+	})
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

This PR introduces a change that allows k8 spec parsing to handle multiple concatenated json files.

## QA steps

At the moment just run unit tests. Still working on a manual test to confirm.

```sh
cd caas/kubernetes/provider/specs
go test -check.f=decoderSuite .
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1880637
