### PR TITLE
improve openstack network config error messages

### DIFF
--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -6,6 +6,7 @@ package openstack
 import (
 	"regexp"
 
+	"github.com/juju/collections/set"
 	"gopkg.in/goose.v2/neutron"
 	"gopkg.in/goose.v2/nova"
 	"gopkg.in/goose.v2/swift"
@@ -131,6 +132,11 @@ func ResolveNetwork(e environs.Environ, networkName string, external bool) (stri
 	return e.(*Environ).networking.ResolveNetwork(networkName, external)
 }
 
+// ResolveNetwork exposes environ helper function resolveNetwork for testing
+func FindNetworks(e environs.Environ, internal bool) (set.Strings, error) {
+	return e.(*Environ).networking.FindNetworks(internal)
+}
+
 var PortsToRuleInfo = rulesToRuleInfo
 var SecGroupMatchesIngressRule = secGroupMatchesIngressRule
 
@@ -161,4 +167,8 @@ func GetModelGroupNames(e environs.Environ) ([]string, error) {
 func GetFirewaller(e environs.Environ) Firewaller {
 	env := e.(*Environ)
 	return env.firewaller
+}
+
+func GetEnvironConfigNetwork(e environs.Environ) string {
+	return e.(*Environ).ecfg().network()
 }

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -132,7 +132,7 @@ func ResolveNetwork(e environs.Environ, networkName string, external bool) (stri
 	return e.(*Environ).networking.ResolveNetwork(networkName, external)
 }
 
-// ResolveNetwork exposes environ helper function resolveNetwork for testing
+// FindNetworks exposes environ helper function FindNetworks for testing
 func FindNetworks(e environs.Environ, internal bool) (set.Strings, error) {
 	return e.(*Environ).networking.FindNetworks(internal)
 }
@@ -167,8 +167,4 @@ func GetModelGroupNames(e environs.Environ) ([]string, error) {
 func GetFirewaller(e environs.Environ) Firewaller {
 	env := e.(*Environ)
 	return env.firewaller
-}
-
-func GetEnvironConfigNetwork(e environs.Environ) string {
-	return e.(*Environ).ecfg().network()
 }

--- a/provider/openstack/network_mock_test.go
+++ b/provider/openstack/network_mock_test.go
@@ -5,13 +5,13 @@
 package openstack
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	set "github.com/juju/collections/set"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	neutron "gopkg.in/goose.v2/neutron"
 	nova "gopkg.in/goose.v2/nova"
+	reflect "reflect"
 )
 
 // MockSSLHostnameConfig is a mock of SSLHostnameConfig interface
@@ -131,6 +131,21 @@ func (m *MockNetworking) DeletePortByID(arg0 string) error {
 func (mr *MockNetworkingMockRecorder) DeletePortByID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePortByID", reflect.TypeOf((*MockNetworking)(nil).DeletePortByID), arg0)
+}
+
+// FindNetworks mocks base method
+func (m *MockNetworking) FindNetworks(arg0 bool) (set.Strings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindNetworks", arg0)
+	ret0, _ := ret[0].(set.Strings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindNetworks indicates an expected call of FindNetworks
+func (mr *MockNetworkingMockRecorder) FindNetworks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNetworks", reflect.TypeOf((*MockNetworking)(nil).FindNetworks), arg0)
 }
 
 // NetworkInterfaces mocks base method

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -50,8 +50,8 @@ type Networking interface {
 	// Needed for Environ.Networking
 	NetworkInterfaces(ids []instance.Id) ([]corenetwork.InterfaceInfos, error)
 
-	// FindNetworks returns a set of names of internal or external network
-	// names depending on the provided argument.
+	// FindNetworks returns a set of internal or external network names
+	// depending on the provided argument.
 	FindNetworks(internal bool) (set.Strings, error)
 }
 
@@ -85,7 +85,7 @@ type NeutronNetworking struct {
 }
 
 // projectIDFilter returns a neutron.Filter to match Neutron Networks with
-// the give projectID.
+// the given projectID.
 func projectIDFilter(projectID string) *neutron.Filter {
 	filter := neutron.NewFilter()
 	filter.Set(neutron.FilterProjectId, projectID)
@@ -262,8 +262,8 @@ func (n *NeutronNetworking) DeletePortByID(portID string) error {
 	return client.DeletePortV2(portID)
 }
 
-// FindNetworks returns a set of names of internal or external network
-// names depending on the provided argument.
+// FindNetworks returns a set of internal or external network names
+// depending on the provided argument.
 func (n *NeutronNetworking) FindNetworks(internal bool) (set.Strings, error) {
 	var filter *neutron.Filter
 	switch internal {

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -835,7 +835,7 @@ func (s *providerUnitTests) TestNetworksForInstance(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("", false).Return("network-id-foo", nil)
+	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
 	expectDefaultNetworks(mockNetworking)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
@@ -861,7 +861,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("", false).Return("network-id-foo", nil)
+	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
 	mockNetworking.EXPECT().CreatePort("", "network-id-foo", corenetwork.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{
@@ -909,7 +909,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithNoMatchingAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("", false).Return("network-id-foo", nil)
+	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
 	expectDefaultNetworks(mockNetworking)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
@@ -929,7 +929,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithNoMatchingAZ(c *gc.C) {
 func envWithNetworking(net Networking) *Environ {
 	return &Environ{
 		ecfgUnlocked: &environConfig{
-			attrs: map[string]interface{}{NetworkKey: ""},
+			attrs: map[string]interface{}{NetworkKey: "network-id-foo"},
 		},
 		networking: net,
 	}


### PR DESCRIPTION

## Description of change

Be more helpful to the user with network config for openstack clouds.

If no network is specified in the config, attempt to look for a single internal network. If one is found, use it.  If more than one is found, error with instructional message.  If no network is found, attempt to create the instance anyway.  There are clouds like this.

If we fail to start instance with a BadRequest related to no defined network, error with an message including the error and information to make it understandable.
## QA steps


```console
# before attempting to bootstrap, ensure you do not have a network defined in clouds.yaml
$ juju bootstrap serverstack test --config use-floating-ip=true
Creating Juju controller "test" on microstack/microstack
Looking for packaged Juju agent version 2.8.2 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on microstack/microstack...
ERROR failed to bootstrap model: cannot start bootstrap instance: no network provided and one network is available: "test"
	To resolve this error, set a value for "network" in model-config or model-defaults;
	or supply it via --config when creating a new model

# destroy controller "test"
#
# create an empty network in the project of your openstack cloud.
$ openstack network create testing

$ juju bootstrap serverstack test
Creating Juju controller "test" on serverstack/serverstack
Looking for packaged Juju agent version 2.8.2 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on serverstack/serverstack...
ERROR failed to bootstrap model: cannot start bootstrap instance: no network provided and multiple available: "admin_net, testing"
	To resolve this error, set a value for "network" in model-config or model-defaults;
	or supply it via --config when creating a new model

$ juju bootstrap serverstack test --config network=admin_net --config use-floating-ip=true
Creating Juju controller "test" on serverstack/serverstack
…
Bootstrap complete, controller "test" is now available
Controller machines are in the "controller" model
Initial model "default" added

# delete all openstack networks in the project on your openstack cloud
# attempt to bootstrap
$ juju bootstrap serverstack test
# you should see the failure trace with extra messaging:
caused by: request (http://10.20.20.1:8774/v2.1/servers) returned unexpected status: 400; error info: {"badRequest": {"code": 400, "message": "Invalid input for field/attribute networks. Value: None. None is not of type 'array'"}}
	No network has been configured, nor could juju find a single internal network;
	This error was caused by juju attempting to create an instance with no network defined.

# find an openstack where your project has no network defined, which 
# does not require a network to bootstrap.
$ juju bootstrap <openstack> test
Creating Juju controller "test" on serverstack/serverstack
…
Bootstrap complete, controller "test" is now available
Controller machines are in the "controller" model
Initial model "default" added
```



## Bug reference

https://bugs.launchpad.net/juju/+bug/1889153
