### PR TITLE
Pass all env vars to unit commands

### DIFF
--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -148,10 +148,12 @@ type ExecParams struct {
 
 // execOnMachine executes commands on current machine.
 func execOnMachine(params ExecParams) (*utilexec.ExecResponse, error) {
+	hostEnv := os.Environ()
+	hostEnv = append(hostEnv, params.Env...)
 	command := utilexec.RunParams{
 		Commands:    strings.Join(params.Commands, " "),
 		WorkingDir:  params.WorkingDir,
-		Environment: params.Env,
+		Environment: hostEnv,
 		Clock:       params.Clock,
 	}
 	err := command.Run()


### PR DESCRIPTION
## Description of change

When the unit agent sets up params to run a command (ie hook or action or run script), it set the env to just the path and hook context variables, like JUJU_UNIT_NAME etc. Any other env vars already set on the host were omitted.

This breaks things on k8s, since the core KUBERNETES_* env variables are then not available and these are needed to do things like set up an in cluster client.

This PR passes all env vars to the uniter command process, but the hook context vars are added last so they take precedence.

## QA steps

Deploy a k8s charm. Execute this juju run script on the operator pod and the workload.

operator:
```
$ juju exec --operator --unit mariadb-k8s/0 env | grep KUBERNETES
KUBERNETES_SERVICE_PORT_HTTPS=443
KUBERNETES_SERVICE_PORT=443
KUBERNETES_PORT_443_TCP=tcp://10.152.183.1:443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_PORT_443_TCP_ADDR=10.152.183.1
KUBERNETES_SERVICE_HOST=10.152.183.1
KUBERNETES_PORT=tcp://10.152.183.1:443
KUBERNETES_PORT_443_TCP_PORT=443
```

workload:
```
$ juju exec --unit mariadb-k8s/0 env | grep KUBERNETES
KUBERNETES_SERVICE_PORT=443
KUBERNETES_PORT=tcp://10.152.183.1:443
KUBERNETES_PORT_443_TCP_ADDR=10.152.183.1
KUBERNETES_PORT_443_TCP_PORT=443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_PORT_443_TCP=tcp://10.152.183.1:443
KUBERNETES_SERVICE_PORT_HTTPS=443
KUBERNETES_SERVICE_HOST=10.152.183.1

```

Previously the operator script would return nothing.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1892255
