### PR TITLE
[2.8] Support @-syntax for 'juju deploy --config' values

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -510,7 +510,10 @@ func (s *DeploySuite) TestConfigValues(c *gc.C) {
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withAliasedCharmDeployable(s.fakeAPI, curl, "dummy-name", "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
-	err := s.runDeployForState(c, charmDir.Path, "dummy-application", "--config", "skill-level=9000", "--config", "outlook=good", "--series", "bionic")
+	confPath := filepath.Join(c.MkDir(), "include.txt")
+	c.Assert(ioutil.WriteFile(confPath, []byte("lorem\nipsum"), os.ModePerm), jc.ErrorIsNil)
+
+	err := s.runDeployForState(c, charmDir.Path, "dummy-application", "--config", "skill-level=9000", "--config", "outlook=good", "--config", "title=@"+confPath, "--series", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.Application("dummy-application")
 	c.Assert(err, jc.ErrorIsNil)
@@ -522,6 +525,7 @@ func (s *DeploySuite) TestConfigValues(c *gc.C) {
 		"outlook":     "good",
 		"skill-level": int64(9000),
 		"username":    "admin001",
+		"title":       "lorem\nipsum",
 	}))
 }
 


### PR DESCRIPTION
## Description of change

This makes the 'juju deploy` command's behavior consistent with the way that `juju config` handles config values. With this change, you can pass config values to `juju deploy` with the following ways:
1) All config settings in an external file: `--config stuff.yaml`.
2) KV pairs: `--config foo=bar --config bar=baz`.
3) Use the contents of a file as a config value: `--config schema=@modern-api.wsdl`. (added via this PR).

## QA steps

```console
$ juju bootstrap lxd test --no-gui

$ echo "lorem\nipsum" > title.txt

$  juju deploy testcharms/charm-repo/bionic/dummy --config title="@title.txt" --config skill-level=999

$ juju config dummy
application: dummy
application-config:
  trust:
    default: false
    description: Does this application have access to trusted credentials
    source: default
    type: bool
    value: false
charm: dummy
settings:
  outlook:
    description: No default outlook.
    source: unset
    type: string
  skill-level:
    description: A number indicating skill.
    source: user
    type: int
    value: 999      <------
  title:
    default: My Title
    description: A descriptive title used for the application.
    source: user
    type: string
    value: |   <----- ensure that the line-feed between lorem/ipsum exists
      lorem
      ipsum
  username:
    default: admin001
    description: The name of the initial account (given admin permissions).
    source: default
    type: string
    value: admin001
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1889785