### PR TITLE
Only use shell with a terminal

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -152,7 +152,7 @@ func (m main) Run(args []string) int {
 	jujuArgs := set.NewStrings(args[1:]...)
 	helpArgs := set.NewStrings("help", "-h", "--help")
 	showHelp := jujuArgs.Intersection(helpArgs).Size() > 0 && jujuArgs.Size() == 1
-	repl := jujuArgs.Size() == 0
+	repl := jujuArgs.Size() == 0 && isTerminal(ctx.Stdout) && isTerminal(ctx.Stdin)
 	if repl || showHelp {
 		return cmd.Main(newReplCommand(showHelp), ctx, nil)
 	}


### PR DESCRIPTION
## Description of change

Somehow the check for running in a terminal got lost when deciding to run the juju shell.

## QA steps

juju | grep help
juju > aaa.txt

