### PR TITLE
Add abstraction for CLI filesystem access

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -454,7 +453,7 @@ func (c *configCommand) validateValues(ctx *cmd.Context) (map[string]string, err
 			settings[k] = v
 			continue
 		}
-		nv, err := readValue(ctx, v[1:])
+		nv, err := readValue(ctx, c.Filesystem(), v[1:])
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -469,9 +468,9 @@ func (c *configCommand) validateValues(ctx *cmd.Context) (map[string]string, err
 // readValue reads the value of an option out of the named file.
 // An empty content is valid, like in parsing the options. The upper
 // size is 5M.
-func readValue(ctx *cmd.Context, filename string) (string, error) {
+func readValue(ctx *cmd.Context, filesystem modelcmd.Filesystem, filename string) (string, error) {
 	absFilename := ctx.AbsPath(filename)
-	fi, err := os.Stat(absFilename)
+	fi, err := filesystem.Stat(absFilename)
 	if err != nil {
 		return "", errors.Errorf("cannot read option from file %q: %v", filename, err)
 	}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -148,6 +148,7 @@ func (s *DeploySuiteBase) SetUpTest(c *gc.C) {
 		filesAndRevisions map[string]string,
 		resources map[string]charmresource.Meta,
 		conn base.APICallCloser,
+		filesystem modelcmd.Filesystem,
 	) (ids map[string]string, err error) {
 		return deployResources(s.State, applicationID, resources)
 	}
@@ -1095,6 +1096,7 @@ func (s *CAASDeploySuite) TestDevices(c *gc.C) {
 		filesAndRevisions map[string]string,
 		resources map[string]charmresource.Meta,
 		conn base.APICallCloser,
+		filesystem modelcmd.Filesystem,
 	) (ids map[string]string, err error) {
 		fakeAPI.AddCall("DeployResources", applicationID, chID, csMac, filesAndRevisions, resources, conn)
 		return nil, fakeAPI.NextErr()
@@ -2271,6 +2273,7 @@ func newDeployCommandForTest(fakeApi *fakeDeployAPI) *DeployCommand {
 			filesAndRevisions map[string]string,
 			resources map[string]charmresource.Meta,
 			conn base.APICallCloser,
+			filesystem modelcmd.Filesystem,
 		) (ids map[string]string, err error) {
 			return nil, nil
 		},

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -158,6 +158,7 @@ func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAP
 
 	return bundleDeploySpec{
 		ctx:                  ctx,
+		filesystem:           d.model.Filesystem(),
 		dryRun:               d.dryRun,
 		force:                d.force,
 		trust:                d.trust,

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -851,6 +852,7 @@ func (s *BundleDeployCharmStoreSuite) bundleDeploySpec() bundleDeploySpec {
 		_ map[string]string,
 		_ map[string]charmresource.Meta,
 		_ base.APICallCloser,
+		_ modelcmd.Filesystem,
 	) (_ map[string]string, _ error) {
 		return nil, nil
 	}

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -208,6 +208,7 @@ func (d *deployCharm) deploy(
 		d.resources,
 		charmInfo.Meta.Resources,
 		deployAPI,
+		d.model.Filesystem(),
 	)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -237,7 +237,7 @@ func (d *factory) newDeployCharm() deployCharm {
 
 func (d *factory) maybeReadLocalBundle() (Deployer, error) {
 	bundleFile := d.charmOrBundle
-	_, statErr := os.Stat(bundleFile)
+	_, statErr := d.model.Filesystem().Stat(bundleFile)
 	if statErr == nil && !charm.IsValidLocalCharmOrBundlePath(bundleFile) {
 		return nil, errors.Errorf(""+
 			"The charm or bundle %q is ambiguous.\n"+

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -7,14 +7,15 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/cmd"
 	"github.com/juju/gnuflag"
-	"github.com/juju/juju/api"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/base"
 	apicharms "github.com/juju/juju/api/charms"
 	apiparams "github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/application/store"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/model"
@@ -140,4 +141,9 @@ type ModelCommand interface {
 
 	// ModelType returns the type of the model.
 	ModelType() (model.ModelType, error)
+
+	// Filesystem returns an instance that provides access to
+	// the filesystem, either delegating to calling os functions
+	// or functions which always return an error.
+	Filesystem() modelcmd.Filesystem
 }

--- a/cmd/juju/application/upgradecharm.go
+++ b/cmd/juju/application/upgradecharm.go
@@ -536,6 +536,7 @@ func (c *upgradeCharmCommand) upgradeResources(
 		c.Resources,
 		filtered,
 		apiRoot,
+		c.Filesystem(),
 	)
 	return ids, errors.Trace(err)
 }

--- a/cmd/juju/application/upgradecharm_resources_test.go
+++ b/cmd/juju/application/upgradecharm_resources_test.go
@@ -141,6 +141,7 @@ func (s *UpgradeCharmStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 		filesAndRevisions map[string]string,
 		resources map[string]charmresource.Meta,
 		conn base.APICallCloser,
+		filesystem modelcmd.Filesystem,
 	) (ids map[string]string, err error) {
 		return deployResources(s.State, applicationID, resources)
 	}
@@ -263,6 +264,7 @@ Deploying charm "cs:bionic/starsay-1".`
 			filesAndRevisions map[string]string,
 			resources map[string]charmresource.Meta,
 			conn base.APICallCloser,
+			filesystem modelcmd.Filesystem,
 		) (ids map[string]string, err error) {
 			return deployResources(s.State, applicationID, resources)
 		},

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -92,6 +92,7 @@ func (s *BaseUpgradeCharmSuite) SetUpTest(c *gc.C) {
 		filesAndRevisions map[string]string,
 		resources map[string]charmresource.Meta,
 		conn base.APICallCloser,
+		filesystem modelcmd.Filesystem,
 	) (ids map[string]string, err error) {
 		s.AddCall("DeployResources", applicationID, chID, csMac, filesAndRevisions, resources, conn)
 		return nil, s.NextErr()

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -6,7 +6,6 @@ package backups
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/juju/cmd"
@@ -190,7 +189,7 @@ func (c *createCommand) download(ctx *cmd.Context, client APIClient, copyFrom st
 	}
 	defer resultArchive.Close()
 
-	archive, err := os.Create(archiveFilename)
+	archive, err := c.Filesystem().Create(archiveFilename)
 	if err != nil {
 		return errors.Annotatef(err, "while creating local archive file %v", archiveFilename)
 	}

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -6,7 +6,6 @@ package backups
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -87,7 +86,7 @@ func (c *downloadCommand) Run(ctx *cmd.Context) error {
 
 	// Prepare the local archive.
 	filename := c.ResolveFilename()
-	archive, err := os.Create(filename)
+	archive, err := c.Filesystem().Create(filename)
 	if err != nil {
 		return errors.Annotate(err, "while creating local archive file")
 	}

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -370,6 +370,7 @@ func (c *AddCAASCommand) getConfigReader(ctx *cmd.Context) (io.Reader, string, e
 
 func (c *AddCAASCommand) getGKEKubeConfig(ctx *cmd.Context) (io.Reader, string, error) {
 	p := &clusterParams{
+		openFile:   c.Filesystem().Open,
 		name:       c.clusterName,
 		region:     c.hostCloudRegion,
 		project:    c.project,
@@ -391,7 +392,8 @@ func (c *AddCAASCommand) getGKEKubeConfig(ctx *cmd.Context) (io.Reader, string, 
 
 func (c *AddCAASCommand) getEKSKubeConfig(ctx *cmd.Context) (io.Reader, string, error) {
 	p := &clusterParams{
-		name: c.clusterName,
+		openFile: c.Filesystem().Open,
+		name:     c.clusterName,
 	}
 	var err error
 	if len(c.hostCloudRegion) > 0 {
@@ -414,6 +416,7 @@ func (c *AddCAASCommand) getEKSKubeConfig(ctx *cmd.Context) (io.Reader, string, 
 
 func (c *AddCAASCommand) getAKSKubeConfig(ctx *cmd.Context) (io.Reader, string, error) {
 	p := &clusterParams{
+		openFile:      c.Filesystem().Open,
 		name:          c.clusterName,
 		region:        c.hostCloudRegion,
 		resourceGroup: c.resourceGroup,

--- a/cmd/juju/caas/aks.go
+++ b/cmd/juju/caas/aks.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/juju/cmd"
 	"github.com/juju/collections/set"
@@ -61,7 +60,7 @@ func (a *aks) getKubeConfig(p *clusterParams) (io.ReadCloser, string, error) {
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	reader, err := os.Open(kubeconfig)
+	reader, err := p.openFile(kubeconfig)
 	return reader, p.name, err
 }
 

--- a/cmd/juju/caas/aks_test.go
+++ b/cmd/juju/caas/aks_test.go
@@ -58,6 +58,7 @@ func (s *aksSuite) TestGetKubeConfig(c *gc.C) {
 	)
 
 	rdr, clusterName, err := aks.getKubeConfig(&clusterParams{
+		openFile:      osFilesystem{}.Open,
 		name:          "mycluster",
 		resourceGroup: "resourceGroup",
 	})

--- a/cmd/juju/caas/cluster.go
+++ b/cmd/juju/caas/cluster.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/utils/exec"
+
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/runner_mock.go github.com/juju/juju/cmd/juju/caas CommandRunner
@@ -80,6 +82,7 @@ var runCommand = func(runner CommandRunner, params []string, kubeconfig string) 
 }
 
 type clusterParams struct {
+	openFile   func(name string) (modelcmd.ReadSeekCloser, error)
 	name       string
 	project    string
 	region     string

--- a/cmd/juju/caas/eks.go
+++ b/cmd/juju/caas/eks.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -67,7 +66,7 @@ func (e *eks) getKubeConfig(p *clusterParams) (io.ReadCloser, string, error) {
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-	reader, err := os.Open(kubeconfig)
+	reader, err := p.openFile(kubeconfig)
 	return reader, fmt.Sprintf("%s.%s.%s", p.name, p.region, eksDomain), err
 }
 

--- a/cmd/juju/caas/eks_test.go
+++ b/cmd/juju/caas/eks_test.go
@@ -59,8 +59,9 @@ func (s *eksSuite) TestGetKubeConfig(c *gc.C) {
 	)
 
 	rdr, clusterName, err := eksCMD.getKubeConfig(&clusterParams{
-		name:   "mycluster",
-		region: "ap-southeast-2",
+		openFile: osFilesystem{}.Open,
+		name:     "mycluster",
+		region:   "ap-southeast-2",
 	})
 	c.Check(err, jc.ErrorIsNil)
 	defer rdr.Close()

--- a/cmd/juju/caas/gke.go
+++ b/cmd/juju/caas/gke.go
@@ -6,7 +6,6 @@ package caas
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
@@ -66,7 +65,7 @@ func (g *gke) getKubeConfig(p *clusterParams) (io.ReadCloser, string, error) {
 	if result.Code != 0 {
 		return nil, "", errors.New(string(result.Stderr))
 	}
-	rdr, err := os.Open(kubeconfig)
+	rdr, err := p.openFile(kubeconfig)
 	return rdr, qualifiedClusterName, err
 }
 

--- a/cmd/juju/caas/gke_test.go
+++ b/cmd/juju/caas/gke_test.go
@@ -19,6 +19,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/caas/mocks"
+	"github.com/juju/juju/cmd/modelcmd"
 )
 
 type gkeSuite struct {
@@ -200,6 +201,14 @@ Select cluster [mycluster in asia-southeast1]:
 	})
 }
 
+type osFilesystem struct {
+	modelcmd.Filesystem
+}
+
+func (osFilesystem) Open(name string) (modelcmd.ReadSeekCloser, error) {
+	return os.Open(name)
+}
+
 func (s *gkeSuite) TestGetKubeConfig(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -222,6 +231,7 @@ func (s *gkeSuite) TestGetKubeConfig(c *gc.C) {
 			}, nil),
 	)
 	rdr, clusterName, err := gke.getKubeConfig(&clusterParams{
+		openFile:   osFilesystem{}.Open,
 		project:    "myproject",
 		zone:       "asia-southeast1-a",
 		region:     "asia-southeast1",

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -284,7 +284,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *bootstrapCommand) Init(args []string) (err error) {
 	if c.JujuDbSnapPath != "" {
-		_, err := os.Stat(c.JujuDbSnapPath)
+		_, err := c.Filesystem().Stat(c.JujuDbSnapPath)
 		if err != nil {
 			return errors.Annotatef(err, "problem with --db-snap")
 		}
@@ -298,7 +298,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	}
 
 	if c.JujuDbSnapAssertionsPath != "" {
-		_, err := os.Stat(c.JujuDbSnapAssertionsPath)
+		_, err := c.Filesystem().Stat(c.JujuDbSnapAssertionsPath)
 		if err != nil {
 			return errors.Annotatef(err, "problem with --db-snap-asserts")
 		}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -609,9 +609,6 @@ func registerCommands(r commandRegistry) {
 			}
 			return resourceadapters.NewAPIClient(apiRoot)
 		},
-		OpenResource: func(s string) (resource.ReadSeekCloser, error) {
-			return os.Open(s)
-		},
 	}))
 	r.Register(resource.NewListCommand(resource.ListDeps{
 		NewClient: func(c *resource.ListCommand) (resource.ListClient, error) {

--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -130,7 +129,7 @@ func (c *configCommand) handleZeroArgs() error {
 
 func (c *configCommand) handleOneArg(arg string) error {
 	// We may have a single config.yaml file
-	_, err := os.Stat(arg)
+	_, err := c.Filesystem().Stat(arg)
 	if err == nil || strings.Contains(arg, "=") {
 		return c.parseSetKeys([]string{arg})
 	}
@@ -145,7 +144,7 @@ func (c *configCommand) handleArgs(args []string) error {
 	}
 	for _, arg := range args {
 		// We may have a config.yaml file.
-		_, err := os.Stat(arg)
+		_, err := c.Filesystem().Stat(arg)
 		if err != nil && !strings.Contains(arg, "=") {
 			return errors.New("can only retrieve a single value, or all values")
 		}

--- a/cmd/juju/gui/upgradegui.go
+++ b/cmd/juju/gui/upgradegui.go
@@ -119,7 +119,7 @@ func (c *upgradeGUICommand) Run(ctx *cmd.Context) error {
 		return nil
 	}
 	// Retrieve the dashboard archive and its related info.
-	archive, err := openArchive(c.guiStream, c.versOrPath, ctrlVersion.Major, ctrlVersion.Minor)
+	archive, err := c.openArchive(c.guiStream, c.versOrPath, ctrlVersion.Major, ctrlVersion.Minor)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -173,7 +173,7 @@ type openedArchive struct {
 
 // openArchive opens a Juju Dashboard archive from the given version or file path.
 // The readSeekCloser returned in openedArchive.r must be closed by callers.
-func openArchive(stream, versOrPath string, major, minor int) (openedArchive, error) {
+func (c *upgradeGUICommand) openArchive(stream, versOrPath string, major, minor int) (openedArchive, error) {
 	if versOrPath == "" {
 		// Return the most recent Juju Dashboard from simplestreams.
 		allMeta, err := remoteArchiveMetadata(stream, major, minor)
@@ -193,7 +193,7 @@ func openArchive(stream, versOrPath string, major, minor int) (openedArchive, er
 			vers: metadata.Version,
 		}, nil
 	}
-	f, err := os.Open(versOrPath)
+	f, err := c.Filesystem().Open(versOrPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return openedArchive{}, errors.Annotate(err, "cannot open Dashboard archive")

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -247,7 +247,7 @@ func (c *configCommand) handleOneArg(arg string) error {
 	}
 
 	// We may have a single config.yaml file
-	if _, err := os.Stat(arg); err == nil {
+	if _, err := c.Filesystem().Stat(arg); err == nil {
 		return c.parseYAMLFile(arg)
 	} else if strings.Contains(arg, "=") {
 		return c.parseSetKeys([]string{arg})
@@ -270,7 +270,7 @@ func (c *configCommand) handleArgs(args []string) error {
 	}
 	for _, arg := range args {
 		// We may have a config.yaml file.
-		_, err := os.Stat(arg)
+		_, err := c.Filesystem().Stat(arg)
 		if err != nil && !strings.Contains(arg, "=") {
 			return errors.New("can only retrieve a single value, or all values")
 		}

--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -367,7 +367,7 @@ func (c *defaultsCommand) parseArgs(args []string) error {
 	if len(args) > 0 {
 		lastArg := args[len(args)-1]
 		// We may have a config.yaml file
-		_, err := os.Stat(lastArg)
+		_, err := c.Filesystem().Stat(lastArg)
 		wantSet = err == nil || strings.Contains(lastArg, "=")
 	}
 
@@ -463,7 +463,7 @@ func (c *defaultsCommand) parseCloudRegion(args []string) ([]string, error) {
 	}
 
 	// Ensure we exit early when we have a settings file or key=value.
-	info, err := os.Stat(maybeRegion)
+	info, err := c.Filesystem().Stat(maybeRegion)
 	isFile := err == nil && !info.IsDir()
 	// TODO(redir) 2016-10-05 #1627162
 	if isFile {
@@ -578,7 +578,7 @@ func (c *defaultsCommand) validCloudRegion(cloudName, maybeRegion string) (bool,
 // handleSetArgs parses args for setting defaults.
 func (c *defaultsCommand) handleSetArgs(args []string) error {
 	// We may have a config.yaml file
-	_, err := os.Stat(args[0])
+	_, err := c.Filesystem().Stat(args[0])
 	argZeroKeyOnly := err != nil && !strings.Contains(args[0], "=")
 	// If an invalid region was specified, the first positional arg won't have
 	// an "=". If we see one here we know it is invalid.
@@ -661,7 +661,7 @@ func (c *defaultsCommand) handleExtraArgs(args []string) error {
 	// value after setting them.
 	for _, arg := range args {
 		// We may have a config.yaml file
-		_, err := os.Stat(arg)
+		_, err := c.Filesystem().Stat(arg)
 		if err == nil || strings.Contains(arg, "=") {
 			return errors.New("cannot set and retrieve default values simultaneously")
 		}

--- a/cmd/juju/model/exportbundle.go
+++ b/cmd/juju/model/exportbundle.go
@@ -122,7 +122,7 @@ func (c *exportBundleCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 	filename := c.Filename
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	file, err := c.Filesystem().OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
 		return errors.Annotate(err, "while creating local file")
 	}

--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -46,8 +46,9 @@ func NewListCharmResourcesCommandForTest(resourceLister ResourceLister) modelcmd
 	return modelcmd.Wrap(&c)
 }
 
-func NewUploadCommandForTest(deps UploadDeps) *UploadCommand {
+func NewUploadCommandForTest(deps UploadDeps, filesystem modelcmd.Filesystem) *UploadCommand {
 	cmd := &UploadCommand{deps: deps}
+	cmd.SetFilesystem(filesystem)
 	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return cmd
 }

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -29,20 +29,11 @@ type UploadClient interface {
 	Close() error
 }
 
-// ReadSeekCloser combines 2 interfaces.
-type ReadSeekCloser interface {
-	io.ReadCloser
-	io.Seeker
-}
-
 // UploadDeps is a type that contains external functions that Upload depends on
 // to function.
 type UploadDeps struct {
 	// NewClient returns the value that wraps the API for uploading to the server.
 	NewClient func(*UploadCommand) (UploadClient, error)
-
-	// OpenResource handles creating a reader from the resource path.
-	OpenResource func(path string) (ReadSeekCloser, error)
 }
 
 // UploadCommand implements the upload command.
@@ -150,7 +141,7 @@ func (c *UploadCommand) Run(*cmd.Context) error {
 // upload opens the given file and calls the apiclient to upload it to the given
 // application with the given name.
 func (c *UploadCommand) upload(rf resourceValue, client UploadClient) error {
-	f, err := OpenResource(rf.value, rf.resourceType, c.deps.OpenResource)
+	f, err := OpenResource(rf.value, rf.resourceType, c.Filesystem().Open)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -134,6 +134,10 @@ type CommandBase struct {
 
 	// Embedded is true if this command is being run inside a controller.
 	Embedded bool
+
+	// filesystem provides access to os calls to access files.
+	// For embedded commands, methods will always return an error.
+	filesystem Filesystem
 }
 
 func (c *CommandBase) assertRunStarted() {
@@ -160,6 +164,11 @@ func (c *CommandBase) closeAPIContexts() {
 // SetEmbedded sets whether the command is embedded.
 func (c *CommandBase) SetEmbedded(embedded bool) {
 	c.Embedded = embedded
+	if embedded {
+		c.filesystem = restrictedFilesystem{}
+	} else {
+		c.filesystem = osFilesystem{}
+	}
 }
 
 // SetFlags implements cmd.Command.SetFlags.

--- a/cmd/modelcmd/filesystem.go
+++ b/cmd/modelcmd/filesystem.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/juju/errors"
+)
+
+// ReadSeekCloser is a minimal interface used for os.File.
+type ReadSeekCloser interface {
+	io.ReadCloser
+	io.Seeker
+}
+
+// Filesystem is an interface providing access to the filesystem,
+// either delegating to calling os functions or functions which
+// always return an error.
+type Filesystem interface {
+	Stat(name string) (os.FileInfo, error)
+	Open(name string) (ReadSeekCloser, error)
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+	Create(name string) (*os.File, error)
+	RemoveAll(path string) error
+}
+
+type osFilesystem struct{}
+
+func (osFilesystem) Create(name string) (*os.File, error) {
+	return os.Create(name)
+}
+
+func (osFilesystem) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (osFilesystem) Open(name string) (ReadSeekCloser, error) {
+	return os.Open(name)
+}
+
+func (osFilesystem) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (osFilesystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+var notSupported = errors.NotSupportedf("access to filesystem")
+
+type restrictedFilesystem struct{}
+
+func (restrictedFilesystem) Create(string) (*os.File, error) {
+	return nil, notSupported
+}
+
+func (restrictedFilesystem) RemoveAll(string) error {
+	return notSupported
+}
+
+func (restrictedFilesystem) Open(string) (ReadSeekCloser, error) {
+	return nil, notSupported
+}
+
+func (restrictedFilesystem) OpenFile(string, int, os.FileMode) (*os.File, error) {
+	return nil, notSupported
+}
+
+func (restrictedFilesystem) Stat(string) (os.FileInfo, error) {
+	return nil, notSupported
+}
+
+// SetFilesystem sets the Filesystem instance on the command.
+func (c *CommandBase) SetFilesystem(fs Filesystem) {
+	c.filesystem = fs
+}
+
+// Filesystem returns an instance that provides access to
+// the filesystem, either delegating to calling os functions
+// or functions which always return an error.
+func (c *CommandBase) Filesystem() Filesystem {
+	if c.filesystem == nil {
+		c.filesystem = osFilesystem{}
+	}
+	return c.filesystem
+}

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -4,11 +4,161 @@
 package cmd_test
 
 import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	stdtesting "testing"
 
+	"github.com/juju/collections/set"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
 
 func Test(t *stdtesting.T) {
 	gc.TestingT(t)
+}
+
+var disallowedCalls = set.NewStrings(
+	"Chdir",
+	"Chmod",
+	"Chown",
+	"Create",
+	"Lchown",
+	"Lstat",
+	"Mkdir",
+	"Open",
+	"OpenFile",
+	"Remove",
+	"RemoveAll",
+	"Rename",
+	"TempDir",
+	"Stat",
+	"Symlink",
+	"UserCacheDir",
+	"UserConfigDir",
+	"UserHomeDir",
+)
+
+var allowedCalls = map[string]set.Strings{
+	// Used for checking for new Juju 2 installs.
+	"juju/commands/main.go": set.NewStrings("Stat"),
+	// upgrade-model is not a whitelisted embedded CLI command.
+	"juju/commands/upgrademodel.go": set.NewStrings("Open", "RemoveAll"),
+	// ssh is not a whitelisted embedded CLI command.
+	"juju/commands/ssh_machine.go": set.NewStrings("Remove"),
+	// upgrade-gui is not a whitelisted embedded CLI command.
+	"juju/gui/upgradegui.go": set.NewStrings("Remove"),
+	// Ignore the actual os calls.
+	"modelcmd/filesystem.go": set.NewStrings("*"),
+	// signmetadata is not a whitelisted embedded CLI command.
+	"plugins/juju-metadata/signmetadata.go": set.NewStrings("Open"),
+}
+
+var ignoredPackages = set.NewStrings(
+	"jujuc", "jujud", "ks8agent", "juju-bridge", "service")
+
+type OSCallTest struct{}
+
+var _ = gc.Suite(&OSCallTest{})
+
+// TestNoDirectFilesystemAccess ensures Juju CLI commands do
+// not directly access the filesystem va the "os" package.
+// This ensures embedded commands do not accidentally bypass
+// the restrictions to filesystem access.
+func (s *OSCallTest) TestNoDirectFilesystemAccess(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("not needed on Windows, checking for imports on Ubuntu sufficient")
+	}
+	fset := token.NewFileSet()
+	calls := make(map[string]set.Strings)
+
+	err := filepath.Walk(".",
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() || info.Name() == "mocks" {
+				return nil
+			}
+			s.parseDir(fset, calls, path)
+			return nil
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(calls, gc.HasLen, 0)
+}
+
+func (s *OSCallTest) parseDir(fset *token.FileSet, calls map[string]set.Strings, dir string) {
+	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	for _, pkg := range pkgs {
+		for fName, f := range pkg.Files {
+			osImportAliases := set.NewStrings("os")
+			// Ensure we also capture os calls where the import tis aliased.
+			for _, imp := range f.Imports {
+				if imp.Name == nil {
+					continue
+				}
+				if imp.Name.Name != "" && imp.Path.Value == `"os"` {
+					osImportAliases.Add(imp.Name.Name)
+				}
+			}
+			s.parseFile(f, fName, osImportAliases, calls)
+		}
+	}
+}
+
+func (*OSCallTest) parseFile(f *ast.File, fName string, osImportAliases set.Strings, calls map[string]set.Strings) {
+	for _, decl := range f.Decls {
+		if decl, ok := decl.(*ast.FuncDecl); ok {
+			ast.Inspect(decl.Body, func(n ast.Node) bool {
+				switch n.(type) {
+				case *ast.SelectorExpr:
+				default:
+					return true
+				}
+				expr := n.(*ast.SelectorExpr)
+				switch expr.X.(type) {
+				case *ast.CallExpr:
+					return true
+				case *ast.Ident:
+				default:
+					return false
+				}
+
+				if !disallowedCalls.Contains(expr.Sel.Name) {
+					return false
+				}
+				if allowed, ok := allowedCalls[fName]; ok {
+					if allowed.Contains("*") || allowed.Contains(expr.Sel.Name) {
+						return false
+					}
+				}
+				pkg := strings.Split(fName, string(os.PathSeparator))[0]
+				if ignoredPackages.Contains(pkg) {
+					return false
+				}
+				exprIdent := expr.X.(*ast.Ident)
+				if osImportAliases.Contains(exprIdent.Name) {
+					funcs := calls[fName]
+					if funcs == nil {
+						funcs = set.NewStrings()
+					}
+					funcs.Add(fmt.Sprintf("%v.%v()", exprIdent.Name, expr.Sel.Name))
+					calls[fName] = funcs
+				}
+				return false
+			})
+		}
+	}
 }

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -229,7 +228,7 @@ func (c *validateImageMetadataCommand) createLookupParams(context *cmd.Context) 
 	}
 	if c.metadataDir != "" {
 		dir := filepath.Join(c.metadataDir, "images")
-		if _, err := os.Stat(dir); err != nil {
+		if _, err := c.Filesystem().Stat(dir); err != nil {
 			return nil, err
 		}
 		params.Sources = imagesDataSources(dir)

--- a/cmd/plugins/juju-metadata/validatetoolsmetadata.go
+++ b/cmd/plugins/juju-metadata/validatetoolsmetadata.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/juju/cmd"
@@ -208,7 +207,7 @@ func (c *validateToolsMetadataCommand) Run(context *cmd.Context) error {
 		params.Endpoint = c.endpoint
 	}
 	if c.metadataDir != "" {
-		if _, err := os.Stat(c.metadataDir); err != nil {
+		if _, err := c.Filesystem().Stat(c.metadataDir); err != nil {
 			return err
 		}
 		toolsURL, err := tools.ToolsURL(c.metadataDir)

--- a/resource/resourceadapters/deploy.go
+++ b/resource/resourceadapters/deploy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/charmstore"
 	resourcecmd "github.com/juju/juju/cmd/juju/resource"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/resource/api/client"
 )
 
@@ -24,6 +25,7 @@ type DeployResourcesFunc func(
 	filesAndRevisions map[string]string,
 	resources map[string]charmresource.Meta,
 	conn base.APICallCloser,
+	filesystem modelcmd.Filesystem,
 ) (ids map[string]string, err error)
 
 // DeployResources uploads the bytes for the given files to the server and
@@ -36,6 +38,7 @@ func DeployResources(
 	filesAndRevisions map[string]string,
 	resources map[string]charmresource.Meta,
 	conn base.APICallCloser,
+	filesystem modelcmd.Filesystem,
 ) (ids map[string]string, err error) {
 
 	if len(filesAndRevisions)+len(resources) == 0 {
@@ -67,6 +70,7 @@ func DeployResources(
 		Revisions:          revisions,
 		ResourcesMeta:      resources,
 		Client:             &deployClient{client},
+		Filesystem:         filesystem,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
## Description of change

When running as embedded CLI commands for the Dashboard, we need to disallow access to the filesystem.
This PR introduces a Filesystem interface on the base command struct, which delegates to the os pkg calls when the commands are run from a terminal, but when embedded the various functions return an error.

A new test is added to the juju/cmd package which parses all of the CLi code and fails if there are any calls to filesystem related functions from the os package. This includes assigning an os function to a variable for later use, and where an import alias may be used for the os pkg.

A followup PR will disable various flags which allow for file access so that the user isn't even given the option in the first place.

## QA steps

bootstrap
run commands which access the filesystem, eg
juju model-config somefile.yaml
juju deploy . --resource foo=bar.zip
juju upgrade-charm foo --path . --resource foo=baz.zip

Now run the commands embedded using https://gist.github.com/wallyworld/4e8de75d5a439bd511e27d9bf5046c31 and ensure they fail.
