### PR TITLE
Changes the labels used by Juju for Kubernetes.

### DIFF
--- a/caas/kubernetes/provider/admissionregistration.go
+++ b/caas/kubernetes/provider/admissionregistration.go
@@ -22,6 +22,7 @@ func (k *kubernetesClient) getAdmissionControllerLabels(appName string) map[stri
 		LabelsForApp(appName, k.IsLegacyLabels()),
 		LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
 	)
+
 	if !k.IsLegacyLabels() {
 		labels = LabelsMerge(labels, LabelsJuju)
 	}
@@ -48,7 +49,7 @@ func (k *kubernetesClient) ensureMutatingWebhookConfigurations(
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        decideNameForGlobalResource(v.Meta, k.namespace),
 				Namespace:   k.namespace,
-				Labels:      k8slabels.Merge(v.Labels, k.getAdmissionControllerLabels(appName)),
+				Labels:      LabelsMerge(v.Labels, k.getAdmissionControllerLabels(appName)),
 				Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
 			},
 			Webhooks: v.Webhooks,
@@ -170,7 +171,7 @@ func (k *kubernetesClient) ensureValidatingWebhookConfigurations(
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        decideNameForGlobalResource(v.Meta, k.namespace),
 				Namespace:   k.namespace,
-				Labels:      k8slabels.Merge(v.Labels, k.getAdmissionControllerLabels(appName)),
+				Labels:      LabelsMerge(v.Labels, k.getAdmissionControllerLabels(appName)),
 				Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
 			},
 			Webhooks: v.Webhooks,

--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -43,7 +43,7 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Labels: provider.LabelsForApp("app-name", false),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -53,12 +53,12 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: provider.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: provider.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -176,9 +176,13 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreate(c *gc.C) 
 
 	cfg1 := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-mutatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-mutatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
@@ -240,9 +244,13 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepName(c
 
 	cfg1 := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "example-mutatingwebhookconfiguration", // This name kept no change.
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "example-mutatingwebhookconfiguration", // This name kept no change.
+			Namespace: "test",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id(), "juju.io/disable-name-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
@@ -301,9 +309,13 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdate(c *gc.C) 
 
 	cfg1 := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-mutatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-mutatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
@@ -313,7 +325,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdate(c *gc.C) 
 		c, cfgs,
 		s.mockMutatingWebhookConfiguration.EXPECT().Create(cfg1).Return(cfg1, s.k8sAlreadyExistsError()),
 		s.mockMutatingWebhookConfiguration.EXPECT().
-			List(metav1.ListOptions{LabelSelector: "juju-app=app-name,juju-model=test"}).
+			List(metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
 			Return(&admissionregistration.MutatingWebhookConfigurationList{Items: []admissionregistration.MutatingWebhookConfiguration{*cfg1}}, nil),
 		s.mockMutatingWebhookConfiguration.EXPECT().
 			Get("test-example-mutatingwebhookconfiguration", metav1.GetOptions{}).
@@ -338,7 +350,7 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Labels: provider.LabelsForApp("app-name", false),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -348,12 +360,12 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: provider.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: provider.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -467,9 +479,13 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreate(c *gc.C
 
 	cfg1 := &admissionregistration.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-validatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-validatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
@@ -531,9 +547,13 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 
 	cfg1 := &admissionregistration.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "example-validatingwebhookconfiguration", // This name kept no change.
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "example-validatingwebhookconfiguration", // This name kept no change.
+			Namespace: "test",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id(), "juju.io/disable-name-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
@@ -592,9 +612,13 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdate(c *gc.C
 
 	cfg1 := &admissionregistration.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-validatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-validatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
@@ -604,7 +628,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdate(c *gc.C
 		c, cfgs,
 		s.mockValidatingWebhookConfiguration.EXPECT().Create(cfg1).Return(cfg1, s.k8sAlreadyExistsError()),
 		s.mockValidatingWebhookConfiguration.EXPECT().
-			List(metav1.ListOptions{LabelSelector: "juju-app=app-name,juju-model=test"}).
+			List(metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
 			Return(&admissionregistration.ValidatingWebhookConfigurationList{Items: []admissionregistration.ValidatingWebhookConfiguration{*cfg1}}, nil),
 		s.mockValidatingWebhookConfiguration.EXPECT().
 			Get("test-example-validatingwebhookconfiguration", metav1.GetOptions{}).

--- a/caas/kubernetes/provider/annotations.go
+++ b/caas/kubernetes/provider/annotations.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"github.com/juju/juju/core/annotations"
+)
+
+const (
+	// AnnotationJujuStorageName is the Juju annotation that represents a
+	// storage objects associated Juju name.
+	AnnotationJujuStorageName = "storage.juju.is/name"
+
+	// AnnotationJujuVersion is the version annotation used on operator
+	// deployments.
+	AnnotationJujuVersion = "juju.is/version"
+
+	// legacyAnnotationStorageName is the legacy annotation used by Juju for
+	// dictating storage name on k8s storage objects.
+	legacyAnnotationStorageName = "juju-storage"
+
+	// legacyAnnotationVersion is the legacy annotation used by Juju for
+	// dictating juju agent version on operators.
+	legacyAnnotationVersion = "juju-version"
+)
+
+type AnnotationKeySupplier func() string
+
+// AnnotationsForStorage provides the annotations that should be placed on a
+// storage object. The annotations returned by this function are storage
+// specific only and should be combined with other annotations where
+// appropriate.
+func AnnotationsForStorage(name string, legacy bool) annotations.Annotation {
+	if legacy {
+		return annotations.Annotation{
+			legacyAnnotationStorageName: name,
+		}
+	}
+	return annotations.Annotation{
+		AnnotationJujuStorageName: name,
+	}
+}
+
+// AnnotationsForVersion provides the annotations that should be placed on an
+// object that requires juju version information. The annotations returned by
+// this function are version specific and may need to be combined with other
+// annotations for a complete set.
+func AnnotationsForVersion(vers string, legacy bool) annotations.Annotation {
+	return annotations.Annotation{
+		AnnotationVersionKey(legacy): vers,
+	}
+}
+
+// AnnotationVersionKey returns the key used un in annotations to describe the
+// Juju version. Legacy controls if the key returns is a legacy annotation key
+// or newer style.
+func AnnotationVersionKey(legacy bool) string {
+	if legacy {
+		return legacyAnnotationVersion
+	}
+	return AnnotationJujuVersion
+}

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -186,10 +186,15 @@ func (s *BaseSuite) getNamespace() string {
 
 func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
+
 	newK8sClientFunc, newK8sRestFunc := s.setupK8sRestClient(c, ctrl, s.getNamespace())
 	randomPrefixFunc := func() (string, error) {
 		return "appuuid", nil
 	}
+
+	s.mockNamespaces.EXPECT().Get(s.getNamespace(), v1.GetOptions{}).
+		Return(nil, s.k8sNotFoundError())
+
 	return s.setupBroker(c, ctrl, newK8sClientFunc, newK8sRestFunc, randomPrefixFunc)
 }
 

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/juju/juju/agent"
@@ -201,10 +202,12 @@ func newcontrollerStack(
 	agentConfig.SetStateServingInfo(si)
 	pcfg.Bootstrap.StateServingInfo = si
 
+	labels := k8slabels.Merge(LabelsForApp(stackName, false), LabelsJuju)
+
 	cs := &controllerStack{
 		ctx:              ctx,
 		stackName:        stackName,
-		stackLabels:      map[string]string{labelApplication: stackName},
+		stackLabels:      labels,
 		stackAnnotations: map[string]string{annotationControllerUUIDKey: pcfg.ControllerTag.Id()},
 		broker:           broker,
 
@@ -466,6 +469,7 @@ func (c *controllerStack) createControllerService() error {
 			logger.Debugf("polling k8s controller svc DNS, in %d attempt, %v", attempt, err)
 		},
 	}
+
 	return errors.Trace(retry.Call(retryCallArgs))
 }
 

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -14,9 +14,7 @@ import (
 )
 
 func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string {
-	return map[string]string{
-		labelApplication: appName,
-	}
+	return LabelsForApp(appName, k.IsLegacyLabels())
 }
 
 func (k *kubernetesClient) ensureConfigMaps(
@@ -126,7 +124,7 @@ func (k *kubernetesClient) deleteConfigMap(name string, uid types.UID) error {
 
 func (k *kubernetesClient) listConfigMaps(labels map[string]string) ([]core.ConfigMap, error) {
 	listOps := v1.ListOptions{
-		LabelSelector: labelSetToSelector(labels).String(),
+		LabelSelector: LabelSetToSelector(labels).String(),
 	}
 	cmList, err := k.client().CoreV1().ConfigMaps(k.namespace).List(listOps)
 	if err != nil {
@@ -142,7 +140,7 @@ func (k *kubernetesClient) deleteConfigMaps(appName string) error {
 	err := k.client().CoreV1().ConfigMaps(k.namespace).DeleteCollection(&v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	}, v1.ListOptions{
-		LabelSelector: labelSetToSelector(k.getConfigMapLabels(appName)).String(),
+		LabelSelector: LabelSetToSelector(k.getConfigMapLabels(appName)).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -35,6 +35,10 @@ func (d *dummyUpgradeCAASController) Client() kubernetes.Interface {
 	return d.client
 }
 
+func (d *dummyUpgradeCAASController) IsLegacyLabels() bool {
+	return false
+}
+
 func (d *dummyUpgradeCAASController) Namespace() string {
 	return "test"
 }
@@ -83,8 +87,8 @@ func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ss.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 
-	c.Assert(ss.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
-	c.Assert(ss.Spec.Template.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Annotations[AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Spec.Template.Annotations[AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
 }
 
 func (s *ControllerUpgraderSuite) TestControllerDoesNotExist(c *gc.C) {

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -43,7 +43,7 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Labels: provider.LabelsForApp("app-name", false),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -53,12 +53,12 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: provider.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: provider.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -181,8 +181,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreate(c *gc.
 
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "tfjobs.kubeflow.org",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
@@ -293,8 +297,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdate(c *gc.
 
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "tfjobs.kubeflow.org",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsForModel("test", false),
+				provider.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
@@ -367,7 +375,7 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Labels: provider.LabelsForApp("app-name", false),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -377,12 +385,12 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: provider.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: provider.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -559,10 +567,16 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 	crRaw2 := getCR2()
 
 	cr1 := getCR1()
-	cr1.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr1.SetLabels(provider.LabelsMerge(
+		provider.LabelsForApp("app-name", false),
+		provider.LabelsJuju,
+	))
 	cr1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	cr2 := getCR2()
-	cr2.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr2.SetLabels(provider.LabelsMerge(
+		provider.LabelsForApp("app-name", false),
+		provider.LabelsJuju,
+	))
 	cr2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 
 	crs := map[string][]unstructured.Unstructured{
@@ -677,19 +691,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 	crRaw2 := getCR2()
 
 	cr1 := getCR1()
-	cr1.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr1.SetLabels(provider.LabelsMerge(
+		provider.LabelsForApp("app-name", false),
+		provider.LabelsJuju,
+	))
 	cr1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	cr2 := getCR2()
-	cr2.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr2.SetLabels(provider.LabelsMerge(
+		provider.LabelsForApp("app-name", false),
+		provider.LabelsJuju,
+	))
 	cr2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 
 	crUpdatedResourceVersion1 := getCR1()
-	crUpdatedResourceVersion1.SetLabels(map[string]string{"juju-app": "app-name"})
+	crUpdatedResourceVersion1.SetLabels(provider.LabelsMerge(
+		provider.LabelsForApp("app-name", false),
+		provider.LabelsJuju,
+	))
 	crUpdatedResourceVersion1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion1.SetResourceVersion("11111")
 
 	crUpdatedResourceVersion2 := getCR2()
-	crUpdatedResourceVersion2.SetLabels(map[string]string{"juju-app": "app-name"})
+	crUpdatedResourceVersion2.SetLabels(provider.LabelsMerge(
+		provider.LabelsForApp("app-name", false),
+		provider.LabelsJuju,
+	))
 	crUpdatedResourceVersion2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion2.SetResourceVersion("11111")
 

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -37,7 +37,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Labels: provider.LabelsForApp("app-name", false),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -47,12 +47,12 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: provider.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: provider.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -162,10 +162,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
 	ingress := &extensionsv1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-ingress",
-			Labels: map[string]string{
-				"foo":      "bar",
-				"juju-app": "app-name",
-			},
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsJuju,
+				map[string]string{"foo": "bar"},
+			),
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
 				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
@@ -217,10 +218,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
 	ingress := &extensionsv1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-ingress",
-			Labels: map[string]string{
-				"foo":      "bar",
-				"juju-app": "app-name",
-			},
+			Labels: provider.LabelsMerge(
+				provider.LabelsForApp("app-name", false),
+				provider.LabelsJuju,
+				map[string]string{"foo": "bar"},
+			),
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
 				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
@@ -276,10 +278,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 		return &extensionsv1beta1.Ingress{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "test-ingress",
-				Labels: map[string]string{
-					"foo":      "bar",
-					"juju-app": "app-name",
-				},
+				Labels: provider.LabelsMerge(
+					provider.LabelsForApp("app-name", false),
+					provider.LabelsJuju,
+					map[string]string{"foo": "bar"},
+				),
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/rewrite-target": "/",
 					"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",

--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -24,6 +24,11 @@ const (
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
 	LabelKubernetesAppManaged = "app.kubernetes.io/managed-by"
 
+	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
+	// created by applications managed by Juju. Think istio, kubeflow etc
+	// See https://bugs.launchpad.net/juju/+bug/1892285
+	LabelJujuAppCreatedBy = "app.juju.is/created-by"
+
 	// LabelJujuModelName is the juju label applied for juju models.
 	LabelJujuModelName = "model.juju.is/name"
 
@@ -148,6 +153,12 @@ func LabelsForStorage(name string, legacy bool) labels.Set {
 	}
 	return map[string]string{
 		LabelJujuStorageName: name,
+	}
+}
+
+func LabelForKeyValue(key, value string) labels.Set {
+	return labels.Set{
+		key: value,
 	}
 }
 

--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -3,44 +3,190 @@
 
 package provider
 
-// AppendLabels adds the labels defined in src to dest returning the result.
-// Overlapping keys in sources maps are overwritten by the very last defined
-// value for a duplicate key.
-func AppendLabels(dest map[string]string, sources ...map[string]string) map[string]string {
-	if dest == nil {
-		dest = map[string]string{}
+import (
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	core "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/juju/errors"
+)
+
+const (
+	// LabelKubernetesAppName is the common meta key for kubernetes app names.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+	LabelKubernetesAppName = "app.kubernetes.io/name"
+
+	// LabelKubernetesAppManaged is the common meta key for kubernetes apps
+	// that are managed by a non k8s process (such as Juju).
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+	LabelKubernetesAppManaged = "app.kubernetes.io/managed-by"
+
+	// LabelJujuModelName is the juju label applied for juju models.
+	LabelJujuModelName = "model.juju.is/name"
+
+	// LabelJujuOperatorName is the juju label applied to Juju operators to
+	// identify their name. Operator names are generally named after the thing
+	// the operator is controlling. i.e an operator name for a model test would be
+	// "test"
+	LabelJujuOperatorName = "operator.juju.is/name"
+
+	// LabelJujuOperatorTarget is the juju label applied to Juju operators to
+	// describe the modeling paradigm they target. For example model,
+	// application
+	LabelJujuOperatorTarget = "operator.juju.is/target"
+
+	// LabelJujuStorageName is the juju label applied to Juju storage objects to
+	// describe their name.
+	LabelJujuStorageName = "storage.juju.is/name"
+
+	// legacyLabelKubernetesAppName is the legacy label key used for juju app
+	// identification. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	legacyLabelKubernetesAppName = "juju-app"
+
+	// legacyLabelModelName is the legacy label key used for juju models. This
+	// purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	legacyLabelModelName = "juju-model"
+
+	// legacyLabelKubernetesOperatorName is the legacy label key used for juju
+	// operators. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	legacyLabelKubernetesOperatorName = "juju-operator"
+
+	// legacyLabelJujuStorageName is the legacy label key used for juju storage
+	// pvc. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	legacyLabelStorageName = "juju-storage"
+)
+
+var (
+	// LabelsJuju is a common set
+	LabelsJuju = map[string]string{
+		LabelKubernetesAppManaged: "juju",
 	}
-	if sources == nil {
-		return dest
-	}
-	for _, s := range sources {
-		for k, v := range s {
-			dest[k] = v
-		}
-	}
-	return dest
+)
+
+func AppLabelSelector(appName string) (labels.Selector, error) {
+	return labels.Parse(fmt.Sprintf("%s=%s", LabelKubernetesAppName, appName))
 }
 
 func (k *kubernetesClient) getlabelsForApp(appName string, isNamespaced bool) map[string]string {
-	labels := LabelsForApp(appName)
+	labels := LabelsForApp(appName, k.IsLegacyLabels())
 	if !isNamespaced {
-		labels = AppendLabels(labels, LabelsForModel(k.CurrentModel()))
+		labels = LabelsMerge(labels, LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()))
 	}
 	return labels
 }
 
+// HasLabels returns true if the src contains the labels in has
+func HasLabels(src, has labels.Set) bool {
+	for k, v := range has {
+		if src[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// LabelSetToSelector converts a set of Kubernetes labels
+func LabelSetToSelector(l labels.Set) labels.Selector {
+	return labels.SelectorFromValidatedSet(l)
+}
+
 // LabelsForApp returns the labels that should be on a k8s object for a given
 // application name
-func LabelsForApp(name string) map[string]string {
-	return map[string]string{
-		labelApplication: name,
+func LabelsForApp(name string, legacy bool) labels.Set {
+	if legacy {
+		return labels.Set{
+			legacyLabelKubernetesAppName: name,
+		}
+	}
+	return labels.Set{
+		LabelKubernetesAppName: name,
 	}
 }
 
 // LabelsForModel returns the labels that should be on a k8s object for a given
 // model name
-func LabelsForModel(name string) map[string]string {
-	return map[string]string{
-		labelModel: name,
+func LabelsForModel(name string, legacy bool) labels.Set {
+	if legacy {
+		return map[string]string{
+			legacyLabelModelName: name,
+		}
 	}
+	return map[string]string{
+		LabelJujuModelName: name,
+	}
+}
+
+// LabelsForOperator returns the labels that should be placed on a juju operator
+// Takes the operator name, type and a legacy flag to indicate these labels are
+// being used on a model that is operating in "legacy" label mode
+func LabelsForOperator(name, target string, legacy bool) labels.Set {
+	if legacy {
+		return map[string]string{
+			legacyLabelKubernetesOperatorName: name,
+		}
+	}
+	return map[string]string{
+		LabelJujuOperatorName:   name,
+		LabelJujuOperatorTarget: target,
+	}
+}
+
+// LabelsForStorage return the labels that should be placed on a k8s storage
+// object. Takes the storage name and a legacy flat.
+func LabelsForStorage(name string, legacy bool) labels.Set {
+	if legacy {
+		return map[string]string{
+			legacyLabelStorageName: name,
+		}
+	}
+	return map[string]string{
+		LabelJujuStorageName: name,
+	}
+}
+
+// LabelsMerge
+func LabelsMerge(a labels.Set, merges ...labels.Set) labels.Set {
+	for _, merge := range merges {
+		a = labels.Merge(a, merge)
+	}
+	return a
+}
+
+// LabelsToSelector transforms the supplied label set to a valid Kubernetes
+// label selector
+func LabelsToSelector(ls labels.Set) labels.Selector {
+	return labels.SelectorFromValidatedSet(ls)
+}
+
+// IsLegacyLabels indicates if this provider is operating on a legacy label schema
+func (k *kubernetesClient) IsLegacyLabels() bool {
+	return k.isLegacyLabels
+}
+
+// IsLegacyModelLabels checks to see if the provided model is running on an older
+// labeling scheme or a newer one.
+func IsLegacyModelLabels(model string, namespaceI core.NamespaceInterface) (bool, error) {
+	ns, err := namespaceI.Get(model, meta.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return true, errors.Annotatef(err, "unable to determine legacy status for namespace %s", model)
+	}
+
+	return !HasLabels(ns.Labels, LabelsForModel(model, false)), nil
+}
+
+func StorageNameFromLabels(labels labels.Set) string {
+	if labels[LabelJujuStorageName] != "" {
+		return labels[LabelJujuStorageName]
+	}
+	return labels[legacyLabelStorageName]
 }

--- a/caas/kubernetes/provider/labels_test.go
+++ b/caas/kubernetes/provider/labels_test.go
@@ -1,0 +1,49 @@
+package provider_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/caas/kubernetes/provider"
+)
+
+type LabelSuite struct {
+	client *fake.Clientset
+}
+
+var _ = gc.Suite(&LabelSuite{})
+
+func (l *LabelSuite) SetUpTest(c *gc.C) {
+	l.client = fake.NewSimpleClientset()
+}
+
+func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
+	tests := []struct {
+		IsLegacy  bool
+		Model     string
+		Namespace *core.Namespace
+	}{
+		{
+			IsLegacy: false,
+			Model:    "legacy-model-label-test-1",
+			Namespace: &core.Namespace{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   "legacy-model-label-test-1",
+					Labels: provider.LabelsForModel("legacy-model-label-test-1"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		_, err := l.client.CoreV1().Namespaces().Create(test.Namespace)
+		c.Assert(err, jc.ErrorIsNil)
+
+		legacy, err := provider.IsLegacyModelLabels(test.Model, l.client.CoreV1().Namespaces())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(legacy, gc.Equals, test.IsLegacy)
+	}
+}

--- a/caas/kubernetes/provider/labels_test.go
+++ b/caas/kubernetes/provider/labels_test.go
@@ -32,7 +32,7 @@ func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
 			Namespace: &core.Namespace{
 				ObjectMeta: meta.ObjectMeta{
 					Name:   "legacy-model-label-test-1",
-					Labels: provider.LabelsForModel("legacy-model-label-test-1"),
+					Labels: provider.LabelsForModel("legacy-model-label-test-1", false),
 				},
 			},
 		},

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -38,10 +38,6 @@ func labelSetToRequirements(labels k8slabels.Set) []k8slabels.Requirement {
 	return out
 }
 
-func labelSetToSelector(labels k8slabels.Set) k8slabels.Selector {
-	return k8slabels.SelectorFromValidatedSet(labels)
-}
-
 func mergeSelectors(selectors ...k8slabels.Selector) k8slabels.Selector {
 	s := k8slabels.NewSelector()
 	for _, v := range selectors {

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -227,7 +227,7 @@ func modelOperatorConfigMap(
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
 			Namespace: namespace,
-			Labels:    AppendLabels(labels, moLabels),
+			Labels:    LabelsMerge(labels, moLabels),
 		},
 		Data: map[string]string{
 			modelOperatorConfigMapAgentConfKey(operatorName): string(agentConf),
@@ -259,7 +259,7 @@ func modelOperatorDeployment(
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
 			Namespace: namespace,
-			Labels:    AppendLabels(labels, moLabels),
+			Labels:    LabelsMerge(labels, moLabels),
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: int32Ptr(1),

--- a/caas/kubernetes/provider/modeloperator_upgrade.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade.go
@@ -12,12 +12,16 @@ import (
 type upgradeCAASModelOperatorBridge struct {
 	clientFn    func() kubernetes.Interface
 	namespaceFn func() string
+	isLegacyFn  func() bool
 }
 
 type UpgradeCAASModelOperatorBroker interface {
 	// Client returns a Kubernetes client associated with the current broker's
 	// cluster
 	Client() kubernetes.Interface
+
+	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
+	IsLegacyLabels() bool
 
 	// Namespace returns the targeted Kubernetes namespace for this broker
 	Namespace() string
@@ -27,11 +31,19 @@ func (u *upgradeCAASModelOperatorBridge) Client() kubernetes.Interface {
 	return u.clientFn()
 }
 
+func (u *upgradeCAASModelOperatorBridge) IsLegacyLabels() bool {
+	return u.isLegacyFn()
+}
+
 func modelOperatorUpgrade(
 	operatorName string,
 	vers version.Number,
 	broker UpgradeCAASModelOperatorBroker) error {
-	return upgradeDeployment(operatorName, "", vers,
+	return upgradeDeployment(
+		operatorName,
+		"",
+		vers,
+		broker.IsLegacyLabels(),
 		broker.Client().AppsV1().Deployments(broker.Namespace()))
 }
 
@@ -43,6 +55,7 @@ func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version
 	broker := &upgradeCAASModelOperatorBridge{
 		clientFn:    k.client,
 		namespaceFn: k.GetCurrentNamespace,
+		isLegacyFn:  k.IsLegacyLabels,
 	}
 	return modelOperatorUpgrade(modelOperatorName, vers, broker)
 }

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -32,6 +32,10 @@ func (d *dummyUpgradeCAASModel) Client() kubernetes.Interface {
 	return d.client
 }
 
+func (d *dummyUpgradeCAASModel) IsLegacyLabels() bool {
+	return false
+}
+
 func (d *dummyUpgradeCAASModel) Namespace() string {
 	return "test"
 }
@@ -80,6 +84,6 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(de.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 
-	c.Assert(de.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
-	c.Assert(de.Spec.Template.Annotations[labelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Annotations[AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Spec.Template.Annotations[AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
 }

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -117,7 +117,10 @@ func (k *kubernetesClient) ensureNamespaceAnnotations(ns *core.Namespace) error 
 // createNamespace creates a named namespace.
 func (k *kubernetesClient) createNamespace(name string) error {
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: name}}
-	ns.SetLabels(AppendLabels(ns.GetLabels(), LabelsForModel(k.CurrentModel())))
+	ns.SetLabels(LabelsMerge(
+		ns.GetLabels(),
+		LabelsForModel(k.CurrentModel(), false),
+		LabelsJuju))
 	if err := k.ensureNamespaceAnnotations(ns); err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -682,6 +682,7 @@ func operatorPod(
 	mountToken := true
 	return &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
+			Name:        podName,
 			Annotations: podAnnotations(annotations.Copy()).ToMap(),
 			Labels:      selectorLabels,
 		},

--- a/caas/kubernetes/provider/operator_upgrade_test.go
+++ b/caas/kubernetes/provider/operator_upgrade_test.go
@@ -45,6 +45,10 @@ func (d *DummyUpgradeCAASOperator) DeploymentName(n string, _ bool) string {
 	return n
 }
 
+func (d *DummyUpgradeCAASOperator) IsLegacyLabels() bool {
+	return false
+}
+
 func (d *DummyUpgradeCAASOperator) Namespace() string {
 	return "test"
 }

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -16,9 +16,7 @@ import (
 )
 
 func (k *kubernetesClient) getStatefulSetLabels(appName string) map[string]string {
-	return map[string]string{
-		labelApplication: appName,
-	}
+	return LabelsForApp(appName, k.IsLegacyLabels())
 }
 
 func updateStrategyForStatefulSet(strategy specs.UpdateStrategy) (o apps.StatefulSetUpdateStrategy, err error) {
@@ -73,7 +71,7 @@ func (k *kubernetesClient) configureStatefulSet(
 		Spec: apps.StatefulSetSpec{
 			Replicas: replicas,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{labelApplication: appName},
+				MatchLabels: k.getStatefulSetLabels(appName),
 			},
 			RevisionHistoryLimit: int32Ptr(statefulSetRevisionHistoryLimit),
 			Template: core.PodTemplateSpec{
@@ -195,7 +193,7 @@ func (k *kubernetesClient) deleteStatefulSets(appName string) error {
 	err := k.client().AppsV1().StatefulSets(k.namespace).DeleteCollection(&v1.DeleteOptions{
 		PropagationPolicy: &defaultPropagationPolicy,
 	}, v1.ListOptions{
-		LabelSelector: labelSetToSelector(k.getStatefulSetLabels(appName)).String(),
+		LabelSelector: LabelSetToSelector(k.getStatefulSetLabels(appName)).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -19,9 +19,8 @@ import (
 func (k *kubernetesClient) deleteClusterScopeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
 	defer wg.Done()
 
-	labels := map[string]string{
-		labelModel: k.namespace,
-	}
+	labels := LabelsForModel(k.CurrentModel(), k.IsLegacyLabels())
+
 	selector := k8slabels.NewSelector().Add(
 		labelSetToRequirements(labels)...,
 	)

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -22,7 +22,7 @@ metadata:
   name: $name
   namespace: $namespace
   labels:
-    juju-app: test-app
+    app.kubernetes.io/name: test-app
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -68,7 +68,7 @@ data:
   test: test
 EOF
 
-juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.app\.juju\.is\/created-by}')
   check_contains "${juju_app}" "test-app"
 
   echo "$juju_app" | check test-app
@@ -89,7 +89,7 @@ metadata:
   name: $name
   namespace: $namespace
   labels:
-    juju-app: test-app
+    app.kubernetes.io/name: test-app
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -134,7 +134,7 @@ data:
   test: test
 EOF
 
-juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.app\.juju\.is\/created-by}')
   check_contains "${juju_app}" "test-app"
 
   echo "$juju_app" | check test-app

--- a/worker/caasadmission/admission.go
+++ b/worker/caasadmission/admission.go
@@ -46,6 +46,7 @@ func (a AdmissionCreatorFunc) EnsureMutatingWebhookConfiguration() (func(), erro
 func NewAdmissionCreator(
 	authority pki.Authority,
 	namespace, modelName string,
+	legacyLabels bool,
 	ensureConfig func(*admission.MutatingWebhookConfiguration) (func(), error),
 	service *admission.ServiceReference) (AdmissionCreator, error) {
 
@@ -64,7 +65,7 @@ func NewAdmissionCreator(
 	// MutatingWebjook Obj
 	obj := admission.MutatingWebhookConfiguration{
 		ObjectMeta: meta.ObjectMeta{
-			Labels:    provider.LabelsForModel(modelName),
+			Labels:    provider.LabelsForModel(modelName, legacyLabels),
 			Name:      fmt.Sprintf("juju-model-admission-%s", namespace),
 			Namespace: namespace,
 		},
@@ -79,7 +80,7 @@ func NewAdmissionCreator(
 				MatchPolicy:   &matchPolicy,
 				Name:          provider.MakeK8sDomain(Component),
 				NamespaceSelector: &meta.LabelSelector{
-					MatchLabels: provider.LabelsForModel(modelName),
+					MatchLabels: provider.LabelsForModel(modelName, legacyLabels),
 				},
 				Rules: []admission.RuleWithOperations{
 					{

--- a/worker/caasadmission/controller.go
+++ b/worker/caasadmission/controller.go
@@ -31,6 +31,7 @@ func NewController(
 	logger Logger,
 	mux Mux,
 	path string,
+	legacyLabels bool,
 	admissionCreator AdmissionCreator,
 	rbacMapper RBACMapper) (*Controller, error) {
 
@@ -41,7 +42,8 @@ func NewController(
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &c.catacomb,
 		Work: c.makeLoop(admissionCreator,
-			admissionHandler(logger, rbacMapper), logger, mux, path),
+			admissionHandler(logger, rbacMapper, legacyLabels),
+			logger, mux, path),
 	}); err != nil {
 		return c, errors.Trace(err)
 	}

--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -182,7 +182,7 @@ func patchForLabels(
 	legacyLabels bool) []patchOperation {
 	patches := []patchOperation{}
 
-	neededLabels := provider.LabelsForApp(appName, legacyLabels)
+	neededLabels := provider.LabelForKeyValue(provider.LabelJujuAppCreatedBy, appName)
 
 	if len(labels) == 0 {
 		patches = append(patches, patchOperation{

--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -171,9 +171,8 @@ func errToAdmissionResponse(err error) *admission.AdmissionResponse {
 }
 
 func patchEscape(s string) string {
-	r := strings.Replace(s, "/", "~1", -1)
-	r = strings.Replace(r, "~", "~0", -1)
-	return r
+	r := strings.Replace(s, "~", "~0", -1)
+	return strings.Replace(r, "/", "~1", -1)
 }
 
 func patchForLabels(

--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -50,7 +50,7 @@ var (
 	}
 )
 
-func admissionHandler(logger Logger, rbacMapper RBACMapper) http.Handler {
+func admissionHandler(logger Logger, rbacMapper RBACMapper, legacyLabels bool) http.Handler {
 	codecFactory := serializer.NewCodecFactory(runtime.NewScheme())
 
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -139,7 +139,7 @@ func admissionHandler(logger Logger, rbacMapper RBACMapper) http.Handler {
 		}
 
 		patchJSON, err := json.Marshal(
-			patchForLabels(metaObj.Labels, appName))
+			patchForLabels(metaObj.Labels, appName, legacyLabels))
 		if err != nil {
 			http.Error(res,
 				fmt.Sprintf("marshalling patch object to json: %v", err),
@@ -176,10 +176,13 @@ func patchEscape(s string) string {
 	return r
 }
 
-func patchForLabels(labels map[string]string, appName string) []patchOperation {
+func patchForLabels(
+	labels map[string]string,
+	appName string,
+	legacyLabels bool) []patchOperation {
 	patches := []patchOperation{}
 
-	neededLabels := provider.LabelsForApp(appName)
+	neededLabels := provider.LabelsForApp(appName, legacyLabels)
 
 	if len(labels) == 0 {
 		patches = append(patches, patchOperation{

--- a/worker/caasadmission/manifold.go
+++ b/worker/caasadmission/manifold.go
@@ -32,6 +32,10 @@ type K8sBroker interface {
 	// when called and a subsequent error if there was a problem. If error is
 	// not nil then no other return values should be considered valid.
 	EnsureMutatingWebhookConfiguration(*admission.MutatingWebhookConfiguration) (func(), error)
+
+	// IsLegacyLabels reports if the k8s broker requires legacy labels to be
+	// used for the broker model/namespace
+	IsLegacyLabels() bool
 }
 
 // Logger represents the methods used by the worker to log details
@@ -124,6 +128,7 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 	admissionPath := AdmissionPathForModel(currentConfig.Model().Id())
 	admissionCreator, err := NewAdmissionCreator(authority,
 		broker.GetCurrentNamespace(), broker.CurrentModel(),
+		broker.IsLegacyLabels(),
 		broker.EnsureMutatingWebhookConfiguration,
 		&admission.ServiceReference{
 			Name:      c.ServiceName,
@@ -140,6 +145,7 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 		c.Logger,
 		mux,
 		AdmissionPathForModel(currentConfig.Model().Id()),
+		broker.IsLegacyLabels(),
 		admissionCreator,
 		rbacMapper)
 }


### PR DESCRIPTION
Juju now adopts more idiomatic way of adding Kubernetes labels as per
k8s docs
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

We are adopting k8s standard labels and also adding juju.is labels such
as model.juju.is/name

This change will not retroactively change labels for existing models

## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

*Please replace with a description about why this change is needed, along with a description of what changed?*

## QA steps

*Please replace with how we can verify that the change works?*

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow? CLI? API?*

## Bug reference

*Please add a link to any bugs that this change is related to.*
