### PR TITLE
For storage-pools command, spell out "Attrs" in full as "Attributes"

### DIFF
--- a/cmd/juju/storage/poollist_test.go
+++ b/cmd/juju/storage/poollist_test.go
@@ -84,7 +84,7 @@ func (s *poolListSuite) TestPoolListTabular(c *gc.C) {
 			"--name", "xyz", "--name", "abc",
 			"--format", "tabular"},
 		`
-Name       Provider  Attrs
+Name       Provider  Attributes
 abc        testType  key=value one=1 two=2
 testName0  a         key=value one=1 two=2
 testName1  b         key=value one=1 two=2
@@ -102,7 +102,7 @@ func (s *poolListSuite) TestPoolListTabularSortedWithAttrs(c *gc.C) {
 		[]string{"--name", "myaw", "--name", "xyz", "--name", "abc",
 			"--format", "tabular"},
 		`
-Name  Provider  Attrs
+Name  Provider  Attributes
 abc   testType  a=true b=maybe c=well
 myaw  testType  a=true b=maybe c=well
 xyz   testType  a=true b=maybe c=well

--- a/cmd/juju/storage/poollistformatters.go
+++ b/cmd/juju/storage/poollistformatters.go
@@ -32,7 +32,7 @@ func formatPoolsTabular(writer io.Writer, pools map[string]PoolInfo) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
 
-	print("Name", "Provider", "Attrs")
+	print("Name", "Provider", "Attributes")
 
 	poolNames := make([]string, 0, len(pools))
 	for name := range pools {

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -250,7 +250,7 @@ func (s *cmdStorageSuite) TestListPoolsTabular(c *gc.C) {
 	stdout, _, err := runPoolList(c)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-Name                      Provider                  Attrs
+Name                      Provider                  Attributes
 block                     loop                      it=works
 loop                      loop                      
 machinescoped             machinescoped             


### PR DESCRIPTION
## Description

Title is self-explanatory. Motivation in ticket is: to avoid ambiguity, especially for non-native speakers, we should use "Attributes" in full.

## QA steps

```sh
$ juju storage-pools
Name    Provider  Attributes
...
#                 ^^^^^^^^^^ this should say "Attributes" now instead of "Attrs"

```

## Documentation changes

Open question: should we update docs like https://discourse.juju.is/t/using-juju-storage/1079 and https://juju.is/docs/k8s-static-pv-tutorial ?

## Bug reference

Fixes [#1884153](https://bugs.launchpad.net/juju/+bug/1884153)
