### PR TITLE
core/network AvailabilityZone

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -16,7 +16,6 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
-	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 )
 
@@ -106,11 +105,11 @@ type NetworkBacking interface {
 
 	// AvailabilityZones returns all cached availability zones (i.e.
 	// not from the provider, but in state).
-	AvailabilityZones() ([]providercommon.AvailabilityZone, error)
+	AvailabilityZones() (corenetwork.AvailabilityZones, error)
 
 	// SetAvailabilityZones replaces the cached list of availability
 	// zones with the given zones.
-	SetAvailabilityZones([]providercommon.AvailabilityZone) error
+	SetAvailabilityZones(corenetwork.AvailabilityZones) error
 
 	// AddSpace creates a space
 	AddSpace(string, corenetwork.Id, []string, bool) (BackingSpace, error)

--- a/apiserver/facades/client/subnets/cache.go
+++ b/apiserver/facades/client/subnets/cache.go
@@ -384,7 +384,7 @@ func networkingEnviron(getter environs.EnvironConfigGetter) (environs.Networking
 func allZones(ctx context.ProviderCallContext, api Backing) (params.ZoneResults, error) {
 	var results params.ZoneResults
 
-	zonesAsString := func(zones []providercommon.AvailabilityZone) string {
+	zonesAsString := func(zones network.AvailabilityZones) string {
 		results := make([]string, len(zones))
 		for i, zone := range zones {
 			results[i] = zone.Name()
@@ -423,7 +423,7 @@ func allZones(ctx context.ProviderCallContext, api Backing) (params.ZoneResults,
 // updateZones attempts to retrieve all availability zones from the environment
 // provider (if supported) and then updates the persisted list of zones in
 // state, returning them as well on success.
-func updateZones(ctx context.ProviderCallContext, api Backing) ([]providercommon.AvailabilityZone, error) {
+func updateZones(ctx context.ProviderCallContext, api Backing) (network.AvailabilityZones, error) {
 	zoned, err := zonedEnviron(api)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/subnets/mocks/package_mock.go
+++ b/apiserver/facades/client/subnets/mocks/package_mock.go
@@ -7,9 +7,9 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	networkingcommon "github.com/juju/juju/apiserver/common/networkingcommon"
+	network "github.com/juju/juju/core/network"
 	cloudspec "github.com/juju/juju/environs/cloudspec"
 	config "github.com/juju/juju/environs/config"
-	common "github.com/juju/juju/provider/common"
 	names "github.com/juju/names/v4"
 	reflect "reflect"
 )
@@ -83,10 +83,10 @@ func (mr *MockBackingMockRecorder) AllSubnets() *gomock.Call {
 }
 
 // AvailabilityZones mocks base method
-func (m *MockBacking) AvailabilityZones() ([]common.AvailabilityZone, error) {
+func (m *MockBacking) AvailabilityZones() (network.AvailabilityZones, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZones")
-	ret0, _ := ret[0].([]common.AvailabilityZone)
+	ret0, _ := ret[0].(network.AvailabilityZones)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -142,7 +142,7 @@ func (mr *MockBackingMockRecorder) ModelTag() *gomock.Call {
 }
 
 // SetAvailabilityZones mocks base method
-func (m *MockBacking) SetAvailabilityZones(arg0 []common.AvailabilityZone) error {
+func (m *MockBacking) SetAvailabilityZones(arg0 network.AvailabilityZones) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAvailabilityZones", arg0)
 	ret0, _ := ret[0].(error)

--- a/apiserver/facades/client/subnets/shims.go
+++ b/apiserver/facades/client/subnets/shims.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	"github.com/juju/juju/core/network"
-	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -85,14 +84,14 @@ func (s *stateShim) SubnetsByCIDR(cidr string) ([]networkingcommon.BackingSubnet
 	return result, nil
 }
 
-func (s *stateShim) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
+func (s *stateShim) AvailabilityZones() (network.AvailabilityZones, error) {
 	// TODO (hml) 2019-09-13
 	// now available... include.
 	// AvailabilityZones() is defined in the common.ZonedEnviron interface
 	return nil, nil
 }
 
-func (s *stateShim) SetAvailabilityZones(zones []providercommon.AvailabilityZone) error {
+func (s *stateShim) SetAvailabilityZones(_ network.AvailabilityZones) error {
 	return nil
 }
 

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/state"
 )
 
@@ -32,11 +31,11 @@ type Backing interface {
 
 	// AvailabilityZones returns all cached availability zones (i.e.
 	// not from the provider, but in state).
-	AvailabilityZones() ([]providercommon.AvailabilityZone, error)
+	AvailabilityZones() (network.AvailabilityZones, error)
 
 	// SetAvailabilityZones replaces the cached list of availability
 	// zones with the given zones.
-	SetAvailabilityZones([]providercommon.AvailabilityZone) error
+	SetAvailabilityZones(network.AvailabilityZones) error
 
 	// AddSubnet creates a backing subnet for an existing subnet.
 	AddSubnet(networkingcommon.BackingSubnetInfo) (networkingcommon.BackingSubnet, error)

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/context"
-	providercommon "github.com/juju/juju/provider/common"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -163,7 +162,7 @@ func (s *SubnetsSuite) TearDownTest(c *gc.C) {
 }
 
 // AssertAllZonesResult makes it easier to verify AllZones results.
-func (s *SubnetsSuite) AssertAllZonesResult(c *gc.C, got params.ZoneResults, expected []providercommon.AvailabilityZone) {
+func (s *SubnetsSuite) AssertAllZonesResult(c *gc.C, got params.ZoneResults, expected network.AvailabilityZones) {
 	results := make([]params.ZoneResult, len(expected))
 	for i, zone := range expected {
 		results[i].Name = zone.Name()
@@ -476,12 +475,12 @@ func (s *SubnetsSuite) CheckAddSubnetsFails(
 
 	if !withZones && withSpaces {
 		// Set provider zones to empty for this test.
-		originalZones := make([]providercommon.AvailabilityZone, len(apiservertesting.ProviderInstance.Zones))
+		originalZones := make(network.AvailabilityZones, len(apiservertesting.ProviderInstance.Zones))
 		copy(originalZones, apiservertesting.ProviderInstance.Zones)
-		apiservertesting.ProviderInstance.Zones = []providercommon.AvailabilityZone{}
+		apiservertesting.ProviderInstance.Zones = network.AvailabilityZones{}
 
 		defer func() {
-			apiservertesting.ProviderInstance.Zones = make([]providercommon.AvailabilityZone, len(originalZones))
+			apiservertesting.ProviderInstance.Zones = make(network.AvailabilityZones, len(originalZones))
 			copy(apiservertesting.ProviderInstance.Zones, originalZones)
 		}()
 

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -58,7 +58,7 @@ func (s StubNetwork) SetUpSuite(c *gc.C) {
 		}
 	}
 
-	ProviderInstance.Zones = []providercommon.AvailabilityZone{
+	ProviderInstance.Zones = network.AvailabilityZones{
 		&FakeZone{"zone1", true},
 		&FakeZone{"zone2", false},
 		&FakeZone{"zone3", true},
@@ -246,15 +246,6 @@ func ProviderCall(name string, args ...interface{}) StubMethodCall {
 	}
 }
 
-// EnvironCall makes it easy to check method calls on EnvironInstance.
-func EnvironCall(name string, args ...interface{}) StubMethodCall {
-	return StubMethodCall{
-		Receiver: EnvironInstance,
-		FuncName: name,
-		Args:     args,
-	}
-}
-
 // ZonedEnvironCall makes it easy to check method calls on
 // ZonedEnvironInstance.
 func ZonedEnvironCall(name string, args ...interface{}) StubMethodCall {
@@ -305,7 +296,7 @@ type FakeZone struct {
 	ZoneAvailable bool
 }
 
-var _ providercommon.AvailabilityZone = (*FakeZone)(nil)
+var _ network.AvailabilityZone = (*FakeZone)(nil)
 
 func (f *FakeZone) Name() string {
 	return f.ZoneName
@@ -386,7 +377,7 @@ type StubBacking struct {
 	EnvConfig *config.Config
 	Cloud     environscloudspec.CloudSpec
 
-	Zones   []providercommon.AvailabilityZone
+	Zones   network.AvailabilityZones
 	Spaces  []networkingcommon.BackingSpace
 	Subnets []networkingcommon.BackingSubnet
 }
@@ -424,9 +415,9 @@ func (sb *StubBacking) SetUp(c *gc.C, envName string, withZones, withSpaces, wit
 		IdentityEndpoint: "identity-endpoint",
 		StorageEndpoint:  "storage-endpoint",
 	}
-	sb.Zones = []providercommon.AvailabilityZone{}
+	sb.Zones = network.AvailabilityZones{}
 	if withZones {
-		sb.Zones = make([]providercommon.AvailabilityZone, len(ProviderInstance.Zones))
+		sb.Zones = make(network.AvailabilityZones, len(ProviderInstance.Zones))
 		copy(sb.Zones, ProviderInstance.Zones)
 	}
 	sb.Spaces = []networkingcommon.BackingSpace{}
@@ -515,7 +506,7 @@ func (sb *StubBacking) CloudSpec() (environscloudspec.CloudSpec, error) {
 	return sb.Cloud, nil
 }
 
-func (sb *StubBacking) AvailabilityZones() ([]providercommon.AvailabilityZone, error) {
+func (sb *StubBacking) AvailabilityZones() (network.AvailabilityZones, error) {
 	sb.MethodCall(sb, "AvailabilityZones")
 	if err := sb.NextErr(); err != nil {
 		return nil, err
@@ -523,7 +514,7 @@ func (sb *StubBacking) AvailabilityZones() ([]providercommon.AvailabilityZone, e
 	return sb.Zones, nil
 }
 
-func (sb *StubBacking) SetAvailabilityZones(zones []providercommon.AvailabilityZone) error {
+func (sb *StubBacking) SetAvailabilityZones(zones network.AvailabilityZones) error {
 	sb.MethodCall(sb, "SetAvailabilityZones", zones)
 	return sb.NextErr()
 }
@@ -627,7 +618,7 @@ func (sb *StubBacking) GoString() string {
 type StubProvider struct {
 	*testing.Stub
 
-	Zones   []providercommon.AvailabilityZone
+	Zones   network.AvailabilityZones
 	Subnets []network.SubnetInfo
 
 	environs.EnvironProvider // panic on any not implemented method call.
@@ -682,7 +673,7 @@ type StubZonedEnviron struct {
 
 var _ providercommon.ZonedEnviron = (*StubZonedEnviron)(nil)
 
-func (se *StubZonedEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([]providercommon.AvailabilityZone, error) {
+func (se *StubZonedEnviron) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 	se.MethodCall(se, "AvailabilityZones", ctx)
 	if err := se.NextErr(); err != nil {
 		return nil, err
@@ -770,7 +761,7 @@ func (se *StubZonedNetworkingEnviron) Subnets(
 	return ProviderInstance.Subnets, nil
 }
 
-func (se *StubZonedNetworkingEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([]providercommon.AvailabilityZone, error) {
+func (se *StubZonedNetworkingEnviron) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 	se.MethodCall(se, "AvailabilityZones", ctx)
 	if err := se.NextErr(); err != nil {
 		return nil, err

--- a/core/network/zone.go
+++ b/core/network/zone.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import "github.com/juju/errors"
+
+// AvailabilityZone describes the common methods
+// for general interaction with an AZ.
+type AvailabilityZone interface {
+	// Name returns the name of the availability zone.
+	Name() string
+
+	// Available reports whether the availability zone is currently available.
+	Available() bool
+}
+
+type AvailabilityZones []AvailabilityZone
+
+func (a AvailabilityZones) Validate(zoneName string) error {
+	for _, az := range a {
+		if az.Name() == zoneName {
+			if az.Available() {
+				return nil
+			}
+			return errors.Errorf("zone %q is unavailable", zoneName)
+		}
+	}
+	return errors.NotValidf("availability zone %q", zoneName)
+}

--- a/core/network/zone.go
+++ b/core/network/zone.go
@@ -15,8 +15,12 @@ type AvailabilityZone interface {
 	Available() bool
 }
 
+// AvailabilityZones is a collection of AvailabilityZone.
 type AvailabilityZones []AvailabilityZone
 
+// Validate checks that a zone with the input name exists and is available
+// according to the topology represented by the receiver.
+// An error is returned if either of these conditions are not met.
 func (a AvailabilityZones) Validate(zoneName string) error {
 	for _, az := range a {
 		if az.Name() == zoneName {

--- a/core/network/zone_test.go
+++ b/core/network/zone_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"github.com/juju/errors"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type zoneSuite struct {
+	jujutesting.IsolationSuite
+
+	zones AvailabilityZones
+}
+
+var _ = gc.Suite(&zoneSuite{})
+
+func (s *zoneSuite) SetUpTest(c *gc.C) {
+	s.zones = AvailabilityZones{
+		&az{name: "zone1", available: true},
+		&az{name: "zone2"},
+	}
+
+	s.IsolationSuite.SetUpTest(c)
+}
+
+func (s *zoneSuite) TestAvailabilityZones(c *gc.C) {
+	c.Assert(s.zones.Validate("zone1"), jc.ErrorIsNil)
+	c.Assert(s.zones.Validate("zone2"), gc.ErrorMatches, `zone "zone2" is unavailable`)
+	c.Assert(s.zones.Validate("zone3"), jc.Satisfies, errors.IsNotValid)
+}
+
+type az struct {
+	name      string
+	available bool
+}
+
+var _ = AvailabilityZone(&az{})
+
+func (a *az) Name() string {
+	return a.name
+}
+
+func (a *az) Available() bool {
+	return a.available
+}

--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -9,19 +9,10 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 )
-
-// AvailabilityZone describes a provider availability zone.
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/availability_zone.go github.com/juju/juju/provider/common AvailabilityZone
-type AvailabilityZone interface {
-	// Name returns the name of the availability zone.
-	Name() string
-
-	// Available reports whether the availability zone is currently available.
-	Available() bool
-}
 
 // ZonedEnviron is an environs.Environ that has support for availability zones.
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/zoned_environ.go github.com/juju/juju/provider/common ZonedEnviron
@@ -29,7 +20,7 @@ type ZonedEnviron interface {
 	environs.Environ
 
 	// AvailabilityZones returns all availability zones in the environment.
-	AvailabilityZones(ctx context.ProviderCallContext) ([]AvailabilityZone, error)
+	AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error)
 
 	// InstanceAvailabilityZoneNames returns the names of the availability
 	// zones for the specified instances. The error returned follows the same

--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -6,8 +6,6 @@ package common
 import (
 	"sort"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
@@ -193,23 +191,4 @@ func DistributeInstances(
 		}
 	}
 	return eligible, nil
-}
-
-// ValidateAvailabilityZone returns nil iff the availability
-// zone exists and is available, otherwise returns a NotValid
-// error.
-func ValidateAvailabilityZone(env ZonedEnviron, ctx context.ProviderCallContext, zone string) error {
-	zones, err := env.AvailabilityZones(ctx)
-	if err != nil {
-		return err
-	}
-	for _, z := range zones {
-		if z.Name() == zone {
-			if z.Available() {
-				return nil
-			}
-			return errors.Errorf("availability zone %q is unavailable", zone)
-		}
-	}
-	return errors.NotValidf("availability zone %q", zone)
 }

--- a/provider/common/availabilityzones_test.go
+++ b/provider/common/availabilityzones_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
@@ -39,14 +40,14 @@ func (s *AvailabilityZoneSuite) SetUpSuite(c *gc.C) {
 		return allInstances, nil
 	}
 
-	availabilityZones := make([]common.AvailabilityZone, 3)
+	availabilityZones := make(network.AvailabilityZones, 3)
 	for i := range availabilityZones {
 		availabilityZones[i] = &mockAvailabilityZone{
 			name:      fmt.Sprintf("az%d", i),
 			available: i > 0,
 		}
 	}
-	s.env.availabilityZones = func(context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+	s.env.availabilityZones = func(context.ProviderCallContext) (network.AvailabilityZones, error) {
 		return availabilityZones, nil
 	}
 }
@@ -133,9 +134,9 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsNoZones(c *gc.C) 
 		calls = append(calls, "InstanceAvailabilityZoneNames")
 		return []string{"", "", ""}, nil
 	})
-	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) (network.AvailabilityZones, error) {
 		calls = append(calls, "AvailabilityZones")
-		return []common.AvailabilityZone{}, nil
+		return network.AvailabilityZones{}, nil
 	})
 	zoneInstances, err := common.AvailabilityZoneAllocations(&s.env, s.callCtx, nil)
 	c.Assert(calls, gc.DeepEquals, []string{"InstanceAvailabilityZoneNames", "AvailabilityZones"})
@@ -151,7 +152,7 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsErrors(c *gc.C) {
 		return []string{"", "", ""}, nil
 	})
 	resultErr := fmt.Errorf("u can haz no az")
-	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) (network.AvailabilityZones, error) {
 		calls = append(calls, "AvailabilityZones")
 		return nil, resultErr
 	})
@@ -163,8 +164,8 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsErrors(c *gc.C) {
 
 func (s *AvailabilityZoneSuite) TestValidateAvailabilityZone(c *gc.C) {
 	var calls []string
-	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) ([]common.AvailabilityZone, error) {
-		availabilityZones := make([]common.AvailabilityZone, 2)
+	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) (network.AvailabilityZones, error) {
+		availabilityZones := make(network.AvailabilityZones, 2)
 		availabilityZones[0] = &mockAvailabilityZone{name: "az1", available: true}
 		availabilityZones[1] = &mockAvailabilityZone{name: "az2", available: false}
 		calls = append(calls, "AvailabilityZones")

--- a/provider/common/availabilityzones_test.go
+++ b/provider/common/availabilityzones_test.go
@@ -6,7 +6,6 @@ package common_test
 import (
 	"fmt"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -160,32 +159,6 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsErrors(c *gc.C) {
 	c.Assert(calls, gc.DeepEquals, []string{"InstanceAvailabilityZoneNames", "AvailabilityZones"})
 	c.Assert(err, gc.Equals, resultErr)
 	c.Assert(zoneInstances, gc.HasLen, 0)
-}
-
-func (s *AvailabilityZoneSuite) TestValidateAvailabilityZone(c *gc.C) {
-	var calls []string
-	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) (network.AvailabilityZones, error) {
-		availabilityZones := make(network.AvailabilityZones, 2)
-		availabilityZones[0] = &mockAvailabilityZone{name: "az1", available: true}
-		availabilityZones[1] = &mockAvailabilityZone{name: "az2", available: false}
-		calls = append(calls, "AvailabilityZones")
-		return availabilityZones, nil
-	})
-	tests := map[string]error{
-		"az1": nil,
-		"az2": errors.Errorf("availability zone %q is unavailable", "az2"),
-		"az3": errors.NotValidf("availability zone %q", "az3"),
-	}
-	for i, t := range tests {
-		err := common.ValidateAvailabilityZone(&s.env, s.callCtx, i)
-		if t == nil {
-			c.Assert(err, jc.ErrorIsNil)
-		} else {
-			c.Assert(err, gc.ErrorMatches, err.Error())
-		}
-		c.Assert(calls, gc.DeepEquals, []string{"AvailabilityZones"})
-		calls = []string{}
-	}
 }
 
 func (s *AvailabilityZoneSuite) TestDistributeInstancesGroup(c *gc.C) {

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -116,7 +116,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		c.Assert(args.Placement, gc.DeepEquals, checkPlacement)
@@ -290,7 +290,7 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		c.Assert(args.AvailabilityZone, gc.Equals, "derived-zone")
@@ -318,11 +318,11 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", false}
 			z2 := &mockAvailabilityZone{"z2", true}
-			return []common.AvailabilityZone{z0, z1, z2}, nil
+			return network.AvailabilityZones{z0, z1, z2}, nil
 		},
 	}
 
@@ -330,7 +330,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -359,12 +359,12 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			z2 := &mockAvailabilityZone{"z2", true}
 			z3 := &mockAvailabilityZone{"z3", true}
-			return []common.AvailabilityZone{z0, z1, z2, z3}, nil
+			return network.AvailabilityZones{z0, z1, z2, z3}, nil
 		},
 	}
 
@@ -372,7 +372,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -404,12 +404,12 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			z2 := &mockAvailabilityZone{"z2", true}
 			z3 := &mockAvailabilityZone{"z3", true}
-			return []common.AvailabilityZone{z0, z1, z2, z3}, nil
+			return network.AvailabilityZones{z0, z1, z2, z3}, nil
 		},
 	}
 
@@ -417,7 +417,7 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -449,10 +449,10 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
-			return []common.AvailabilityZone{z0, z1}, nil
+			return network.AvailabilityZones{z0, z1}, nil
 		},
 	}
 
@@ -460,7 +460,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		callZones = append(callZones, args.AvailabilityZone)
@@ -487,9 +487,9 @@ func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {
 		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 			z0 := &mockAvailabilityZone{"z0", false}
-			return []common.AvailabilityZone{z0}, nil
+			return network.AvailabilityZones{z0}, nil
 		},
 	}
 
@@ -511,12 +511,12 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	var innerInstanceConfig *instancecfg.InstanceConfig
 	inst := &mockInstance{
 		id:        checkInstanceId,
-		addresses: corenetwork.NewProviderAddresses("testing.invalid"),
+		addresses: network.NewProviderAddresses("testing.invalid"),
 	}
 	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		icfg := args.InstanceConfig
@@ -618,12 +618,12 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	var innerInstanceConfig *instancecfg.InstanceConfig
 	inst := &mockInstance{
 		id:        "i-success",
-		addresses: corenetwork.NewProviderAddresses("testing.invalid"),
+		addresses: network.NewProviderAddresses("testing.invalid"),
 	}
 	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
-		corenetwork.InterfaceInfos,
+		network.InterfaceInfos,
 		error,
 	) {
 		icfg := args.InstanceConfig
@@ -693,7 +693,7 @@ type neverAddresses struct {
 	neverRefreshes
 }
 
-func (neverAddresses) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (neverAddresses) Addresses(ctx context.ProviderCallContext) (network.ProviderAddresses, error) {
 	return nil, nil
 }
 
@@ -702,7 +702,7 @@ type failsProvisioning struct {
 	message string
 }
 
-func (f failsProvisioning) Status(ctx context.ProviderCallContext) instance.Status {
+func (f failsProvisioning) Status(_ context.ProviderCallContext) instance.Status {
 	return instance.Status{
 		Status:  status.ProvisioningError,
 		Message: f.message,
@@ -755,7 +755,7 @@ type brokenAddresses struct {
 	neverRefreshes
 }
 
-func (brokenAddresses) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (brokenAddresses) Addresses(ctx context.ProviderCallContext) (network.ProviderAddresses, error) {
 	return nil, errors.Errorf("Addresses will never work")
 }
 
@@ -774,8 +774,8 @@ type neverOpensPort struct {
 	addr string
 }
 
-func (n *neverOpensPort) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
-	return corenetwork.NewProviderAddresses(n.addr), nil
+func (n *neverOpensPort) Addresses(ctx context.ProviderCallContext) (network.ProviderAddresses, error) {
+	return network.NewProviderAddresses(n.addr), nil
 }
 
 func (s *BootstrapSuite) TestWaitSSHTimesOutWaitingForDial(c *gc.C) {
@@ -799,7 +799,7 @@ type interruptOnDial struct {
 	returned    bool
 }
 
-func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) (network.ProviderAddresses, error) {
 	// kill the tomb the second time Addresses is called
 	if !i.returned {
 		i.returned = true
@@ -809,7 +809,7 @@ func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) (corenetwor
 			i.interrupted = nil
 		}
 	}
-	return corenetwork.NewProviderAddresses(i.name), nil
+	return network.NewProviderAddresses(i.name), nil
 }
 
 func (s *BootstrapSuite) TestWaitSSHKilledWaitingForDial(c *gc.C) {
@@ -843,8 +843,8 @@ func (ac *addressesChange) Status(ctx context.ProviderCallContext) instance.Stat
 	return instance.Status{}
 }
 
-func (ac *addressesChange) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
-	return corenetwork.NewProviderAddresses(ac.addrs[0]...), nil
+func (ac *addressesChange) Addresses(ctx context.ProviderCallContext) (network.ProviderAddresses, error) {
+	return network.NewProviderAddresses(ac.addrs[0]...), nil
 }
 
 func (s *BootstrapSuite) TestWaitSSHRefreshAddresses(c *gc.C) {
@@ -937,7 +937,7 @@ func fakeAvailableTools() tools.List {
 func fakeStartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
 	instances.Instance,
 	*instance.HardwareCharacteristics,
-	corenetwork.InterfaceInfos,
+	network.InterfaceInfos,
 	error,
 ) {
 	checkInstanceId := "i-success"

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -7,20 +7,19 @@ import (
 	"io"
 
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
-	"github.com/juju/juju/provider/common"
 	jujustorage "github.com/juju/juju/storage"
 )
 
 type allInstancesFunc func(context.ProviderCallContext) ([]instances.Instance, error)
 type instancesFunc func(context.ProviderCallContext, []instance.Id) ([]instances.Instance, error)
-type startInstanceFunc func(context.ProviderCallContext, environs.StartInstanceParams) (instances.Instance, *instance.HardwareCharacteristics, corenetwork.InterfaceInfos, error)
+type startInstanceFunc func(context.ProviderCallContext, environs.StartInstanceParams) (instances.Instance, *instance.HardwareCharacteristics, network.InterfaceInfos, error)
 type stopInstancesFunc func(context.ProviderCallContext, []instance.Id) error
 type getToolsSourcesFunc func() ([]simplestreams.DataSource, error)
 type configFunc func() *config.Config
@@ -98,7 +97,7 @@ func (env *mockEnviron) StorageProvider(t jujustorage.ProviderType) (jujustorage
 	return env.storageProviders.StorageProvider(t)
 }
 
-type availabilityZonesFunc func(context.ProviderCallContext) ([]common.AvailabilityZone, error)
+type availabilityZonesFunc func(context.ProviderCallContext) (network.AvailabilityZones, error)
 type instanceAvailabilityZoneNamesFunc func(context.ProviderCallContext, []instance.Id) ([]string, error)
 type deriveAvailabilityZonesFunc func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error)
 
@@ -109,7 +108,7 @@ type mockZonedEnviron struct {
 	deriveAvailabilityZones       deriveAvailabilityZonesFunc
 }
 
-func (env *mockZonedEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (env *mockZonedEnviron) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 	return env.availabilityZones(ctx)
 }
 
@@ -123,7 +122,7 @@ func (env *mockZonedEnviron) DeriveAvailabilityZones(ctx context.ProviderCallCon
 
 type mockInstance struct {
 	id                 string
-	addresses          []corenetwork.ProviderAddress
+	addresses          network.ProviderAddresses
 	addressesErr       error
 	dnsName            string
 	dnsNameErr         error
@@ -139,7 +138,7 @@ func (inst *mockInstance) Status(context.ProviderCallContext) instance.Status {
 	return inst.status
 }
 
-func (inst *mockInstance) Addresses(context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (inst *mockInstance) Addresses(context.ProviderCallContext) (network.ProviderAddresses, error) {
 	return inst.addresses, inst.addressesErr
 }
 

--- a/provider/common/mocks/instance_configurator.go
+++ b/provider/common/mocks/instance_configurator.go
@@ -5,10 +5,9 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/network"
+	reflect "reflect"
 )
 
 // MockInstanceConfigurator is a mock of InstanceConfigurator interface
@@ -36,6 +35,7 @@ func (m *MockInstanceConfigurator) EXPECT() *MockInstanceConfiguratorMockRecorde
 
 // ChangeIngressRules mocks base method
 func (m *MockInstanceConfigurator) ChangeIngressRules(arg0 string, arg1 bool, arg2 []network.IngressRule) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeIngressRules", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +43,13 @@ func (m *MockInstanceConfigurator) ChangeIngressRules(arg0 string, arg1 bool, ar
 
 // ChangeIngressRules indicates an expected call of ChangeIngressRules
 func (mr *MockInstanceConfiguratorMockRecorder) ChangeIngressRules(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeIngressRules", reflect.TypeOf((*MockInstanceConfigurator)(nil).ChangeIngressRules), arg0, arg1, arg2)
 }
 
 // ConfigureExternalIpAddress mocks base method
 func (m *MockInstanceConfigurator) ConfigureExternalIpAddress(arg0 int) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigureExternalIpAddress", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -55,11 +57,13 @@ func (m *MockInstanceConfigurator) ConfigureExternalIpAddress(arg0 int) error {
 
 // ConfigureExternalIpAddress indicates an expected call of ConfigureExternalIpAddress
 func (mr *MockInstanceConfiguratorMockRecorder) ConfigureExternalIpAddress(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureExternalIpAddress", reflect.TypeOf((*MockInstanceConfigurator)(nil).ConfigureExternalIpAddress), arg0)
 }
 
 // DropAllPorts mocks base method
 func (m *MockInstanceConfigurator) DropAllPorts(arg0 []int, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DropAllPorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -67,11 +71,13 @@ func (m *MockInstanceConfigurator) DropAllPorts(arg0 []int, arg1 string) error {
 
 // DropAllPorts indicates an expected call of DropAllPorts
 func (mr *MockInstanceConfiguratorMockRecorder) DropAllPorts(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropAllPorts", reflect.TypeOf((*MockInstanceConfigurator)(nil).DropAllPorts), arg0, arg1)
 }
 
 // FindIngressRules mocks base method
 func (m *MockInstanceConfigurator) FindIngressRules() ([]network.IngressRule, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindIngressRules")
 	ret0, _ := ret[0].([]network.IngressRule)
 	ret1, _ := ret[1].(error)
@@ -80,5 +86,6 @@ func (m *MockInstanceConfigurator) FindIngressRules() ([]network.IngressRule, er
 
 // FindIngressRules indicates an expected call of FindIngressRules
 func (mr *MockInstanceConfiguratorMockRecorder) FindIngressRules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindIngressRules", reflect.TypeOf((*MockInstanceConfigurator)(nil).FindIngressRules))
 }

--- a/provider/common/mocks/zoned_environ.go
+++ b/provider/common/mocks/zoned_environ.go
@@ -5,19 +5,17 @@
 package mocks
 
 import (
-	"reflect"
-
-	"github.com/golang/mock/gomock"
-	"github.com/juju/version"
-
-	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/storage"
+	gomock "github.com/golang/mock/gomock"
+	constraints "github.com/juju/juju/core/constraints"
+	instance "github.com/juju/juju/core/instance"
+	network "github.com/juju/juju/core/network"
+	environs "github.com/juju/juju/environs"
+	config "github.com/juju/juju/environs/config"
+	context "github.com/juju/juju/environs/context"
+	instances "github.com/juju/juju/environs/instances"
+	storage "github.com/juju/juju/storage"
+	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockZonedEnviron is a mock of ZonedEnviron interface
@@ -45,6 +43,7 @@ func (m *MockZonedEnviron) EXPECT() *MockZonedEnvironMockRecorder {
 
 // AdoptResources mocks base method
 func (m *MockZonedEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -52,11 +51,13 @@ func (m *MockZonedEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1
 
 // AdoptResources indicates an expected call of AdoptResources
 func (mr *MockZonedEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdoptResources", reflect.TypeOf((*MockZonedEnviron)(nil).AdoptResources), arg0, arg1, arg2)
 }
 
 // AllInstances mocks base method
 func (m *MockZonedEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -65,11 +66,13 @@ func (m *MockZonedEnviron) AllInstances(arg0 context.ProviderCallContext) ([]ins
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockZonedEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockZonedEnviron)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
 func (m *MockZonedEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -78,24 +81,28 @@ func (m *MockZonedEnviron) AllRunningInstances(arg0 context.ProviderCallContext)
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockZonedEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockZonedEnviron)(nil).AllRunningInstances), arg0)
 }
 
 // AvailabilityZones mocks base method
-func (m *MockZonedEnviron) AvailabilityZones(arg0 context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (m *MockZonedEnviron) AvailabilityZones(arg0 context.ProviderCallContext) (network.AvailabilityZones, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZones", arg0)
-	ret0, _ := ret[0].([]common.AvailabilityZone)
+	ret0, _ := ret[0].(network.AvailabilityZones)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailabilityZones indicates an expected call of AvailabilityZones
 func (mr *MockZonedEnvironMockRecorder) AvailabilityZones(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZones", reflect.TypeOf((*MockZonedEnviron)(nil).AvailabilityZones), arg0)
 }
 
 // Bootstrap mocks base method
 func (m *MockZonedEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
@@ -104,11 +111,13 @@ func (m *MockZonedEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 contex
 
 // Bootstrap indicates an expected call of Bootstrap
 func (mr *MockZonedEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockZonedEnviron)(nil).Bootstrap), arg0, arg1, arg2)
 }
 
 // Config mocks base method
 func (m *MockZonedEnviron) Config() *config.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*config.Config)
 	return ret0
@@ -116,11 +125,13 @@ func (m *MockZonedEnviron) Config() *config.Config {
 
 // Config indicates an expected call of Config
 func (mr *MockZonedEnvironMockRecorder) Config() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockZonedEnviron)(nil).Config))
 }
 
 // ConstraintsValidator mocks base method
 func (m *MockZonedEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
 	ret1, _ := ret[1].(error)
@@ -129,11 +140,13 @@ func (m *MockZonedEnviron) ConstraintsValidator(arg0 context.ProviderCallContext
 
 // ConstraintsValidator indicates an expected call of ConstraintsValidator
 func (mr *MockZonedEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsValidator", reflect.TypeOf((*MockZonedEnviron)(nil).ConstraintsValidator), arg0)
 }
 
 // ControllerInstances mocks base method
 func (m *MockZonedEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -142,11 +155,13 @@ func (m *MockZonedEnviron) ControllerInstances(arg0 context.ProviderCallContext,
 
 // ControllerInstances indicates an expected call of ControllerInstances
 func (mr *MockZonedEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerInstances", reflect.TypeOf((*MockZonedEnviron)(nil).ControllerInstances), arg0, arg1)
 }
 
 // Create mocks base method
 func (m *MockZonedEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -154,11 +169,13 @@ func (m *MockZonedEnviron) Create(arg0 context.ProviderCallContext, arg1 environ
 
 // Create indicates an expected call of Create
 func (mr *MockZonedEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockZonedEnviron)(nil).Create), arg0, arg1)
 }
 
 // DeriveAvailabilityZones mocks base method
 func (m *MockZonedEnviron) DeriveAvailabilityZones(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeriveAvailabilityZones", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -167,11 +184,13 @@ func (m *MockZonedEnviron) DeriveAvailabilityZones(arg0 context.ProviderCallCont
 
 // DeriveAvailabilityZones indicates an expected call of DeriveAvailabilityZones
 func (mr *MockZonedEnvironMockRecorder) DeriveAvailabilityZones(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeriveAvailabilityZones", reflect.TypeOf((*MockZonedEnviron)(nil).DeriveAvailabilityZones), arg0, arg1)
 }
 
 // Destroy mocks base method
 func (m *MockZonedEnviron) Destroy(arg0 context.ProviderCallContext) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -179,11 +198,13 @@ func (m *MockZonedEnviron) Destroy(arg0 context.ProviderCallContext) error {
 
 // Destroy indicates an expected call of Destroy
 func (mr *MockZonedEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockZonedEnviron)(nil).Destroy), arg0)
 }
 
 // DestroyController mocks base method
 func (m *MockZonedEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -191,11 +212,13 @@ func (m *MockZonedEnviron) DestroyController(arg0 context.ProviderCallContext, a
 
 // DestroyController indicates an expected call of DestroyController
 func (mr *MockZonedEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyController", reflect.TypeOf((*MockZonedEnviron)(nil).DestroyController), arg0, arg1)
 }
 
 // InstanceAvailabilityZoneNames mocks base method
 func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceAvailabilityZoneNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -204,11 +227,13 @@ func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context.ProviderCa
 
 // InstanceAvailabilityZoneNames indicates an expected call of InstanceAvailabilityZoneNames
 func (mr *MockZonedEnvironMockRecorder) InstanceAvailabilityZoneNames(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceAvailabilityZoneNames", reflect.TypeOf((*MockZonedEnviron)(nil).InstanceAvailabilityZoneNames), arg0, arg1)
 }
 
 // InstanceTypes mocks base method
 func (m *MockZonedEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
 	ret1, _ := ret[1].(error)
@@ -217,11 +242,13 @@ func (m *MockZonedEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 
 
 // InstanceTypes indicates an expected call of InstanceTypes
 func (mr *MockZonedEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceTypes", reflect.TypeOf((*MockZonedEnviron)(nil).InstanceTypes), arg0, arg1)
 }
 
 // Instances mocks base method
 func (m *MockZonedEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -230,11 +257,13 @@ func (m *MockZonedEnviron) Instances(arg0 context.ProviderCallContext, arg1 []in
 
 // Instances indicates an expected call of Instances
 func (mr *MockZonedEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instances", reflect.TypeOf((*MockZonedEnviron)(nil).Instances), arg0, arg1)
 }
 
 // MaintainInstance mocks base method
 func (m *MockZonedEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -242,11 +271,13 @@ func (m *MockZonedEnviron) MaintainInstance(arg0 context.ProviderCallContext, ar
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockZonedEnvironMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockZonedEnviron)(nil).MaintainInstance), arg0, arg1)
 }
 
 // PrecheckInstance mocks base method
 func (m *MockZonedEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -254,11 +285,13 @@ func (m *MockZonedEnviron) PrecheckInstance(arg0 context.ProviderCallContext, ar
 
 // PrecheckInstance indicates an expected call of PrecheckInstance
 func (mr *MockZonedEnvironMockRecorder) PrecheckInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrecheckInstance", reflect.TypeOf((*MockZonedEnviron)(nil).PrecheckInstance), arg0, arg1)
 }
 
 // PrepareForBootstrap mocks base method
 func (m *MockZonedEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareForBootstrap", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -266,11 +299,13 @@ func (m *MockZonedEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, a
 
 // PrepareForBootstrap indicates an expected call of PrepareForBootstrap
 func (mr *MockZonedEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForBootstrap", reflect.TypeOf((*MockZonedEnviron)(nil).PrepareForBootstrap), arg0, arg1)
 }
 
 // Provider mocks base method
 func (m *MockZonedEnviron) Provider() environs.EnvironProvider {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Provider")
 	ret0, _ := ret[0].(environs.EnvironProvider)
 	return ret0
@@ -278,11 +313,13 @@ func (m *MockZonedEnviron) Provider() environs.EnvironProvider {
 
 // Provider indicates an expected call of Provider
 func (mr *MockZonedEnvironMockRecorder) Provider() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockZonedEnviron)(nil).Provider))
 }
 
 // SetConfig mocks base method
 func (m *MockZonedEnviron) SetConfig(arg0 *config.Config) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -290,11 +327,13 @@ func (m *MockZonedEnviron) SetConfig(arg0 *config.Config) error {
 
 // SetConfig indicates an expected call of SetConfig
 func (mr *MockZonedEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockZonedEnviron)(nil).SetConfig), arg0)
 }
 
 // StartInstance mocks base method
 func (m *MockZonedEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -303,11 +342,13 @@ func (m *MockZonedEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockZonedEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockZonedEnviron)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockZonedEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -319,12 +360,14 @@ func (m *MockZonedEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockZonedEnvironMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockZonedEnviron)(nil).StopInstances), varargs...)
 }
 
 // StorageProvider mocks base method
 func (m *MockZonedEnviron) StorageProvider(arg0 storage.ProviderType) (storage.Provider, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProvider", arg0)
 	ret0, _ := ret[0].(storage.Provider)
 	ret1, _ := ret[1].(error)
@@ -333,11 +376,13 @@ func (m *MockZonedEnviron) StorageProvider(arg0 storage.ProviderType) (storage.P
 
 // StorageProvider indicates an expected call of StorageProvider
 func (mr *MockZonedEnvironMockRecorder) StorageProvider(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProvider", reflect.TypeOf((*MockZonedEnviron)(nil).StorageProvider), arg0)
 }
 
 // StorageProviderTypes mocks base method
 func (m *MockZonedEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProviderTypes")
 	ret0, _ := ret[0].([]storage.ProviderType)
 	ret1, _ := ret[1].(error)
@@ -346,5 +391,6 @@ func (m *MockZonedEnviron) StorageProviderTypes() ([]storage.ProviderType, error
 
 // StorageProviderTypes indicates an expected call of StorageProviderTypes
 func (mr *MockZonedEnvironMockRecorder) StorageProviderTypes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProviderTypes", reflect.TypeOf((*MockZonedEnviron)(nil).StorageProviderTypes))
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -76,7 +76,6 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/pubsub/centralhub"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -653,7 +652,7 @@ func (*environProvider) DetectCredentials() (*cloud.CloudCredential, error) {
 	return cloud.NewEmptyCloudCredential(), nil
 }
 
-func (*environProvider) FinalizeCredential(ctx environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
+func (*environProvider) FinalizeCredential(_ environs.FinalizeCredentialContext, args environs.FinalizeCredentialParams) (*cloud.Credential, error) {
 	return &args.Credential, nil
 }
 
@@ -1503,9 +1502,9 @@ func (az azShim) Available() bool {
 }
 
 // AvailabilityZones implements environs.ZonedEnviron.
-func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (corenetwork.AvailabilityZones, error) {
 	// TODO(dimitern): Fix this properly.
-	return []common.AvailabilityZone{
+	return corenetwork.AvailabilityZones{
 		azShim{"zone1", true},
 		azShim{"zone2", false},
 		azShim{"zone3", true},

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -71,7 +71,7 @@ type environ struct {
 	ecfgUnlocked *environConfig
 
 	availabilityZonesMutex sync.Mutex
-	availabilityZones      []common.AvailabilityZone
+	availabilityZones      corenetwork.AvailabilityZones
 
 	instTypesMutex sync.Mutex
 	instTypes      []instances.InstanceType
@@ -223,7 +223,7 @@ func (z *ec2AvailabilityZone) Available() bool {
 
 // AvailabilityZones returns a slice of availability zones
 // for the configured region.
-func (e *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (e *environ) AvailabilityZones(ctx context.ProviderCallContext) (corenetwork.AvailabilityZones, error) {
 	e.availabilityZonesMutex.Lock()
 	defer e.availabilityZonesMutex.Unlock()
 	if e.availabilityZones == nil {
@@ -234,7 +234,7 @@ func (e *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.A
 			return nil, maybeConvertCredentialError(err, ctx)
 		}
 		logger.Debugf("availability zones: %+v", resp)
-		e.availabilityZones = make([]common.AvailabilityZone, len(resp.Zones))
+		e.availabilityZones = make(corenetwork.AvailabilityZones, len(resp.Zones))
 		for i, z := range resp.Zones {
 			e.availabilityZones[i] = &ec2AvailabilityZone{z}
 		}

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/common"
@@ -15,13 +16,13 @@ import (
 )
 
 // AvailabilityZones returns all availability zones in the environment.
-func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 	zones, err := env.gce.AvailabilityZones(env.cloud.Region)
 	if err != nil {
 		return nil, google.HandleCredentialError(errors.Trace(err), ctx)
 	}
 
-	var result []common.AvailabilityZone
+	var result network.AvailabilityZones
 	for _, zone := range zones {
 		if zone.Deprecated() {
 			continue

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -178,7 +179,7 @@ func (env *environ) Config() *config.Config {
 }
 
 // PrepareForBootstrap implements environs.Environ.
-func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
+func (env *environ) PrepareForBootstrap(_ environs.BootstrapContext, _ string) error {
 	return nil
 }
 
@@ -268,13 +269,13 @@ func (z *lxdAvailabilityZone) Available() bool {
 
 // AvailabilityZones (ZonedEnviron) returns all availability zones in the
 // environment. For LXD, this means the cluster node names.
-func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 	// If we are not using a clustered server (which includes those not
 	// supporting the clustering API) just represent the single server as the
 	// only availability zone.
 	server := env.server()
 	if !server.IsClustered() {
-		return []common.AvailabilityZone{
+		return network.AvailabilityZones{
 			&lxdAvailabilityZone{
 				ClusterMember: api.ClusterMember{
 					ServerName: server.Name(),
@@ -289,7 +290,7 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		return nil, errors.Annotate(err, "listing cluster members")
 	}
-	aZones := make([]common.AvailabilityZone, len(nodes))
+	aZones := make(network.AvailabilityZones, len(nodes))
 	for i, n := range nodes {
 		aZones[i] = &lxdAvailabilityZone{n}
 	}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -284,7 +284,11 @@ func (env *environ) parsePlacement(ctx context.ProviderCallContext, placement st
 		return &lxdPlacement{}, nil
 	}
 
-	if err := common.ValidateAvailabilityZone(env, ctx, node); err != nil {
+	zones, err := env.AvailabilityZones(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := zones.Validate(node); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -250,7 +250,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 	args.Placement = "zone=node01"
 
 	_, err := env.StartInstance(s.callCtx, args)
-	c.Assert(err, gc.ErrorMatches, "availability zone \"node01\" is unavailable")
+	c.Assert(err, gc.ErrorMatches, "zone \"node01\" is unavailable")
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) {

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	envcontext "github.com/juju/juju/environs/context"
@@ -177,7 +178,7 @@ func (e *Environ) ping() error {
 }
 
 // AvailabilityZones is defined in the common.ZonedEnviron interface
-func (e *Environ) AvailabilityZones(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (e *Environ) AvailabilityZones(ctx envcontext.ProviderCallContext) (network.AvailabilityZones, error) {
 	request := ociIdentity.ListAvailabilityDomainsRequest{
 		CompartmentId: e.ecfg().compartmentID(),
 	}
@@ -190,7 +191,7 @@ func (e *Environ) AvailabilityZones(ctx envcontext.ProviderCallContext) ([]commo
 		return nil, errors.Trace(err)
 	}
 
-	zones := []common.AvailabilityZone{}
+	zones := network.AvailabilityZones{}
 
 	for _, val := range domains.Items {
 		zones = append(zones, NewAvailabilityZone(*val.Name))

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1544,7 +1544,7 @@ func (s *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
 	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
-	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
+	c.Assert(err, gc.ErrorMatches, `zone "test-unavailable" is unavailable`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
@@ -1652,7 +1652,7 @@ func (s *localServerSuite) TestDeriveAvailabilityZonesUnavailable(c *gc.C) {
 		environs.StartInstanceParams{
 			Placement: placement,
 		})
-	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
+	c.Assert(err, gc.ErrorMatches, `zone "test-unavailable" is unavailable`)
 	c.Assert(zones, gc.HasLen, 0)
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -331,7 +331,7 @@ type Environ struct {
 	keystoneToolsDataSource      simplestreams.DataSource
 
 	availabilityZonesMutex sync.Mutex
-	availabilityZones      []common.AvailabilityZone
+	availabilityZones      corenetwork.AvailabilityZones
 	firewaller             Firewaller
 	networking             Networking
 	configurator           ProviderConfigurator
@@ -614,7 +614,7 @@ func (z *openstackAvailabilityZone) Available() bool {
 }
 
 // AvailabilityZones returns a slice of availability zones.
-func (e *Environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (e *Environ) AvailabilityZones(ctx context.ProviderCallContext) (corenetwork.AvailabilityZones, error) {
 	e.availabilityZonesMutex.Lock()
 	defer e.availabilityZonesMutex.Unlock()
 	if e.availabilityZones == nil {
@@ -626,7 +626,7 @@ func (e *Environ) AvailabilityZones(ctx context.ProviderCallContext) ([]common.A
 			handleCredentialError(err, ctx)
 			return nil, err
 		}
-		e.availabilityZones = make([]common.AvailabilityZone, len(zones))
+		e.availabilityZones = make(corenetwork.AvailabilityZones, len(zones))
 		for i, z := range zones {
 			e.availabilityZones[i] = &openstackAvailabilityZone{z}
 		}
@@ -726,7 +726,7 @@ func (e *Environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 }
 
 // PrepareForBootstrap is part of the Environ interface.
-func (e *Environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
+func (e *Environ) PrepareForBootstrap(_ environs.BootstrapContext, _ string) error {
 	// Verify credentials.
 	if err := authenticateClient(e.client()); err != nil {
 		return err

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -82,8 +82,8 @@ type EnvironAPI interface {
 }
 
 // AvailabilityZones is defined in the common.ZonedEnviron interface
-func (o *OracleEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
-	return []common.AvailabilityZone{
+func (o *OracleEnviron) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
+	return network.AvailabilityZones{
 		oraclenet.NewAvailabilityZone("default"),
 	}, nil
 }
@@ -132,7 +132,7 @@ func NewOracleEnviron(p *EnvironProvider, args environs.OpenParams, client Envir
 }
 
 // PrepareForBootstrap is part of the Environ interface.
-func (o *OracleEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
+func (o *OracleEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, _ string) error {
 	if ctx.ShouldVerifyCredentials() {
 		logger.Infof("Logging into the oracle cloud infrastructure")
 		if err := o.client.Authenticate(); err != nil {

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -11,9 +11,9 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/provider/common"
 )
 
 // poolPathPrefixParts is the number of path components to chop off a
@@ -53,7 +53,7 @@ func (z *vmwareAvailZone) Available() bool {
 }
 
 // AvailabilityZones is part of the common.ZonedEnviron interface.
-func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (zones []common.AvailabilityZone, err error) {
+func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (zones network.AvailabilityZones, err error) {
 	err = env.withSession(ctx, func(env *sessionEnviron) error {
 		zones, err = env.AvailabilityZones(ctx)
 		return err
@@ -62,14 +62,14 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (zones []
 }
 
 // AvailabilityZones is part of the common.ZonedEnviron interface.
-func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
 	if env.zones == nil {
 		computeResources, err := env.client.ComputeResources(env.ctx)
 		if err != nil {
 			HandleCredentialError(err, env, ctx)
 			return nil, errors.Trace(err)
 		}
-		var zones []common.AvailabilityZone
+		var zones network.AvailabilityZones
 		for _, cr := range computeResources {
 			if cr.Summary.GetComputeResourceSummary().EffectiveCpu == 0 {
 				logger.Debugf("skipping empty compute resource %q", cr.Name)

--- a/provider/vsphere/session.go
+++ b/provider/vsphere/session.go
@@ -6,8 +6,8 @@ package vsphere
 import (
 	"golang.org/x/net/context"
 
+	"github.com/juju/juju/core/network"
 	callcontext "github.com/juju/juju/environs/context"
-	"github.com/juju/juju/provider/common"
 )
 
 // sessionEnviron implements common.ZonedEnviron. An instance of
@@ -30,7 +30,7 @@ type sessionEnviron struct {
 	// the number of API calls required by StartInstance.
 	// We only cache per session, so there is no issue of
 	// staleness.
-	zones []common.AvailabilityZone
+	zones network.AvailabilityZones
 }
 
 func (env *environ) withSession(callCtx callcontext.ProviderCallContext, f func(*sessionEnviron) error) error {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/juju/core/network"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -37,7 +39,6 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/common/mocks"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/provisioner"
@@ -585,7 +586,7 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller) *mocks
 	}
 
 	// Environ has 3 availability zones: az1, az2, az3.
-	zones := make([]common.AvailabilityZone, 3)
+	zones := make(network.AvailabilityZones, 3)
 	for i := 0; i < 3; i++ {
 		az := mocks.NewMockAvailabilityZone(ctrl)
 		az.EXPECT().Name().Return(fmt.Sprintf("az%d", i+1))

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1935,7 +1935,7 @@ func (b *mockBroker) getRetryCount(id string) int {
 // ZonedEnviron necessary for provisionerTask.populateAvailabilityZoneMachines where
 // mockBroker used.
 
-func (b *mockBroker) AvailabilityZones(ctx context.ProviderCallContext) ([]providercommon.AvailabilityZone, error) {
+func (b *mockBroker) AvailabilityZones(ctx context.ProviderCallContext) (corenetwork.AvailabilityZones, error) {
 	return b.Environ.(providercommon.ZonedEnviron).AvailabilityZones(ctx)
 }
 


### PR DESCRIPTION
## Description of change

This patch introduces some preparatory work for modelling availability zones.
- The `AvailabilityZone` indirection now resides in `core/network` and has an accompanying collection type, `AvailabilityZones`.
- `AvailabilityZones` includes a method `Validate`, which replaces `ValidateAvailabilityZone` from `provider/common`.

The benefits of this will be more fully realised later, but as of now they are:
- The ability to validate a zone wherever we have a materialised zone list, without depending on access to an environ.
- Clearer usage, by pushing acquisition into the specific providers, of `AvailabilityZones` calls. We will audit these later and appropriately remove lifetime AZ caching from providers implementing it.

## QA steps

Purely mechanical changes, verified by unit tests.

## Documentation changes

None.

## Bug reference

N/A
