### PR TITLE
[dev] Support endpoints in port-related hook tools

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -951,28 +952,28 @@ func NewCommitHookParamsBuilder(unitTag names.UnitTag) *CommitHookParamsBuilder 
 }
 
 // OpenPortRange records a request to open a particular port range.
-func (b *CommitHookParamsBuilder) OpenPortRange(endpoint, protocol string, fromPort, toPort int) {
+func (b *CommitHookParamsBuilder) OpenPortRange(endpoint string, portRange network.PortRange) {
 	b.arg.OpenPorts = append(b.arg.OpenPorts, params.EntityPortRange{
 		// The Tag is optional as the call uses the Tag from the
 		// CommitHookChangesArg; it is included here for consistency.
 		Tag:      b.arg.Tag,
 		Endpoint: endpoint,
-		Protocol: protocol,
-		FromPort: fromPort,
-		ToPort:   toPort,
+		Protocol: portRange.Protocol,
+		FromPort: portRange.FromPort,
+		ToPort:   portRange.ToPort,
 	})
 }
 
 // ClosePortRange records a request to close a particular port range.
-func (b *CommitHookParamsBuilder) ClosePortRange(endpoint, protocol string, fromPort, toPort int) {
+func (b *CommitHookParamsBuilder) ClosePortRange(endpoint string, portRange network.PortRange) {
 	b.arg.ClosePorts = append(b.arg.ClosePorts, params.EntityPortRange{
 		// The Tag is optional as the call uses the Tag from the
 		// CommitHookChangesArg; it is included here for consistency.
 		Tag:      b.arg.Tag,
 		Endpoint: endpoint,
-		Protocol: protocol,
-		FromPort: fromPort,
-		ToPort:   toPort,
+		Protocol: portRange.Protocol,
+		FromPort: portRange.FromPort,
+		ToPort:   portRange.ToPort,
 	})
 }
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -5036,9 +5036,9 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChanges(c *gc.C) {
 	b.UpdateNetworkInfo()
 	b.UpdateRelationUnitSettings(relList[0].Tag().String(), params.Settings{"just": "added"}, params.Settings{"app_data": "updated"})
 	// Manipulate ports for one of the charm's endpoints.
-	b.OpenPortRange("monitoring-port", "tcp", 80, 81)
-	b.OpenPortRange("monitoring-port", "tcp", 7337, 7337) // same port closed below; this should be a no-op
-	b.ClosePortRange("monitoring-port", "tcp", 7337, 7337)
+	b.OpenPortRange("monitoring-port", network.MustParsePortRange("80-81/tcp"))
+	b.OpenPortRange("monitoring-port", network.MustParsePortRange("7337/tcp")) // same port closed below; this should be a no-op
+	b.ClosePortRange("monitoring-port", network.MustParsePortRange("7337/tcp"))
 	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
 	req, _ := b.Build()
 
@@ -5139,9 +5139,9 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	stCount := uint64(1)
 	b := apiuniter.NewCommitHookParamsBuilder(unit.UnitTag())
 	b.UpdateNetworkInfo()
-	b.OpenPortRange(allEndpoints, "tcp", 80, 81)
-	b.OpenPortRange(allEndpoints, "tcp", 7337, 7337) // same port closed below; this should be a no-op
-	b.ClosePortRange(allEndpoints, "tcp", 7337, 7337)
+	b.OpenPortRange(allEndpoints, network.MustParsePortRange("80-81/tcp"))
+	b.OpenPortRange(allEndpoints, network.MustParsePortRange("7337/tcp")) // same port closed below; this should be a no-op
+	b.ClosePortRange(allEndpoints, network.MustParsePortRange("7337/tcp"))
 	b.UpdateCharmState(map[string]string{"charm-key": "charm-value"})
 	b.AddStorage(map[string][]params.StorageConstraints{
 		"multi1to10": {{Count: &stCount}},

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -51,7 +51,7 @@ Currently available charm hook tools are:
     action-set               set action results
     add-metric               add metrics
     application-version-set  specify which version of the application is deployed
-    close-port               ensure a port or range is always closed
+    close-port               register a request to close a port or port range
     config-get               print application configuration
     credential-get           access cloud credentials
     goal-state               print the status of the charm's peers and related units
@@ -65,8 +65,8 @@ Currently available charm hook tools are:
     leader-get               print application leadership settings
     leader-set               write application leadership settings
     network-get              get network config
-    open-port                register a port or range to open
-    opened-ports             lists all ports or ranges opened by the unit
+    open-port                register a request to open a port or port range
+    opened-ports             list all ports or port ranges opened by the unit
     pod-spec-get             get k8s spec information (deprecated)
     pod-spec-set             set k8s spec information (deprecated)
     relation-get             get relation settings

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -125,12 +125,10 @@ type HookProcess interface {
 type HookUnit interface {
 	Application() (*uniter.Application, error)
 	ApplicationName() string
-	ClosePorts(protocol string, fromPort, toPort int) error
 	ConfigSettings() (charm.Settings, error)
 	LogActionMessage(names.ActionTag, string) error
 	Name() string
 	NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error)
-	OpenPorts(protocol string, fromPort, toPort int) error
 	RequestReboot() error
 	SetUnitStatus(unitStatus status.Status, info string, data map[string]interface{}) error
 	SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error
@@ -235,14 +233,8 @@ type HookContext struct {
 	// meterStatus is the status of the unit's metering.
 	meterStatus *meterStatus
 
-	// pendingPorts contains a list of port ranges to be opened or
-	// closed when the current hook is committed.
-	pendingPorts map[PortRange]PortRangeInfo
-
-	// machinePorts contains cached information about all opened port
-	// ranges on the unit's assigned machine, mapped to the unit that
-	// opened each range and the relevant relation.
-	machinePorts map[network.PortRange]params.RelationUnit
+	// a helper for recording requests to open/close port ranges for this unit.
+	portRangeChanges *portRangeChangeRecorder
 
 	// assignedMachineTag contains the tag of the unit's assigned
 	// machine.
@@ -697,42 +689,25 @@ func (ctx *HookContext) AddUnitStorage(cons map[string]params.StorageConstraints
 	return nil
 }
 
-// OpenPorts marks the supplied port range for opening when the
-// executing unit's application is exposed.
+// OpenPortRange marks the supplied port range for opening.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) OpenPorts(protocol string, fromPort, toPort int) error {
-	return tryOpenPorts(
-		protocol, fromPort, toPort,
-		ctx.unit.Tag(),
-		ctx.machinePorts, ctx.pendingPorts,
-	)
+func (ctx *HookContext) OpenPortRange(endpointName string, portRange network.PortRange) error {
+	return ctx.portRangeChanges.OpenPortRange(endpointName, portRange)
 }
 
-// ClosePorts ensures the supplied port range is closed even when
+// ClosePortRange ensures the supplied port range is closed even when
 // the executing unit's application is exposed (unless it is opened
 // separately by a co- located unit).
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) ClosePorts(protocol string, fromPort, toPort int) error {
-	return tryClosePorts(
-		protocol, fromPort, toPort,
-		ctx.unit.Tag(),
-		ctx.machinePorts, ctx.pendingPorts,
-	)
+func (ctx *HookContext) ClosePortRange(endpointName string, portRange network.PortRange) error {
+	return ctx.portRangeChanges.ClosePortRange(endpointName, portRange)
 }
 
-// OpenedPorts returns all port ranges currently opened by this
-// unit on its assigned machine. The result is sorted first by
-// protocol, then by number.
+// OpenedPortRanges returns all port ranges currently opened by this
+// unit on its assigned machine grouped by endpoint.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) OpenedPorts() []network.PortRange {
-	var unitRanges []network.PortRange
-	for portRange, relUnit := range ctx.machinePorts {
-		if relUnit.Unit == ctx.unit.Tag().String() {
-			unitRanges = append(unitRanges, portRange)
-		}
-	}
-	network.SortPortRanges(unitRanges)
-	return unitRanges
+func (ctx *HookContext) OpenedPortRanges() map[string][]network.PortRange {
+	return ctx.portRangeChanges.OpenedUnitPortRanges()
 }
 
 // Config returns the current application configuration of the executing unit.
@@ -1120,11 +1095,14 @@ func (ctx *HookContext) doFlush(process string) error {
 		b.UpdateRelationUnitSettings(rctx.RelationTag().String(), unitSettings, appSettings)
 	}
 
-	for portRange, info := range ctx.pendingPorts {
-		if info.ShouldOpen {
-			b.OpenPortRange(info.Endpoint, portRange.Ports.Protocol, portRange.Ports.FromPort, portRange.Ports.ToPort)
-		} else {
-			b.ClosePortRange(info.Endpoint, portRange.Ports.Protocol, portRange.Ports.FromPort, portRange.Ports.ToPort)
+	for endpointName, portRanges := range ctx.portRangeChanges.pendingOpenRanges {
+		for _, pr := range portRanges {
+			b.OpenPortRange(endpointName, pr)
+		}
+	}
+	for endpointName, portRanges := range ctx.portRangeChanges.pendingCloseRanges {
+		for _, pr := range portRanges {
+			b.ClosePortRange(endpointName, pr)
 		}
 	}
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -576,7 +576,7 @@ func (s *mockHookContextSuite) TestDeleteCharmStateValue(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	err := hookContext.DeleteCharmStateValue("one")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -589,7 +589,7 @@ func (s *mockHookContextSuite) TestDeleteCacheStateErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	err := hookContext.DeleteCharmStateValue("five")
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
@@ -598,7 +598,7 @@ func (s *mockHookContextSuite) TestGetCharmState(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	obtainedCache, err := hookContext.GetCharmState()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedCache, gc.DeepEquals, s.mockCache.CharmState)
@@ -608,7 +608,7 @@ func (s *mockHookContextSuite) TestGetCharmStateStateErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	_, err := hookContext.GetCharmState()
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
@@ -617,7 +617,7 @@ func (s *mockHookContextSuite) TestGetCharmStateValue(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	obtainedVale, err := hookContext.GetCharmStateValue("one")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedVale, gc.Equals, "two")
@@ -627,7 +627,7 @@ func (s *mockHookContextSuite) TestGetCharmStateValueEmpty(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	obtainedVale, err := hookContext.GetCharmStateValue("seven")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedVale, gc.Equals, "")
@@ -637,7 +637,7 @@ func (s *mockHookContextSuite) TestGetCharmStateValueNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	obtainedCache, err := hookContext.GetCharmStateValue("five")
 	c.Assert(err, gc.ErrorMatches, "\"five\" not found")
 	c.Assert(obtainedCache, gc.Equals, "")
@@ -647,7 +647,7 @@ func (s *mockHookContextSuite) TestGetCharmStateValueStateErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	_, err := hookContext.GetCharmStateValue("key")
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
@@ -663,7 +663,7 @@ func (s *mockHookContextSuite) TestSetCache(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateValues()
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 
 	// Test key len limit
 	err := hookContext.SetCharmStateValue(
@@ -690,7 +690,7 @@ func (s *mockHookContextSuite) TestSetCacheEmptyStartState(c *gc.C) {
 }
 
 func (s *mockHookContextSuite) testSetCache(c *gc.C) {
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	err := hookContext.SetCharmStateValue("five", "six")
 	c.Assert(err, jc.ErrorIsNil)
 	obtainedCache, err := hookContext.GetCharmState()
@@ -704,14 +704,14 @@ func (s *mockHookContextSuite) TestSetCacheStateErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.mockUnit.EXPECT().State().Return(params.UnitStateResult{}, errors.Errorf("testing an error"))
 
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	err := hookContext.SetCharmStateValue("five", "six")
 	c.Assert(err, gc.ErrorMatches, "loading unit state from database: testing an error")
 }
 
 func (s *mockHookContextSuite) TestFlushWithNonDirtyCache(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 	s.expectStateValues()
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0"))
 
@@ -729,7 +729,7 @@ func (s *mockHookContextSuite) TestFlushWithNonDirtyCache(c *gc.C) {
 
 func (s *mockHookContextSuite) TestSequentialFlushOfCacheValues(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	hookContext := context.NewMockUnitHookContext(s.mockUnit)
+	hookContext := context.NewMockUnitHookContext("wordpress/0", s.mockUnit)
 
 	// We expect a single call for the following API endpoints
 	s.expectStateValues()
@@ -811,7 +811,7 @@ func (s *mockHookContextSuite) TestActionAbort(c *gc.C) {
 		})
 		s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
 		st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-		hookContext := context.NewMockUnitHookContextWithState(s.mockUnit, st)
+		hookContext := context.NewMockUnitHookContextWithState("wordpress/0", s.mockUnit, st)
 		cancel := make(chan struct{})
 		if test.Cancel {
 			close(cancel)
@@ -851,7 +851,7 @@ func (s *mockHookContextSuite) TestMissingAction(c *gc.C) {
 	})
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
 	st := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-	hookContext := context.NewMockUnitHookContextWithState(s.mockUnit, st)
+	hookContext := context.NewMockUnitHookContextWithState("wordpress/0", s.mockUnit, st)
 
 	context.WithActionContext(hookContext, nil, nil)
 	err := hookContext.Flush("action", charmrunner.NewMissingHookError("noaction"))

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -220,17 +220,17 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	err = ctx.OpenPortRange("", network.MustParsePortRange("100-200/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // duplicates are ignored
 	err = ctx.OpenPortRange("", network.MustParsePortRange("200-300/udp"))
-	c.Assert(err, gc.ErrorMatches, `cannot open 200-300/udp \(unit "u/0"\): conflicts with existing 200-300/udp \(unit "u/1"\)`)
+	c.Assert(err, gc.ErrorMatches, `cannot open 200-300/udp \(unit "u/0"\): port range conflicts with 200-300/udp \(unit "u/1"\)`)
 	err = ctx.OpenPortRange("", network.MustParsePortRange("100-200/udp"))
-	c.Assert(err, gc.ErrorMatches, `cannot open 100-200/udp \(unit "u/0"\): conflicts with existing 200-300/udp \(unit "u/1"\)`)
+	c.Assert(err, gc.ErrorMatches, `cannot open 100-200/udp \(unit "u/0"\): port range conflicts with 200-300/udp \(unit "u/1"\)`)
 	err = ctx.OpenPortRange("", network.MustParsePortRange("10-20/udp"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.OpenPortRange("", network.MustParsePortRange("50-100/tcp"))
-	c.Assert(err, gc.ErrorMatches, `cannot open 50-100/tcp \(unit "u/0"\): conflicts with existing 100-200/tcp \(unit "u/0"\)`)
+	c.Assert(err, gc.ErrorMatches, `cannot open 50-100/tcp \(unit "u/0"\): port range conflicts with 100-200/tcp \(unit "u/0"\)`)
 	err = ctx.OpenPortRange("", network.MustParsePortRange("50-80/tcp"))
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.OpenPortRange("", network.MustParsePortRange("40-90/tcp"))
-	c.Assert(err, gc.ErrorMatches, `cannot open 40-90/tcp \(unit "u/0"\): conflicts with 50-80/tcp requested earlier`)
+	c.Assert(err, gc.ErrorMatches, `cannot open 40-90/tcp \(unit "u/0"\): port range conflicts with 50-80/tcp \(unit "u/0"\) requested earlier`)
 
 	// Now try closing some ports as well.
 	err = ctx.ClosePortRange("", network.MustParsePortRange("8080-8088/udp"))
@@ -240,7 +240,7 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	err = ctx.ClosePortRange("", network.MustParsePortRange("100-200/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // duplicates are ignored
 	err = ctx.ClosePortRange("", network.MustParsePortRange("200-300/udp"))
-	c.Assert(err, gc.ErrorMatches, `cannot close 200-300/udp \(opened by "u/1"\) from "u/0"`)
+	c.Assert(err, gc.ErrorMatches, `.*port range conflicts with 200-300/udp \(unit "u/1"\)`)
 	err = ctx.ClosePortRange("", network.MustParsePortRange("50-80/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // still pending -> no longer pending
 

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -217,31 +217,31 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	ctx := s.context(c)
 
 	// Try opening some ports via the context.
-	err = ctx.OpenPorts("tcp", 100, 200)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("100-200/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // duplicates are ignored
-	err = ctx.OpenPorts("udp", 200, 300)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("200-300/udp"))
 	c.Assert(err, gc.ErrorMatches, `cannot open 200-300/udp \(unit "u/0"\): conflicts with existing 200-300/udp \(unit "u/1"\)`)
-	err = ctx.OpenPorts("udp", 100, 200)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("100-200/udp"))
 	c.Assert(err, gc.ErrorMatches, `cannot open 100-200/udp \(unit "u/0"\): conflicts with existing 200-300/udp \(unit "u/1"\)`)
-	err = ctx.OpenPorts("udp", 10, 20)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("10-20/udp"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.OpenPorts("tcp", 50, 100)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("50-100/tcp"))
 	c.Assert(err, gc.ErrorMatches, `cannot open 50-100/tcp \(unit "u/0"\): conflicts with existing 100-200/tcp \(unit "u/0"\)`)
-	err = ctx.OpenPorts("tcp", 50, 80)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("50-80/tcp"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.OpenPorts("tcp", 40, 90)
+	err = ctx.OpenPortRange("", network.MustParsePortRange("40-90/tcp"))
 	c.Assert(err, gc.ErrorMatches, `cannot open 40-90/tcp \(unit "u/0"\): conflicts with 50-80/tcp requested earlier`)
 
 	// Now try closing some ports as well.
-	err = ctx.ClosePorts("udp", 8080, 8088)
+	err = ctx.ClosePortRange("", network.MustParsePortRange("8080-8088/udp"))
 	c.Assert(err, jc.ErrorIsNil) // not existing -> ignored
-	err = ctx.ClosePorts("tcp", 100, 200)
+	err = ctx.ClosePortRange("", network.MustParsePortRange("100-200/tcp"))
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.ClosePorts("tcp", 100, 200)
+	err = ctx.ClosePortRange("", network.MustParsePortRange("100-200/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // duplicates are ignored
-	err = ctx.ClosePorts("udp", 200, 300)
+	err = ctx.ClosePortRange("", network.MustParsePortRange("200-300/udp"))
 	c.Assert(err, gc.ErrorMatches, `cannot close 200-300/udp \(opened by "u/1"\) from "u/0"`)
-	err = ctx.ClosePorts("tcp", 50, 80)
+	err = ctx.ClosePortRange("", network.MustParsePortRange("50-80/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // still pending -> no longer pending
 
 	// Ensure the ports are not actually changed on the unit yet.

--- a/worker/uniter/runner/context/ports.go
+++ b/worker/uniter/runner/context/ports.go
@@ -4,180 +4,178 @@
 package context
 
 import (
-	"strings"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/network"
 )
 
-// PortRangeInfo contains information about a pending open- or
-// close-port operation for a port range. This is only exported for
-// testing.
-type PortRangeInfo struct {
-	ShouldOpen  bool
-	RelationTag names.RelationTag
+type portRangeChangeRecorder struct {
+	machinePortRanges map[names.UnitTag]map[string][]network.PortRange
 
-	// The application endpoint that the port range refers to. It may
-	// be left empty to indicate that a port range applies to all known
-	// application endpoints.
-	Endpoint string
+	// The tag of the unit that the following pending open/close ranges apply to.
+	unitTag            names.UnitTag
+	pendingOpenRanges  map[string][]network.PortRange
+	pendingCloseRanges map[string][]network.PortRange
 }
 
-// PortRange contains a port range and a relation id. Used as key to
-// pendingRelations and is only exported for testing.
-type PortRange struct {
-	Ports      network.PortRange
-	RelationId int
+func newPortRangeChangeRecorder(unit names.UnitTag, machinePortRanges map[names.UnitTag]map[string][]network.PortRange) *portRangeChangeRecorder {
+	return &portRangeChangeRecorder{
+		machinePortRanges: machinePortRanges,
+		unitTag:           unit,
+	}
 }
 
-func validatePortRange(protocol string, fromPort, toPort int) (network.PortRange, error) {
-	// Validate the given range.
-	newRange := network.PortRange{
-		Protocol: strings.ToLower(protocol),
-		FromPort: fromPort,
-		ToPort:   toPort,
-	}
-	if err := newRange.Validate(); err != nil {
-		return network.PortRange{}, err
-	}
-	return newRange, nil
-}
-
-func tryOpenPorts(
-	protocol string,
-	fromPort, toPort int,
-	unitTag names.UnitTag,
-	machinePorts map[network.PortRange]params.RelationUnit,
-	pendingPorts map[PortRange]PortRangeInfo,
-) error {
-	// TODO(dimitern) Once port ranges are linked to relations in
-	// addition to networks, refactor this functions and test it
-	// better to ensure it handles relations properly.
-	relationId := -1
-
-	// Validate the given range.
-	newRange, err := validatePortRange(protocol, fromPort, toPort)
-	if err != nil {
-		return err
-	}
-	rangeKey := PortRange{
-		Ports:      newRange,
-		RelationId: relationId,
+// OpenPortRange registers a request to open the specified port range for the
+// provided endpoint name.
+func (r *portRangeChangeRecorder) OpenPortRange(endpointName string, portRange network.PortRange) error {
+	if err := portRange.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 
-	rangeInfo, isKnown := pendingPorts[rangeKey]
-	if isKnown {
-		if !rangeInfo.ShouldOpen {
-			// If the same range is already pending to be closed, just
-			// mark is pending to be opened.
-			rangeInfo.ShouldOpen = true
-			pendingPorts[rangeKey] = rangeInfo
+	// Ensure port range does not conflict with the ones already recorded
+	// for opening by this unit.
+	if err := r.checkForConflict(endpointName, portRange, r.unitTag, r.pendingOpenRanges, true); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return errors.Annotatef(err, "cannot open %v (unit %q)", portRange, r.unitTag.Id())
 		}
+
+		// Already exists; this is a no-op.
 		return nil
 	}
 
-	// Ensure there are no conflicts with existing ports on the
-	// machine.
-	for portRange, relUnit := range machinePorts {
-		relUnitTag, err := names.ParseUnitTag(relUnit.Unit)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"machine ports %v contain invalid unit tag",
-				portRange,
-			)
-		}
-		if newRange.ConflictsWith(portRange) {
-			if portRange == newRange && relUnitTag == unitTag {
-				// The same unit trying to open the same range is just
-				// ignored.
-				return nil
+	// Ensure port range does not conflict with existing open port ranges
+	// for all units deployed to the machine.
+	for otherUnitTag, otherUnitRanges := range r.machinePortRanges {
+		if err := r.checkForConflict(endpointName, portRange, otherUnitTag, otherUnitRanges, false); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return errors.Annotatef(err, "cannot open %v (unit %q)", portRange, r.unitTag.Id())
 			}
-			return errors.Errorf(
-				"cannot open %v (unit %q): conflicts with existing %v (unit %q)",
-				newRange, unitTag.Id(), portRange, relUnitTag.Id(),
-			)
-		}
-	}
-	// Ensure other pending port ranges do not conflict with this one.
-	for rangeKey, rangeInfo := range pendingPorts {
-		if newRange.ConflictsWith(rangeKey.Ports) && rangeInfo.ShouldOpen {
-			return errors.Errorf(
-				"cannot open %v (unit %q): conflicts with %v requested earlier",
-				newRange, unitTag.Id(), rangeKey.Ports,
-			)
+
+			// Already exists; this is a no-op.
+			return nil
 		}
 	}
 
-	rangeInfo = pendingPorts[rangeKey]
+	// If a close request is pending for this port, remove it.
+	for i, pr := range r.pendingCloseRanges[endpointName] {
+		if pr == portRange {
+			r.pendingCloseRanges[endpointName] = append(r.pendingCloseRanges[endpointName][:i], r.pendingCloseRanges[endpointName][i+1:]...)
+			break
+		}
+	}
 
-	// TODO(achilleas) update this after changing the hook tools to work
-	// with endpoints. For now, just use an empty endpoint name to emulate
-	// the pre-2.9 behavior where ports are opened to all endpoints.
-	rangeInfo.Endpoint = ""
-	rangeInfo.ShouldOpen = true
-	pendingPorts[rangeKey] = rangeInfo
+	if r.pendingOpenRanges == nil {
+		r.pendingOpenRanges = make(map[string][]network.PortRange)
+	}
+	r.pendingOpenRanges[endpointName] = append(r.pendingOpenRanges[endpointName], portRange)
 	return nil
 }
 
-func tryClosePorts(
-	protocol string,
-	fromPort, toPort int,
-	unitTag names.UnitTag,
-	machinePorts map[network.PortRange]params.RelationUnit,
-	pendingPorts map[PortRange]PortRangeInfo,
-) error {
-	// TODO(dimitern) Once port ranges are linked to relations in
-	// addition to networks, refactor this functions and test it
-	// better to ensure it handles relations properly.
-	relationId := -1
-
-	// Validate the given range.
-	newRange, err := validatePortRange(protocol, fromPort, toPort)
-	if err != nil {
-		return err
-	}
-	rangeKey := PortRange{
-		Ports:      newRange,
-		RelationId: relationId,
+// ClosePortRange registers a request to close the specified port range for the
+// provided endpoint name. If the machine has no ports open yet, this is a no-op.
+func (r *portRangeChangeRecorder) ClosePortRange(endpointName string, portRange network.PortRange) error {
+	if err := portRange.Validate(); err != nil {
+		return errors.Trace(err)
 	}
 
-	rangeInfo, isKnown := pendingPorts[rangeKey]
-	if isKnown {
-		if rangeInfo.ShouldOpen {
-			// If the same range is already pending to be opened, just
-			// remove it from pending.
-			delete(pendingPorts, rangeKey)
+	// Ensure port range does not conflict with the ones already recorded
+	// for closing by this unit.
+	if err := r.checkForConflict(endpointName, portRange, r.unitTag, r.pendingCloseRanges, true); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return errors.Annotatef(err, "cannot close %v (unit %q)", portRange, r.unitTag.Id())
 		}
+
+		// Already exists; this is a no-op.
 		return nil
 	}
 
-	// Ensure the range we're trying to close is opened on the
-	// machine.
-	relUnit, found := machinePorts[newRange]
-	if !found {
-		// Trying to close a range which is not open is ignored.
-		return nil
-	} else if relUnit.Unit != unitTag.String() {
-		relUnitTag, err := names.ParseUnitTag(relUnit.Unit)
-		if err != nil {
-			return errors.Annotatef(
-				err,
-				"machine ports %v contain invalid unit tag",
-				newRange,
-			)
+	// The port range should be accepted for closing if:
+	// - it exactly matches a an already open port for this unit, or
+	// - it doesn't conflict with any open port range; this could be either
+	//   because it matches an existing port range for this unit but the endpoints
+	//   do not match (e.g. open X for all endpoints, close X for endpoint "foo")
+	//   or because the port range is not open in which case this will be a
+	//   no-op and filtered out by the controller.
+	for otherUnitTag, otherUnitRanges := range r.machinePortRanges {
+		if err := r.checkForConflict(endpointName, portRange, otherUnitTag, otherUnitRanges, false); err != nil {
+			// Conflicts with an open port range for another unit.
+			if !errors.IsAlreadyExists(err) {
+				return errors.Annotatef(err, "cannot close %v (unit %q)", portRange, r.unitTag.Id())
+			}
 		}
-		return errors.Errorf(
-			"cannot close %v (opened by %q) from %q",
-			newRange, relUnitTag.Id(), unitTag.Id(),
-		)
 	}
 
-	rangeInfo = pendingPorts[rangeKey]
-	rangeInfo.ShouldOpen = false
-	pendingPorts[rangeKey] = rangeInfo
+	// If an open request is pending for this port, remove it.
+	for i, pr := range r.pendingOpenRanges[endpointName] {
+		if pr == portRange {
+			r.pendingOpenRanges[endpointName] = append(r.pendingOpenRanges[endpointName][:i], r.pendingOpenRanges[endpointName][i+1:]...)
+			break
+		}
+	}
+
+	// If the machine has no open ports then this is a no-op.
+	if len(r.machinePortRanges) == 0 {
+		return nil
+	}
+
+	if r.pendingCloseRanges == nil {
+		r.pendingCloseRanges = make(map[string][]network.PortRange)
+	}
+	r.pendingCloseRanges[endpointName] = append(r.pendingCloseRanges[endpointName], portRange)
 	return nil
+}
+
+// checkForConflict ensures the opening incomingPortRange for the current unit
+// does not conflict with the set of port ranges for another unit. If otherUnit
+// matches the current unit and incomingPortRange already exists in the known
+// port ranges, the method returns an AlreadyExists error.
+func (r *portRangeChangeRecorder) checkForConflict(incomingEndpoint string, incomingPortRange network.PortRange, otherUnitTag names.UnitTag, otherUnitRanges map[string][]network.PortRange, checkingAgainstPending bool) error {
+	for existingEndpoint, existingPortRanges := range otherUnitRanges {
+		for _, existingPortRange := range existingPortRanges {
+			if !incomingPortRange.ConflictsWith(existingPortRange) {
+				continue
+			}
+
+			// If these are different units then this is definitely a conflict.
+			if r.unitTag != otherUnitTag {
+				var extraDetails string
+				if checkingAgainstPending {
+					extraDetails = " requested earlier"
+				}
+				return errors.Errorf("port range conflicts with %v (unit %q)%s", existingPortRange, otherUnitTag.Id(), extraDetails)
+			} else if incomingPortRange == existingPortRange {
+				// Same unit and port range. If the endpoints
+				// do not match then this is a legal change.
+				// (e.g. open X for endpoint foo and then open
+				// X for endpoint bar).
+				if incomingEndpoint != existingEndpoint {
+					continue
+				}
+
+				return errors.AlreadyExistsf("%v (endpoint %q)", incomingPortRange, incomingEndpoint)
+			}
+
+			var extraDetails string
+			if checkingAgainstPending {
+				extraDetails = " requested earlier"
+			}
+			return errors.Errorf("port range conflicts with %v (unit %q)%s", existingPortRange, otherUnitTag.Id(), extraDetails)
+		}
+	}
+
+	// No conflict
+	return nil
+}
+
+// OpenedUnitPortRanges returns the set of port ranges currently open by the
+// current unit grouped by endpoint.
+func (r *portRangeChangeRecorder) OpenedUnitPortRanges() map[string][]network.PortRange {
+	return r.machinePortRanges[r.unitTag]
+}
+
+// PendingChanges returns the set of recorded open/close port range requests
+// (grouped by endpoint mame) for the current unit.
+func (r *portRangeChangeRecorder) PendingChanges() (map[string][]network.PortRange, map[string][]network.PortRange) {
+	return r.pendingOpenRanges, r.pendingCloseRanges
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -183,19 +183,17 @@ type ContextNetworking interface {
 	// error if it is not available.
 	PrivateAddress() (string, error)
 
-	// OpenPorts marks the supplied port range for opening when the
-	// executing unit's application is exposed.
-	OpenPorts(protocol string, fromPort, toPort int) error
+	// OpenPortRange marks the supplied port range for opening.
+	OpenPortRange(endpointName string, portRange network.PortRange) error
 
-	// ClosePorts ensures the supplied port range is closed even when
+	// ClosePortRange ensures the supplied port range is closed even when
 	// the executing unit's application is exposed (unless it is opened
 	// separately by a co- located unit).
-	ClosePorts(protocol string, fromPort, toPort int) error
+	ClosePortRange(endpointName string, portRange network.PortRange) error
 
-	// OpenedPorts returns all port ranges currently opened by this
-	// unit on its assigned machine. The result is sorted first by
-	// protocol, then by number.
-	OpenedPorts() []network.PortRange
+	// OpenedPortRanges returns all port ranges currently opened by this
+	// unit on its assigned machine grouped by endpoint name.
+	OpenedPortRanges() map[string][]network.PortRange
 
 	// NetworkInfo returns the network info for the given bindings on the given relation.
 	NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -126,18 +126,18 @@ func (mr *MockContextMockRecorder) AvailabilityZone() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockContext)(nil).AvailabilityZone))
 }
 
-// ClosePorts mocks base method
-func (m *MockContext) ClosePorts(arg0 string, arg1, arg2 int) error {
+// ClosePortRange mocks base method
+func (m *MockContext) ClosePortRange(arg0 string, arg1 network.PortRange) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClosePorts", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ClosePortRange", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ClosePorts indicates an expected call of ClosePorts
-func (mr *MockContextMockRecorder) ClosePorts(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ClosePortRange indicates an expected call of ClosePortRange
+func (mr *MockContextMockRecorder) ClosePortRange(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePorts", reflect.TypeOf((*MockContext)(nil).ClosePorts), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePortRange", reflect.TypeOf((*MockContext)(nil).ClosePortRange), arg0, arg1)
 }
 
 // CloudSpec mocks base method
@@ -363,32 +363,32 @@ func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1)
 }
 
-// OpenPorts mocks base method
-func (m *MockContext) OpenPorts(arg0 string, arg1, arg2 int) error {
+// OpenPortRange mocks base method
+func (m *MockContext) OpenPortRange(arg0 string, arg1 network.PortRange) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenPorts", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "OpenPortRange", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// OpenPorts indicates an expected call of OpenPorts
-func (mr *MockContextMockRecorder) OpenPorts(arg0, arg1, arg2 interface{}) *gomock.Call {
+// OpenPortRange indicates an expected call of OpenPortRange
+func (mr *MockContextMockRecorder) OpenPortRange(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPorts", reflect.TypeOf((*MockContext)(nil).OpenPorts), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPortRange", reflect.TypeOf((*MockContext)(nil).OpenPortRange), arg0, arg1)
 }
 
-// OpenedPorts mocks base method
-func (m *MockContext) OpenedPorts() []network.PortRange {
+// OpenedPortRanges mocks base method
+func (m *MockContext) OpenedPortRanges() map[string][]network.PortRange {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenedPorts")
-	ret0, _ := ret[0].([]network.PortRange)
+	ret := m.ctrl.Call(m, "OpenedPortRanges")
+	ret0, _ := ret[0].(map[string][]network.PortRange)
 	return ret0
 }
 
-// OpenedPorts indicates an expected call of OpenedPorts
-func (mr *MockContextMockRecorder) OpenedPorts() *gomock.Call {
+// OpenedPortRanges indicates an expected call of OpenedPortRanges
+func (mr *MockContextMockRecorder) OpenedPortRanges() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedPorts", reflect.TypeOf((*MockContext)(nil).OpenedPorts))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedPortRanges", reflect.TypeOf((*MockContext)(nil).OpenedPortRanges))
 }
 
 // PrivateAddress mocks base method

--- a/worker/uniter/runner/jujuc/opened-ports.go
+++ b/worker/uniter/runner/jujuc/opened-ports.go
@@ -4,8 +4,13 @@
 package jujuc
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/set"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/core/network"
@@ -14,8 +19,9 @@ import (
 // OpenedPortsCommand implements the opened-ports command.
 type OpenedPortsCommand struct {
 	cmd.CommandBase
-	ctx Context
-	out cmd.Output
+	ctx           Context
+	showEndpoints bool
+	out           cmd.Output
 }
 
 func NewOpenedPortsCommand(ctx Context) (cmd.Command, error) {
@@ -23,17 +29,29 @@ func NewOpenedPortsCommand(ctx Context) (cmd.Command, error) {
 }
 
 func (c *OpenedPortsCommand) Info() *cmd.Info {
-	doc := `Each list entry has format <port>/<protocol> (e.g. "80/tcp") or
-<from>-<to>/<protocol> (e.g. "8080-8088/udp").`
 	return jujucmd.Info(&cmd.Info{
 		Name:    "opened-ports",
-		Purpose: "lists all ports or ranges opened by the unit",
-		Doc:     doc,
+		Purpose: "list all ports or port ranges opened by the unit",
+		Doc: `
+opened-ports lists all ports or port ranges opened by a unit.
+
+By default, the port range listing does not include information about the 
+application endpoints that each port range applies to. Each list entry is
+formatted as <port>/<protocol> (e.g. "80/tcp") or <from>-<to>/<protocol> 
+(e.g. "8080-8088/udp").
+
+If the --endpoints option is specified, each entry in the port list will be
+augmented with a comma-delimited list of endpoints that the port range 
+applies to (e.g. "80/tcp (endpoint1, endpoint2)"). If a port range applies to
+all endpoints, this will be indicated by the presence of a '*' character
+(e.g. "80/tcp (*)").
+`,
 	})
 }
 
 func (c *OpenedPortsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "smart", cmd.DefaultFormatters.Formatters())
+	f.BoolVar(&c.showEndpoints, "endpoints", false, "display the list of target application endpoints for each port range")
 }
 
 func (c *OpenedPortsCommand) Init(args []string) error {
@@ -41,11 +59,57 @@ func (c *OpenedPortsCommand) Init(args []string) error {
 }
 
 func (c *OpenedPortsCommand) Run(ctx *cmd.Context) error {
-	unitPortRanges := uniquePortRanges(c.ctx.OpenedPortRanges())
-	results := make([]string, len(unitPortRanges))
-	for i, portRange := range unitPortRanges {
+	unitPortRanges := c.ctx.OpenedPortRanges()
+	if !c.showEndpoints {
+		return c.renderPortsWithoutEndpointDetails(ctx, unitPortRanges)
+	}
+
+	return c.renderPortsWithEndpointDetails(ctx, unitPortRanges)
+}
+
+func (c *OpenedPortsCommand) renderPortsWithoutEndpointDetails(ctx *cmd.Context, unitPortRanges map[string][]network.PortRange) error {
+	uniquePortRanges := uniquePortRanges(unitPortRanges)
+	results := make([]string, len(uniquePortRanges))
+	for i, portRange := range uniquePortRanges {
 		results[i] = portRange.String()
 	}
+	return c.out.Write(ctx, results)
+}
+
+func (c *OpenedPortsCommand) renderPortsWithEndpointDetails(ctx *cmd.Context, unitPortRanges map[string][]network.PortRange) error {
+	endpointsByPort := make(map[network.PortRange]set.Strings)
+	for endpointName, portRanges := range unitPortRanges {
+		for _, pr := range portRanges {
+			if endpointsByPort[pr] == nil {
+				endpointsByPort[pr] = set.NewStrings()
+			}
+			endpointsByPort[pr].Add(endpointName)
+		}
+	}
+
+	// Sort port ranges so we can generate consistent output
+	var uniquePortRanges []network.PortRange
+	for pr := range endpointsByPort {
+		uniquePortRanges = append(uniquePortRanges, pr)
+	}
+	network.SortPortRanges(uniquePortRanges)
+
+	// Convert to port range entries and sort them by port range
+	results := make([]string, len(uniquePortRanges))
+	for i, pr := range uniquePortRanges {
+		endpoints := endpointsByPort[pr]
+
+		var endpointDescr string
+		if endpoints.Contains("") { // all endpoints?
+			endpointDescr = "*"
+		} else { // sort them by name
+			endpointList := endpoints.Values()
+			sort.Strings(endpointList)
+			endpointDescr = strings.Join(endpointList, ", ")
+		}
+		results[i] = fmt.Sprintf("%s (%s)", pr, endpointDescr)
+	}
+
 	return c.out.Write(ctx, results)
 }
 

--- a/worker/uniter/runner/jujuc/opened-ports_test.go
+++ b/worker/uniter/runner/jujuc/opened-ports_test.go
@@ -22,15 +22,17 @@ type OpenedPortsSuite struct {
 var _ = gc.Suite(&OpenedPortsSuite{})
 
 func (s *OpenedPortsSuite) TestRunAllFormats(c *gc.C) {
-	expectedPorts := []network.PortRange{
-		{10, 20, "tcp"},
-		{80, 80, "tcp"},
-		{53, 55, "udp"},
-		{63, 63, "udp"},
+	expectedPorts := map[string][]network.PortRange{
+		"": []network.PortRange{
+			network.MustParsePortRange("10-20/tcp"),
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("53-55/udp"),
+			network.MustParsePortRange("63/udp"),
+		},
 	}
-	network.SortPortRanges(expectedPorts)
-	portsAsStrings := make([]string, len(expectedPorts))
-	for i, portRange := range expectedPorts {
+	network.SortPortRanges(expectedPorts[""])
+	portsAsStrings := make([]string, len(expectedPorts[""]))
+	for i, portRange := range expectedPorts[""] {
 		portsAsStrings[i] = portRange.String()
 	}
 	defaultOutput := strings.Join(portsAsStrings, "\n") + "\n"
@@ -54,7 +56,7 @@ func (s *OpenedPortsSuite) TestRunAllFormats(c *gc.C) {
 		}
 		c.Check(stdout, gc.Equals, expectedOutput)
 		c.Check(stderr, gc.Equals, "")
-		hctx.info.CheckPorts(c, expectedPorts)
+		hctx.info.CheckPortRanges(c, expectedPorts)
 	}
 }
 
@@ -85,10 +87,10 @@ Each list entry has format <port>/<protocol> (e.g. "80/tcp") or
 
 func (s *OpenedPortsSuite) getContextAndOpenPorts(c *gc.C) *Context {
 	hctx := s.GetHookContext(c, -1, "")
-	hctx.OpenPorts("tcp", 80, 80)
-	hctx.OpenPorts("tcp", 10, 20)
-	hctx.OpenPorts("udp", 63, 63)
-	hctx.OpenPorts("udp", 53, 55)
+	hctx.OpenPortRange("", network.MustParsePortRange("80/tcp"))
+	hctx.OpenPortRange("", network.MustParsePortRange("10-20/tcp"))
+	hctx.OpenPortRange("", network.MustParsePortRange("63/udp"))
+	hctx.OpenPortRange("", network.MustParsePortRange("53-55/udp"))
 	return hctx
 }
 

--- a/worker/uniter/runner/jujuc/ports_test.go
+++ b/worker/uniter/runner/jujuc/ports_test.go
@@ -22,28 +22,53 @@ var _ = gc.Suite(&PortsSuite{})
 
 var portsTests = []struct {
 	cmd    []string
-	expect []network.PortRange
+	expect map[string][]network.PortRange
 }{
-	{[]string{"open-port", "80"}, makeRanges("80/tcp")},
-	{[]string{"open-port", "99/tcp"}, makeRanges("80/tcp", "99/tcp")},
-	{[]string{"open-port", "100-200"}, makeRanges("80/tcp", "99/tcp", "100-200/tcp")},
-	{[]string{"open-port", "443/udp"}, makeRanges("80/tcp", "99/tcp", "100-200/tcp", "443/udp")},
-	{[]string{"close-port", "80/TCP"}, makeRanges("99/tcp", "100-200/tcp", "443/udp")},
-	{[]string{"close-port", "100-200/tcP"}, makeRanges("99/tcp", "443/udp")},
-	{[]string{"close-port", "443"}, makeRanges("99/tcp", "443/udp")},
-	{[]string{"close-port", "443/udp"}, makeRanges("99/tcp")},
-	{[]string{"open-port", "123/udp"}, makeRanges("99/tcp", "123/udp")},
-	{[]string{"close-port", "9999/UDP"}, makeRanges("99/tcp", "123/udp")},
-	{[]string{"open-port", "icmp"}, makeRanges("icmp", "99/tcp", "123/udp")},
+	{[]string{"open-port", "80"}, makeAllEndpointsRanges("80/tcp")},
+	{[]string{"open-port", "99/tcp"}, makeAllEndpointsRanges("80/tcp", "99/tcp")},
+	{[]string{"open-port", "100-200"}, makeAllEndpointsRanges("80/tcp", "99/tcp", "100-200/tcp")},
+	{[]string{"open-port", "443/udp"}, makeAllEndpointsRanges("80/tcp", "99/tcp", "100-200/tcp", "443/udp")},
+	{[]string{"close-port", "80/TCP"}, makeAllEndpointsRanges("99/tcp", "100-200/tcp", "443/udp")},
+	{[]string{"close-port", "100-200/tcP"}, makeAllEndpointsRanges("99/tcp", "443/udp")},
+	{[]string{"close-port", "443"}, makeAllEndpointsRanges("99/tcp", "443/udp")},
+	{[]string{"close-port", "443/udp"}, makeAllEndpointsRanges("99/tcp")},
+	{[]string{"open-port", "123/udp"}, makeAllEndpointsRanges("99/tcp", "123/udp")},
+	{[]string{"close-port", "9999/UDP"}, makeAllEndpointsRanges("99/tcp", "123/udp")},
+	{[]string{"open-port", "icmp"}, makeAllEndpointsRanges("icmp", "99/tcp", "123/udp")},
+	// Tests with --endpoints.
+	{[]string{"open-port", "--endpoints", "foo,bar", "1337/tcp"}, map[string][]network.PortRange{
+		// Pre-existing ports from previous tests
+		"": []network.PortRange{
+			network.MustParsePortRange("icmp"),
+			network.MustParsePortRange("99/tcp"),
+			network.MustParsePortRange("123/udp"),
+		},
+		// Endpoint-specific ports
+		"foo": []network.PortRange{network.MustParsePortRange("1337/tcp")},
+		"bar": []network.PortRange{network.MustParsePortRange("1337/tcp")},
+	}},
+	{[]string{"close-port", "--endpoints", "foo", "1337/tcp"}, map[string][]network.PortRange{
+		"": []network.PortRange{
+			network.MustParsePortRange("icmp"),
+			network.MustParsePortRange("99/tcp"),
+			network.MustParsePortRange("123/udp"),
+		},
+		"foo": []network.PortRange{
+			// Removed
+		},
+		"bar": []network.PortRange{network.MustParsePortRange("1337/tcp")},
+	}},
 }
 
-func makeRanges(stringRanges ...string) []network.PortRange {
+func makeAllEndpointsRanges(stringRanges ...string) map[string][]network.PortRange {
 	var results []network.PortRange
 	for _, s := range stringRanges {
 		results = append(results, network.MustParsePortRange(s))
 	}
 	network.SortPortRanges(results)
-	return results
+	return map[string][]network.PortRange{
+		"": results,
+	}
 }
 
 func (s *PortsSuite) TestOpenClose(c *gc.C) {
@@ -56,9 +81,7 @@ func (s *PortsSuite) TestOpenClose(c *gc.C) {
 		c.Check(code, gc.Equals, 0)
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-		hctx.info.CheckPortRanges(c, map[string][]network.PortRange{
-			"": t.expect,
-		})
+		hctx.info.CheckPortRanges(c, t.expect)
 	}
 }
 
@@ -71,10 +94,14 @@ func (s *PortsSuite) TestHelp(c *gc.C) {
 Usage: open-port <port>[/<protocol>] or <from>-<to>[/<protocol>] or icmp
 
 Summary:
-register a port or range to open
+register a request to open a port or port range
 
 Details:
-The port range will only be open while the application is exposed.
+open-port registers a request to open the specified port or port range.
+
+By default, the specified port or port range will be opened for all defined
+application endpoints. The --endpoints option can be used to constrain the 
+open request to a comma-delimited list of application endpoints.
 `[1:])
 
 	close, err := jujuc.NewCommand(hctx, cmdString("close-port"))
@@ -83,13 +110,20 @@ The port range will only be open while the application is exposed.
 Usage: close-port <port>[/<protocol>] or <from>-<to>[/<protocol>] or icmp
 
 Summary:
-ensure a port or range is always closed
+register a request to close a port or port range
+
+Details:
+close-port registers a request to open the specified port or port range.
+
+By default, the specified port or port range will be closed for all defined
+application endpoints. The --endpoints option can be used to constrain the 
+close request to a comma-delimited list of application endpoints.
 `[1:])
 }
 
 // Since the deprecation warning gets output during Run, we really need
 // some valid commands to run
-var portsFormatDeprectaionTests = []struct {
+var portsFormatDeprecationTests = []struct {
 	cmd []string
 }{
 	{[]string{"open-port", "--format", "foo", "80"}},
@@ -98,7 +132,7 @@ var portsFormatDeprectaionTests = []struct {
 
 func (s *PortsSuite) TestOpenCloseDeprecation(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	for _, t := range portsFormatDeprectaionTests {
+	for _, t := range portsFormatDeprecationTests {
 		name := t.cmd[0]
 		com, err := jujuc.NewCommand(hctx, cmdString(name))
 		c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -108,18 +108,18 @@ func (*RestrictedContext) PublicAddress() (string, error) { return "", ErrRestri
 // PrivateAddress implements hooks.Context.
 func (*RestrictedContext) PrivateAddress() (string, error) { return "", ErrRestrictedContext }
 
-// OpenPorts implements hooks.Context.
-func (*RestrictedContext) OpenPorts(protocol string, fromPort, toPort int) error {
+// OpenPortRange implements hooks.Context.
+func (*RestrictedContext) OpenPortRange(string, network.PortRange) error {
 	return ErrRestrictedContext
 }
 
-// ClosePorts implements hooks.Context.
-func (*RestrictedContext) ClosePorts(protocol string, fromPort, toPort int) error {
+// ClosePortRange implements hooks.Context.
+func (*RestrictedContext) ClosePortRange(string, network.PortRange) error {
 	return ErrRestrictedContext
 }
 
-// OpenedPorts implements hooks.Context.
-func (*RestrictedContext) OpenedPorts() []network.PortRange { return nil }
+// OpenedPortRanges implements hooks.Context.
+func (*RestrictedContext) OpenedPortRanges() map[string][]network.PortRange { return nil }
 
 // NetworkInfo implements hooks.Context.
 func (*RestrictedContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {


### PR DESCRIPTION
## Description of change

This PR builds on top of the changes introduced by #11877 (the OpenedMachinePorts API call) to enable the port-related hook tools (open-ports, close-ports, opened-ports) to work with endpoints. 

The **default** mode of operation for the aforementioned tools has been preserved as-is for backwards compatibility reasons:
- `open/close-ports` (unless explicitly instructed) assume that open/close requests always apply to **all** application endpoints. This matches the pre-2.9 juju behavior.
- `opened-ports` will list the _unique_ set of open port ranges without any endpoint details (even if opened for a specific endpoint). This ensures that we don't break existing charms (and/or frameworks) that might be attempting to parse the command output.

Newer charms that want to leverage this new feature (they can use version sniffing to see if it is supported) can provide the `--endpoints` flag to the tools. More specifically:
- the `open/close-ports` tools allow charms to target the open/close request to a comma delimited list of endpoints. 
- the `opened-ports` tool will group opened ports by endpoint and include the list the endpoints (or `*` if the range is open across **all** endpoints) in its output.

## Implementation details

The PR includes a few important refactoring changes:
- the duplicated code for parsing and validating port ranges (and tests) has been removed from the hook tools; instead, we now use the (thoroughly tested) `core/network.ParsePortRange` to do the parsing/validation steps.
- the port range logic in the uniter's context has been rewritten from scratch so that it works with the various edge cases you might bump into when working with endpoints (e.g. a unit opens the same range for different endpoints). The new version is wrapped as a neat helper type which does not suffer from the pass-map-by-value (and then modify) issues of the previous implementation.
- several methods in the path from the hook tools to the uniter context operations that used to take a [from, to, protocol] tuple as argument have been changed to accept a port range.

Finally, the help docs for these hook tools have been rewritten so they match the style and layout of other hook tools' help docs.

## QA steps

*Please replace with how we can verify that the change works?*

```console
$ juju bootstrap lxd test --no-gui

$ juju deploy percona-cluster

# Mysql opens 3306 for all endpoints
$ juju run --unit percona-cluster/0 "opened-ports"
3306/tcp

# Check the detailed port listing
$ juju run --unit percona-cluster/0 "opened-ports --endpoints"
3306/tcp (*)

# Close 3306 for the db-admin and shared-db endpoints
# Juju should carve out the port from these endpoints and
# retain it for the rest
$ juju run --unit percona-cluster/0 "close-port 3306/tcp --endpoints db-admin,shared-db"

$ juju run --unit percona-cluster/0 "opened-ports --endpoints"
3306/tcp (access, cluster, db, ha, master, nrpe-external-master, slave)

# Open 1337 for the db-admin endpoint
$ juju run --unit percona-cluster/0 "open-port 1337/udp --endpoints db-admin"

$ juju run --unit percona-cluster/0 "opened-ports --endpoints"
3306/tcp (access, cluster, db, ha, master, nrpe-external-master, slave)
1337/udp (db-admin)

# Open 3306 for *all* endpoints
$ juju run --unit percona-cluster/0 "open-port 3306/tcp"

$ juju run --unit percona-cluster/0 "opened-ports --endpoints"
3306/tcp (*)
1337/udp (db-admin)

# Try to open port for a bogus endpoint
$ juju run --unit percona-cluster/0 "open-port 3306/tcp --endpoints bogus"

$ juju debug-log
...
ERROR juju.worker.uniter.context cannot apply changes: cannot open/close ports: open port range: endpoint "bogus" for unit "percona-cluster/0" not found
```

## Documentation changes

There is a card to do an audit of the related docs after all chunks of work land and make sure everything reflects the changes.