### PR TITLE
Fix k8s upgrade version selection

### DIFF
--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -290,6 +290,9 @@ func (c *baseUpgradeCommand) initCAASVersions(
 		if majorVersion != -1 && vers.Major != majorVersion {
 			continue
 		}
+		if jujuversion.OfficialBuild == 0 && vers.Build > 0 {
+			continue
+		}
 		// Only include a docker image if we've published simple streams
 		// metadata for that version.
 		vers.Build = 0

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -252,7 +252,7 @@ var upgradeCAASControllerTests = []upgradeTest{{
 	expectInitErr:  "invalid version .*",
 }, {
 	about:          "latest supported stable release",
-	available:      []string{"2.1.0", "2.1.2", "2.1.3", "2.1-dev1"},
+	available:      []string{"2.1.0", "2.1.2", "2.1.3", "2.1.3.666", "2.1-dev1"},
 	streams:        []string{"2.1.0-quantal-amd64", "2.1.2-quantal-amd64", "2.1.3-quantal-amd64", "2.1-dev1-quantal-amd64"},
 	currentVersion: "2.0.0",
 	agentVersion:   "2.0.0",


### PR DESCRIPTION
## Description of change

On k8s, with a released version of Juju, juju upgrade-controller would select a docker image with a tag including the build number. These are intended only for snap edge builds.
Fix the filtering so that only correctly tagged images without the build number are used.

## QA steps

bootstrap k8s with Juju 2.7
juju upgrade-controller --dry-run
best version = 2.8.1

(previously would have been 2.8.1.3902)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892492
