### PR TITLE
Enable scp for CAAS model;

### DIFF
--- a/cmd/juju/commands/export_test.go
+++ b/cmd/juju/commands/export_test.go
@@ -13,6 +13,10 @@ type (
 	ResolvedTarget = resolvedTarget
 )
 
+var (
+	GetInterruptAbortChan = getInterruptAbortChan
+)
+
 func (r resolvedTarget) GetEntity() string {
 	return r.entity
 }
@@ -33,6 +37,10 @@ func (c *sshContainer) SSH(ctx Context, enablePty bool, target *resolvedTarget) 
 	return c.ssh(ctx, enablePty, target)
 }
 
+func (c *sshContainer) Copy(ctx Context) error {
+	return c.copy(ctx)
+}
+
 func (c *sshContainer) GetExecClient() (k8sexec.Executor, error) {
 	return c.getExecClient()
 }
@@ -45,6 +53,7 @@ type SSHContainerInterfaceForTest interface {
 	CleanupRun()
 	ResolveTarget(string) (*resolvedTarget, error)
 	SSH(Context, bool, *resolvedTarget) error
+	Copy(ctx Context) error
 	GetExecClient() (k8sexec.Executor, error)
 
 	SetArgs([]string)
@@ -57,6 +66,7 @@ func NewSSHContainer(
 	applicationAPI ApplicationAPI,
 	execClient k8sexec.Executor,
 	remote bool,
+	containerName string,
 ) SSHContainerInterfaceForTest {
 	return &sshContainer{
 		modelUUID:          modelUUID,
@@ -67,6 +77,7 @@ func NewSSHContainer(
 		execClientGetter: func(string, cloudspec.CloudSpec) (k8sexec.Executor, error) {
 			return execClient, nil
 		},
-		remote: remote,
+		remote:    remote,
+		container: containerName,
 	}
 }

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -115,8 +115,9 @@ func newSCPCommand(hostChecker jujussh.ReachableChecker) cmd.Command {
 
 // scpCommand is responsible for launching a scp command to copy files to/from remote machine(s)
 type scpCommand struct {
-	modelType model.ModelType
 	modelcmd.ModelCommandBase
+
+	modelType model.ModelType
 
 	sshMachine
 	sshContainer
@@ -161,21 +162,9 @@ func (c *scpCommand) Init(args []string) (err error) {
 // Run resolves c.Target to a machine, or host of a unit and
 // forks ssh with c.Args, if provided.
 func (c *scpCommand) Run(ctx *cmd.Context) error {
-	if err := c.provider.initRun(c.ModelCommandBase); err != nil {
+	if err := c.provider.initRun(&c.ModelCommandBase); err != nil {
 		return errors.Trace(err)
 	}
 	defer c.provider.cleanupRun()
-
-	// args, targets, err := expandArgs(c.provider.getArgs(), c.provider.resolveTarget)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// options, err := c.getSSHOptions(false, targets...)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// return ssh.Copy(args, options)
 	return c.provider.copy(ctx)
 }

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -4,15 +4,13 @@
 package commands
 
 import (
-	"net"
-	"strings"
-
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/utils/ssh"
+	"github.com/juju/gnuflag"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	jujussh "github.com/juju/juju/network/ssh"
 )
 
@@ -117,11 +115,20 @@ func newSCPCommand(hostChecker jujussh.ReachableChecker) cmd.Command {
 
 // scpCommand is responsible for launching a scp command to copy files to/from remote machine(s)
 type scpCommand struct {
+	modelType model.ModelType
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
-	SSHMachine
+
+	sshMachine
+	sshContainer
+
+	provider sshProvider
 
 	hostChecker jujussh.ReachableChecker
+}
+
+func (c *scpCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.sshMachine.SetFlags(f)
+	c.sshContainer.SetFlags(f)
 }
 
 func (c *scpCommand) Info() *cmd.Info {
@@ -133,65 +140,42 @@ func (c *scpCommand) Info() *cmd.Info {
 	})
 }
 
-func (c *scpCommand) Init(args []string) error {
+func (c *scpCommand) Init(args []string) (err error) {
 	if len(args) < 2 {
 		return errors.Errorf("at least two arguments required")
 	}
-	c.setArgs(args)
-	c.setHostChecker(c.hostChecker)
+	if c.modelType, err = c.ModelType(); err != nil {
+		return err
+	}
+	if c.modelType == model.CAAS {
+		c.provider = &c.sshContainer
+	} else {
+		c.provider = &c.sshMachine
+	}
+
+	c.provider.setArgs(args)
+	c.provider.setHostChecker(c.hostChecker)
 	return nil
 }
 
 // Run resolves c.Target to a machine, or host of a unit and
 // forks ssh with c.Args, if provided.
 func (c *scpCommand) Run(ctx *cmd.Context) error {
-	err := c.initRun(c.ModelCommandBase)
-	if err != nil {
+	if err := c.provider.initRun(c.ModelCommandBase); err != nil {
 		return errors.Trace(err)
 	}
-	defer c.cleanupRun()
+	defer c.provider.cleanupRun()
 
-	args, targets, err := expandArgs(c.getArgs(), c.resolveTarget)
-	if err != nil {
-		return err
-	}
+	// args, targets, err := expandArgs(c.provider.getArgs(), c.provider.resolveTarget)
+	// if err != nil {
+	// 	return err
+	// }
 
-	options, err := c.getSSHOptions(false, targets...)
-	if err != nil {
-		return err
-	}
+	// options, err := c.getSSHOptions(false, targets...)
+	// if err != nil {
+	// 	return err
+	// }
 
-	return ssh.Copy(args, options)
-}
-
-// expandArgs takes a list of arguments and looks for ones in the form of
-// 0:some/path or application/0:some/path, and translates them into
-// ubuntu@machine:some/path so they can be passed as arguments to scp, and pass
-// the rest verbatim on to scp
-func expandArgs(args []string, resolveTarget func(string) (*resolvedTarget, error)) (
-	[]string, []*resolvedTarget, error,
-) {
-	outArgs := make([]string, len(args))
-	var targets []*resolvedTarget
-	for i, arg := range args {
-		v := strings.SplitN(arg, ":", 2)
-		if strings.HasPrefix(arg, "-") || len(v) <= 1 {
-			// Can't be an interesting target, so just pass it along
-			outArgs[i] = arg
-			continue
-		}
-
-		target, err := resolveTarget(v[0])
-		if err != nil {
-			return nil, nil, err
-		}
-		arg := net.JoinHostPort(target.host, v[1])
-		if target.user != "" {
-			arg = target.user + "@" + arg
-		}
-		outArgs[i] = arg
-
-		targets = append(targets, target)
-	}
-	return outArgs, targets, nil
+	// return ssh.Copy(args, options)
+	return c.provider.copy(ctx)
 }

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujussh "github.com/juju/juju/network/ssh"
-	"github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&SCPSuiteLegacy{})
@@ -237,9 +236,3 @@ func (s *SCPSuiteLegacy) TestSCPCommand(c *gc.C) {
 		}
 	}
 }
-
-type scpSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&scpSuite{})

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -14,11 +14,12 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujussh "github.com/juju/juju/network/ssh"
+	"github.com/juju/juju/testing"
 )
 
-var _ = gc.Suite(&SCPSuite{})
+var _ = gc.Suite(&SCPSuiteLegacy{})
 
-type SCPSuite struct {
+type SCPSuiteLegacy struct {
 	SSHMachineSuite
 }
 
@@ -211,7 +212,7 @@ var scpTests = []struct {
 	},
 }
 
-func (s *SCPSuite) TestSCPCommand(c *gc.C) {
+func (s *SCPSuiteLegacy) TestSCPCommand(c *gc.C) {
 	s.setupModel(c)
 
 	for i, t := range scpTests {
@@ -236,3 +237,9 @@ func (s *SCPSuite) TestSCPCommand(c *gc.C) {
 		}
 	}
 }
+
+type scpSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&scpSuite{})

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -143,7 +143,6 @@ func (c *sshCommand) Init(args []string) (err error) {
 
 // ModelCommand defines methods of the model command.
 type ModelCommand interface {
-	// modelcmd.ModelCommand
 	NewControllerAPIRoot() (api.Connection, error)
 	ModelDetails() (string, *jujuclient.ModelDetails, error)
 	NewAPIRoot() (api.Connection, error)

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -11,9 +11,11 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
+	"github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/jujuclient"
 	jujussh "github.com/juju/juju/network/ssh"
 )
 
@@ -139,9 +141,18 @@ func (c *sshCommand) Init(args []string) (err error) {
 	return nil
 }
 
+// ModelCommand defines methods of the model command.
+type ModelCommand interface {
+	// modelcmd.ModelCommand
+	NewControllerAPIRoot() (api.Connection, error)
+	ModelDetails() (string, *jujuclient.ModelDetails, error)
+	NewAPIRoot() (api.Connection, error)
+	ModelIdentifier() (string, error)
+}
+
 // sshProvider is implemented by either either a CaaS or IaaS model instance.
 type sshProvider interface {
-	initRun(modelcmd.ModelCommandBase) error
+	initRun(ModelCommand) error
 	cleanupRun()
 	setHostChecker(checker jujussh.ReachableChecker)
 	resolveTarget(string) (*resolvedTarget, error)
@@ -158,7 +169,7 @@ type sshProvider interface {
 // Run resolves c.Target to a machine, to the address of a i
 // machine or unit forks ssh passing any arguments provided.
 func (c *sshCommand) Run(ctx *cmd.Context) error {
-	if err := c.provider.initRun(c.ModelCommandBase); err != nil {
+	if err := c.provider.initRun(&c.ModelCommandBase); err != nil {
 		return errors.Trace(err)
 	}
 	defer c.provider.cleanupRun()

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -96,7 +96,7 @@ type sshCommand struct {
 	modelType model.ModelType
 	modelcmd.ModelCommandBase
 
-	SSHMachine
+	sshMachine
 	sshContainer
 
 	provider sshProvider
@@ -107,7 +107,7 @@ type sshCommand struct {
 }
 
 func (c *sshCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.SSHMachine.SetFlags(f)
+	c.sshMachine.SetFlags(f)
 	c.sshContainer.SetFlags(f)
 	f.Var(&c.pty, "pty", "Enable pseudo-tty allocation")
 }
@@ -125,14 +125,13 @@ func (c *sshCommand) Init(args []string) (err error) {
 	if len(args) == 0 {
 		return errors.Errorf("no target name specified")
 	}
-	c.modelType, err = c.ModelType()
-	if err != nil {
+	if c.modelType, err = c.ModelType(); err != nil {
 		return err
 	}
 	if c.modelType == model.CAAS {
 		c.provider = &c.sshContainer
 	} else {
-		c.provider = &c.SSHMachine
+		c.provider = &c.sshMachine
 	}
 	c.provider.setTarget(args[0])
 	c.provider.setArgs(args[1:])
@@ -147,6 +146,7 @@ type sshProvider interface {
 	setHostChecker(checker jujussh.ReachableChecker)
 	resolveTarget(string) (*resolvedTarget, error)
 	ssh(ctx Context, enablePty bool, target *resolvedTarget) error
+	copy(Context) error
 
 	getTarget() string
 	setTarget(target string)

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -20,7 +20,6 @@ import (
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	k8sexec "github.com/juju/juju/caas/kubernetes/provider/exec"
 	jujucloud "github.com/juju/juju/cloud"
-	// "github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/cloudspec"
 	jujussh "github.com/juju/juju/network/ssh"
 )
@@ -241,7 +240,6 @@ func getInterruptAbortChan(ctx Context) (<-chan struct{}, func()) {
 }
 
 func (c *sshContainer) copy(ctx Context) error {
-	// TODO: enable exec framework to support copy from pod to local!!!
 	args := c.getArgs()
 	if len(args) < 2 {
 		return errors.New("source and destination are required")

--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/juju/juju/api/sshclient"
 	"github.com/juju/juju/apiserver/params"
-	// "github.com/juju/juju/cmd/modelcmd"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 	jujussh "github.com/juju/juju/network/ssh"

--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -256,7 +256,9 @@ func (c *sshMachine) copy(ctx Context) error {
 // 0:some/path or application/0:some/path, and translates them into
 // ubuntu@machine:some/path so they can be passed as arguments to scp, and pass
 // the rest verbatim on to scp
-func (c *sshMachine) expandSCPArgs(args []string) (outArgs []string, targets []*resolvedTarget, err error) {
+func (c *sshMachine) expandSCPArgs(args []string) ([]string, []*resolvedTarget, error) {
+	outArgs := make([]string, len(args))
+	var targets []*resolvedTarget
 	for i, arg := range args {
 		v := strings.SplitN(arg, ":", 2)
 		if strings.HasPrefix(arg, "-") || len(v) <= 1 {

--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -28,9 +28,9 @@ import (
 	jujussh "github.com/juju/juju/network/ssh"
 )
 
-// SSHMachine implements functionality shared by sshCommand, SCPCommand
+// sshMachine implements functionality shared by sshCommand, SCPCommand
 // and DebugHooksCommand.
-type SSHMachine struct {
+type sshMachine struct {
 	modelName string
 
 	proxy           bool
@@ -110,28 +110,28 @@ var sshHostFromTargetAttemptStrategy attemptStarter = attemptStrategy{
 	Delay: SSHRetryDelay,
 }
 
-func (c *SSHMachine) SetFlags(f *gnuflag.FlagSet) {
+func (c *sshMachine) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.proxy, "proxy", false, "Proxy through the API server")
 	f.BoolVar(&c.noHostKeyChecks, "no-host-key-checks", false, "Skip host key checking (INSECURE)")
 }
 
 // getTarget returns the target.
-func (c *SSHMachine) getTarget() string {
+func (c *sshMachine) getTarget() string {
 	return c.target
 }
 
 // setTarget sets the target.
-func (c *SSHMachine) setTarget(target string) {
+func (c *sshMachine) setTarget(target string) {
 	c.target = target
 }
 
 // getArgs returns the args.
-func (c *SSHMachine) getArgs() []string {
+func (c *sshMachine) getArgs() []string {
 	return c.args
 }
 
 // setArgs sets the args.
-func (c *SSHMachine) setArgs(args []string) {
+func (c *sshMachine) setArgs(args []string) {
 	c.args = args
 }
 
@@ -141,7 +141,7 @@ func defaultReachableChecker() jujussh.ReachableChecker {
 	return jujussh.NewReachableChecker(&net.Dialer{Timeout: SSHRetryDelay}, SSHTimeout)
 }
 
-func (c *SSHMachine) setHostChecker(checker jujussh.ReachableChecker) {
+func (c *sshMachine) setHostChecker(checker jujussh.ReachableChecker) {
 	if checker == nil {
 		checker = defaultReachableChecker()
 	}
@@ -153,7 +153,7 @@ func (c *SSHMachine) setHostChecker(checker jujussh.ReachableChecker) {
 // command's Run method.
 //
 // The apiClient, apiAddr and proxy fields are initialized after this call.
-func (c *SSHMachine) initRun(mc modelcmd.ModelCommandBase) (err error) {
+func (c *sshMachine) initRun(mc modelcmd.ModelCommandBase) (err error) {
 	if c.modelName, err = mc.ModelIdentifier(); err != nil {
 		return errors.Trace(err)
 	}
@@ -175,7 +175,7 @@ func (c *SSHMachine) initRun(mc modelcmd.ModelCommandBase) (err error) {
 // cleanupRun removes the temporary SSH known_hosts file (if one was
 // created) and closes the API connection. It must be called at the
 // end of the command's Run (i.e. as a defer).
-func (c *SSHMachine) cleanupRun() {
+func (c *sshMachine) cleanupRun() {
 	if c.knownHostsPath != "" {
 		os.Remove(c.knownHostsPath)
 		c.knownHostsPath = ""
@@ -188,7 +188,7 @@ func (c *SSHMachine) cleanupRun() {
 
 // getSSHOptions configures SSH options based on command line
 // arguments and the SSH targets specified.
-func (c *SSHMachine) getSSHOptions(enablePty bool, targets ...*resolvedTarget) (*ssh.Options, error) {
+func (c *sshMachine) getSSHOptions(enablePty bool, targets ...*resolvedTarget) (*ssh.Options, error) {
 	var options ssh.Options
 
 	if c.noHostKeyChecks {
@@ -226,7 +226,7 @@ func (c *SSHMachine) getSSHOptions(enablePty bool, targets ...*resolvedTarget) (
 	return &options, nil
 }
 
-func (c *SSHMachine) ssh(ctx Context, enablePty bool, target *resolvedTarget) error {
+func (c *sshMachine) ssh(ctx Context, enablePty bool, target *resolvedTarget) error {
 	options, err := c.getSSHOptions(enablePty, target)
 	if err != nil {
 		return err
@@ -239,10 +239,51 @@ func (c *SSHMachine) ssh(ctx Context, enablePty bool, target *resolvedTarget) er
 	return cmd.Run()
 }
 
+func (c *sshMachine) copy(ctx Context) error {
+	args, targets, err := c.expandSCPArgs(c.getArgs())
+	if err != nil {
+		return err
+	}
+
+	options, err := c.getSSHOptions(false, targets...)
+	if err != nil {
+		return err
+	}
+	return ssh.Copy(args, options)
+}
+
+// expandSCPArgs takes a list of arguments and looks for ones in the form of
+// 0:some/path or application/0:some/path, and translates them into
+// ubuntu@machine:some/path so they can be passed as arguments to scp, and pass
+// the rest verbatim on to scp
+func (c *sshMachine) expandSCPArgs(args []string) (outArgs []string, targets []*resolvedTarget, err error) {
+	for i, arg := range args {
+		v := strings.SplitN(arg, ":", 2)
+		if strings.HasPrefix(arg, "-") || len(v) <= 1 {
+			// Can't be an interesting target, so just pass it along
+			outArgs[i] = arg
+			continue
+		}
+
+		target, err := c.resolveTarget(v[0])
+		if err != nil {
+			return nil, nil, err
+		}
+		arg := net.JoinHostPort(target.host, v[1])
+		if target.user != "" {
+			arg = target.user + "@" + arg
+		}
+		outArgs[i] = arg
+
+		targets = append(targets, target)
+	}
+	return outArgs, targets, nil
+}
+
 // generateKnownHosts takes the provided targets, retrieves the SSH
 // public host keys for them and generates a temporary known_hosts
 // file for them.
-func (c *SSHMachine) generateKnownHosts(targets []*resolvedTarget) (string, error) {
+func (c *sshMachine) generateKnownHosts(targets []*resolvedTarget) (string, error) {
 	knownHosts := newKnownHostsBuilder()
 	agentCount := 0
 	nonAgentCount := 0
@@ -282,7 +323,7 @@ func (c *SSHMachine) generateKnownHosts(targets []*resolvedTarget) (string, erro
 
 // proxySSH returns false if both c.proxy and the proxy-ssh model
 // configuration are false -- otherwise it returns true.
-func (c *SSHMachine) proxySSH() (bool, error) {
+func (c *sshMachine) proxySSH() (bool, error) {
 	if c.proxy {
 		// No need to check the API if user explicitly requested
 		// proxying.
@@ -297,7 +338,7 @@ func (c *SSHMachine) proxySSH() (bool, error) {
 }
 
 // setProxyCommand sets the proxy command option.
-func (c *SSHMachine) setProxyCommand(options *ssh.Options) error {
+func (c *sshMachine) setProxyCommand(options *ssh.Options) error {
 	apiServerHost, _, err := net.SplitHostPort(c.apiAddr)
 	if err != nil {
 		return errors.Errorf("failed to get proxy address: %v", err)
@@ -326,7 +367,7 @@ func (c *SSHMachine) setProxyCommand(options *ssh.Options) error {
 	return nil
 }
 
-func (c *SSHMachine) ensureAPIClient(mc modelcmd.ModelCommandBase) error {
+func (c *sshMachine) ensureAPIClient(mc modelcmd.ModelCommandBase) error {
 	if c.apiClient != nil {
 		return nil
 	}
@@ -334,7 +375,7 @@ func (c *SSHMachine) ensureAPIClient(mc modelcmd.ModelCommandBase) error {
 }
 
 // initAPIClient initialises the API connection.
-func (c *SSHMachine) initAPIClient(mc modelcmd.ModelCommandBase) error {
+func (c *sshMachine) initAPIClient(mc modelcmd.ModelCommandBase) error {
 	conn, err := mc.NewAPIRoot()
 	if err != nil {
 		return errors.Trace(err)
@@ -344,7 +385,7 @@ func (c *SSHMachine) initAPIClient(mc modelcmd.ModelCommandBase) error {
 	return nil
 }
 
-func (c *SSHMachine) resolveTarget(target string) (*resolvedTarget, error) {
+func (c *sshMachine) resolveTarget(target string) (*resolvedTarget, error) {
 	out, ok := c.resolveAsAgent(target)
 	if !ok {
 		// Not a machine or unit agent target - use directly.
@@ -374,7 +415,7 @@ func (c *SSHMachine) resolveTarget(target string) (*resolvedTarget, error) {
 	return c.resolveWithRetry(*out, getAddress)
 }
 
-func (c *SSHMachine) resolveAsAgent(target string) (*resolvedTarget, bool) {
+func (c *sshMachine) resolveAsAgent(target string) (*resolvedTarget, bool) {
 	out := new(resolvedTarget)
 	out.user, out.entity = splitUserTarget(target)
 	isAgent := out.isAgent()
@@ -391,7 +432,7 @@ func (c *SSHMachine) resolveAsAgent(target string) (*resolvedTarget, bool) {
 
 type addressGetterFunc func(target string) (string, error)
 
-func (c *SSHMachine) resolveWithRetry(target resolvedTarget, getAddress addressGetterFunc) (*resolvedTarget, error) {
+func (c *sshMachine) resolveWithRetry(target resolvedTarget, getAddress addressGetterFunc) (*resolvedTarget, error) {
 	// A target may not initially have an address (e.g. the
 	// address updater hasn't yet run), so we must do this in
 	// a loop.
@@ -419,7 +460,7 @@ func (c *SSHMachine) resolveWithRetry(target resolvedTarget, getAddress addressG
 // legacyAddressGetter returns the preferred public or private address of the
 // given entity (private when c.proxy is true), using the apiClient. Only used
 // when the SSHClient API facade v2 is not available or when proxy-ssh is set.
-func (c *SSHMachine) legacyAddressGetter(entity string) (string, error) {
+func (c *sshMachine) legacyAddressGetter(entity string) (string, error) {
 	if c.proxy {
 		return c.apiClient.PrivateAddress(entity)
 	}
@@ -430,7 +471,7 @@ func (c *SSHMachine) legacyAddressGetter(entity string) (string, error) {
 // reachableAddressGetter dials all addresses of the given entity, returning the
 // first one that succeeds. Only used with SSHClient API facade v2 or later is
 // available. It does not try to dial if only one address is available.
-func (c *SSHMachine) reachableAddressGetter(entity string) (string, error) {
+func (c *sshMachine) reachableAddressGetter(entity string) (string, error) {
 	addresses, err := c.apiClient.AllAddresses(entity)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -460,7 +501,7 @@ func (c *SSHMachine) reachableAddressGetter(entity string) (string, error) {
 // AllowInterspersedFlags for ssh/scp is set to false so that
 // flags after the unit name are passed through to ssh, for eg.
 // `juju ssh -v application-name/0 uname -a`.
-func (c *SSHMachine) AllowInterspersedFlags() bool {
+func (c *sshMachine) AllowInterspersedFlags() bool {
 	return false
 }
 

--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/juju/juju/api/sshclient"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cmd/modelcmd"
+	// "github.com/juju/juju/cmd/modelcmd"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 	jujussh "github.com/juju/juju/network/ssh"
@@ -153,7 +153,7 @@ func (c *sshMachine) setHostChecker(checker jujussh.ReachableChecker) {
 // command's Run method.
 //
 // The apiClient, apiAddr and proxy fields are initialized after this call.
-func (c *sshMachine) initRun(mc modelcmd.ModelCommandBase) (err error) {
+func (c *sshMachine) initRun(mc ModelCommand) (err error) {
 	if c.modelName, err = mc.ModelIdentifier(); err != nil {
 		return errors.Trace(err)
 	}
@@ -369,7 +369,7 @@ func (c *sshMachine) setProxyCommand(options *ssh.Options) error {
 	return nil
 }
 
-func (c *sshMachine) ensureAPIClient(mc modelcmd.ModelCommandBase) error {
+func (c *sshMachine) ensureAPIClient(mc ModelCommand) error {
 	if c.apiClient != nil {
 		return nil
 	}
@@ -377,7 +377,7 @@ func (c *sshMachine) ensureAPIClient(mc modelcmd.ModelCommandBase) error {
 }
 
 // initAPIClient initialises the API connection.
-func (c *sshMachine) initAPIClient(mc modelcmd.ModelCommandBase) error {
+func (c *sshMachine) initAPIClient(mc ModelCommand) error {
 	conn, err := mc.NewAPIRoot()
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Implement `juju scp` for K8s application;

## QA steps

```console
$ juju deploy /tmp/charm-builds/mariadb-k8s --resource mysql_image=mariadb

$ juju ssh -m k1:t1 mariadb-k8s/0 ls -al /opt | grep Makefile

$ juju scp -m k1:t1  ./Makefile mariadb-k8s/0:/opt/

$ juju ssh -m k1:t1 mariadb-k8s/0 ls -al /opt | grep Makefile
-rw-rw-r-- 1 1000 1000     11436 Aug 20 05:14 Makefile

$ ls -al ~/Downloads/Makefile
ls: cannot access '/home/kelvinliu/Downloads/Makefile': No such file or directory

$ juju scp -m k1:t1 mariadb-k8s/0:/opt/ ~/Downloads/

$ ls -al ~/Downloads/Makefile
-rw-rw-r-- 1 kelvinliu kelvinliu 11436 Aug 20 15:17 /home/kelvinliu/Downloads/Makefile

```

## Documentation changes

No(same as the IaaS model)

## Bug reference

None
