### PR TITLE
Ensure `juju deploy` works with contraints and bindings on AWS

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -347,6 +347,20 @@ func (api *ProvisionerAPI) machineTags(m *state.Machine, jobs []model.MachineJob
 	return machineTags, nil
 }
 
+// machineSpaces returns the list of spaces that the machine must be in.
+// Note that we will send a topology for the *union* of space constraints
+// and bindings.
+//
+// We need to do this because some providers need to *choose* an instance
+// fulfilling them all (MAAS/AWS) whereas others *create* an instance to
+// fulfill them (OpenStack will create the NICs it needs).
+//
+// This means there is a difference between add-machine, which will only
+// include the spaces based on constraints, and deploy/add-unit,
+// which will include spaces for any endpoint bindings.
+//
+// It is the responsibility of the provider to negotiate this information
+// appropriately.
 func (api *ProvisionerAPI) machineSpaces(m *state.Machine,
 	allSpaceInfos network.SpaceInfos,
 	endpointBindings map[string]*state.Bindings,
@@ -356,18 +370,25 @@ func (api *ProvisionerAPI) machineSpaces(m *state.Machine,
 		return nil, errors.Annotate(err, "retrieving machine constraints")
 	}
 
-	spaceNames := set.NewStrings(cons.IncludeSpaces()...)
-	for _, endpointBinding := range endpointBindings {
+	includeSpaces := set.NewStrings(cons.IncludeSpaces()...)
+	excludeSpaces := set.NewStrings(cons.ExcludeSpaces()...)
+
+	for appName, endpointBinding := range endpointBindings {
 		bindingSpaces, err := endpointBinding.MapWithSpaceNames(allSpaceInfos)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		for _, spaceName := range bindingSpaces {
-			spaceNames.Add(spaceName)
+		for endpoint, spaceName := range bindingSpaces {
+			if excludeSpaces.Contains(spaceName) {
+				return nil, errors.Errorf(
+					"negative space constraint %q conflicts with %s endpoint binding for %q",
+					spaceName, appName, endpoint)
+			}
+			includeSpaces.Add(spaceName)
 		}
 	}
 
-	return spaceNames.SortedValues(), nil
+	return includeSpaces.SortedValues(), nil
 }
 
 func (api *ProvisionerAPI) machineSpaceTopology(machineID string, spaceNames []string) (params.ProvisioningNetworkTopology, error) {

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -578,16 +578,6 @@ func (api *ProvisionerAPI) translateEndpointBindingsToSpaces(spaceInfos network.
 		}
 
 		for endpoint, spaceID := range bindings.Map() {
-			// All endpoint bindings having a value is a side effect of
-			// changing the endpoint bindings from a space name to id.
-			// For the provisioning code, assuming that the default space
-			// should be handled as unspecified was previously.
-			if spaceID == network.AlphaSpaceId {
-				// Skip unspecified bindings, as they won't affect the instance
-				// selected for provisioning.
-				continue
-			}
-
 			space := spaceInfos.GetByID(spaceID)
 			if space != nil {
 				bound := string(space.ProviderId)

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -235,23 +235,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithMultiplePositiveSpaceCo
 
 }
 
-func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {
-	// Add a couple of spaces.
-	space1, err := s.State.AddSpace("space1", "first space id", nil, true)
-	c.Assert(err, jc.ErrorIsNil)
-	space2, err := s.State.AddSpace("space2", "", nil, false) // no provider ID
-	c.Assert(err, jc.ErrorIsNil)
-	// Add 1 subnet into space1, and 2 into space2.
-	// Each subnet is in a matching zone (e.g "subnet-#" in "zone#").
-	testing.AddSubnetsWithTemplate(c, s.State, 3, network.SubnetInfo{
-		CIDR:              "10.10.{{.}}.0/24",
-		ProviderId:        "subnet-{{.}}",
-		AvailabilityZones: []string{"zone{{.}}"},
-		SpaceID:           fmt.Sprintf("{{if (eq . 0)}}%s{{else}}%s{{end}}", space1.Id(), space2.Id()),
-		VLANTag:           42,
-	})
-}
-
 func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.C) {
 	s.addSpacesAndSubnets(c)
 
@@ -272,8 +255,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Use juju names for spaces in bindings, simulating ''juju deploy
-	// --bind...' was called.
+	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
 		"url": "space1", // has both name and provider ID
 		"db":  "space2", // has only name, no provider ID
@@ -343,8 +325,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindingsAndNoAl
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Use juju names for spaces in bindings, simulating ''juju deploy
-	// --bind...' was called.
+	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
 		"url": "space1", // has both name and provider ID
 		"db":  "space2", // has only name, no provider ID
@@ -364,7 +345,8 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindingsAndNoAl
 
 	expected := params.ProvisioningInfoResultsV10{
 		Results: []params.ProvisioningInfoResultV10{{
-			Error: apiservertesting.ServerError("matching subnets to zones: cannot use space \"alpha\" as deployment target: no subnets"),
+			Error: apiservertesting.ServerError(
+				"matching subnets to zones: cannot use space \"alpha\" as deployment target: no subnets"),
 		}},
 	}
 	c.Assert(result, jc.DeepEquals, expected)
@@ -379,8 +361,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithAlphaEndpointBindings(c
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Use juju names for spaces in bindings, simulating ''juju deploy
-	// --bind...' was called.
+	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
 		"url": "alpha",
 	}
@@ -419,6 +400,72 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithAlphaEndpointBindings(c
 		}},
 	}
 	c.Assert(result, jc.DeepEquals, expected)
+}
+
+func (s *withoutControllerSuite) TestConflictingNegativeConstraintWithBindingError(c *gc.C) {
+	s.addSpacesAndSubnets(c)
+
+	alphaSpace, err := s.State.SpaceByName("alpha")
+	c.Assert(err, jc.ErrorIsNil)
+
+	testing.AddSubnetsWithTemplate(c, s.State, 1, network.SubnetInfo{
+		CIDR:              "10.10.{{add 4 .}}.0/24",
+		ProviderId:        "subnet-alpha",
+		AvailabilityZones: []string{"zone-alpha"},
+		SpaceID:           alphaSpace.Id(),
+		VLANTag:           43,
+	})
+
+	cons := constraints.MustParse("spaces=^space1")
+	wordpressMachine, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series:      "quantal",
+		Jobs:        []state.MachineJob{state.JobHostUnits},
+		Constraints: cons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Simulates running `juju deploy --bind "..."`.
+	bindings := map[string]string{
+		"url": "space1", // has both name and provider ID
+		"db":  "space2", // has only name, no provider ID
+	}
+	wordpressCharm := s.AddTestingCharm(c, "wordpress")
+	wordpressService := s.AddTestingApplicationWithBindings(c, "wordpress", wordpressCharm, bindings)
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	err = wordpressUnit.AssignToMachine(wordpressMachine)
+	c.Assert(err, jc.ErrorIsNil)
+
+	args := params.Entities{Entities: []params.Entity{
+		{Tag: wordpressMachine.Tag().String()},
+	}}
+	result, err := s.provisioner.ProvisioningInfo(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := params.ProvisioningInfoResultsV10{
+		Results: []params.ProvisioningInfoResultV10{{
+			Error: apiservertesting.ServerError(
+				`negative space constraint "space1" conflicts with wordpress endpoint binding for "url"`),
+		}},
+	}
+	c.Assert(result, jc.DeepEquals, expected)
+}
+
+func (s *withoutControllerSuite) addSpacesAndSubnets(c *gc.C) {
+	// Add a couple of spaces.
+	space1, err := s.State.AddSpace("space1", "first space id", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+	space2, err := s.State.AddSpace("space2", "", nil, false) // no provider ID
+	c.Assert(err, jc.ErrorIsNil)
+	// Add 1 subnet into space1, and 2 into space2.
+	// Each subnet is in a matching zone (e.g "subnet-#" in "zone#").
+	testing.AddSubnetsWithTemplate(c, s.State, 3, network.SubnetInfo{
+		CIDR:              "10.10.{{.}}.0/24",
+		ProviderId:        "subnet-{{.}}",
+		AvailabilityZones: []string{"zone{{.}}"},
+		SpaceID:           fmt.Sprintf("{{if (eq . 0)}}%s{{else}}%s{{end}}", space1.Id(), space2.Id()),
+		VLANTag:           42,
+	})
 }
 
 func (s *withoutControllerSuite) TestProvisioningInfoWithUnsuitableSpacesConstraints(c *gc.C) {

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -290,9 +290,15 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 					// Ensure space names are translated to provider IDs, where
 					// possible.
 					EndpointBindings: map[string]string{
-						"db":  "space2",         // just name, no provider ID
-						"url": "first space id", // has provider ID
-						// We expect none of the unspecified bindings in the result.
+						"":                network.AlphaSpaceName,
+						"admin-api":       network.AlphaSpaceName,
+						"cache":           network.AlphaSpaceName,
+						"db-client":       network.AlphaSpaceName,
+						"logging-dir":     network.AlphaSpaceName,
+						"monitoring-port": network.AlphaSpaceName,
+						"foo-bar":         network.AlphaSpaceName,
+						"db":              "space2",         // just name, no provider ID
+						"url":             "first space id", // has provider ID
 					},
 				},
 				ProvisioningNetworkTopology: params.ProvisioningNetworkTopology{
@@ -347,56 +353,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindingsAndNoAl
 		Results: []params.ProvisioningInfoResultV10{{
 			Error: apiservertesting.ServerError(
 				"matching subnets to zones: cannot use space \"alpha\" as deployment target: no subnets"),
-		}},
-	}
-	c.Assert(result, jc.DeepEquals, expected)
-}
-
-func (s *withoutControllerSuite) TestProvisioningInfoWithAlphaEndpointBindings(c *gc.C) {
-	s.addSpacesAndSubnets(c)
-
-	wordpressMachine, err := s.State.AddOneMachine(state.MachineTemplate{
-		Series: "quantal",
-		Jobs:   []state.MachineJob{state.JobHostUnits},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Simulates running `juju deploy --bind "..."`.
-	bindings := map[string]string{
-		"url": "alpha",
-	}
-	wordpressCharm := s.AddTestingCharm(c, "wordpress")
-	wordpressService := s.AddTestingApplicationWithBindings(c, "wordpress", wordpressCharm, bindings)
-	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
-	c.Assert(err, jc.ErrorIsNil)
-	err = wordpressUnit.AssignToMachine(wordpressMachine)
-	c.Assert(err, jc.ErrorIsNil)
-
-	args := params.Entities{Entities: []params.Entity{
-		{Tag: wordpressMachine.Tag().String()},
-	}}
-	result, err := s.provisioner.ProvisioningInfo(args)
-	c.Assert(err, jc.ErrorIsNil)
-
-	controllerCfg := s.ControllerConfig
-	expected := params.ProvisioningInfoResultsV10{
-		Results: []params.ProvisioningInfoResultV10{{
-			Result: &params.ProvisioningInfoV10{
-				ProvisioningInfoBase: params.ProvisioningInfoBase{
-					ControllerConfig: controllerCfg,
-					Series:           "quantal",
-					Jobs:             []model.MachineJob{model.JobHostUnits},
-					Tags: map[string]string{
-						tags.JujuController:    coretesting.ControllerTag.Id(),
-						tags.JujuModel:         coretesting.ModelTag.Id(),
-						tags.JujuMachine:       "controller-machine-5",
-						tags.JujuUnitsDeployed: wordpressUnit.Name(),
-					},
-					// Ensure space names are translated to provider IDs, where
-					// possible.
-					EndpointBindings: map[string]string{},
-				},
-			},
 		}},
 	}
 	c.Assert(result, jc.DeepEquals, expected)
@@ -544,7 +500,11 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 						tags.JujuMachine:       "controller-machine-5",
 						tags.JujuUnitsDeployed: profileUnit.Name(),
 					},
-					EndpointBindings: make(map[string]string),
+					EndpointBindings: map[string]string{
+						"":        network.AlphaSpaceName,
+						"another": network.AlphaSpaceName,
+						"ubuntu":  network.AlphaSpaceName,
+					},
 					CharmLXDProfiles: []string{pName},
 				},
 			},

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -72,8 +72,13 @@ type StartInstanceParams struct {
 	// SubnetsToZones is an optional collection of maps of provider-specific
 	// subnet IDs to a list of availability zone names each subnet is available
 	// in.
-	// It is only populated when valid positive spaces constraints
-	// are present; one for each such constraint.
+	// It is populated when valid positive spaces constraints are present,
+	// or when the instance to be started will host an application with bound
+	// endpoints.
+	// The subnets present are derived from the union of
+	// constrained/bound spaces.
+	// Negative space constraints will have already been validated when
+	// retrieving `ProvisioningInfo`.
 	SubnetsToZones []map[corenetwork.Id][]string
 
 	// EndpointBindings holds the mapping between application endpoint names to

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -145,14 +145,14 @@ const (
 var deviceInUseRegexp = regexp.MustCompile(".*Attachment point .* is already in use")
 
 // StorageProviderTypes implements storage.ProviderRegistry.
-func (env *environ) StorageProviderTypes() ([]storage.ProviderType, error) {
+func (e *environ) StorageProviderTypes() ([]storage.ProviderType, error) {
 	return []storage.ProviderType{EBS_ProviderType}, nil
 }
 
 // StorageProvider implements storage.ProviderRegistry.
-func (env *environ) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
+func (e *environ) StorageProvider(t storage.ProviderType) (storage.Provider, error) {
 	if t == EBS_ProviderType {
-		return &ebsProvider{env}, nil
+		return &ebsProvider{e}, nil
 	}
 	return nil, errors.NotFoundf("storage provider %q", t)
 }

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/retry"
 	"github.com/juju/utils"
+	"github.com/juju/utils/set"
 	"github.com/juju/version"
 	"gopkg.in/amz.v3/aws"
 	"gopkg.in/amz.v3/ec2"
@@ -112,30 +113,30 @@ func (e *environ) Name() string {
 }
 
 // PrepareForBootstrap is part of the Environ interface.
-func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
+func (e *environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
 	callCtx := context.NewCloudCallContext()
 	// Cannot really invalidate a credential here since nothing is bootstrapped yet.
 	callCtx.InvalidateCredentialFunc = func(string) error { return nil }
 	if ctx.ShouldVerifyCredentials() {
-		if err := verifyCredentials(env, callCtx); err != nil {
+		if err := verifyCredentials(e, callCtx); err != nil {
 			return err
 		}
 	}
-	ecfg := env.ecfg()
+	ecfg := e.ecfg()
 	vpcID, forceVPCID := ecfg.vpcID(), ecfg.forceVPCID()
-	if err := validateBootstrapVPC(env.ec2, callCtx, env.cloud.Region, vpcID, forceVPCID, ctx); err != nil {
+	if err := validateBootstrapVPC(e.ec2, callCtx, e.cloud.Region, vpcID, forceVPCID, ctx); err != nil {
 		return errors.Trace(maybeConvertCredentialError(err, callCtx))
 	}
 	return nil
 }
 
 // Create is part of the Environ interface.
-func (env *environ) Create(ctx context.ProviderCallContext, args environs.CreateParams) error {
-	if err := verifyCredentials(env, ctx); err != nil {
+func (e *environ) Create(ctx context.ProviderCallContext, args environs.CreateParams) error {
+	if err := verifyCredentials(e, ctx); err != nil {
 		return err
 	}
-	vpcID := env.ecfg().vpcID()
-	if err := validateModelVPC(env.ec2, ctx, env.name, vpcID); err != nil {
+	vpcID := e.ecfg().vpcID()
+	if err := validateModelVPC(e.ec2, ctx, e.name, vpcID); err != nil {
 		return errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
 	// TODO(axw) 2016-08-04 #1609643
@@ -361,7 +362,7 @@ func (e *environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 	return fmt.Errorf("invalid AWS instance type %q and arch %q specified", *args.Constraints.InstanceType, *args.Constraints.Arch)
 }
 
-// MetadataLookupParams returns parameters which are used to query simplestreams metadata.
+// MetadataLookupParams returns parameters which are used to query simple-streams metadata.
 func (e *environ) MetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
 	var endpoint string
 	if region == "" {
@@ -416,7 +417,9 @@ func resourceName(tag names.Tag, envName string) string {
 }
 
 // StartInstance is specified in the InstanceBroker interface.
-func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (_ *environs.StartInstanceResult, resultErr error) {
+func (e *environ) StartInstance(
+	ctx context.ProviderCallContext, args environs.StartInstanceParams,
+) (_ *environs.StartInstanceResult, resultErr error) {
 	var inst *ec2Instance
 	callback := args.StatusCallback
 	defer func() {
@@ -429,7 +432,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 	}()
 
-	callback(status.Allocating, "Verifying availability zone", nil)
+	_ = callback(status.Allocating, "Verifying availability zone", nil)
 
 	annotateWrapError := func(received error, annotation string) error {
 		if received == nil {
@@ -437,9 +440,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 		// If there is a problem with authentication/authorisation,
 		// we want a correctly typed error.
-		annotatedErr := errors.Annotate(
-			maybeConvertCredentialError(received, ctx),
-			annotation)
+		annotatedErr := errors.Annotate(maybeConvertCredentialError(received, ctx), annotation)
 		if common.IsCredentialNotValid(annotatedErr) {
 			return annotatedErr
 		}
@@ -461,7 +462,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		if !zoneSpecific {
 			return nil, wrapError(err)
 		}
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	ec2Session := EC2Session(e.cloud.Region, e.ec2.AccessKey, e.ec2.SecretKey)
@@ -490,7 +491,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		return nil, common.ZoneIndependentError(err)
 	}
 
-	callback(status.Allocating, "Making user data", nil)
+	_ = callback(status.Allocating, "Making user data", nil)
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, nil, AmazonRenderer{})
 	if err != nil {
 		return nil, common.ZoneIndependentError(errors.Annotate(err, "constructing user data"))
@@ -508,7 +509,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		apiPorts = append(apiPorts, args.InstanceConfig.APIInfo.Ports()[0])
 	}
 
-	callback(status.Allocating, "Setting up groups", nil)
+	_ = callback(status.Allocating, "Setting up groups", nil)
 	groups, err := e.setUpGroups(ctx, args.ControllerUUID, args.InstanceConfig.MachineId, apiPorts)
 	if err != nil {
 		return nil, annotateWrapError(err, "cannot set up groups")
@@ -520,19 +521,6 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		args.InstanceConfig.Controller != nil,
 	)
 	rootDiskSize := uint64(blockDeviceMappings[0].VolumeSize) * 1024
-
-	// If --constraints spaces=foo was passed, the provisioner will populate
-	// args.SubnetsToZones map. In AWS a subnet can span only one zone, so here
-	// we build the reverse map zonesToSubnets, which we will use to below in
-	// the RunInstance loop to provide an explicit subnet ID, rather than just
-	// AZ. This ensures instances in the same group (units of an application or all
-	// instances when adding a machine manually) will still be evenly
-	// distributed across AZs, but only within subnets of the space constraint.
-	//
-	// TODO(dimitern): This should be done in a provider-independent way.
-	if spaces := args.Constraints.IncludeSpaces(); len(spaces) > 1 {
-		logger.Infof("ignoring all but the first positive space from constraints: %v", spaces)
-	}
 
 	var instResp *ec2.RunInstancesResp
 	commonRunArgs := &ec2.RunInstances{
@@ -548,14 +536,21 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	runArgs := commonRunArgs
 	runArgs.AvailZone = availabilityZone
 
+	subnetZones, err := getValidSubnetZoneMap(args)
+	if err != nil {
+		return nil, common.ZoneIndependentError(err)
+	}
+
 	hasVPCID := isVPCIDSet(e.ecfg().vpcID())
 
-	runArgs.SubnetId, err = e.selectSubnetIDForInstance(ctx, hasVPCID, args.SubnetsToZones, placementSubnetID, availabilityZone)
+	runArgs.SubnetId, err = e.selectSubnetIDForInstance(ctx, hasVPCID, subnetZones, placementSubnetID, availabilityZone)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	callback(status.Allocating, fmt.Sprintf("Trying to start instance in availability zone %q", availabilityZone), nil)
+	_ = callback(status.Allocating,
+		fmt.Sprintf("Trying to start instance in availability zone %q", availabilityZone), nil)
+
 	instResp, err = runInstances(e.ec2, ctx, runArgs, callback)
 	if err != nil {
 		if !isZoneOrSubnetConstrainedError(err) {
@@ -640,23 +635,100 @@ func (e *environ) finishInstanceConfig(args *environs.StartInstanceParams, spec 
 	return nil
 }
 
+// GetValidSubnetZoneMap ensures that (a single one of) any supplied space
+// requirements are congruent and can be met, and that the representative
+// subnet-zone map is returned, with Fan networks filtered out.
+// The returned map will be nil if there are no space requirements.
+func getValidSubnetZoneMap(args environs.StartInstanceParams) (map[corenetwork.Id][]string, error) {
+	spaceCons := args.Constraints.IncludeSpaces()
+
+	bindings := set.NewStrings()
+	for _, spaceName := range args.EndpointBindings {
+		bindings.Add(spaceName.String())
+	}
+
+	conCount := len(spaceCons)
+	bindCount := len(bindings)
+
+	// If there are no bindings or space constraints, we have no limitations
+	// and should not have even received start arguments with a subnet/zone
+	// mapping - just return nil and attempt provisioning in the current AZ.
+	if conCount == 0 && bindCount == 0 {
+		return nil, nil
+	}
+
+	sort.Strings(spaceCons)
+	allSpaceReqs := bindings.Union(set.NewStrings(spaceCons...)).SortedValues()
+
+	// We only need to validate if both bindings and constraints are present.
+	// If one is supplied without the other, we know that the value for
+	// args.SubnetsToZones correctly reflects the set of spaces.
+	var indexInCommon int
+	if conCount > 0 && bindCount > 0 {
+		// If we have spaces in common between bindings and constraints,
+		// the union count will be fewer than the sum.
+		// If it is not, just error out here.
+		if len(allSpaceReqs) == conCount+bindCount {
+			return nil, errors.Errorf("unable to satisfy supplied space requirements; spaces: %v, bindings: %v",
+				spaceCons, bindings.SortedValues())
+		}
+
+		// Now get the first index of the space in common.
+		for _, conSpaceName := range spaceCons {
+			if !bindings.Contains(conSpaceName) {
+				continue
+			}
+
+			for i, spaceName := range allSpaceReqs {
+				if conSpaceName == spaceName {
+					indexInCommon = i
+					break
+				}
+			}
+		}
+	}
+
+	// TODO (manadart 2020-02-07): We only take a single subnet/zones
+	// mapping to create a NIC for the instance.
+	// This is behaviour that dates from the original spaces MVP.
+	// It will not take too much effort to enable multi-NIC support for EC2
+	// if we use them all when constructing the instance creation request.
+	if conCount > 1 || bindCount > 1 {
+		logger.Warningf("only considering the space requirement for %q", allSpaceReqs[indexInCommon])
+	}
+
+	// We should always have a mapping if there are space requirements,
+	// and it should always have the same length as the union of
+	// constraints + bindings.
+	// However unlikely, rather than taking this for granted and possibly
+	// panicking, log a warning and let the provisioning continue.
+	mappingCount := len(args.SubnetsToZones)
+	if mappingCount == 0 || mappingCount <= indexInCommon {
+		logger.Warningf(
+			"got space requirements, but not a valid subnet-zone map; constraints/bindings not applied")
+		return nil, nil
+	}
+
+	// Select the subnet-zone mapping at the index we determined minus Fan
+	// networks which we can not consider for provisioning non-containers.
+	// We know that the index determined from the spaces union corresponds
+	// with the right mapping because of consistent sorting by the provisioner.
+	subnetZones := make(map[corenetwork.Id][]string)
+	for id, zones := range args.SubnetsToZones[indexInCommon] {
+		if !corenetwork.IsInFanNetwork(id) {
+			subnetZones[id] = zones
+		}
+	}
+
+	return subnetZones, nil
+}
+
 func (e *environ) selectSubnetIDForInstance(ctx context.ProviderCallContext,
 	hasVPCID bool,
-	subnetsToZones []map[corenetwork.Id][]string,
+	subnetZones map[corenetwork.Id][]string,
 	placementSubnetID corenetwork.Id,
 	availabilityZone string,
 ) (string, error) {
-	// TODO (manadart 2020-02-07): We only take the first subnet/zones
-	// mapping to create a NIC for the instance.
-	// This effectively uses a single positive space constraint if many are
-	// specified; behaviour that dates from the original spaces MVP.
-	// It will not take too much effort to enable multi-NIC support for EC2
-	// if we use them all when constructing the instance creation request.
-	var subnetZones map[corenetwork.Id][]string
-	if len(subnetsToZones) > 0 {
-		subnetZones = filterSubnetsToZones(subnetsToZones)
-	}
-
 	var (
 		subnetIDsForZone []corenetwork.Id
 		err              error
@@ -730,9 +802,6 @@ func (e *environ) selectSubnetIDsForZone(subnetZones map[corenetwork.Id][]string
 		return nil, errors.Errorf("availability zone %q has no subnets satisfying space constraints", availabilityZone)
 	}
 
-	// Filter out any fan networks.
-	subnets = corenetwork.FilterInFanNetwork(subnets)
-
 	// Use the placement to locate a subnet ID.
 	if placementSubnetID != "" {
 		asSet := corenetwork.MakeIDSet(subnets...)
@@ -743,29 +812,6 @@ func (e *environ) selectSubnetIDsForZone(subnetZones map[corenetwork.Id][]string
 	}
 
 	return subnets, nil
-}
-
-// FilterSubnetsToZones removes the INFAN network types from possible subnets.
-// We can't use the INFAN networks as they require you to use the underlay
-// network.
-// TODO (stickupkid): We should lift this to core package if more providers need
-// this.
-// TODO (stickupkid): We should consider removing them during the generation of
-// ProvisioningInfo provided that container provisioning was unaffected.
-func filterSubnetsToZones(subnetsToZones []map[corenetwork.Id][]string) map[corenetwork.Id][]string {
-	if len(subnetsToZones) == 0 {
-		return nil
-	}
-
-	subnetZones := make(map[corenetwork.Id][]string)
-	// Use the first subnets zones until we support multiple NIC
-	for id, zones := range subnetsToZones[0] {
-		if corenetwork.IsInFanNetwork(id) {
-			continue
-		}
-		subnetZones[id] = zones
-	}
-	return subnetZones
 }
 
 func (e *environ) deriveAvailabilityZone(
@@ -785,10 +831,12 @@ func (e *environ) deriveAvailabilityZoneAndSubnetID(
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
+
 	placementZone, placementSubnetID, err := e.instancePlacementZone(ctx, args.Placement, volumeAttachmentsZone)
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
+
 	var availabilityZone string
 	if placementZone != "" {
 		availabilityZone = placementZone

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -972,10 +972,15 @@ func (env *maasEnviron) StartInstance(
 	var interfaceBindings []interfaceBinding
 	if len(args.EndpointBindings) != 0 {
 		for endpoint, spaceProviderID := range args.EndpointBindings {
-			interfaceBindings = append(interfaceBindings, interfaceBinding{
-				Name:            endpoint,
-				SpaceProviderId: string(spaceProviderID),
-			})
+			// Ignore alpha space bindings, which we assume will be the result
+			// defaults. It doesn't have a provider ID, and so will be passed
+			// by name.
+			if spaceProviderID != corenetwork.AlphaSpaceName {
+				interfaceBindings = append(interfaceBindings, interfaceBinding{
+					Name:            endpoint,
+					SpaceProviderId: string(spaceProviderID),
+				})
+			}
 		}
 	}
 	selectNode := env.selectNode2

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1326,10 +1326,17 @@ func subnetZonesFromNetworkTopology(topology params.ProvisioningNetworkTopology)
 		return nil
 	}
 
-	subnetsToZones := make([]map[network.Id][]string, 0, len(topology.SpaceSubnets))
-	for _, subnets := range topology.SpaceSubnets {
+	// We want to ensure consistent ordering of the return based on the spaces.
+	spaceNames := make([]string, 0, len(topology.SpaceSubnets))
+	for spaceName := range topology.SpaceSubnets {
+		spaceNames = append(spaceNames, spaceName)
+	}
+	sort.Strings(spaceNames)
+
+	subnetsToZones := make([]map[network.Id][]string, 0, len(spaceNames))
+	for _, spaceName := range spaceNames {
 		subnetAZs := make(map[network.Id][]string)
-		for _, subnet := range subnets {
+		for _, subnet := range topology.SpaceSubnets[spaceName] {
 			subnetAZs[network.Id(subnet)] = topology.SubnetAZs[subnet]
 		}
 		subnetsToZones = append(subnetsToZones, subnetAZs)


### PR DESCRIPTION
## Description of change

This patch fixes erroneous behaviour on AWS when `juju deploy` is used in conjunction with both bindings and space constraints.

To achieve this we need to include _alpha_ bindings in the `ProvisioningInfo` result, so we can reason about what spaces the subnets-to-zones mappings apply. In turn we now need to filter alpha space bindings during MAAS provisioner - the only provider that was using the bindings up to this point.

AWS instance provisioning now ensures that there is an intersection between constraints and bindings if both are present, and it selects the subnet/zones mapping based on the index of the first space intersection.

This is a lot of effort to go to, but it is in the interest of preserving existing (permissive) AWS behaviour. We should consider restricting harder, and simplifying the logic in a future major release.

## QA steps

- Bootstrap to AWS.
- `juju add-space space-1 172.31.80.0/20`.
- `juju deploy percona-cluster mysql --constraints spaces=space-1` will fail, because of the default binding (_alpha_) conflicting with the space constraint.
- `juju remove-application mysql`
- `juju deploy percona-cluster mysql --constraints spaces=alpha` will correctly deploy into an _alpha_ subnet.
- `juju remove-application mysql`
- `juju deploy percona-cluster mysql --constraints spaces=space-1,alpha --bind "space-1"` will correctly deploy into a _space-1_ subnet.

## Documentation changes

I will ensure that the long-standing behaviour (satisfaction of a at most one space requirement on AWS) is indicated clearly.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1890347
