### PR TITLE
Ensure unavailable instance types are filtered out

### DIFF
--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -144,11 +144,12 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclient.MemStore) {
 
 	azureUUID := utils.MustNewUUID().String()
 	azureConfig, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":            "azure",
-		"type":            "azure",
-		"controller-uuid": coretesting.ControllerTag.Id(),
-		"uuid":            azureUUID,
-		"default-series":  "raring",
+		"name":                "azure",
+		"type":                "azure",
+		"controller-uuid":     coretesting.ControllerTag.Id(),
+		"uuid":                azureUUID,
+		"default-series":      "raring",
+		"resource-group-name": "rg",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	store.Controllers["azure-controller"] = jujuclient.ControllerDetails{

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -62,10 +62,10 @@ func (s *configSuite) TestValidateInvalidFirewallMode(c *gc.C) {
 
 func (s *configSuite) TestValidateModelNameLength(c *gc.C) {
 	s.assertConfigInvalid(
-		c, testing.Attrs{"name": "someextremelyoverlylongishmodelname"},
-		`resource group name "juju-someextremelyoverlylongishmodelname-model-deadbeef-0bad-400d-8000-4b1d0d06f00d" is too long
+		c, testing.Attrs{"name": "someextremelyoverlylongishmodelname-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		`resource group name "juju-someextremelyoverlylongishmodelname-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-deadbeef" is too long
 
-Please choose a model name of no more than 32 characters.`)
+Please choose a model name of no more than 66 characters.`)
 }
 
 func (s *configSuite) TestValidateResourceGroupNameLength(c *gc.C) {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -206,6 +206,23 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 			Name:  to.StringPtr("OSVhdSizeMB"),
 			Value: to.StringPtr("1047552"),
 		}},
+	}, {
+		Name:         to.StringPtr("Standard_D666"),
+		Locations:    to.StringSlicePtr([]string{"westus"}),
+		ResourceType: to.StringPtr("virtualMachines"),
+		Restrictions: &[]compute.ResourceSkuRestrictions{{
+			ReasonCode: compute.NotAvailableForSubscription,
+		}},
+		Capabilities: &[]compute.ResourceSkuCapabilities{{
+			Name:  to.StringPtr("MemoryGB"),
+			Value: to.StringPtr("7"),
+		}, {
+			Name:  to.StringPtr("vCPUs"),
+			Value: to.StringPtr("2"),
+		}, {
+			Name:  to.StringPtr("OSVhdSizeMB"),
+			Value: to.StringPtr("1047552"),
+		}},
 	}}
 	s.skus = &compute.ResourceSkusResult{Value: &resourceSkus}
 
@@ -278,7 +295,9 @@ func (s *environSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *environSuite) openEnviron(c *gc.C, attrs ...testing.Attrs) environs.Environ {
-	return openEnviron(c, s.provider, &s.sender, attrs...)
+	env := openEnviron(c, s.provider, &s.sender, attrs...)
+	s.requests = nil
+	return env
 }
 
 func openEnviron(
@@ -290,6 +309,10 @@ func openEnviron(
 	// Opening the environment should not incur network communication,
 	// so we don't set s.sender until after opening.
 	cfg := makeTestModelConfig(c, attrs...)
+	*sender = azuretesting.Senders{
+		makeResourceGroupNotFoundSender(fmt.Sprintf(".*/resourcegroups/juju-%s-model-deadbeef-.*", cfg.Name())),
+		makeSender(fmt.Sprintf(".*/resourcegroups/juju-%s-.*", cfg.Name()), makeResourceGroupResult()),
+	}
 	env, err := environs.Open(provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: cfg,
@@ -323,6 +346,10 @@ func prepareForBootstrap(
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	*sender = azuretesting.Senders{
+		makeResourceGroupNotFoundSender(".*/resourcegroups/juju-testmodel-model-deadbeef-.*"),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+	}
 	env, err := environs.Open(provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: cfg,
@@ -378,19 +405,19 @@ func discoverAuthSender() *azuretesting.MockSender {
 }
 
 func (s *environSuite) initResourceGroupSenders(resourceGroupName string) azuretesting.Senders {
-	senders := azuretesting.Senders{s.makeSender(".*/resourcegroups/"+resourceGroupName, s.group)}
+	senders := azuretesting.Senders{makeSender(".*/resourcegroups/"+resourceGroupName, s.group)}
 	return senders
 }
 
 func (s *environSuite) startInstanceSenders(bootstrap bool) azuretesting.Senders {
 	senders := azuretesting.Senders{s.resourceSkusSender()}
 	if s.ubuntuServerSKUs != nil {
-		senders = append(senders, s.makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
+		senders = append(senders, makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
 	}
 	if !bootstrap {
 		// When starting an instance, we must wait for the common
 		// deployment to complete.
-		senders = append(senders, s.makeSender("/deployments/common", s.commonDeployment))
+		senders = append(senders, makeSender("/deployments/common", s.commonDeployment))
 
 		// If the deployment has any providers, then we assume
 		// storage accounts are in use, for unmanaged storage.
@@ -402,36 +429,36 @@ func (s *environSuite) startInstanceSenders(bootstrap bool) azuretesting.Senders
 					},
 				},
 			}
-			senders = append(senders, s.makeSender("/storageAccounts/juju400d80004b1d0d06f00d", storageAccount))
+			senders = append(senders, makeSender("/storageAccounts/juju400d80004b1d0d06f00d", storageAccount))
 		}
 	}
-	senders = append(senders, s.makeSender("/deployments/machine-0", s.deployment))
+	senders = append(senders, makeSender("/deployments/machine-0", s.deployment))
 	return senders
 }
 
 func (s *environSuite) startInstanceSendersNoSizes() azuretesting.Senders {
 	senders := azuretesting.Senders{}
 	if s.ubuntuServerSKUs != nil {
-		senders = append(senders, s.makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
+		senders = append(senders, makeSender(".*/Canonical/.*/UbuntuServer/skus", s.ubuntuServerSKUs))
 	}
-	senders = append(senders, s.makeSender("/deployments/machine-0", s.deployment))
+	senders = append(senders, makeSender("/deployments/machine-0", s.deployment))
 	return senders
 }
 
 func (s *environSuite) networkInterfacesSender(nics ...network.Interface) *azuretesting.MockSender {
-	return s.makeSender(".*/networkInterfaces", network.InterfaceListResult{Value: &nics})
+	return makeSender(".*/networkInterfaces", network.InterfaceListResult{Value: &nics})
 }
 
 func (s *environSuite) publicIPAddressesSender(pips ...network.PublicIPAddress) *azuretesting.MockSender {
-	return s.makeSender(".*/publicIPAddresses", network.PublicIPAddressListResult{Value: &pips})
+	return makeSender(".*/publicIPAddresses", network.PublicIPAddressListResult{Value: &pips})
 }
 
 func (s *environSuite) resourceSkusSender() *azuretesting.MockSender {
-	return s.makeSender(".*/skus", s.skus)
+	return makeSender(".*/skus", s.skus)
 }
 
 func (s *environSuite) storageAccountSender() *azuretesting.MockSender {
-	return s.makeSender(".*/storageAccounts/"+storageAccountName, s.storageAccount)
+	return makeSender(".*/storageAccounts/"+storageAccountName, s.storageAccount)
 }
 
 func (s *environSuite) storageAccountErrorSender(c *gc.C, err error, repeat int) *azuretesting.MockSender {
@@ -439,14 +466,23 @@ func (s *environSuite) storageAccountErrorSender(c *gc.C, err error, repeat int)
 }
 
 func (s *environSuite) storageAccountKeysSender() *azuretesting.MockSender {
-	return s.makeSender(".*/storageAccounts/.*/listKeys", s.storageAccountKeys)
+	return makeSender(".*/storageAccounts/.*/listKeys", s.storageAccountKeys)
 }
 
 func (s *environSuite) storageAccountKeysErrorSender(c *gc.C, err error, repeat int) *azuretesting.MockSender {
 	return s.makeErrorSenderWithContent(c, ".*/storageAccounts/.*/listKeys", s.storageAccountKeys, err, repeat)
 }
 
-func (s *environSuite) makeSender(pattern string, v interface{}) *azuretesting.MockSender {
+func makeResourceGroupNotFoundSender(pattern string) *azuretesting.MockSender {
+	sender := azuretesting.MockSender{Sender: mocks.NewSender()}
+	sender.PathPattern = pattern
+	sender.AppendAndRepeatResponse(mocks.NewResponseWithStatus(
+		"resource group not found", http.StatusNotFound,
+	), 1)
+	return &sender
+}
+
+func makeSender(pattern string, v interface{}) *azuretesting.MockSender {
 	sender := azuretesting.NewSenderWithValue(v)
 	sender.PathPattern = pattern
 	return sender
@@ -832,7 +868,7 @@ func (s *environSuite) TestStartInstanceCommonDeploymentRetryTimeout(c *gc.C) {
 	const failures = 60 // 5 minutes / 5 seconds
 	head, tail := senders[:2], senders[2:]
 	for i := 0; i < failures; i++ {
-		head = append(head, s.makeSender("/deployments/common", s.commonDeployment))
+		head = append(head, makeSender("/deployments/common", s.commonDeployment))
 	}
 	senders = append(head, tail...)
 	s.sender = senders
@@ -1248,7 +1284,7 @@ type startInstanceRequests struct {
 	deployment     *http.Request
 }
 
-const resourceGroupName = "juju-testmodel-model-deadbeef-0bad-400d-8000-4b1d0d06f00d"
+const resourceGroupName = "juju-testmodel-deadbeef"
 
 func (s *environSuite) TestBootstrap(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
@@ -1478,7 +1514,7 @@ func (s *environSuite) TestAllRunningInstancesIgnoresCommonDeployment(c *gc.C) {
 	}}
 	result := resources.DeploymentListResult{Value: &deployments}
 	s.sender = azuretesting.Senders{
-		s.makeSender("/deployments", result),
+		makeSender("/deployments", result),
 	}
 
 	instances, err := env.AllRunningInstances(s.callCtx)
@@ -1527,15 +1563,15 @@ func (s *environSuite) TestStopInstancesResourceGroupNotFound(c *gc.C) {
 	nsgSender := s.makeErrorSenderWithContent(c, ".*/networkSecurityGroups/juju-internal-nsg", makeSecurityGroup(), nsgErr, 2)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		makeSender("/deployments/machine-0", s.deployment), // Cancel
 		s.storageAccountSender(),
 		s.storageAccountKeysSender(),
-		s.networkInterfacesSender(),                       // GET: no NICs
-		s.publicIPAddressesSender(),                       // GET: no public IPs
-		s.makeSender(".*/virtualMachines/machine-0", nil), // DELETE
-		s.makeSender(".*/disks/machine-0", nil),           // DELETE
-		nsgSender,                                         // GET with failure
-		s.makeSender(".*/deployments/machine-0", nil),     // DELETE
+		s.networkInterfacesSender(),                     // GET: no NICs
+		s.publicIPAddressesSender(),                     // GET: no public IPs
+		makeSender(".*/virtualMachines/machine-0", nil), // DELETE
+		makeSender(".*/disks/machine-0", nil),           // DELETE
+		nsgSender,                                       // GET with failure
+		makeSender(".*/deployments/machine-0", nil),     // DELETE
 	}
 	err := env.StopInstances(s.callCtx, "machine-0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1558,18 +1594,18 @@ func (s *environSuite) TestStopInstances(c *gc.C) {
 	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/deployments/machine-0/cancel", nil), // POST
+		makeSender(".*/deployments/machine-0/cancel", nil), // POST
 		s.storageAccountSender(),
 		s.storageAccountKeysSender(),
 		s.networkInterfacesSender(nic0),
 		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "machine-0", "1.2.3.4")),
-		s.makeSender(".*/virtualMachines/machine-0", nil),                                                 // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", nsg),                                   // GET
-		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-80", nil),        // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-1000-2000", nil), // DELETE
-		s.makeSender(".*/networkInterfaces/nic-0", nil),                                                   // DELETE
-		s.makeSender(".*/publicIPAddresses/pip-0", nil),                                                   // DELETE
-		s.makeSender(".*/deployments/machine-0", nil),                                                     // DELETE
+		makeSender(".*/virtualMachines/machine-0", nil),                                                 // DELETE
+		makeSender(".*/networkSecurityGroups/juju-internal-nsg", nsg),                                   // GET
+		makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-80", nil),        // DELETE
+		makeSender(".*/networkSecurityGroups/juju-internal-nsg/securityRules/machine-0-1000-2000", nil), // DELETE
+		makeSender(".*/networkInterfaces/nic-0", nil),                                                   // DELETE
+		makeSender(".*/publicIPAddresses/pip-0", nil),                                                   // DELETE
+		makeSender(".*/deployments/machine-0", nil),                                                     // DELETE
 	}
 
 	machine0Blob := azuretesting.MockStorageBlob{Name_: "machine-0"}
@@ -1593,8 +1629,8 @@ func (s *environSuite) TestStopInstancesMultiple(c *gc.C) {
 	vmDeleteSender1 := s.makeErrorSender(c, ".*/virtualMachines/machine-[01]", errors.New("blargh"), 2)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/deployments/machine-[01]/cancel", nil), // POST
-		s.makeSender(".*/deployments/machine-[01]/cancel", nil), // POST
+		makeSender(".*/deployments/machine-[01]/cancel", nil), // POST
+		makeSender(".*/deployments/machine-[01]/cancel", nil), // POST
 
 		// We should only query the NICs, public IPs, and storage
 		// account/keys, regardless of how many instances are deleted.
@@ -1636,15 +1672,15 @@ func (s *environSuite) TestStopInstancesStorageAccountNoFullKey(c *gc.C) {
 func (s *environSuite) testStopInstancesStorageAccountNotFound(c *gc.C) {
 	env := s.openEnviron(c)
 	s.sender = azuretesting.Senders{
-		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		makeSender("/deployments/machine-0", s.deployment), // Cancel
 		s.storageAccountSender(),
 		s.storageAccountKeysSender(),
-		s.networkInterfacesSender(),                                                     // GET: no NICs
-		s.publicIPAddressesSender(),                                                     // GET: no public IPs
-		s.makeSender(".*/virtualMachines/machine-0", nil),                               // DELETE
-		s.makeSender(".*/disks/machine-0", nil),                                         // DELETE
-		s.makeSender(".*/networkSecurityGroups/juju-internal-nsg", makeSecurityGroup()), // GET: no rules
-		s.makeSender(".*/deployments/machine-0", nil),                                   // DELETE
+		s.networkInterfacesSender(),                                                   // GET: no NICs
+		s.publicIPAddressesSender(),                                                   // GET: no public IPs
+		makeSender(".*/virtualMachines/machine-0", nil),                               // DELETE
+		makeSender(".*/disks/machine-0", nil),                                         // DELETE
+		makeSender(".*/networkSecurityGroups/juju-internal-nsg", makeSecurityGroup()), // GET: no rules
+		makeSender(".*/deployments/machine-0", nil),                                   // DELETE
 	}
 	err := env.StopInstances(s.callCtx, "machine-0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1655,7 +1691,7 @@ func (s *environSuite) TestStopInstancesStorageAccountError(c *gc.C) {
 	azure.SetRetries(env)
 	errorSender := s.storageAccountErrorSender(c, errors.New("blargh"), 2)
 	s.sender = azuretesting.Senders{
-		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		makeSender("/deployments/machine-0", s.deployment), // Cancel
 		errorSender,
 	}
 	err := env.StopInstances(s.callCtx, "machine-0")
@@ -1667,7 +1703,7 @@ func (s *environSuite) TestStopInstancesStorageAccountKeysError(c *gc.C) {
 	azure.SetRetries(env)
 	errorSender := s.storageAccountKeysErrorSender(c, errors.New("blargh"), 2)
 	s.sender = azuretesting.Senders{
-		s.makeSender("/deployments/machine-0", s.deployment), // Cancel
+		makeSender("/deployments/machine-0", s.deployment), // Cancel
 		s.storageAccountSender(),
 		errorSender,
 	}
@@ -1728,7 +1764,7 @@ func (s *environSuite) TestAgentMirror(c *gc.C) {
 func (s *environSuite) TestDestroyHostedModel(c *gc.C) {
 	env := s.openEnviron(c, testing.Attrs{"controller-uuid": utils.MustNewUUID().String()})
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-model-"+testing.ModelTag.Id(), nil), // DELETE
+		makeSender(".*/resourcegroups/juju-testmodel-"+testing.ModelTag.Id()[:8], nil), // DELETE
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1740,7 +1776,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 	env := s.openEnviron(c,
 		testing.Attrs{"controller-uuid": utils.MustNewUUID().String(), "resource-group-name": "foo"})
 	s.sender = azuretesting.Senders{
-		s.makeSender("/deployments/purge-resource-group", nil), // PUT
+		makeSender("/deployments/purge-resource-group", nil), // PUT
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1770,9 +1806,9 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 
 	env := s.openEnviron(c)
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups", result),        // GET
-		s.makeSender(".*/resourcegroups/group[12]", nil), // DELETE
-		s.makeSender(".*/resourcegroups/group[12]", nil), // DELETE
+		makeSender(".*/resourcegroups", result),        // GET
+		makeSender(".*/resourcegroups/group[12]", nil), // DELETE
+		makeSender(".*/resourcegroups/group[12]", nil), // DELETE
 	}
 	err := env.DestroyController(s.callCtx, s.controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1826,9 +1862,9 @@ func (s *environSuite) TestDestroyControllerErrors(c *gc.C) {
 	env := s.openEnviron(c)
 	s.requests = nil
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups", result), // GET
-		makeErrorSender("foo"),                    // DELETE
-		makeErrorSender("bar"),                    // DELETE
+		makeSender(".*/resourcegroups", result), // GET
+		makeErrorSender("foo"),                  // DELETE
+		makeErrorSender("bar"),                  // DELETE
 	}
 	destroyErr := env.DestroyController(s.callCtx, s.controllerUUID)
 	// checked below, once we know the order of deletions.
@@ -1891,20 +1927,20 @@ func (s *environSuite) TestAdoptResources(c *gc.C) {
 	env := s.openEnviron(c)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
 
-		s.makeSender(".*/providers", providersResult),
-		s.makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
+		makeSender(".*/providers", providersResult),
+		makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
 
 		// First request is the get, second is the update. (The
 		// lowercase resourcegroups here is a quirk of the
 		// autogenerated Go SDK.)
-		s.makeSender(".*/resourcegroups/.*/providers/Beck.Replica/liars/scissor/boxing-day-blues", res1),
-		s.makeSender(".*/resourcegroups/.*/providers/Beck.Replica/liars/scissor/boxing-day-blues", res1),
+		makeSender(".*/resourcegroups/.*/providers/Beck.Replica/liars/scissor/boxing-day-blues", res1),
+		makeSender(".*/resourcegroups/.*/providers/Beck.Replica/liars/scissor/boxing-day-blues", res1),
 
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
 	}
 
 	err := env.AdoptResources(s.callCtx, "new-controller", version.MustParse("1.2.4"))
@@ -1959,6 +1995,7 @@ func (s *environSuite) TestAdoptResources(c *gc.C) {
 	gTags := to.StringMap(group.Tags)
 	c.Check(gTags["something else"], gc.Equals, "good")
 	c.Check(gTags[tags.JujuController], gc.Equals, "new-controller")
+	c.Check(gTags[tags.JujuModel], gc.Equals, "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 }
 
 func makeProvidersResult() resources.ProviderListResult {
@@ -2016,6 +2053,7 @@ func makeResourceGroupResult() resources.Group {
 		},
 		Tags: map[string]*string{
 			tags.JujuController: to.StringPtr("old-controller"),
+			tags.JujuModel:      to.StringPtr("deadbeef-0bad-400d-8000-4b1d0d06f00d"),
 			"something else":    to.StringPtr("good"),
 		},
 	}
@@ -2043,7 +2081,7 @@ func (s *environSuite) TestAdoptResourcesErrorUpdatingGroup(c *gc.C) {
 		errors.New("uhoh"),
 		2)
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
 		errorSender,
 	}
 
@@ -2060,8 +2098,8 @@ func (s *environSuite) TestAdoptResourcesErrorGettingVersions(c *gc.C) {
 		errors.New("uhoh"),
 		2)
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
 		errorSender,
 	}
 
@@ -2078,9 +2116,9 @@ func (s *environSuite) TestAdoptResourcesErrorListingResources(c *gc.C) {
 		errors.New("ouch!"),
 		2)
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
-		s.makeSender(".*/providers", resources.ProviderListResult{}),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
+		makeSender(".*/providers", resources.ProviderListResult{}),
 		errorSender,
 	}
 
@@ -2111,14 +2149,14 @@ func (s *environSuite) TestAdoptResourcesNoUpdateNeeded(c *gc.C) {
 	env := s.openEnviron(c)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
-		s.makeSender(".*/providers", providersResult),
-		s.makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
+		makeSender(".*/providers", providersResult),
+		makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
 
 		// Doesn't bother updating res1, continues to do res2.
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
 	}
 
 	err := env.AdoptResources(s.callCtx, "new-controller", version.MustParse("1.2.4"))
@@ -2141,16 +2179,16 @@ func (s *environSuite) TestAdoptResourcesErrorGettingFullResource(c *gc.C) {
 		2)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
-		s.makeSender(".*/providers", providersResult),
-		s.makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
+		makeSender(".*/providers", providersResult),
+		makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
 
 		// The first resource yields an error but the update continues.
 		errorSender,
 
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
 	}
 
 	err := env.AdoptResources(s.callCtx, "new-controller", version.MustParse("1.2.4"))
@@ -2174,17 +2212,17 @@ func (s *environSuite) TestAdoptResourcesErrorUpdating(c *gc.C) {
 		2)
 
 	s.sender = azuretesting.Senders{
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
-		s.makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
-		s.makeSender(".*/providers", providersResult),
-		s.makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", nil),
+		makeSender(".*/providers", providersResult),
+		makeSender(".*/resourceGroups/juju-testmodel-.*/resources", resourcesResult),
 
 		// Updating the first resource yields an error but the update continues.
-		s.makeSender(".*/resourcegroups/.*/providers/Beck.Replica/liars/scissor/boxing-day-blues", res1),
+		makeSender(".*/resourcegroups/.*/providers/Beck.Replica/liars/scissor/boxing-day-blues", res1),
 		errorSender,
 
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
-		s.makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
+		makeSender(".*/resourcegroups/.*/providers/Tuneyards.Bizness/micachu/drop-dead", res2),
 	}
 
 	err := env.AdoptResources(s.callCtx, "new-controller", version.MustParse("1.2.4"))

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -73,6 +73,10 @@ func (s *environProviderSuite) TestPrepareConfig(c *gc.C) {
 }
 
 func (s *environProviderSuite) TestOpen(c *gc.C) {
+	s.sender = azuretesting.Senders{
+		makeResourceGroupNotFoundSender(".*/resourcegroups/juju-testmodel-model-deadbeef-.*"),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+	}
 	env, err := environs.Open(s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: makeTestModelConfig(c),
@@ -93,6 +97,10 @@ func (s *environProviderSuite) TestOpenUnsupportedCredential(c *gc.C) {
 }
 
 func (s *environProviderSuite) testOpenError(c *gc.C, spec environs.CloudSpec, expect string) {
+	s.sender = azuretesting.Senders{
+		makeResourceGroupNotFoundSender(".*/resourcegroups/juju-testmodel-model-deadbeef-.*"),
+		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
+	}
 	_, err := environs.Open(s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: makeTestModelConfig(c),

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -618,7 +618,7 @@ func (s *instanceSuite) TestControllerInstances(c *gc.C) {
 
 var internalSecurityGroupPath = path.Join(
 	"/subscriptions", fakeSubscriptionId,
-	"resourceGroups", "juju-testmodel-model-"+testing.ModelTag.Id(),
+	"resourceGroups", "juju-testmodel-"+testing.ModelTag.Id()[:8],
 	"providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg",
 )
 

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -883,7 +883,7 @@ func (s *storageSuite) testAttachVolumes(c *gc.C, legacy bool) {
 			return nil
 		}
 		return &compute.ManagedDiskParameters{
-			ID: to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testmodel-model-deadbeef-0bad-400d-8000-4b1d0d06f00d/providers/Microsoft.Compute/disks/" + volumeName),
+			ID: to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testmodel-deadbeef/providers/Microsoft.Compute/disks/" + volumeName),
 		}
 	}
 

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -47,6 +47,7 @@ func (s *environUpgradeSuite) SetUpTest(c *gc.C) {
 		RandomWindowsAdminPassword: func() string { return "sorandom" },
 	})
 	s.env = openEnviron(c, s.provider, &s.sender)
+	s.requests = nil
 	s.invalidCredential = false
 	s.callCtx = &context.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
@@ -188,8 +189,8 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeployment(
 
 func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeploymentControllerModel(c *gc.C) {
 	s.sender = nil
-	s.requests = nil
 	env := openEnviron(c, s.provider, &s.sender, testing.Attrs{"name": "controller"})
+	s.requests = nil
 	upgrader := env.(environs.Upgrader)
 
 	controllerTags := make(map[string]*string)


### PR DESCRIPTION
## Description of change

When Azure provider was selecting an instance type to use, the logic to filter out unavailable instance types was broken and it was including those which the user could not use. This caused bootstrap errors depending on region and credential used.

Also, the resource group name was to long - it included the model name and full model UUID when instead we only really need the first chunk of the UUID plus model name. This allows longer model names to be used without hitting the length limit on resource group names.

## QA steps

bootstrap 2.7.7 azure
upgrade to this PR
add a machine
check in the azure portal the resource group names of the models are the full UUID and the machine goes to the correct group
add a model and a machine
check that the short resource group name is now used

## Bug reference

https://bugs.launchpad.net/juju/+bug/1887887
