### PR TITLE
Upgrade-series validation

### DIFF
--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -60,8 +60,8 @@ func isUnknownModelError(err error) bool {
 	return ok
 }
 
-// DischargeRequiredError is the error returned when a macaroon requires discharging
-// to complete authentication.
+// DischargeRequiredError is the error returned when a macaroon requires
+// discharging to complete authentication.
 type DischargeRequiredError struct {
 	Cause          error
 	LegacyMacaroon *macaroon.Macaroon
@@ -80,13 +80,32 @@ func IsDischargeRequiredError(err error) bool {
 	return ok
 }
 
-// IsUpgradeInProgress returns true if this error is caused
+// IsUpgradeInProgressError returns true if this error is caused
 // by an upgrade in progress.
 func IsUpgradeInProgressError(err error) bool {
 	if state.IsUpgradeInProgressError(err) {
 		return true
 	}
 	return errors.Cause(err) == params.UpgradeInProgressError
+}
+
+// UpgradeSeriesValidationError is the error returns when a upgrade-series
+// can not be run because of a validation error.
+type UpgradeSeriesValidationError struct {
+	Cause  error
+	Status string
+}
+
+// Error implements the error interface.
+func (e *UpgradeSeriesValidationError) Error() string {
+	return e.Cause.Error()
+}
+
+// IsUpgradeSeriesValidationError returns true if this error is caused by a
+// upgrade-series validation error.
+func IsUpgradeSeriesValidationError(err error) bool {
+	_, ok := errors.Cause(err).(*UpgradeSeriesValidationError)
+	return ok
 }
 
 // RedirectError is the error returned when a model (previously accessible by
@@ -293,6 +312,11 @@ func ServerError(err error) *params.Error {
 			BakeryMacaroon: dischErr.Macaroon,
 			// One macaroon fits all.
 			MacaroonPath: "/",
+		}.AsMap()
+	case IsUpgradeSeriesValidationError(err):
+		rawErr := errors.Cause(err).(*UpgradeSeriesValidationError)
+		info = params.UpgradeSeriesValidationErrorInfo{
+			Status: rawErr.Status,
 		}.AsMap()
 	case IsRedirectError(err):
 		redirErr := errors.Cause(err).(*RedirectError)

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -512,10 +512,11 @@ func (s *MachineManagerSuite) TestDestroyMachineWithParamsNilWait(c *gc.C) {
 
 func (s *MachineManagerSuite) setupUpgradeSeries(c *gc.C) {
 	s.st.machines = map[string]*mockMachine{
-		"0": {series: "trusty", units: []string{"foo/0", "test/0"}},
-		"1": {series: "trusty", units: []string{"foo/1", "test/1"}},
-		"2": {series: "centos7", units: []string{"foo/1", "test/1"}},
-		"3": {series: "bionic", isManager: true},
+		"0": {id: "0", series: "trusty", units: []string{"foo/0", "test/0"}},
+		"1": {id: "1", series: "trusty", units: []string{"foo/1", "test/1"}},
+		"2": {id: "2", series: "centos7", units: []string{"foo/1", "test/1"}},
+		"3": {id: "3", series: "bionic", isManager: true},
+		"4": {id: "4", series: "trusty", isLockedForSeriesUpgrade: true},
 	}
 }
 
@@ -564,6 +565,23 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateIsControllerError(c *gc.C
 
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
 		"machine-3 is a controller and cannot be targeted for series upgrade")
+}
+
+func (s *MachineManagerSuite) TestUpgradeSeriesValidateIsLockedForSeriesUpgradeError(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.setupUpgradeSeries(c)
+	apiV5 := s.apiV5()
+	args := params.UpdateSeriesArgs{
+		Args: []params.UpdateSeriesArg{{
+			Entity: params.Entity{Tag: names.NewMachineTag("4").String()},
+		}},
+	}
+	results, err := apiV5.UpgradeSeriesValidate(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results.Results[0].Error, gc.ErrorMatches,
+		`upgrade series lock for machine "4" already exists`)
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateNoSeriesError(c *gc.C) {
@@ -1027,14 +1045,21 @@ type mockMachine struct {
 	jtesting.Stub
 	machinemanager.Machine
 
-	keep           bool
-	series         string
-	units          []string
-	unitAgentState status.Status
-	unitState      status.Status
-	isManager      bool
+	id                       string
+	keep                     bool
+	series                   string
+	units                    []string
+	unitAgentState           status.Status
+	unitState                status.Status
+	isManager                bool
+	isLockedForSeriesUpgrade bool
 
 	unitsF func() ([]machinemanager.Unit, error)
+}
+
+func (m *mockMachine) Id() string {
+	m.MethodCall(m, "Id")
+	return m.id
 }
 
 func (m *mockMachine) Destroy() error {
@@ -1106,6 +1131,11 @@ func (m *mockMachine) CompleteUpgradeSeries() error {
 func (m *mockMachine) IsManager() bool {
 	m.MethodCall(m, "IsManager")
 	return m.isManager
+}
+
+func (m *mockMachine) IsLockedForSeriesUpgrade() (bool, error) {
+	m.MethodCall(m, "IsLockedForSeriesUpgrade")
+	return m.isLockedForSeriesUpgrade, nil
 }
 
 type mockUnit struct {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -581,7 +581,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesValidateIsLockedForSeriesUpgradeE
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
-		`upgrade series lock for machine "4" already exists`)
+		`upgrade series lock found for "4"; series upgrade is in the "not started" state`)
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesValidateNoSeriesError(c *gc.C) {
@@ -1136,6 +1136,11 @@ func (m *mockMachine) IsManager() bool {
 func (m *mockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.MethodCall(m, "IsLockedForSeriesUpgrade")
 	return m.isLockedForSeriesUpgrade, nil
+}
+
+func (m *mockMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
+	m.MethodCall(m, "UpgradeSeriesStatus")
+	return model.UpgradeSeriesNotStarted, nil
 }
 
 type mockUnit struct {

--- a/apiserver/facades/client/machinemanager/mocks/leadership_mock.go
+++ b/apiserver/facades/client/machinemanager/mocks/leadership_mock.go
@@ -5,11 +5,10 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
-	v4 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockLeadership is a mock of Leadership interface
@@ -37,6 +36,7 @@ func (m *MockLeadership) EXPECT() *MockLeadershipMockRecorder {
 
 // GetMachineApplicationNames mocks base method
 func (m *MockLeadership) GetMachineApplicationNames(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineApplicationNames", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -45,11 +45,13 @@ func (m *MockLeadership) GetMachineApplicationNames(arg0 string) ([]string, erro
 
 // GetMachineApplicationNames indicates an expected call of GetMachineApplicationNames
 func (mr *MockLeadershipMockRecorder) GetMachineApplicationNames(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineApplicationNames", reflect.TypeOf((*MockLeadership)(nil).GetMachineApplicationNames), arg0)
 }
 
 // UnpinApplicationLeadersByName mocks base method
-func (m *MockLeadership) UnpinApplicationLeadersByName(arg0 v4.Tag, arg1 []string) (params.PinApplicationsResults, error) {
+func (m *MockLeadership) UnpinApplicationLeadersByName(arg0 names.Tag, arg1 []string) (params.PinApplicationsResults, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnpinApplicationLeadersByName", arg0, arg1)
 	ret0, _ := ret[0].(params.PinApplicationsResults)
 	ret1, _ := ret[1].(error)
@@ -58,5 +60,6 @@ func (m *MockLeadership) UnpinApplicationLeadersByName(arg0 v4.Tag, arg1 []strin
 
 // UnpinApplicationLeadersByName indicates an expected call of UnpinApplicationLeadersByName
 func (mr *MockLeadershipMockRecorder) UnpinApplicationLeadersByName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinApplicationLeadersByName", reflect.TypeOf((*MockLeadership)(nil).UnpinApplicationLeadersByName), arg0, arg1)
 }

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
@@ -58,6 +59,7 @@ type Machine interface {
 	GetUpgradeSeriesMessages() ([]string, bool, error)
 	IsManager() bool
 	IsLockedForSeriesUpgrade() (bool, error)
+	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
 }
 
 type stateShim struct {

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -43,6 +43,7 @@ type Model interface {
 }
 
 type Machine interface {
+	Id() string
 	Destroy() error
 	ForceDestroy(time.Duration) error
 	Series() string
@@ -56,6 +57,7 @@ type Machine interface {
 	WatchUpgradeSeriesNotifications() (state.NotifyWatcher, error)
 	GetUpgradeSeriesMessages() ([]string, bool, error)
 	IsManager() bool
+	IsLockedForSeriesUpgrade() (bool, error)
 }
 
 type stateShim struct {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1162,6 +1162,15 @@ type UpgradeSeriesUnitsResult struct {
 	UnitNames []string `json:"unit-names"`
 }
 
+type UpgradeSeriesValidationErrorInfo struct {
+	Status string
+}
+
+// AsMap encodes the error info as a map that can be attached to an Error.
+func (e UpgradeSeriesValidationErrorInfo) AsMap() map[string]interface{} {
+	return serializeToMap(e)
+}
+
 type ProfileArg struct {
 	Entity   Entity `json:"entity"`
 	UnitName string `json:"unit-name"`

--- a/core/model/upgradeseries.go
+++ b/core/model/upgradeseries.go
@@ -10,6 +10,10 @@ import (
 // UpgradeSeriesStatus is the current status of a series upgrade for units
 type UpgradeSeriesStatus string
 
+func (s UpgradeSeriesStatus) String() string {
+	return string(s)
+}
+
 var UpgradeSeriesStatusOrder = map[UpgradeSeriesStatus]int{
 	UpgradeSeriesNotStarted:       0,
 	UpgradeSeriesPrepareStarted:   1,


### PR DESCRIPTION
## Description of change

The following updates the upgrade-series validation to ensure that you
haven't already got a prepare already running for that machine. Although
it is eventually picked up when trying to create a lock, the user had to
jump through a series of prompts to find that information out.

Instead, we just lift the validation higher and the problem surfaces much
sooner in the workflow.

## QA steps


```sh
juju bootstrap lxd test
juju deploy cs:~jameinel/ubuntu-lite-7 --series xenial
juju upgrade-series 0 prepare bionic
juju upgrade-series 0 prepare bionic
```

Output should be:

```sh
ERROR Upgrade series is already prepared for machine "0" and the current
state is "prepare completed".

Juju is now ready for the series to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade series process:

juju upgrade-series 0 complete
```

## Documentation changes

More robust error messaging around series-upgrade.

## Bug reference

This isn't solving https://bugs.launchpad.net/juju/+bug/1855013 in its entirety, 
but is solidifying the workflow.
