### PR TITLE
Introduce a nested context for the deployer worker.

### DIFF
--- a/worker/deployer/deployer.go
+++ b/worker/deployer/deployer.go
@@ -36,6 +36,8 @@ type Deployer struct {
 // strategies; where a Deployer is responsible for what to deploy, a Context
 // is responsible for how to deploy.
 type Context interface {
+	worker.Worker
+
 	// DeployUnit causes the agent for the specified unit to be started and run
 	// continuously until further notice without further intervention. It will
 	// return an error if the agent is already deployed.
@@ -52,6 +54,8 @@ type Context interface {
 	// AgentConfig returns the agent config for the machine agent that is
 	// running the deployer.
 	AgentConfig() agent.Config
+
+	Report() map[string]interface{}
 }
 
 // NewDeployer returns a Worker that deploys and recalls unit agents

--- a/worker/deployer/nested.go
+++ b/worker/deployer/nested.go
@@ -1,0 +1,377 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer
+
+import (
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/juju/clock"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/juju/os/series"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	"github.com/juju/worker/v2"
+	"github.com/juju/worker/v2/dependency"
+	"github.com/kr/pretty"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/tools"
+	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
+	jujuversion "github.com/juju/juju/version"
+	jworker "github.com/juju/juju/worker"
+)
+
+const (
+	deployedUnitsKey = "deployed-units"
+	stoppedUnitsKey  = "stopped-units"
+)
+
+// Logger represents a logger used by the context.
+type Logger interface {
+	Criticalf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
+	Infof(string, ...interface{})
+	Debugf(string, ...interface{})
+	Tracef(string, ...interface{})
+}
+
+// The nested deployer context is responsible for creating dependency engine
+// manifolds to run workers for each unit and add them to the worker.
+// The context itself is a worker where that worker is the dependency engine
+// for the unit workers.
+
+var _ Context = (*nestedContext)(nil)
+
+type nestedContext struct {
+	logger            Logger
+	agentConfig       agent.Config
+	baseUnitConfig    UnitAgentConfig
+	updateConfigValue func(string, string) error
+
+	mu     sync.Mutex
+	units  map[string]*UnitAgent
+	runner *worker.Runner
+}
+
+// ContextConfig contains all the information that the nested context
+// needs to run.
+type ContextConfig struct {
+	AgentConfig       agent.Config
+	Clock             clock.Clock
+	Logger            Logger
+	UnitEngineConfig  func() dependency.EngineConfig
+	SetupLogging      func(*loggo.Context, agent.Config)
+	UpdateConfigValue func(string, string) error
+	UnitManifolds     func(config UnitManifoldsConfig) dependency.Manifolds
+}
+
+// Validate ensures all the required values are set.
+func (c *ContextConfig) Validate() error {
+	if c.AgentConfig == nil {
+		return errors.NotValidf("missing AgentConfig")
+	}
+	if c.Clock == nil {
+		return errors.NotValidf("missing Clock")
+	}
+	if c.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if c.SetupLogging == nil {
+		return errors.NotValidf("missing SetupLogging")
+	}
+	if c.UnitEngineConfig == nil {
+		return errors.NotValidf("missing UnitEngineConfig")
+	}
+	if c.UpdateConfigValue == nil {
+		return errors.NotValidf("missing UpdateConfigValue")
+	}
+	if c.UnitManifolds == nil {
+		return errors.NotValidf("missing UnitManifolds")
+	}
+	return nil
+}
+
+// NewNestedContext creates a new deployer context that is responsible for
+// running the workers for units as individual dependency engines in a runner it
+// owns.
+func NewNestedContext(config ContextConfig) (*nestedContext, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	context := &nestedContext{
+		logger:      config.Logger,
+		agentConfig: config.AgentConfig,
+		baseUnitConfig: UnitAgentConfig{
+			DataDir:          config.AgentConfig.DataDir(),
+			Clock:            config.Clock,
+			Logger:           config.Logger,
+			UnitEngineConfig: config.UnitEngineConfig,
+			UnitManifolds:    config.UnitManifolds,
+			SetupLogging:     config.SetupLogging,
+		},
+		updateConfigValue: config.UpdateConfigValue,
+
+		units: make(map[string]*UnitAgent),
+		runner: worker.NewRunner(worker.RunnerParams{
+			IsFatal:       agenterrors.IsFatal,
+			MoreImportant: agenterrors.MoreImportant,
+			RestartDelay:  jworker.RestartDelay,
+		}),
+	}
+
+	// Stat all the units that context should have deployed and started.
+	units := context.deployedUnits()
+	stopped := context.stoppedUnits()
+	config.Logger.Infof("new context: units %q, stopped %q", pretty.Sprint(units), pretty.Sprint(stopped))
+	hasError := false
+	for _, u := range units.SortedValues() {
+		if u == "" {
+			config.Logger.Warningf("empty unit")
+			continue
+		}
+		unitConfig := context.baseUnitConfig
+		unitConfig.Name = u
+		agent, err := NewUnitAgent(unitConfig)
+		if err != nil {
+			hasError = true
+			config.Logger.Errorf("unable to start unit %q: %v", u, err)
+			continue
+		}
+		context.units[u] = agent
+		if !stopped.Contains(u) {
+			if err := context.startUnit(u); err != nil {
+				return nil, errors.Annotatef(err, "issues starting workers for unit %q", u)
+			}
+		}
+	}
+	// if has errors, stop things///
+	if hasError {
+		context.runner.Kill()
+		context.runner.Wait()
+		return nil, errors.Errorf("unable to start units")
+	}
+
+	return context, nil
+}
+
+// Kill the embedded running.
+func (c *nestedContext) Kill() {
+	c.runner.Kill()
+}
+
+// Wait for the embedded runner to finish.
+func (c *nestedContext) Wait() error {
+	return c.runner.Wait()
+}
+
+// Report shows both the expected units and the status of the
+// engine reports for those units.
+func (c *nestedContext) Report() map[string]interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	running := c.runner.Report()
+
+	deployed := c.deployedUnits()
+	stopped := c.stoppedUnits()
+
+	result := map[string]interface{}{
+		"deployed": deployed.SortedValues(),
+		"units":    running,
+	}
+	if len(stopped) > 0 {
+		result["stopped"] = stopped.SortedValues()
+	}
+	return result
+}
+
+func (c *nestedContext) DeployUnit(unitName, initialPassword string) error {
+	// Create unit agent config file.
+	tag := names.NewUnitTag(unitName)
+	_, err := c.createUnitAgentConfig(tag, initialPassword)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Create a symlink for the unit "agent" binaries.
+	// This is used because the uniter is still using the tools directory
+	// for the unit agent for creating the jujuc symlinks.
+	c.logger.Tracef("creating symlink for %q to tools directory for jujuc", unitName)
+	dataDir := c.agentConfig.DataDir()
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	current := version.Binary{
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		Series: hostSeries,
+	}
+	toolsDir := tools.ToolsDir(dataDir, tag.String())
+	defer removeOnErr(&err, c.logger, toolsDir)
+	_, err = tools.ChangeAgentTools(dataDir, tag.String(), current)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.logger.Tracef("starting the unit workers for %q", unitName)
+	if err := c.startUnit(unitName); err != nil {
+		return errors.Trace(err)
+	}
+
+	c.logger.Tracef("updating the deployed units to add %q", unitName)
+	// Add to deployed-units stored in the machine agent config.
+	units := c.deployedUnits()
+	units.Add(unitName)
+	allUnits := strings.Join(units.SortedValues(), ",")
+	if err := c.updateConfigValue(deployedUnitsKey, allUnits); err != nil {
+		return errors.Annotatef(err, "couldn't update deployed units to add %q", unitName)
+	}
+
+	return nil
+}
+
+func (c *nestedContext) startUnit(unitName string) error {
+	// Assumes lock is held.
+	c.logger.Infof("starting workers for %q", unitName)
+	agent, found := c.units[unitName]
+	if !found {
+		unitConfig := c.baseUnitConfig
+		unitConfig.Name = unitName
+		var err error
+		agent, err = NewUnitAgent(unitConfig)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.units[unitName] = agent
+	}
+	return errors.Trace(c.runner.StartWorker(unitName, agent.start))
+}
+
+func (c *nestedContext) stopUnitWorkers(unitName string) error {
+	// Assumes lock is held.
+	agent := c.units[unitName]
+	if !agent.running {
+		c.logger.Infof("unit workers for %q not running", unitName)
+		return nil
+	}
+	if err := c.runner.StopWorker(unitName); err != nil {
+		return errors.Annotatef(err, "unable to stop workers for %q", unitName)
+	}
+	return nil
+}
+
+func (c *nestedContext) StopUnit(unitName string) error {
+	// TODO: add a StartUnit for the stop/start behaviour.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.stopUnitWorkers(unitName); err != nil {
+		return errors.Trace(err)
+	}
+
+	units := c.stoppedUnits()
+	units.Add(unitName)
+	allUnits := strings.Join(units.SortedValues(), ",")
+	if err := c.updateConfigValue(stoppedUnitsKey, allUnits); err != nil {
+		return errors.Annotatef(err, "couldn't update stopped units to add %q", unitName)
+	}
+
+	return nil
+}
+
+func (c *nestedContext) createUnitAgentConfig(tag names.UnitTag, initialPassword string) (agent.Config, error) {
+	c.logger.Tracef("create unit agent config for %q", tag)
+	dataDir := c.agentConfig.DataDir()
+	logDir := c.agentConfig.LogDir()
+	apiAddresses, err := c.agentConfig.APIAddresses()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	conf, err := agent.NewAgentConfig(
+		agent.AgentConfigParams{
+			Paths: agent.Paths{
+				DataDir:         dataDir,
+				LogDir:          logDir,
+				MetricsSpoolDir: agent.DefaultPaths.MetricsSpoolDir,
+			},
+			Tag:               tag,
+			Password:          initialPassword,
+			Nonce:             "unused",
+			Controller:        c.agentConfig.Controller(),
+			Model:             c.agentConfig.Model(),
+			APIAddresses:      apiAddresses,
+			CACert:            c.agentConfig.CACert(),
+			UpgradedToVersion: c.agentConfig.UpgradedToVersion(),
+		})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return conf, errors.Trace(conf.Write())
+}
+
+func (c *nestedContext) RecallUnit(unitName string) error {
+	// Stop runner for unit
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.stopUnitWorkers(unitName); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Remove unit from deployed-units
+	units := c.deployedUnits()
+	units.Remove(unitName)
+	allUnits := strings.Join(units.SortedValues(), ",")
+	if err := c.updateConfigValue(deployedUnitsKey, allUnits); err != nil {
+		return errors.Annotatef(err, "couldn't update deployed units to remove %q", unitName)
+	}
+	stoppedUnits := c.stoppedUnits()
+	if stoppedUnits.Contains(unitName) {
+		stoppedUnits.Remove(unitName)
+		allUnits := strings.Join(stoppedUnits.SortedValues(), ",")
+		if err := c.updateConfigValue(stoppedUnitsKey, allUnits); err != nil {
+			return errors.Annotatef(err, "couldn't update stopped units to remove %q", unitName)
+		}
+	}
+
+	// Remove agent directory.
+	agentDir := agent.Dir(c.agentConfig.DataDir(), names.NewUnitTag(unitName))
+	if err := os.RemoveAll(agentDir); err != nil {
+		return errors.Annotate(err, "unable to remove agent dir")
+	}
+
+	return nil
+}
+
+func (c *nestedContext) stoppedUnits() set.Strings {
+	return set.NewStrings(c.getUnits(stoppedUnitsKey)...)
+}
+
+func (c *nestedContext) deployedUnits() set.Strings {
+	return set.NewStrings(c.getUnits(deployedUnitsKey)...)
+}
+
+func (c *nestedContext) getUnits(key string) []string {
+	value := c.agentConfig.Value(key)
+	if value == "" {
+		return nil
+	}
+	units := strings.Split(value, ",")
+	return units
+}
+
+func (c *nestedContext) DeployedUnits() ([]string, error) {
+	return c.getUnits(deployedUnitsKey), nil
+}
+
+func (c *nestedContext) AgentConfig() agent.Config {
+	return c.agentConfig
+}

--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package deployer_test
@@ -74,6 +74,48 @@ func (s *NestedContextSuite) TestConfigMissingAgentConfig(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "missing AgentConfig not valid")
 }
 
+func (s *NestedContextSuite) TestConfigMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing Clock not valid")
+}
+
+func (s *NestedContextSuite) TestConfigMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing Logger not valid")
+}
+
+func (s *NestedContextSuite) TestConfigMissingSetupLogging(c *gc.C) {
+	s.config.SetupLogging = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing SetupLogging not valid")
+}
+
+func (s *NestedContextSuite) TestConfigMissingUnitEngineConfig(c *gc.C) {
+	s.config.UnitEngineConfig = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing UnitEngineConfig not valid")
+}
+
+func (s *NestedContextSuite) TestConfigMissingUpdateConfigValue(c *gc.C) {
+	s.config.UpdateConfigValue = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing UpdateConfigValue not valid")
+}
+
+func (s *NestedContextSuite) TestConfigMissingUnitManifolds(c *gc.C) {
+	s.config.UnitManifolds = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing UnitManifolds not valid")
+}
+
 func (s *NestedContextSuite) newContext(c *gc.C) deployer.Context {
 	context, err := deployer.NewNestedContext(s.config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -89,9 +131,6 @@ func (s *NestedContextSuite) newContext(c *gc.C) deployer.Context {
 	// Make that directory.
 	err = os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	// 	jujudPath := filepath.Join(toolsDir, "jujud")
-	// 	err = ioutil.WriteFile(jujudPath, []byte(fakeJujud), 0755)
-	// 	c.Assert(err, jc.ErrorIsNil)
 	toolsPath := filepath.Join(toolsDir, "downloaded-tools.txt")
 	testTools := coretools.Tools{Version: current, URL: "http://testing.invalid/tools"}
 	data, err := json.Marshal(testTools)

--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -1,0 +1,278 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/juju/os/series"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/arch"
+	"github.com/juju/version"
+	"github.com/juju/worker/v2/workertest"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	jt "github.com/juju/juju/testing"
+	coretools "github.com/juju/juju/tools"
+	jv "github.com/juju/juju/version"
+	"github.com/juju/juju/worker/deployer"
+)
+
+type NestedContextSuite struct {
+	testing.IsolationSuite
+
+	config  deployer.ContextConfig
+	agent   *fakeAgent
+	workers *unitWorkersStub
+}
+
+var _ = gc.Suite(&NestedContextSuite{})
+
+func (s *NestedContextSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	logger := loggo.GetLogger("test.nestedcontext")
+	logger.SetLogLevel(loggo.TRACE)
+
+	s.agent = &fakeAgent{
+		c:      c,
+		values: make(map[string]string),
+	}
+	s.workers = &unitWorkersStub{
+		started: make(chan string, 10), // eval size later
+		stopped: make(chan string, 10), // eval size later
+		logger:  logger,
+	}
+	s.config = deployer.ContextConfig{
+		AgentConfig:      s.agent,
+		Clock:            clock.WallClock,
+		Logger:           logger,
+		UnitEngineConfig: engine.DependencyEngineConfig,
+		SetupLogging: func(c *loggo.Context, _ agent.Config) {
+			c.GetLogger("").SetLogLevel(loggo.DEBUG)
+		},
+		UpdateConfigValue: s.agent.setValue,
+		UnitManifolds:     s.workers.Manifolds,
+	}
+}
+
+func (s *NestedContextSuite) TestConfigMissingAgentConfig(c *gc.C) {
+	s.config.AgentConfig = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing AgentConfig not valid")
+}
+
+func (s *NestedContextSuite) newContext(c *gc.C) deployer.Context {
+	context, err := deployer.NewNestedContext(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, context) })
+	// Initialize the tools directory for the agent.
+	// This should be <DataDir>/tools/<version>-<series>-<arch>.
+	current := version.Binary{
+		Number: jv.Current,
+		Arch:   arch.HostArch(),
+		Series: series.MustHostSeries(),
+	}
+	toolsDir := tools.SharedToolsDir(s.agent.DataDir(), current)
+	// Make that directory.
+	err = os.MkdirAll(toolsDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	// 	jujudPath := filepath.Join(toolsDir, "jujud")
+	// 	err = ioutil.WriteFile(jujudPath, []byte(fakeJujud), 0755)
+	// 	c.Assert(err, jc.ErrorIsNil)
+	toolsPath := filepath.Join(toolsDir, "downloaded-tools.txt")
+	testTools := coretools.Tools{Version: current, URL: "http://testing.invalid/tools"}
+	data, err := json.Marshal(testTools)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ioutil.WriteFile(toolsPath, data, 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	return context
+}
+
+func (s *NestedContextSuite) TestContextStops(c *gc.C) {
+	// Create a context and make sure the clean kill is good.
+	ctx := s.newContext(c)
+	report := ctx.Report()
+	c.Assert(report, jc.DeepEquals, map[string]interface{}{
+		"deployed": []string{},
+		"units": map[string]interface{}{
+			"workers": map[string]interface{}{},
+		},
+	})
+}
+
+func (s *NestedContextSuite) TestDeployUnit(c *gc.C) {
+	ctx := s.newContext(c)
+	unitName := "something/0"
+	err := ctx.DeployUnit(unitName, "password")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Wait for unit to start.
+	s.workers.waitForStart(c, unitName)
+
+	// Unit agent dir exists.
+	unitConfig := agent.ConfigPath(s.agent.DataDir(), names.NewUnitTag(unitName))
+	c.Assert(unitConfig, jc.IsNonEmptyFile)
+
+	// Unit written into the config value as deployed units.
+	c.Assert(s.agent.Value("deployed-units"), gc.Equals, unitName)
+}
+
+func (s *NestedContextSuite) TestRecallUnit(c *gc.C) {
+	ctx := s.newContext(c)
+	unitName := "something/0"
+	err := ctx.DeployUnit(unitName, "password")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Wait for unit to start.
+	s.workers.waitForStart(c, unitName)
+
+	err = ctx.RecallUnit(unitName)
+
+	// Unit agent dir no longer exists.
+	unitAgentDir := agent.Dir(s.agent.DataDir(), names.NewUnitTag(unitName))
+	c.Assert(unitAgentDir, jc.DoesNotExist)
+
+	// Unit written into the config value as deployed units.
+	c.Assert(s.agent.Value("deployed-units"), gc.HasLen, 0)
+}
+
+func (s *NestedContextSuite) TestReport(c *gc.C) {
+	ctx := s.newContext(c)
+
+	// Units are conveniently in alphabetical order.
+	for _, unitName := range []string{"first/0", "second/0", "third/0"} {
+		err := ctx.DeployUnit(unitName, "password")
+		c.Assert(err, jc.ErrorIsNil)
+		// Wait for unit to start.
+		s.workers.waitForStart(c, unitName)
+	}
+
+	check := jc.NewMultiChecker()
+	check.AddExpr(`_["units"][_][_][_][_][_]["started"]`, jc.Ignore)
+	check.AddExpr(`_["units"][_][_]["started"]`, jc.Ignore)
+	// Dates are shown here as an example, but are ignored by the checker.
+	c.Assert(ctx.Report(), check, map[string]interface{}{
+		"deployed": []string{"first/0", "second/0", "third/0"},
+		"units": map[string]interface{}{
+			"workers": map[string]interface{}{
+				"first/0": map[string]interface{}{
+					"report": map[string]interface{}{
+						"manifolds": map[string]interface{}{
+							"worker": map[string]interface{}{
+								"inputs":      []string{},
+								"start-count": 1,
+								"started":     "2020-07-24 03:01:20",
+								"state":       "started",
+							},
+						},
+						"state": "started",
+					},
+					"started": "2020-07-24 03:01:20",
+					"state":   "started",
+				},
+				"second/0": map[string]interface{}{
+					"report": map[string]interface{}{
+						"manifolds": map[string]interface{}{
+							"worker": map[string]interface{}{
+								"inputs":      []string{},
+								"start-count": 1,
+								"started":     "2020-07-24 03:01:20",
+								"state":       "started",
+							},
+						},
+						"state": "started",
+					},
+					"started": "2020-07-24 03:01:20",
+					"state":   "started",
+				},
+				"third/0": map[string]interface{}{
+					"report": map[string]interface{}{
+						"manifolds": map[string]interface{}{
+							"worker": map[string]interface{}{
+								"inputs":      []string{},
+								"start-count": 1,
+								"started":     "2020-07-24 03:01:20",
+								"state":       "started",
+							},
+						},
+						"state": "started",
+					},
+					"started": "2020-07-24 03:01:20",
+					"state":   "started",
+				},
+			},
+		},
+	})
+
+}
+
+type fakeClock struct {
+	clock.Clock
+}
+
+type fakeAgent struct {
+	agent.Agent
+	agent.Config
+
+	c       *gc.C
+	dataDir string
+	logDir  string
+	values  map[string]string
+}
+
+func (f *fakeAgent) Model() names.ModelTag {
+	return jt.ModelTag
+}
+
+func (f *fakeAgent) Controller() names.ControllerTag {
+	return jt.ControllerTag
+}
+
+func (f *fakeAgent) UpgradedToVersion() version.Number {
+	return jv.Current
+}
+
+func (f *fakeAgent) CACert() string {
+	return "fake CACert"
+}
+
+func (f *fakeAgent) APIAddresses() ([]string, error) {
+	return []string{"a1:123", "a2:123"}, nil
+}
+
+func (f *fakeAgent) DataDir() string {
+	if f.dataDir == "" {
+		f.dataDir = f.c.MkDir()
+	}
+	return f.dataDir
+}
+
+func (f *fakeAgent) LogDir() string {
+	if f.logDir == "" {
+		f.logDir = f.c.MkDir()
+	}
+	return f.logDir
+}
+
+func (f *fakeAgent) setValue(key, value string) error {
+	f.values[key] = value
+	return nil
+}
+
+func (f *fakeAgent) Value(key string) string {
+	return f.values[key]
+}

--- a/worker/deployer/stub_manifolds_test.go
+++ b/worker/deployer/stub_manifolds_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer_test
+
+import (
+	"time"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/deployer"
+	"github.com/juju/loggo"
+	"github.com/juju/worker/v2"
+	"github.com/juju/worker/v2/dependency"
+	gc "gopkg.in/check.v1"
+)
+
+func (s *unitWorkersStub) Manifolds(config deployer.UnitManifoldsConfig) dependency.Manifolds {
+	return dependency.Manifolds{
+		"worker": s.Manifold(config.Agent.CurrentConfig().Tag().Id()),
+	}
+}
+
+func (s *unitWorkersStub) Manifold(unitName string) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			s.logger.Infof("manifold start called for %q", unitName)
+			w := &unitWorker{
+				logger:  s.logger,
+				stop:    make(chan struct{}),
+				name:    unitName,
+				started: s.started,
+				stopped: s.stopped,
+			}
+			w.start()
+			return w, nil
+		},
+	}
+}
+
+type unitWorkersStub struct {
+	started chan string
+	stopped chan string
+	logger  loggo.Logger
+}
+
+func (s *unitWorkersStub) waitForStart(c *gc.C, unitName string) {
+	for {
+		select {
+		case unit := <-s.started:
+			if unit == unitName {
+				return
+			}
+			c.Logf("unexpected start %q", unit)
+		case <-time.After(testing.LongWait):
+			c.Fatalf("unit %q didn't start", unitName)
+		}
+	}
+}
+
+type unitWorker struct {
+	logger  loggo.Logger
+	stop    chan struct{}
+	name    string
+	started chan<- string
+	stopped chan<- string
+}
+
+func (w *unitWorker) start() {
+	w.logger.Infof("%q start", w.name)
+	w.started <- w.name
+}
+func (w *unitWorker) Kill() {
+	w.logger.Infof("%q kill", w.name)
+	select {
+	case <-w.stop:
+	default:
+		close(w.stop)
+	}
+	w.stopped <- w.name
+}
+func (w *unitWorker) Wait() error {
+	<-w.stop
+	return nil
+}

--- a/worker/deployer/stub_manifolds_test.go
+++ b/worker/deployer/stub_manifolds_test.go
@@ -6,12 +6,13 @@ package deployer_test
 import (
 	"time"
 
-	"github.com/juju/juju/testing"
-	"github.com/juju/juju/worker/deployer"
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/deployer"
 )
 
 func (s *unitWorkersStub) Manifolds(config deployer.UnitManifoldsConfig) dependency.Manifolds {
@@ -24,6 +25,9 @@ func (s *unitWorkersStub) Manifold(unitName string) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{},
 		Start: func(context dependency.Context) (worker.Worker, error) {
+			if s.startError != nil {
+				return nil, s.startError
+			}
 			s.logger.Infof("manifold start called for %q", unitName)
 			w := &unitWorker{
 				logger:  s.logger,
@@ -31,6 +35,7 @@ func (s *unitWorkersStub) Manifold(unitName string) dependency.Manifold {
 				name:    unitName,
 				started: s.started,
 				stopped: s.stopped,
+				waitErr: s.workerError,
 			}
 			w.start()
 			return w, nil
@@ -42,6 +47,11 @@ type unitWorkersStub struct {
 	started chan string
 	stopped chan string
 	logger  loggo.Logger
+
+	// If startError is non-nil, it is returned from the manifold Start func.
+	startError error
+	// this is the error that is returned from the worker Wait function.
+	workerError error
 }
 
 func (s *unitWorkersStub) waitForStart(c *gc.C, unitName string) {
@@ -58,18 +68,34 @@ func (s *unitWorkersStub) waitForStart(c *gc.C, unitName string) {
 	}
 }
 
+func (s *unitWorkersStub) waitForStop(c *gc.C, unitName string) {
+	for {
+		select {
+		case unit := <-s.stopped:
+			if unit == unitName {
+				return
+			}
+			c.Logf("unexpected stop %q", unit)
+		case <-time.After(testing.LongWait):
+			c.Fatalf("unit %q didn't stop", unitName)
+		}
+	}
+}
+
 type unitWorker struct {
 	logger  loggo.Logger
 	stop    chan struct{}
 	name    string
 	started chan<- string
 	stopped chan<- string
+	waitErr error
 }
 
 func (w *unitWorker) start() {
 	w.logger.Infof("%q start", w.name)
 	w.started <- w.name
 }
+
 func (w *unitWorker) Kill() {
 	w.logger.Infof("%q kill", w.name)
 	select {
@@ -79,7 +105,11 @@ func (w *unitWorker) Kill() {
 	}
 	w.stopped <- w.name
 }
+
 func (w *unitWorker) Wait() error {
+	if w.waitErr != nil {
+		return w.waitErr
+	}
 	<-w.stop
 	return nil
 }

--- a/worker/deployer/unit_agent.go
+++ b/worker/deployer/unit_agent.go
@@ -84,7 +84,11 @@ func (u *UnitAgentConfig) Validate() error {
 
 // NewUnitAgent constructs an "agent" that is responsible for
 // defining the workers for the unit and wraps access and updates
-// to the agent.conf file for the unit.
+// to the agent.conf file for the unit. The method expects that there
+// is an agent.conf file written in the <datadir>/agents/unit-<name>
+// directory. It would be good to remove this need moving forwards
+// and have unit agent logging overrides allowable in the machine
+// agent config file.
 func NewUnitAgent(config UnitAgentConfig) (*UnitAgent, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)

--- a/worker/deployer/unit_agent.go
+++ b/worker/deployer/unit_agent.go
@@ -1,0 +1,254 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/juju/utils/voyeur"
+	"github.com/juju/worker/v2"
+	"github.com/juju/worker/v2/dependency"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/uniter"
+	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/paths"
+	"github.com/juju/juju/version"
+	"github.com/juju/juju/worker/logsender"
+)
+
+// UnitAgent wraps the agent config for this unit.
+type UnitAgent struct {
+	tag    names.UnitTag
+	name   string
+	clock  clock.Clock
+	logger Logger
+
+	mu               sync.Mutex
+	agentConf        agent.ConfigSetterWriter
+	configChangedVal *voyeur.Value
+
+	setupLogging     func(*loggo.Context, agent.Config)
+	unitEngineConfig func() dependency.EngineConfig
+	unitManifolds    func(UnitManifoldsConfig) dependency.Manifolds
+
+	// Able to disable running units.
+	running bool
+}
+
+// UnitAgentConfig is a params struct with the values necessary to
+// construct a working unit agent.
+type UnitAgentConfig struct {
+	Name             string
+	DataDir          string
+	Clock            clock.Clock
+	Logger           Logger
+	UnitEngineConfig func() dependency.EngineConfig
+	UnitManifolds    func(UnitManifoldsConfig) dependency.Manifolds
+	SetupLogging     func(*loggo.Context, agent.Config)
+}
+
+// Validate ensures all the required values are set.
+func (u *UnitAgentConfig) Validate() error {
+	if u.Name == "" {
+		return errors.NotValidf("missing Name")
+	}
+	if u.DataDir == "" {
+		return errors.NotValidf("missing DataDir")
+	}
+	if u.Clock == nil {
+		return errors.NotValidf("missing Clock")
+	}
+	if u.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	if u.SetupLogging == nil {
+		return errors.NotValidf("missing SetupLogging")
+	}
+	if u.UnitEngineConfig == nil {
+		return errors.NotValidf("missing UnitEngineConfig")
+	}
+	if u.UnitManifolds == nil {
+		return errors.NotValidf("missing UnitManifolds")
+	}
+	return nil
+}
+
+// NewUnitAgent constructs an "agent" that is responsible for
+// defining the workers for the unit and wraps access and updates
+// to the agent.conf file for the unit.
+func NewUnitAgent(config UnitAgentConfig) (*UnitAgent, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	config.Logger.Infof("creating new agent config for %q", config.Name)
+	tag := names.NewUnitTag(config.Name)
+	conf, err := agent.ReadConfig(agent.ConfigPath(config.DataDir, tag))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	unit := &UnitAgent{
+		tag:              tag,
+		name:             config.Name,
+		clock:            config.Clock,
+		logger:           config.Logger,
+		agentConf:        conf,
+		configChangedVal: voyeur.NewValue(true),
+		setupLogging:     config.SetupLogging,
+		unitEngineConfig: config.UnitEngineConfig,
+		unitManifolds:    config.UnitManifolds,
+	}
+	// Update the 'upgradedToVersion' in the agent.conf file if it is
+	// different to the current version.
+	if conf.UpgradedToVersion() != version.Current {
+		unit.ChangeConfig(func(setter agent.ConfigSetter) error {
+			setter.SetUpgradedToVersion(version.Current)
+			return nil
+		})
+	}
+	return unit, nil
+}
+
+func (a *UnitAgent) start() (worker.Worker, error) {
+	a.logger.Tracef("starting workers for %q", a.name)
+	loggingContext, bufferedLogger, err := a.initLogging()
+	if err != nil {
+		a.logger.Tracef("init logging failed %s", err)
+		return nil, errors.Trace(err)
+	}
+
+	updateAgentConfLogging := func(loggingConfig string) error {
+		return a.ChangeConfig(func(setter agent.ConfigSetter) error {
+			setter.SetLoggingConfig(loggingConfig)
+			return nil
+		})
+	}
+
+	machineLock, err := machinelock.New(machinelock.Config{
+		AgentName:   a.tag.String(),
+		Clock:       a.clock,
+		Logger:      loggingContext.GetLogger("juju.machinelock"),
+		LogFilename: agent.MachineLockLogFilename(a.agentConf),
+	})
+	// There will only be an error if the required configuration
+	// values are not passed in.
+	if err != nil {
+		a.logger.Tracef("creating machine lock failed %s", err)
+		return nil, errors.Trace(err)
+	}
+
+	// construct unit agent manifold
+	a.logger.Tracef("creating unit manifolds for %q", a.name)
+	manifolds := a.unitManifolds(UnitManifoldsConfig{
+		LoggingContext:      loggingContext,
+		Agent:               a,
+		LogSource:           bufferedLogger.Logs(),
+		LeadershipGuarantee: 30 * time.Second,
+		AgentConfigChanged:  a.configChangedVal,
+		ValidateMigration:   a.validateMigration,
+		UpdateLoggerConfig:  updateAgentConfLogging,
+		MachineLock:         machineLock,
+		Clock:               a.clock,
+	})
+	depEngineConfig := a.unitEngineConfig()
+	// TODO: tweak IsFatal error func, maybe?
+	depEngineConfig.Logger = loggingContext.GetLogger("juju.worker.dependency")
+	// Tweak as necessary.
+	engine, err := dependency.NewEngine(depEngineConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	a.logger.Tracef("installing manifolds for %q", a.name)
+	if err := dependency.Install(engine, manifolds); err != nil {
+		if err := worker.Stop(engine); err != nil {
+			a.logger.Errorf("while stopping engine with bad manifolds: %v", err)
+		}
+		return nil, err
+	}
+	a.running = true
+	a.logger.Tracef("engine for %q running", a.name)
+	return engine, nil
+}
+
+func (a *UnitAgent) initLogging() (*loggo.Context, *logsender.BufferedLogWriter, error) {
+	loggingContext := loggo.NewContext(loggo.INFO)
+
+	logFilename := agent.LogFilename(a.agentConf)
+	if err := paths.PrimeLogFile(logFilename); err != nil {
+		// This isn't a fatal error so log and continue if priming
+		// fails.
+		a.logger.Errorf("unable to prime %s (proceeding anyway): %v", logFilename, err)
+	}
+	// TODO: allow model-config for number of backups and logfile max size.
+	writer := &lumberjack.Logger{
+		Filename:   logFilename,
+		MaxSize:    300, // megabytes
+		MaxBackups: 2,
+		Compress:   true,
+	}
+	if err := loggingContext.AddWriter(
+		"file", loggo.NewSimpleWriter(writer, loggo.DefaultFormatter)); err != nil {
+		a.logger.Errorf("unable to configure file logging for unit %q: %v", a.name, err)
+	}
+
+	bufferedLogger, err := logsender.InstallBufferedLogWriter(loggingContext, 1048576)
+	if err != nil {
+		return nil, nil, errors.Annotate(err, "unable to add buffered log writer")
+	}
+	// Add line for starting agent to logging context.
+	loggingContext.GetLogger("juju").Infof("Starting unit workers for %q", a.name)
+	a.setupLogging(loggingContext, a.agentConf)
+	return loggingContext, bufferedLogger, nil
+}
+
+// ChangeConfig modifies this configuration using the given mutator.
+func (a *UnitAgent) ChangeConfig(change agent.ConfigMutator) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if err := change(a.agentConf); err != nil {
+		return errors.Trace(err)
+	}
+	if err := a.agentConf.Write(); err != nil {
+		return errors.Annotate(err, "cannot write agent configuration")
+	}
+	a.configChangedVal.Set(true)
+	return nil
+}
+
+// CurrentConfig returns the agent config for this agent.
+func (a *UnitAgent) CurrentConfig() agent.Config {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.agentConf.Clone()
+}
+
+// validateMigration is called by the migrationminion to help check
+// that the agent will be ok when connected to a new controller.
+func (a *UnitAgent) validateMigration(apiCaller base.APICaller) error {
+	// TODO(mjs) - more extensive checks to come.
+	facade := uniter.NewState(apiCaller, a.tag)
+	_, err := facade.Unit(a.tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	model, err := facade.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	curModelUUID := a.CurrentConfig().Model().Id()
+	newModelUUID := model.UUID
+	if newModelUUID != curModelUUID {
+		return errors.Errorf("model mismatch when validating: got %q, expected %q",
+			newModelUUID, curModelUUID)
+	}
+	return nil
+}

--- a/worker/deployer/unit_agent_test.go
+++ b/worker/deployer/unit_agent_test.go
@@ -1,0 +1,153 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer_test
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	jt "github.com/juju/juju/testing"
+	jv "github.com/juju/juju/version"
+	"github.com/juju/juju/worker/deployer"
+)
+
+type UnitAgentSuite struct {
+	testing.IsolationSuite
+
+	workers *unitWorkersStub
+	config  deployer.UnitAgentConfig
+}
+
+var _ = gc.Suite(&UnitAgentSuite{})
+
+func (s *UnitAgentSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	logger := loggo.GetLogger("test.unitagent")
+	logger.SetLogLevel(loggo.TRACE)
+
+	s.workers = &unitWorkersStub{
+		started: make(chan string, 10), // eval size later
+		stopped: make(chan string, 10), // eval size later
+		logger:  logger,
+	}
+
+	s.config = deployer.UnitAgentConfig{
+		Name:    "someunit/42",
+		DataDir: c.MkDir(),
+		Clock:   clock.WallClock,
+		Logger:  logger,
+		SetupLogging: func(c *loggo.Context, _ agent.Config) {
+			c.GetLogger("").SetLogLevel(loggo.DEBUG)
+		},
+		UnitEngineConfig: engine.DependencyEngineConfig,
+		UnitManifolds:    s.workers.Manifolds,
+	}
+}
+
+func (s *UnitAgentSuite) TestConfigMissingName(c *gc.C) {
+	s.config.Name = ""
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing Name not valid")
+}
+
+func (s *UnitAgentSuite) TestConfigMissingDataDir(c *gc.C) {
+	s.config.DataDir = ""
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing DataDir not valid")
+}
+
+func (s *UnitAgentSuite) TestConfigMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing Clock not valid")
+}
+
+func (s *UnitAgentSuite) TestConfigMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing Logger not valid")
+}
+
+func (s *UnitAgentSuite) TestConfigMissingSetupLogging(c *gc.C) {
+	s.config.SetupLogging = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing SetupLogging not valid")
+}
+
+func (s *UnitAgentSuite) TestConfigMissingUnitEngineConfig(c *gc.C) {
+	s.config.UnitEngineConfig = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing UnitEngineConfig not valid")
+}
+
+func (s *UnitAgentSuite) TestConfigMissingUnitManifolds(c *gc.C) {
+	s.config.UnitManifolds = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing UnitManifolds not valid")
+}
+
+func (s *UnitAgentSuite) writeAgentConf(c *gc.C) {
+	conf, err := agent.NewAgentConfig(
+		agent.AgentConfigParams{
+			Paths: agent.Paths{
+				DataDir:         s.config.DataDir,
+				LogDir:          c.MkDir(),
+				MetricsSpoolDir: agent.DefaultPaths.MetricsSpoolDir,
+			},
+			Tag:          names.NewUnitTag(s.config.Name),
+			Password:     "sekrit",
+			Nonce:        "unused",
+			Controller:   jt.ControllerTag,
+			Model:        jt.ModelTag,
+			APIAddresses: []string{"unused:1234"},
+			CACert:       jt.CACert,
+			// We'll use an old version number here to confirm
+			// that it gets updated.
+			UpgradedToVersion: version.Number{Major: 2, Minor: 2},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	err = conf.Write()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UnitAgentSuite) newUnitAgent(c *gc.C) *deployer.UnitAgent {
+	agent, err := deployer.NewUnitAgent(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	return agent
+}
+
+func (s *UnitAgentSuite) TestNewAgentSetsUpgradedToVersion(c *gc.C) {
+	s.writeAgentConf(c)
+	agent := s.newUnitAgent(c)
+	config := agent.CurrentConfig()
+	c.Assert(config.UpgradedToVersion(), gc.Equals, jv.Current)
+}
+
+func (s *UnitAgentSuite) TestChangeConfigWritesChanges(c *gc.C) {
+	s.writeAgentConf(c)
+	ua := s.newUnitAgent(c)
+	err := ua.ChangeConfig(func(setter agent.ConfigSetter) error {
+		setter.SetValue("foo", "bar")
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	ub := s.newUnitAgent(c)
+	config := ub.CurrentConfig()
+	c.Assert(config.Value("foo"), gc.Equals, "bar")
+}

--- a/worker/deployer/unit_manifolds.go
+++ b/worker/deployer/unit_manifolds.go
@@ -1,0 +1,304 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer
+
+import (
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/utils/voyeur"
+	"github.com/juju/worker/v2/dependency"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	commonapi "github.com/juju/juju/api/common"
+	msapi "github.com/juju/juju/api/meterstatus"
+	"github.com/juju/juju/cmd/jujud/agent/engine"
+	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/agent"
+	"github.com/juju/juju/worker/apiaddressupdater"
+	"github.com/juju/juju/worker/apicaller"
+	"github.com/juju/juju/worker/apiconfigwatcher"
+	"github.com/juju/juju/worker/fortress"
+	"github.com/juju/juju/worker/leadership"
+	loggerworker "github.com/juju/juju/worker/logger"
+	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/meterstatus"
+	"github.com/juju/juju/worker/metrics/collect"
+	"github.com/juju/juju/worker/metrics/sender"
+	"github.com/juju/juju/worker/metrics/spool"
+	"github.com/juju/juju/worker/migrationflag"
+	"github.com/juju/juju/worker/migrationminion"
+	"github.com/juju/juju/worker/retrystrategy"
+	"github.com/juju/juju/worker/uniter"
+	"github.com/juju/juju/worker/upgrader"
+)
+
+// UnitManifoldsConfig allows specialisation of the result of Manifolds.
+type UnitManifoldsConfig struct {
+
+	// LoggingContext holds the unit writers so that the loggers
+	// for the unit get tagged with the right source.
+	LoggingContext *loggo.Context
+
+	// Agent contains the agent that will be wrapped and made available to
+	// its dependencies via a dependency.Engine.
+	Agent coreagent.Agent
+
+	// LogSource will be read from by the logsender component.
+	LogSource logsender.LogRecordCh
+
+	// LeadershipGuarantee controls the behaviour of the leadership tracker.
+	LeadershipGuarantee time.Duration
+
+	// AgentConfigChanged is set whenever the unit agent's config
+	// is updated.
+	AgentConfigChanged *voyeur.Value
+
+	// ValidateMigration is called by the migrationminion during the
+	// migration process to check that the agent will be ok when
+	// connected to the new target controller.
+	ValidateMigration func(base.APICaller) error
+
+	// UpdateLoggerConfig is a function that will save the specified
+	// config value as the logging config in the agent.conf file.
+	UpdateLoggerConfig func(string) error
+
+	// MachineLock is a central source for acquiring the machine lock.
+	// This is used by a number of workers to ensure serialisation of actions
+	// across the machine.
+	MachineLock machinelock.Lock
+
+	// Clock supplies timekeeping services to various workers.
+	Clock clock.Clock
+}
+
+// UnitManifolds returns a set of co-configured manifolds covering the various
+// responsibilities of nested unit agent.
+//
+// Thou Shalt Not Use String Literals In This Function. Or Else.
+func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
+
+	// connectFilter exists to let us retry api connections immediately
+	// on password change, rather than causing the dependency engine to
+	// wait for a while.
+	connectFilter := func(err error) error {
+		cause := errors.Cause(err)
+		if cause == apicaller.ErrChangedPassword {
+			return dependency.ErrBounce
+		} else if cause == apicaller.ErrConnectImpossible {
+			// TODO: almost certainly want a different error here.
+			return worker.ErrTerminateAgent
+		}
+		return err
+	}
+
+	return dependency.Manifolds{
+
+		// The agent manifold references the enclosing agent, and is the
+		// foundation stone on which most other manifolds ultimately depend.
+		// (Currently, that is "all manifolds", but consider a shared clock.)
+		agentName: agent.Manifold(config.Agent),
+
+		// The api-config-watcher manifold monitors the API server
+		// addresses in the agent config and bounces when they
+		// change. It's required as part of model migrations.
+		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
+			AgentName:          agentName,
+			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.apiconfigwatcher"),
+		}),
+
+		// The api caller is a thin concurrent wrapper around a connection
+		// to some API server. It's used by many other manifolds, which all
+		// select their own desired facades. It will be interesting to see
+		// how this works when we consolidate the agents; might be best to
+		// handle the auth changes server-side..?
+		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName:            agentName,
+			APIConfigWatcherName: apiConfigWatcherName,
+			APIOpen:              api.Open,
+			NewConnection:        apicaller.ScaryConnect,
+			Filter:               connectFilter,
+			Logger:               config.LoggingContext.GetLogger("juju.worker.apicaller"),
+		}),
+
+		// The log sender is a leaf worker that sends log messages to some
+		// API server, when configured so to do. We should only need one of
+		// these in a consolidated agent.
+		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
+			APICallerName: apiCallerName,
+			LogSource:     config.LogSource,
+		}),
+
+		// The migration workers collaborate to run migrations;
+		// and to create a mechanism for running other workers
+		// so they can't accidentally interfere with a migration
+		// in progress. Such a manifold should (1) depend on the
+		// migration-inactive flag, to know when to start or die;
+		// and (2) occupy the migration-fortress, so as to avoid
+		// possible interference with the minion (which will not
+		// take action until it's gained sole control of the
+		// fortress).
+		migrationFortressName: fortress.Manifold(),
+		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
+			APICallerName: apiCallerName,
+			Check:         migrationflag.IsTerminal,
+			NewFacade:     migrationflag.NewFacade,
+			NewWorker:     migrationflag.NewWorker,
+		}),
+		migrationMinionName: migrationminion.Manifold(migrationminion.ManifoldConfig{
+			AgentName:         agentName,
+			APICallerName:     apiCallerName,
+			FortressName:      migrationFortressName,
+			Clock:             config.Clock,
+			APIOpen:           api.Open,
+			ValidateMigration: config.ValidateMigration,
+			NewFacade:         migrationminion.NewFacade,
+			NewWorker:         migrationminion.NewWorker,
+		}),
+
+		// The logging config updater is a leaf worker that indirectly
+		// controls the messages sent via the log sender according to
+		// changes in environment config. We should only need one of
+		// these in a consolidated agent (not yet).
+		loggingConfigUpdaterName: ifNotMigrating(loggerworker.Manifold(loggerworker.ManifoldConfig{
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			LoggingContext:  config.LoggingContext,
+			Logger:          config.LoggingContext.GetLogger("juju.worker.logger"),
+			UpdateAgentFunc: config.UpdateLoggerConfig,
+		})),
+
+		// The api address updater is a leaf worker that rewrites agent config
+		// as the controller addresses change. We should only need one of
+		// these in a consolidated agent.
+		apiAddressUpdaterName: ifNotMigrating(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+		})),
+
+		// The charmdir resource coordinates whether the charm directory is
+		// available or not; after 'start' hook and before 'stop' hook
+		// executes, and not during upgrades.
+		charmDirName: ifNotMigrating(fortress.Manifold()),
+
+		// The leadership tracker attempts to secure and retain leadership of
+		// the unit's service, and is consulted on such matters by the
+		// uniter. As it stands today, we'll need one per unit in a
+		// consolidated agent.
+		leadershipTrackerName: ifNotMigrating(leadership.Manifold(leadership.ManifoldConfig{
+			AgentName:           agentName,
+			APICallerName:       apiCallerName,
+			Clock:               config.Clock,
+			LeadershipGuarantee: config.LeadershipGuarantee,
+		})),
+
+		// HookRetryStrategy uses a retrystrategy worker to get a
+		// retry strategy that will be used by the uniter to run its hooks.
+		hookRetryStrategyName: ifNotMigrating(retrystrategy.Manifold(retrystrategy.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			NewFacade:     retrystrategy.NewFacade,
+			NewWorker:     retrystrategy.NewRetryStrategyWorker,
+			Logger:        config.LoggingContext.GetLogger("juju.worker.retrystrategy"),
+		})),
+
+		// The uniter installs charms; manages the unit's presence in its
+		// relations; creates subordinate units; runs all the hooks; sends
+		// metrics; etc etc etc. We expect to break it up further in the
+		// coming weeks, and to need one per unit in a consolidated agent
+		// (and probably one for each component broken out).
+		uniterName: ifNotMigrating(uniter.Manifold(uniter.ManifoldConfig{
+			AgentName:             agentName,
+			APICallerName:         apiCallerName,
+			MachineLock:           config.MachineLock,
+			Clock:                 config.Clock,
+			LeadershipTrackerName: leadershipTrackerName,
+			CharmDirName:          charmDirName,
+			HookRetryStrategyName: hookRetryStrategyName,
+			TranslateResolverErr:  uniter.TranslateFortressErrors,
+		})),
+
+		// TODO (mattyw) should be added to machine agent.
+		metricSpoolName: ifNotMigrating(spool.Manifold(spool.ManifoldConfig{
+			AgentName: agentName,
+		})),
+
+		// The metric collect worker executes the collect-metrics hook in a
+		// restricted context that can safely run concurrently with other hooks.
+		metricCollectName: ifNotMigrating(collect.Manifold(collect.ManifoldConfig{
+			AgentName:       agentName,
+			MetricSpoolName: metricSpoolName,
+			CharmDirName:    charmDirName,
+		})),
+
+		// The meter status worker executes the meter-status-changed hook when it detects
+		// that the meter status has changed.
+		meterStatusName: ifNotMigrating(meterstatus.Manifold(meterstatus.ManifoldConfig{
+			AgentName:                agentName,
+			APICallerName:            apiCallerName,
+			MachineLock:              config.MachineLock,
+			Clock:                    config.Clock,
+			NewHookRunner:            meterstatus.NewHookRunner,
+			NewMeterStatusAPIClient:  msapi.NewClient,
+			NewUniterStateAPIClient:  commonapi.NewUniterStateAPI,
+			NewConnectedStatusWorker: meterstatus.NewConnectedStatusWorker,
+			NewIsolatedStatusWorker:  meterstatus.NewIsolatedStatusWorker,
+		})),
+
+		// The metric sender worker periodically sends accumulated metrics to the controller.
+		metricSenderName: ifNotMigrating(sender.Manifold(sender.ManifoldConfig{
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			MetricSpoolName: metricSpoolName,
+		})),
+
+		// For the nested deployer, the upgrade worker is only used to record
+		// the running agent version for the unit. It then stops.
+		upgraderName: upgrader.Manifold(upgrader.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			Logger:        loggo.GetLogger("juju.worker.upgrader"),
+			Clock:         config.Clock,
+		}),
+	}
+}
+
+var ifNotMigrating = engine.Housing{
+	Flags: []string{
+		migrationInactiveFlagName,
+	},
+	Occupy: migrationFortressName,
+}.Decorate
+
+const (
+	agentName            = "agent"
+	apiConfigWatcherName = "api-config-watcher"
+	apiCallerName        = "api-caller"
+	logSenderName        = "log-sender"
+
+	migrationFortressName     = "migration-fortress"
+	migrationInactiveFlagName = "migration-inactive-flag"
+	migrationMinionName       = "migration-minion"
+
+	loggingConfigUpdaterName = "logging-config-updater"
+	proxyConfigUpdaterName   = "proxy-config-updater"
+	apiAddressUpdaterName    = "api-address-updater"
+
+	charmDirName          = "charm-dir"
+	leadershipTrackerName = "leadership-tracker"
+	hookRetryStrategyName = "hook-retry-strategy"
+	uniterName            = "uniter"
+	upgraderName          = "upgrader"
+
+	metricSpoolName   = "metric-spool"
+	meterStatusName   = "meter-status"
+	metricCollectName = "metric-collect"
+	metricSenderName  = "metric-sender"
+)

--- a/worker/deployer/unit_manifolds_test.go
+++ b/worker/deployer/unit_manifolds_test.go
@@ -1,0 +1,225 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package deployer_test
+
+import (
+	"sort"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/jujud/agent/agenttest"
+	"github.com/juju/juju/worker/deployer"
+)
+
+type ManifoldsSuite struct {
+	testing.IsolationSuite
+
+	config deployer.UnitManifoldsConfig
+}
+
+var _ = gc.Suite(&ManifoldsSuite{})
+
+func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = deployer.UnitManifoldsConfig{
+		Agent:          fakeAgent{},
+		LoggingContext: loggo.NewContext(loggo.DEBUG),
+	}
+}
+
+func (s *ManifoldsSuite) TestStartFuncs(c *gc.C) {
+	manifolds := deployer.UnitManifolds(s.config)
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, gc.NotNil)
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
+	manifolds := deployer.UnitManifolds(s.config)
+	expectedKeys := []string{
+		"agent",
+		"api-address-updater",
+		"api-caller",
+		"api-config-watcher",
+		"charm-dir",
+		"hook-retry-strategy",
+		"leadership-tracker",
+		"log-sender",
+		"logging-config-updater",
+		"meter-status",
+		"metric-collect",
+		"metric-sender",
+		"metric-spool",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-minion",
+		"uniter",
+		"upgrader",
+	}
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	c.Assert(keys, jc.SameContents, expectedKeys)
+}
+
+func (s *ManifoldsSuite) TestMigrationGuards(c *gc.C) {
+	exempt := set.NewStrings(
+		"agent",
+		"machine-lock",
+		"api-config-watcher",
+		"api-caller",
+		"log-sender",
+		"upgrader",
+		"migration-fortress",
+		"migration-minion",
+		"migration-inactive-flag",
+	)
+	manifolds := deployer.UnitManifolds(s.config)
+	for name, manifold := range manifolds {
+		c.Logf("%v [%v]", name, manifold.Inputs)
+		if !exempt.Contains(name) {
+			checkContains(c, manifold.Inputs, "migration-inactive-flag")
+			checkContains(c, manifold.Inputs, "migration-fortress")
+		}
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldsDependencies(c *gc.C) {
+	agenttest.AssertManifoldsDependencies(c,
+		deployer.UnitManifolds(s.config),
+		expectedUnitManifoldsWithDependencies,
+	)
+}
+
+func checkContains(c *gc.C, names []string, seek string) {
+	for _, name := range names {
+		if name == seek {
+			return
+		}
+	}
+	c.Errorf("%q not present in %v", seek, names)
+}
+
+var expectedUnitManifoldsWithDependencies = map[string][]string{
+
+	"agent": {},
+
+	"api-address-updater": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"api-caller": {"agent", "api-config-watcher"},
+
+	"api-config-watcher": {"agent"},
+
+	"charm-dir": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"hook-retry-strategy": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"leadership-tracker": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"log-sender": {"agent", "api-caller", "api-config-watcher"},
+
+	"logging-config-updater": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"meter-status": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"metric-collect": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"charm-dir",
+		"metric-spool",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"metric-sender": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"metric-spool",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"metric-spool": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"migration-fortress": {},
+
+	"migration-inactive-flag": {
+		"agent",
+		"api-caller",
+		"api-config-watcher"},
+
+	"migration-minion": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"migration-fortress"},
+
+	"uniter": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"charm-dir",
+		"hook-retry-strategy",
+		"leadership-tracker",
+		"migration-fortress",
+		"migration-inactive-flag",
+	},
+
+	"upgrader": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+	},
+}


### PR DESCRIPTION
This isn't yet hooked up into the deployer, but the nested context will
be hooked up to have the unit workers run in a nested dependency engine within
the deployer worker.

The Context interface is expanded to support the worker.Worker methods as
the NestedContext is a worker, but the SimpleContext has nothing running,
so its implementation are no-ops.

## QA steps

The unit tests coverage of the worker/deployer is all there is right now.

## Documentation changes

This is internal only for now.
