### PR TITLE
Containers Maintain Their Own Link-Layer Data

### DIFF
--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -5,16 +5,15 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	instance "github.com/juju/juju/core/instance"
 	life "github.com/juju/juju/core/life"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockMachineProvisioner is a mock of MachineProvisioner interface
@@ -159,10 +158,10 @@ func (mr *MockMachineProvisionerMockRecorder) Life() *gomock.Call {
 }
 
 // MachineTag mocks base method
-func (m *MockMachineProvisioner) MachineTag() names_v3.MachineTag {
+func (m *MockMachineProvisioner) MachineTag() names.MachineTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names_v3.MachineTag)
+	ret0, _ := ret[0].(names.MachineTag)
 	return ret0
 }
 
@@ -407,10 +406,10 @@ func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *gomock.Cal
 }
 
 // Tag mocks base method
-func (m *MockMachineProvisioner) Tag() names_v3.Tag {
+func (m *MockMachineProvisioner) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(names_v3.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -246,37 +246,12 @@ func (st *State) ReleaseContainerAddresses(containerTag names.MachineTag) (err e
 // PrepareContainerInterfaceInfo allocates an address and returns information to
 // configure networking for a container. It accepts container tags as arguments.
 func (st *State) PrepareContainerInterfaceInfo(containerTag names.MachineTag) (corenetwork.InterfaceInfos, error) {
-	return st.prepareOrGetContainerInterfaceInfo(containerTag, true)
-}
-
-// GetContainerInterfaceInfo returns information to configure networking
-// for a container. It accepts container tags as arguments.
-func (st *State) GetContainerInterfaceInfo(containerTag names.MachineTag) (corenetwork.InterfaceInfos, error) {
-	return st.prepareOrGetContainerInterfaceInfo(containerTag, false)
-}
-
-// prepareOrGetContainerInterfaceInfo returns the necessary information to
-// configure network interfaces of a container with allocated static
-// IP addresses.
-//
-// TODO(dimitern): Before we start using this, we need to rename both
-// the method and the network.InterfaceInfo type to be called
-// InterfaceConfig.
-func (st *State) prepareOrGetContainerInterfaceInfo(
-	containerTag names.MachineTag,
-	allocateNewAddress bool,
-) (corenetwork.InterfaceInfos, error) {
 	var result params.MachineNetworkConfigResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: containerTag.String()}},
 	}
-	methodName := ""
-	if allocateNewAddress {
-		methodName = "PrepareContainerInterfaceInfo"
-	} else {
-		methodName = "GetContainerInterfaceInfo"
-	}
-	if err := st.facade.FacadeCall(methodName, args, &result); err != nil {
+
+	if err := st.facade.FacadeCall("PrepareContainerInterfaceInfo", args, &result); err != nil {
 		return nil, err
 	}
 	if len(result.Results) != 1 {

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -41,9 +41,7 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if m.IsContainer() {
-		return nil
-	}
+
 	observedConfig := args.Config
 	logger.Tracef("observed network config of machine %q: %+v", m.Id(), observedConfig)
 	if len(observedConfig) == 0 {
@@ -114,10 +112,6 @@ func (api *NetworkConfigAPI) getMachineForSettingNetworkConfig(machineTag string
 		return nil, errors.Trace(common.ErrPerm)
 	} else if err != nil {
 		return nil, errors.Trace(err)
-	}
-
-	if m.IsContainer() {
-		logger.Debugf("not updating network config for container %q", m.Id())
 	}
 
 	return m, nil

--- a/apiserver/facades/agent/provisioner/interface.go
+++ b/apiserver/facades/agent/provisioner/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/instance"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/network/containerizer"
 )
@@ -36,7 +37,9 @@ type BridgePolicy interface {
 	// PopulateContainerLinkLayerDevices sets the link-layer devices of the input
 	// guest, setting each device to be a child of the corresponding bridge on the
 	// host machine.
-	PopulateContainerLinkLayerDevices(containerizer.Machine, containerizer.Container) error
+	PopulateContainerLinkLayerDevices(
+		containerizer.Machine, containerizer.Container, bool,
+	) (corenetwork.InterfaceInfos, error)
 }
 
 // Unit is an indirection for state.Unit.

--- a/apiserver/facades/agent/provisioner/mocks/containerizer_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/containerizer_mock.go
@@ -5,12 +5,11 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
 	containerizer "github.com/juju/juju/network/containerizer"
 	state "github.com/juju/juju/state"
+	reflect "reflect"
 )
 
 // MockLinkLayerDevice is a mock of LinkLayerDevice interface
@@ -38,6 +37,7 @@ func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 
 // Addresses mocks base method
 func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addresses")
 	ret0, _ := ret[0].([]*state.Address)
 	ret1, _ := ret[1].(error)
@@ -46,24 +46,28 @@ func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 
 // Addresses indicates an expected call of Addresses
 func (mr *MockLinkLayerDeviceMockRecorder) Addresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockLinkLayerDevice)(nil).Addresses))
 }
 
 // EthernetDeviceForBridge mocks base method
-func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string) (state.LinkLayerDeviceArgs, error) {
-	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0)
-	ret0, _ := ret[0].(state.LinkLayerDeviceArgs)
+func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string, arg1 bool) (network.InterfaceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0, arg1)
+	ret0, _ := ret[0].(network.InterfaceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge
-func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0)
+func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0, arg1)
 }
 
 // IsAutoStart mocks base method
 func (m *MockLinkLayerDevice) IsAutoStart() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAutoStart")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -71,11 +75,13 @@ func (m *MockLinkLayerDevice) IsAutoStart() bool {
 
 // IsAutoStart indicates an expected call of IsAutoStart
 func (mr *MockLinkLayerDeviceMockRecorder) IsAutoStart() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAutoStart", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsAutoStart))
 }
 
 // IsUp mocks base method
 func (m *MockLinkLayerDevice) IsUp() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUp")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -83,11 +89,13 @@ func (m *MockLinkLayerDevice) IsUp() bool {
 
 // IsUp indicates an expected call of IsUp
 func (mr *MockLinkLayerDeviceMockRecorder) IsUp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUp", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsUp))
 }
 
 // MACAddress mocks base method
 func (m *MockLinkLayerDevice) MACAddress() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MACAddress")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -95,11 +103,13 @@ func (m *MockLinkLayerDevice) MACAddress() string {
 
 // MACAddress indicates an expected call of MACAddress
 func (mr *MockLinkLayerDeviceMockRecorder) MACAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MACAddress", reflect.TypeOf((*MockLinkLayerDevice)(nil).MACAddress))
 }
 
 // MTU mocks base method
 func (m *MockLinkLayerDevice) MTU() uint {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MTU")
 	ret0, _ := ret[0].(uint)
 	return ret0
@@ -107,11 +117,13 @@ func (m *MockLinkLayerDevice) MTU() uint {
 
 // MTU indicates an expected call of MTU
 func (mr *MockLinkLayerDeviceMockRecorder) MTU() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockLinkLayerDevice)(nil).MTU))
 }
 
 // Name mocks base method
 func (m *MockLinkLayerDevice) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -119,11 +131,13 @@ func (m *MockLinkLayerDevice) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
 // ParentDevice mocks base method
 func (m *MockLinkLayerDevice) ParentDevice() (containerizer.LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentDevice")
 	ret0, _ := ret[0].(containerizer.LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -132,11 +146,13 @@ func (m *MockLinkLayerDevice) ParentDevice() (containerizer.LinkLayerDevice, err
 
 // ParentDevice indicates an expected call of ParentDevice
 func (mr *MockLinkLayerDeviceMockRecorder) ParentDevice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentDevice", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentDevice))
 }
 
 // ParentName mocks base method
 func (m *MockLinkLayerDevice) ParentName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -144,11 +160,13 @@ func (m *MockLinkLayerDevice) ParentName() string {
 
 // ParentName indicates an expected call of ParentName
 func (mr *MockLinkLayerDeviceMockRecorder) ParentName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentName", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentName))
 }
 
 // Type mocks base method
 func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
 	ret0, _ := ret[0].(network.LinkLayerDeviceType)
 	return ret0
@@ -156,5 +174,6 @@ func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 
 // Type indicates an expected call of Type
 func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
 }

--- a/apiserver/facades/agent/provisioner/mocks/package_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/package_mock.go
@@ -5,18 +5,18 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
+	charm "github.com/juju/charm/v7"
 	set "github.com/juju/collections/set"
 	provisioner "github.com/juju/juju/apiserver/facades/agent/provisioner"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
-	network "github.com/juju/juju/network"
+	network "github.com/juju/juju/core/network"
+	network0 "github.com/juju/juju/network"
 	containerizer "github.com/juju/juju/network/containerizer"
 	state "github.com/juju/juju/state"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockMachine is a mock of Machine interface
@@ -44,6 +44,7 @@ func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 
 // AllAddresses mocks base method
 func (m *MockMachine) AllAddresses() ([]containerizer.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllAddresses")
 	ret0, _ := ret[0].([]containerizer.Address)
 	ret1, _ := ret[1].(error)
@@ -52,11 +53,13 @@ func (m *MockMachine) AllAddresses() ([]containerizer.Address, error) {
 
 // AllAddresses indicates an expected call of AllAddresses
 func (mr *MockMachineMockRecorder) AllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockMachine)(nil).AllAddresses))
 }
 
 // AllLinkLayerDevices mocks base method
 func (m *MockMachine) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllLinkLayerDevices")
 	ret0, _ := ret[0].([]containerizer.LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -65,11 +68,13 @@ func (m *MockMachine) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, er
 
 // AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices
 func (mr *MockMachineMockRecorder) AllLinkLayerDevices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllLinkLayerDevices", reflect.TypeOf((*MockMachine)(nil).AllLinkLayerDevices))
 }
 
 // AllSpaces mocks base method
 func (m *MockMachine) AllSpaces() (set.Strings, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
 	ret0, _ := ret[0].(set.Strings)
 	ret1, _ := ret[1].(error)
@@ -78,11 +83,13 @@ func (m *MockMachine) AllSpaces() (set.Strings, error) {
 
 // AllSpaces indicates an expected call of AllSpaces
 func (mr *MockMachineMockRecorder) AllSpaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockMachine)(nil).AllSpaces))
 }
 
 // Constraints mocks base method
 func (m *MockMachine) Constraints() (constraints.Value, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
 	ret0, _ := ret[0].(constraints.Value)
 	ret1, _ := ret[1].(error)
@@ -91,11 +98,13 @@ func (m *MockMachine) Constraints() (constraints.Value, error) {
 
 // Constraints indicates an expected call of Constraints
 func (mr *MockMachineMockRecorder) Constraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockMachine)(nil).Constraints))
 }
 
 // ContainerType mocks base method
 func (m *MockMachine) ContainerType() instance.ContainerType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
 	ret0, _ := ret[0].(instance.ContainerType)
 	return ret0
@@ -103,11 +112,13 @@ func (m *MockMachine) ContainerType() instance.ContainerType {
 
 // ContainerType indicates an expected call of ContainerType
 func (mr *MockMachineMockRecorder) ContainerType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMachine)(nil).ContainerType))
 }
 
 // Id mocks base method
 func (m *MockMachine) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -115,11 +126,13 @@ func (m *MockMachine) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockMachineMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
 }
 
 // InstanceId mocks base method
 func (m *MockMachine) InstanceId() (instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
@@ -128,11 +141,13 @@ func (m *MockMachine) InstanceId() (instance.Id, error) {
 
 // InstanceId indicates an expected call of InstanceId
 func (mr *MockMachineMockRecorder) InstanceId() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachine)(nil).InstanceId))
 }
 
 // IsManual mocks base method
 func (m *MockMachine) IsManual() (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsManual")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -141,23 +156,27 @@ func (m *MockMachine) IsManual() (bool, error) {
 
 // IsManual indicates an expected call of IsManual
 func (mr *MockMachineMockRecorder) IsManual() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManual", reflect.TypeOf((*MockMachine)(nil).IsManual))
 }
 
 // MachineTag mocks base method
-func (m *MockMachine) MachineTag() names_v3.MachineTag {
+func (m *MockMachine) MachineTag() names.MachineTag {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
-	ret0, _ := ret[0].(names_v3.MachineTag)
+	ret0, _ := ret[0].(names.MachineTag)
 	return ret0
 }
 
 // MachineTag indicates an expected call of MachineTag
 func (mr *MockMachineMockRecorder) MachineTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachine)(nil).MachineTag))
 }
 
 // Raw mocks base method
 func (m *MockMachine) Raw() *state.Machine {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Raw")
 	ret0, _ := ret[0].(*state.Machine)
 	return ret0
@@ -165,11 +184,13 @@ func (m *MockMachine) Raw() *state.Machine {
 
 // Raw indicates an expected call of Raw
 func (mr *MockMachineMockRecorder) Raw() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Raw", reflect.TypeOf((*MockMachine)(nil).Raw))
 }
 
 // RemoveAllAddresses mocks base method
 func (m *MockMachine) RemoveAllAddresses() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllAddresses")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -177,11 +198,13 @@ func (m *MockMachine) RemoveAllAddresses() error {
 
 // RemoveAllAddresses indicates an expected call of RemoveAllAddresses
 func (mr *MockMachineMockRecorder) RemoveAllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllAddresses", reflect.TypeOf((*MockMachine)(nil).RemoveAllAddresses))
 }
 
 // SetConstraints mocks base method
 func (m *MockMachine) SetConstraints(arg0 constraints.Value) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConstraints", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -189,11 +212,13 @@ func (m *MockMachine) SetConstraints(arg0 constraints.Value) error {
 
 // SetConstraints indicates an expected call of SetConstraints
 func (mr *MockMachineMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockMachine)(nil).SetConstraints), arg0)
 }
 
 // SetDevicesAddresses mocks base method
 func (m *MockMachine) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -205,11 +230,13 @@ func (m *MockMachine) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) 
 
 // SetDevicesAddresses indicates an expected call of SetDevicesAddresses
 func (mr *MockMachineMockRecorder) SetDevicesAddresses(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicesAddresses", reflect.TypeOf((*MockMachine)(nil).SetDevicesAddresses), arg0...)
 }
 
 // SetLinkLayerDevices mocks base method
 func (m *MockMachine) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -221,11 +248,13 @@ func (m *MockMachine) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) err
 
 // SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices
 func (mr *MockMachineMockRecorder) SetLinkLayerDevices(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkLayerDevices", reflect.TypeOf((*MockMachine)(nil).SetLinkLayerDevices), arg0...)
 }
 
 // SetParentLinkLayerDevicesBeforeTheirChildren mocks base method
 func (m *MockMachine) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetParentLinkLayerDevicesBeforeTheirChildren", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -233,11 +262,13 @@ func (m *MockMachine) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.
 
 // SetParentLinkLayerDevicesBeforeTheirChildren indicates an expected call of SetParentLinkLayerDevicesBeforeTheirChildren
 func (mr *MockMachineMockRecorder) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParentLinkLayerDevicesBeforeTheirChildren", reflect.TypeOf((*MockMachine)(nil).SetParentLinkLayerDevicesBeforeTheirChildren), arg0)
 }
 
 // Units mocks base method
 func (m *MockMachine) Units() ([]provisioner.Unit, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units")
 	ret0, _ := ret[0].([]provisioner.Unit)
 	ret1, _ := ret[1].(error)
@@ -246,6 +277,7 @@ func (m *MockMachine) Units() ([]provisioner.Unit, error) {
 
 // Units indicates an expected call of Units
 func (mr *MockMachineMockRecorder) Units() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockMachine)(nil).Units))
 }
 
@@ -273,9 +305,10 @@ func (m *MockBridgePolicy) EXPECT() *MockBridgePolicyMockRecorder {
 }
 
 // FindMissingBridgesForContainer mocks base method
-func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Machine, arg1 containerizer.Container) ([]network.DeviceToBridge, int, error) {
+func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Machine, arg1 containerizer.Container) ([]network0.DeviceToBridge, int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindMissingBridgesForContainer", arg0, arg1)
-	ret0, _ := ret[0].([]network.DeviceToBridge)
+	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -283,19 +316,23 @@ func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Mac
 
 // FindMissingBridgesForContainer indicates an expected call of FindMissingBridgesForContainer
 func (mr *MockBridgePolicyMockRecorder) FindMissingBridgesForContainer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMissingBridgesForContainer", reflect.TypeOf((*MockBridgePolicy)(nil).FindMissingBridgesForContainer), arg0, arg1)
 }
 
 // PopulateContainerLinkLayerDevices mocks base method
-func (m *MockBridgePolicy) PopulateContainerLinkLayerDevices(arg0 containerizer.Machine, arg1 containerizer.Container) error {
-	ret := m.ctrl.Call(m, "PopulateContainerLinkLayerDevices", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (m *MockBridgePolicy) PopulateContainerLinkLayerDevices(arg0 containerizer.Machine, arg1 containerizer.Container, arg2 bool) (network.InterfaceInfos, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PopulateContainerLinkLayerDevices", arg0, arg1, arg2)
+	ret0, _ := ret[0].(network.InterfaceInfos)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PopulateContainerLinkLayerDevices indicates an expected call of PopulateContainerLinkLayerDevices
-func (mr *MockBridgePolicyMockRecorder) PopulateContainerLinkLayerDevices(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopulateContainerLinkLayerDevices", reflect.TypeOf((*MockBridgePolicy)(nil).PopulateContainerLinkLayerDevices), arg0, arg1)
+func (mr *MockBridgePolicyMockRecorder) PopulateContainerLinkLayerDevices(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopulateContainerLinkLayerDevices", reflect.TypeOf((*MockBridgePolicy)(nil).PopulateContainerLinkLayerDevices), arg0, arg1, arg2)
 }
 
 // MockUnit is a mock of Unit interface
@@ -323,6 +360,7 @@ func (m *MockUnit) EXPECT() *MockUnitMockRecorder {
 
 // Application mocks base method
 func (m *MockUnit) Application() (provisioner.Application, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application")
 	ret0, _ := ret[0].(provisioner.Application)
 	ret1, _ := ret[1].(error)
@@ -331,11 +369,13 @@ func (m *MockUnit) Application() (provisioner.Application, error) {
 
 // Application indicates an expected call of Application
 func (mr *MockUnitMockRecorder) Application() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUnit)(nil).Application))
 }
 
 // Name mocks base method
 func (m *MockUnit) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -343,6 +383,7 @@ func (m *MockUnit) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockUnitMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockUnit)(nil).Name))
 }
 
@@ -371,6 +412,7 @@ func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 
 // Charm mocks base method
 func (m *MockApplication) Charm() (provisioner.Charm, bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm")
 	ret0, _ := ret[0].(provisioner.Charm)
 	ret1, _ := ret[1].(bool)
@@ -380,11 +422,13 @@ func (m *MockApplication) Charm() (provisioner.Charm, bool, error) {
 
 // Charm indicates an expected call of Charm
 func (mr *MockApplicationMockRecorder) Charm() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockApplication)(nil).Charm))
 }
 
 // Name mocks base method
 func (m *MockApplication) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -392,6 +436,7 @@ func (m *MockApplication) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockApplicationMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockApplication)(nil).Name))
 }
 
@@ -419,19 +464,22 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 }
 
 // LXDProfile mocks base method
-func (m *MockCharm) LXDProfile() *charm_v6.LXDProfile {
+func (m *MockCharm) LXDProfile() *charm.LXDProfile {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfile")
-	ret0, _ := ret[0].(*charm_v6.LXDProfile)
+	ret0, _ := ret[0].(*charm.LXDProfile)
 	return ret0
 }
 
 // LXDProfile indicates an expected call of LXDProfile
 func (mr *MockCharmMockRecorder) LXDProfile() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfile", reflect.TypeOf((*MockCharm)(nil).LXDProfile))
 }
 
 // Revision mocks base method
 func (m *MockCharm) Revision() int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revision")
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -439,5 +487,6 @@ func (m *MockCharm) Revision() int {
 
 // Revision indicates an expected call of Revision
 func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -950,6 +950,9 @@ func (api *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
 
 // GetContainerInterfaceInfo returns information to configure networking for a
 // container. It accepts container tags as arguments.
+// TODO (manadart 2020-07-23): This method is not used and can be removed when
+// next this facade version is bumped.
+// We then don't need the parameterised prepareOrGet...
 func (api *ProvisionerAPI) GetContainerInterfaceInfo(args params.Entities) (
 	params.MachineNetworkConfigResults,
 	error,

--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -29,7 +29,6 @@ var logger = loggo.GetLogger("juju.container.broker")
 type APICalls interface {
 	ContainerConfig() (params.ContainerConfig, error)
 	PrepareContainerInterfaceInfo(names.MachineTag) (corenetwork.InterfaceInfos, error)
-	GetContainerInterfaceInfo(names.MachineTag) (corenetwork.InterfaceInfos, error)
 	GetContainerProfileInfo(names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error)
 	ReleaseContainerAddresses(names.MachineTag) error
 	SetHostMachineNetworkConfig(names.MachineTag, []params.NetworkConfig) error
@@ -40,22 +39,9 @@ type APICalls interface {
 // system. Defined here so it can be overridden for testing.
 var resolvConfFiles = []string{"/etc/resolv.conf", "/etc/systemd/resolved.conf", "/run/systemd/resolve/resolv.conf"}
 
-func prepareOrGetContainerInterfaceInfo(
-	api APICalls,
-	machineID string,
-	allocateOrMaintain bool,
-	log loggo.Logger,
+func prepareContainerInterfaceInfo(
+	api APICalls, machineID string, log loggo.Logger,
 ) (corenetwork.InterfaceInfos, error) {
-	maintain := !allocateOrMaintain
-
-	if maintain {
-		// TODO(jam): 2016-12-14 The function is called
-		// 'prepareOrGet', but the only time we would handle the 'Get'
-		// side, we explicitly abort. Something seems wrong.
-		log.Debugf("not running maintenance for machine %q", machineID)
-		return nil, nil
-	}
-
 	log.Debugf("using multi-bridge networking for container %q", machineID)
 
 	containerTag := names.NewMachineTag(machineID)

--- a/container/broker/kvm-broker.go
+++ b/container/broker/kvm-broker.go
@@ -76,11 +76,7 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, errors.Trace(err)
 	}
 
-	preparedInfo, err := prepareContainerInterfaceInfo(
-		broker.api,
-		containerMachineID,
-		kvmLogger,
-	)
+	preparedInfo, err := prepareContainerInterfaceInfo(broker.api, containerMachineID, kvmLogger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/container/broker/kvm-broker.go
+++ b/container/broker/kvm-broker.go
@@ -76,10 +76,9 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, errors.Trace(err)
 	}
 
-	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
+	preparedInfo, err := prepareContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
-		true, // allocate if possible, do not maintain existing.
 		kvmLogger,
 	)
 	if err != nil {
@@ -89,7 +88,7 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 	// Something to fallback to if there are no devices given in args.NetworkInfo
 	// TODO(jam): 2017-02-07, this feels like something that should never need
 	// to be invoked, because either StartInstance or
-	// prepareOrGetContainerInterfaceInfo should always return a value. The
+	// prepareContainerInterfaceInfo should always return a value. The
 	// test suite currently doesn't think so, and I'm hesitant to munge it too
 	// much.
 	interfaces, err := finishNetworkConfig(bridgeDevice, preparedInfo)
@@ -158,20 +157,9 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 	}, nil
 }
 
-// MaintainInstance ensures the container's host has the required iptables and
-// routing rules to make the container visible to both the host and other
-// machines on the same subnet.
-func (broker *kvmBroker) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {
-	machineID := args.InstanceConfig.MachineId
-
-	// There's no InterfaceInfo we expect to get below.
-	_, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineID,
-		false, // maintain, do not allocate.
-		kvmLogger,
-	)
-	return err
+// MaintainInstance is a no-op.
+func (broker *kvmBroker) MaintainInstance(_ context.ProviderCallContext, _ environs.StartInstanceParams) error {
+	return nil
 }
 
 // StopInstances shuts down the given instances.

--- a/container/broker/kvm-broker.go
+++ b/container/broker/kvm-broker.go
@@ -147,9 +147,8 @@ func (broker *kvmBroker) StartInstance(ctx context.ProviderCallContext, args env
 	}
 	kvmLogger.Infof("started kvm container for containerMachineID: %s, %s, %s", containerMachineID, inst.Id(), hardware.String())
 	return &environs.StartInstanceResult{
-		Instance:    inst,
-		Hardware:    hardware,
-		NetworkInfo: interfaces,
+		Instance: inst,
+		Hardware: hardware,
 	}, nil
 }
 

--- a/container/broker/kvm-broker_test.go
+++ b/container/broker/kvm-broker_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/container/kvm/mock"
 	kvmtesting "github.com/juju/juju/container/kvm/testing"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	coretesting "github.com/juju/juju/testing"
@@ -206,30 +205,6 @@ func (s *kvmBrokerSuite) kvmContainerDir(result *environs.StartInstanceResult) s
 func (s *kvmBrokerSuite) kvmRemovedContainerDir(result *environs.StartInstanceResult) string {
 	inst := result.Instance
 	return filepath.Join(s.RemovedDir, string(inst.Id()))
-}
-
-func (s *kvmBrokerSuite) TestStartInstancePopulatesNetworkInfo(c *gc.C) {
-	broker, brokerErr := s.newKVMBroker(c)
-	c.Assert(brokerErr, jc.ErrorIsNil)
-
-	patchResolvConf(s, c)
-
-	result, err := s.startInstance(c, broker, "1/kvm/42")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(result.NetworkInfo, gc.HasLen, 1)
-	iface := result.NetworkInfo[0]
-	c.Assert(iface, jc.DeepEquals, corenetwork.InterfaceInfo{
-		DeviceIndex:         0,
-		CIDR:                "0.1.2.0/24",
-		InterfaceName:       "dummy0",
-		ParentInterfaceName: "virbr0",
-		MACAddress:          "aa:bb:cc:dd:ee:ff",
-		Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.1.2.3")},
-		GatewayAddress:      corenetwork.NewProviderAddress("0.1.2.1"),
-		DNSServers:          corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
-		DNSSearchDomains:    []string{"dummy", "invalid"},
-	})
 }
 
 func (s *kvmBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) {

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -70,11 +70,7 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, errors.Trace(err)
 	}
 
-	preparedInfo, err := prepareContainerInterfaceInfo(
-		broker.api,
-		containerMachineID,
-		lxdLogger,
-	)
+	preparedInfo, err := prepareContainerInterfaceInfo(broker.api, containerMachineID, lxdLogger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -145,9 +145,8 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 	}
 
 	return &environs.StartInstanceResult{
-		Instance:    inst,
-		Hardware:    hardware,
-		NetworkInfo: interfaces,
+		Instance: inst,
+		Hardware: hardware,
 	}, nil
 }
 

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -70,10 +70,9 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, errors.Trace(err)
 	}
 
-	preparedInfo, err := prepareOrGetContainerInterfaceInfo(
+	preparedInfo, err := prepareContainerInterfaceInfo(
 		broker.api,
 		containerMachineID,
-		true, // allocate if possible, do not maintain existing.
 		lxdLogger,
 	)
 	if err != nil {
@@ -82,7 +81,7 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 	// Something to fallback to if there are no devices given in args.NetworkInfo
 	// TODO(jam): 2017-02-07, this feels like something that should never need
 	// to be invoked, because either StartInstance or
-	// prepareOrGetContainerInterfaceInfo should always return a value. The
+	// prepareContainerInterfaceInfo should always return a value. The
 	// test suite currently doesn't think so, and I'm hesitant to munge it too
 	// much.
 	bridgeDevice := broker.agentConfig.Value(agent.LxdBridge)
@@ -179,20 +178,9 @@ func (broker *lxdBroker) AllRunningInstances(ctx context.ProviderCallContext) (r
 	return broker.manager.ListContainers()
 }
 
-// MaintainInstance ensures the container's host has the required iptables and
-// routing rules to make the container visible to both the host and other
-// machines on the same subnet.
-func (broker *lxdBroker) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {
-	machineID := args.InstanceConfig.MachineId
-
-	// There's no InterfaceInfo we expect to get below.
-	_, err := prepareOrGetContainerInterfaceInfo(
-		broker.api,
-		machineID,
-		false, // maintain, do not allocate.
-		lxdLogger,
-	)
-	return err
+// MaintainInstance is a no-op.
+func (broker *lxdBroker) MaintainInstance(_ context.ProviderCallContext, _ environs.StartInstanceParams) error {
+	return nil
 }
 
 // LXDProfileNames returns all the profiles for a container that the broker

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -106,29 +106,6 @@ func (s *lxdBrokerSuite) TestStartInstanceWithoutHostNetworkChanges(c *gc.C) {
 	c.Assert(instanceConfig.ToolsList().Arches(), jc.DeepEquals, []string{"amd64"})
 }
 
-func (s *lxdBrokerSuite) TestStartInstancePopulatesNetworkInfo(c *gc.C) {
-	broker, brokerErr := s.newLXDBroker(c)
-	c.Assert(brokerErr, jc.ErrorIsNil)
-
-	patchResolvConf(s, c)
-
-	result, err := s.startInstance(c, broker, "1/lxd/0")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.NetworkInfo, gc.HasLen, 1)
-	iface := result.NetworkInfo[0]
-	c.Assert(iface, jc.DeepEquals, corenetwork.InterfaceInfo{
-		DeviceIndex:         0,
-		CIDR:                "0.1.2.0/24",
-		InterfaceName:       "dummy0",
-		ParentInterfaceName: "lxdbr0",
-		MACAddress:          "aa:bb:cc:dd:ee:ff",
-		Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.1.2.3")},
-		GatewayAddress:      corenetwork.NewProviderAddress("0.1.2.1"),
-		DNSServers:          corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
-		DNSSearchDomains:    []string{"dummy", "invalid"},
-	})
-}
-
 func (s *lxdBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) {
 	broker, brokerErr := s.newLXDBroker(c)
 	c.Assert(brokerErr, jc.ErrorIsNil)

--- a/container/broker/mocks/apicalls_mock.go
+++ b/container/broker/mocks/apicalls_mock.go
@@ -5,14 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	provisioner "github.com/juju/juju/api/provisioner"
 	params "github.com/juju/juju/apiserver/params"
-	corenetwork "github.com/juju/juju/core/network"
-	network "github.com/juju/juju/network"
-	names_v3 "github.com/juju/names/v4"
+	network "github.com/juju/juju/core/network"
+	network0 "github.com/juju/juju/network"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockAPICalls is a mock of APICalls interface
@@ -40,6 +39,7 @@ func (m *MockAPICalls) EXPECT() *MockAPICallsMockRecorder {
 
 // ContainerConfig mocks base method
 func (m *MockAPICalls) ContainerConfig() (params.ContainerConfig, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerConfig")
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
@@ -48,24 +48,13 @@ func (m *MockAPICalls) ContainerConfig() (params.ContainerConfig, error) {
 
 // ContainerConfig indicates an expected call of ContainerConfig
 func (mr *MockAPICallsMockRecorder) ContainerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockAPICalls)(nil).ContainerConfig))
 }
 
-// GetContainerInterfaceInfo mocks base method
-func (m *MockAPICalls) GetContainerInterfaceInfo(arg0 names_v3.MachineTag) (corenetwork.InterfaceInfos, error) {
-	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].(corenetwork.InterfaceInfos)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetContainerInterfaceInfo indicates an expected call of GetContainerInterfaceInfo
-func (mr *MockAPICallsMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfaceInfo", reflect.TypeOf((*MockAPICalls)(nil).GetContainerInterfaceInfo), arg0)
-}
-
 // GetContainerProfileInfo mocks base method
-func (m *MockAPICalls) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+func (m *MockAPICalls) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
@@ -74,13 +63,15 @@ func (m *MockAPICalls) GetContainerProfileInfo(arg0 names_v3.MachineTag) ([]*pro
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo
 func (mr *MockAPICallsMockRecorder) GetContainerProfileInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockAPICalls)(nil).GetContainerProfileInfo), arg0)
 }
 
 // HostChangesForContainer mocks base method
-func (m *MockAPICalls) HostChangesForContainer(arg0 names_v3.MachineTag) ([]network.DeviceToBridge, int, error) {
+func (m *MockAPICalls) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
-	ret0, _ := ret[0].([]network.DeviceToBridge)
+	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -88,24 +79,28 @@ func (m *MockAPICalls) HostChangesForContainer(arg0 names_v3.MachineTag) ([]netw
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer
 func (mr *MockAPICallsMockRecorder) HostChangesForContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockAPICalls)(nil).HostChangesForContainer), arg0)
 }
 
 // PrepareContainerInterfaceInfo mocks base method
-func (m *MockAPICalls) PrepareContainerInterfaceInfo(arg0 names_v3.MachineTag) (corenetwork.InterfaceInfos, error) {
+func (m *MockAPICalls) PrepareContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].(corenetwork.InterfaceInfos)
+	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo
 func (mr *MockAPICallsMockRecorder) PrepareContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockAPICalls)(nil).PrepareContainerInterfaceInfo), arg0)
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockAPICalls) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error {
+func (m *MockAPICalls) ReleaseContainerAddresses(arg0 names.MachineTag) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -113,11 +108,13 @@ func (m *MockAPICalls) ReleaseContainerAddresses(arg0 names_v3.MachineTag) error
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses
 func (mr *MockAPICallsMockRecorder) ReleaseContainerAddresses(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockAPICalls)(nil).ReleaseContainerAddresses), arg0)
 }
 
 // SetHostMachineNetworkConfig mocks base method
-func (m *MockAPICalls) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg1 []params.NetworkConfig) error {
+func (m *MockAPICalls) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -125,5 +122,6 @@ func (m *MockAPICalls) SetHostMachineNetworkConfig(arg0 names_v3.MachineTag, arg
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig
 func (mr *MockAPICallsMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockAPICalls)(nil).SetHostMachineNetworkConfig), arg0, arg1)
 }

--- a/network/containerizer/bridgepolicy_mock_test.go
+++ b/network/containerizer/bridgepolicy_mock_test.go
@@ -5,14 +5,13 @@
 package containerizer
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
+	reflect "reflect"
 )
 
 // MockContainer is a mock of Container interface
@@ -40,6 +39,7 @@ func (m *MockContainer) EXPECT() *MockContainerMockRecorder {
 
 // AllAddresses mocks base method
 func (m *MockContainer) AllAddresses() ([]Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllAddresses")
 	ret0, _ := ret[0].([]Address)
 	ret1, _ := ret[1].(error)
@@ -48,11 +48,13 @@ func (m *MockContainer) AllAddresses() ([]Address, error) {
 
 // AllAddresses indicates an expected call of AllAddresses
 func (mr *MockContainerMockRecorder) AllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockContainer)(nil).AllAddresses))
 }
 
 // AllLinkLayerDevices mocks base method
 func (m *MockContainer) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllLinkLayerDevices")
 	ret0, _ := ret[0].([]LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -61,11 +63,13 @@ func (m *MockContainer) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
 
 // AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices
 func (mr *MockContainerMockRecorder) AllLinkLayerDevices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllLinkLayerDevices", reflect.TypeOf((*MockContainer)(nil).AllLinkLayerDevices))
 }
 
 // AllSpaces mocks base method
 func (m *MockContainer) AllSpaces() (set.Strings, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
 	ret0, _ := ret[0].(set.Strings)
 	ret1, _ := ret[1].(error)
@@ -74,11 +78,13 @@ func (m *MockContainer) AllSpaces() (set.Strings, error) {
 
 // AllSpaces indicates an expected call of AllSpaces
 func (mr *MockContainerMockRecorder) AllSpaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockContainer)(nil).AllSpaces))
 }
 
 // Constraints mocks base method
 func (m *MockContainer) Constraints() (constraints.Value, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
 	ret0, _ := ret[0].(constraints.Value)
 	ret1, _ := ret[1].(error)
@@ -87,11 +93,13 @@ func (m *MockContainer) Constraints() (constraints.Value, error) {
 
 // Constraints indicates an expected call of Constraints
 func (mr *MockContainerMockRecorder) Constraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockContainer)(nil).Constraints))
 }
 
 // ContainerType mocks base method
 func (m *MockContainer) ContainerType() instance.ContainerType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
 	ret0, _ := ret[0].(instance.ContainerType)
 	return ret0
@@ -99,11 +107,13 @@ func (m *MockContainer) ContainerType() instance.ContainerType {
 
 // ContainerType indicates an expected call of ContainerType
 func (mr *MockContainerMockRecorder) ContainerType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockContainer)(nil).ContainerType))
 }
 
 // Id mocks base method
 func (m *MockContainer) Id() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -111,11 +121,13 @@ func (m *MockContainer) Id() string {
 
 // Id indicates an expected call of Id
 func (mr *MockContainerMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockContainer)(nil).Id))
 }
 
 // Raw mocks base method
 func (m *MockContainer) Raw() *state.Machine {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Raw")
 	ret0, _ := ret[0].(*state.Machine)
 	return ret0
@@ -123,11 +135,13 @@ func (m *MockContainer) Raw() *state.Machine {
 
 // Raw indicates an expected call of Raw
 func (mr *MockContainerMockRecorder) Raw() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Raw", reflect.TypeOf((*MockContainer)(nil).Raw))
 }
 
 // RemoveAllAddresses mocks base method
 func (m *MockContainer) RemoveAllAddresses() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllAddresses")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -135,11 +149,13 @@ func (m *MockContainer) RemoveAllAddresses() error {
 
 // RemoveAllAddresses indicates an expected call of RemoveAllAddresses
 func (mr *MockContainerMockRecorder) RemoveAllAddresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllAddresses", reflect.TypeOf((*MockContainer)(nil).RemoveAllAddresses))
 }
 
 // SetConstraints mocks base method
 func (m *MockContainer) SetConstraints(arg0 constraints.Value) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConstraints", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -147,11 +163,13 @@ func (m *MockContainer) SetConstraints(arg0 constraints.Value) error {
 
 // SetConstraints indicates an expected call of SetConstraints
 func (mr *MockContainerMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockContainer)(nil).SetConstraints), arg0)
 }
 
 // SetDevicesAddresses mocks base method
 func (m *MockContainer) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -163,11 +181,13 @@ func (m *MockContainer) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress
 
 // SetDevicesAddresses indicates an expected call of SetDevicesAddresses
 func (mr *MockContainerMockRecorder) SetDevicesAddresses(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicesAddresses", reflect.TypeOf((*MockContainer)(nil).SetDevicesAddresses), arg0...)
 }
 
 // SetLinkLayerDevices mocks base method
 func (m *MockContainer) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -179,11 +199,13 @@ func (m *MockContainer) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) e
 
 // SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices
 func (mr *MockContainerMockRecorder) SetLinkLayerDevices(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkLayerDevices", reflect.TypeOf((*MockContainer)(nil).SetLinkLayerDevices), arg0...)
 }
 
 // SetParentLinkLayerDevicesBeforeTheirChildren mocks base method
 func (m *MockContainer) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.LinkLayerDeviceArgs) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetParentLinkLayerDevicesBeforeTheirChildren", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -191,6 +213,7 @@ func (m *MockContainer) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []stat
 
 // SetParentLinkLayerDevicesBeforeTheirChildren indicates an expected call of SetParentLinkLayerDevicesBeforeTheirChildren
 func (mr *MockContainerMockRecorder) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParentLinkLayerDevicesBeforeTheirChildren", reflect.TypeOf((*MockContainer)(nil).SetParentLinkLayerDevicesBeforeTheirChildren), arg0)
 }
 
@@ -219,6 +242,7 @@ func (m *MockAddress) EXPECT() *MockAddressMockRecorder {
 
 // DeviceName mocks base method
 func (m *MockAddress) DeviceName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeviceName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -226,11 +250,13 @@ func (m *MockAddress) DeviceName() string {
 
 // DeviceName indicates an expected call of DeviceName
 func (mr *MockAddressMockRecorder) DeviceName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeviceName", reflect.TypeOf((*MockAddress)(nil).DeviceName))
 }
 
 // Subnet mocks base method
 func (m *MockAddress) Subnet() (Subnet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnet")
 	ret0, _ := ret[0].(Subnet)
 	ret1, _ := ret[1].(error)
@@ -239,6 +265,7 @@ func (m *MockAddress) Subnet() (Subnet, error) {
 
 // Subnet indicates an expected call of Subnet
 func (mr *MockAddressMockRecorder) Subnet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockAddress)(nil).Subnet))
 }
 
@@ -267,6 +294,7 @@ func (m *MockSubnet) EXPECT() *MockSubnetMockRecorder {
 
 // SpaceID mocks base method
 func (m *MockSubnet) SpaceID() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpaceID")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -274,6 +302,7 @@ func (m *MockSubnet) SpaceID() string {
 
 // SpaceID indicates an expected call of SpaceID
 func (mr *MockSubnetMockRecorder) SpaceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceID", reflect.TypeOf((*MockSubnet)(nil).SpaceID))
 }
 
@@ -302,6 +331,7 @@ func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 
 // Addresses mocks base method
 func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addresses")
 	ret0, _ := ret[0].([]*state.Address)
 	ret1, _ := ret[1].(error)
@@ -310,24 +340,28 @@ func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 
 // Addresses indicates an expected call of Addresses
 func (mr *MockLinkLayerDeviceMockRecorder) Addresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockLinkLayerDevice)(nil).Addresses))
 }
 
 // EthernetDeviceForBridge mocks base method
-func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string) (state.LinkLayerDeviceArgs, error) {
-	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0)
-	ret0, _ := ret[0].(state.LinkLayerDeviceArgs)
+func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string, arg1 bool) (network.InterfaceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0, arg1)
+	ret0, _ := ret[0].(network.InterfaceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge
-func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0)
+func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0, arg1)
 }
 
 // IsAutoStart mocks base method
 func (m *MockLinkLayerDevice) IsAutoStart() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAutoStart")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -335,11 +369,13 @@ func (m *MockLinkLayerDevice) IsAutoStart() bool {
 
 // IsAutoStart indicates an expected call of IsAutoStart
 func (mr *MockLinkLayerDeviceMockRecorder) IsAutoStart() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAutoStart", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsAutoStart))
 }
 
 // IsUp mocks base method
 func (m *MockLinkLayerDevice) IsUp() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUp")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -347,11 +383,13 @@ func (m *MockLinkLayerDevice) IsUp() bool {
 
 // IsUp indicates an expected call of IsUp
 func (mr *MockLinkLayerDeviceMockRecorder) IsUp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUp", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsUp))
 }
 
 // MACAddress mocks base method
 func (m *MockLinkLayerDevice) MACAddress() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MACAddress")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -359,11 +397,13 @@ func (m *MockLinkLayerDevice) MACAddress() string {
 
 // MACAddress indicates an expected call of MACAddress
 func (mr *MockLinkLayerDeviceMockRecorder) MACAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MACAddress", reflect.TypeOf((*MockLinkLayerDevice)(nil).MACAddress))
 }
 
 // MTU mocks base method
 func (m *MockLinkLayerDevice) MTU() uint {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MTU")
 	ret0, _ := ret[0].(uint)
 	return ret0
@@ -371,11 +411,13 @@ func (m *MockLinkLayerDevice) MTU() uint {
 
 // MTU indicates an expected call of MTU
 func (mr *MockLinkLayerDeviceMockRecorder) MTU() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockLinkLayerDevice)(nil).MTU))
 }
 
 // Name mocks base method
 func (m *MockLinkLayerDevice) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -383,11 +425,13 @@ func (m *MockLinkLayerDevice) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
 // ParentDevice mocks base method
 func (m *MockLinkLayerDevice) ParentDevice() (LinkLayerDevice, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentDevice")
 	ret0, _ := ret[0].(LinkLayerDevice)
 	ret1, _ := ret[1].(error)
@@ -396,11 +440,13 @@ func (m *MockLinkLayerDevice) ParentDevice() (LinkLayerDevice, error) {
 
 // ParentDevice indicates an expected call of ParentDevice
 func (mr *MockLinkLayerDeviceMockRecorder) ParentDevice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentDevice", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentDevice))
 }
 
 // ParentName mocks base method
 func (m *MockLinkLayerDevice) ParentName() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentName")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -408,11 +454,13 @@ func (m *MockLinkLayerDevice) ParentName() string {
 
 // ParentName indicates an expected call of ParentName
 func (mr *MockLinkLayerDeviceMockRecorder) ParentName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentName", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentName))
 }
 
 // Type mocks base method
 func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
 	ret0, _ := ret[0].(network.LinkLayerDeviceType)
 	return ret0
@@ -420,5 +468,6 @@ func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 
 // Type indicates an expected call of Type
 func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
 }

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -28,7 +28,7 @@ type LinkLayerDevice interface {
 	MACAddress() string
 	ParentName() string
 	ParentDevice() (LinkLayerDevice, error)
-	EthernetDeviceForBridge(name string) (state.LinkLayerDeviceArgs, error)
+	EthernetDeviceForBridge(name string, askForProviderAddress bool) (network.InterfaceInfo, error)
 	Addresses() ([]*state.Address, error)
 
 	// These are recruited in tests. See comment on Machine below.

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -525,21 +525,53 @@ func (dev *LinkLayerDevice) RemoveAddresses() error {
 	return dev.st.db().RunTransaction(ops)
 }
 
-// EthernetDeviceForBridge returns LinkLayerDeviceArgs representing an ethernet
+// EthernetDeviceForBridge an InterfaceInfo representing an ethernet
 // device with the input name and this device as its parent.
+// The detail supplied reflects whether the provider is expected to supply the
+// interface's eventual address.
 // If the device is not a bridge, an error is returned.
-func (dev *LinkLayerDevice) EthernetDeviceForBridge(name string) (LinkLayerDeviceArgs, error) {
+func (dev *LinkLayerDevice) EthernetDeviceForBridge(
+	name string, askProviderForAddress bool,
+) (network.InterfaceInfo, error) {
+	var newDev network.InterfaceInfo
+
 	if dev.Type() != network.BridgeDevice {
-		return LinkLayerDeviceArgs{}, errors.Errorf("device must be a Bridge Device, receiver has type %q", dev.Type())
+		return newDev, errors.Errorf("device must be a Bridge Device, but is type %q", dev.Type())
 	}
 
-	return LinkLayerDeviceArgs{
-		Name:        name,
-		Type:        network.EthernetDevice,
-		MACAddress:  network.GenerateVirtualMACAddress(),
-		MTU:         dev.MTU(),
-		IsUp:        true,
-		IsAutoStart: true,
-		ParentName:  dev.ID(),
-	}, nil
+	addrs, err := dev.Addresses()
+	if err != nil {
+		return network.InterfaceInfo{}, errors.Trace(err)
+	}
+
+	newDev = network.InterfaceInfo{
+		InterfaceName:       name,
+		MACAddress:          network.GenerateVirtualMACAddress(),
+		ConfigType:          network.ConfigManual,
+		InterfaceType:       network.EthernetInterface,
+		MTU:                 int(dev.MTU()),
+		ParentInterfaceName: dev.Name(),
+	}
+
+	if len(addrs) > 0 {
+		addr := addrs[0]
+		if askProviderForAddress {
+			sub, err := addr.Subnet()
+			if err != nil {
+				return newDev, errors.Annotatef(err,
+					"retrieving subnet %q used by address %q of host machine device %q",
+					addr.SubnetCIDR(), addr.Value(), dev.Name(),
+				)
+			}
+			newDev.ConfigType = network.ConfigStatic
+			newDev.CIDR = sub.CIDR()
+			newDev.ProviderSubnetId = sub.ProviderId()
+			newDev.VLANTag = sub.VLANTag()
+			newDev.IsDefaultGateway = addr.IsDefaultGateway()
+		} else {
+			newDev.CIDR = addr.SubnetCIDR()
+		}
+	}
+
+	return newDev, nil
 }

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -525,7 +525,7 @@ func (dev *LinkLayerDevice) RemoveAddresses() error {
 	return dev.st.db().RunTransaction(ops)
 }
 
-// EthernetDeviceForBridge an InterfaceInfo representing an ethernet
+// EthernetDeviceForBridge returns an InterfaceInfo representing an ethernet
 // device with the input name and this device as its parent.
 // The detail supplied reflects whether the provider is expected to supply the
 // interface's eventual address.
@@ -547,7 +547,7 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(
 	newDev = network.InterfaceInfo{
 		InterfaceName:       name,
 		MACAddress:          network.GenerateVirtualMACAddress(),
-		ConfigType:          network.ConfigManual,
+		ConfigType:          network.ConfigDHCP,
 		InterfaceType:       network.EthernetInterface,
 		MTU:                 int(dev.MTU()),
 		ParentInterfaceName: dev.Name(),

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -732,7 +732,7 @@ func (s *linkLayerDevicesStateSuite) TestEthernetDeviceForBridge(c *gc.C) {
 	child, err = dev.EthernetDeviceForBridge("eth0", false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(child.ConfigType, gc.Equals, corenetwork.ConfigManual)
+	c.Check(child.ConfigType, gc.Equals, corenetwork.ConfigDHCP)
 	c.Check(child.ProviderSubnetId, gc.Equals, corenetwork.Id(""))
 
 	dev = s.addNamedDevice(c, "bond0")

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -708,6 +708,38 @@ func (s *linkLayerDevicesStateSuite) TestUpdateOps(c *gc.C) {
 	c.Check(dev.MACAddress(), gc.Equals, mac)
 }
 
+func (s *linkLayerDevicesStateSuite) TestEthernetDeviceForBridge(c *gc.C) {
+	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{
+		CIDR:       "10.0.0.0/24",
+		ProviderId: "ps-01",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.createBridgeWithIP(c, s.machine, "br0", "10.0.0.9/24")
+
+	dev, err := s.machine.LinkLayerDevice("br0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	child, err := dev.EthernetDeviceForBridge("eth0", true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(child.InterfaceName, gc.Equals, "eth0")
+	c.Check(child.ConfigType, gc.Equals, corenetwork.ConfigStatic)
+	c.Check(child.ParentInterfaceName, gc.Equals, "br0")
+	c.Check(child.CIDR, gc.Equals, "10.0.0.0/24")
+	c.Check(child.ProviderSubnetId, gc.Equals, corenetwork.Id("ps-01"))
+
+	child, err = dev.EthernetDeviceForBridge("eth0", false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(child.ConfigType, gc.Equals, corenetwork.ConfigManual)
+	c.Check(child.ProviderSubnetId, gc.Equals, corenetwork.Id(""))
+
+	dev = s.addNamedDevice(c, "bond0")
+	_, err = dev.EthernetDeviceForBridge("eth0", false)
+	c.Assert(err, gc.NotNil)
+}
+
 func (s *linkLayerDevicesStateSuite) createSpaceAndSubnet(c *gc.C, spaceName, CIDR string) {
 	s.createSpaceAndSubnetWithProviderID(c, spaceName, CIDR, "")
 }


### PR DESCRIPTION
## Description of change

This patch changes behaviour for setting container/KVM link-layer data.

Old:
- Containers have their link-layer data generated and written to state.
- This data is retrieved and used to provision the container.
- The data never changes and container machine agents sending link-layer updates is a no-op.

New:
- Containers now have link-layer data generated, but returned directly to the provisioner without writing to state.
- Containers are provisioned with the *same* interface configuration as they were previously.
- Container machine agents set and maintain their link-layer data.

One important change from this patch is that container devices will no longer reference their parents devices on the host. This change is already manifest on the 2.7 branch and an audit of the code indicates that this will not affect any Juju behaviour.

Various logic clean-ups accompany these changes, with redundant code removed where it is effectively a no-op, or is unused.

## QA steps

For at least LXD, AWS and MAAS (container networking methods local/fan/provider):
- Bootstrap, add a machine and add a LXD container to the machine.
- Check that once up, `juju show-machine 0` includes a container with link-layer device info.

For MAAS
- Add a KVM to the machine and check for link-layer devices when it comes up.

## Documentation changes

None.

## Bug reference

N/A
