### PR TITLE
Fix/lp 1875481

### DIFF
--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -162,8 +162,9 @@ func (c *Client) WatchPodSpec(application string) (watcher.NotifyWatcher, error)
 
 // DeploymentInfo holds deployment info from charm metadata.
 type DeploymentInfo struct {
-	DeploymentType string
-	ServiceType    string
+	DeploymentType       string
+	ServiceType          string
+	CharmModifiedVersion int `json:"charm-modified-version"`
 }
 
 // ProvisioningInfo holds unit provisioning info.
@@ -207,8 +208,9 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 	}
 	if result.DeploymentInfo != nil {
 		info.DeploymentInfo = DeploymentInfo{
-			DeploymentType: result.DeploymentInfo.DeploymentType,
-			ServiceType:    result.DeploymentInfo.ServiceType,
+			DeploymentType:       result.DeploymentInfo.DeploymentType,
+			ServiceType:          result.DeploymentInfo.ServiceType,
+			CharmModifiedVersion: result.DeploymentInfo.CharmModifiedVersion,
 		}
 	}
 

--- a/api/caasunitprovisioner/client.go
+++ b/api/caasunitprovisioner/client.go
@@ -162,21 +162,21 @@ func (c *Client) WatchPodSpec(application string) (watcher.NotifyWatcher, error)
 
 // DeploymentInfo holds deployment info from charm metadata.
 type DeploymentInfo struct {
-	DeploymentType       string
-	ServiceType          string
-	CharmModifiedVersion int `json:"charm-modified-version"`
+	DeploymentType string
+	ServiceType    string
 }
 
 // ProvisioningInfo holds unit provisioning info.
 type ProvisioningInfo struct {
-	DeploymentInfo    DeploymentInfo
-	PodSpec           string
-	RawK8sSpec        string
-	Constraints       constraints.Value
-	Filesystems       []storage.KubernetesFilesystemParams
-	Devices           []devices.KubernetesDeviceParams
-	Tags              map[string]string
-	OperatorImagePath string
+	DeploymentInfo       DeploymentInfo
+	PodSpec              string
+	RawK8sSpec           string
+	Constraints          constraints.Value
+	Filesystems          []storage.KubernetesFilesystemParams
+	Devices              []devices.KubernetesDeviceParams
+	Tags                 map[string]string
+	OperatorImagePath    string
+	CharmModifiedVersion int
 }
 
 // ProvisioningInfo returns the provisioning info for the specified CAAS
@@ -200,17 +200,17 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 	}
 	result := results.Results[0].Result
 	info := &ProvisioningInfo{
-		PodSpec:           result.PodSpec,
-		RawK8sSpec:        result.RawK8sSpec,
-		Constraints:       result.Constraints,
-		Tags:              result.Tags,
-		OperatorImagePath: result.OperatorImagePath,
+		PodSpec:              result.PodSpec,
+		RawK8sSpec:           result.RawK8sSpec,
+		Constraints:          result.Constraints,
+		Tags:                 result.Tags,
+		OperatorImagePath:    result.OperatorImagePath,
+		CharmModifiedVersion: result.CharmModifiedVersion,
 	}
 	if result.DeploymentInfo != nil {
 		info.DeploymentInfo = DeploymentInfo{
-			DeploymentType:       result.DeploymentInfo.DeploymentType,
-			ServiceType:          result.DeploymentInfo.ServiceType,
-			CharmModifiedVersion: result.DeploymentInfo.CharmModifiedVersion,
+			DeploymentType: result.DeploymentInfo.DeploymentType,
+			ServiceType:    result.DeploymentInfo.ServiceType,
 		}
 	}
 

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -189,6 +189,11 @@ func (a *mockApplication) ClearResources() error {
 	return nil
 }
 
+func (a *mockApplication) CharmModifiedVersion() int {
+	a.MethodCall(a, "CharmModifiedVersion")
+	return 888
+}
+
 func (a *mockApplication) StorageConstraints() (map[string]state.StorageConstraints, error) {
 	return map[string]state.StorageConstraints{
 		"data": {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -360,20 +360,20 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 	}
 
 	info := &params.KubernetesProvisioningInfo{
-		PodSpec:           podSpec,
-		RawK8sSpec:        rawSpec,
-		Filesystems:       filesystemParams,
-		Devices:           devices,
-		Constraints:       mergedCons,
-		Tags:              resourceTags,
-		OperatorImagePath: operatorImagePath,
+		PodSpec:              podSpec,
+		RawK8sSpec:           rawSpec,
+		Filesystems:          filesystemParams,
+		Devices:              devices,
+		Constraints:          mergedCons,
+		Tags:                 resourceTags,
+		OperatorImagePath:    operatorImagePath,
+		CharmModifiedVersion: app.CharmModifiedVersion(),
 	}
 	deployInfo := ch.Meta().Deployment
 	if deployInfo != nil {
 		info.DeploymentInfo = &params.KubernetesDeploymentInfo{
-			DeploymentType:       string(deployInfo.DeploymentType),
-			ServiceType:          string(deployInfo.ServiceType),
-			CharmModifiedVersion: app.CharmModifiedVersion(),
+			DeploymentType: string(deployInfo.DeploymentType),
+			ServiceType:    string(deployInfo.ServiceType),
 		}
 	}
 	return info, nil

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -371,8 +371,9 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 	deployInfo := ch.Meta().Deployment
 	if deployInfo != nil {
 		info.DeploymentInfo = &params.KubernetesDeploymentInfo{
-			DeploymentType: string(deployInfo.DeploymentType),
-			ServiceType:    string(deployInfo.ServiceType),
+			DeploymentType:       string(deployInfo.DeploymentType),
+			ServiceType:          string(deployInfo.ServiceType),
+			CharmModifiedVersion: app.CharmModifiedVersion(),
 		}
 	}
 	return info, nil

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -267,6 +267,7 @@ func (s *CAASProvisionerSuite) assertProvisioningInfo(c *gc.C, isRawK8sSpec bool
 	c.Assert(obtained.RawK8sSpec, jc.DeepEquals, expectedResult.RawK8sSpec)
 	c.Assert(obtained.DeploymentInfo, jc.DeepEquals, expectedResult.DeploymentInfo)
 	c.Assert(obtained.OperatorImagePath, gc.Equals, expectedResult.OperatorImagePath)
+	c.Assert(obtained.CharmModifiedVersion, jc.DeepEquals, 888)
 	c.Assert(len(obtained.Filesystems), gc.Equals, len(expectedFileSystems))
 	for _, fs := range obtained.Filesystems {
 		c.Assert(fs, gc.DeepEquals, expectedFileSystems[fs.StorageName])

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -91,6 +91,7 @@ type Application interface {
 	SetStatus(statusInfo status.StatusInfo) error
 	Charm() (Charm, bool, error)
 	ClearResources() error
+	CharmModifiedVersion() int
 }
 
 type stateShim struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -8851,9 +8851,6 @@
                 "KubernetesDeploymentInfo": {
                     "type": "object",
                     "properties": {
-                        "charm-modified-version": {
-                            "type": "integer"
-                        },
                         "deployment-type": {
                             "type": "string"
                         },
@@ -8864,8 +8861,7 @@
                     "additionalProperties": false,
                     "required": [
                         "deployment-type",
-                        "service-type",
-                        "charm-modified-version"
+                        "service-type"
                     ]
                 },
                 "KubernetesDeviceParams": {
@@ -9005,6 +9001,9 @@
                 "KubernetesProvisioningInfo": {
                     "type": "object",
                     "properties": {
+                        "charm-modified-version": {
+                            "type": "integer"
+                        },
                         "constraints": {
                             "$ref": "#/definitions/Value"
                         },
@@ -9050,7 +9049,8 @@
                     "additionalProperties": false,
                     "required": [
                         "pod-spec",
-                        "constraints"
+                        "constraints",
+                        "charm-modified-version"
                     ]
                 },
                 "KubernetesProvisioningInfoResult": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -8851,6 +8851,9 @@
                 "KubernetesDeploymentInfo": {
                     "type": "object",
                     "properties": {
+                        "charm-modified-version": {
+                            "type": "integer"
+                        },
                         "deployment-type": {
                             "type": "string"
                         },
@@ -8861,7 +8864,8 @@
                     "additionalProperties": false,
                     "required": [
                         "deployment-type",
-                        "service-type"
+                        "service-type",
+                        "charm-modified-version"
                     ]
                 },
                 "KubernetesDeviceParams": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9049,8 +9049,7 @@
                     "additionalProperties": false,
                     "required": [
                         "pod-spec",
-                        "constraints",
-                        "charm-modified-version"
+                        "constraints"
                     ]
                 },
                 "KubernetesProvisioningInfoResult": {

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -11,22 +11,22 @@ import (
 
 // KubernetesDeploymentInfo holds deployment info from charm metadata.
 type KubernetesDeploymentInfo struct {
-	DeploymentType       string `json:"deployment-type"`
-	ServiceType          string `json:"service-type"`
-	CharmModifiedVersion int    `json:"charm-modified-version"`
+	DeploymentType string `json:"deployment-type"`
+	ServiceType    string `json:"service-type"`
 }
 
 // KubernetesProvisioningInfo holds unit provisioning info.
 type KubernetesProvisioningInfo struct {
-	DeploymentInfo    *KubernetesDeploymentInfo    `json:"deployment-info,omitempty"`
-	PodSpec           string                       `json:"pod-spec"`
-	RawK8sSpec        string                       `json:"raw-k8s-spec,omitempty"`
-	Constraints       constraints.Value            `json:"constraints"`
-	Tags              map[string]string            `json:"tags,omitempty"`
-	Filesystems       []KubernetesFilesystemParams `json:"filesystems,omitempty"`
-	Volumes           []KubernetesVolumeParams     `json:"volumes,omitempty"`
-	Devices           []KubernetesDeviceParams     `json:"devices,omitempty"`
-	OperatorImagePath string                       `json:"operator-image-path,omitempty"`
+	DeploymentInfo       *KubernetesDeploymentInfo    `json:"deployment-info,omitempty"`
+	PodSpec              string                       `json:"pod-spec"`
+	RawK8sSpec           string                       `json:"raw-k8s-spec,omitempty"`
+	Constraints          constraints.Value            `json:"constraints"`
+	Tags                 map[string]string            `json:"tags,omitempty"`
+	Filesystems          []KubernetesFilesystemParams `json:"filesystems,omitempty"`
+	Volumes              []KubernetesVolumeParams     `json:"volumes,omitempty"`
+	Devices              []KubernetesDeviceParams     `json:"devices,omitempty"`
+	OperatorImagePath    string                       `json:"operator-image-path,omitempty"`
+	CharmModifiedVersion int                          `json:"charm-modified-version"`
 }
 
 // KubernetesProvisioningInfoResult holds unit provisioning info or an error.

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -26,7 +26,7 @@ type KubernetesProvisioningInfo struct {
 	Volumes              []KubernetesVolumeParams     `json:"volumes,omitempty"`
 	Devices              []KubernetesDeviceParams     `json:"devices,omitempty"`
 	OperatorImagePath    string                       `json:"operator-image-path,omitempty"`
-	CharmModifiedVersion int                          `json:"charm-modified-version"`
+	CharmModifiedVersion int                          `json:"charm-modified-version,omitempty"`
 }
 
 // KubernetesProvisioningInfoResult holds unit provisioning info or an error.

--- a/apiserver/params/kubernetes.go
+++ b/apiserver/params/kubernetes.go
@@ -11,8 +11,9 @@ import (
 
 // KubernetesDeploymentInfo holds deployment info from charm metadata.
 type KubernetesDeploymentInfo struct {
-	DeploymentType string `json:"deployment-type"`
-	ServiceType    string `json:"service-type"`
+	DeploymentType       string `json:"deployment-type"`
+	ServiceType          string `json:"service-type"`
+	CharmModifiedVersion int    `json:"charm-modified-version"`
 }
 
 // KubernetesProvisioningInfo holds unit provisioning info.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -118,9 +118,8 @@ const (
 
 // DeploymentParams defines parameters for specifying how a service is deployed.
 type DeploymentParams struct {
-	DeploymentType       DeploymentType
-	ServiceType          ServiceType
-	CharmModifiedVersion int
+	DeploymentType DeploymentType
+	ServiceType    ServiceType
 }
 
 // ServiceParams defines parameters used to create a service.
@@ -149,6 +148,9 @@ type ServiceParams struct {
 
 	// OperatorImagePath is the path to the OCI image shared by the operator and pod init.
 	OperatorImagePath string
+
+	// CharmModifiedVersion increases when the charm changes in some way.
+	CharmModifiedVersion int
 }
 
 // OperatorState is returned by the OperatorExists call.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -118,8 +118,9 @@ const (
 
 // DeploymentParams defines parameters for specifying how a service is deployed.
 type DeploymentParams struct {
-	DeploymentType DeploymentType
-	ServiceType    ServiceType
+	DeploymentType       DeploymentType
+	ServiceType          ServiceType
+	CharmModifiedVersion int
 }
 
 // ServiceParams defines parameters used to create a service.

--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -45,8 +45,9 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -62,6 +63,7 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -338,8 +340,9 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -355,6 +358,7 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -45,8 +45,9 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -62,6 +63,7 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -367,8 +369,9 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -384,6 +387,7 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -39,8 +39,9 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -56,6 +57,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1012,13 +1012,7 @@ func (k *kubernetesClient) ensureService(
 		return errors.Annotatef(err, "parsing unit spec for %s", appName)
 	}
 
-	annotations := resourceTagsToAnnotations(params.ResourceTags).
-		// To solve https://bugs.launchpad.net/juju/+bug/1875481/comments/23 (`jujud caas-unit-init --upgrade`
-		// does NOT work on containers are not using root as default USER),
-		// CharmModifiedVersion is added for triggering rolling upgrade on workload pods to synchronise
-		// charm files to workload pods via init container when charm was upgraded.
-		// This approach was inspired from `kubectl rollout restart`.
-		Add(annotationCharmModifiedVersionKey, strconv.Itoa(params.Deployment.CharmModifiedVersion))
+	annotations := resourceTagsToAnnotations(params.ResourceTags)
 
 	// ensure configmap.
 	if len(workloadSpec.ConfigMaps) > 0 {
@@ -1179,24 +1173,32 @@ func (k *kubernetesClient) ensureService(
 	}
 
 	numPods := int32(numUnits)
+	workloadResourceAnnotations := annotations.Copy().
+		// To solve https://bugs.launchpad.net/juju/+bug/1875481/comments/23 (`jujud caas-unit-init --upgrade`
+		// does NOT work on containers are not using root as default USER),
+		// CharmModifiedVersion is added for triggering rolling upgrade on workload pods to synchronise
+		// charm files to workload pods via init container when charm was upgraded.
+		// This approach was inspired from `kubectl rollout restart`.
+		Add(annotationCharmModifiedVersionKey, strconv.Itoa(params.CharmModifiedVersion))
+
 	switch params.Deployment.DeploymentType {
 	case caas.DeploymentStateful:
 		if err := k.configureHeadlessService(appName, deploymentName, annotations.Copy()); err != nil {
 			return errors.Annotate(err, "creating or updating headless service")
 		}
 		cleanups = append(cleanups, func() { _ = k.deleteService(headlessServiceName(deploymentName)) })
-		if err := k.configureStatefulSet(appName, deploymentName, annotations.Copy(), workloadSpec, params.PodSpec.Containers, &numPods, params.Filesystems); err != nil {
+		if err := k.configureStatefulSet(appName, deploymentName, workloadResourceAnnotations.Copy(), workloadSpec, params.PodSpec.Containers, &numPods, params.Filesystems); err != nil {
 			return errors.Annotate(err, "creating or updating StatefulSet")
 		}
 		cleanups = append(cleanups, func() { _ = k.deleteDeployment(appName) })
 	case caas.DeploymentStateless:
-		cleanUpDeployment, err := k.configureDeployment(appName, deploymentName, annotations.Copy(), workloadSpec, params.PodSpec.Containers, &numPods, params.Filesystems)
+		cleanUpDeployment, err := k.configureDeployment(appName, deploymentName, workloadResourceAnnotations.Copy(), workloadSpec, params.PodSpec.Containers, &numPods, params.Filesystems)
 		cleanups = append(cleanups, cleanUpDeployment...)
 		if err != nil {
 			return errors.Annotate(err, "creating or updating Deployment")
 		}
 	case caas.DeploymentDaemon:
-		cleanUpDaemonSet, err := k.configureDaemonSet(appName, deploymentName, annotations.Copy(), workloadSpec, params.PodSpec.Containers, params.Filesystems)
+		cleanUpDaemonSet, err := k.configureDaemonSet(appName, deploymentName, workloadResourceAnnotations.Copy(), workloadSpec, params.PodSpec.Containers, params.Filesystems)
 		cleanups = append(cleanups, cleanUpDaemonSet...)
 		if err != nil {
 			return errors.Annotate(err, "creating or updating DaemonSet")

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1710,8 +1710,9 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -1727,6 +1728,7 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -1979,9 +1981,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"fred":                           "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -1998,8 +2001,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2151,9 +2155,10 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"fred":                           "mary",
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2170,8 +2175,9 @@ password: shhhh`[1:],
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2439,8 +2445,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 			Name:   appName,
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -2455,6 +2462,7 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -2527,8 +2535,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 			Name:   appName,
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"fred":                           "mary",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2544,8 +2553,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2602,9 +2612,13 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 
 	workload := &appsv1.DaemonSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "app-name",
-			Labels:      map[string]string{"juju-app": "app-name"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()}},
+			Name:   "app-name",
+			Labels: map[string]string{"juju-app": "app-name"},
+			Annotations: map[string]string{
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
+			},
+		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"juju-app": "app-name"},
@@ -2617,6 +2631,7 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -2700,9 +2715,10 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"fred":                           "mary",
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2719,8 +2735,9 @@ password: shhhh`[1:],
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2883,8 +2900,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -2900,6 +2918,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -2965,8 +2984,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":      "appuuid",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -2982,6 +3002,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3095,9 +3116,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"fred":                           "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3114,8 +3136,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -3255,9 +3278,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"fred":                           "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3274,8 +3298,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -3453,9 +3478,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"fred":                           "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3472,8 +3498,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -3629,9 +3656,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"fred":                           "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3648,8 +3676,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -3839,9 +3868,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"fred":                           "mary",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3858,8 +3888,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"fred":               "mary",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"fred":                           "mary",
+						"juju.io/controller":             testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -4098,9 +4129,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"fred":                           "mary",
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -4120,6 +4152,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
 						"fred":                                     "mary",
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -4376,9 +4409,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"fred":                           "mary",
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -4398,6 +4432,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
 						"fred":                                     "mary",
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: provider.PodSpec(workloadSpec),
@@ -4748,8 +4783,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -4765,6 +4801,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -4873,8 +4910,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -4890,6 +4928,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5018,8 +5057,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5035,6 +5075,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5185,8 +5226,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5201,6 +5243,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5349,8 +5392,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5365,6 +5409,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5490,8 +5535,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5506,6 +5552,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5605,8 +5652,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 			Name:   "app-name",
 			Labels: map[string]string{"juju-app": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
-				"juju-app-uuid":      "appuuid",
+				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju-app-uuid":                  "appuuid",
+				"juju.io/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5621,6 +5669,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.io/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -107,7 +107,9 @@ func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPod
 	if err != nil {
 		return errors.Trace(err)
 	}
+	existing.SetAnnotations(spec.GetAnnotations())
 	existing.Spec.Replicas = spec.Spec.Replicas
+	existing.Spec.Template.SetAnnotations(spec.Spec.Template.GetAnnotations())
 	// TODO(caas) - allow storage `request` configurable - currently we only allow `limit`.
 	existing.Spec.Template.Spec.Containers = existingPodSpec.Containers
 	existing.Spec.Template.Spec.ServiceAccountName = existingPodSpec.ServiceAccountName

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -801,7 +801,7 @@ func (ps *backingPodSpec) asPodSpec() *multiwatcher.PodSpec {
 		Spec:    ps.Spec,
 		Counter: ps.UpgradeCounter,
 	}
-	if podSpec.Spec == "" {
+	if len(podSpec.Spec) == 0 && len(ps.RawSpec) > 0 {
 		podSpec.Spec = ps.RawSpec
 		podSpec.Raw = true
 	}

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -677,6 +677,11 @@ func (op *caasOperator) remoteInit(client exec.Executor, unit names.UnitTag, run
 	default:
 		return errors.NotFoundf("container not running")
 	}
+	if params.InitType == UnitUpgrade {
+		op.config.Logger.Debugf("init process has been disabled for upgrade-charm for CAAS.")
+		// TODO(caas): remove remote-init for upgrade-charm process.
+		return nil
+	}
 	return errors.Trace(initializeUnit(params, cancel))
 }
 

--- a/worker/caasoperator/initializer_test.go
+++ b/worker/caasoperator/initializer_test.go
@@ -46,9 +46,8 @@ func (s *UnitInitializerSuite) TestInitialize(c *gc.C) {
 		ReTrier: func(f func() error, _ func(error) bool, _ caasoperator.Logger, _ jujuclock.Clock, _ <-chan struct{}) error {
 			return f()
 		},
-		InitType: caasoperator.UnitInit,
-		UnitTag:  names.NewUnitTag("gitlab/0"),
-		Logger:   loggo.GetLogger("test"),
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
 		Paths: caasoperator.Paths{
 			State: caasoperator.StatePaths{
 				CharmDir: "dir/charm",
@@ -139,9 +138,8 @@ func (s *UnitInitializerSuite) TestInitializeUnitMissingProviderID(c *gc.C) {
 		ReTrier: func(f func() error, _ func(error) bool, _ caasoperator.Logger, _ jujuclock.Clock, _ <-chan struct{}) error {
 			return f()
 		},
-		InitType: caasoperator.UnitInit,
-		UnitTag:  names.NewUnitTag("gitlab/0"),
-		Logger:   loggo.GetLogger("test"),
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
 		Paths: caasoperator.Paths{
 			State: caasoperator.StatePaths{
 				CharmDir: "dir/charm",
@@ -177,9 +175,8 @@ func (s *UnitInitializerSuite) TestInitializeContainerMissing(c *gc.C) {
 		ReTrier: func(f func() error, _ func(error) bool, _ caasoperator.Logger, _ jujuclock.Clock, _ <-chan struct{}) error {
 			return f()
 		},
-		InitType: caasoperator.UnitInit,
-		UnitTag:  names.NewUnitTag("gitlab/0"),
-		Logger:   loggo.GetLogger("test"),
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
 		Paths: caasoperator.Paths{
 			State: caasoperator.StatePaths{
 				CharmDir: "dir/charm",
@@ -233,9 +230,8 @@ func (s *UnitInitializerSuite) TestInitializePodNotFound(c *gc.C) {
 		ReTrier: func(f func() error, _ func(error) bool, _ caasoperator.Logger, _ jujuclock.Clock, _ <-chan struct{}) error {
 			return f()
 		},
-		InitType: caasoperator.UnitInit,
-		UnitTag:  names.NewUnitTag("gitlab/0"),
-		Logger:   loggo.GetLogger("test"),
+		UnitTag: names.NewUnitTag("gitlab/0"),
+		Logger:  loggo.GetLogger("test"),
 		Paths: caasoperator.Paths{
 			State: caasoperator.StatePaths{
 				CharmDir: "dir/charm",

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -221,15 +221,15 @@ func provisionInfoToServiceParams(info *apicaasunitprovisioner.ProvisioningInfo)
 	}
 
 	serviceParams = &caas.ServiceParams{
-		Constraints:       info.Constraints,
-		ResourceTags:      info.Tags,
-		Filesystems:       info.Filesystems,
-		Devices:           info.Devices,
-		OperatorImagePath: info.OperatorImagePath,
+		Constraints:          info.Constraints,
+		ResourceTags:         info.Tags,
+		Filesystems:          info.Filesystems,
+		Devices:              info.Devices,
+		OperatorImagePath:    info.OperatorImagePath,
+		CharmModifiedVersion: info.CharmModifiedVersion,
 		Deployment: caas.DeploymentParams{
-			DeploymentType:       caas.DeploymentType(info.DeploymentInfo.DeploymentType),
-			ServiceType:          caas.ServiceType(info.DeploymentInfo.ServiceType),
-			CharmModifiedVersion: info.DeploymentInfo.CharmModifiedVersion,
+			DeploymentType: caas.DeploymentType(info.DeploymentInfo.DeploymentType),
+			ServiceType:    caas.ServiceType(info.DeploymentInfo.ServiceType),
 		},
 	}
 	if len(info.PodSpec) > 0 {
@@ -254,7 +254,7 @@ func isProvisionInfoEqual(newInfo, oldInfo *apicaasunitprovisioner.ProvisioningI
 
 	return newInfo.PodSpec == oldInfo.PodSpec &&
 		newInfo.RawK8sSpec == oldInfo.RawK8sSpec &&
-		newInfo.DeploymentInfo.CharmModifiedVersion == oldInfo.DeploymentInfo.CharmModifiedVersion
+		newInfo.CharmModifiedVersion == oldInfo.CharmModifiedVersion
 }
 
 func updateApplicationService(appTag names.ApplicationTag, svc *caas.Service, updater ApplicationUpdater) error {

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -227,8 +227,9 @@ func provisionInfoToServiceParams(info *apicaasunitprovisioner.ProvisioningInfo)
 		Devices:           info.Devices,
 		OperatorImagePath: info.OperatorImagePath,
 		Deployment: caas.DeploymentParams{
-			DeploymentType: caas.DeploymentType(info.DeploymentInfo.DeploymentType),
-			ServiceType:    caas.ServiceType(info.DeploymentInfo.ServiceType),
+			DeploymentType:       caas.DeploymentType(info.DeploymentInfo.DeploymentType),
+			ServiceType:          caas.ServiceType(info.DeploymentInfo.ServiceType),
+			CharmModifiedVersion: info.DeploymentInfo.CharmModifiedVersion,
 		},
 	}
 	if len(info.PodSpec) > 0 {
@@ -245,16 +246,15 @@ func provisionInfoToServiceParams(info *apicaasunitprovisioner.ProvisioningInfo)
 
 // isProvisionInfoChanged checks if podspec or raw k8s spec changed or not.
 func isProvisionInfoEqual(newInfo, oldInfo *apicaasunitprovisioner.ProvisioningInfo) bool {
-	var newK8sSpec, newRawK8sSpec, oldK8sSpec, oldRawK8sSpec string
-	if newInfo != nil {
-		newK8sSpec = newInfo.PodSpec
-		newRawK8sSpec = newInfo.RawK8sSpec
+	if newInfo == nil && oldInfo == nil {
+		return true
+	} else if newInfo == nil || oldInfo == nil {
+		return false
 	}
-	if oldInfo != nil {
-		oldK8sSpec = oldInfo.PodSpec
-		oldRawK8sSpec = oldInfo.RawK8sSpec
-	}
-	return newK8sSpec == oldK8sSpec && newRawK8sSpec == oldRawK8sSpec
+
+	return newInfo.PodSpec == oldInfo.PodSpec &&
+		newInfo.RawK8sSpec == oldInfo.RawK8sSpec &&
+		newInfo.DeploymentInfo.CharmModifiedVersion == oldInfo.DeploymentInfo.CharmModifiedVersion
 }
 
 func updateApplicationService(appTag names.ApplicationTag, svc *caas.Service, updater ApplicationUpdater) error {


### PR DESCRIPTION
### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

`Upgrade-charm` now is changed to always trigger pods to restart to finish the `remote-init` process because the previous way of `remote-init` for `upgrade-charm` was `not` possible to succeed in a container running using non-root USER.

Currently, we got below error when charm was upgraded;
```
application-mariadb-k8s: 14:05:27 ERROR juju.worker.caasoperator exited "mariadb-k8s/0": executing operation "remote init": caas-unit-init for unit "mariadb-k8s/0" with command: "/var/lib/juju/tools/jujud caas-unit-init --unit unit-mariadb-k8s-0 --charm-dir /tmp/unit-mariadb-k8s-0386991581/charm --upgrade" failed: : command terminated with exit code 1
application-mariadb-k8s: 14:05:30 ERROR juju.worker.uniter resolver loop error: executing operation "remote init": caas-unit-init for unit "mariadb-k8s/0" with command: "/var/lib/juju/tools/jujud caas-unit-init --unit unit-mariadb-k8s-0 --charm-dir /tmp/unit-mariadb-k8s-0972517399/charm --upgrade" failed: ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
: command terminated with exit code 1
application-mariadb-k8s: 14:05:30 ERROR juju.worker.caasoperator exited "mariadb-k8s/0": executing operation "remote init": caas-unit-init for unit "mariadb-k8s/0" with command: "/var/lib/juju/tools/jujud caas-unit-init --unit unit-mariadb-k8s-0 --charm-dir /tmp/unit-mariadb-k8s-0972517399/charm --upgrade" failed: ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
: command terminated with exit code 1
application-mariadb-k8s: 14:05:34 ERROR juju.worker.uniter resolver loop error: executing operation "remote init": caas-unit-init for unit "mariadb-k8s/0" with command: "/var/lib/juju/tools/jujud caas-unit-init --unit unit-mariadb-k8s-0 --charm-dir /tmp/unit-mariadb-k8s-0337241697/charm --upgrade" failed: ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
: command terminated with exit code 1
application-mariadb-k8s: 14:05:34 ERROR juju.worker.caasoperator exited "mariadb-k8s/0": executing operation "remote init": caas-unit-init for unit "mariadb-k8s/0" with command: "/var/lib/juju/tools/jujud caas-unit-init --unit unit-mariadb-k8s-0 --charm-dir /tmp/unit-mariadb-k8s-0337241697/charm --upgrade" failed: ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
ERROR failed to remove unit tools dir /var/lib/juju/tools/unit-mariadb-k8s-0: unlinkat /var/lib/juju/tools/unit-mariadb-k8s-0/close-port: permission denied
```

## QA steps

```console
# This docker image sets USER to `mysql`;
$ juju run --unit mariadb-k8s/0  'whoami'
mysql

$ juju status --format json | jq '.applications["mariadb-k8s"]["charm-rev"]'
6

$ mkubectl -nt1 get pod/mariadb-k8s-0 -o json | jq '.metadata.annotations["juju.io/charm-modified-version"]'
null

$ mkubectl -nt1 get pod/mariadb-k8s-0 -o json | jq '.status.startTime'
"2020-07-20T05:22:00Z"

# run upgrade-charm
$ juju upgrade-charm mariadb-k8s --path /tmp/charm-builds/mariadb-k8s/ --debug --resource mysql_image=xxx/mariadb

$ juju status --format json | jq '.applications["mariadb-k8s"]["charm-rev"]'
7

$ mkubectl -nt1 get pod/mariadb-k8s-0 -o json | jq '.metadata.annotations["juju.io/charm-modified-version"]'
"7"

$ mkubectl -nt1 get pod/mariadb-k8s-0 -o json | jq '.status.startTime'
"2020-07-20T05:39:30Z"

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1875481
