### PR TITLE
[dev] Introduce new firewaller API for getting opened machine ports grouped by unit and by CIDR

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -49,7 +49,7 @@ var facadeVersions = map[string]int{
 	"ExternalControllerUpdater":    1,
 	"FanConfigurer":                1,
 	"FilesystemAttachmentsWatcher": 2,
-	"Firewaller":                   5,
+	"Firewaller":                   6,
 	"FirewallRules":                1,
 	"HighAvailability":             2,
 	"HostKeyReporter":              1,

--- a/api/firewaller/machine.go
+++ b/api/firewaller/machine.go
@@ -172,7 +172,7 @@ func (m *Machine) IsManual() (bool, error) {
 // OpenedMachinePortRanges queries the open port ranges for all units on this
 // machine and returns back a map where keys are unit names and values are maps
 // of the opened port ranges by the unit grouped by subnet CIDR.
-func (m *Machine) OpenedMachinePortRanges() (map[names.UnitTag]map[string][]network.PortRange, error) {
+func (m *Machine) OpenedMachinePortRanges() (map[names.UnitTag]network.GroupedPortRanges, error) {
 	if m.st.BestAPIVersion() < 6 {
 		// OpenedMachinePortRanges() was introduced in FirewallerAPIV6.
 		return nil, errors.NotImplementedf("OpenedMachinePortRanges() (need V6+)")
@@ -196,13 +196,13 @@ func (m *Machine) OpenedMachinePortRanges() (map[names.UnitTag]map[string][]netw
 		return nil, fmt.Errorf("expected open unit port ranges to be grouped by subnet CIDR, got %s", result.GroupKey)
 	}
 
-	portRangeMap := make(map[names.UnitTag]map[string][]network.PortRange)
+	portRangeMap := make(map[names.UnitTag]network.GroupedPortRanges)
 	for _, unitPortRanges := range result.UnitPortRanges {
 		unitTag, err := names.ParseUnitTag(unitPortRanges.UnitTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		portRangeMap[unitTag] = make(map[string][]network.PortRange)
+		portRangeMap[unitTag] = make(network.GroupedPortRanges)
 
 		for cidr, portRanges := range unitPortRanges.PortRangeGroups {
 			portList := make([]network.PortRange, len(portRanges))

--- a/api/firewaller/machine.go
+++ b/api/firewaller/machine.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/names/v4"
 )
 
 // Machine represents a juju machine as seen by the firewaller worker.

--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -8,9 +8,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/state"
@@ -186,4 +188,107 @@ func mustClosePortRanges(c *gc.C, st *state.State, u *state.Unit, endpointName s
 	}
 
 	c.Assert(st.ApplyOperation(unitPortRanges.Changes()), jc.ErrorIsNil)
+}
+
+func (s *machineSuite) TestOpenedPortRanges(c *gc.C) {
+	mockResponse := params.OpenMachinePortRangesResults{
+		Results: []params.OpenMachinePortRangesResult{
+			{
+				GroupKey: "cidr",
+				UnitPortRanges: []params.OpenUnitPortRanges{
+					{
+						UnitTag: "unit-mysql-0",
+						PortRangeGroups: map[string][]params.PortRange{
+							// The subnet CIDRs for space "42" that "foo"
+							// is bound to.
+							"192.168.0.0/24": []params.PortRange{
+								params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
+							},
+							"192.168.1.0/24": []params.PortRange{
+								params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
+							},
+						},
+					},
+					{
+						UnitTag: "unit-wordpress-0",
+						PortRangeGroups: map[string][]params.PortRange{
+							// Wordpress has opened port 80 to
+							// all bound spaces (alpha and 42). We should
+							// get an entry in each subnet
+							"10.0.0.0/24": []params.PortRange{
+								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
+							},
+							"10.0.1.0/24": []params.PortRange{
+								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
+							},
+							"192.168.0.0/24": []params.PortRange{
+								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
+							},
+							"192.168.1.0/24": []params.PortRange{
+								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	apiCaller := basetesting.BestVersionCaller{
+		BestVersion: 6, // we need V6+ to use this API
+		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Assert(objType, gc.Equals, "Firewaller")
+
+			// When we access the machine, the client checks that it's alive
+			if request == "Life" {
+				c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
+				*(result.(*params.LifeResults)) = params.LifeResults{
+					Results: []params.LifeResult{
+						{Life: life.Alive},
+					},
+				}
+				return nil
+			}
+
+			// This is the actual call we are testing.
+			c.Assert(request, gc.Equals, "OpenedMachinePortRanges")
+			c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: s.machines[0].MachineTag().String()}}})
+			c.Assert(result, gc.FitsTypeOf, &params.OpenMachinePortRangesResults{})
+			*(result.(*params.OpenMachinePortRangesResults)) = mockResponse
+			return nil
+		},
+	}
+
+	client, err := firewaller.NewClient(apiCaller)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mach, err := client.Machine(s.machines[0].MachineTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	portsRangesByCIDR, err := mach.OpenedMachinePortRanges()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(portsRangesByCIDR, jc.DeepEquals, map[names.UnitTag]map[string][]network.PortRange{
+		names.NewUnitTag("mysql/0"): map[string][]network.PortRange{
+			"192.168.0.0/24": []network.PortRange{
+				network.MustParsePortRange("3306/tcp"),
+			},
+			"192.168.1.0/24": []network.PortRange{
+				network.MustParsePortRange("3306/tcp"),
+			},
+		},
+		names.NewUnitTag("wordpress/0"): map[string][]network.PortRange{
+			"10.0.0.0/24": []network.PortRange{
+				network.MustParsePortRange("80/tcp"),
+			},
+			"10.0.1.0/24": []network.PortRange{
+				network.MustParsePortRange("80/tcp"),
+			},
+			"192.168.0.0/24": []network.PortRange{
+				network.MustParsePortRange("80/tcp"),
+			},
+			"192.168.1.0/24": []network.PortRange{
+				network.MustParsePortRange("80/tcp"),
+			},
+		},
+	})
 }

--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -267,8 +267,8 @@ func (s *machineSuite) TestOpenedPortRanges(c *gc.C) {
 
 	portsRangesByCIDR, err := mach.OpenedMachinePortRanges()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(portsRangesByCIDR, jc.DeepEquals, map[names.UnitTag]map[string][]network.PortRange{
-		names.NewUnitTag("mysql/0"): map[string][]network.PortRange{
+	c.Assert(portsRangesByCIDR, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
+		names.NewUnitTag("mysql/0"): network.GroupedPortRanges{
 			"192.168.0.0/24": []network.PortRange{
 				network.MustParsePortRange("3306/tcp"),
 			},
@@ -276,7 +276,7 @@ func (s *machineSuite) TestOpenedPortRanges(c *gc.C) {
 				network.MustParsePortRange("3306/tcp"),
 			},
 		},
-		names.NewUnitTag("wordpress/0"): map[string][]network.PortRange{
+		names.NewUnitTag("wordpress/0"): network.GroupedPortRanges{
 			"10.0.0.0/24": []network.PortRange{
 				network.MustParsePortRange("80/tcp"),
 			},

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -112,12 +112,12 @@ func (s *stateSuite) TestOpenedMachinePortRanges(c *gc.C) {
 
 	portRangesMap, err := client.OpenedMachinePortRanges(names.NewMachineTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(portRangesMap, jc.DeepEquals, map[names.UnitTag]map[string][]network.PortRange{
-		names.NewUnitTag("mysql/0"): map[string][]network.PortRange{
+	c.Assert(portRangesMap, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
+		names.NewUnitTag("mysql/0"): network.GroupedPortRanges{
 			"":       []network.PortRange{network.MustParsePortRange("100-200/tcp")},
 			"server": []network.PortRange{network.MustParsePortRange("3306/tcp")},
 		},
-		names.NewUnitTag("wordpress/0"): map[string][]network.PortRange{
+		names.NewUnitTag("wordpress/0"): network.GroupedPortRanges{
 			"monitoring-port": []network.PortRange{network.MustParsePortRange("1337/udp")},
 		},
 	})

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -397,7 +397,7 @@ func (st *State) AllMachinePorts(machineTag names.MachineTag) (map[network.PortR
 
 // OpenedMachinePortRanges returns all port ranges currently open on the given
 // machine, grouped by unit tag and application endpoint.
-func (st *State) OpenedMachinePortRanges(machineTag names.MachineTag) (map[names.UnitTag]map[string][]network.PortRange, error) {
+func (st *State) OpenedMachinePortRanges(machineTag names.MachineTag) (map[names.UnitTag]network.GroupedPortRanges, error) {
 	if st.BestAPIVersion() < 17 {
 		// OpenedMachinePortRanges() was introduced in UniterAPIV17.
 		return nil, errors.NotImplementedf("OpenedMachinePortRanges() (need V17+)")
@@ -420,13 +420,13 @@ func (st *State) OpenedMachinePortRanges(machineTag names.MachineTag) (map[names
 		return nil, fmt.Errorf("expected open unit port ranges to be grouped by endpoint, got %s", result.GroupKey)
 	}
 
-	portRangeMap := make(map[names.UnitTag]map[string][]network.PortRange)
+	portRangeMap := make(map[names.UnitTag]network.GroupedPortRanges)
 	for _, unitPortRanges := range result.UnitPortRanges {
 		unitTag, err := names.ParseUnitTag(unitPortRanges.UnitTag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		portRangeMap[unitTag] = make(map[string][]network.PortRange)
+		portRangeMap[unitTag] = make(network.GroupedPortRanges)
 
 		for endpointName, portRanges := range unitPortRanges.PortRangeGroups {
 			portList := make([]network.PortRange, len(portRanges))

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -213,6 +213,7 @@ func AllFacades() *facade.Registry {
 	reg("Firewaller", 3, firewaller.NewStateFirewallerAPIV3)
 	reg("Firewaller", 4, firewaller.NewStateFirewallerAPIV4)
 	reg("Firewaller", 5, firewaller.NewStateFirewallerAPIV5)
+	reg("Firewaller", 6, firewaller.NewStateFirewallerAPIV6)
 	reg("FirewallRules", 1, firewallrules.NewFacade)
 	reg("HighAvailability", 2, highavailability.NewHighAvailabilityAPI)
 	reg("HostKeyReporter", 1, hostkeyreporter.NewFacade)

--- a/apiserver/common/firewall/mock_test.go
+++ b/apiserver/common/firewall/mock_test.go
@@ -400,9 +400,12 @@ func (u *mockUnit) updateAddress(value string) {
 }
 
 type mockMachine struct {
+	firewall.Machine
+
 	testing.Stub
-	id      string
-	watcher *mockAddressWatcher
+	id       string
+	watcher  *mockAddressWatcher
+	isManual bool
 }
 
 func newMockMachine(id string) *mockMachine {

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -89,6 +89,9 @@ func (st stateShim) Unit(name string) (Unit, error) {
 type Machine interface {
 	Id() string
 	WatchAddresses() state.NotifyWatcher
+	OpenedPortRanges() (state.MachinePortRanges, error)
+	SubnetCIDRsBySpaceID() (map[string][]string, error)
+	IsManual() (bool, error)
 }
 
 func (st stateShim) Machine(id string) (Machine, error) {

--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -90,7 +90,6 @@ type Machine interface {
 	Id() string
 	WatchAddresses() state.NotifyWatcher
 	OpenedPortRanges() (state.MachinePortRanges, error)
-	SubnetCIDRsBySpaceID() (map[string][]string, error)
 	IsManual() (bool, error)
 }
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -559,8 +559,8 @@ func (mockUnitPortRanges) ForEndpoint(endpointName string) []network.PortRange {
 	return nil
 }
 
-func (mockUnitPortRanges) ByEndpoint() map[string][]network.PortRange {
-	return map[string][]network.PortRange{
+func (mockUnitPortRanges) ByEndpoint() network.GroupedPortRanges {
+	return network.GroupedPortRanges{
 		"": {
 			network.MustParsePortRange("100-102/tcp"),
 		},

--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -676,8 +676,8 @@ func (f *FirewallerAPIV6) resolveApplicationBindings(apps set.Strings) (map[stri
 //
 // After the above step, all opened port ranges are then grouped by subnet CIDR,
 // de-dupped and sorted before they are returned to the caller.
-func mapUnitPortsToSubnetCIDRs(unitName string, portRangesByEndpoint map[string][]network.PortRange, endpointBindings map[string]string, subnetCIDRsBySpaceID map[string][]string) map[string][]network.PortRange {
-	portRangesByCIDR := make(map[string][]network.PortRange)
+func mapUnitPortsToSubnetCIDRs(unitName string, portRangesByEndpoint network.GroupedPortRanges, endpointBindings map[string]string, subnetCIDRsBySpaceID map[string][]string) network.GroupedPortRanges {
+	portRangesByCIDR := make(network.GroupedPortRanges)
 
 	for endpointName, portRanges := range portRangesByEndpoint {
 		// These port ranges target an explicit endpoint; just iterate

--- a/apiserver/facades/controller/firewaller/firewaller_internal_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_internal_test.go
@@ -18,7 +18,7 @@ type UnitToCIDRMappingSuite struct {
 
 func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 	unitName := "u/0"
-	portRangesByEndpoint := map[string][]network.PortRange{
+	portRangesByEndpoint := network.GroupedPortRanges{
 		"foo": []network.PortRange{
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("456/tcp"),
@@ -50,7 +50,7 @@ func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 	}
 
 	got := mapUnitPortsToSubnetCIDRs(unitName, portRangesByEndpoint, endpointBindings, subnetCIDRsBySpaceID)
-	exp := map[string][]network.PortRange{
+	exp := network.GroupedPortRanges{
 		"192.168.0.0/24": []network.PortRange{
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("456/tcp"),
@@ -68,7 +68,7 @@ func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 
 func (s *UnitToCIDRMappingSuite) TestWildcardExpansion(c *gc.C) {
 	unitName := "u/0"
-	portRangesByEndpoint := map[string][]network.PortRange{
+	portRangesByEndpoint := network.GroupedPortRanges{
 		"": []network.PortRange{
 			// These ranges should be added to the CIDRs of each
 			// bound endpoint (so, both alpha and "42").
@@ -97,7 +97,7 @@ func (s *UnitToCIDRMappingSuite) TestWildcardExpansion(c *gc.C) {
 	}
 
 	got := mapUnitPortsToSubnetCIDRs(unitName, portRangesByEndpoint, endpointBindings, subnetCIDRsBySpaceID)
-	exp := map[string][]network.PortRange{
+	exp := network.GroupedPortRanges{
 		"10.0.0.0/24": []network.PortRange{
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("456/tcp"),

--- a/apiserver/facades/controller/firewaller/firewaller_internal_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_internal_test.go
@@ -17,7 +17,6 @@ type UnitToCIDRMappingSuite struct {
 }
 
 func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
-	unitName := "u/0"
 	portRangesByEndpoint := network.GroupedPortRanges{
 		"foo": []network.PortRange{
 			network.MustParsePortRange("123/tcp"),
@@ -38,18 +37,18 @@ func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 		"bar": "42",
 	}
 
-	subnetCIDRsBySpaceID := map[string][]string{
-		network.AlphaSpaceId: []string{
-			"10.0.0.0/24",
-			"10.0.1.0/24",
-		},
-		"42": []string{
-			"192.168.0.0/24",
-			"192.168.1.0/24",
-		},
+	spaceInfos := network.SpaceInfos{
+		{ID: network.AlphaSpaceId, Name: "alpha", Subnets: []network.SubnetInfo{
+			{ID: "11", CIDR: "10.0.0.0/24"},
+			{ID: "12", CIDR: "10.0.1.0/24"},
+		}},
+		{ID: "42", Name: "questions-about-the-universe", Subnets: []network.SubnetInfo{
+			{ID: "13", CIDR: "192.168.0.0/24"},
+			{ID: "14", CIDR: "192.168.1.0/24"},
+		}},
 	}
 
-	got := mapUnitPortsToSubnetCIDRs(unitName, portRangesByEndpoint, endpointBindings, subnetCIDRsBySpaceID)
+	got := mapUnitPortsToSubnetCIDRs(portRangesByEndpoint, endpointBindings, spaceInfos.SubnetCIDRsBySpaceID())
 	exp := network.GroupedPortRanges{
 		"192.168.0.0/24": []network.PortRange{
 			network.MustParsePortRange("123/tcp"),
@@ -67,7 +66,6 @@ func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 }
 
 func (s *UnitToCIDRMappingSuite) TestWildcardExpansion(c *gc.C) {
-	unitName := "u/0"
 	portRangesByEndpoint := network.GroupedPortRanges{
 		"": []network.PortRange{
 			// These ranges should be added to the CIDRs of each
@@ -85,18 +83,18 @@ func (s *UnitToCIDRMappingSuite) TestWildcardExpansion(c *gc.C) {
 		"bar": "42",
 	}
 
-	subnetCIDRsBySpaceID := map[string][]string{
-		network.AlphaSpaceId: []string{
-			"10.0.0.0/24",
-			"10.0.1.0/24",
-		},
-		"42": []string{
-			"192.168.0.0/24",
-			"192.168.1.0/24",
-		},
+	spaceInfos := network.SpaceInfos{
+		{ID: network.AlphaSpaceId, Name: "alpha", Subnets: []network.SubnetInfo{
+			{ID: "11", CIDR: "10.0.0.0/24"},
+			{ID: "12", CIDR: "10.0.1.0/24"},
+		}},
+		{ID: "42", Name: "questions-about-the-universe", Subnets: []network.SubnetInfo{
+			{ID: "13", CIDR: "192.168.0.0/24"},
+			{ID: "14", CIDR: "192.168.1.0/24"},
+		}},
 	}
 
-	got := mapUnitPortsToSubnetCIDRs(unitName, portRangesByEndpoint, endpointBindings, subnetCIDRsBySpaceID)
+	got := mapUnitPortsToSubnetCIDRs(portRangesByEndpoint, endpointBindings, spaceInfos.SubnetCIDRsBySpaceID())
 	exp := network.GroupedPortRanges{
 		"10.0.0.0/24": []network.PortRange{
 			network.MustParsePortRange("123/tcp"),

--- a/apiserver/facades/controller/firewaller/firewaller_internal_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_internal_test.go
@@ -1,0 +1,122 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package firewaller
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+)
+
+var _ = gc.Suite(&UnitToCIDRMappingSuite{})
+
+type UnitToCIDRMappingSuite struct {
+	testing.IsolationSuite
+}
+
+func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
+	unitName := "u/0"
+	portRangesByEndpoint := map[string][]network.PortRange{
+		"foo": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+		},
+		"bar": []network.PortRange{
+			// The descending ordering here is intentional so that
+			// we can verify that the output list entries do get
+			// sorted.
+			network.MustParsePortRange("777/tcp"),
+			network.MustParsePortRange("123/tcp"),
+		},
+	}
+	endpointBindings := map[string]string{
+		"": network.AlphaSpaceId,
+		// Both endpoints bound to same space
+		"foo": "42",
+		"bar": "42",
+	}
+
+	subnetCIDRsBySpaceID := map[string][]string{
+		network.AlphaSpaceId: []string{
+			"10.0.0.0/24",
+			"10.0.1.0/24",
+		},
+		"42": []string{
+			"192.168.0.0/24",
+			"192.168.1.0/24",
+		},
+	}
+
+	got := mapUnitPortsToSubnetCIDRs(unitName, portRangesByEndpoint, endpointBindings, subnetCIDRsBySpaceID)
+	exp := map[string][]network.PortRange{
+		"192.168.0.0/24": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+			network.MustParsePortRange("777/tcp"),
+		},
+		"192.168.1.0/24": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+			network.MustParsePortRange("777/tcp"),
+		},
+	}
+
+	c.Assert(got, gc.DeepEquals, exp)
+}
+
+func (s *UnitToCIDRMappingSuite) TestWildcardExpansion(c *gc.C) {
+	unitName := "u/0"
+	portRangesByEndpoint := map[string][]network.PortRange{
+		"": []network.PortRange{
+			// These ranges should be added to the CIDRs of each
+			// bound endpoint (so, both alpha and "42").
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+		},
+		"bar": []network.PortRange{
+			network.MustParsePortRange("999/tcp"),
+		},
+	}
+	endpointBindings := map[string]string{
+		"":    network.AlphaSpaceId,
+		"foo": network.AlphaSpaceId,
+		"bar": "42",
+	}
+
+	subnetCIDRsBySpaceID := map[string][]string{
+		network.AlphaSpaceId: []string{
+			"10.0.0.0/24",
+			"10.0.1.0/24",
+		},
+		"42": []string{
+			"192.168.0.0/24",
+			"192.168.1.0/24",
+		},
+	}
+
+	got := mapUnitPortsToSubnetCIDRs(unitName, portRangesByEndpoint, endpointBindings, subnetCIDRsBySpaceID)
+	exp := map[string][]network.PortRange{
+		"10.0.0.0/24": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+		},
+		"10.0.1.0/24": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+		},
+		"192.168.0.0/24": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+			network.MustParsePortRange("999/tcp"),
+		},
+		"192.168.1.0/24": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+			network.MustParsePortRange("999/tcp"),
+		},
+	}
+
+	c.Assert(got, gc.DeepEquals, exp)
+}

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -177,7 +177,7 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 	mockMachine.openedPortRanges = newMockMachinePortRanges(
 		newMockUnitPortRanges(
 			"wordpress/0",
-			map[string][]network.PortRange{
+			network.GroupedPortRanges{
 				"": []network.PortRange{
 					network.MustParsePortRange("80/tcp"),
 				},
@@ -185,7 +185,7 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 		),
 		newMockUnitPortRanges(
 			"mysql/0",
-			map[string][]network.PortRange{
+			network.GroupedPortRanges{
 				"foo": []network.PortRange{
 					network.MustParsePortRange("3306/tcp"),
 				},

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -192,17 +192,17 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 			},
 		),
 	)
-	mockMachine.subnetCIDRsBySpaceID = map[string][]string{
-		network.AlphaSpaceId: []string{
-			"10.0.0.0/24",
-			"10.0.1.0/24",
-		},
-		"42": []string{
-			"192.168.0.0/24",
-			"192.168.1.0/24",
-		},
-	}
 	s.st.machines["0"] = mockMachine
+	s.st.spaceInfos = network.SpaceInfos{
+		{ID: network.AlphaSpaceId, Name: "alpha", Subnets: []network.SubnetInfo{
+			{ID: "11", CIDR: "10.0.0.0/24"},
+			{ID: "12", CIDR: "10.0.1.0/24"},
+		}},
+		{ID: "42", Name: "questions-about-the-universe", Subnets: []network.SubnetInfo{
+			{ID: "13", CIDR: "192.168.0.0/24"},
+			{ID: "14", CIDR: "192.168.1.0/24"},
+		}},
+	}
 	s.st.applicationEndpointBindings = map[string]map[string]string{
 		"mysql": map[string]string{
 			"":    network.AlphaSpaceId,

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/common/firewall"
-	"github.com/juju/juju/apiserver/facades/controller/firewaller"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
@@ -137,14 +136,6 @@ func (st *mockState) FirewallRule(service corefirewall.WellKnownServiceType) (*s
 		return nil, errors.NotFoundf("firewall rule for %q", service)
 	}
 	return r, nil
-}
-
-func (st *mockState) SubnetByCIDR(cidr string) (firewaller.Subnet, error) {
-	return nil, errors.NotImplementedf("SubnetByCIDR")
-}
-
-func (st *mockState) Subnet(id string) (firewaller.Subnet, error) {
-	return nil, errors.NotImplementedf("Subnet")
 }
 
 type mockWatcher struct {

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
 	corefirewall "github.com/juju/juju/core/firewall"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
@@ -37,17 +38,21 @@ type mockState struct {
 	remoteEntities map[names.Tag]string
 	macaroons      map[names.Tag]*macaroon.Macaroon
 	relations      map[string]*mockRelation
+	machines       map[string]*mockMachine
 	controllerInfo map[string]*mockControllerInfo
 	firewallRules  map[corefirewall.WellKnownServiceType]*state.FirewallRule
 	subnetsWatcher *mockStringsWatcher
 	modelWatcher   *mockNotifyWatcher
 	configAttrs    map[string]interface{}
+
+	applicationEndpointBindings map[string]map[string]string
 }
 
 func newMockState(modelUUID string) *mockState {
 	return &mockState{
 		modelUUID:      modelUUID,
 		relations:      make(map[string]*mockRelation),
+		machines:       make(map[string]*mockMachine),
 		remoteEntities: make(map[names.Tag]string),
 		macaroons:      make(map[names.Tag]*macaroon.Macaroon),
 		controllerInfo: make(map[string]*mockControllerInfo),
@@ -55,6 +60,8 @@ func newMockState(modelUUID string) *mockState {
 		subnetsWatcher: newMockStringsWatcher(),
 		modelWatcher:   newMockNotifyWatcher(),
 		configAttrs:    coretesting.FakeConfig(),
+
+		applicationEndpointBindings: make(map[string]map[string]string),
 	}
 }
 
@@ -97,6 +104,18 @@ func (st *mockState) ModelUUID() string {
 func (st *mockState) WatchSubnets(func(id interface{}) bool) state.StringsWatcher {
 	st.MethodCall(st, "WatchSubnets")
 	return st.subnetsWatcher
+}
+
+func (st *mockState) Machine(id string) (firewall.Machine, error) {
+	st.MethodCall(st, "Machine", id)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	mach, ok := st.machines[id]
+	if !ok {
+		return nil, errors.NotFoundf("machine %q", id)
+	}
+	return mach, nil
 }
 
 func (st *mockState) WatchOpenedPorts() state.StringsWatcher {
@@ -281,4 +300,109 @@ func (st *mockState) KeyRelation(key string) (firewall.Relation, error) {
 		return nil, errors.NotFoundf("relation %q", key)
 	}
 	return r, nil
+}
+
+func (st *mockState) ApplicationEndpointBindings(appName string) (map[string]string, error) {
+	st.MethodCall(st, "ApplicationEndpointBindings", appName)
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	b, ok := st.applicationEndpointBindings[appName]
+	if !ok {
+		return nil, errors.NotFoundf("endpoint bindings for application %q", appName)
+	}
+	return b, nil
+}
+
+type mockMachine struct {
+	testing.Stub
+	firewall.Machine
+
+	id                   string
+	subnetCIDRsBySpaceID map[string][]string
+	openedPortRanges     *mockMachinePortRanges
+	isManual             bool
+}
+
+func newMockMachine(id string) *mockMachine {
+	return &mockMachine{
+		id:                   id,
+		subnetCIDRsBySpaceID: make(map[string][]string),
+	}
+}
+
+func (st *mockMachine) Id() string {
+	st.MethodCall(st, "Id")
+	return st.id
+}
+
+func (st *mockMachine) IsManual() (bool, error) {
+	st.MethodCall(st, "IsManual")
+	if err := st.NextErr(); err != nil {
+		return false, err
+	}
+	return st.isManual, nil
+}
+
+func (st *mockMachine) OpenedPortRanges() (state.MachinePortRanges, error) {
+	st.MethodCall(st, "OpenedPortRanges")
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	if st.openedPortRanges == nil {
+		return nil, errors.NotFoundf("opened port ranges for machine %q", st.id)
+	}
+	return st.openedPortRanges, nil
+}
+
+func (st *mockMachine) SubnetCIDRsBySpaceID() (map[string][]string, error) {
+	st.MethodCall(st, "SubnetCIDRsBySpaceID")
+	if err := st.NextErr(); err != nil {
+		return nil, err
+	}
+	return st.subnetCIDRsBySpaceID, nil
+}
+
+type mockMachinePortRanges struct {
+	state.MachinePortRanges
+
+	byUnit map[string]*mockUnitPortRanges
+}
+
+func newMockMachinePortRanges(unitRanges ...*mockUnitPortRanges) *mockMachinePortRanges {
+	byUnit := make(map[string]*mockUnitPortRanges)
+	for _, upr := range unitRanges {
+		byUnit[upr.unitName] = upr
+	}
+
+	return &mockMachinePortRanges{
+		byUnit: byUnit,
+	}
+}
+
+func (st *mockMachinePortRanges) ByUnit() map[string]state.UnitPortRanges {
+	out := make(map[string]state.UnitPortRanges)
+	for k, v := range st.byUnit {
+		out[k] = v
+	}
+
+	return out
+}
+
+type mockUnitPortRanges struct {
+	state.UnitPortRanges
+
+	unitName   string
+	byEndpoint map[string][]network.PortRange
+}
+
+func newMockUnitPortRanges(unitName string, byEndpoint map[string][]network.PortRange) *mockUnitPortRanges {
+	return &mockUnitPortRanges{
+		unitName:   unitName,
+		byEndpoint: byEndpoint,
+	}
+}
+
+func (st *mockUnitPortRanges) ByEndpoint() map[string][]network.PortRange {
+	return st.byEndpoint
 }

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -393,16 +393,16 @@ type mockUnitPortRanges struct {
 	state.UnitPortRanges
 
 	unitName   string
-	byEndpoint map[string][]network.PortRange
+	byEndpoint network.GroupedPortRanges
 }
 
-func newMockUnitPortRanges(unitName string, byEndpoint map[string][]network.PortRange) *mockUnitPortRanges {
+func newMockUnitPortRanges(unitName string, byEndpoint network.GroupedPortRanges) *mockUnitPortRanges {
 	return &mockUnitPortRanges{
 		unitName:   unitName,
 		byEndpoint: byEndpoint,
 	}
 }
 
-func (st *mockUnitPortRanges) ByEndpoint() map[string][]network.PortRange {
+func (st *mockUnitPortRanges) ByEndpoint() network.GroupedPortRanges {
 	return st.byEndpoint
 }

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -30,6 +30,8 @@ type State interface {
 	Subnet(id string) (Subnet, error)
 
 	SubnetByCIDR(cidr string) (Subnet, error)
+
+	ApplicationEndpointBindings(appName string) (map[string]string, error)
 }
 
 // TODO(wallyworld) - for tests, remove when remaining firewaller tests become unit tests.
@@ -75,4 +77,8 @@ func (st stateShim) Subnet(id string) (Subnet, error) {
 
 func (st stateShim) SubnetByCIDR(cidr string) (Subnet, error) {
 	return st.st.SubnetByCIDR(cidr)
+}
+
+func (st stateShim) ApplicationEndpointBindings(appName string) (map[string]string, error) {
+	return state.ReadApplicationEndpointBindings(st.st, appName)
 }

--- a/apiserver/facades/controller/firewaller/state.go
+++ b/apiserver/facades/controller/firewaller/state.go
@@ -29,10 +29,6 @@ type State interface {
 
 	FirewallRule(service corefirewall.WellKnownServiceType) (*state.FirewallRule, error)
 
-	// TODO(achilleasa) remove
-	Subnet(id string) (Subnet, error)
-	SubnetByCIDR(cidr string) (Subnet, error)
-
 	AllEndpointBindings() (map[string]map[string]string, error)
 
 	SpaceInfos() (network.SpaceInfos, error)
@@ -68,19 +64,6 @@ func (st stateShim) WatchOpenedPorts() state.StringsWatcher {
 func (st stateShim) FirewallRule(service corefirewall.WellKnownServiceType) (*state.FirewallRule, error) {
 	api := state.NewFirewallRules(st.st)
 	return api.Rule(service)
-}
-
-type Subnet interface {
-	ID() string
-	CIDR() string
-}
-
-func (st stateShim) Subnet(id string) (Subnet, error) {
-	return st.st.Subnet(id)
-}
-
-func (st stateShim) SubnetByCIDR(cidr string) (Subnet, error) {
-	return st.st.SubnetByCIDR(cidr)
 }
 
 func (st stateShim) AllEndpointBindings() (map[string]map[string]string, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -17668,8 +17668,8 @@
     },
     {
         "Name": "Firewaller",
-        "Description": "FirewallerAPIV5 provides access to the Firewaller v5 API facade.",
-        "Version": 5,
+        "Description": "FirewallerAPIV6 provides access to the Firewaller v6 API facade.",
+        "Version": 6,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -17840,6 +17840,18 @@
                         }
                     },
                     "description": "ModelConfig returns the current model's configuration."
+                },
+                "OpenedMachinePortRanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/OpenMachinePortRangesResults"
+                        }
+                    },
+                    "description": "OpenedMachinePortRanges returns a list of the opened port ranges for the\nspecified machines where each result is broken down by unit and by subnet\nCIDR."
                 },
                 "SetRelationsStatus": {
                     "type": "object",
@@ -18475,6 +18487,67 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "OpenMachinePortRangesResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "group-key": {
+                            "type": "string"
+                        },
+                        "unit-port-ranges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OpenUnitPortRanges"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "group-key",
+                        "unit-port-ranges"
+                    ]
+                },
+                "OpenMachinePortRangesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OpenMachinePortRangesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "OpenUnitPortRanges": {
+                    "type": "object",
+                    "properties": {
+                        "port-range-groups": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/PortRange"
+                                    }
+                                }
+                            }
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-tag",
+                        "port-range-groups"
                     ]
                 },
                 "PortRange": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -801,25 +801,23 @@ type OpenMachinePortRangesResults struct {
 	Results []OpenMachinePortRangesResult `json:"results"`
 }
 
-// OpenMachinePortRangesResult holds a single result of a request to the uniter's
-// OpenedMachinePortRanges API. It provides information about the set of open
-// port ranges by each one of the units deployed to the machine.
+// OpenMachinePortRangesResult holds a single result of a request to the
+// uniter's or the firewaller's OpenedMachinePortRanges API. It provides
+// information about the set of open port ranges by each one of the units
+// deployed to the machine.
 type OpenMachinePortRangesResult struct {
 	Error *Error `json:"error,omitempty"`
 
 	// GroupKey defines the attribute used to group the opened port ranges.
-	// Currently, this is always set to "endpoint".
-	// @TODO(achilleasa) similar to the legacy MachinePortsResult, this
-	// payload will also be used by the firewaller facade in the future; in
-	// that case, the grouping will be "subnetCIDR".
+	// This is set either to "endpoint" or to "cidr".
 	GroupKey string `json:"group-key"`
 
 	UnitPortRanges []OpenUnitPortRanges `json:"unit-port-ranges"`
 }
 
 // OpenUnitPortRanges describes the set of port ranges (grouped by a particular
-// attribute, eg. endpoint) that have been opened by a unit on the machine it
-// is deployed to.
+// attribute, eg. endpoint, or subnet CIDR) that have been opened by a unit on
+// the machine it is deployed to.
 type OpenUnitPortRanges struct {
 	UnitTag         string                 `json:"unit-tag"`
 	PortRangeGroups map[string][]PortRange `json:"port-range-groups"`

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -363,16 +363,12 @@ func (aw *SrvAllWatcher) mapRangesIntoPorts(portRanges []params.PortRange) []par
 // a list of unique port ranges. This method ignores subnet IDs and is provided
 // for backwards compatibility with pre 2.9 clients that assume that open-ports
 // applies to all subnets.
-func (aw *SrvAllWatcher) translatePortRanges(portsByEndpoint map[string][]network.PortRange) []params.PortRange {
+func (aw *SrvAllWatcher) translatePortRanges(portsByEndpoint network.GroupedPortRanges) []params.PortRange {
 	if portsByEndpoint == nil {
 		return nil
 	}
 
-	var uniquePortRanges []network.PortRange
-	for _, portRanges := range portsByEndpoint {
-		uniquePortRanges = append(uniquePortRanges, portRanges...)
-	}
-	uniquePortRanges = network.UniquePortRanges(uniquePortRanges)
+	uniquePortRanges := portsByEndpoint.UniquePortRanges()
 	network.SortPortRanges(uniquePortRanges)
 
 	result := make([]params.PortRange, len(uniquePortRanges))

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -359,28 +359,20 @@ func (aw *SrvAllWatcher) mapRangesIntoPorts(portRanges []params.PortRange) []par
 	return result
 }
 
-// translatePortRanges flattens a set of port ranges grouped by subnet ID into
+// translatePortRanges flattens a set of port ranges grouped by endpoint into
 // a list of unique port ranges. This method ignores subnet IDs and is provided
 // for backwards compatibility with pre 2.9 clients that assume that open-ports
 // applies to all subnets.
-func (aw *SrvAllWatcher) translatePortRanges(portsBySubnet map[string][]network.PortRange) []params.PortRange {
-	if portsBySubnet == nil {
+func (aw *SrvAllWatcher) translatePortRanges(portsByEndpoint map[string][]network.PortRange) []params.PortRange {
+	if portsByEndpoint == nil {
 		return nil
 	}
 
-	var (
-		processed        = make(map[network.PortRange]struct{})
-		uniquePortRanges []network.PortRange
-	)
-	for _, openedInSubnet := range portsBySubnet {
-		for _, pr := range openedInSubnet {
-			if _, seen := processed[pr]; seen {
-				continue
-			}
-			processed[pr] = struct{}{}
-			uniquePortRanges = append(uniquePortRanges, pr)
-		}
+	var uniquePortRanges []network.PortRange
+	for _, portRanges := range portsByEndpoint {
+		uniquePortRanges = append(uniquePortRanges, portRanges...)
 	}
+	uniquePortRanges = network.UniquePortRanges(uniquePortRanges)
 	network.SortPortRanges(uniquePortRanges)
 
 	result := make([]params.PortRange, len(uniquePortRanges))

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -217,6 +217,9 @@ func (c *sshContainer) getExecClient() (k8sexec.Executor, error) {
 		return nil, errors.Annotatef(mInfo.Error, "getting model information")
 	}
 	credentialTag, err := names.ParseCloudCredentialTag(mInfo.Result.CloudCredentialTag)
+	if err != nil {
+		return nil, err
+	}
 	remoteContents, err := c.cloudCredentialAPI.CredentialContents(credentialTag.Cloud().Id(), credentialTag.Name(), true)
 	if err != nil {
 		return nil, err

--- a/core/cache/changes.go
+++ b/core/cache/changes.go
@@ -157,7 +157,7 @@ type UnitChange struct {
 	PublicAddress            string
 	PrivateAddress           string
 	MachineId                string
-	OpenPortRangesByEndpoint map[string][]network.PortRange
+	OpenPortRangesByEndpoint network.GroupedPortRanges
 	Principal                string
 	Subordinate              bool
 
@@ -168,7 +168,7 @@ type UnitChange struct {
 
 // copy returns a deep copy of the UnitChange.
 func (u UnitChange) copy() UnitChange {
-	u.OpenPortRangesByEndpoint = copyPortRangeMap(u.OpenPortRangesByEndpoint)
+	u.OpenPortRangesByEndpoint = u.OpenPortRangesByEndpoint.Clone()
 	u.Annotations = copyStringMap(u.Annotations)
 	u.WorkloadStatus = copyStatusInfo(u.WorkloadStatus)
 	u.AgentStatus = copyStatusInfo(u.AgentStatus)
@@ -391,18 +391,6 @@ func copyStringMap(data map[string]string) map[string]string {
 		for i, d := range data {
 			cData[i] = d
 		}
-	}
-	return cData
-}
-
-func copyPortRangeMap(data map[string][]network.PortRange) map[string][]network.PortRange {
-	if data == nil {
-		return nil
-	}
-
-	cData := make(map[string][]network.PortRange, len(data))
-	for i, d := range data {
-		cData[i] = append([]network.PortRange(nil), d...)
 	}
 	return cData
 }

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -254,7 +254,7 @@ func (s *ModelSuite) TestUnitReturnsCopy(c *gc.C) {
 	m := s.NewModel(modelChange)
 
 	ch := unitChange
-	ch.OpenPortRangesByEndpoint = map[string][]network.PortRange{
+	ch.OpenPortRangesByEndpoint = network.GroupedPortRanges{
 		allEndpoints: {network.MustParsePortRange("54321/tcp")},
 	}
 

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -75,7 +75,7 @@ func (u *Unit) CharmURL() string {
 
 // OpenbPortRangesByEndpoint returns a map where keys are endpoint names and values
 // are the port ranges opened by the unit for each endpoint.
-func (u *Unit) OpenPortRangesByEndpoint() map[string][]network.PortRange {
+func (u *Unit) OpenPortRangesByEndpoint() network.GroupedPortRanges {
 	return u.details.OpenPortRangesByEndpoint
 }
 

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -368,7 +368,7 @@ type UnitInfo struct {
 	PublicAddress            string
 	PrivateAddress           string
 	MachineID                string
-	OpenPortRangesByEndpoint map[string][]network.PortRange
+	OpenPortRangesByEndpoint network.GroupedPortRanges
 	Principal                string
 	Subordinate              bool
 	// Workload and agent state are modelled separately.
@@ -397,16 +397,8 @@ func (i *UnitInfo) Clone() EntityInfo {
 		}
 	}
 
-	clone.OpenPortRangesByEndpoint = copyPortRangeMap(i.OpenPortRangesByEndpoint)
+	clone.OpenPortRangesByEndpoint = i.OpenPortRangesByEndpoint.Clone()
 	return &clone
-}
-
-func copyPortRangeMap(input map[string][]network.PortRange) map[string][]network.PortRange {
-	out := make(map[string][]network.PortRange, len(input))
-	for k, v := range input {
-		out[k] = append([]network.PortRange(nil), v...)
-	}
-	return out
 }
 
 // ActionInfo holds the information about a action that is tracked by

--- a/core/network/portrange.go
+++ b/core/network/portrange.go
@@ -114,6 +114,25 @@ func SortPortRanges(portRanges []PortRange) {
 	})
 }
 
+// UniquePortRanges removes any duplicate port ranges from the input and
+// returns de-dupped list back.
+func UniquePortRanges(portRanges []PortRange) []PortRange {
+	var (
+		res       []PortRange
+		processed = make(map[PortRange]struct{})
+	)
+
+	for _, pr := range portRanges {
+		if _, seen := processed[pr]; seen {
+			continue
+		}
+
+		res = append(res, pr)
+		processed[pr] = struct{}{}
+	}
+	return res
+}
+
 // ParsePortRange builds a PortRange from the provided string. If the
 // string does not include a protocol then "tcp" is used. Validate()
 // gets called on the result before returning. If validation fails the

--- a/core/network/portrange.go
+++ b/core/network/portrange.go
@@ -12,6 +12,34 @@ import (
 	"github.com/juju/errors"
 )
 
+// GroupedPortRanges represents a list of PortRange instances grouped by a
+// particular feature.
+type GroupedPortRanges map[string][]PortRange
+
+// UniquePortRanges returns the unique set of PortRanges in this group.
+func (grp GroupedPortRanges) UniquePortRanges() []PortRange {
+	var allPorts []PortRange
+	for _, portRanges := range grp {
+		allPorts = append(allPorts, portRanges...)
+	}
+	uniquePortRanges := UniquePortRanges(allPorts)
+	SortPortRanges(uniquePortRanges)
+	return uniquePortRanges
+}
+
+// Clone returns a copy of this port range grouping.
+func (grp GroupedPortRanges) Clone() GroupedPortRanges {
+	if len(grp) == 0 {
+		return nil
+	}
+
+	grpCopy := make(GroupedPortRanges, len(grp))
+	for k, v := range grp {
+		grpCopy[k] = append([]PortRange(nil), v...)
+	}
+	return grpCopy
+}
+
 // PortRange represents a single range of ports on a particular subnet.
 type PortRange struct {
 	FromPort int

--- a/core/network/portrange_test.go
+++ b/core/network/portrange_test.go
@@ -407,3 +407,24 @@ func (p *PortRangeSuite) TestUniquePortRanges(c *gc.C) {
 	got := network.UniquePortRanges(in)
 	c.Assert(got, gc.DeepEquals, exp, gc.Commentf("expected duplicate port ranges to be removed"))
 }
+
+func (p *PortRangeSuite) TestUniquePortRangesInGroup(c *gc.C) {
+	in := network.GroupedPortRanges{
+		"foxtrot": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("123/tcp"),
+		},
+		"unicorn": []network.PortRange{
+			network.MustParsePortRange("123/tcp"),
+			network.MustParsePortRange("456/tcp"),
+		},
+	}
+
+	exp := []network.PortRange{
+		network.MustParsePortRange("123/tcp"),
+		network.MustParsePortRange("456/tcp"),
+	}
+
+	got := in.UniquePortRanges()
+	c.Assert(got, gc.DeepEquals, exp, gc.Commentf("expected duplicate port ranges to be removed"))
+}

--- a/core/network/portrange_test.go
+++ b/core/network/portrange_test.go
@@ -390,3 +390,20 @@ func (p *PortRangeSuite) TestSanitizeBounds(c *gc.C) {
 		c.Check(t.input.SanitizeBounds(), jc.DeepEquals, t.output)
 	}
 }
+
+func (p *PortRangeSuite) TestUniquePortRanges(c *gc.C) {
+	in := []network.PortRange{
+		network.MustParsePortRange("123/tcp"),
+		network.MustParsePortRange("123/tcp"),
+		network.MustParsePortRange("123/tcp"),
+		network.MustParsePortRange("456/tcp"),
+	}
+
+	exp := []network.PortRange{
+		network.MustParsePortRange("123/tcp"),
+		network.MustParsePortRange("456/tcp"),
+	}
+
+	got := network.UniquePortRanges(in)
+	c.Assert(got, gc.DeepEquals, exp, gc.Commentf("expected duplicate port ranges to be removed"))
+}

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -292,6 +292,18 @@ func (s SpaceInfos) InferSpaceFromCIDRAndSubnetID(cidr, providerSubnetID string)
 		nil, fmt.Sprintf("unable to infer space for CIDR %q and provider subnet ID %q", cidr, providerSubnetID))
 }
 
+// SubnetCIDRsBySpaceID returns the set of known subnet CIDRs grouped by the
+// space ID they belong to.
+func (s SpaceInfos) SubnetCIDRsBySpaceID() map[string][]string {
+	res := make(map[string][]string)
+	for _, space := range s {
+		for _, sub := range space.Subnets {
+			res[space.ID] = append(res[space.ID], sub.CIDR)
+		}
+	}
+	return res
+}
+
 var (
 	invalidSpaceNameChars = regexp.MustCompile("[^0-9a-z-]")
 	dashPrefix            = regexp.MustCompile("^-*")

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -201,6 +201,15 @@ func (s *spaceSuite) TestMoveSubnets(c *gc.C) {
 	})
 }
 
+func (s *spaceSuite) TestSubnetCIDRsBySpaceID(c *gc.C) {
+	res := s.spaces.SubnetCIDRsBySpaceID()
+	c.Assert(res, gc.DeepEquals, map[string][]string{
+		"1": []string{"10.0.0.0/24"},
+		"2": []string{"10.0.1.0/24"},
+		"3": []string{"10.0.2.0/24"},
+	})
+}
+
 func (s *spaceSuite) TestConvertSpaceName(c *gc.C) {
 	empty := set.Strings{}
 	nameTests := []struct {

--- a/go.sum
+++ b/go.sum
@@ -100,9 +100,11 @@ github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+Wji
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -551,7 +551,7 @@ func (u *backingUnit) updated(ctx *allWatcherContext) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		info.OpenPortRangesByEndpoint = unitPortRangesByEndpoint
+		info.OpenPortRangesByEndpoint = unitPortRangesByEndpoint.Clone()
 		if modelType == ModelTypeCAAS {
 			containerStatus, err := ctx.getStatus(globalCloudContainerKey(u.Name), "cloud container")
 			if err == nil {
@@ -1499,7 +1499,7 @@ func updateUnitPorts(ctx *allWatcherContext, u *Unit) error {
 			return errors.Trace(err)
 		}
 		unitInfo := *oldInfo
-		unitInfo.OpenPortRangesByEndpoint = unitPortRangesByEndpoint
+		unitInfo.OpenPortRangesByEndpoint = unitPortRangesByEndpoint.Clone()
 		ctx.store.Update(&unitInfo)
 	default:
 		return nil
@@ -2137,13 +2137,13 @@ func (ctx *allWatcherContext) permissionsForModel(uuid string) (map[string]permi
 	return result, nil
 }
 
-func (ctx *allWatcherContext) getUnitPortRangesByEndpoint(unit *Unit) (map[string][]network.PortRange, error) {
+func (ctx *allWatcherContext) getUnitPortRangesByEndpoint(unit *Unit) (network.GroupedPortRanges, error) {
 	machineID, err := unit.AssignedMachineId()
 	if err != nil {
 		if errors.IsNotAssigned(err) {
 			// Not assigned, so there won't be any ports opened.
 			// Return an empty port map (see Bug #1425435).
-			return make(map[string][]network.PortRange), nil
+			return make(network.GroupedPortRanges), nil
 		}
 		return nil, errors.Trace(err)
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -270,15 +270,14 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 
 		pairs := map[string]string{"name": fmt.Sprintf("bar %d", i)}
 		add(&multiwatcher.UnitInfo{
-			ModelUUID:                modelUUID,
-			Name:                     fmt.Sprintf("wordpress/%d", i),
-			Application:              wordpress.Name(),
-			Series:                   m.Series(),
-			Life:                     life.Alive,
-			MachineID:                m.Id(),
-			OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
-			Annotations:              pairs,
-			Subordinate:              false,
+			ModelUUID:   modelUUID,
+			Name:        fmt.Sprintf("wordpress/%d", i),
+			Application: wordpress.Name(),
+			Series:      m.Series(),
+			Life:        life.Alive,
+			MachineID:   m.Id(),
+			Annotations: pairs,
+			Subordinate: false,
 			WorkloadStatus: multiwatcher.StatusInfo{
 				Current: "waiting",
 				Message: "waiting for machine",
@@ -352,15 +351,14 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		c.Assert(lu.IsPrincipal(), jc.IsFalse)
 		unitName := fmt.Sprintf("wordpress/%d", i)
 		add(&multiwatcher.UnitInfo{
-			ModelUUID:                modelUUID,
-			Name:                     fmt.Sprintf("logging/%d", i),
-			Application:              "logging",
-			Series:                   "quantal",
-			Life:                     life.Alive,
-			OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
-			MachineID:                m.Id(),
-			Principal:                unitName,
-			Subordinate:              true,
+			ModelUUID:   modelUUID,
+			Name:        fmt.Sprintf("logging/%d", i),
+			Application: "logging",
+			Series:      "quantal",
+			Life:        life.Alive,
+			MachineID:   m.Id(),
+			Principal:   unitName,
+			Subordinate: true,
 			WorkloadStatus: multiwatcher.StatusInfo{
 				Current: "waiting",
 				Message: "waiting for machine",
@@ -815,12 +813,11 @@ func (s *allWatcherStateSuite) TestChangeCAASUnits(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                caasSt.ModelUUID(),
-						Name:                     "mysql/0",
-						Application:              "mysql",
-						Series:                   "kubernetes",
-						Life:                     "alive",
-						OpenPortRangesByEndpoint: make(map[string][]corenetwork.PortRange),
+						ModelUUID:   caasSt.ModelUUID(),
+						Name:        "mysql/0",
+						Application: "mysql",
+						Series:      "kubernetes",
+						Life:        "alive",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "waiting",
 							Message: "agent initializing",
@@ -864,11 +861,10 @@ func (s *allWatcherStateSuite) TestChangeCAASUnits(c *gc.C) {
 				about: "container status updates existing unit",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                caasSt.ModelUUID(),
-						Name:                     "mysql/0",
-						Application:              "mysql",
-						Series:                   "kubernetes",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   caasSt.ModelUUID(),
+						Name:        "mysql/0",
+						Application: "mysql",
+						Series:      "kubernetes",
 					},
 				},
 				change: watcher.Change{
@@ -877,11 +873,10 @@ func (s *allWatcherStateSuite) TestChangeCAASUnits(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                caasSt.ModelUUID(),
-						Name:                     "mysql/0",
-						Application:              "mysql",
-						Series:                   "kubernetes",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   caasSt.ModelUUID(),
+						Name:        "mysql/0",
+						Application: "mysql",
+						Series:      "kubernetes",
 						ContainerStatus: multiwatcher.StatusInfo{
 							Current: "maintenance",
 							Message: "setting up",
@@ -1074,7 +1069,7 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 			MachineID:      "0",
 			PublicAddress:  "1.2.3.4",
 			PrivateAddress: "4.3.2.1",
-			OpenPortRangesByEndpoint: map[string][]network.PortRange{
+			OpenPortRangesByEndpoint: corenetwork.GroupedPortRanges{
 				allEndpoints: {corenetwork.MustParsePortRange("12345/tcp")},
 			},
 			WorkloadStatus: multiwatcher.StatusInfo{
@@ -1101,15 +1096,14 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	entities = all.All()
 	assertEntitiesEqual(c, entities, []multiwatcher.EntityInfo{
 		&multiwatcher.UnitInfo{
-			ModelUUID:                s.state.ModelUUID(),
-			Name:                     "wordpress/0",
-			Application:              "wordpress",
-			Series:                   "quantal",
-			MachineID:                "0",
-			Life:                     life.Alive,
-			PublicAddress:            "1.2.3.4",
-			PrivateAddress:           "4.3.2.1",
-			OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+			ModelUUID:      s.state.ModelUUID(),
+			Name:           "wordpress/0",
+			Application:    "wordpress",
+			Series:         "quantal",
+			MachineID:      "0",
+			Life:           life.Alive,
+			PublicAddress:  "1.2.3.4",
+			PrivateAddress: "4.3.2.1",
 			WorkloadStatus: multiwatcher.StatusInfo{
 				Current: "waiting",
 				Message: "waiting for machine",
@@ -2175,10 +2169,9 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 				about: "workload version is updated when set on a unit",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 					},
 					&multiwatcher.ApplicationInfo{
 						ModelUUID: st.ModelUUID(),
@@ -2198,10 +2191,9 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 						WorkloadVersion: "42.47",
 					},
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 					},
 				},
 			}
@@ -2216,10 +2208,9 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 				about: "workload version is not updated when empty",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 					},
 					&multiwatcher.ApplicationInfo{
 						ModelUUID:       st.ModelUUID(),
@@ -2240,10 +2231,9 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 						WorkloadVersion: "ultimate",
 					},
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 					},
 				},
 			}
@@ -2538,10 +2528,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				about: "unit is removed if it's not in backing",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/1",
-						Life:                     life.Alive,
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID: st.ModelUUID(),
+						Name:      "wordpress/1",
+						Life:      life.Alive,
 					},
 				},
 				change: watcher.Change{
@@ -2586,7 +2575,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Series:      "quantal",
 						Life:        life.Alive,
 						MachineID:   "0",
-						OpenPortRangesByEndpoint: map[string][]network.PortRange{
+						OpenPortRangesByEndpoint: network.GroupedPortRanges{
 							allEndpoints: {
 								corenetwork.MustParsePortRange("5555-5558/tcp"),
 								corenetwork.MustParsePortRange("12345/tcp"),
@@ -2637,7 +2626,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Data:    map[string]interface{}{},
 						Since:   &now,
 					},
-					OpenPortRangesByEndpoint: map[string][]network.PortRange{
+					OpenPortRangesByEndpoint: network.GroupedPortRanges{
 						allEndpoints: {
 							corenetwork.MustParsePortRange("17070/udp"),
 						},
@@ -2655,7 +2644,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						Series:      "quantal",
 						Life:        life.Alive,
 						MachineID:   "0",
-						OpenPortRangesByEndpoint: map[string][]network.PortRange{
+						OpenPortRangesByEndpoint: network.GroupedPortRanges{
 							allEndpoints: {
 								corenetwork.MustParsePortRange("17070/udp"),
 							},
@@ -2689,9 +2678,8 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				about: "unit info is updated if a port is opened on the machine it is placed in",
 				initialContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID: st.ModelUUID(),
+						Name:      "wordpress/0",
 					},
 					&multiwatcher.MachineInfo{
 						ModelUUID: st.ModelUUID(),
@@ -2706,7 +2694,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 					&multiwatcher.UnitInfo{
 						ModelUUID: st.ModelUUID(),
 						Name:      "wordpress/0",
-						OpenPortRangesByEndpoint: map[string][]network.PortRange{
+						OpenPortRangesByEndpoint: network.GroupedPortRanges{
 							allEndpoints: {
 								corenetwork.MustParsePortRange("4242/tcp"),
 							},
@@ -2759,7 +2747,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 							Data:    map[string]interface{}{},
 							Since:   &now,
 						},
-						OpenPortRangesByEndpoint: map[string][]network.PortRange{
+						OpenPortRangesByEndpoint: network.GroupedPortRanges{
 							allEndpoints: {
 								corenetwork.MustParsePortRange("21-22/tcp"),
 							},
@@ -2815,7 +2803,7 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 						PublicAddress:  "public",
 						PrivateAddress: "private",
 						MachineID:      "0",
-						OpenPortRangesByEndpoint: map[string][]network.PortRange{
+						OpenPortRangesByEndpoint: network.GroupedPortRanges{
 							allEndpoints: {
 								corenetwork.MustParsePortRange("12345/tcp"),
 							},
@@ -2855,10 +2843,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			return changeTestCase{
 				about: "no change if status is not in backing",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
-					ModelUUID:                st.ModelUUID(),
-					Name:                     "wordpress/0",
-					Application:              "wordpress",
-					OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+					ModelUUID:   st.ModelUUID(),
+					Name:        "wordpress/0",
+					Application: "wordpress",
 					AgentStatus: multiwatcher.StatusInfo{
 						Current: "idle",
 						Message: "",
@@ -2878,10 +2865,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 						AgentStatus: multiwatcher.StatusInfo{
 							Current: "idle",
 							Message: "",
@@ -2914,10 +2900,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			return changeTestCase{
 				about: "status is changed if the unit exists in the store",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
-					ModelUUID:                st.ModelUUID(),
-					Name:                     "wordpress/0",
-					Application:              "wordpress",
-					OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+					ModelUUID:   st.ModelUUID(),
+					Name:        "wordpress/0",
+					Application: "wordpress",
 					AgentStatus: multiwatcher.StatusInfo{
 						Current: "idle",
 						Message: "",
@@ -2937,10 +2922,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "maintenance",
 							Message: "working",
@@ -2980,10 +2964,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			return changeTestCase{
 				about: "unit status is changed if the agent comes off error state",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
-					ModelUUID:                st.ModelUUID(),
-					Name:                     "wordpress/0",
-					Application:              "wordpress",
-					OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+					ModelUUID:   st.ModelUUID(),
+					Name:        "wordpress/0",
+					Application: "wordpress",
 					AgentStatus: multiwatcher.StatusInfo{
 						Current: "idle",
 						Message: "",
@@ -3003,10 +2986,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "maintenance",
 							Message: "doing work",
@@ -3042,10 +3024,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			return changeTestCase{
 				about: "agent status is changed with additional status data",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
-					ModelUUID:                st.ModelUUID(),
-					Name:                     "wordpress/0",
-					Application:              "wordpress",
-					OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+					ModelUUID:   st.ModelUUID(),
+					Name:        "wordpress/0",
+					Application: "wordpress",
 					AgentStatus: multiwatcher.StatusInfo{
 						Current: "idle",
 						Message: "",
@@ -3063,10 +3044,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "error",
 							Message: "hook error",
@@ -3106,10 +3086,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			return changeTestCase{
 				about: "workload status takes into account agent error",
 				initialContents: []multiwatcher.EntityInfo{&multiwatcher.UnitInfo{
-					ModelUUID:                st.ModelUUID(),
-					Name:                     "wordpress/0",
-					Application:              "wordpress",
-					OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+					ModelUUID:   st.ModelUUID(),
+					Name:        "wordpress/0",
+					Application: "wordpress",
 					WorkloadStatus: multiwatcher.StatusInfo{
 						Current: "error",
 						Message: "hook error",
@@ -3133,10 +3112,9 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "error",
 							Message: "hook error",
@@ -3217,13 +3195,12 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						Series:                   "quantal",
-						Life:                     life.Alive,
-						MachineID:                "0",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+						Series:      "quantal",
+						Life:        life.Alive,
+						MachineID:   "0",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "waiting",
 							Message: "waiting for machine",
@@ -3256,7 +3233,7 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 						Series:      "quantal",
 						Life:        life.Alive,
 						MachineID:   "0",
-						OpenPortRangesByEndpoint: map[string][]network.PortRange{
+						OpenPortRangesByEndpoint: network.GroupedPortRanges{
 							allEndpoints: {corenetwork.MustParsePortRange("12345/tcp")},
 						},
 						WorkloadStatus: multiwatcher.StatusInfo{
@@ -3285,13 +3262,12 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						Series:                   "quantal",
-						Life:                     life.Alive,
-						MachineID:                "0",
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+						Series:      "quantal",
+						Life:        life.Alive,
+						MachineID:   "0",
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "waiting",
 							Message: "waiting for machine",
@@ -3318,12 +3294,11 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.UnitInfo{
-						ModelUUID:                st.ModelUUID(),
-						Name:                     "wordpress/0",
-						Application:              "wordpress",
-						Series:                   "quantal",
-						Life:                     life.Alive,
-						OpenPortRangesByEndpoint: make(map[string][]network.PortRange),
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+						Series:      "quantal",
+						Life:        life.Alive,
 						WorkloadStatus: multiwatcher.StatusInfo{
 							Current: "waiting",
 							Message: "waiting for machine",

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -364,13 +364,6 @@ func removeEndpointBindingsOp(key string) txn.Op {
 	}
 }
 
-// ReadApplicationEndpointBindings returns a map where keys are application
-// endpoints and values are the IDs of the spaces they are bound to.
-func ReadApplicationEndpointBindings(st *State, appName string) (map[string]string, error) {
-	bindings, _, err := readEndpointBindings(st, applicationGlobalKey(appName))
-	return bindings, err
-}
-
 // readEndpointBindings returns the stored bindings and TxnRevno for the given
 // application global key, or an error satisfying errors.IsNotFound() otherwise.
 func readEndpointBindings(st *State, key string) (map[string]string, int64, error) {

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -364,6 +364,13 @@ func removeEndpointBindingsOp(key string) txn.Op {
 	}
 }
 
+// ReadApplicationEndpointBindings returns a map where keys are application
+// endpoints and values are the IDs of the spaces they are bound to.
+func ReadApplicationEndpointBindings(st *State, appName string) (map[string]string, error) {
+	bindings, _, err := readEndpointBindings(st, applicationGlobalKey(appName))
+	return bindings, err
+}
+
 // readEndpointBindings returns the stored bindings and TxnRevno for the given
 // application global key, or an error satisfying errors.IsNotFound() otherwise.
 func readEndpointBindings(st *State, key string) (map[string]string, int64, error) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1609,22 +1609,6 @@ func (m *Machine) AddressesBySpaceID() (map[string][]corenetwork.SpaceAddress, e
 	return res, nil
 }
 
-// SubnetCIDRsBySpaceID resolves the subnet assignments for each space the
-// machine is associated with and returns them back as a map where keys are
-// space IDs and each value is a slice of subnet CIDRs assigned to a particular
-// space.
-func (m *Machine) SubnetCIDRsBySpaceID() (map[string][]string, error) {
-	res := make(map[string][]string)
-	err := m.visitAddressesInSpaces(func(subnet *Subnet, address *Address) {
-		spaceID := subnet.SpaceID()
-		res[spaceID] = append(res[spaceID], subnet.CIDR())
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return res, nil
-}
-
 // visitAddressesInSpaces invokes visitFn for each non-loopback machine address
 // that is assigned to a space.
 func (m *Machine) visitAddressesInSpaces(visitFn func(subnet *Subnet, address *Address)) error {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1609,14 +1609,15 @@ func (m *Machine) AddressesBySpaceID() (map[string][]corenetwork.SpaceAddress, e
 	return res, nil
 }
 
-// SubnetsBySpaceID resolves the subnet assignments for each space the machine
-// is associated with and returns them back as a map where keys are space IDs
-// and each value is a slice of subnet IDs assigned to a particular space.
-func (m *Machine) SubnetsBySpaceID() (map[string][]string, error) {
+// SubnetCIDRsBySpaceID resolves the subnet assignments for each space the
+// machine is associated with and returns them back as a map where keys are
+// space IDs and each value is a slice of subnet CIDRs assigned to a particular
+// space.
+func (m *Machine) SubnetCIDRsBySpaceID() (map[string][]string, error) {
 	res := make(map[string][]string)
 	err := m.visitAddressesInSpaces(func(subnet *Subnet, address *Address) {
 		spaceID := subnet.SpaceID()
-		res[spaceID] = append(res[spaceID], subnet.ID())
+		res[spaceID] = append(res[spaceID], subnet.CIDR())
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/machine_ports_ops.go
+++ b/state/machine_ports_ops.go
@@ -27,7 +27,7 @@ type openClosePortRangesOperation struct {
 	// assembled.
 	openedPortRangeToUnit map[network.PortRange]string
 	endpointsNamesByApp   map[string]set.Strings
-	updatedUnitPortRanges map[string]unitPortRangesDoc
+	updatedUnitPortRanges map[string]network.GroupedPortRanges
 }
 
 // Build implements ModelOperation.
@@ -146,9 +146,9 @@ func (op *openClosePortRangesOperation) Done(err error) error {
 }
 
 func (op *openClosePortRangesOperation) cloneExistingUnitPortRanges() {
-	op.updatedUnitPortRanges = make(map[string]unitPortRangesDoc)
+	op.updatedUnitPortRanges = make(map[string]network.GroupedPortRanges)
 	for unitName, existingDoc := range op.mpr.doc.UnitRanges {
-		newDoc := make(unitPortRangesDoc)
+		newDoc := make(network.GroupedPortRanges)
 		for endpointName, portRanges := range existingDoc {
 			newDoc[endpointName] = append([]network.PortRange(nil), portRanges...)
 		}
@@ -268,7 +268,7 @@ func (op *openClosePortRangesOperation) mergePendingOpenPortRanges() (bool, erro
 
 				// We can safely add the new port range to the updated port list.
 				if op.updatedUnitPortRanges[pendingUnitName] == nil {
-					op.updatedUnitPortRanges[pendingUnitName] = make(unitPortRangesDoc)
+					op.updatedUnitPortRanges[pendingUnitName] = make(network.GroupedPortRanges)
 				}
 				op.updatedUnitPortRanges[pendingUnitName][pendingEndpointName] = append(
 					op.updatedUnitPortRanges[pendingUnitName][pendingEndpointName],

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -529,11 +529,11 @@ func (i *importer) machinePortsOp(m description.Machine) txn.Op {
 		DocID:      i.st.docID(machineID),
 		MachineID:  machineID,
 		ModelUUID:  modelUUID,
-		UnitRanges: make(map[string]unitPortRangesDoc),
+		UnitRanges: make(map[string]network.GroupedPortRanges),
 	}
 
 	for unitName, unitPorts := range m.OpenedPortRanges().ByUnit() {
-		portRangeDoc.UnitRanges[unitName] = make(unitPortRangesDoc)
+		portRangeDoc.UnitRanges[unitName] = make(network.GroupedPortRanges)
 
 		for endpointName, portRanges := range unitPorts.ByEndpoint() {
 			portRangeList := make([]network.PortRange, len(portRanges))

--- a/state/unit_ports.go
+++ b/state/unit_ports.go
@@ -90,22 +90,12 @@ func (p *unitPortRanges) ByEndpoint() map[string][]network.PortRange {
 // UniquePortRanges returns a slice of unique open PortRanges across all
 // endpoints.
 func (p *unitPortRanges) UniquePortRanges() []network.PortRange {
-	var (
-		res  []network.PortRange
-		seen = make(map[network.PortRange]struct{})
-	)
-
+	var res []network.PortRange
 	for _, portRangesForEndpoint := range p.machinePortRanges.doc.UnitRanges[p.unitName] {
-		for _, portRange := range portRangesForEndpoint {
-			if _, found := seen[portRange]; found {
-				continue
-			}
-
-			seen[portRange] = struct{}{}
-			res = append(res, portRange)
-		}
+		res = append(res, portRangesForEndpoint...)
 	}
 
+	res = network.UniquePortRanges(res)
 	network.SortPortRanges(res)
 	return res
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3015,7 +3015,7 @@ func RollUpAndConvertOpenedPortDocuments(pool *StatePool) error {
 					DocID:      st.docID(oldDoc.MachineID),
 					MachineID:  oldDoc.MachineID,
 					ModelUUID:  oldDoc.ModelUUID,
-					UnitRanges: make(map[string]unitPortRangesDoc),
+					UnitRanges: make(map[string]network.GroupedPortRanges),
 				}
 			}
 
@@ -3025,7 +3025,7 @@ func RollUpAndConvertOpenedPortDocuments(pool *StatePool) error {
 			// format assuming it is open for all application endpoints.
 			for _, pr := range oldDoc.Ports {
 				if newDoc.UnitRanges[pr.UnitName] == nil {
-					newDoc.UnitRanges[pr.UnitName] = make(unitPortRangesDoc)
+					newDoc.UnitRanges[pr.UnitName] = make(network.GroupedPortRanges)
 				}
 
 				newDoc.UnitRanges[pr.UnitName][allEndpoints] = append(

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -706,7 +706,7 @@ func (ctx *HookContext) ClosePortRange(endpointName string, portRange network.Po
 // OpenedPortRanges returns all port ranges currently opened by this
 // unit on its assigned machine grouped by endpoint.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) OpenedPortRanges() map[string][]network.PortRange {
+func (ctx *HookContext) OpenedPortRanges() network.GroupedPortRanges {
 	return ctx.portRangeChanges.OpenedUnitPortRanges()
 }
 

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -336,7 +336,7 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 		info: statusInfo,
 	}
 
-	var machPortRanges map[names.UnitTag]map[string][]network.PortRange
+	var machPortRanges map[names.UnitTag]network.GroupedPortRanges
 	if f.modelType == model.IAAS {
 		if machPortRanges, err = f.state.OpenedMachinePortRanges(f.machineTag); err != nil {
 			return errors.Trace(err)

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -193,7 +193,7 @@ type ContextNetworking interface {
 
 	// OpenedPortRanges returns all port ranges currently opened by this
 	// unit on its assigned machine grouped by endpoint name.
-	OpenedPortRanges() map[string][]network.PortRange
+	OpenedPortRanges() network.GroupedPortRanges
 
 	// NetworkInfo returns the network info for the given bindings on the given relation.
 	NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)

--- a/worker/uniter/runner/jujuc/jujuctesting/networking.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/networking.go
@@ -16,19 +16,19 @@ import (
 type NetworkInterface struct {
 	PublicAddress        string
 	PrivateAddress       string
-	PortRangesByEndpoint map[string][]network.PortRange
+	PortRangesByEndpoint network.GroupedPortRanges
 	NetworkInfoResults   map[string]params.NetworkInfoResult
 }
 
 // CheckPorts checks the current ports.
-func (ni *NetworkInterface) CheckPortRanges(c *gc.C, expected map[string][]network.PortRange) {
+func (ni *NetworkInterface) CheckPortRanges(c *gc.C, expected network.GroupedPortRanges) {
 	c.Check(ni.PortRangesByEndpoint, jc.DeepEquals, expected)
 }
 
 // AddPortRanges adds the specified port range.
 func (ni *NetworkInterface) AddPortRange(endpoint string, portRange network.PortRange) {
 	if ni.PortRangesByEndpoint == nil {
-		ni.PortRangesByEndpoint = make(map[string][]network.PortRange)
+		ni.PortRangesByEndpoint = make(network.GroupedPortRanges)
 	}
 	ni.PortRangesByEndpoint[endpoint] = append(ni.PortRangesByEndpoint[endpoint], portRange)
 	network.SortPortRanges(ni.PortRangesByEndpoint[endpoint])
@@ -94,7 +94,7 @@ func (c *ContextNetworking) ClosePortRange(endpoint string, portRange network.Po
 }
 
 // OpenedPortRanges implements jujuc.ContextNetworking.
-func (c *ContextNetworking) OpenedPortRanges() map[string][]network.PortRange {
+func (c *ContextNetworking) OpenedPortRanges() network.GroupedPortRanges {
 	c.stub.AddCall("OpenedPortRanges")
 	c.stub.NextErr()
 

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -5,6 +5,9 @@
 package mocks
 
 import (
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v7"
 	params "github.com/juju/juju/apiserver/params"
@@ -12,8 +15,6 @@ import (
 	network "github.com/juju/juju/core/network"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
-	time "time"
 )
 
 // MockContext is a mock of Context interface
@@ -378,10 +379,10 @@ func (mr *MockContextMockRecorder) OpenPortRange(arg0, arg1 interface{}) *gomock
 }
 
 // OpenedPortRanges mocks base method
-func (m *MockContext) OpenedPortRanges() map[string][]network.PortRange {
+func (m *MockContext) OpenedPortRanges() network.GroupedPortRanges {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenedPortRanges")
-	ret0, _ := ret[0].(map[string][]network.PortRange)
+	ret0, _ := ret[0].(network.GroupedPortRanges)
 	return ret0
 }
 

--- a/worker/uniter/runner/jujuc/opened-ports.go
+++ b/worker/uniter/runner/jujuc/opened-ports.go
@@ -68,7 +68,13 @@ func (c *OpenedPortsCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *OpenedPortsCommand) renderPortsWithoutEndpointDetails(ctx *cmd.Context, unitPortRanges map[string][]network.PortRange) error {
-	uniquePortRanges := uniquePortRanges(unitPortRanges)
+	var allPorts []network.PortRange
+	for _, portRanges := range unitPortRanges {
+		allPorts = append(allPorts, portRanges...)
+	}
+	uniquePortRanges := network.UniquePortRanges(allPorts)
+	network.SortPortRanges(uniquePortRanges)
+
 	results := make([]string, len(uniquePortRanges))
 	for i, portRange := range uniquePortRanges {
 		results[i] = portRange.String()
@@ -111,26 +117,4 @@ func (c *OpenedPortsCommand) renderPortsWithEndpointDetails(ctx *cmd.Context, un
 	}
 
 	return c.out.Write(ctx, results)
-}
-
-func uniquePortRanges(portRangesByEndpoint map[string][]network.PortRange) []network.PortRange {
-	var (
-		res       []network.PortRange
-		processed = make(map[network.PortRange]struct{})
-	)
-
-	for _, portRanges := range portRangesByEndpoint {
-		for _, pr := range portRanges {
-			if _, seen := processed[pr]; seen {
-				continue
-			}
-
-			processed[pr] = struct{}{}
-			res = append(res, pr)
-		}
-	}
-
-	network.SortPortRanges(res)
-	return res
-
 }

--- a/worker/uniter/runner/jujuc/opened-ports.go
+++ b/worker/uniter/runner/jujuc/opened-ports.go
@@ -67,14 +67,8 @@ func (c *OpenedPortsCommand) Run(ctx *cmd.Context) error {
 	return c.renderPortsWithEndpointDetails(ctx, unitPortRanges)
 }
 
-func (c *OpenedPortsCommand) renderPortsWithoutEndpointDetails(ctx *cmd.Context, unitPortRanges map[string][]network.PortRange) error {
-	var allPorts []network.PortRange
-	for _, portRanges := range unitPortRanges {
-		allPorts = append(allPorts, portRanges...)
-	}
-	uniquePortRanges := network.UniquePortRanges(allPorts)
-	network.SortPortRanges(uniquePortRanges)
-
+func (c *OpenedPortsCommand) renderPortsWithoutEndpointDetails(ctx *cmd.Context, unitPortRanges network.GroupedPortRanges) error {
+	uniquePortRanges := unitPortRanges.UniquePortRanges()
 	results := make([]string, len(uniquePortRanges))
 	for i, portRange := range uniquePortRanges {
 		results[i] = portRange.String()
@@ -82,7 +76,7 @@ func (c *OpenedPortsCommand) renderPortsWithoutEndpointDetails(ctx *cmd.Context,
 	return c.out.Write(ctx, results)
 }
 
-func (c *OpenedPortsCommand) renderPortsWithEndpointDetails(ctx *cmd.Context, unitPortRanges map[string][]network.PortRange) error {
+func (c *OpenedPortsCommand) renderPortsWithEndpointDetails(ctx *cmd.Context, unitPortRanges network.GroupedPortRanges) error {
 	endpointsByPort := make(map[network.PortRange]set.Strings)
 	for endpointName, portRanges := range unitPortRanges {
 		for _, pr := range portRanges {

--- a/worker/uniter/runner/jujuc/ports_test.go
+++ b/worker/uniter/runner/jujuc/ports_test.go
@@ -22,7 +22,7 @@ var _ = gc.Suite(&PortsSuite{})
 
 var portsTests = []struct {
 	cmd    []string
-	expect map[string][]network.PortRange
+	expect network.GroupedPortRanges
 }{
 	{[]string{"open-port", "80"}, makeAllEndpointsRanges("80/tcp")},
 	{[]string{"open-port", "99/tcp"}, makeAllEndpointsRanges("80/tcp", "99/tcp")},
@@ -36,7 +36,7 @@ var portsTests = []struct {
 	{[]string{"close-port", "9999/UDP"}, makeAllEndpointsRanges("99/tcp", "123/udp")},
 	{[]string{"open-port", "icmp"}, makeAllEndpointsRanges("icmp", "99/tcp", "123/udp")},
 	// Tests with --endpoints.
-	{[]string{"open-port", "--endpoints", "foo,bar", "1337/tcp"}, map[string][]network.PortRange{
+	{[]string{"open-port", "--endpoints", "foo,bar", "1337/tcp"}, network.GroupedPortRanges{
 		// Pre-existing ports from previous tests
 		"": []network.PortRange{
 			network.MustParsePortRange("icmp"),
@@ -47,7 +47,7 @@ var portsTests = []struct {
 		"foo": []network.PortRange{network.MustParsePortRange("1337/tcp")},
 		"bar": []network.PortRange{network.MustParsePortRange("1337/tcp")},
 	}},
-	{[]string{"close-port", "--endpoints", "foo", "1337/tcp"}, map[string][]network.PortRange{
+	{[]string{"close-port", "--endpoints", "foo", "1337/tcp"}, network.GroupedPortRanges{
 		"": []network.PortRange{
 			network.MustParsePortRange("icmp"),
 			network.MustParsePortRange("99/tcp"),
@@ -60,13 +60,13 @@ var portsTests = []struct {
 	}},
 }
 
-func makeAllEndpointsRanges(stringRanges ...string) map[string][]network.PortRange {
+func makeAllEndpointsRanges(stringRanges ...string) network.GroupedPortRanges {
 	var results []network.PortRange
 	for _, s := range stringRanges {
 		results = append(results, network.MustParsePortRange(s))
 	}
 	network.SortPortRanges(results)
-	return map[string][]network.PortRange{
+	return network.GroupedPortRanges{
 		"": results,
 	}
 }

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -119,7 +119,7 @@ func (*RestrictedContext) ClosePortRange(string, network.PortRange) error {
 }
 
 // OpenedPortRanges implements hooks.Context.
-func (*RestrictedContext) OpenedPortRanges() map[string][]network.PortRange { return nil }
+func (*RestrictedContext) OpenedPortRanges() network.GroupedPortRanges { return nil }
 
 // NetworkInfo implements hooks.Context.
 func (*RestrictedContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {


### PR DESCRIPTION
## Description of change

This PR introduces a new API call for the firewaller facade that allows the firewaller worker to obtain the list of open port ranges on a machine grouped by unit and by CIDR. The new call has the same signature with the similarly named call of the
Uniter (V17) facade (introduced in #11877) and shares the same response payload. However, while the uniter cares about the port ranges opened by units grouped by endpoint, the firewall worker requires the port ranges grouped by a subnet CIDR.

To produce the result for this API method, the implementation makes use of the following bits of information:
- the application endpoint to spaceID bindings for each machine unit deployed to the machine.
- the space ID to endpoint CIDRs mappings for the targeted machine.

Using this information, we can transitively resolve an endpoint (port ranges are stored in the DB grouped by unit and endpoint name) to a list of subnets and group the port ranges by CIDR. The special case of the wildcard (`""`) endpoint name is handled by expanding it to all known application endpoints and gathering the CIDRs that correspond to each one given their bound space. 

This call is _not_ yet wired into the firewaller. Once that's done (in a future PR), we will be able to lazily resolve the opened port ranges into the CIDRs needed for generating the firewall ingress rules.

## QA steps

No QA steps needed; the new API call is not wired yet.