### PR TITLE
Fix k8s workload version

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -1220,22 +1219,20 @@ func (context *statusContext) processApplication(application *state.Application)
 		processedStatus.MeterStatuses = context.processUnitMeterStatuses(units)
 	}
 
-	// TODO(caas) - there's no way for a CAAS charm to set workload version yet
-	if context.model.Type() == state.ModelTypeIAAS {
-		versions := make([]status.StatusInfo, 0, len(units))
-		for _, unit := range units {
-			workloadVersion, err := context.status.FullUnitWorkloadVersion(unit.Name())
-			if err != nil {
-				processedStatus.Err = common.ServerError(err)
-				return processedStatus
-			}
-			versions = append(versions, workloadVersion)
+	versions := make([]status.StatusInfo, 0, len(units))
+	for _, unit := range units {
+		workloadVersion, err := context.status.FullUnitWorkloadVersion(unit.Name())
+		if err != nil {
+			processedStatus.Err = common.ServerError(err)
+			return processedStatus
 		}
-		if len(versions) > 0 {
-			sort.Sort(bySinceDescending(versions))
-			processedStatus.WorkloadVersion = versions[0].Message
-		}
-	} else {
+		versions = append(versions, workloadVersion)
+	}
+	if len(versions) > 0 {
+		sort.Sort(bySinceDescending(versions))
+		processedStatus.WorkloadVersion = versions[0].Message
+	}
+	if processedStatus.WorkloadVersion == "" && context.model.Type() == state.ModelTypeCAAS {
 		// We'll punt on using the docker image name.
 		caasModel, err := context.model.CAASModel()
 		if err != nil {
@@ -1252,7 +1249,11 @@ func (context *statusContext) processApplication(application *state.Application)
 				return params.ApplicationStatus{Err: common.ServerError(err)}
 			}
 			// Container zero is the primary.
-			processedStatus.WorkloadVersion = fmt.Sprintf("%v", spec.Containers[0].Image)
+			primary := spec.Containers[0]
+			processedStatus.WorkloadVersion = primary.ImageDetails.ImagePath
+			if processedStatus.WorkloadVersion == "" {
+				processedStatus.WorkloadVersion = spec.Containers[0].Image
+			}
 		}
 		serviceInfo, err := application.ServiceInfo()
 		if err == nil {

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -970,6 +970,22 @@ func (s *CAASStatusSuite) assertUnitStatus(c *gc.C, appStatus params.Application
 	})
 }
 
+func (s *CAASStatusSuite) TestStatusWorkloadVersionSetByCharm(c *gc.C) {
+	loggo.GetLogger("juju.state.allwatcher").SetLogLevel(loggo.TRACE)
+	client := s.APIState.Client()
+	err := s.app.SetOperatorStatus(status.StatusInfo{Status: status.Active})
+	c.Assert(err, jc.ErrorIsNil)
+	u, err := s.app.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u, gc.HasLen, 1)
+	err = u[0].SetWorkloadVersion("666")
+	c.Assert(err, jc.ErrorIsNil)
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Applications, gc.HasLen, 1)
+	c.Assert(status.Applications[s.app.Name()].WorkloadVersion, gc.Equals, "666")
+}
+
 type filteringBranchesSuite struct {
 	baseSuite
 


### PR DESCRIPTION
## Description of change

On k8s charms, we were not displaying the workload version properly.
It is meant to be the docker image path, but an update to how that is modelled broke it.
And if the charm explicitly called application-version-set, we were ignoring that.

## QA steps

deploy a k8s charm
juju status shows Version as "mariadb:latest"

`juju exec --unit mariadb-k8s/0 "application-version-set 666"`
juju status shows Version as "666"

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892216
