### PR TITLE
Move upgrade step to move unit state from machine to unit agents

### DIFF
--- a/apiserver/facades/agent/upgradesteps/upgradesteps.go
+++ b/apiserver/facades/agent/upgradesteps/upgradesteps.go
@@ -73,7 +73,7 @@ func NewUpgradeStepsAPI(st UpgradeStepsState,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*UpgradeStepsAPI, error) {
-	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() {
+	if !authorizer.AuthMachineAgent() && !authorizer.AuthController() && !authorizer.AuthUnitAgent() {
 		return nil, common.ErrPerm
 	}
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -41727,7 +41727,8 @@
         "Version": 2,
         "AvailableTo": [
             "controller-machine-agent",
-            "machine-agent"
+            "machine-agent",
+            "unit-agent"
         ],
         "Schema": {
             "type": "object",

--- a/upgrades/steps_28.go
+++ b/upgrades/steps_28.go
@@ -111,20 +111,12 @@ func moveUnitAgentStateToController(ctx Context) error {
 	// Lookup the names of all unit agents installed on this machine.
 	agentConf := ctx.AgentConfig()
 	ctxTag := agentConf.Tag()
-	if ctxTag.Kind() != names.MachineTagKind {
-		logger.Infof("skipping agent %q, not a machine", ctxTag.String())
-		return nil
-	}
-	_, unitNames, _, err := service.FindAgents(agentConf.DataDir())
-	if err != nil {
-		return errors.Annotate(err, "looking up unit agents")
-	}
-	if len(unitNames) == 0 {
-		// No units, nothing to do.
+	if ctxTag.Kind() != names.UnitTagKind {
+		logger.Infof("skipping agent %q, not a unit", ctxTag.String())
 		return nil
 	}
 
-	fileNames, err := uniterState(ctx, unitNames)
+	fileNames, err := uniterState(ctx, ctxTag.String())
 	if err != nil {
 		return err
 	}
@@ -152,57 +144,54 @@ type UpgradeStepsClient interface {
 	WriteAgentState([]params.SetUnitStateArg) error
 }
 
-func uniterState(ctx Context, unitNames []string) ([]string, error) {
+func uniterState(ctx Context, unitName string) ([]string, error) {
 	// Read the uniter state for each unit on this machine.
 	// Leave in yaml format as a string to push to the controller.
 	fileNames := set.NewStrings()
-	uniterStates := make([]params.SetUnitStateArg, len(unitNames))
 	dataDir := ctx.AgentConfig().DataDir()
-	for i, unitName := range unitNames {
-		tag, err := names.ParseUnitTag(unitName)
-		if err != nil {
-			return nil, errors.Annotatef(err, "unable to parse unit agent tag %q", unitName)
-		}
-
-		uniterStates[i].Tag = tag.String()
-		// e.g. /var/lib/juju/agents/unit-ubuntu-0/state/uniter
-		uniterStateDir := filepath.Join(agent.BaseDir(dataDir), unitName, "state")
-
-		uniterSt, filename, err := readUniterState(uniterStateDir)
-		if err != nil && !os.IsNotExist(err) {
-			// Note: we may want to error on NotExist.  Something is very
-			// broken if the uniter state files does not exist.  On the
-			// other hand, all that will happen is that the uniter will act
-			// like the unit is just starting with regards to hook execution.
-			// With properly written idempotent charms, this is not an issue.
-			return nil, err
-		} else if err == nil {
-			fileNames.Add(filename)
-			uniterStates[i].UniterState = &uniterSt
-		}
-
-		storageData, err := readStorageState(uniterStateDir)
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, err
-		} else if err == nil {
-			uniterStates[i].StorageState = &storageData.dataString
-		}
-		if storageData.filename != "" {
-			fileNames.Add(storageData.filename)
-		}
-
-		relationData, err := readRelationState(uniterStateDir)
-		if err != nil && !os.IsNotExist(err) {
-			return nil, err
-		} else if err == nil && len(relationData.data) > 0 {
-			uniterStates[i].RelationState = &relationData.data
-			fileNames.Add(relationData.filename)
-		}
-
-		// NOTE(achilleasa): meter status is transparently migrated to
-		// the controller by the meterstatus worker so we don't need
-		// to do anything special here.
+	tag, err := names.ParseUnitTag(unitName)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unable to parse unit agent tag %q", unitName)
 	}
+
+	uniterState := params.SetUnitStateArg{Tag: tag.String()}
+	// e.g. /var/lib/juju/agents/unit-ubuntu-0/state/uniter
+	uniterStateDir := filepath.Join(agent.BaseDir(dataDir), unitName, "state")
+
+	uniterSt, filename, err := readUniterState(uniterStateDir)
+	if err != nil && !os.IsNotExist(err) {
+		// Note: we may want to error on NotExist.  Something is very
+		// broken if the uniter state files does not exist.  On the
+		// other hand, all that will happen is that the uniter will act
+		// like the unit is just starting with regards to hook execution.
+		// With properly written idempotent charms, this is not an issue.
+		return nil, err
+	} else if err == nil {
+		fileNames.Add(filename)
+		uniterState.UniterState = &uniterSt
+	}
+
+	storageData, err := readStorageState(uniterStateDir)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	} else if err == nil {
+		uniterState.StorageState = &storageData.dataString
+	}
+	if storageData.filename != "" {
+		fileNames.Add(storageData.filename)
+	}
+
+	relationData, err := readRelationState(uniterStateDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	} else if err == nil && len(relationData.data) > 0 {
+		uniterState.RelationState = &relationData.data
+		fileNames.Add(relationData.filename)
+	}
+
+	// NOTE(achilleasa): meter status is transparently migrated to
+	// the controller by the meterstatus worker so we don't need
+	// to do anything special here.
 
 	// No state files, nothing to do.
 	if fileNames.IsEmpty() {
@@ -210,8 +199,8 @@ func uniterState(ctx Context, unitNames []string) ([]string, error) {
 	}
 
 	client := getUpgradeStepsClient(ctx.APIState())
-	if err := client.WriteAgentState(uniterStates); err != nil {
-		return nil, errors.Annotatef(err, "unable to set state for units %q", strings.Join(unitNames, ", "))
+	if err := client.WriteAgentState([]params.SetUnitStateArg{uniterState}); err != nil {
+		return nil, errors.Annotatef(err, "unable to set state for units %q", unitName)
 	}
 	return fileNames.Values(), nil
 }


### PR DESCRIPTION
## Description of change

There is a window where the machine agent is trying to write unit state to the controller during upgrade, where running units can attempt to read relation data.  This would be more obvious on machines running many units as seen in production with many subordinates.

Move writing of a unit's state to be the unit's responsibility during upgrade.

## QA steps

Bootstrap 2.6.x or 2.7.x.  Deploy a config where units have many monitoring subordinates.  Or many units on the same machine. Upgrade juju. 

Failure if units try to install themselves again.  Relations lost. Storage is lost.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1890828
