### PR TITLE
Remove charm.LXDProfile from state

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -510,7 +510,11 @@ func (api *ProvisionerAPI) machineLXDProfileNames(m *state.Machine, env environs
 		pName := lxdprofile.Name(api.m.Name(), app.Name(), ch.Revision())
 		// Lock here, we get a new env for every call to ProvisioningInfo().
 		api.mu.Lock()
-		if err := profileEnv.MaybeWriteLXDProfile(pName, profile); err != nil {
+		if err := profileEnv.MaybeWriteLXDProfile(pName, lxdprofile.Profile{
+			Description: profile.Description,
+			Config:      profile.Config,
+			Devices:     profile.Devices,
+		}); err != nil {
 			api.mu.Unlock()
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1538,7 +1538,13 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 	c.Assert(expected.URL(), gc.DeepEquals, curl)
 	c.Assert(expected.Meta(), gc.DeepEquals, ch.Meta())
 	c.Assert(expected.Config(), gc.DeepEquals, ch.Config())
-	c.Assert(expected.LXDProfile(), gc.DeepEquals, ch.(charm.LXDProfiler).LXDProfile())
+
+	expectedProfile := ch.(charm.LXDProfiler).LXDProfile()
+	c.Assert(expected.LXDProfile(), gc.DeepEquals, &state.LXDProfile{
+		Description: expectedProfile.Description,
+		Config:      expectedProfile.Config,
+		Devices:     expectedProfile.Devices,
+	})
 
 	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
 	c.Assert(errs, gc.DeepEquals, []error{nil})
@@ -1590,7 +1596,13 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	c.Assert(expected.URL(), gc.DeepEquals, curl)
 	c.Assert(expected.Meta(), gc.DeepEquals, ch.Meta())
 	c.Assert(expected.Config(), gc.DeepEquals, ch.Config())
-	c.Assert(expected.LXDProfile(), gc.DeepEquals, ch.(charm.LXDProfiler).LXDProfile())
+
+	expectedProfile := ch.(charm.LXDProfiler).LXDProfile()
+	c.Assert(expected.LXDProfile(), gc.DeepEquals, &state.LXDProfile{
+		Description: expectedProfile.Description,
+		Config:      expectedProfile.Config,
+		Devices:     expectedProfile.Devices,
+	})
 
 	errs, err := s.APIState.UnitAssigner().AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
 	c.Assert(errs, gc.DeepEquals, []error{nil})

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -337,7 +337,7 @@ func convertCharmExtraBindingMap(bindings map[string]charm.ExtraBinding) map[str
 	return result
 }
 
-func convertCharmLXDProfile(profile *charm.LXDProfile) *params.CharmLXDProfile {
+func convertCharmLXDProfile(profile *state.LXDProfile) *params.CharmLXDProfile {
 	return &params.CharmLXDProfile{
 		Description: profile.Description,
 		Config:      convertCharmLXDProfileConfig(profile.Config),

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -789,7 +789,11 @@ func fetchAllApplicationsAndUnits(
 		}
 		chName := lxdprofile.Name(model.Name(), app.Name(), ch.Revision())
 		if profile := ch.LXDProfile(); profile != nil {
-			lxdProfiles[chName] = profile
+			lxdProfiles[chName] = &charm.LXDProfile{
+				Description: profile.Description,
+				Config:      profile.Config,
+				Devices:     profile.Devices,
+			}
 		}
 	}
 

--- a/charmhub/refresh_integration_test.go
+++ b/charmhub/refresh_integration_test.go
@@ -1,4 +1,4 @@
-// build integration
+// +build integration
 
 // Copyright 2020 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/charm/v7"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/names/v4"
@@ -400,14 +399,14 @@ func (e *minModelWorkersEnviron) Instances(ctx context.ProviderCallContext, ids 
 	return nil, environs.ErrNoInstances
 }
 
-func (env *minModelWorkersEnviron) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+func (*minModelWorkersEnviron) MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error {
 	return nil
 }
 
-func (env *minModelWorkersEnviron) LXDProfileNames(containerName string) ([]string, error) {
+func (*minModelWorkersEnviron) LXDProfileNames(containerName string) ([]string, error) {
 	return nil, nil
 }
 
-func (env *minModelWorkersEnviron) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
+func (*minModelWorkersEnviron) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
 	return profilesNames, nil
 }

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"path/filepath"
 
-	"github.com/juju/charm/v7"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	gitjujutesting "github.com/juju/testing"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/container/broker"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/lxdprofile"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -245,7 +245,7 @@ func (m *fakeContainerManager) IsInitialized() bool {
 	return true
 }
 
-func (m *fakeContainerManager) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+func (m *fakeContainerManager) MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error {
 	m.MethodCall(m, "MaybeWriteLXDProfile")
 	return m.NextErr()
 }

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -4,7 +4,6 @@
 package broker
 
 import (
-	"github.com/juju/charm/v7"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -203,7 +202,7 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 		if profile.Name == "" {
 			return nil, errors.Errorf("request to write LXD profile for machine %s with no profile name", machineID)
 		}
-		err := broker.MaybeWriteLXDProfile(profile.Name, &charm.LXDProfile{
+		err := broker.MaybeWriteLXDProfile(profile.Name, lxdprofile.Profile{
 			Config:      profile.Config,
 			Description: profile.Description,
 			Devices:     profile.Devices,
@@ -217,7 +216,7 @@ func (broker *lxdBroker) writeProfiles(machineID string) ([]string, error) {
 }
 
 // MaybeWriteLXDProfile implements environs.LXDProfiler.
-func (broker *lxdBroker) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+func (broker *lxdBroker) MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error {
 	profileMgr, ok := broker.manager.(container.LXDProfileManager)
 	if !ok {
 		return nil
@@ -226,10 +225,10 @@ func (broker *lxdBroker) MaybeWriteLXDProfile(pName string, put *charm.LXDProfil
 }
 
 // AssignLXDProfiles implements environs.LXDProfiler.
-func (broker *lxdBroker) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error) {
+func (broker *lxdBroker) AssignLXDProfiles(instID string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error) {
 	profileMgr, ok := broker.manager.(container.LXDProfileManager)
 	if !ok {
 		return []string{}, nil
 	}
-	return profileMgr.AssignLXDProfiles(instId, profilesNames, profilePosts)
+	return profileMgr.AssignLXDProfiles(instID, profilesNames, profilePosts)
 }

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -190,17 +190,17 @@ func (s *lxdBrokerSuite) TestStartInstanceWithContainerInheritProperties(c *gc.C
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
-	ctlr := gomock.NewController(c)
-	defer ctlr.Finish()
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
 	machineId := "1/lxd/0"
 	containerTag := names.NewMachineTag("1-lxd-0")
 
-	mockApi := mocks.NewMockAPICalls(ctlr)
+	mockApi := mocks.NewMockAPICalls(ctrl)
 	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
 	mockApi.EXPECT().ContainerConfig().Return(fakeContainerConfig(), nil)
 
-	put := &charm.LXDProfile{
+	put := lxdprofile.Profile{
 		Config: map[string]string{
 			"security.nesting": "true",
 		},
@@ -218,8 +218,8 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 	}
 	mockApi.EXPECT().GetContainerProfileInfo(gomock.Eq(containerTag)).Return([]*apiprovisioner.LXDProfileResult{result}, nil)
 
-	mockManager := testing.NewMockTestLXDManager(ctlr)
-	mockManager.EXPECT().MaybeWriteLXDProfile("juju-test-profile", gomock.Eq(put)).Return(nil)
+	mockManager := testing.NewMockTestLXDManager(ctrl)
+	mockManager.EXPECT().MaybeWriteLXDProfile("juju-test-profile", put).Return(nil)
 
 	inst := mockInstance{id: "testinst"}
 	arch := "testarch"
@@ -237,13 +237,13 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceWithNoNameLXDProfile(c *gc.C) {
-	ctlr := gomock.NewController(c)
-	defer ctlr.Finish()
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
 	machineId := "1/lxd/0"
 	containerTag := names.NewMachineTag("1-lxd-0")
 
-	mockApi := mocks.NewMockAPICalls(ctlr)
+	mockApi := mocks.NewMockAPICalls(ctrl)
 	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
 	mockApi.EXPECT().ContainerConfig().Return(fakeContainerConfig(), nil)
 
@@ -258,7 +258,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithNoNameLXDProfile(c *gc.C) {
 	}
 	mockApi.EXPECT().GetContainerProfileInfo(gomock.Eq(containerTag)).Return([]*apiprovisioner.LXDProfileResult{result}, nil)
 
-	mockManager := testing.NewMockTestLXDManager(ctlr)
+	mockManager := testing.NewMockTestLXDManager(ctrl)
 
 	broker, err := broker.NewLXDBroker(
 		func(containerTag names.MachineTag, log loggo.Logger, abort <-chan struct{}) error { return nil },

--- a/container/interface.go
+++ b/container/interface.go
@@ -4,8 +4,6 @@
 package container
 
 import (
-	"github.com/juju/charm/v7"
-
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -86,11 +84,11 @@ type LXDProfileManager interface {
 	// AssignLXDProfiles assigns the given profile names to the lxd instance
 	// provided.  The slice of ProfilePosts provides details for adding to
 	// and removing profiles from the lxd server.
-	AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
+	AssignLXDProfiles(instID string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
 
 	// MaybeWriteLXDProfile, write given LXDProfile to machine if not already
 	// there.
-	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
+	MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error
 }
 
 // LXDProfileNameRetriever defines an interface for dealing with lxd profile

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -8,7 +8,6 @@ import (
 	stdtesting "testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/charm/v7"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
@@ -523,7 +522,7 @@ func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 	proMgr, ok := s.manager.(container.LXDProfileManager)
 	c.Assert(ok, jc.IsTrue)
 
-	put := charm.LXDProfile{
+	put := lxdprofile.Profile{
 		Config: map[string]string{
 			"security.nesting":    "true",
 			"security.privileged": "true",
@@ -545,7 +544,7 @@ func (s *managerSuite) TestMaybeWriteLXDProfile(c *gc.C) {
 	expProfile := lxdapi.Profile{ProfilePut: lxdapi.ProfilePut(put)}
 	s.cSvr.EXPECT().GetProfile(post.Name).Return(&expProfile, "etag", nil)
 
-	err := proMgr.MaybeWriteLXDProfile("juju-default-lxd-0", &put)
+	err := proMgr.MaybeWriteLXDProfile("juju-default-lxd-0", put)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/container/testing/interface_mock.go
+++ b/container/testing/interface_mock.go
@@ -5,10 +5,7 @@
 package testing
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
 	instancecfg "github.com/juju/juju/cloudconfig/instancecfg"
 	container "github.com/juju/juju/container"
 	constraints "github.com/juju/juju/core/constraints"
@@ -16,6 +13,7 @@ import (
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
 	instances "github.com/juju/juju/environs/instances"
+	reflect "reflect"
 )
 
 // MockTestLXDManager is a mock of TestLXDManager interface
@@ -43,6 +41,7 @@ func (m *MockTestLXDManager) EXPECT() *MockTestLXDManagerMockRecorder {
 
 // AssignLXDProfiles mocks base method
 func (m *MockTestLXDManager) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -51,11 +50,13 @@ func (m *MockTestLXDManager) AssignLXDProfiles(arg0 string, arg1 []string, arg2 
 
 // AssignLXDProfiles indicates an expected call of AssignLXDProfiles
 func (mr *MockTestLXDManagerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockTestLXDManager)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
 // CreateContainer mocks base method
 func (m *MockTestLXDManager) CreateContainer(arg0 *instancecfg.InstanceConfig, arg1 constraints.Value, arg2 string, arg3 *container.NetworkConfig, arg4 *container.StorageConfig, arg5 environs.StatusCallbackFunc) (instances.Instance, *instance.HardwareCharacteristics, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(instances.Instance)
 	ret1, _ := ret[1].(*instance.HardwareCharacteristics)
@@ -65,11 +66,13 @@ func (m *MockTestLXDManager) CreateContainer(arg0 *instancecfg.InstanceConfig, a
 
 // CreateContainer indicates an expected call of CreateContainer
 func (mr *MockTestLXDManagerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockTestLXDManager)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // DestroyContainer mocks base method
 func (m *MockTestLXDManager) DestroyContainer(arg0 instance.Id) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyContainer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -77,11 +80,13 @@ func (m *MockTestLXDManager) DestroyContainer(arg0 instance.Id) error {
 
 // DestroyContainer indicates an expected call of DestroyContainer
 func (mr *MockTestLXDManagerMockRecorder) DestroyContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyContainer", reflect.TypeOf((*MockTestLXDManager)(nil).DestroyContainer), arg0)
 }
 
 // IsInitialized mocks base method
 func (m *MockTestLXDManager) IsInitialized() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsInitialized")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -89,11 +94,13 @@ func (m *MockTestLXDManager) IsInitialized() bool {
 
 // IsInitialized indicates an expected call of IsInitialized
 func (mr *MockTestLXDManagerMockRecorder) IsInitialized() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInitialized", reflect.TypeOf((*MockTestLXDManager)(nil).IsInitialized))
 }
 
 // LXDProfileNames mocks base method
 func (m *MockTestLXDManager) LXDProfileNames(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -102,11 +109,13 @@ func (m *MockTestLXDManager) LXDProfileNames(arg0 string) ([]string, error) {
 
 // LXDProfileNames indicates an expected call of LXDProfileNames
 func (mr *MockTestLXDManagerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockTestLXDManager)(nil).LXDProfileNames), arg0)
 }
 
 // ListContainers mocks base method
 func (m *MockTestLXDManager) ListContainers() ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainers")
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -115,11 +124,13 @@ func (m *MockTestLXDManager) ListContainers() ([]instances.Instance, error) {
 
 // ListContainers indicates an expected call of ListContainers
 func (mr *MockTestLXDManagerMockRecorder) ListContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*MockTestLXDManager)(nil).ListContainers))
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockTestLXDManager) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
+func (m *MockTestLXDManager) MaybeWriteLXDProfile(arg0 string, arg1 lxdprofile.Profile) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -127,11 +138,13 @@ func (m *MockTestLXDManager) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LX
 
 // MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
 func (mr *MockTestLXDManagerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockTestLXDManager)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
 // Namespace mocks base method
 func (m *MockTestLXDManager) Namespace() instance.Namespace {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Namespace")
 	ret0, _ := ret[0].(instance.Namespace)
 	return ret0
@@ -139,18 +152,6 @@ func (m *MockTestLXDManager) Namespace() instance.Namespace {
 
 // Namespace indicates an expected call of Namespace
 func (mr *MockTestLXDManagerMockRecorder) Namespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockTestLXDManager)(nil).Namespace))
-}
-
-// ReplaceOrAddInstanceProfile mocks base method
-func (m *MockTestLXDManager) ReplaceOrAddInstanceProfile(arg0, arg1, arg2 string, arg3 *charm_v6.LXDProfile) ([]string, error) {
-	ret := m.ctrl.Call(m, "ReplaceOrAddInstanceProfile", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplaceOrAddInstanceProfile indicates an expected call of ReplaceOrAddInstanceProfile
-func (mr *MockTestLXDManagerMockRecorder) ReplaceOrAddInstanceProfile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddInstanceProfile", reflect.TypeOf((*MockTestLXDManager)(nil).ReplaceOrAddInstanceProfile), arg0, arg1, arg2, arg3)
 }

--- a/container/testing/package_mock.go
+++ b/container/testing/package_mock.go
@@ -5,15 +5,14 @@
 package testing
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	instancecfg "github.com/juju/juju/cloudconfig/instancecfg"
 	container "github.com/juju/juju/container"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	environs "github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/instances"
+	instances "github.com/juju/juju/environs/instances"
+	reflect "reflect"
 )
 
 // MockManager is a mock of Manager interface
@@ -41,6 +40,7 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 
 // CreateContainer mocks base method
 func (m *MockManager) CreateContainer(arg0 *instancecfg.InstanceConfig, arg1 constraints.Value, arg2 string, arg3 *container.NetworkConfig, arg4 *container.StorageConfig, arg5 environs.StatusCallbackFunc) (instances.Instance, *instance.HardwareCharacteristics, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateContainer", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(instances.Instance)
 	ret1, _ := ret[1].(*instance.HardwareCharacteristics)
@@ -50,11 +50,13 @@ func (m *MockManager) CreateContainer(arg0 *instancecfg.InstanceConfig, arg1 con
 
 // CreateContainer indicates an expected call of CreateContainer
 func (mr *MockManagerMockRecorder) CreateContainer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContainer", reflect.TypeOf((*MockManager)(nil).CreateContainer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // DestroyContainer mocks base method
 func (m *MockManager) DestroyContainer(arg0 instance.Id) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyContainer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -62,11 +64,13 @@ func (m *MockManager) DestroyContainer(arg0 instance.Id) error {
 
 // DestroyContainer indicates an expected call of DestroyContainer
 func (mr *MockManagerMockRecorder) DestroyContainer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyContainer", reflect.TypeOf((*MockManager)(nil).DestroyContainer), arg0)
 }
 
 // IsInitialized mocks base method
 func (m *MockManager) IsInitialized() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsInitialized")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -74,11 +78,13 @@ func (m *MockManager) IsInitialized() bool {
 
 // IsInitialized indicates an expected call of IsInitialized
 func (mr *MockManagerMockRecorder) IsInitialized() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInitialized", reflect.TypeOf((*MockManager)(nil).IsInitialized))
 }
 
 // ListContainers mocks base method
 func (m *MockManager) ListContainers() ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainers")
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -87,11 +93,13 @@ func (m *MockManager) ListContainers() ([]instances.Instance, error) {
 
 // ListContainers indicates an expected call of ListContainers
 func (mr *MockManagerMockRecorder) ListContainers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainers", reflect.TypeOf((*MockManager)(nil).ListContainers))
 }
 
 // Namespace mocks base method
 func (m *MockManager) Namespace() instance.Namespace {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Namespace")
 	ret0, _ := ret[0].(instance.Namespace)
 	return ret0
@@ -99,6 +107,7 @@ func (m *MockManager) Namespace() instance.Namespace {
 
 // Namespace indicates an expected call of Namespace
 func (mr *MockManagerMockRecorder) Namespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespace", reflect.TypeOf((*MockManager)(nil).Namespace))
 }
 
@@ -127,6 +136,7 @@ func (m *MockInitialiser) EXPECT() *MockInitialiserMockRecorder {
 
 // Initialise mocks base method
 func (m *MockInitialiser) Initialise() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialise")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -134,5 +144,6 @@ func (m *MockInitialiser) Initialise() error {
 
 // Initialise indicates an expected call of Initialise
 func (mr *MockInitialiserMockRecorder) Initialise() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialise", reflect.TypeOf((*MockInitialiser)(nil).Initialise))
 }

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -4,8 +4,6 @@
 package environs
 
 import (
-	"github.com/juju/charm/v7"
-
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -178,10 +176,10 @@ type LXDProfiler interface {
 	// AssignLXDProfiles assigns the given profile names to the lxd instance
 	// provided.  The slice of ProfilePosts provides details for adding to
 	// and removing profiles from the lxd server.
-	AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
+	AssignLXDProfiles(instID string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
 
 	// MaybeWriteLXDProfile, write given LXDProfile to if not already there.
-	MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error
+	MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error
 
 	// LXDProfileNames returns all the profiles associated to a container name
 	LXDProfileNames(containerName string) ([]string, error)

--- a/go.sum
+++ b/go.sum
@@ -100,9 +100,11 @@ github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+Wji
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -31,7 +31,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/charm/v7"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
@@ -1949,17 +1948,17 @@ func (*environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space
 }
 
 // MaybeWriteLXDProfile implements environs.LXDProfiler.
-func (env *environ) MaybeWriteLXDProfile(pName string, put *charm.LXDProfile) error {
+func (*environ) MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error {
 	return nil
 }
 
 // LXDProfileNames implements environs.LXDProfiler.
-func (env *environ) LXDProfileNames(containerName string) ([]string, error) {
+func (*environ) LXDProfileNames(containerName string) ([]string, error) {
 	return nil, nil
 }
 
 // AssignLXDProfiles implements environs.LXDProfiler.
-func (env *environ) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
+func (*environ) AssignLXDProfiles(instId string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) (current []string, err error) {
 	return profilesNames, nil
 }
 

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -5,7 +5,6 @@ package lxd_test
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/juju/charm/v7"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	gitjujutesting "github.com/juju/testing"
@@ -455,7 +454,7 @@ func (s *environProfileSuite) TestMaybeWriteLXDProfileYes(c *gc.C) {
 	profile := "testname"
 	s.expectMaybeWriteLXDProfile(false, profile)
 
-	err := s.lxdEnv.MaybeWriteLXDProfile(profile, &charm.LXDProfile{
+	err := s.lxdEnv.MaybeWriteLXDProfile(profile, lxdprofile.Profile{
 		Config: map[string]string{
 			"security.nesting": "true",
 		},
@@ -470,7 +469,7 @@ func (s *environProfileSuite) TestMaybeWriteLXDProfileNo(c *gc.C) {
 	profile := "testname"
 	s.expectMaybeWriteLXDProfile(true, profile)
 
-	err := s.lxdEnv.MaybeWriteLXDProfile(profile, nil)
+	err := s.lxdEnv.MaybeWriteLXDProfile(profile, lxdprofile.Profile{})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -827,7 +827,7 @@ func (ch *backingCharm) mongoID() string {
 	return id
 }
 
-func toMultiwatcherProfile(profile *charm.LXDProfile) *multiwatcher.Profile {
+func toMultiwatcherProfile(profile *LXDProfile) *multiwatcher.Profile {
 	unescapedProfile := unescapeLXDProfile(profile)
 	return &multiwatcher.Profile{
 		Config:      unescapedProfile.Config,

--- a/state/application.go
+++ b/state/application.go
@@ -1370,6 +1370,9 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 	if profile := cfg.Charm.LXDProfile(); profile != nil {
 		// Validate the config devices, to ensure we don't apply an invalid
 		// profile, if we know it's never going to work.
+		// TODO (stickupkid): Validation of config devices is totally in the
+		// wrong place. Validation should be done at the API server layer, not
+		// at the state layer.
 		if err := profile.ValidateConfigDevices(); err != nil && !cfg.Force {
 			return errors.Annotate(err, "validating lxd profile")
 		}

--- a/worker/containerbroker/mocks/environs_mock.go
+++ b/worker/containerbroker/mocks/environs_mock.go
@@ -6,7 +6,6 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	charm "github.com/juju/charm/v7"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
@@ -69,7 +68,7 @@ func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 lxdprofile.Profile) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/containerbroker/mocks/state_mock.go
+++ b/worker/containerbroker/mocks/state_mock.go
@@ -67,21 +67,6 @@ func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockState)(nil).ContainerManagerConfig), arg0)
 }
 
-// GetContainerInterfaceInfo mocks base method
-func (m *MockState) GetContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContainerInterfaceInfo", arg0)
-	ret0, _ := ret[0].(network.InterfaceInfos)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetContainerInterfaceInfo indicates an expected call of GetContainerInterfaceInfo
-func (mr *MockStateMockRecorder) GetContainerInterfaceInfo(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).GetContainerInterfaceInfo), arg0)
-}
-
 // GetContainerProfileInfo mocks base method
 func (m *MockState) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -6,7 +6,6 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	charm "github.com/juju/charm/v7"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
@@ -405,7 +404,7 @@ func (mr *MockLXDProfilerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 *charm.LXDProfile) error {
+func (m *MockLXDProfiler) MaybeWriteLXDProfile(arg0 string, arg1 lxdprofile.Profile) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -297,9 +297,9 @@ func (m MutaterMachine) gatherProfileData(info *instancemutater.UnitProfileInfo)
 	return result, nil
 }
 
-func (m MutaterMachine) verifyCurrentProfiles(instId string, expectedProfiles []string) (bool, error) {
+func (m MutaterMachine) verifyCurrentProfiles(instID string, expectedProfiles []string) (bool, error) {
 	broker := m.context.getBroker()
-	obtainedProfiles, err := broker.LXDProfileNames(instId)
+	obtainedProfiles, err := broker.LXDProfileNames(instID)
 	if err != nil {
 		return false, err
 	}

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -57,7 +57,7 @@ type Config struct {
 	// or a container broker.
 	GetMachineWatcher func() (watcher.StringsWatcher, error)
 
-	// GetRequiredLXPprofiles provides a slice of strings representing the
+	// GetRequiredLXDProfiles provides a slice of strings representing the
 	// lxd profiles to be included on every LXD machine used given the
 	// current model name.
 	GetRequiredLXDProfiles RequiredLXDProfilesFunc
@@ -226,7 +226,7 @@ func (w *mutaterWorker) Wait() error {
 	return w.catacomb.Wait()
 }
 
-// Stop stops the instancemutaterworker and returns any
+// Stop stops the mutaterWorker and returns any
 // error it encountered when running.
 func (w *mutaterWorker) Stop() error {
 	w.Kill()

--- a/worker/provisioner/mocks/lxdprofileinstancebroker_mock.go
+++ b/worker/provisioner/mocks/lxdprofileinstancebroker_mock.go
@@ -5,15 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-	charm_v6 "github.com/juju/charm/v7"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
+	reflect "reflect"
 )
 
 // MockLXDProfileInstanceBroker is a mock of LXDProfileInstanceBroker interface
@@ -41,6 +39,7 @@ func (m *MockLXDProfileInstanceBroker) EXPECT() *MockLXDProfileInstanceBrokerMoc
 
 // AllInstances mocks base method
 func (m *MockLXDProfileInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -49,11 +48,28 @@ func (m *MockLXDProfileInstanceBroker) AllInstances(arg0 context.ProviderCallCon
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AllInstances), arg0)
+}
+
+// AllRunningInstances mocks base method
+func (m *MockLXDProfileInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
+	ret0, _ := ret[0].([]instances.Instance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRunningInstances indicates an expected call of AllRunningInstances
+func (mr *MockLXDProfileInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
 // AssignLXDProfiles mocks base method
 func (m *MockLXDProfileInstanceBroker) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -62,11 +78,13 @@ func (m *MockLXDProfileInstanceBroker) AssignLXDProfiles(arg0 string, arg1 []str
 
 // AssignLXDProfiles indicates an expected call of AssignLXDProfiles
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
 // LXDProfileNames mocks base method
 func (m *MockLXDProfileInstanceBroker) LXDProfileNames(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -75,11 +93,13 @@ func (m *MockLXDProfileInstanceBroker) LXDProfileNames(arg0 string) ([]string, e
 
 // LXDProfileNames indicates an expected call of LXDProfileNames
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).LXDProfileNames), arg0)
 }
 
 // MaintainInstance mocks base method
 func (m *MockLXDProfileInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -87,11 +107,13 @@ func (m *MockLXDProfileInstanceBroker) MaintainInstance(arg0 context.ProviderCal
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).MaintainInstance), arg0, arg1)
 }
 
 // MaybeWriteLXDProfile mocks base method
-func (m *MockLXDProfileInstanceBroker) MaybeWriteLXDProfile(arg0 string, arg1 *charm_v6.LXDProfile) error {
+func (m *MockLXDProfileInstanceBroker) MaybeWriteLXDProfile(arg0 string, arg1 lxdprofile.Profile) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -99,24 +121,13 @@ func (m *MockLXDProfileInstanceBroker) MaybeWriteLXDProfile(arg0 string, arg1 *c
 
 // MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).MaybeWriteLXDProfile), arg0, arg1)
-}
-
-// ReplaceOrAddInstanceProfile mocks base method
-func (m *MockLXDProfileInstanceBroker) ReplaceOrAddInstanceProfile(arg0, arg1, arg2 string, arg3 *charm_v6.LXDProfile) ([]string, error) {
-	ret := m.ctrl.Call(m, "ReplaceOrAddInstanceProfile", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplaceOrAddInstanceProfile indicates an expected call of ReplaceOrAddInstanceProfile
-func (mr *MockLXDProfileInstanceBrokerMockRecorder) ReplaceOrAddInstanceProfile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceOrAddInstanceProfile", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).ReplaceOrAddInstanceProfile), arg0, arg1, arg2, arg3)
 }
 
 // StartInstance mocks base method
 func (m *MockLXDProfileInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -125,11 +136,13 @@ func (m *MockLXDProfileInstanceBroker) StartInstance(arg0 context.ProviderCallCo
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
 func (m *MockLXDProfileInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -141,6 +154,7 @@ func (m *MockLXDProfileInstanceBroker) StopInstances(arg0 context.ProviderCallCo
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).StopInstances), varargs...)
 }


### PR DESCRIPTION
## Description of change

The following attempts to resolve a long outstanding issue in state. The
`charmDoc` writes directly to the database the `charm.LXDProfile`, which is
an external dependency and means that any update of that charm
dependency could potentially break our database.

The following attempts to fix the issue in a piecemeal fashion, by
tackling one field at a time. Here we're tackling the LXD profile from
the charm package.

The code is very mechanical and just requires to correctly marshal
between state, lxdprofile and charm profiles. Each correctly contained
to their vertical boundary.

I suspect Meta, Config and Actions will be the hardest to move, but baby
steps are more than welcome!

## QA steps

```sh
juju bootstrap lxd test
juju deploy lxd-profile-test
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1467964
