### PR TITLE
Fix resolveNeutronNetworks for lp:1891561

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -625,6 +625,36 @@ func (s *localServerSuite) TestStartInstanceNoNetworksNetworkNotSetNoError(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *localServerSuite) TestStartInstanceOneNetworkNetworkNotSetNoError(c *gc.C) {
+	// Modify the Openstack service that is created by default,
+	// to remove all but 1 internal network.
+	model := neutronmodel.New()
+	var foundOne bool
+	for _, net := range model.AllNetworks() {
+		if !net.External {
+			if !foundOne {
+				foundOne = true
+				continue
+			}
+			err := model.RemoveNetwork(net.Id)
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+	s.srv.OpenstackSvc.Neutron.AddNeutronModel(model)
+	s.srv.OpenstackSvc.Nova.AddNeutronModel(model)
+
+	cfg, err := s.env.Config().Apply(coretesting.Attrs{
+		"network": "",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.env.SetConfig(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
+	c.Check(inst, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *localServerSuite) TestStartInstanceNetworksDifferentAZ(c *gc.C) {
 	// If both the network and external-network config values are
 	// specified, there is not check for them being on different


### PR DESCRIPTION
## Description of change

Until recently, sending an empty string in an OpenStack API filter caused that section of the filter to be ignored.  If you specified name and external-router, sections of the filter and name was empty.  All results for the external-router filter would be returned.  This led to juju unintentionally searching for and finding an internal network to use if only one was available instead of determining that a network named "" did not exist.

As of the Rocky release of OpenStack, there is a neutron extension called empty-string-filtering.  When used, allows for an empty string to be used for filter values. Thus if the OpenStack cloud used by juju is upgraded to a release of Rocky or later, it may appear that juju stopped working.

Given the unknown amount of time this has been the user expected behavior of juju, we will keep.  Making a deliberate choice to do so, instead of accidentally.

## QA steps

Bootstrap serverstack both specifying and not specifying the network.  It appears to have old pre-Rocky behavior.

Bootstrap microstack which is using the empty-string-filtering extension when installed with --edge.

You can check for the extension by running:
openstack extension show empty-string-filtering

## Bug reference

https://bugs.launchpad.net/juju/+bug/1891561
