### PR TITLE
Add a juju repl CLI

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -947,11 +947,12 @@ func (api *ProvisionerAPI) PrepareContainerInterfaceInfo(args params.Entities) (
 	return api.prepareOrGetContainerInterfaceInfo(args, false)
 }
 
-// GetContainerInterfaceInfo returns information to configure networking for a
-// container. It accepts container tags as arguments.
 // TODO (manadart 2020-07-23): This method is not used and can be removed when
 // next this facade version is bumped.
 // We then don't need the parameterised prepareOrGet...
+
+// GetContainerInterfaceInfo returns information to configure networking for a
+// container. It accepts container tags as arguments.
 func (api *ProvisionerAPI) GetContainerInterfaceInfo(args params.Entities) (
 	params.MachineNetworkConfigResults,
 	error,

--- a/cmd/juju/commands/repl.go
+++ b/cmd/juju/commands/repl.go
@@ -1,0 +1,228 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+type replCommand struct {
+	cmd.CommandBase
+
+	store    jujuclient.ClientStore
+	showHelp bool
+
+	execJujuCommand func(cmd.Command, *cmd.Context, []string) int
+}
+
+func newReplCommand(showHelp bool) cmd.Command {
+	return &replCommand{
+		showHelp:        showHelp,
+		store:           jujuclient.NewFileClientStore(),
+		execJujuCommand: cmd.Main,
+	}
+}
+
+const replDoc = `
+When run without arguments, enter an interactive shell which can be
+used to run any Juju command directly. When in the shell:
+  type "help" to see a list of available commands.
+  type "q" or ^D or ^C to quit.
+
+Otherwise, the supported command usage is described below.
+`
+
+var firstPrompt = `
+Welcome to the Juju interactive shell.
+Type "help" to see a list of available commands.
+Type "q" or ^D or ^C to quit.
+`[1:]
+
+// Info implements Command.
+func (c *replCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "juju",
+		Purpose: "Enter an interactive shell for running Juju commands",
+	})
+}
+
+// filterInput is used to exclude characters
+// from being accepted from stdin.
+func filterInput(r rune) (rune, bool) {
+	switch r {
+	// block CtrlZ feature
+	case readline.CharCtrlZ:
+		return r, false
+	}
+	return r, true
+}
+
+// Run implements Command.
+func (c *replCommand) Run(ctx *cmd.Context) error {
+	if err := c.Init(nil); err != nil {
+		return errors.Trace(err)
+	}
+	if c.showHelp {
+		jujuCmd := NewJujuCommand(ctx, "")
+		f := gnuflag.NewFlagSet(c.Info().Name, gnuflag.ContinueOnError)
+		f.SetOutput(ioutil.Discard)
+		jujuCmd.SetFlags(f)
+		if err := jujuCmd.Init([]string{"help"}); err != nil {
+			return errors.Trace(err)
+		}
+		fmt.Fprintln(ctx.Stdout, replDoc)
+		return jujuCmd.Run(ctx)
+	}
+
+	history, err := ioutil.TempFile("", "juju-repl")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer history.Close()
+
+	l, err := readline.NewEx(&readline.Config{
+		Stdin:               readline.NewCancelableStdin(ctx.Stdin),
+		Stdout:              ctx.Stdout,
+		Stderr:              ctx.Stderr,
+		HistoryFile:         history.Name(),
+		InterruptPrompt:     "^C",
+		HistorySearchFold:   true,
+		FuncFilterInputRune: filterInput,
+		// TODO(wallyworld) - add auto complete support
+		//AutoComplete:    jujuCompleter,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer l.Close()
+
+	// Record the default loggo writer so we can
+	// reset it before each command invocation.
+	defaultWriter, err := loggo.RemoveWriter(loggo.DefaultWriterName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	first := true
+	for {
+		// loggo maintains global state so reset before each command.
+		loggo.ResetLogging()
+		_ = loggo.RegisterWriter(loggo.DefaultWriterName, defaultWriter)
+
+		jujuCmd := NewJujuCommand(ctx, "")
+		if c.showHelp {
+			f := gnuflag.NewFlagSet(c.Info().Name, gnuflag.ContinueOnError)
+			f.SetOutput(ioutil.Discard)
+			jujuCmd.SetFlags(f)
+			if err := jujuCmd.Init([]string{"help"}); err != nil {
+				return errors.Trace(err)
+			}
+			fmt.Fprintln(ctx.Stderr, replDoc)
+			return jujuCmd.Run(ctx)
+		}
+		// Get the prompt based on the current controller/model/user.
+		prompt, err := c.getPrompt()
+		if err != nil {
+			// There's no controller, so ask the user to bootstrap first.
+			if errors.Cause(err) == modelcmd.ErrNoControllersDefined {
+				fmt.Fprintln(ctx.Stderr, modelcmd.ErrNoControllersDefined.Error())
+				return cmd.ErrSilent
+			}
+			return errors.Trace(err)
+		}
+
+		if first {
+			fmt.Fprintln(ctx.Stdout, firstPrompt)
+			first = false
+		}
+		l.SetPrompt(prompt)
+		line, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
+			} else {
+				continue
+			}
+		} else if err == io.EOF {
+			break
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.ToLower(line) == "q" {
+			break
+		}
+		args := strings.Fields(line)
+		c.execJujuCommand(jujuCmd, ctx, args)
+	}
+	return nil
+}
+
+func (c *replCommand) getPrompt() (prompt string, err error) {
+	defer func() {
+		if err == nil {
+			prompt += "$ "
+		}
+	}()
+
+	store := modelcmd.QualifyingClientStore{c.store}
+
+	controllerName, err := modelcmd.DetermineCurrentController(store)
+	if err != nil && !errors.IsNotFound(err) {
+		return "", errors.Trace(err)
+	}
+	if err != nil {
+		all, err := c.store.AllControllers()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		if len(all) == 0 {
+			return "", modelcmd.ErrNoControllersDefined
+		}
+		// There are controllers but none selected as current.
+		return "", nil
+	}
+	modelName, err := store.CurrentModel(controllerName)
+	if errors.IsNotFound(err) {
+		modelName = ""
+	} else if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	userName := ""
+	account, err := store.AccountDetails(controllerName)
+	if err != nil && !errors.IsNotFound(err) {
+		return "", errors.Trace(err)
+	}
+	if err == nil {
+		userName = account.User
+	}
+	if userName != "" {
+		controllerName = userName + "@" + controllerName
+		if jujuclient.IsQualifiedModelName(modelName) {
+			baseModelName, userTag, _ := jujuclient.SplitModelName(modelName)
+			if userName == userTag.Name() {
+				modelName = baseModelName
+			}
+		}
+	}
+	prompt = controllerName
+	if modelName != "" {
+		prompt = controllerName + ":" + modelName
+	}
+	return prompt, nil
+}

--- a/cmd/juju/commands/repl_test.go
+++ b/cmd/juju/commands/repl_test.go
@@ -1,0 +1,186 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package commands
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&ReplSuite{})
+
+type ReplSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	store *jujuclient.MemStore
+}
+
+func (*ReplSuite) TestPromptNoControllersAtAll(c *gc.C) {
+	r := &replCommand{store: jujuclient.NewMemStore()}
+
+	_, err := r.getPrompt()
+	c.Assert(err, gc.ErrorMatches, `No controllers registered.
+
+Please either create a new controller using "juju bootstrap" or connect to
+another controller that you have been given access to using "juju register".
+`)
+}
+
+func (*ReplSuite) TestPromptNoCurrentController(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	r := &replCommand{store: store}
+
+	p, err := r.getPrompt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, "$ ")
+}
+
+func (*ReplSuite) TestPromptControllerNoLogin(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "somecontroller"
+	r := &replCommand{store: store}
+
+	p, err := r.getPrompt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, "somecontroller$ ")
+}
+
+func (*ReplSuite) TestPromptControllerNoModel(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "somecontroller"
+	store.Accounts["somecontroller"] = jujuclient.AccountDetails{User: "fred"}
+	r := &replCommand{store: store}
+
+	p, err := r.getPrompt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, "fred@somecontroller$ ")
+}
+
+func (*ReplSuite) TestPromptControllerWithModel(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "somecontroller"
+	store.Accounts["somecontroller"] = jujuclient.AccountDetails{User: "fred"}
+	store.Models["somecontroller"] = &jujuclient.ControllerModels{
+		CurrentModel: "fred/test",
+	}
+	r := &replCommand{store: store}
+
+	p, err := r.getPrompt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, "fred@somecontroller:test$ ")
+}
+
+func (*ReplSuite) TestPromptControllerWithModelDifferentUser(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "somecontroller"
+	store.Accounts["somecontroller"] = jujuclient.AccountDetails{User: "fred"}
+	store.Models["somecontroller"] = &jujuclient.ControllerModels{
+		CurrentModel: "mary/test",
+	}
+	r := &replCommand{store: store}
+
+	p, err := r.getPrompt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, "fred@somecontroller:mary/test$ ")
+}
+
+func (*ReplSuite) TestPromptControllerWithModelNoLogin(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "somecontroller"
+	store.Models["somecontroller"] = &jujuclient.ControllerModels{
+		CurrentModel: "test",
+	}
+	r := &replCommand{store: store}
+
+	p, err := r.getPrompt()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.Equals, "somecontroller:test$ ")
+}
+
+func (s *ReplSuite) assertOutMatches(c *gc.C, out []byte, match string) {
+	stripped := strings.Replace(string(out), "\n", "", -1)
+	c.Assert(stripped, gc.Matches, match)
+}
+
+func (s *ReplSuite) TestHelp(c *gc.C) {
+	for _, arg := range []string{"-h", "--help", "help"} {
+		s.assertHelp(c, arg)
+	}
+}
+
+func (s *ReplSuite) assertHelp(c *gc.C, helpArg string) {
+	f := func() {
+		main{
+			execCommand: func(command string, args ...string) *exec.Cmd {
+				c.Fail()
+				return nil
+			},
+		}.Run([]string{"juju", helpArg})
+	}
+
+	stdout, _ := jujutesting.CaptureOutput(c, f)
+	s.assertOutMatches(c, stdout,
+		"When run without arguments, enter an interactive shell.*")
+}
+
+func (s *ReplSuite) TestJujuCommandHelp(c *gc.C) {
+	f := func() {
+		main{
+			execCommand: func(command string, args ...string) *exec.Cmd {
+				c.Fail()
+				return nil
+			},
+		}.Run([]string{"juju", "help", "status"})
+	}
+
+	stdout, _ := jujutesting.CaptureOutput(c, f)
+	s.assertOutMatches(c, stdout,
+		"Usage: juju show-status.*")
+}
+
+func (s *ReplSuite) TestRepl(c *gc.C) {
+	store := jujuclient.NewMemStore()
+	store.Controllers["somecontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "somecontroller"
+
+	var cmds []string
+	r := &replCommand{
+		store: store,
+		execJujuCommand: func(c cmd.Command, _ *cmd.Context, args []string) int {
+			cmds = append(cmds, c.Info().Name+" "+strings.Join(args, " "))
+			return 0
+		},
+	}
+	err := cmdtesting.InitCommand(r, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: bytes.NewBuffer(nil),
+		Stderr: bytes.NewBuffer(nil),
+		Stdin:  bytes.NewReader([]byte("\nstatus --format yaml\ncontrollers\n\nQ\n")),
+	}
+	err = r.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmds, gc.HasLen, 2)
+	c.Assert(cmds, jc.DeepEquals, []string{
+		"juju status --format yaml",
+		"juju controllers",
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 	github.com/aws/aws-sdk-go v1.29.8
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/docker/distribution v2.6.0-rc.1.0.20180522175653-f0cc92778478+incompatible

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
## Description of change

Add a new interactive Juju shell. It is invoked by running the juju command without any args.
The shell will include in the prompt the current controller/model/user. If there's no bootstrapped
controller, it will tell you to bootstrap one.
Running juju help still prints out the expected help text, but with an additional instruction on how to run the shell.
There's support for cmd history via ^R and the usual ^A, ^E, up, down keys etc. Todo is to add support for tab completion.

## QA steps

```sh
$ juju
Welcome to the Juju interactive shell.
Type "help" to see a list of available commands.
Type "q" or ^D or ^C to quit.

admin@ctrl:default$ status
Model    Controller  Cloud/Region       Version  SLA          Timestamp
default  ctrl        testlxd/localhost  2.8.2.1  unsupported  12:09:55+10:00

App      Version  Status  Scale  Charm    Store       Rev  OS      Notes
mariadb  10.1.40  active      1  mariadb  jujucharms    7  ubuntu  

Unit        Workload  Agent  Machine  Public address  Ports  Message
mariadb/0*  active    idle   0        10.115.246.142         ready

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.115.246.142  juju-946997-0  trusty      Running

admin@ctrl:default$ models
Controller: ctrl

Model       Cloud/Region       Type  Status     Machines  Units  Access  Last connection
controller  testlxd/localhost  lxd   available         1      -  admin   just now
default*    testlxd/localhost  lxd   available         1      1  admin   15 seconds ago
foo         testlxd/localhost  lxd   available         0      -  admin   2 hours ago

admin@ctrl:default$ switch foo
ctrl:admin/default -> ctrl:admin/foo
admin@ctrl:foo$ 
```

