### PR TITLE
Introduce bash functions to stop and start unit workers. 

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -23057,7 +23057,7 @@
                             "$ref": "#/definitions/SetMachineNetworkConfig"
                         }
                     },
-                    "description": "SetObservedNetworkConfig reads the network config for the machine identified\nby the input args. This config is merged with the new network config supplied\nin the same args and updated if it has changed."
+                    "description": "SetObservedNetworkConfig reads the network config for the machine\nidentified by the input args.\nThis config is merged with the new network config supplied in the\nsame args and updated if it has changed."
                 },
                 "SetStatus": {
                     "type": "object",
@@ -28589,7 +28589,7 @@
                             "$ref": "#/definitions/MachineNetworkConfigResults"
                         }
                     },
-                    "description": "GetContainerInterfaceInfo returns information to configure networking for a\ncontainer. It accepts container tags as arguments.\nTODO (manadart 2020-07-23): This method is not used and can be removed when\nnext this facade version is bumped.\nWe then don't need the parameterised prepareOrGet..."
+                    "description": "GetContainerInterfaceInfo returns information to configure networking for a\ncontainer. It accepts container tags as arguments."
                 },
                 "GetContainerProfileInfo": {
                     "type": "object",
@@ -28825,7 +28825,7 @@
                             "$ref": "#/definitions/SetMachineNetworkConfig"
                         }
                     },
-                    "description": "SetObservedNetworkConfig reads the network config for the machine identified\nby the input args. This config is merged with the new network config supplied\nin the same args and updated if it has changed."
+                    "description": "SetObservedNetworkConfig reads the network config for the machine\nidentified by the input args.\nThis config is merged with the new network config supplied in the\nsame args and updated if it has changed."
                 },
                 "SetPasswords": {
                     "type": "object",

--- a/cmd/jujud/agent/addons/addons.go
+++ b/cmd/jujud/agent/addons/addons.go
@@ -6,9 +6,11 @@ package addons
 import (
 	"runtime"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/pubsub"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,8 +40,11 @@ type IntrospectionConfig struct {
 	MachineLock        machinelock.Lock
 	PrometheusGatherer prometheus.Gatherer
 	PresenceRecorder   presence.Recorder
-	NewSocketName      func(names.Tag) string
-	WorkerFunc         func(config introspection.Config) (worker.Worker, error)
+	Clock              clock.Clock
+	LocalHub           *pubsub.SimpleHub
+
+	NewSocketName func(names.Tag) string
+	WorkerFunc    func(config introspection.Config) (worker.Worker, error)
 }
 
 // StartIntrospection creates the introspection worker. It cannot and should
@@ -63,6 +68,8 @@ func StartIntrospection(cfg IntrospectionConfig) error {
 		MachineLock:        cfg.MachineLock,
 		PrometheusGatherer: cfg.PrometheusGatherer,
 		Presence:           cfg.PresenceRecorder,
+		Clock:              cfg.Clock,
+		Hub:                cfg.LocalHub,
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -258,6 +258,9 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		NewSocketName:      addons.DefaultIntrospectionSocketName,
 		PrometheusGatherer: op.prometheusRegistry,
 		WorkerFunc:         introspection.NewWorker,
+		// If the caas operator gains the ability to interact with the
+		// introspection worker, the introspection worker should be configured
+		// with a clock and hub. See the machine agent.
 	}); err != nil {
 		// If the introspection worker failed to start, we just log error
 		// but continue. It is very unlikely to happen in the real world

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -197,6 +197,11 @@ type ManifoldsConfig struct {
 	// CentralHub is the primary hub that exists in the apiserver.
 	CentralHub *pubsub.StructuredHub
 
+	// LocalHub is a simple pubsub that is used for internal agent
+	// messaging only. This is used for interactions between workers
+	// and the introspection worker.
+	LocalHub *pubsub.SimpleHub
+
 	// PubSubReporter is the introspection reporter for the pubsub forwarding
 	// worker.
 	PubSubReporter psworker.Reporter
@@ -958,6 +963,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			Clock:         config.Clock,
+			Hub:           config.LocalHub,
 			Logger:        loggo.GetLogger("juju.worker.deployer"),
 
 			UnitEngineConfig: config.UnitEngineConfig,

--- a/cmd/jujud/introspect/introspect_test.go
+++ b/cmd/jujud/introspect/introspect_test.go
@@ -112,18 +112,12 @@ func (s *IntrospectCommandSuite) TestQueryFails(c *gc.C) {
 
 	ctx, err := s.run(c, "missing", "--agent=machine-0")
 	c.Assert(err.Error(), gc.Equals, "response returned 404 (Not Found)")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
-Querying @%s introspection socket: missing
-404 page not found
-`[1:], filepath.Join(config.DataDir, "jujud-machine-0")))
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "404 page not found\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 
 	ctx, err = s.run(c, "badness", "--agent=machine-0")
 	c.Assert(err.Error(), gc.Equals, "response returned 500 (Internal Server Error)")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
-Querying @%s introspection socket: badness
-argh
-`[1:], filepath.Join(config.DataDir, "jujud-machine-0")))
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "argh\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }
 
@@ -138,10 +132,7 @@ func (s *IntrospectCommandSuite) TestGetToPostEndpoint(c *gc.C) {
 
 	ctx, err := s.run(c, "postonly", "--agent=machine-0")
 	c.Assert(err, gc.ErrorMatches, `response returned 405 \(Method Not Allowed\)`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf(`
-Querying @%s introspection socket: postonly
-postonly requires a POST request
-`[1:], filepath.Join(config.DataDir, "jujud-machine-0")))
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "postonly requires a POST request\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 }
 

--- a/cmd/k8sagent/unit/agent.go
+++ b/cmd/k8sagent/unit/agent.go
@@ -192,6 +192,9 @@ func (c *k8sUnitAgent) workers() (worker.Worker, error) {
 		NewSocketName:      addons.DefaultIntrospectionSocketName,
 		PrometheusGatherer: c.prometheusRegistry,
 		WorkerFunc:         introspection.NewWorker,
+		// If the k8sagent gains the ability to interact with the introspection
+		// worker, the introspection worker should be configured with a clock
+		// and hub. See the machine agent.
 	}); err != nil {
 		// If the introspection worker failed to start, we just log error
 		// but continue. It is very unlikely to happen in the real world

--- a/cmd/k8sagent/unit/package_test.go
+++ b/cmd/k8sagent/unit/package_test.go
@@ -6,6 +6,7 @@ package unit_test
 import (
 	"testing"
 
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,10 +22,10 @@ type ImportSuite struct{}
 var _ = gc.Suite(&ImportSuite{})
 
 func (*ImportSuite) TestImports(c *gc.C) {
-	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/cmd/k8sagent/unit")
+	found := set.NewStrings(
+		coretesting.FindJujuCoreImports(c, "github.com/juju/juju/cmd/k8sagent/unit")...)
 
-	// TODO: review if there are any un-expected imports!
-	c.Assert(found, jc.SameContents, []string{
+	expected := set.NewStrings(
 		"agent",
 		"agent/tools",
 		"api",
@@ -141,6 +142,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"packaging/dependency",
 		"pki",
 		"provider/lxd/lxdnames",
+		"pubsub/agent",
 		"resource",
 		"rpc",
 		"rpc/jsoncodec",
@@ -193,5 +195,15 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"worker/uniter/upgradeseries",
 		"worker/uniter/verifycharmprofile",
 		"wrench",
-	})
+	)
+
+	unexpected := found.Difference(expected)
+	// TODO: review if there are any un-expected imports!
+	// Show the values rather than just checking the length so a failing
+	// test shows them.
+	c.Check(unexpected.SortedValues(), jc.DeepEquals, []string{})
+	// If unneeded show any values this is good as we've reduced
+	// dependencies, and they should be removed from expected above.
+	unneeded := expected.Difference(found)
+	c.Check(unneeded.SortedValues(), jc.DeepEquals, []string{})
 }

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/go.sum
+++ b/go.sum
@@ -1091,6 +1091,7 @@ k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.3.0 h1:WmkrnW7fdrm0/DMClc+HIxtftvxVIPAhlVwMQo5yLco=
 k8s.io/klog/v2 v2.3.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
+k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200724153422-f32512634ab7 h1:bYyloM4UeWug24euLZfEH7muFQoqvFj9h/pxAnOZLt4=

--- a/pubsub/agent/messages.go
+++ b/pubsub/agent/messages.go
@@ -11,9 +11,17 @@ package agent
 // The payload for a StartUnitTopic is the Units structure.
 const StartUnitTopic = "unit.start"
 
+// StartUnitResponseTopic is the topic to respond to a start request.
+// The payload is the StartStopResponse type below.
+const StartUnitResponseTopic = "unit.start.response"
+
 // StopUnitTopic is used to request one or more units to stop.
 // The payload for a StopUnitTopic is the Units structure.
 const StopUnitTopic = "unit.stop"
+
+// StopUnitResponseTopic is the topic to respond to a stop request.
+// The payload is the StartStopResponse type below.
+const StopUnitResponseTopic = "unit.stop.response"
 
 // UnitStatusTopic is used to request the current status for the units.
 // There is no payload for this request.
@@ -27,6 +35,10 @@ const UnitStatusResponseTopic = "unit.status.response"
 type Units struct {
 	Names []string
 }
+
+// StartStopResponse returns a map of the requested unit names, and
+// whether they were stopped, started, or not found.
+type StartStopResponse map[string]interface{}
 
 // Status is a map of unit name to the status value. An interace{} value is returned
 // to allow for simple expansion later. The output of the status is expected to just

--- a/pubsub/agent/messages.go
+++ b/pubsub/agent/messages.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package agent contains messages for all agents rather than controllers.
+//
+// All these structures are expected to be used with a SimpleHub that doesn't
+// seralize, hence no serialization directives.
+package agent
+
+// StartUnitTopic is used to request one or more units to start.
+// The payload for a StartUnitTopic is the Units structure.
+const StartUnitTopic = "unit.start"
+
+// StopUnitTopic is used to request one or more units to stop.
+// The payload for a StopUnitTopic is the Units structure.
+const StopUnitTopic = "unit.stop"
+
+// UnitStatusTopic is used to request the current status for the units.
+// There is no payload for this request.
+const UnitStatusTopic = "unit.status"
+
+// UnitStatusResponseTopic is the topic to respond to a status request.
+// The payload is the Status type below.
+const UnitStatusResponseTopic = "unit.status.response"
+
+// Units provides a way to request start or stop multiple units.
+type Units struct {
+	Names []string
+}
+
+// Status is a map of unit name to the status value. An interace{} value is returned
+// to allow for simple expansion later. The output of the status is expected to just
+// show a nice string representation of the map.
+type Status map[string]interface{}

--- a/worker/deployer/manifold.go
+++ b/worker/deployer/manifold.go
@@ -17,11 +17,18 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 )
 
+// Hub is a pubsub hub used for internal messaging.
+type Hub interface {
+	Publish(topic string, data interface{}) <-chan struct{}
+	Subscribe(topic string, handler func(string, interface{})) func()
+}
+
 // ManifoldConfig defines the names of the manifolds on which a Manifold will depend.
 type ManifoldConfig struct {
 	AgentName     string
 	APICallerName string
 	Clock         clock.Clock
+	Hub           Hub
 	Logger        Logger
 
 	UnitEngineConfig func() dependency.EngineConfig
@@ -56,6 +63,7 @@ func (config ManifoldConfig) newWorker(a agent.Agent, apiCaller base.APICaller) 
 	contextConfig := ContextConfig{
 		Agent:            a,
 		Clock:            config.Clock,
+		Hub:              config.Hub,
 		Logger:           config.Logger,
 		UnitEngineConfig: config.UnitEngineConfig,
 		SetupLogging:     config.SetupLogging,

--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/series"
+	"github.com/juju/pubsub"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
@@ -26,6 +27,7 @@ import (
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	message "github.com/juju/juju/pubsub/agent"
 	jt "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jv "github.com/juju/juju/version"
@@ -40,6 +42,7 @@ type NestedContextSuite struct {
 
 	config  deployer.ContextConfig
 	agent   agentconf.AgentConf
+	hub     *pubsub.SimpleHub
 	workers *unitWorkersStub
 }
 
@@ -49,7 +52,9 @@ func (s *NestedContextSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	logger := loggo.GetLogger("test.nestedcontext")
 	logger.SetLogLevel(loggo.TRACE)
-
+	s.hub = pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
+		Logger: logger,
+	})
 	datadir := c.MkDir()
 	machine := names.NewMachineTag("42")
 	config, err := agent.NewAgentConfig(
@@ -83,6 +88,7 @@ func (s *NestedContextSuite) SetUpTest(c *gc.C) {
 	s.config = deployer.ContextConfig{
 		Agent:            s.agent,
 		Clock:            clock.WallClock,
+		Hub:              s.hub,
 		Logger:           logger,
 		UnitEngineConfig: engine.DependencyEngineConfig,
 		SetupLogging: func(c *loggo.Context, _ agent.Config) {
@@ -104,6 +110,13 @@ func (s *NestedContextSuite) TestConfigMissingClock(c *gc.C) {
 	err := s.config.Validate()
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 	c.Assert(err.Error(), gc.Equals, "missing Clock not valid")
+}
+
+func (s *NestedContextSuite) TestConfigMissingHub(c *gc.C) {
+	s.config.Hub = nil
+	err := s.config.Validate()
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	c.Assert(err.Error(), gc.Equals, "missing Hub not valid")
 }
 
 func (s *NestedContextSuite) TestConfigMissingLogger(c *gc.C) {
@@ -225,11 +238,23 @@ func (s *NestedContextSuite) TestErrTerminateAgentFromAgentWorker(c *gc.C) {
 	// Unit is marked as stopped. There is a potential race due to the
 	// number of goroutines that need to fire to get the information back
 	// to the nested context.
+	report := s.waitForStoppedCount(c, ctx, 1)
+
+	c.Assert(report, jc.DeepEquals, map[string]interface{}{
+		"deployed": []string{"something/0"},
+		"stopped":  []string{"something/0"},
+		"units": map[string]interface{}{
+			"workers": map[string]interface{}{},
+		},
+	})
+}
+
+func (s *NestedContextSuite) waitForStoppedCount(c *gc.C, ctx deployer.Context, length int) map[string]interface{} {
 	report := ctx.Report()
 	maxTime := time.After(testing.LongWait)
 	for {
 		stopped := report["stopped"]
-		if stopped != nil {
+		if stopped != nil && len(stopped.([]string)) == length {
 			break
 		}
 		select {
@@ -239,19 +264,68 @@ func (s *NestedContextSuite) TestErrTerminateAgentFromAgentWorker(c *gc.C) {
 			c.Fatal("unit not stopped")
 		}
 	}
-
-	c.Assert(ctx.Report(), jc.DeepEquals, map[string]interface{}{
-		"deployed": []string{"something/0"},
-		"stopped":  []string{"something/0"},
-		"units": map[string]interface{}{
-			"workers": map[string]interface{}{},
-		},
-	})
+	return report
 }
 
-func (s *NestedContextSuite) TestReport(c *gc.C) {
+func (s *NestedContextSuite) TestStopStartUnits(c *gc.C) {
 	ctx := s.newContext(c)
+	s.deployThreeUnits(c, ctx)
 
+	handled := s.hub.Publish(message.StopUnitTopic, message.Units{
+		Names: []string{"first/0", "second/0", "unknown/2"},
+	})
+	s.waitForEventHandled(c, handled)
+	report := ctx.Report()
+	c.Assert(report["stopped"], jc.DeepEquals, []string{"first/0", "second/0"})
+
+	// Start one back up again.
+	handled = s.hub.Publish(message.StartUnitTopic, message.Units{
+		Names: []string{"first/0", "third/0", "unknown/2"},
+	})
+	s.waitForEventHandled(c, handled)
+	report = ctx.Report()
+	c.Assert(report["stopped"], jc.DeepEquals, []string{"second/0"})
+}
+
+func (s *NestedContextSuite) TestUnitStatus(c *gc.C) {
+	responseHandled := make(chan struct{})
+	unsub := s.hub.Subscribe(message.UnitStatusResponseTopic, func(_ string, payload interface{}) {
+		response := payload.(message.Status) // TODO rename to unit status
+		c.Check(response, jc.DeepEquals, message.Status{
+			"agent": "machine-42",
+			"units": map[string]string{
+				"first/0":  "running",
+				"second/0": "stopped",
+				"third/0":  "running",
+			},
+		})
+		close(responseHandled)
+	})
+	defer unsub()
+
+	ctx := s.newContext(c)
+	s.deployThreeUnits(c, ctx)
+	// And stop one.
+	handled := s.hub.Publish(message.StopUnitTopic, message.Units{
+		Names: []string{"second/0"},
+	})
+	s.waitForEventHandled(c, handled)
+
+	handled = s.hub.Publish(message.UnitStatusTopic, nil)
+	s.waitForEventHandled(c, handled)
+	s.waitForEventHandled(c, responseHandled)
+}
+
+func (s *NestedContextSuite) waitForEventHandled(c *gc.C, handled <-chan struct{}) {
+	select {
+	case <-handled:
+		// All good.
+	case <-time.After(testing.LongWait):
+		c.Fatalf("event not handled")
+	}
+}
+
+func (s *NestedContextSuite) deployThreeUnits(c *gc.C, ctx deployer.Context) {
 	// Units are conveniently in alphabetical order.
 	for _, unitName := range []string{"first/0", "second/0", "third/0"} {
 		err := ctx.DeployUnit(unitName, "password")
@@ -260,9 +334,6 @@ func (s *NestedContextSuite) TestReport(c *gc.C) {
 		s.workers.waitForStart(c, unitName)
 	}
 
-	check := jc.NewMultiChecker()
-	check.AddExpr(`_["units"][_][_][_][_][_]["started"]`, jc.Ignore)
-	check.AddExpr(`_["units"][_][_]["started"]`, jc.Ignore)
 	report := ctx.Report()
 	// There is a race condition here between the worker, which says the
 	// start function was called, and the engine report itself having recorded
@@ -284,7 +355,15 @@ func (s *NestedContextSuite) TestReport(c *gc.C) {
 			c.Fatal("third unit worker did not start")
 		}
 	}
+}
 
+func (s *NestedContextSuite) TestReport(c *gc.C) {
+	ctx := s.newContext(c)
+	s.deployThreeUnits(c, ctx)
+
+	check := jc.NewMultiChecker()
+	check.AddExpr(`_["units"][_][_][_][_][_]["started"]`, jc.Ignore)
+	check.AddExpr(`_["units"][_][_]["started"]`, jc.Ignore)
 	// Dates are shown here as an example, but are ignored by the checker.
 	c.Assert(ctx.Report(), check, map[string]interface{}{
 		"deployed": []string{"first/0", "second/0", "third/0"},

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -122,6 +122,11 @@ juju_unit_status () {
 }
 
 juju_stop_unit () {
+  # This requires some arguments.
+  if [ "$#" -lt 1 ]; then
+    echo "usage: juju_stop_unit <unit-name> [<unit-name>...]"
+    return 1
+  fi
   arr=("$@")
   local -a args
   for i in "${arr[@]}"; do
@@ -131,6 +136,11 @@ juju_stop_unit () {
 }
 
 juju_start_unit () {
+  # This requires some arguments.
+  if [ "$#" -lt 1 ]; then
+    echo "usage: juju_start_unit <unit-name> [<unit-name>...]"
+    return 1
+  fi
   arr=("$@")
   local -a args
   for i in "${arr[@]}"; do

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v2"
-	"github.com/kr/pretty"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/tomb.v2"
@@ -345,7 +344,6 @@ func (h unitsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "%s\n", err)
 		return
 	}
-	logger.Criticalf("%s, %s: %s", r.Method, r.URL.String(), pretty.Sprint(r.Form))
 
 	switch action := r.Form.Get("action"); action {
 	case "":


### PR DESCRIPTION
The introspection endpoint gains a new endpoint to handle post
methods to request unit start and stop. This endpoint then uses
a new simple hub to publish the request.

The deployer now requires a simple hub to be passed in through the
manifold rather than creating one itself. The internal stop unit
message is now replaced with a centrally defined one. An additional
start unit method, as well as a status method, is added.

The scripts file that is written out into /etc/profile.d is updated
to remove the unit agent aspects, as now there is only a machine
agent. This also allows better argument passing from the other
defined functions.

## QA steps

```sh
juju bootstrap lxd test
juju deploy cs:~jameinel/ubuntu-lite ubuntu
juju deploy filebeat
juju relate ubuntu filebeat
juju add-unit ubuntu --to 0
juju ssh 0
# in another shell window start debug-log
juju debug-log
```
Wait for the model to finish deploying, and then start poking the introspection endpoint.
```
# confirm that the other functions work
juju_engine_report
juju_goroutines
juju_heap_profile
juju_metrics
# now for the new ones
juju_unit_status
juju_stop_unit ubuntu/0 filebeat/1
juju_unit_status
juju_engine_report
```
Observe that the units are shown as stopped in the `juju_unit_status`, and in the `juju_engine_report` the deployer has them as stopped.  `juju status` on the model from the outside will list the units as `lost`.

```
sudo service jujud-machine-0 restart
juju_unit_status
juju_engine_report
```
Observe that the stopped units are still stopped.
```
juju_start_unit ubuntu/0 filebeat/1
juju_unit_status
```
Observe that the units have started again, and `juju_status` shows the units as connected and idle.

## Documentation changes

Potentially worth documenting in the operational guides around managing the agent workers.
