### PR TITLE
Remove incorrect assumption.  Shorten goose error message.

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -534,7 +534,7 @@ func (s *localServerSuite) TestStartInstanceMultiNetworkFound(c *gc.C) {
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
 	c.Check(inst, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, `no network provided and multiple available: .*
+	c.Assert(err, gc.ErrorMatches, `multiple networks with label .*
 	To resolve this error, set a value for "network" in model-config or model-defaults;
 	or supply it via --config when creating a new model`)
 }
@@ -700,8 +700,7 @@ func (s *localServerSuite) TestStartInstanceGetServerFail(c *gc.C) {
 	defer cleanup()
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
 	c.Check(inst, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "cannot run instance: (\\n|.)*"+
-		"caused by: "+
+	c.Assert(err, gc.ErrorMatches, "cannot run instance: "+
 		"request \\(.*/servers\\) returned unexpected status: "+
 		"500; error info: .*GetServer failed on purpose")
 	c.Assert(err, jc.Satisfies, environs.IsAvailabilityZoneIndependent)

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1339,14 +1339,14 @@ func (e *Environ) startInstance(
 }
 
 func (e *Environ) userFriendlyInvalidNetworkError(err error) error {
-	msg := fmt.Sprintf("%s\n\t%s\n\t%s", err,
+	msg := fmt.Sprintf("%s\n\t%s\n\t%s", err.Error(),
 		"This error was caused by juju attempting to create an OpenStack instance with no network defined.",
 		"No network has been configured.")
 	networks, err := e.networking.FindNetworks(true)
 	if err != nil {
-		msg = fmt.Sprintf("%s\n\t%s\n\t\t%s", msg, "Error attempting to find internal networks:", err.Error())
+		msg += fmt.Sprintf("\n\t%s\n\t\t%s", "Error attempting to find internal networks:", err.Error())
 	} else {
-		msg = fmt.Sprintf("%s %s\n\t\t%q", msg, "The following internal networks are available: ", strings.Join(networks.Values(), ", "))
+		msg += fmt.Sprintf(" %s\n\t\t%q", "The following internal networks are available: ", strings.Join(networks.Values(), ", "))
 	}
 	return errors.New(msg)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1275,11 +1275,12 @@ func (e *Environ) startInstance(
 
 	server, err := tryStartNovaInstance(shortAttempt, e.nova(), opts)
 	if err != nil || server == nil {
-		err := errors.Annotate(err, "cannot run instance")
+		logger.Debugf("cannot run instance full error: %q", err)
+		errCause := errors.Cause(err)
+		err := errors.Annotate(errCause, "cannot run instance")
 		// Improve the error message if there is no valid network.
 		if isInvalidNetworkError(err) {
-			msg := "\n\tThis error was caused by juju attempting to create an OpenStack instance with no network defined.\n\tNo network has been configured, nor could juju find an internal OpenStack network to suggest."
-			err = errors.New(fmt.Sprintf("%s%s", err.Error(), msg))
+			err = errors.New(fmt.Sprintf("%s%s", err.Error(), e.invalidNetworkErrorMessageForUser()))
 		}
 		// 'No valid host available' is typically a resource error,
 		// let the provisioner know it is a good idea to try another
@@ -1336,6 +1337,19 @@ func (e *Environ) startInstance(
 		Instance: inst,
 		Hardware: inst.hardwareCharacteristics(),
 	}, nil
+}
+
+func (e *Environ) invalidNetworkErrorMessageForUser() string {
+	msg := fmt.Sprintf("\n\t%s\n\t%s",
+		"This error was caused by juju attempting to create an OpenStack instance with no network defined.",
+		"No network has been configured.")
+	networks, err := e.networking.FindNetworks(true)
+	if err != nil {
+		msg = fmt.Sprintf("%s\n\t%s\n\t\t%s", msg, "Error attempting to find internal networks:", err.Error())
+	} else {
+		msg = fmt.Sprintf("%s %s\n\t\t%q", msg, "The following internal networks are available: ", strings.Join(networks.Values(), ", "))
+	}
+	return msg
 }
 
 // validateAvailabilityZone validates AZs supplied in StartInstanceParams.
@@ -1496,10 +1510,7 @@ func (e *Environ) networksForModel() ([]nova.ServerNetworks, error) {
 		return nil, errors.Annotate(err, "getting initial networks")
 	}
 
-	usingNetwork, err := e.useNetwork()
-	if err != nil {
-		return nil, err
-	}
+	usingNetwork := e.ecfg().network()
 	networkID, err := e.networking.ResolveNetwork(usingNetwork, false)
 	if err != nil {
 		if usingNetwork == "" {
@@ -1517,49 +1528,6 @@ func (e *Environ) networksForModel() ([]nova.ServerNetworks, error) {
 
 	logger.Debugf("using network id %q", networkID)
 	return append(networks, nova.ServerNetworks{NetworkId: networkID}), nil
-}
-
-// useNetwork returns the name of the network to use.
-// First check the model config.  If that is empty, look
-// for internal networks.  If there is more than one, error.
-// If there is only one, use it and set the network model
-// config to use it in the future.
-func (e *Environ) useNetwork() (string, error) {
-	usingNetwork := e.ecfg().network()
-	if usingNetwork != "" {
-		return usingNetwork, nil
-	}
-	foundNetwork, err := e.findOneInternalNetwork()
-	if err != nil {
-		return "", err
-	}
-	// TODO (hml) 2020-07-30
-	// Ideally juju would start using the single network found and add it to
-	// the model and default configs.  If you call SetConfig() during bootstrap,
-	// the network is added to the controller model.  Subsequently, deploy
-	// also find a network, however it is not added to the model config.
-	// A method of getting the new config to the save config out the environ
-	// is needed.
-	if foundNetwork != "" {
-		err := errors.Errorf("no network provided and one network is available: %q", foundNetwork)
-		return "", errors.New(noNetConfigMsg(err))
-	}
-	return "", nil
-}
-
-func (e *Environ) findOneInternalNetwork() (string, error) {
-	networks, err := e.networking.FindNetworks(true)
-	if err != nil {
-		return "", err
-	}
-	if networks.IsEmpty() {
-		return "", nil
-	}
-	if networks.Size() > 1 {
-		err := errors.Errorf("no network provided and multiple available: %q", strings.Join(networks.SortedValues(), ", "))
-		return "", errors.New(noNetConfigMsg(err))
-	}
-	return networks.Values()[0], nil
 }
 
 func (e *Environ) configureRootDisk(ctx context.ProviderCallContext, args environs.StartInstanceParams,


### PR DESCRIPTION
## Description of change
The assumption you cannot create an OpenStack instance with no network
defined if there is an vailable network is false.  Remove that logic.

Keep the output change to suggest a network to specify if
tryStartInstance fails due to missing network.

If StartInstance fails due to error from RunServer, print the cause, not the
entire thing which includes a []byte.  Instead print the error cause,
and log the entire message as Debug.

ERROR failed to bootstrap model: cannot start bootstrap instance: cannot run instance: request (http://10.20.20.1:8774/v2.1/servers) returned unexpected status: 400; error info: {"badRequest": {"code": 400, "message": "Invalid input for field/attribute networks. Value: None. None is not of type 'array'"}}
	This error was caused by juju attempting to create an OpenStack instance with no network defined.
	No network has been configured. The following internal networks are available:
		"test"

## QA steps

- Bootstrap microstack with no network specified on the command line, nor config - expect failure, see new error output
- Bootstrap microstack --debug with no network specified on the command line, nor config - expect failure, see big struct in debug output.
- Bootstrap microstack with no network specified on the command line, nor config - expect success
- Bootstrap serverstack with no network specified on the command line, nor config. - expect success
- Bootstrap serverstack with network specified - expect success
