### PR TITLE
Identification code for empty API Addresses.

### DIFF
--- a/worker/apiaddressupdater/manifold.go
+++ b/worker/apiaddressupdater/manifold.go
@@ -22,6 +22,7 @@ type Logger interface {
 	Errorf(string, ...interface{})
 	Infof(string, ...interface{})
 	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
 }
 
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Users in discourse have identified a situation where juju agents have
empty api addresses written out to their agent.conf files. It's not yet
clear on why this happening but we believe that the api address update
worker is the one responsible for writing out the empty values to the
agent.conf file.

This change introduces some logging and a conditional statement to not
allow writing out of empty api address structures.

## QA steps

```sh
cd worker/apiaddressupdater
go test .
```

## Bug reference

LP: https://bugs.launchpad.net/juju/+bug/1888453
Discourse: https://discourse.juju.is/t/file-agent-conf-missing-apiaddresses-entry-after-network-outage-or-upgrade/2975
