### PR TITLE
Add the ability to post to introspection endpoint.

### DIFF
--- a/cmd/jujud/agent/addons/addons.go
+++ b/cmd/jujud/agent/addons/addons.go
@@ -33,8 +33,8 @@ func DefaultIntrospectionSocketName(entityTag names.Tag) string {
 type IntrospectionConfig struct {
 	Agent              agent.Agent
 	Engine             *dependency.Engine
-	StatePoolReporter  introspection.IntrospectionReporter
-	PubSubReporter     introspection.IntrospectionReporter
+	StatePoolReporter  introspection.Reporter
+	PubSubReporter     introspection.Reporter
 	MachineLock        machinelock.Lock
 	PrometheusGatherer prometheus.Gatherer
 	PresenceRecorder   presence.Recorder

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -551,12 +552,7 @@ func (a *MachineAgent) makeEngineCreator(
 		// tracker in controller agents.
 		var statePoolReporter statePoolIntrospectionReporter
 		registerIntrospectionHandlers := func(handle func(path string, h http.Handler)) {
-			introspection.RegisterHTTPHandlers(introspection.ReportSources{
-				DependencyEngine:   engine,
-				StatePool:          &statePoolReporter,
-				PubSub:             pubsubReporter,
-				PrometheusGatherer: a.prometheusRegistry,
-			}, handle)
+			handle("/metrics/", promhttp.HandlerFor(a.prometheusRegistry, promhttp.HandlerOpts{}))
 		}
 
 		manifoldsCfg := machine.ManifoldsConfig{


### PR DESCRIPTION
This adds post to the juju-introspect CLI command. 

The worker itself was cleaned up but doesn't yet use the post functionality.
That is coming in a follow up branch.

## QA steps

Just the unit tests at this stage.
