### PR TITLE
Unique Identification of NICs in Network Config Updates

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -236,20 +236,20 @@ func (o *MachineLinkLayerOp) AssertAliveOp() txn.Op {
 // MarkDevProcessed indicates that the input hardware address was present in
 // the incoming data and its updates have been handled by the build step.
 func (o *MachineLinkLayerOp) MarkDevProcessed(name, hwAddr string) {
-	o.processedDevs.Add(name + hwAddr)
+	o.processedDevs.Add(deviceKey(name, hwAddr))
 }
 
 // IsDevProcessed returns a boolean indicating whether the input incoming
 // device matches a known device that was marked as processed by the method
 // above.
 func (o *MachineLinkLayerOp) IsDevProcessed(dev network.InterfaceInfo) bool {
-	return o.processedDevs.Contains(dev.InterfaceName + dev.MACAddress)
+	return o.processedDevs.Contains(deviceKey(dev.InterfaceName, dev.MACAddress))
 }
 
 // MarkAddrProcessed indicates that the input (known) IP address was present in
 // the incoming data for the device with input hardware address.
 func (o *MachineLinkLayerOp) MarkAddrProcessed(name, hwAddr, ipAddr string) {
-	key := name + hwAddr
+	key := deviceKey(name, hwAddr)
 
 	if _, ok := o.processedAddrs[key]; !ok {
 		o.processedAddrs[key] = set.NewStrings(ipAddr)
@@ -262,7 +262,7 @@ func (o *MachineLinkLayerOp) MarkAddrProcessed(name, hwAddr, ipAddr string) {
 // device/address pair matches an entry that was marked as processed by the
 // method above.
 func (o *MachineLinkLayerOp) IsAddrProcessed(name, hwAddr, ipAddr string) bool {
-	if addrs, ok := o.processedAddrs[name+hwAddr]; ok {
+	if addrs, ok := o.processedAddrs[deviceKey(name, hwAddr)]; ok {
 		return addrs.Contains(ipAddr)
 	}
 	return false
@@ -271,4 +271,8 @@ func (o *MachineLinkLayerOp) IsAddrProcessed(name, hwAddr, ipAddr string) bool {
 // Done (state.ModelOperation) returns the result of running the operation.
 func (o *MachineLinkLayerOp) Done(err error) error {
 	return err
+}
+
+func deviceKey(name, hwAddr string) string {
+	return name + hwAddr
 }

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -212,7 +212,6 @@ func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.Inte
 // It would embed ProviderAddress and could be obtained directly via a method
 // or property of InterfaceInfos.
 func (o *MachineLinkLayerOp) MatchingIncomingAddrs(name, hwAddress string) []state.LinkLayerDeviceAddress {
-	logger.Criticalf("%+v", o.incoming)
 	return networkAddressStateArgsForDevice(o.Incoming(), name, hwAddress)
 }
 

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -132,8 +132,8 @@ type MachineLinkLayerOp struct {
 	// incoming is the network interface information supplied for update.
 	incoming network.InterfaceInfos
 
-	// processedDevs is the set of hardware IDs that we have
-	// processed from the incoming interfaces.
+	// processedDevs is the set of name and hardware ID combinations
+	// that we have processed from the incoming interfaces.
 	processedDevs set.Strings
 
 	// processedAddrs is the set of IP addresses that we have processed,
@@ -192,24 +192,25 @@ func (o *MachineLinkLayerOp) PopulateExistingAddresses() error {
 	return errors.Trace(err)
 }
 
-// MatchingIncoming returns the first incoming interface that
-// matches the input known device, based on hardware address.
+// MatchingIncoming returns the first incoming interface that matches
+// the input known device, based on name and hardware address.
 // Nil is returned if there is no match.
 func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.InterfaceInfo {
-	if matches := o.incoming.GetByHardwareAddress(dev.MACAddress()); len(matches) > 0 {
+	if matches := o.incoming.GetByNameAndHardwareAddress(dev.Name(), dev.MACAddress()); len(matches) > 0 {
 		return &matches[0]
 	}
 	return nil
 }
 
 // MatchingIncomingAddrs finds all the primary addresses on devices matching
-// the input hardware address, and returns them as state args.
+// the input name and hardware address, and returns them as state args.
 // TODO (manadart 2020-07-15): We should investigate making an enhanced
 // core/network address type instead of this state type.
 // It would embed ProviderAddress and could be obtained directly via a method
 // or property of InterfaceInfos.
-func (o *MachineLinkLayerOp) MatchingIncomingAddrs(hwAddress string) []state.LinkLayerDeviceAddress {
-	return networkAddressStateArgsForHWAddr(o.Incoming(), hwAddress)
+func (o *MachineLinkLayerOp) MatchingIncomingAddrs(name, hwAddress string) []state.LinkLayerDeviceAddress {
+	logger.Criticalf("%+v", o.incoming)
+	return networkAddressStateArgsForDevice(o.Incoming(), name, hwAddress)
 }
 
 // DeviceAddresses returns all currently known
@@ -232,32 +233,34 @@ func (o *MachineLinkLayerOp) AssertAliveOp() txn.Op {
 
 // MarkDevProcessed indicates that the input hardware address was present in
 // the incoming data and its updates have been handled by the build step.
-func (o *MachineLinkLayerOp) MarkDevProcessed(hwAddr string) {
-	o.processedDevs.Add(hwAddr)
+func (o *MachineLinkLayerOp) MarkDevProcessed(name, hwAddr string) {
+	o.processedDevs.Add(name + hwAddr)
 }
 
 // IsDevProcessed returns a boolean indicating whether the input incoming
 // device matches a known device that was marked as processed by the method
 // above.
 func (o *MachineLinkLayerOp) IsDevProcessed(dev network.InterfaceInfo) bool {
-	return o.processedDevs.Contains(dev.MACAddress)
+	return o.processedDevs.Contains(dev.InterfaceName + dev.MACAddress)
 }
 
 // MarkAddrProcessed indicates that the input (known) IP address was present in
 // the incoming data for the device with input hardware address.
-func (o *MachineLinkLayerOp) MarkAddrProcessed(hwAddr, ipAddr string) {
-	if _, ok := o.processedAddrs[hwAddr]; !ok {
-		o.processedAddrs[hwAddr] = set.NewStrings(ipAddr)
+func (o *MachineLinkLayerOp) MarkAddrProcessed(name, hwAddr, ipAddr string) {
+	key := name + hwAddr
+
+	if _, ok := o.processedAddrs[key]; !ok {
+		o.processedAddrs[key] = set.NewStrings(ipAddr)
 	} else {
-		o.processedAddrs[hwAddr].Add(ipAddr)
+		o.processedAddrs[key].Add(ipAddr)
 	}
 }
 
 // IsAddrProcessed returns a boolean indicating whether the input incoming
 // device/address pair matches an entry that was marked as processed by the
 // method above.
-func (o *MachineLinkLayerOp) IsAddrProcessed(hwAddr, ipAddr string) bool {
-	if addrs, ok := o.processedAddrs[hwAddr]; ok {
+func (o *MachineLinkLayerOp) IsAddrProcessed(name, hwAddr, ipAddr string) bool {
+	if addrs, ok := o.processedAddrs[name+hwAddr]; ok {
 		return addrs.Contains(ipAddr)
 	}
 	return false

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -23,6 +23,9 @@ type LinkLayerDevice interface {
 	// ProviderID returns the provider-specific identifier for this device.
 	ProviderID() network.Id
 
+	// Type returns the device's type.
+	Type() network.LinkLayerDeviceType
+
 	// SetProviderIDOps returns the operations required to set the input
 	// provider ID for the link-layer device.
 	SetProviderIDOps(id network.Id) ([]txn.Op, error)

--- a/apiserver/common/networkingcommon/mocks/package_mock.go
+++ b/apiserver/common/networkingcommon/mocks/package_mock.go
@@ -366,6 +366,20 @@ func (mr *MockLinkLayerDeviceMockRecorder) SetProviderIDOps(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProviderIDOps", reflect.TypeOf((*MockLinkLayerDevice)(nil).SetProviderIDOps), arg0)
 }
 
+// Type mocks base method
+func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(network.LinkLayerDeviceType)
+	return ret0
+}
+
+// Type indicates an expected call of Type
+func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
+}
+
 // UpdateOps mocks base method
 func (m *MockLinkLayerDevice) UpdateOps(arg0 state.LinkLayerDeviceArgs) []txn.Op {
 	m.ctrl.T.Helper()

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -179,7 +179,7 @@ func NetworkInterfacesToStateArgs(devs corenetwork.InterfaceInfos) (
 		}
 		addr, err := networkAddressToStateArgs(dev, dev.PrimaryAddress())
 		if err != nil {
-			logger.Warningf("ignoring address for device %q: %v", dev.InterfaceName, err)
+			logger.Warningf("ignoring address for device %+v: %v", dev, err)
 			continue
 		}
 
@@ -209,22 +209,24 @@ func networkDeviceToStateArgs(dev corenetwork.InterfaceInfo) state.LinkLayerDevi
 	}
 }
 
-// networkAddressStateArgsForHWAddr accommodates the fact that network
+// networkAddressStateArgsForDevice accommodates the fact that network
 // configuration is sometimes supplied with a duplicated device for each
 // address.
 // This is a normalisation that returns state args for all primary addresses
-// of interfaces with the input hardware address.
-func networkAddressStateArgsForHWAddr(devs corenetwork.InterfaceInfos, hwAddr string) []state.LinkLayerDeviceAddress {
+// of interfaces with the input name and hardware address.
+func networkAddressStateArgsForDevice(
+	devs corenetwork.InterfaceInfos, name, hwAddr string,
+) []state.LinkLayerDeviceAddress {
 	var res []state.LinkLayerDeviceAddress
 
-	for _, dev := range devs.GetByHardwareAddress(hwAddr) {
+	for _, dev := range devs.GetByNameAndHardwareAddress(name, hwAddr) {
 		if dev.PrimaryAddress().Value == "" {
 			continue
 		}
 
 		addr, err := networkAddressToStateArgs(dev, dev.PrimaryAddress())
 		if err != nil {
-			logger.Warningf("ignoring address for device %q: %v", dev.InterfaceName, err)
+			logger.Warningf("ignoring address for device %+v: %v", dev, err)
 			continue
 		}
 		res = append(res, addr)

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -125,7 +125,9 @@ func (a *InstancePollerAPI) getOneMachine(tag string, canAccess common.AuthFunc)
 // network, subnet or address IDs), this method will also iterate any present
 // link layer devices (and their addresses) and merge in any missing
 // provider-specific information.
-func (a *InstancePollerAPI) SetProviderNetworkConfig(req params.SetProviderNetworkConfig) (params.SetProviderNetworkConfigResults, error) {
+func (a *InstancePollerAPI) SetProviderNetworkConfig(
+	req params.SetProviderNetworkConfig,
+) (params.SetProviderNetworkConfigResults, error) {
 	result := params.SetProviderNetworkConfigResults{
 		Results: make([]params.SetProviderNetworkConfigResult, len(req.Args)),
 	}
@@ -196,7 +198,9 @@ func (a *InstancePollerAPI) mergeLinkLayer(m StateMachine, devs network.Interfac
 // configuration parameters, extracts all usable private/shadow IP addresses,
 // attempts to resolve each one to a known space and returns back a list of
 // scoped, space-aware ProviderAddresses.
-func mapNetworkConfigsToProviderAddresses(cfgs []params.NetworkConfig, spaceInfos network.SpaceInfos) (network.ProviderAddresses, error) {
+func mapNetworkConfigsToProviderAddresses(
+	cfgs []params.NetworkConfig, spaceInfos network.SpaceInfos,
+) (network.ProviderAddresses, error) {
 	addrs := make(network.ProviderAddresses, 0, len(cfgs))
 
 	alphaSpaceInfo := spaceInfos.GetByID(network.AlphaSpaceId)
@@ -249,7 +253,9 @@ func mapNetworkConfigsToProviderAddresses(cfgs []params.NetworkConfig, spaceInfo
 	return addrs, nil
 }
 
-func spaceInfoForAddress(spaceInfos network.SpaceInfos, CIDR, providerSubnetID, addr string) (*network.SpaceInfo, error) {
+func spaceInfoForAddress(
+	spaceInfos network.SpaceInfos, CIDR, providerSubnetID, addr string,
+) (*network.SpaceInfo, error) {
 	if CIDR != "" {
 		return spaceInfos.InferSpaceFromCIDRAndSubnetID(CIDR, providerSubnetID)
 	}

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -6,6 +6,7 @@ package instancepoller
 import (
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn"
 	"gopkg.in/mgo.v2/txn"
@@ -20,13 +21,18 @@ import (
 // machine/host/container.
 type mergeMachineLinkLayerOp struct {
 	*networkingcommon.MachineLinkLayerOp
+
+	// namelessHWAddrs stores the hardware addresses of
+	// incoming devices that have no accompanying name.
+	namelessHWAddrs set.Strings
 }
 
 func newMergeMachineLinkLayerOp(
 	machine networkingcommon.LinkLayerMachine, incoming network.InterfaceInfos,
 ) *mergeMachineLinkLayerOp {
 	return &mergeMachineLinkLayerOp{
-		networkingcommon.NewMachineLinkLayerOp(machine, incoming),
+		MachineLinkLayerOp: networkingcommon.NewMachineLinkLayerOp(machine, incoming),
+		namelessHWAddrs:    set.NewStrings(),
 	}
 }
 
@@ -40,11 +46,13 @@ func (o *mergeMachineLinkLayerOp) Build(_ int) ([]txn.Op, error) {
 	// If the machine agent has not yet populated any link-layer devices,
 	// then we do nothing here. We have already set addresses directly on the
 	// machine document, so the incoming provider-sourced addresses are usable.
-	// For now we ensure that the instance poller only adds device information
+	// For now we ensure that the instance-poller only adds device information
 	// that the machine agent is unaware of.
 	if len(o.ExistingDevices()) == 0 {
 		return nil, jujutxn.ErrNoOperations
 	}
+
+	o.normaliseIncoming()
 
 	if err := o.PopulateExistingAddresses(); err != nil {
 		return nil, errors.Trace(err)
@@ -67,19 +75,70 @@ func (o *mergeMachineLinkLayerOp) Build(_ int) ([]txn.Op, error) {
 	return ops, nil
 }
 
+// normaliseIncoming is intended accommodate providers such as EC2
+// that know device hardware addresses, but not device names.
+// We populate names on the incoming data based on
+// matching existing devices by hardware address.
+// If we locate multiple existing devices with the hardware address,
+// such as will be the case for bridged NICs, fallback through the
+// following options.
+// - If there is a device that already has a provider ID, use that name.
+// - If the devices are of different types, choose an ethernet device over
+//   a bridge (as observed for MAAS).
+func (o *mergeMachineLinkLayerOp) normaliseIncoming() {
+	incoming := o.Incoming()
+
+	// If the incoming devices have names, no action is required
+	// (assuming all or none here).
+	if len(incoming) > 0 && incoming[0].InterfaceName != "" {
+		return
+	}
+
+	// First get the best device per hardware address.
+	devByHWAddr := map[string]networkingcommon.LinkLayerDevice{}
+	for _, dev := range o.ExistingDevices() {
+		hwAddr := dev.MACAddress()
+
+		current, ok := devByHWAddr[hwAddr]
+		if !ok {
+			devByHWAddr[hwAddr] = dev
+			continue
+		}
+
+		if current.ProviderID() != "" {
+			continue
+		}
+
+		if dev.Type() == network.EthernetDevice {
+			devByHWAddr[hwAddr] = dev
+		}
+	}
+
+	// Now set the names.
+	for i, dev := range incoming {
+		if existing, ok := devByHWAddr[dev.MACAddress]; ok && dev.InterfaceName == "" {
+			o.namelessHWAddrs.Add(dev.MACAddress)
+			incoming[i].InterfaceName = existing.Name()
+		}
+	}
+}
+
 func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.LinkLayerDevice) ([]txn.Op, error) {
-	// Match the incoming device by hardware address in order to
-	// identify addresses by device name.
-	// Not all providers (such as AWS) have names for NIC devices.
 	incomingDev := o.MatchingIncoming(dev)
 
 	var ops []txn.Op
 	var err error
 
-	// If this device was not observed by the provider,
-	// ensure that responsibility for the addresses is relinquished
-	// to the machine agent.
+	// If this device was not observed by the provider *and* it is identified
+	// by both name and hardware address, ensure that responsibility for the
+	// addresses is relinquished to the machine agent.
 	if incomingDev == nil {
+		// If this device matches an incoming hardware address that we gave a
+		// surrogate name to, do not relinquish it.
+		if o.namelessHWAddrs.Contains(dev.MACAddress()) {
+			return nil, nil
+		}
+
 		ops, err = o.opsForDeviceOriginRelinquishment(dev)
 		return ops, errors.Trace(err)
 	}
@@ -104,7 +163,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// TODO (manadart 2020-07-15): We also need to set shadow addresses.
 	// These are sent where appropriate by the provider,
 	// but we do not yet process them.
-	incomingAddrs := o.MatchingIncomingAddrs(dev.MACAddress())
+	incomingAddrs := o.MatchingIncomingAddrs(dev.Name(), dev.MACAddress())
 
 	for _, addr := range o.DeviceAddresses(dev) {
 		addrOps, err := o.processExistingDeviceAddress(dev, addr, incomingAddrs)
@@ -116,7 +175,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 
 	// TODO (manadart 2020-07-15): Process (log) new addresses on the device.
 
-	o.MarkDevProcessed(dev.MACAddress())
+	o.MarkDevProcessed(dev.Name(), dev.MACAddress())
 	return ops, nil
 }
 
@@ -145,12 +204,13 @@ func (o *mergeMachineLinkLayerOp) processExistingDeviceAddress(
 ) ([]txn.Op, error) {
 	addrValue := addr.Value()
 	hwAddr := dev.MACAddress()
+	name := dev.Name()
 
 	// If one of the incoming addresses matches the existing one,
 	// return ops for setting the incoming provider IDs.
 	for _, incomingAddr := range incomingAddrs {
 		if strings.HasPrefix(incomingAddr.CIDRAddress, addrValue) {
-			if o.IsAddrProcessed(hwAddr, addrValue) {
+			if o.IsAddrProcessed(name, hwAddr, addrValue) {
 				continue
 			}
 
@@ -159,7 +219,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDeviceAddress(
 				return nil, errors.Trace(err)
 			}
 
-			o.MarkAddrProcessed(hwAddr, addrValue)
+			o.MarkAddrProcessed(name, hwAddr, addrValue)
 
 			return append(ops, addr.SetProviderNetIDsOps(
 				incomingAddr.ProviderNetworkID, incomingAddr.ProviderSubnetID)...), nil

--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -234,7 +234,7 @@ func combinedCloudInitData(
 }
 
 // proxyConfigurationFromContainerCfg populates a ProxyConfiguration object
-// from an ContenerConfig API response.
+// from an ContainerConfig API response.
 func proxyConfigurationFromContainerCfg(cfg params.ContainerConfig) instancecfg.ProxyConfiguration {
 	return instancecfg.ProxyConfiguration{
 		Legacy:              cfg.LegacyProxy,

--- a/container/broker/instance_broker.go
+++ b/container/broker/instance_broker.go
@@ -117,7 +117,7 @@ func prepareHost(config Config) PrepareHostFunc {
 			MachineTag:         config.MachineTag,
 			Logger:             log,
 		})
-		return preparer.Prepare(containerTag)
+		return errors.Trace(preparer.Prepare(containerTag))
 	}
 }
 

--- a/container/broker/lxd-broker.go
+++ b/container/broker/lxd-broker.go
@@ -65,8 +65,7 @@ func (broker *lxdBroker) StartInstance(ctx context.ProviderCallContext, args env
 		return nil, err
 	}
 
-	err = broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger, args.Abort)
-	if err != nil {
+	if err := broker.prepareHost(names.NewMachineTag(containerMachineID), lxdLogger, args.Abort); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -266,12 +266,16 @@ func (s InterfaceInfos) Validate() error {
 	return nil
 }
 
-// GetByHardwareAddress returns a new collection containing any interfaces
-// with the input hardware (MAC) address.
-func (s InterfaceInfos) GetByHardwareAddress(hwAddr string) InterfaceInfos {
+// GetByNameAndHardwareAddress returns a new collection containing any
+// interfaces with the input device name and hardware (MAC) address.
+// This is intended to uniquely identify devices, accommodating the following
+// knowledge:
+// - Bridges have the same MAC address as their child devices.
+// - AWS does not supply device names, but does supply HW address.
+func (s InterfaceInfos) GetByNameAndHardwareAddress(name, hwAddr string) InterfaceInfos {
 	var res InterfaceInfos
 	for _, dev := range s {
-		if dev.MACAddress == hwAddr {
+		if dev.InterfaceName == name && dev.MACAddress == hwAddr {
 			res = append(res, dev)
 		}
 	}

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -130,17 +130,23 @@ func (*nicSuite) TestInterfaceInfosValidate(c *gc.C) {
 	c.Check(getInterFaceInfos().Validate(), jc.ErrorIsNil)
 }
 
-func (s *nicSuite) TestInterfaceInfosGetByHardwareAddress(c *gc.C) {
-	devs := s.info.GetByHardwareAddress("not-there")
-	c.Assert(devs, gc.IsNil)
-
+func (s *nicSuite) TestInterfaceInfosGetByNameAndHardwareAddress(c *gc.C) {
+	name := "eth0"
 	hwAddr := "00:16:3e:aa:bb:cc"
 
-	devs = s.info.GetByHardwareAddress(hwAddr)
-	c.Assert(devs, gc.HasLen, 1)
-	c.Assert(devs[0].InterfaceName, gc.Equals, "eth0")
+	devs := s.info.GetByNameAndHardwareAddress("wrong-name", hwAddr)
+	c.Assert(devs, gc.IsNil)
 
-	devs = append(s.info, network.InterfaceInfo{MACAddress: hwAddr}).GetByHardwareAddress(hwAddr)
+	devs = s.info.GetByNameAndHardwareAddress(name, "wrong-MAC")
+	c.Assert(devs, gc.IsNil)
+
+	devs = s.info.GetByNameAndHardwareAddress(name, hwAddr)
+	c.Assert(devs, gc.HasLen, 1)
+
+	devs = append(s.info, network.InterfaceInfo{
+		InterfaceName: name,
+		MACAddress:    hwAddr,
+	}).GetByNameAndHardwareAddress(name, hwAddr)
 	c.Assert(devs, gc.HasLen, 2)
 }
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1306,6 +1306,7 @@ func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, 
 }
 
 func mapNetworkInterface(iface ec2.NetworkInterface, subnet ec2.Subnet) corenetwork.InterfaceInfo {
+	// Device names and VLAN tags are not returned by EC2.
 	ni := corenetwork.InterfaceInfo{
 		DeviceIndex:       iface.Attachment.DeviceIndex,
 		MACAddress:        iface.MACAddress,
@@ -1313,13 +1314,10 @@ func mapNetworkInterface(iface ec2.NetworkInterface, subnet ec2.Subnet) corenetw
 		ProviderId:        corenetwork.Id(iface.Id),
 		ProviderSubnetId:  corenetwork.Id(iface.SubnetId),
 		AvailabilityZones: []string{subnet.AvailZone},
-		VLANTag:           0, // Not supported on EC2.
-		// Getting the interface name is not supported on EC2, so fake it.
-		InterfaceName: fmt.Sprintf("unsupported%d", iface.Attachment.DeviceIndex),
-		Disabled:      false,
-		NoAutoStart:   false,
-		ConfigType:    corenetwork.ConfigDHCP,
-		InterfaceType: corenetwork.EthernetInterface,
+		Disabled:          false,
+		NoAutoStart:       false,
+		ConfigType:        corenetwork.ConfigDHCP,
+		InterfaceType:     corenetwork.EthernetInterface,
 		// The describe interface responses that we get back from EC2
 		// define a *list* of private IP addresses with one entry that
 		// is tagged as primary and whose value is encoded in the

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1707,7 +1707,6 @@ func (t *localServerSuite) assertInterfaceLooksValid(c *gc.C, expIfaceID, expDev
 		ProviderId:       corenetwork.Id(fmt.Sprintf("eni-%d", expIfaceID)),
 		ProviderSubnetId: subnetId,
 		VLANTag:          0,
-		InterfaceName:    "unsupported0",
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       corenetwork.ConfigDHCP,

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1088,11 +1088,11 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 		if !ok || subnet.CidrBlock == nil {
 			continue
 		}
+		// Provider does not support interface names.
 		nic := corenetwork.InterfaceInfo{
-			InterfaceName: fmt.Sprintf("unsupported%d", iface.Idx),
-			DeviceIndex:   iface.Idx,
-			ProviderId:    corenetwork.Id(*iface.Vnic.Id),
-			MACAddress:    *iface.Vnic.MacAddress,
+			DeviceIndex: iface.Idx,
+			ProviderId:  corenetwork.Id(*iface.Vnic.Id),
+			MACAddress:  *iface.Vnic.MacAddress,
 			Addresses: corenetwork.ProviderAddresses{
 				corenetwork.NewScopedProviderAddress(
 					*iface.Vnic.PrivateIp,

--- a/provider/oci/networking_test.go
+++ b/provider/oci/networking_test.go
@@ -245,7 +245,6 @@ func (n *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 	c.Assert(info, gc.HasLen, 1)
 	c.Assert(info[0].Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{corenetwork.NewScopedProviderAddress("1.1.1.1", corenetwork.ScopeCloudLocal)})
 	c.Assert(info[0].ShadowAddresses, gc.DeepEquals, corenetwork.ProviderAddresses{corenetwork.NewScopedProviderAddress("2.2.2.2", corenetwork.ScopePublic)})
-	c.Assert(info[0].InterfaceName, gc.Equals, "unsupported0")
 	c.Assert(info[0].DeviceIndex, gc.Equals, 0)
 	c.Assert(info[0].ProviderId, gc.Equals, corenetwork.Id(vnicID))
 	c.Assert(info[0].MACAddress, gc.Equals, "aa:aa:aa:aa:aa:aa")


### PR DESCRIPTION
## Description of change

This patch is intended to fix failures in the _nw-network-health-maas-2-3_ acceptance test.

Those failures are caused by device matching on hardware (MAC) address when updating link-layer devices, which was originally intended to accommodate the fact that the EC2 and OCI providers do not know interface names.

The following logic changes affect the fix:
- The EC2 and OCI providers no longer supply interfaces with a contrived name "unsupported{index}" - we work on the basis of an empty name.
- `InterfaceInfos` filtering by hardware address and link-layer processing is now handled on the basis of device name *plus* device hardware address.
- The instance-poller now attempts to update empty names on incoming data if there are hardware address matches with known NICs. It chooses a name based on a simple policy for non-unique matches, preferring devices with an existing provider ID first, falling back to _ethernet_ devices over bridges and other types.

## QA steps

For the reviewer, the efficacy of the change can be verified by shuttling to the _finfolk_ MAAS and deploying the _network-health-2-machines-bind_ test bundle successfully.

It is acknowledged that this area of Juju needs further refinement, but based on the following comparison of behaviour between the current stable 2.7 release and this patch, the changes look OK to release.

The scenarios are container-in-machine deployments for MAAS and AWS. Differences in device/address decoration are a result of changes to instance-poller logic, but also the fact that we no longer generate and set a static container network configuration prior to container creation. Instead we let container machine agents update the observed network configuration.

### MAAS and Juju 2.7

- Ethernet devices have provider IDs; bridges and container NICs do not.
- Ethernet addresses have provider IDs and provider subnet IDs.
- Bridge addresses have provider subnet IDs.
- Container NIC addresses have provider IDs, but not provider subnet IDs.

```
juju:PRIMARY> db.linklayerdevices.find().pretty()
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#ens4",
        "name" : "ens4",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "mtu" : 1500,
        "providerid" : "14",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:5b:62:5c",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d13dc1009d90f061f69ae_1bfa02cb",
                "5f3d13dd1009d90f061f6a01_3d9de4a4"
        ]
}
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#ens5",
        "name" : "ens5",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "mtu" : 1500,
        "providerid" : "18",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:2d:fc:e8",
        "is-auto-start" : false,
        "is-up" : false,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d13dd1009d90f061f6a02_a83425dd"
        ]
}
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#ens3",
        "name" : "ens3",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "mtu" : 1500,
        "providerid" : "19",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:ed:03:6b",
        "is-auto-start" : false,
        "is-up" : false,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d13dd1009d90f061f6a02_a83425dd"
        ]
}
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d13dd1009d90f061f6a02_a83425dd",
                "5f3d13dd1009d90f061f6a03_9370c420"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#eth1",
        "name" : "eth1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 1500,
        "providerid" : "15",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:e9:8f:15",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "br-eth1",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d15e51009d90f061f72e4_d8e1798c"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 1500,
        "providerid" : "24",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:ba:14:14",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d15c91009d90f061f718f_9c976280"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#eth2",
        "name" : "eth2",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 1500,
        "providerid" : "23",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:ff:af:21",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d15c91009d90f061f718f_9c976280"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15c91009d90f061f718f_9c976280",
                "5f3d15c91009d90f061f7190_f9e580e5"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#lxdbr0",
        "name" : "lxdbr0",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "f2:04:15:92:3d:b2",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15d31009d90f061f71db_2fc10292",
                "5f3d15d31009d90f061f71dc_265b6a38"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#br-eth1",
        "name" : "br-eth1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "ea:fa:f9:8a:d1:db",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15e51009d90f061f72e6_c6a16943",
                "5f3d15e61009d90f061f72e7_4d7166cb",
                "5f3d162f1009d90f061f7687_6e4b7a4c"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0/lxd/0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 1500,
        "machine-id" : "0/lxd/0",
        "type" : "ethernet",
        "mac-address" : "00:16:3e:76:97:34",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d162f1009d90f061f7687_6e4b7a4c",
                "5f3d162f1009d90f061f7688_1d1b39f8"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0/lxd/0#d#lo",
        "name" : "lo",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "mtu" : 65536,
        "machine-id" : "0/lxd/0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d162f1009d90f061f7687_6e4b7a4c",
                "5f3d162f1009d90f061f7688_1d1b39f8"
        ]
}
```
```
juju:PRIMARY> db["ip.addresses"].find().pretty()
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#ens4#ip#10.0.30.73",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "providerid" : "96836",
        "provider-subnet-id" : "1",
        "device-name" : "ens4",
        "machine-id" : "0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.73",
        "dns-search-domains" : [
                "maas"
        ],
        "gateway-address" : "10.0.30.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d13dd1009d90f061f6a01_3d9de4a4"
        ]
}
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d13dd1009d90f061f6a03_9370c420"
        ]
}
{
        "_id" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b:m#0#d#lo#ip#::1",
        "model-uuid" : "fafa3fa6-cd27-46c9-8c73-43fd5821c64b",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d13dd1009d90f061f6a03_9370c420"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15c91009d90f061f7190_f9e580e5"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#lo#ip#::1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15c91009d90f061f7190_f9e580e5"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#eth1#ip#10.0.30.80",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "providerid" : "75169",
        "provider-subnet-id" : "1",
        "device-name" : "eth1",
        "machine-id" : "0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.80",
        "dns-search-domains" : [
                "maas"
        ],
        "gateway-address" : "10.0.30.1",
        "is-default-gateway" : true,
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15c91009d90f061f7190_f9e580e5"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#lxdbr0#ip#10.180.171.1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "device-name" : "lxdbr0",
        "machine-id" : "0",
        "subnet-cidr" : "10.180.171.0/24",
        "config-method" : "static",
        "value" : "10.180.171.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15d31009d90f061f71dc_265b6a38"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0#d#br-eth1#ip#10.0.30.80",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "provider-subnet-id" : "1",
        "device-name" : "br-eth1",
        "machine-id" : "0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.80",
        "dns-search-domains" : [
                "maas"
        ],
        "gateway-address" : "10.0.30.1",
        "is-default-gateway" : true,
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d15e51009d90f061f72e6_c6a16943"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0/lxd/0#d#eth0#ip#10.0.30.86",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "providerid" : "141253",
        "provider-subnet-id" : "",
        "device-name" : "eth0",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.86",
        "gateway-address" : "10.0.30.1",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d162f1009d90f061f7688_1d1b39f8"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0/lxd/0#d#lo#ip#127.0.0.1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d162f1009d90f061f7688_1d1b39f8"
        ]
}
{
        "_id" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437:m#0/lxd/0#d#lo#ip#::1",
        "model-uuid" : "7b6e7ee9-eb11-4f7c-8e91-7845d831d437",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d162f1009d90f061f7688_1d1b39f8"
        ]
}
```

### MAAS and This Patch

- Bridge addresses no longer have provider subnet IDs, but the IP is duplicated on NIC and bridge (as before), with NIC in possession of the IDs. This should not affect any known functionality. A future enhancement might involve some hierarchy walking in the instance-poller to place IPs/IDs correctly.
- Container NIC addresses no longer have provider IDs. Now that we let containers update their own interface config, instead of setting it before creation, we should ask the provider about container instances when they support container addresses. MAAS knows the instance ID of containers, and the assigned addresses.

```
juju:PRIMARY> db.linklayerdevices.find().pretty()
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d219d7e2be50f8208522c_b675e47c"
        ]
}
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:7b:0c:5b",
        "is-auto-start" : false,
        "is-up" : false,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d21aa7e2be50f82085751_906ca9e6"
        ],
        "providerid" : "27"
}
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#eth1",
        "name" : "eth1",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:f2:a8:ce",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d21aa7e2be50f82085751_906ca9e6"
        ],
        "providerid" : "16"
}
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#eth2",
        "name" : "eth2",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:99:4f:50",
        "is-auto-start" : false,
        "is-up" : false,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d21aa7e2be50f82085751_906ca9e6"
        ],
        "providerid" : "26"
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#eth1",
        "name" : "eth1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "providerid" : "17",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:27:2d:79",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "br-eth1",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d23e37e2be50f82085bf3_71b0c827"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "providerid" : "37",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:12:7a:d5",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d23cd7e2be50f82085a14_42c2f009"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#eth2",
        "name" : "eth2",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "providerid" : "36",
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "52:54:00:62:f0:80",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d23cd7e2be50f82085a14_42c2f009"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#eth2.465",
        "name" : "eth2.465",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "providerid" : "17837",
        "machine-id" : "0",
        "type" : "802.1q",
        "mac-address" : "52:54:00:62:f0:80",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d23cd7e2be50f82085a14_42c2f009"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d23cd7e2be50f82085a14_42c2f009"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#lxdbr0",
        "name" : "lxdbr0",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "ca:97:68:26:9a:90",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d23d77e2be50f82085b84_d3b7caf1"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#br-eth1",
        "name" : "br-eth1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "a2:e0:5e:41:dc:9c",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d23e37e2be50f82085bf3_71b0c827"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0/lxd/0#d#lo",
        "name" : "lo",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 65536,
        "machine-id" : "0/lxd/0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d242c7e2be50f82085f75_fe9789f6"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0/lxd/0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "mtu" : 1500,
        "machine-id" : "0/lxd/0",
        "type" : "ethernet",
        "mac-address" : "00:16:3e:15:00:3e",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d242c7e2be50f82085f75_fe9789f6"
        ]
}
```
```
juju:PRIMARY> db["ip.addresses"].find().pretty()
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d21aa7e2be50f82085751_906ca9e6"
        ]
}
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#lo#ip#::1",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d21aa7e2be50f82085751_906ca9e6"
        ]
}
{
        "_id" : "56dc9b5e-c857-409d-8270-7f8bce1df519:m#0#d#eth1#ip#10.0.30.27",
        "model-uuid" : "56dc9b5e-c857-409d-8270-7f8bce1df519",
        "device-name" : "eth1",
        "machine-id" : "0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.27",
        "gateway-address" : "10.0.30.1",
        "is-default-gateway" : true,
        "origin" : "provider",
        "txn-revno" : NumberLong(4),
        "txn-queue" : [
                "5f3d21aa7e2be50f82085751_906ca9e6"
        ],
        "providerid" : "75185",
        "provider-subnet-id" : "1"
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#eth1#ip#10.0.30.72",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "eth1",
        "machine-id" : "0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.72",
        "gateway-address" : "10.0.30.1",
        "is-default-gateway" : true,
        "origin" : "provider",
        "txn-revno" : NumberLong(4),
        "txn-queue" : [
                "5f3d23d47e2be50f82085b68_e884a46f"
        ],
        "providerid" : "73366",
        "provider-subnet-id" : "1"
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#eth2.465#ip#192.168.4.1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "eth2.465",
        "machine-id" : "0",
        "subnet-cidr" : "192.168.4.0/24",
        "config-method" : "static",
        "value" : "192.168.4.1",
        "origin" : "provider",
        "txn-revno" : NumberLong(4),
        "txn-queue" : [
                "5f3d23d47e2be50f82085b68_e884a46f"
        ],
        "providerid" : "93466",
        "provider-subnet-id" : "1366"
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d23d47e2be50f82085b68_e884a46f"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#lo#ip#::1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d23d47e2be50f82085b68_e884a46f"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#lxdbr0#ip#10.49.115.1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "lxdbr0",
        "machine-id" : "0",
        "subnet-cidr" : "10.49.115.0/24",
        "config-method" : "static",
        "value" : "10.49.115.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d25277e2be50f820863c1_21de417a"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0#d#br-eth1#ip#10.0.30.72",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "br-eth1",
        "machine-id" : "0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.72",
        "gateway-address" : "10.0.30.1",
        "is-default-gateway" : true,
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d25277e2be50f820863c1_21de417a"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0/lxd/0#d#lo#ip#127.0.0.1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d242c7e2be50f82085f75_fe9789f6"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0/lxd/0#d#lo#ip#::1",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d242c7e2be50f82085f75_fe9789f6"
        ]
}
{
        "_id" : "812251fd-3f7c-45c9-8411-70d85ed9346c:m#0/lxd/0#d#eth0#ip#10.0.30.21",
        "model-uuid" : "812251fd-3f7c-45c9-8411-70d85ed9346c",
        "device-name" : "eth0",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "10.0.30.0/24",
        "config-method" : "static",
        "value" : "10.0.30.21",
        "gateway-address" : "10.0.30.1",
        "is-default-gateway" : true,
        "origin" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d242c7e2be50f82085f75_fe9789f6"
        ]
}
```

This is an example of incoming provider interface configuration for a MAAS container host.
```
machine-0: 16:24:52 CRITICAL juju.apiserver.instancepoller (params.SetProviderNetworkConfig) {
 Args: ([]params.ProviderNetworkConfig) (len=1 cap=4) {
  (params.ProviderNetworkConfig) {
   Tag: (string) (len=9) "machine-0",
   Configs: ([]params.NetworkConfig) (len=5 cap=6) {
    (params.NetworkConfig) {
     DeviceIndex: (int) 0,
     MACAddress: (string) (len=17) "52:54:00:27:2d:79",
     CIDR: (string) (len=12) "10.0.30.0/24",
     MTU: (int) 1500,
     ProviderId: (string) (len=2) "17",
     ProviderNetworkId: (string) "",
     ProviderSubnetId: (string) (len=1) "1",
     ProviderSpaceId: (string) (len=1) "0",
     ProviderAddressId: (string) (len=5) "73366",
     ProviderVLANId: (string) (len=1) "0",
     VLANTag: (int) 0,
     InterfaceName: (string) (len=4) "eth1",
     ParentInterfaceName: (string) "",
     InterfaceType: (string) (len=8) "ethernet",
     Disabled: (bool) false,
     NoAutoStart: (bool) false,
     ConfigType: (string) (len=6) "static",
     Address: (string) (len=10) "10.0.30.72",
     Addresses: ([]params.Address) (len=1 cap=4) {
      (params.Address) {
       Value: (string) (len=10) "10.0.30.72",
       Type: (string) (len=4) "ipv4",
       Scope: (string) (len=11) "local-cloud",
       SpaceName: (string) (len=7) "space-0",
       ProviderSpaceID: (string) (len=1) "0"
      }
     },
     ShadowAddresses: ([]params.Address) <nil>,
     DNSServers: ([]string) <nil>,
     DNSSearchDomains: ([]string) (len=1 cap=4) {
      (string) (len=4) "maas"
     },
     GatewayAddress: (string) (len=9) "10.0.30.1",
     Routes: ([]params.NetworkRoute) <nil>,
     IsDefaultGateway: (bool) false,
     NetworkOrigin: (params.NetworkOrigin) (len=8) "provider"
    },
    (params.NetworkConfig) {
     DeviceIndex: (int) 1,
     MACAddress: (string) (len=17) "52:54:00:12:7a:d5",
     CIDR: (string) "",
     MTU: (int) 0,
     ProviderId: (string) (len=2) "37",
     ProviderNetworkId: (string) "",
     ProviderSubnetId: (string) "",
     ProviderSpaceId: (string) "",
     ProviderAddressId: (string) "",
     ProviderVLANId: (string) "",
     VLANTag: (int) 0,
     InterfaceName: (string) (len=4) "eth0",
     ParentInterfaceName: (string) "",
     InterfaceType: (string) (len=8) "ethernet",
     Disabled: (bool) false,
     NoAutoStart: (bool) false,
     ConfigType: (string) (len=6) "manual",
     Address: (string) "",
     Addresses: ([]params.Address) <nil>,
     ShadowAddresses: ([]params.Address) <nil>,
     DNSServers: ([]string) <nil>,
     DNSSearchDomains: ([]string) <nil>,
     GatewayAddress: (string) "",
     Routes: ([]params.NetworkRoute) <nil>,
     IsDefaultGateway: (bool) false,
     NetworkOrigin: (params.NetworkOrigin) (len=8) "provider"
    },
    (params.NetworkConfig) {
     DeviceIndex: (int) 1,
     MACAddress: (string) (len=17) "52:54:00:12:7a:d5",
     CIDR: (string) "",
     MTU: (int) 0,
     ProviderId: (string) (len=2) "37",
     ProviderNetworkId: (string) "",
     ProviderSubnetId: (string) "",
     ProviderSpaceId: (string) "",
     ProviderAddressId: (string) "",
     ProviderVLANId: (string) "",
     VLANTag: (int) 0,
     InterfaceName: (string) (len=4) "eth0",
     ParentInterfaceName: (string) "",
     InterfaceType: (string) (len=8) "ethernet",
     Disabled: (bool) false,
     NoAutoStart: (bool) false,
     ConfigType: (string) (len=6) "manual",
     Address: (string) "",
     Addresses: ([]params.Address) <nil>,
     ShadowAddresses: ([]params.Address) <nil>,
     DNSServers: ([]string) <nil>,
     DNSSearchDomains: ([]string) <nil>,
     GatewayAddress: (string) "",
     Routes: ([]params.NetworkRoute) <nil>,
     IsDefaultGateway: (bool) false,
     NetworkOrigin: (params.NetworkOrigin) (len=8) "provider"
    },
    (params.NetworkConfig) {
     DeviceIndex: (int) 2,
     MACAddress: (string) (len=17) "52:54:00:62:f0:80",
     CIDR: (string) "",
     MTU: (int) 0,
     ProviderId: (string) (len=2) "36",
     ProviderNetworkId: (string) "",
     ProviderSubnetId: (string) "",
     ProviderSpaceId: (string) "",
     ProviderAddressId: (string) "",
     ProviderVLANId: (string) "",
     VLANTag: (int) 0,
     InterfaceName: (string) (len=4) "eth2",
     ParentInterfaceName: (string) "",
     InterfaceType: (string) (len=8) "ethernet",
     Disabled: (bool) false,
     NoAutoStart: (bool) false,
     ConfigType: (string) "",
     Address: (string) "",
     Addresses: ([]params.Address) <nil>,
     ShadowAddresses: ([]params.Address) <nil>,
     DNSServers: ([]string) <nil>,
     DNSSearchDomains: ([]string) <nil>,
     GatewayAddress: (string) "",
     Routes: ([]params.NetworkRoute) <nil>,
     IsDefaultGateway: (bool) false,
     NetworkOrigin: (params.NetworkOrigin) (len=8) "provider"
    },
    (params.NetworkConfig) {
     DeviceIndex: (int) 3,
     MACAddress: (string) (len=17) "52:54:00:62:f0:80",
     CIDR: (string) (len=14) "192.168.4.0/24",
     MTU: (int) 1500,
     ProviderId: (string) (len=5) "17837",
     ProviderNetworkId: (string) "",
     ProviderSubnetId: (string) (len=4) "1366",
     ProviderSpaceId: (string) (len=2) "77",
     ProviderAddressId: (string) (len=5) "93466",
     ProviderVLANId: (string) (len=4) "7107",
     VLANTag: (int) 465,
     InterfaceName: (string) (len=8) "eth2.465",
     ParentInterfaceName: (string) (len=4) "eth2",
     InterfaceType: (string) (len=6) "802.1q",
     Disabled: (bool) false,
     NoAutoStart: (bool) false,
     ConfigType: (string) (len=6) "static",
     Address: (string) (len=11) "192.168.4.1",
     Addresses: ([]params.Address) (len=1 cap=4) {
      (params.Address) {
       Value: (string) (len=11) "192.168.4.1",
       Type: (string) (len=4) "ipv4",
       Scope: (string) (len=11) "local-cloud",
       SpaceName: (string) (len=8) "ha-space",
       ProviderSpaceID: (string) (len=2) "77"
      }
     },
     ShadowAddresses: ([]params.Address) <nil>,
     DNSServers: ([]string) <nil>,
     DNSSearchDomains: ([]string) (len=1 cap=4) {
      (string) (len=4) "maas"
     },
     GatewayAddress: (string) "",
     Routes: ([]params.NetworkRoute) <nil>,
     IsDefaultGateway: (bool) false,
     NetworkOrigin: (params.NetworkOrigin) (len=8) "provider"
    }
   }
  }
 }
}
```

### EC2 and Juju 2.7

- Only the Fan devices have provider ID, which is a surrogate generated by Juju anyway.
- Ethernet device addresses have provider subnet ID.
- Fan networks and container NICs on them get provider subnet IDs, which look contrived - they are actually VPC IDs.

```
juju:PRIMARY> db.linklayerdevices.find().pretty()
{
        "_id" : "5e6a9368-e5c1-4050-8c87-88a61cb5ec9f:m#0#d#unsupported0",
        "name" : "unsupported0",
        "model-uuid" : "5e6a9368-e5c1-4050-8c87-88a61cb5ec9f",
        "mtu" : 0,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0a:ef:b6:4c:ab:13",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(6),
        "txn-queue" : [
                "5f3d0639eba2660f049ee25e_f8a70e22",
                "5f3d0639eba2660f049ee261_0cd0e381"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec4e_03626b00",
                "5f3d0e54eba2660f049eec50_05c35a8e"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#ens3",
        "name" : "ens3",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 9001,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0a:a1:fa:45:5a:95",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec4e_03626b00",
                "5f3d0e54eba2660f049eec50_05c35a8e"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#fan-252",
        "name" : "fan-252",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 1450,
        "providerid" : "subnet-eca389a6-INFAN-172-31-16-0-20",
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "32:1c:b3:f9:eb:e0",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e94eba2660f049eeedc_d7cb66da"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#ftun0",
        "name" : "ftun0",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 8951,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "32:1c:b3:f9:eb:e0",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "fan-252",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec4f_3fe56244"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#lxdbr0",
        "name" : "lxdbr0",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "a6:06:b7:a3:3d:bb",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e5beba2660f049eeca7_4b142ed7",
                "5f3d0e5ceba2660f049eeca8_212e888c"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0/lxd/0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 1450,
        "machine-id" : "0/lxd/0",
        "type" : "ethernet",
        "mac-address" : "00:16:3e:75:9f:b5",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [ ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0/lxd/0#d#lo",
        "name" : "lo",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "mtu" : 65536,
        "machine-id" : "0/lxd/0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e94eba2660f049eeedc_d7cb66da",
                "5f3d0e94eba2660f049eeedd_8a7afce2"
        ]
}
```
```
juju:PRIMARY> db["ip.addresses"].find().pretty()
{
        "_id" : "5e6a9368-e5c1-4050-8c87-88a61cb5ec9f:m#0#d#unsupported0#ip#172.31.20.56",
        "model-uuid" : "5e6a9368-e5c1-4050-8c87-88a61cb5ec9f",
        "provider-subnet-id" : "subnet-eca389a6",
        "device-name" : "unsupported0",
        "machine-id" : "0",
        "subnet-cidr" : "172.31.16.0/20",
        "config-method" : "dynamic",
        "value" : "172.31.20.56",
        "txn-revno" : NumberLong(4),
        "txn-queue" : [
                "5f3d0639eba2660f049ee261_0cd0e381"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec50_05c35a8e"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#lo#ip#::1",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec50_05c35a8e"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#ens3#ip#172.31.20.185",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "provider-subnet-id" : "subnet-eca389a6",
        "device-name" : "ens3",
        "machine-id" : "0",
        "subnet-cidr" : "172.31.16.0/20",
        "config-method" : "static",
        "value" : "172.31.20.185",
        "gateway-address" : "172.31.16.1",
        "is-default-gateway" : true,
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec50_05c35a8e"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#fan-252#ip#252.20.185.1",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "provider-subnet-id" : "vpc-54a7112e",
        "device-name" : "fan-252",
        "machine-id" : "0",
        "subnet-cidr" : "252.16.0.0/12",
        "config-method" : "static",
        "value" : "252.20.185.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e54eba2660f049eec50_05c35a8e"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0#d#lxdbr0#ip#10.240.110.1",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "device-name" : "lxdbr0",
        "machine-id" : "0",
        "subnet-cidr" : "10.240.110.0/24",
        "config-method" : "static",
        "value" : "10.240.110.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e5ceba2660f049eeca8_212e888c"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0/lxd/0#d#lo#ip#127.0.0.1",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e94eba2660f049eeedd_8a7afce2"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0/lxd/0#d#lo#ip#::1",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e94eba2660f049eeedd_8a7afce2"
        ]
}
{
        "_id" : "56497fcd-956b-46f6-89b8-5af6477b50c5:m#0/lxd/0#d#eth0#ip#252.20.185.231",
        "model-uuid" : "56497fcd-956b-46f6-89b8-5af6477b50c5",
        "provider-subnet-id" : "vpc-54a7112e",
        "device-name" : "eth0",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "252.16.0.0/12",
        "config-method" : "static",
        "value" : "252.20.185.231",
        "gateway-address" : "252.20.185.1",
        "is-default-gateway" : true,
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d0e94eba2660f049eeedd_8a7afce2"
        ]
}
```

### EC2 and This Patch

- Ethernet NIC addresses still get a provider subnet ID. They now also get a provider ID, which is an improvement.
- Fan devices no longer get the fake provider ID.
- Fan addresses and container addresses on them do not get the fake provider ID.

```
juju:PRIMARY> db.linklayerdevices.find().pretty()
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [ ]
}
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#ens5",
        "name" : "ens5",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "mtu" : 9001,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0a:73:ab:5a:04:a3",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d16feb14c8c0ec95133d6_5007e89b"
        ],
        "providerid" : "eni-054728581865e4af5"
}
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#fan-252",
        "name" : "fan-252",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "mtu" : 1450,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "6a:8b:94:3d:8e:2a",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [ ]
}
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#ftun0",
        "name" : "ftun0",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "mtu" : 8951,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "6a:8b:94:3d:8e:2a",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "fan-252",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [ ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#lo",
        "name" : "lo",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 65536,
        "machine-id" : "0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1bb4b14c8c0ec95137f1_1a208a3e"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#ens5",
        "name" : "ens5",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 9001,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "0a:da:35:58:82:b3",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d1bb7b14c8c0ec951394c_e0113d26"
        ],
        "providerid" : "eni-01a859f0a7ce586ae"
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#fan-252",
        "name" : "fan-252",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 1450,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "1a:6f:82:c0:a2:4c",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1bb4b14c8c0ec95137f1_1a208a3e"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#ftun0",
        "name" : "ftun0",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 8951,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "1a:6f:82:c0:a2:4c",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "fan-252",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1bb4b14c8c0ec95137f1_1a208a3e"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#lxdbr0",
        "name" : "lxdbr0",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 1500,
        "machine-id" : "0",
        "type" : "bridge",
        "mac-address" : "de:96:cb:c6:13:15",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1cd6b14c8c0ec9513a5a_f82d41c9"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0/lxd/0#d#lo",
        "name" : "lo",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 65536,
        "machine-id" : "0/lxd/0",
        "type" : "loopback",
        "mac-address" : "",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1d1db14c8c0ec9513c74_b2c1a2bd"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0/lxd/0#d#eth0",
        "name" : "eth0",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 1450,
        "machine-id" : "0/lxd/0",
        "type" : "ethernet",
        "mac-address" : "00:16:3e:65:2d:b8",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1d1db14c8c0ec9513c74_b2c1a2bd"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#vethURHR6P",
        "name" : "vethURHR6P",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "mtu" : 1450,
        "machine-id" : "0",
        "type" : "ethernet",
        "mac-address" : "fe:7d:3d:67:4c:ab",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "fan-252",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d3ddab14c8c234a2cb7e9_39738e9c"
        ]
}
```
```
juju:PRIMARY> db["ip.addresses"].find().pretty()
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d16feb14c8c0ec95133d6_5007e89b"
        ]
}
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#lo#ip#::1",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d16feb14c8c0ec95133d6_5007e89b"
        ]
}
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#ens5#ip#172.31.30.136",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "device-name" : "ens5",
        "machine-id" : "0",
        "subnet-cidr" : "172.31.16.0/20",
        "config-method" : "static",
        "value" : "172.31.30.136",
        "gateway-address" : "172.31.16.1",
        "is-default-gateway" : true,
        "origin" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d16feb14c8c0ec95133d6_5007e89b"
        ],
        "provider-subnet-id" : "subnet-eca389a6"
}
{
        "_id" : "a3d0e676-1b9f-4523-82ef-25adcce0c410:m#0#d#fan-252#ip#252.30.136.1",
        "model-uuid" : "a3d0e676-1b9f-4523-82ef-25adcce0c410",
        "device-name" : "fan-252",
        "machine-id" : "0",
        "subnet-cidr" : "252.0.0.0/8",
        "config-method" : "static",
        "value" : "252.30.136.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d16feb14c8c0ec95133d6_5007e89b"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d1bb7b14c8c0ec951394c_e0113d26"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#lo#ip#::1",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d1bb7b14c8c0ec951394c_e0113d26"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#ens5#ip#172.31.30.132",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "ens5",
        "machine-id" : "0",
        "subnet-cidr" : "172.31.16.0/20",
        "config-method" : "static",
        "value" : "172.31.30.132",
        "gateway-address" : "172.31.16.1",
        "is-default-gateway" : true,
        "origin" : "",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d1bb7b14c8c0ec951394c_e0113d26"
        ],
        "provider-subnet-id" : "subnet-eca389a6"
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#fan-252#ip#252.30.132.1",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "fan-252",
        "machine-id" : "0",
        "subnet-cidr" : "252.16.0.0/12",
        "config-method" : "static",
        "value" : "252.30.132.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d1bb7b14c8c0ec951394c_e0113d26"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0#d#lxdbr0#ip#10.17.195.1",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "lxdbr0",
        "machine-id" : "0",
        "subnet-cidr" : "10.17.195.0/24",
        "config-method" : "static",
        "value" : "10.17.195.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f3d1e00b14c8c0ec9513e57_91dc3f2a"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0/lxd/0#d#lo#ip#127.0.0.1",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1d1db14c8c0ec9513c74_b2c1a2bd"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0/lxd/0#d#lo#ip#::1",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "lo",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1d1db14c8c0ec9513c74_b2c1a2bd"
        ]
}
{
        "_id" : "49e9ed57-97c5-478b-8422-c941c542373d:m#0/lxd/0#d#eth0#ip#252.30.132.193",
        "model-uuid" : "49e9ed57-97c5-478b-8422-c941c542373d",
        "device-name" : "eth0",
        "machine-id" : "0/lxd/0",
        "subnet-cidr" : "252.16.0.0/12",
        "config-method" : "static",
        "value" : "252.30.132.193",
        "gateway-address" : "252.30.132.1",
        "is-default-gateway" : true,
        "origin" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f3d1d1db14c8c0ec9513c74_b2c1a2bd"
        ]
}
```

This is an example of incoming provider interface configuration for an EC2 container host.
```
machine-0: 16:57:43 CRITICAL juju.apiserver.instancepoller (params.SetProviderNetworkConfig) {
 Args: ([]params.ProviderNetworkConfig) (len=1 cap=4) {
  (params.ProviderNetworkConfig) {
   Tag: (string) (len=9) "machine-0",
   Configs: ([]params.NetworkConfig) (len=1 cap=4) {
    (params.NetworkConfig) {
     DeviceIndex: (int) 0,
     MACAddress: (string) (len=17) "0a:da:35:58:82:b3",
     CIDR: (string) (len=14) "172.31.16.0/20",
     MTU: (int) 0,
     ProviderId: (string) (len=21) "eni-01a859f0a7ce586ae",
     ProviderNetworkId: (string) "",
     ProviderSubnetId: (string) (len=15) "subnet-eca389a6",
     ProviderSpaceId: (string) "",
     ProviderAddressId: (string) "",
     ProviderVLANId: (string) "",
     VLANTag: (int) 0,
     InterfaceName: (string) "",
     ParentInterfaceName: (string) "",
     InterfaceType: (string) (len=8) "ethernet",
     Disabled: (bool) false,
     NoAutoStart: (bool) false,
     ConfigType: (string) (len=4) "dhcp",
     Address: (string) (len=13) "172.31.30.132",
     Addresses: ([]params.Address) (len=1 cap=4) {
      (params.Address) {
       Value: (string) (len=13) "172.31.30.132",
       Type: (string) (len=4) "ipv4",
       Scope: (string) (len=11) "local-cloud",
       SpaceName: (string) "",
       ProviderSpaceID: (string) ""
      }
     },
     ShadowAddresses: ([]params.Address) (len=1 cap=4) {
      (params.Address) {
       Value: (string) (len=13) "34.201.44.142",
       Type: (string) (len=4) "ipv4",
       Scope: (string) (len=6) "public",
       SpaceName: (string) "",
       ProviderSpaceID: (string) ""
      }
     },
     DNSServers: ([]string) <nil>,
     DNSSearchDomains: ([]string) <nil>,
     GatewayAddress: (string) "",
     Routes: ([]params.NetworkRoute) <nil>,
     IsDefaultGateway: (bool) false,
     NetworkOrigin: (params.NetworkOrigin) (len=8) "provider"
    }
   }
  }
 }
}
```

## Documentation changes

None.

## Bug reference

N/A
