### PR TITLE
Manual Provider Space Support

### DIFF
--- a/provider/manual/environ_network.go
+++ b/provider/manual/environ_network.go
@@ -1,0 +1,83 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manual
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+)
+
+var _ environs.NetworkingEnviron = &manualEnviron{}
+
+// SupportsSpaces implements environs.NetworkingEnviron.
+func (e *manualEnviron) SupportsSpaces(context.ProviderCallContext) (bool, error) {
+	return true, nil
+}
+
+// Subnets implements environs.NetworkingEnviron.
+func (e *manualEnviron) Subnets(context.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error) {
+	return nil, errors.NotSupportedf("subnets")
+}
+
+// SuperSubnets implements environs.NetworkingEnviron.
+func (e *manualEnviron) SuperSubnets(context.ProviderCallContext) ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
+}
+
+// SupportsSpaceDiscovery implements environs.NetworkingEnviron.
+func (e *manualEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// Spaces implements environs.NetworkingEnviron.
+func (e *manualEnviron) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
+	return nil, errors.NotSupportedf("spaces")
+}
+
+// SupportsContainerAddresses implements environs.NetworkingEnviron.
+func (e *manualEnviron) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// AllocateContainerAddresses implements environs.NetworkingEnviron.
+func (e *manualEnviron) AllocateContainerAddresses(
+	context.ProviderCallContext, instance.Id, names.MachineTag, network.InterfaceInfos,
+) (network.InterfaceInfos, error) {
+	return nil, errors.NotSupportedf("container addresses")
+}
+
+// ReleaseContainerAddresses implements environs.NetworkingEnviron.
+func (e *manualEnviron) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
+	return errors.NotSupportedf("container addresses")
+}
+
+// ProviderSpaceInfo implements environs.NetworkingEnviron.
+func (*manualEnviron) ProviderSpaceInfo(
+	context.ProviderCallContext, *network.SpaceInfo,
+) (*environs.ProviderSpaceInfo, error) {
+	return nil, errors.NotSupportedf("provider space info")
+}
+
+// AreSpacesRoutable implements environs.NetworkingEnviron.
+func (*manualEnviron) AreSpacesRoutable(_ context.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
+	return false, nil
+}
+
+// SSHAddresses implements environs.NetworkingEnviron.
+func (*manualEnviron) SSHAddresses(
+	_ context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
+	return addresses, nil
+}
+
+// NetworkInterfaces implements environs.NetworkingEnviron.
+func (e *manualEnviron) NetworkInterfaces(
+	context.ProviderCallContext, []instance.Id,
+) ([]network.InterfaceInfos, error) {
+	return nil, errors.NotSupportedf("network interfaces")
+}

--- a/provider/manual/environ_network_test.go
+++ b/provider/manual/environ_network_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package manual
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+type environNetworkSuite struct {
+	baseEnvironSuite
+}
+
+var _ = gc.Suite(&environNetworkSuite{})
+
+func (s *environNetworkSuite) TestSupportsSpaces(c *gc.C) {
+	netEnv, ok := environs.SupportsNetworking(s.env)
+	c.Assert(ok, jc.IsTrue)
+
+	spaceSupport, err := netEnv.SupportsSpaces(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(spaceSupport, jc.IsTrue)
+}

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -147,11 +147,6 @@ exit 0
 	}
 }
 
-func (s *environSuite) TestSupportsNetworking(c *gc.C) {
-	_, ok := environs.SupportsNetworking(s.env)
-	c.Assert(ok, jc.IsFalse)
-}
-
 func (s *environSuite) TestConstraintsValidator(c *gc.C) {
 	s.PatchValue(&sshprovisioner.DetectSeriesAndHardwareCharacteristics,
 		func(string) (instance.HardwareCharacteristics, string, error) {


### PR DESCRIPTION
## Description of change

Implements `environs.NetworkingEnviron` for the manual provider and indicates that spaces are supported.

## QA steps

I did this via VMs that I provisioned with MAAS.

- Provision a machine and bootstrap onto it via `juju bootstrap manual/ubuntu@<IP> spaces --no-gui --debug --build-agent`.
- Provision 2 more machines each with a NIC in a different subnet via `juju add-machine ssh:ubuntu@<IP>`.
- `juju spaces` should list the 2 subnets in the alpha space.
- `juju add-space space-<ID> <CIDR>` for the ID/subnet of machines 0 and 1 respectively.
- `juju model-config container-networking-method=provider`.
- `juju deploy postgresql --to lxd:0 --bind space-0` should set up a bridge on machine 0 and deploy to LXD successfully.
- `juju deploy percona-cluster --to lxd:0 --bind space-1` will fail to start a container because machine 0 does not have a NIC in the space.
- Retrying the deployment to lxd:1 should succeed.

## Documentation changes

Will require documentation of manual provider space support.

## Bug reference

N/A
