### PR TITLE
[2.8] Ensure caas specific charm options pass validation checks (v2)

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -492,13 +492,18 @@ func splitApplicationAndCharmConfigFromYAML(modelType state.ModelType, inYaml, a
 	outYaml string,
 	_ error,
 ) {
-	var allSettings map[string]map[string]interface{}
+	var allSettings map[string]interface{}
 	if err := goyaml.Unmarshal([]byte(inYaml), &allSettings); err != nil {
 		return nil, "", errors.Annotate(err, "cannot parse settings data")
 	}
-	settings, ok := allSettings[appName]
+	settings, ok := allSettings[appName].(map[interface{}]interface{})
 	if !ok {
-		return nil, "", errors.Errorf("no settings found for %q", appName)
+		// Application key not present; it might be 'juju get' output.
+		if _, err := charmConfigFromGet(allSettings); err != nil {
+			return nil, "", errors.Errorf("no settings found for %q", appName)
+		}
+
+		return nil, inYaml, nil
 	}
 
 	providerSchema, _, err := applicationConfigSchema(modelType)
@@ -509,8 +514,8 @@ func splitApplicationAndCharmConfigFromYAML(modelType state.ModelType, inYaml, a
 
 	appConfigAttrs := make(map[string]interface{})
 	for k, v := range settings {
-		if appConfigKeys.Contains(k) {
-			appConfigAttrs[k] = v
+		if key, ok := k.(string); ok && appConfigKeys.Contains(key) {
+			appConfigAttrs[key] = v
 			delete(settings, k)
 		}
 	}
@@ -658,58 +663,9 @@ func deployApplication(
 		}
 	}
 
-	// Split out the app config from the charm config for any config
-	// passed in as a map as opposed to YAML.
-	var appConfig map[string]interface{}
-	var charmConfig map[string]string
-	if len(args.Config) > 0 {
-		if appConfig, charmConfig, err = splitApplicationAndCharmConfig(modelType, args.Config); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	// Split out the app config from the charm config for any config
-	// passed in as YAML.
-	var charmYamlConfig string
-	appSettings := make(map[string]interface{})
-	if len(args.ConfigYAML) > 0 {
-		if appSettings, charmYamlConfig, err = splitApplicationAndCharmConfigFromYAML(modelType, args.ConfigYAML, args.ApplicationName); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	// Overlay any app settings in YAML with those from config map.
-	for k, v := range appConfig {
-		appSettings[k] = v
-	}
-
-	var applicationConfig *application.Config
-	configSchema, defaults, err := applicationConfigSchema(modelType)
+	appConfig, _, charmSettings, err := parseCharmSettings(modelType, ch, args.ApplicationName, args.Config, args.ConfigYAML)
 	if err != nil {
 		return errors.Trace(err)
-	}
-	applicationConfig, err = application.NewConfig(appSettings, configSchema, defaults)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	var settings = make(charm.Settings)
-	if len(charmYamlConfig) > 0 {
-		settings, err = ch.Config().ParseSettingsYAML([]byte(charmYamlConfig), args.ApplicationName)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	// Overlay any settings in YAML with those from config map.
-	if len(charmConfig) > 0 {
-		// Parse config in a compatible way (see function comment).
-		overrideSettings, err := parseSettingsCompatible(ch.Config(), charmConfig)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		for k, v := range overrideSettings {
-			settings[k] = v
-		}
 	}
 
 	// Parse storage tags in AttachStorage.
@@ -735,8 +691,8 @@ func deployApplication(
 		Charm:             stateCharm(ch),
 		Channel:           csparams.Channel(args.Channel),
 		NumUnits:          args.NumUnits,
-		ApplicationConfig: applicationConfig,
-		CharmConfig:       settings,
+		ApplicationConfig: appConfig,
+		CharmConfig:       charmSettings,
 		Constraints:       args.Constraints,
 		Placement:         args.Placement,
 		Storage:           args.Storage,
@@ -746,6 +702,77 @@ func deployApplication(
 		Resources:         args.Resources,
 	})
 	return errors.Trace(err)
+}
+
+// parseCharmSettings parses, verifies and combines the config settings for a
+// charm as specified by the provided config map and config yaml payload. Any
+// model-specific application settings will be automatically extracted and
+// returned back as an *application.Config.
+func parseCharmSettings(modelType state.ModelType, ch Charm, appName string, config map[string]string, configYaml string) (*application.Config, environschema.Fields, charm.Settings, error) {
+	// Split out the app config from the charm config for any config
+	// passed in as a map as opposed to YAML.
+	var (
+		applicationConfig map[string]interface{}
+		charmConfig       map[string]string
+		err               error
+	)
+	if len(config) > 0 {
+		if applicationConfig, charmConfig, err = splitApplicationAndCharmConfig(modelType, config); err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+	}
+
+	// Split out the app config from the charm config for any config
+	// passed in as YAML.
+	var (
+		charmYamlConfig string
+		appSettings     = make(map[string]interface{})
+	)
+	if len(configYaml) != 0 {
+		if appSettings, charmYamlConfig, err = splitApplicationAndCharmConfigFromYAML(modelType, configYaml, appName); err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+	}
+
+	// Overlay any app settings in YAML with those from config map.
+	for k, v := range applicationConfig {
+		appSettings[k] = v
+	}
+
+	appCfgSchema, defaults, err := applicationConfigSchema(modelType)
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
+	}
+	appConfig, err := application.NewConfig(appSettings, appCfgSchema, defaults)
+	if err != nil {
+		return nil, nil, nil, errors.Trace(err)
+	}
+
+	charmSettings := make(charm.Settings)
+	if len(charmYamlConfig) > 0 {
+		if charmSettings, err = ch.Config().ParseSettingsYAML([]byte(charmYamlConfig), appName); err != nil {
+			// Check if this is 'juju get' output and parse it as such
+			jujuGetSettings, pErr := charmConfigFromGetYaml(charmYamlConfig)
+			if pErr != nil {
+				// Not 'juju output' either; return original error
+				return nil, nil, nil, errors.Trace(err)
+			}
+			charmSettings = jujuGetSettings
+		}
+	}
+	// Overlay any settings in YAML with those from config map.
+	if len(charmConfig) != 0 {
+		// Parse config in a compatible way (see function comment).
+		overrideSettings, err := parseSettingsCompatible(ch.Config(), charmConfig)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		for k, v := range overrideSettings {
+			charmSettings[k] = v
+		}
+	}
+
+	return appConfig, appCfgSchema, charmSettings, nil
 }
 
 // checkMachinePlacement does a non-exhaustive validation of any supplied
@@ -791,23 +818,6 @@ func checkMachinePlacement(backend Backend, args params.ApplicationDeploy) error
 	}
 
 	return nil
-}
-
-// applicationSetSettingsStrings updates the settings for the given application,
-// taking the configuration from a map of strings.
-func applicationSetSettingsStrings(
-	application Application, gen string, settings map[string]string,
-) error {
-	ch, _, err := application.Charm()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	// Parse config in a compatible way (see function comment).
-	changes, err := parseSettingsCompatible(ch.Config(), settings)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return application.UpdateCharmConfig(gen, changes)
 }
 
 // parseSettingsCompatible parses setting strings in a way that is
@@ -910,22 +920,33 @@ func (api *APIBase) Update(args params.ApplicationUpdate) error {
 		args.Generation = model.GenerationMaster
 	}
 
-	// Set up application's settings.
-	// If the config change is generational, add the app to the generation.
-	configChange := false
-	if args.SettingsYAML != "" {
-		err = applicationSetCharmConfigYAML(args.ApplicationName, app, args.Generation, args.SettingsYAML)
-		if err != nil {
-			return errors.Annotate(err, "setting configuration from YAML")
-		}
-		configChange = true
-	} else if len(args.SettingsStrings) > 0 {
-		if err = applicationSetSettingsStrings(app, args.Generation, args.SettingsStrings); err != nil {
-			return errors.Trace(err)
-		}
-		configChange = true
+	// Update settings for charm and/or application.
+	ch, _, err := app.Charm()
+	if err != nil {
+		return errors.Annotate(err, "obtaining charm for this application")
 	}
-	if configChange && args.Generation != model.GenerationMaster {
+
+	appConfig, appConfigSchema, charmSettings, err := parseCharmSettings(api.modelType, ch, app.Name(), args.SettingsStrings, args.SettingsYAML)
+	if err != nil {
+		return errors.Annotate(err, "parsing settings for application")
+	}
+
+	var configChanged bool
+	if len(charmSettings) != 0 {
+		if err = app.UpdateCharmConfig(args.Generation, charmSettings); err != nil {
+			return errors.Annotate(err, "updating charm config settings")
+		}
+		configChanged = true
+	}
+	if cfgAttrs := appConfig.Attributes(); len(cfgAttrs) > 0 {
+		if err = app.UpdateApplicationConfig(cfgAttrs, nil, appConfigSchema, nil); err != nil {
+			return errors.Annotate(err, "updating application config settings")
+		}
+		configChanged = true
+	}
+
+	// If the config change is generational, add the app to the generation.
+	if configChanged && args.Generation != model.GenerationMaster {
 		if err := api.addAppToBranch(args.Generation, args.ApplicationName); err != nil {
 			return errors.Trace(err)
 		}
@@ -1171,7 +1192,17 @@ func (api *APIBase) applicationSetCharm(
 
 // charmConfigFromGetYaml will parse a yaml produced by juju get and generate
 // charm.Settings from it that can then be sent to the application.
-func charmConfigFromGetYaml(yamlContents map[string]interface{}) (charm.Settings, error) {
+func charmConfigFromGetYaml(yamlContents string) (charm.Settings, error) {
+	var allSettings map[string]interface{}
+	if err := goyaml.Unmarshal([]byte(yamlContents), &allSettings); err != nil {
+		return nil, errors.Annotate(err, "cannot parse settings data")
+	}
+	return charmConfigFromGet(allSettings)
+}
+
+// charmConfigFromGet will parse a yaml produced by juju get and generate
+// charm.Settings from it that can then be sent to the application.
+func charmConfigFromGet(yamlContents map[string]interface{}) (charm.Settings, error) {
 	onlySettings := charm.Settings{}
 	settingsMap, ok := yamlContents["settings"].(map[interface{}]interface{})
 	if !ok {
@@ -1195,37 +1226,6 @@ func charmConfigFromGetYaml(yamlContents map[string]interface{}) (charm.Settings
 		onlySettings[stringSetting] = v
 	}
 	return onlySettings, nil
-}
-
-// applicationSetCharmConfigYAML updates the charm config for the
-// given application, taking the configuration from a YAML string.
-func applicationSetCharmConfigYAML(
-	appName string, application Application, gen string, settings string,
-) error {
-	b := []byte(settings)
-	var all map[string]interface{}
-	if err := goyaml.Unmarshal(b, &all); err != nil {
-		return errors.Annotate(err, "parsing settings data")
-	}
-	// The file is already in the right format.
-	if _, ok := all[appName]; !ok {
-		changes, err := charmConfigFromGetYaml(all)
-		if err != nil {
-			return errors.Annotate(err, "processing YAML generated by get")
-		}
-		return errors.Annotate(application.UpdateCharmConfig(gen, changes), "updating settings with application YAML")
-	}
-
-	ch, _, err := application.Charm()
-	if err != nil {
-		return errors.Annotate(err, "obtaining charm for this application")
-	}
-
-	changes, err := ch.Config().ParseSettingsYAML(b, appName)
-	if err != nil {
-		return errors.Annotate(err, "creating config from YAML")
-	}
-	return errors.Annotate(application.UpdateCharmConfig(gen, changes), "updating settings")
 }
 
 // GetCharmURL returns the charm URL the given application is

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -1896,6 +1896,37 @@ func (s *applicationSuite) TestClientApplicationUpdateSetSettingsGetYAML(c *gc.C
 	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
 }
 
+func (s *applicationSuite) TestApplicationUpdateCombinedStringAndYAMLSettings(c *gc.C) {
+	ch := s.AddTestingCharm(c, "dummy")
+	app := s.AddTestingApplication(c, "dummy", ch)
+
+	const newBranch = "newBranch"
+	c.Assert(s.State.AddBranch(newBranch, "user"), jc.ErrorIsNil)
+
+	// Update settings for the application.
+	args := params.ApplicationUpdate{
+		ApplicationName: "dummy",
+		SettingsStrings: map[string]string{
+			"username": "s-user",
+		},
+		SettingsYAML: "dummy:\n  title: s-title",
+		Generation:   newBranch,
+	}
+	err := s.applicationAPI.Update(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the settings have been correctly updated.
+	expected := charm.Settings{"title": "s-title", "username": "s-user"}
+	obtained, err := app.CharmConfig(newBranch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtained, gc.DeepEquals, s.combinedSettings(ch, expected))
+
+	// Check that the application is recorded against the generation.
+	gen, err := s.State.Branch(newBranch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gen.AssignedUnits(), jc.DeepEquals, map[string][]string{"dummy": {}})
+}
+
 func (s *applicationSuite) TestApplicationUpdateSetConstraints(c *gc.C) {
 	app := s.AddTestingApplication(c, "dummy", s.AddTestingCharm(c, "dummy"))
 
@@ -1953,9 +1984,9 @@ func (s *applicationSuite) TestApplicationUpdateAllParams(c *gc.C) {
 	// Check the minimum number of units.
 	c.Assert(app.MinUnits(), gc.Equals, minUnits)
 
-	// Check the settings: also ensure the YAML settings take precedence
-	// over strings ones.
-	expectedSettings := charm.Settings{"blog-title": "yaml-title"}
+	// Check the settings: also ensure the string settings take precedence
+	// over the YAML ones.
+	expectedSettings := charm.Settings{"blog-title": "string-title"}
 	obtainedSettings, err := app.CharmConfig(model.GenerationMaster)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedSettings, gc.DeepEquals, expectedSettings)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -12,6 +12,7 @@ import (
 	csparams "github.com/juju/charmrepo/v5/csclient/params"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/schema"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -357,6 +358,64 @@ func (s *ApplicationSuite) TestDeployCAASOperatorProtectedByFlag(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
 	c.Assert(msg, gc.Matches, `feature flag "k8s-operators" is required for deploying k8s operator charms`)
+}
+
+func (s *ApplicationSuite) TestUpdateCAASApplicationSettings(c *gc.C) {
+	s.model.modelType = state.ModelTypeCAAS
+	s.setAPIUser(c, names.NewUserTag("admin"))
+	s.backend.charm = &mockCharm{
+		meta: &charm.Meta{
+			Deployment: &charm.Deployment{
+				DeploymentMode: charm.ModeOperator,
+			},
+		},
+	}
+
+	// Update settings for the application.
+	args := params.ApplicationUpdate{
+		ApplicationName: "postgresql",
+		SettingsYAML:    "postgresql:\n  stringOption: bar\n  juju-external-hostname: foo",
+	}
+	err := s.api.Update(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pgApp := s.backend.applications["postgresql"]
+	pgApp.CheckCall(c, 2, "UpdateCharmConfig", "master", charm.Settings{
+		"stringOption": "bar",
+	})
+
+	appDefaults := caas.ConfigDefaults(k8s.ConfigDefaults())
+	appCfgSchema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	c.Assert(err, jc.ErrorIsNil)
+	appCfgSchema, appDefaults, err = application.AddTrustSchemaAndDefaults(appCfgSchema, appDefaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	appCfg, err := coreapplication.NewConfig(map[string]interface{}{
+		"juju-external-hostname": "foo",
+	}, appCfgSchema, appDefaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pgApp.CheckCall(c, 3, "UpdateApplicationConfig", appCfg.Attributes(), []string(nil), appCfgSchema, schema.Defaults(nil))
+}
+
+func (s *ApplicationSuite) TestUpdateCAASApplicationSettingsInIAASModelTriggersError(c *gc.C) {
+	s.model.modelType = state.ModelTypeIAAS
+	s.setAPIUser(c, names.NewUserTag("admin"))
+	s.backend.charm = &mockCharm{
+		meta: &charm.Meta{
+			Deployment: &charm.Deployment{
+				DeploymentMode: charm.ModeOperator,
+			},
+		},
+	}
+
+	// Update settings for the application.
+	args := params.ApplicationUpdate{
+		ApplicationName: "postgresql",
+		SettingsYAML:    "postgresql:\n  stringOption: bar\n  juju-external-hostname: foo",
+	}
+	err := s.api.Update(args)
+	c.Assert(err, gc.ErrorMatches, `.*unknown option "juju-external-hostname"`, gc.Commentf("expected to get an error when attempting to set CAAS-specific app setting in IAAS model"))
 }
 
 func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -24,8 +24,8 @@ type ApplicationDeploy struct {
 	CharmURL         string                         `json:"charm-url"`
 	Channel          string                         `json:"channel"`
 	NumUnits         int                            `json:"num-units"`
-	Config           map[string]string              `json:"config,omitempty"`
-	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Config           map[string]string              `json:"config,omitempty"` // Takes precedence over yaml entries if both are present.
+	ConfigYAML       string                         `json:"config-yaml"`
 	Constraints      constraints.Value              `json:"constraints"`
 	Placement        []*instance.Placement          `json:"placement,omitempty"`
 	Policy           string                         `json:"policy,omitempty"`
@@ -50,7 +50,7 @@ type ApplicationDeployV5 struct {
 	Channel          string                         `json:"channel"`
 	NumUnits         int                            `json:"num-units"`
 	Config           map[string]string              `json:"config,omitempty"`
-	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	ConfigYAML       string                         `json:"config-yaml"`
 	Constraints      constraints.Value              `json:"constraints"`
 	Placement        []*instance.Placement          `json:"placement,omitempty"`
 	Storage          map[string]storage.Constraints `json:"storage,omitempty"`
@@ -72,8 +72,8 @@ type ApplicationDeployV6 struct {
 	CharmURL         string                         `json:"charm-url"`
 	Channel          string                         `json:"channel"`
 	NumUnits         int                            `json:"num-units"`
-	Config           map[string]string              `json:"config,omitempty"`
-	ConfigYAML       string                         `json:"config-yaml"` // Takes precedence over config if both are present.
+	Config           map[string]string              `json:"config,omitempty"` // Takes precedence over yaml entries if both are present.
+	ConfigYAML       string                         `json:"config-yaml"`
 	Constraints      constraints.Value              `json:"constraints"`
 	Placement        []*instance.Placement          `json:"placement,omitempty"`
 	Policy           string                         `json:"policy,omitempty"`
@@ -91,8 +91,8 @@ type ApplicationUpdate struct {
 	ForceSeries     bool               `json:"force-series"`
 	Force           bool               `json:"force"`
 	MinUnits        *int               `json:"min-units,omitempty"`
-	SettingsStrings map[string]string  `json:"settings,omitempty"`
-	SettingsYAML    string             `json:"settings-yaml"` // Takes precedence over SettingsStrings if both are present.
+	SettingsStrings map[string]string  `json:"settings,omitempty"` // Takes precedence over yaml entries if both are present.
+	SettingsYAML    string             `json:"settings-yaml"`
 	Constraints     *constraints.Value `json:"constraints,omitempty"`
 
 	// Generation is the generation version in which this


### PR DESCRIPTION
## Description of change

This PR supersedes #11912.

When attempting to deploy a bundle multiple times, the juju cli (via `bundlechanges`) detects that charms are already present in the controller and instead of performing a `DeployApplication` call, it performs an `Update` call (same facade) to update the charm settings.

Prior to this PR, the `Update` codepath would simply try to unmarshal the YAML (if present) and try to validate it via the charm's Config() instance prior to calling `application.UpdateCharmConfig`. This approach has two issues:
- it does not support updating application settings
- validation would fail if the payload contained any application-specific settings (e.g. `juju-external-hostname` et. al for CAAS models).

To resolve this issue, this PR extracts the charm/application config parse logic from the deploy codepath and ensures that both `Update` and `DeployApplication` delegate the config parsing to it. Furthermore, the `Update` implementation will now call both `UpdateApplicationConfig` and `UpdateCharmConfig` depending on whether a non-empty config set was provided for each one.

## QA steps

```console
# Set up a test bundle with the following contents:
$ cat bundle.yaml
bundle: kubernetes
applications:
  mm-pd-bot:
    charm: cs:~mm-pd-bot-charmers/mm-pd-bot
    scale: 1
    options:
      image_path: stg-is.docker-registry.canonical.com/mm-pd-bot:v1
      tls_secret_name: mm-pd-bot-staging-canonical-com-tls
      # Those parameters are k8s specific
      juju-external-hostname: mm-pd-bot.staging.canonical.com

# Try the following on a 2.8.1 k8s instance
# The second command should fail!
$ juju deploy ./bundle.yaml
$ juju deploy ./bundle.yaml
ERROR cannot deploy bundle: cannot update options for application "mm-pd-bot": setting configuration from YAML: updating settings: unknown option "juju-external-hostname"

# Now set up a k8s instance from this branch
$ make microk8s-operator-update
$ juju bootstrap microk8s mk8s
$ juju add-model foo

# All these should proceed without errors
$ juju deploy ./bundle.yaml
$ juju deploy ./bundle.yaml
$ juju deploy ./bundle.yaml

# Edit the bundle and change the "juju-external-hostname" value to something else
# Then, deploy again
$ juju deploy ./bundle.yaml

# Verify that the application settings have been correctly updated in mongo
> db.settings.find({_id: {$regex: ".*#application"}}).pretty()
{
        "_id" : "fe99c27b-8c60-406b-8dde-aeffc1413702:a#mm-pd-bot#application",
        "model-uuid" : "fe99c27b-8c60-406b-8dde-aeffc1413702",
        "settings" : {
                "kubernetes-ingress-class" : "nginx",
                "kubernetes-ingress-allow-http" : false,
                "kubernetes-ingress-ssl-redirect" : false,
                "trust" : false,
                "kubernetes-ingress-ssl-passthrough" : false,
                "juju-external-hostname" : "kaboom.staging.canonical.com",  <-------
                "juju-application-path" : "/"
        },
        "version" : NumberLong(1),
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d0b3afe5c050010114c75_a1347752"
        ]

# NOTE: the test bundle is missing a required field so it will eventually error
# It is only used to check that the cass-specific option validation bug has been
# addressed.
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1891524