### PR TITLE
Facade schema groups

### DIFF
--- a/generate/schemagen/gen/generator.go
+++ b/generate/schemagen/gen/generator.go
@@ -97,6 +97,8 @@ func Generate(pkgRegistry PackageRegistry, linker Linker, client APIServer, opti
 	unique := make(map[string]facade.Details)
 	for _, list := range groupFacades {
 		for _, f := range list {
+			// Ensure that we create a unique namespace so that any facades that
+			// are composed together are repeated.
 			unique[fmt.Sprintf("%s:%d", f.Name, f.Version)] = f
 		}
 	}

--- a/generate/schemagen/gen/groups.go
+++ b/generate/schemagen/gen/groups.go
@@ -73,11 +73,11 @@ func allFacades(facades []facade.Details) []facade.Details {
 
 func clientFacades(facades []facade.Details, registry Registry) []facade.Details {
 	required := map[string]struct{}{
-		"Admin":               struct{}{},
-		"AllWatcher":          struct{}{},
-		"AllModelWatcher":     struct{}{},
-		"ModelSummaryManager": struct{}{},
-		"Pinger":              struct{}{},
+		"Admin":               {},
+		"AllWatcher":          {},
+		"AllModelWatcher":     {},
+		"ModelSummaryManager": {},
+		"Pinger":              {},
 	}
 
 	results := make([]facade.Details, 0)
@@ -109,13 +109,13 @@ func clientFacades(facades []facade.Details, registry Registry) []facade.Details
 
 func jimmFacades(facades []facade.Details) []facade.Details {
 	required := map[string][]int{
-		"Bundle":              []int{1},
-		"Cloud":               []int{1, 2, 3, 4, 5},
-		"Controller":          []int{3, 4, 5, 6, 7, 8, 9},
-		"ModelManager":        []int{2, 3, 4, 5},
-		"ModelSummaryManager": []int{1},
-		"Pinger":              []int{1},
-		"UserManager":         []int{1},
+		"Bundle":              {1},
+		"Cloud":               {1, 2, 3, 4, 5},
+		"Controller":          {3, 4, 5, 6, 7, 8, 9},
+		"ModelManager":        {2, 3, 4, 5},
+		"ModelSummaryManager": {1},
+		"Pinger":              {1},
+		"UserManager":         {1},
 	}
 
 	result := make([]facade.Details, 0)

--- a/generate/schemagen/gen/groups.go
+++ b/generate/schemagen/gen/groups.go
@@ -23,7 +23,7 @@ const (
 	// facades that the client can use.
 	Client FacadeGroup = "client"
 	// JIMM facade group defines a very select set of facades that only work
-	// JIMM.
+	// with JIMM. This does not include the JIMM facade as defined in JIMM.
 	JIMM FacadeGroup = "jimm"
 )
 
@@ -73,8 +73,11 @@ func allFacades(facades []facade.Details) []facade.Details {
 
 func clientFacades(facades []facade.Details, registry Registry) []facade.Details {
 	required := map[string]struct{}{
-		"AllWatcher":      struct{}{},
-		"AllModelWatcher": struct{}{},
+		"Admin":               struct{}{},
+		"AllWatcher":          struct{}{},
+		"AllModelWatcher":     struct{}{},
+		"ModelSummaryManager": struct{}{},
+		"Pinger":              struct{}{},
 	}
 
 	results := make([]facade.Details, 0)
@@ -109,7 +112,6 @@ func jimmFacades(facades []facade.Details) []facade.Details {
 		"Bundle":              []int{1},
 		"Cloud":               []int{1, 2, 3, 4, 5},
 		"Controller":          []int{3, 4, 5, 6, 7, 8, 9},
-		"JIMM":                []int{1, 2},
 		"ModelManager":        []int{2, 3, 4, 5},
 		"ModelSummaryManager": []int{1},
 		"Pinger":              []int{1},

--- a/generate/schemagen/gen/groups.go
+++ b/generate/schemagen/gen/groups.go
@@ -108,6 +108,9 @@ func clientFacades(facades []facade.Details, registry Registry) []facade.Details
 }
 
 func jimmFacades(facades []facade.Details) []facade.Details {
+	// The JIMM facades are the ones that are baked into JIMM directly. If JIMM
+	// ever updates it's baked in facade schemas, then we should also update the
+	// ones here.
 	required := map[string][]int{
 		"Bundle":              {1},
 		"Cloud":               {1, 2, 3, 4, 5},

--- a/generate/schemagen/schemagen.go
+++ b/generate/schemagen/schemagen.go
@@ -25,7 +25,10 @@ import (
 )
 
 func main() {
-	var adminFacades = flag.Bool("admin-facades", false, "add the admin facades when generating the schema")
+	var (
+		adminFacades = flag.Bool("admin-facades", false, "add the admin facades when generating the schema")
+		facadeGroup  = flag.String("facade-group", "latest", "facade group to export (latest, all, client, jimm)")
+	)
 
 	flag.Parse()
 	args := flag.Args()
@@ -37,9 +40,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	group, err := gen.ParseFacadeGroup(*facadeGroup)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	result, err := gen.Generate(defaultPackages{
 		path: "github.com/juju/juju/apiserver",
-	}, defaultLinker{}, apiServerShim{}, gen.WithAdminFacades(*adminFacades))
+	}, defaultLinker{}, apiServerShim{},
+		gen.WithAdminFacades(*adminFacades),
+		gen.WithFacadeGroup(group),
+	)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
## Description of change

This introduces facade schema groups to the schema gen. It defines these
restricted groups so that it makes it easy to understand what the schema
gen generates.

There are 4 groups:

 1. latest: this is the default group and the one that was previously
 running.
 2. all: this outputs all the facades, everything!
 3. client: this outputs just the facades for client interactions and
 probably should actually be the default!
 4. jimm: this is the JIMM facades.

We can tailor each group so that they're defined and restricted to a
given release. We could make all the facades a giant list with versions,
but then it becomes harder to understand because of the many versions.

## QA steps

### Client

```sh
go run github.com/juju/juju/generate/schemagen -admin-facades --facade-group=client \
                ./apiserver/facades/schema.json
```

### JIMM

```sh
go run github.com/juju/juju/generate/schemagen -admin-facades --facade-group=jimm \
                ./apiserver/facades/schema.json
```

### Compose multiple groups

```sh
go run github.com/juju/juju/generate/schemagen -admin-facades --facade-group=client,jimm \
                ./apiserver/facades/schema.json
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1891404
