### PR TITLE
[WIP] Availability Set machine constraints added

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4192,6 +4192,9 @@
                         "arch": {
                             "type": "string"
                         },
+                        "availability-set": {
+                            "type": "string"
+                        },
                         "container": {
                             "type": "string"
                         },
@@ -9472,6 +9475,9 @@
                         "arch": {
                             "type": "string"
                         },
+                        "availability-set": {
+                            "type": "string"
+                        },
                         "container": {
                             "type": "string"
                         },
@@ -13062,6 +13068,9 @@
                         "arch": {
                             "type": "string"
                         },
+                        "availability-set": {
+                            "type": "string"
+                        },
                         "container": {
                             "type": "string"
                         },
@@ -14210,6 +14219,9 @@
                     "type": "object",
                     "properties": {
                         "arch": {
+                            "type": "string"
+                        },
+                        "availability-set": {
                             "type": "string"
                         },
                         "container": {
@@ -19017,6 +19029,9 @@
                         "arch": {
                             "type": "string"
                         },
+                        "availability-set": {
+                            "type": "string"
+                        },
                         "container": {
                             "type": "string"
                         },
@@ -22922,6 +22937,9 @@
                     "type": "object",
                     "properties": {
                         "arch": {
+                            "type": "string"
+                        },
+                        "availability-set": {
                             "type": "string"
                         },
                         "container": {
@@ -31026,6 +31044,9 @@
                     "type": "object",
                     "properties": {
                         "arch": {
+                            "type": "string"
+                        },
+                        "availability-set": {
                             "type": "string"
                         },
                         "container": {


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:
This pull request adds availability set for Azure provider and allows it to be defined via machine constraints.
Closes-Bug: LP#1892854

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

Availability Set ensures that VMs will be deployed in an HA mode, where VMs won't share the same resources.
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/tutorial-availability-sets#availability-set-overview

This pull request adds availability set for Azure provider and allows it to be defined via machine constraints.
Closes-Bug: LP#1892854

## QA steps

```sh
# Deploy machines with availability-set as a constraint
# Check if availability-set has been correctly configured on the VM post-deployment finished
```

## Documentation changes

Add an entry explaining why and how to use availability-set on Azure provider.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892854