### PR TITLE
Target latest mongo

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -32,7 +32,9 @@ jobs:
       if: (matrix.os == 'ubuntu-latest')
       run: |
         # Remove the default mongo
-        sudo rm /etc/apt/sources.list.d/mongodb-org-4.2.list
+        for version in "4.2" "4.4"; do
+          sudo rm "/etc/apt/sources.list.d/mongodb-org-${version}.list" || true
+        done
         sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y mongodb-org
         sudo DEBIAN_FRONTEND=noninteractive apt autoremove
         sudo rm -rf /usr/bin/mongo* || true


### PR DESCRIPTION
## Description of change

The client tests rely on a certain mongo installed for github.
Unfortunately, github actions install their own default. We can't have
that, as we require what's packaged with the apt cache for the OS (there
is better verbiage for that statement!).

Anyway, we brute force our way through the mongo versions and 
remove them from the source list. The code is terrible and annoying at 
the same time. 

I'm still unsure how we requested ubuntu and we ended up with a
bunch of software on it that I didn't ask for!

## QA steps

github actions client tests pass!
