### PR TITLE
fix intermittent in localTests.TestPortsToRuleInfo

### DIFF
--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -272,7 +272,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 		c.Logf("test %d: %s", i, t.about)
 		rules := PortsToRuleInfo(groupId, t.rules)
 		c.Check(len(rules), gc.Equals, len(t.expected))
-		c.Check(rules, gc.DeepEquals, t.expected)
+		c.Check(rules, jc.SameContents, t.expected)
 	}
 }
 


### PR DESCRIPTION

## Description of change

Use SameContents instead of DeepEquals on slice to avoid intermittent failure.

## QA steps

Ran 27 iterations of stress-race.sh
