### PR TITLE
[2.8] Defer start hooks post reboot when series upgrade is in progress

### DIFF
--- a/worker/uniter/reboot/resolver.go
+++ b/worker/uniter/reboot/resolver.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package reboot
+
+import (
+	"github.com/juju/charm/v7/hooks"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/remotestate"
+	"github.com/juju/juju/worker/uniter/resolver"
+)
+
+// Logger represents the logging methods used in this package.
+type Logger interface {
+	Infof(string, ...interface{})
+}
+
+// NewResolver returns a resolver that runs the start hook to notify install
+// charms that the machine has been rebooted.
+func NewResolver(logger Logger, rebootDetected bool, modelType model.ModelType) resolver.Resolver {
+	if modelType != model.IAAS || !rebootDetected {
+		return nopResolver{}
+	}
+
+	return &rebootResolver{
+		rebootDetected: rebootDetected,
+		logger:         logger,
+	}
+}
+
+type nopResolver struct {
+}
+
+func (nopResolver) NextOp(_ resolver.LocalState, _ remotestate.Snapshot, _ operation.Factory) (operation.Operation, error) {
+	return nil, resolver.ErrNoOperation
+}
+
+type rebootResolver struct {
+	rebootDetected bool
+	logger         Logger
+}
+
+func (r *rebootResolver) NextOp(localState resolver.LocalState, remoteState remotestate.Snapshot, opfactory operation.Factory) (operation.Operation, error) {
+	// Have we already notified that a reboot occurred?
+	if !r.rebootDetected {
+		return nil, resolver.ErrNoOperation
+	}
+
+	// If we performing a series upgrade, suppress start hooks until the
+	// upgrade is complete.
+	if remoteState.UpgradeSeriesStatus != model.UpgradeSeriesNotStarted {
+		return nil, resolver.ErrNoOperation
+	}
+
+	// If we did reboot but the charm has not been installed yet then we
+	// can safely skip the start hook.
+	if !localState.Started {
+		r.rebootDetected = false
+		return nil, resolver.ErrNoOperation
+	}
+
+	op, err := opfactory.NewRunHook(hook.Info{Kind: hooks.Start})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	r.logger.Infof("reboot detected; triggering implicit start hook to notify charm")
+
+	r.rebootDetected = false
+	return op, nil
+}

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -29,6 +29,7 @@ type ResolverConfig struct {
 	StopRetryHookTimer  func()
 	VerifyCharmProfile  resolver.Resolver
 	UpgradeSeries       resolver.Resolver
+	Reboot              resolver.Resolver
 	Leadership          resolver.Resolver
 	Actions             resolver.Resolver
 	CreatedRelations    resolver.Resolver
@@ -70,6 +71,12 @@ func (s *uniterResolver) NextOp(
 		if errors.Cause(err) == resolver.ErrDoNotProceed {
 			return nil, resolver.ErrNoOperation
 		}
+		return op, err
+	}
+
+	// Check if we need to notify the charms because a reboot was detected.
+	op, err = s.config.Reboot.NextOp(localState, remoteState, opFactory)
+	if errors.Cause(err) != resolver.ErrNoOperation {
 		return op, err
 	}
 

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -18,6 +18,7 @@ var logger interface{}
 
 // Logger represents the logging methods used in this package.
 type Logger interface {
+	Errorf(string, ...interface{})
 	Tracef(string, ...interface{})
 }
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	corecharm "github.com/juju/charm/v7"
-	"github.com/juju/charm/v7/hooks"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -36,6 +35,7 @@ import (
 	"github.com/juju/juju/worker/uniter/hook"
 	uniterleadership "github.com/juju/juju/worker/uniter/leadership"
 	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/reboot"
 	"github.com/juju/juju/worker/uniter/relation"
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
@@ -424,23 +424,10 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		return nil
 	}
 
-	// If the machine rebooted and the charm was previously started, inject
-	// a start hook to notify charms of the reboot. This logic only makes
-	// sense for IAAS workloads as pods in a CAAS scenario can be recycled
-	// at any time.
+	var rebootDetected bool
 	if u.modelType == model.IAAS {
-		machineRebooted, err := u.rebootQuerier.Query(unitTag)
-		if err != nil {
+		if rebootDetected, err = u.rebootQuerier.Query(unitTag); err != nil {
 			return errors.Annotatef(err, "could not check reboot status for %q", unitTag)
-		}
-		if opState.Started && machineRebooted {
-			u.logger.Infof("reboot detected; triggering implicit start hook to notify charm")
-			op, err := u.operationFactory.NewRunHook(hook.Info{Kind: hooks.Start})
-			if err != nil {
-				return errors.Trace(err)
-			} else if err = u.operationExecutor.Run(op, nil); err != nil {
-				return errors.Trace(err)
-			}
 		}
 	} else if u.modelType == model.CAAS && u.isRemoteUnit {
 		if u.containerRunningStatusChannel == nil {
@@ -471,6 +458,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				u.logger.Child("verifycharmprofile"),
 				u.modelType,
 			),
+			Reboot:        reboot.NewResolver(u.logger, rebootDetected, u.modelType),
 			UpgradeSeries: upgradeseries.NewResolver(),
 			Leadership: uniterleadership.NewResolver(
 				u.logger.Child("leadership"),


### PR DESCRIPTION
## Description of change

This PR addresses the linked bug where the `start` hook for already started charms was invoked post-reboot even when a series upgrade was in progress. Juju should not run any hooks while a series upgrade is in progress.

As upgrade-related hooks are handled by their own dedicated resolver, the should-the-start-hook-be-triggered-post-reboot logic has been extracted from the uniter and moved into its own resolver (uniter/reboot). The new resolver is executed right after the upgrade resolver and only for IAAS models (for CAAS models this is a no-op resolver).

If a reboot was indeed detected, the start hook will be deferred and only fire once the upgrade steps are complete.

## QA steps

```console
$ juju bootstrap lxd series-test --no-gui
$ juju deploy ./acceptancetests/repository/charms/dummy-sink --series xenial
$ juju deploy ./acceptancetests/repository/charms/dummy-subordinate --series xenial
$ juju relate dummy-sink dummy-subordinate
$ juju config dummy-subordinate token=canonical

# Wait until units are up & running

# Check that the reboot resolver is still idle (you should get NO output)
$ juju debug-log --include-module juju.worker.uniter --replay --level INFO | grep 'reboot detected'

# Start upgrade
$ juju upgrade-series 0 prepare bionic
$ juju run --machine 0 'sudo shutdown -r now'

# SSH in machine 0 (you may need to `lxc exec -t juju-xyz bash`)
# You should still see no reboot detected message
$ fgrep 'reboot detected' /var/log/juju/unit-*.log

$ sudo do-release-upgrade -f DistUpgradeViewNonInteractive
$ sudo reboot now

# SSH in machine 0 (you may need to `lxc exec -t juju-xyz bash`)
# You should still see no reboot detected message
$ fgrep 'reboot detected' /var/log/juju/unit-*.log

# Complete upgrade
$ juju upgrade-series 0 complete 

# This time you should see the reboot detected message
$ juju debug-log --include-module juju.worker.uniter --replay --level INFO | grep 'reboot detected'
reboot detected; triggering implicit start hook to notify charm

# Finally, reboot the machine and check that the start hook fires
$ juju run --machine 0 'sudo shutdown -r now'
$ juju debug-log --include-module juju.worker.uniter --replay --level INFO | grep 'reboot detected'
reboot detected; triggering implicit start hook to notify charm
reboot detected; triggering implicit start hook to notify charm
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1890774