### PR TITLE
2.8 centos7 lxd

### DIFF
--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -309,6 +309,7 @@ func (s *BaseSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *BaseSuite) SetUpTest(c *gc.C) {
+	testing.SkipLXDNotSupported(c)
 	s.BaseSuiteUnpatched.SetUpTest(c)
 
 	s.Stub = &gitjujutesting.Stub{}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Cherry pick of change in develop to 2.8 that disables lxd tests in non ubuntu CI runs.

## QA steps

Run lxd unit tests on a non Ubuntu machine.

```sh
cd provider/lxd
go test .
```