### PR TITLE
Fix the smoke tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -115,7 +115,7 @@ bootstrap() {
             exit 1
         fi
 
-        add_model "${model}" "${provider}" "${bootstrapped_name}"
+        add_model "${model}" "${provider}" "${bootstrapped_name}" "${output}"
         name="${bootstrapped_name}"
     else
         echo "====> Bootstrapping juju ($(green "${version}:${provider}"))"
@@ -136,12 +136,13 @@ add_model() {
     model=${1}
     provider=${2}
     controller=${3}
+    output=${4}
 
     OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${provider}" || true)
     if [ -n "${OUT}" ]; then
-        juju add-model -c "${controller}" "${model}" "${provider}"
+        juju add-model -c "${controller}" "${model}" "${provider}" 2>&1 | OUTPUT "${output}"
     else
-        juju add-model -c "${controller}" "${model}"
+        juju add-model -c "${controller}" "${model}" 2>&1 | OUTPUT "${output}"
     fi
     echo "${model}" >> "${TEST_DIR}/models"
 }
@@ -174,36 +175,14 @@ juju_bootstrap() {
         series="--bootstrap-series=${BOOTSTRAP_SERIES}"
     esac
 
-    debug="false"
-    if [ "${VERBOSE}" -gt 1 ]; then
-        debug="true"
-    fi
+    # When double quotes are added to ${series}, the juju bootstrap
+    # command looks correct, and works outside of the harness, but
+    # does not run, goes directly to cleanup.
+    #shellcheck disable=SC2086
+    juju bootstrap ${series} \
+        --build-agent=${BUILD_AGENT} \
+        "${provider}" "${name}" -d "${model}" "$@" 2>&1 | OUTPUT "${output}"
 
-
-    if [ -n "${output}" ]; then
-        # When double quotes are added to ${series}, the juju bootstrap
-        # command looks correct, and works outside of the harness, but
-        # does not run, goes directly to cleanup.
-        set_test_verbosity
-        case "${VERBOSE}" in
-        1)
-            #shellcheck disable=SC2086
-            juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
-            ;;
-        2)
-            #shellcheck disable=SC2086
-            juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" 2>&1 | tee "${output}"
-            ;;
-        3)
-            #shellcheck disable=SC2086
-            juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
-            ;;
-        esac
-        set_verbosity
-    else
-        #shellcheck disable=SC2086
-        juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@"
-    fi
     echo "${name}" >> "${TEST_DIR}/jujus"
 }
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -184,8 +184,22 @@ juju_bootstrap() {
         # When double quotes are added to ${series}, the juju bootstrap
         # command looks correct, and works outside of the harness, but
         # does not run, goes directly to cleanup.
-        #shellcheck disable=SC2086
-        juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
+        set_test_verbosity
+        case "${VERBOSE}" in
+        1)
+            #shellcheck disable=SC2086
+            juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
+            ;;
+        2)
+            #shellcheck disable=SC2086
+            juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" 2>&1 | tee "${output}"
+            ;;
+        3)
+            #shellcheck disable=SC2086
+            juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@" > "${output}" 2>&1
+            ;;
+        esac
+        set_verbosity
     else
         #shellcheck disable=SC2086
         juju bootstrap ${series} --debug="${debug}" --build-agent=${BUILD_AGENT} "${provider}" "${name}" -d "${model}" "$@"

--- a/tests/includes/output.sh
+++ b/tests/includes/output.sh
@@ -9,12 +9,19 @@ OUTPUT() {
     fi
 
     while read data; do
+        # If there is no output, just dump straight to stdout.
         if [ -z "${output}" ]; then
             echo "${data}"
+        # If there is an output, but we're not in verbose mode, just append to
+        # the output.
         elif [ "${VERBOSE}" -le 1 ]; then
             echo "${data}" >> "${output}"
+        # If we are in verbose mode, but we're an empty line, send to stdout
+        # and also tee it to the output.
         elif echo "${data}" | grep -q "^\s*$"; then
             echo "${data}" | tee -a "${output}"
+        # Finally, we have content and we're in verbose mode. Send the data to
+        # the output and then format it for stdout.
         else
             echo "${data}" | tee -a "${output}" | sed 's/^/    | /g'
         fi

--- a/tests/includes/output.sh
+++ b/tests/includes/output.sh
@@ -1,0 +1,26 @@
+OUTPUT() {
+    local output
+
+    output=${1}
+    shift
+
+    if [ -z "${output}" ] || [ "${VERBOSE}" -gt 1 ]; then
+        echo
+    fi
+
+    while read data; do
+        if [ -z "${output}" ]; then
+            echo "${data}"
+        elif [ "${VERBOSE}" -le 1 ]; then
+            echo "${data}" >> "${output}"
+        elif echo "${data}" | grep -q "^\s*$"; then
+            echo "${data}" | tee -a "${output}"
+        else
+            echo "${data}" | tee -a "${output}" | sed 's/^/    | /g'
+        fi
+    done
+
+    if [ -z "${output}" ] || [ "${VERBOSE}" -gt 1 ]; then
+        echo
+    fi
+}

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -14,19 +14,8 @@ run() {
   echo -n "===> [   ] Running: ${DESC}"
 
   START_TIME=$(date +%s)
-  set_test_verbosity
-  case "${VERBOSE}" in
-  1)
-      $CMD "$@" > "${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
-      ;;
-  2)
-      $CMD "$@" 2>&1 | tee "${TEST_DIR}/${TEST_CURRENT}.log"
-      cat "${TEST_DIR}/${TEST_CURRENT}.log"
-      ;;
-  3)
-      $CMD "$@" > "${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
-      ;;
-  esac
+  set_verbosity
+  $CMD "$@" | OUTPUT "${TEST_DIR}/${TEST_CURRENT}.log"
   set_verbosity
   END_TIME=$(date +%s)
 

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -15,13 +15,16 @@ run() {
 
   START_TIME=$(date +%s)
   set_test_verbosity
-  $CMD "$@" > "${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
   case "${VERBOSE}" in
+  1)
+      $CMD "$@" > "${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
+      ;;
   2)
+      $CMD "$@" 2>&1 | tee "${TEST_DIR}/${TEST_CURRENT}.log"
       cat "${TEST_DIR}/${TEST_CURRENT}.log"
       ;;
   3)
-      cat "${TEST_DIR}/${TEST_CURRENT}.log"
+      $CMD "$@" > "${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
       ;;
   esac
   set_verbosity

--- a/tests/includes/verbose.sh
+++ b/tests/includes/verbose.sh
@@ -5,35 +5,10 @@ set_verbosity() {
     # we could also turn on trace statements for juju.
     case "${VERBOSE}" in
     1)
-        set -e
+        set -eu
         ;;
     2)
-        set -e
-        ;;
-    3)
-        set -eux
-        ;;
-    *)
-        echo "Unexpected verbose level" >&2
-        exit 1
-        ;;
-    esac
-}
-
-set_test_verbosity() {
-    # There are three levels of verbosity, both 1 and 2 will fail on any error,
-    # the difference is that 2 will also turn convoy debug statements on, but not
-    # the shell debug statements. Turning to 3, turns everything on, in theory
-    # we could also turn on trace statements for convoy.
-    case "${TEST_VERBOSE}" in
-    1)
-        set -e
-        ;;
-    2)
-        set -e
-        ;;
-    3)
-        set -eux
+        set -eu
         ;;
     *)
         echo "Unexpected verbose level" >&2

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -2,7 +2,7 @@
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
-export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005 -e SC2181"
 export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -2,7 +2,7 @@
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
-export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005 -e SC2181"
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
 export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -14,7 +14,6 @@ export CURRENT_LTS="focal"
 
 OPTIND=1
 VERBOSE=1
-TEST_VERBOSE=1
 RUN_ALL="false"
 SKIP_LIST=""
 ARITFACT_FILE=""
@@ -76,19 +75,17 @@ show_help() {
     echo "¯¯¯¯¯¯"
     echo "Flags should appear $(red 'before') arguments."
     echo ""
-    echo "cmd [-h] [-vV] [-A] [-s test] [-a file] [-x file] [-r] [-l controller] [-p provider type <lxd|aws>]"
+    echo "cmd [-h] [-v] [-A] [-s test] [-a file] [-x file] [-r] [-l controller] [-p provider type <lxd|aws|manual|microk8s>]"
     echo ""
     echo "    $(green 'cmd -h')        Display this help message"
     echo "    $(green 'cmd -v')        Verbose and debug messages"
-    echo "    $(green 'cmd -V')        Very verbose and debug messages"
-    echo "    $(green 'cmd -t')        Test Verbose and debug messages"
     echo "    $(green 'cmd -A')        Run all the test suites"
     echo "    $(green 'cmd -s')        Skip tests using a comma seperated list"
     echo "    $(green 'cmd -a')        Create an artifact file"
     echo "    $(green 'cmd -x')        Output file from streaming the output"
     echo "    $(green 'cmd -r')        Reuse bootstrapped controller between testing suites"
     echo "    $(green 'cmd -l')        Local bootstrapped controller name to reuse"
-    echo "    $(green 'cmd -p')        Bootstrap provider to use when bootstrapping <lxd|aws>"
+    echo "    $(green 'cmd -p')        Bootstrap provider to use when bootstrapping <lxd|aws|manual|microk8s>"
     echo "    $(green 'cmd -S')        Bootstrap series to use <default is host>, priority over -l"
     echo ""
     echo "Tests:"
@@ -124,7 +121,7 @@ show_help() {
     exit 1
 }
 
-while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
+while getopts "hH?vAs:a:x:rl:p:S:" opt; do
     case "${opt}" in
     h|\?)
         show_help
@@ -134,13 +131,6 @@ while getopts "hH?vVtAs:a:x:rl:p:S:" opt; do
         ;;
     v)
         VERBOSE=2
-        ;;
-    V)
-        VERBOSE=3
-        alias juju="juju --debug"
-        ;;
-    t)
-        TEST_VERBOSE=3
         alias juju="juju --debug"
         ;;
     A)
@@ -181,7 +171,6 @@ shift $((OPTIND-1))
 [ "${1:-}" = "--" ] && shift
 
 export VERBOSE="${VERBOSE}"
-export TEST_VERBOSE="${TEST_VERBOSE}"
 export SKIP_LIST="${SKIP_LIST}"
 
 if [ "$#" -eq 0 ]; then

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -1,11 +1,5 @@
 run_build() {
-    OUT=$(make go-build 2>&1 || true)
-    if [ $? -ne 0 ]; then
-        echo ""
-        echo "$(red 'Found some issues:')"
-        echo "\\n${OUT}"
-        exit 1
-    fi
+    make go-build 2>&1
 }
 
 test_build() {

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -1,6 +1,6 @@
 run_build() {
     OUT=$(make go-build 2>&1 || true)
-    if [ -n "${OUT}" ]; then
+    if [ $? -ne 0 ]; then
         echo ""
         echo "$(red 'Found some issues:')"
         echo "\\n${OUT}"

--- a/tests/suites/smoke/build.sh
+++ b/tests/suites/smoke/build.sh
@@ -1,4 +1,6 @@
 run_build() {
+    echo
+
     make go-build 2>&1
 }
 

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -11,9 +11,10 @@ test_smoke() {
 
     file="${TEST_DIR}/test-smoke.log"
 
+    test_build
+
     bootstrap "test-smoke" "${file}"
 
-    test_build
     test_deploy "${file}"
 
     destroy_controller "test-smoke"


### PR DESCRIPTION
## Description of change

The `make go-build` has changed from 2.7 to 2.8 and the smoke tests
previously checked if there was any output.

The following updates the output from the integration tests to be much
more simplistic. There are now only two modes, the very terse mode,
which is great to just see from a very high-level overview if something
works or broke:

    ./main.sh smoke

Or using the verbose mode that aims to be chatty, but not overly chatty
like with the use of `set -eux`. The `x` part makes it hard to see
what's happening and should be only used for local debugging.

    ./main.sh -v smoke

With this simplistic model, we should be able to see what's failing
within jenkins, as we use `-v` as the default mode for all our testing.

## QA steps

```sh
cd tests && ./make smoke
```
