### PR TITLE
Add support for k8s pod annotations

### DIFF
--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -37,7 +37,7 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
+	podSpec := provider.Pod(workloadSpec).PodSpec
 
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
@@ -332,7 +332,7 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
+	podSpec := provider.Pod(workloadSpec).PodSpec
 
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -37,7 +37,7 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
+	podSpec := provider.Pod(workloadSpec).PodSpec
 
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
@@ -361,7 +361,7 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
+	podSpec := provider.Pod(workloadSpec).PodSpec
 
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
@@ -99,7 +100,7 @@ func NewcontrollerStackForTest(
 	return cs.(*controllerStack), err
 }
 
-func PodSpec(u *workloadSpec) core.PodSpec {
+func Pod(u *workloadSpec) k8sspecs.PodSpecWithAnnotations {
 	return u.Pod
 }
 

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -31,7 +31,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
-	podSpec := provider.PodSpec(workloadSpec)
+	podSpec := provider.Pod(workloadSpec).PodSpec
 
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1108,7 +1108,7 @@ func (k *kubernetesClient) ensureService(
 			return errors.Annotatef(err, "configuring devices for %s", appName)
 		}
 	}
-	if err := processConstraints(&workloadSpec.Pod, appName, params.Constraints); err != nil {
+	if err := processConstraints(&workloadSpec.Pod.PodSpec, appName, params.Constraints); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1332,7 +1332,7 @@ func (k *kubernetesClient) configurePodFiles(
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if err = pushUniqueVolume(&workloadSpec.Pod, vol, false); err != nil {
+			if err = pushUniqueVolume(&workloadSpec.Pod.PodSpec, vol, false); err != nil {
 				return errors.Trace(err)
 			}
 			workloadSpec.Pod.Containers[i].VolumeMounts = append(workloadSpec.Pod.Containers[i].VolumeMounts, core.VolumeMount{
@@ -1547,9 +1547,9 @@ func (k *kubernetesClient) configureDaemonSet(
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
 					Labels:       k.getDaemonSetLabels(appName),
-					Annotations:  podAnnotations(annotations.Copy()).ToMap(),
+					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
-				Spec: workloadSpec.Pod,
+				Spec: workloadSpec.Pod.PodSpec,
 			},
 		},
 	}
@@ -1646,9 +1646,9 @@ func (k *kubernetesClient) configureDeployment(
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
 					Labels:       LabelsForApp(appName),
-					Annotations:  podAnnotations(annotations.Copy()).ToMap(),
+					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
-				Spec: workloadSpec.Pod,
+				Spec: workloadSpec.Pod.PodSpec,
 			},
 		},
 	}
@@ -2389,7 +2389,7 @@ func filesetConfigMap(configMapName string, labels, annotations map[string]strin
 
 // workloadSpec represents the k8s resources need to be created for the workload.
 type workloadSpec struct {
-	Pod     core.PodSpec `json:"pod"`
+	Pod     k8sspecs.PodSpecWithAnnotations
 	Service *specs.ServiceSpec
 
 	Secrets                         []k8sspecs.K8sSecret
@@ -2446,11 +2446,11 @@ func processContainers(deploymentName string, podSpec *specs.PodSpec, spec *core
 func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 	operatorImagePath string) (*workloadSpec, error) {
 	var spec workloadSpec
-	if err := processContainers(deploymentName, podSpec, &spec.Pod); err != nil {
+	if err := processContainers(deploymentName, podSpec, &spec.Pod.PodSpec); err != nil {
 		logger.Errorf("unable to parse %q pod spec: \n%+v", appName, *podSpec)
 		return nil, errors.Annotatef(err, "processing container specs for app %q", appName)
 	}
-	if err := ensureJujuInitContainer(&spec.Pod, operatorImagePath); err != nil {
+	if err := ensureJujuInitContainer(&spec.Pod.PodSpec, operatorImagePath); err != nil {
 		return nil, errors.Annotatef(err, "adding init container for app %q", appName)
 	}
 
@@ -2481,6 +2481,7 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 			spec.ValidatingWebhookConfigurations = k8sResources.ValidatingWebhookConfigurations
 			spec.IngressResources = k8sResources.IngressResources
 			if k8sResources.Pod != nil {
+				spec.Pod.Annotations = k8sResources.Pod.Annotations.Copy()
 				spec.Pod.RestartPolicy = k8sResources.Pod.RestartPolicy
 				spec.Pod.ActiveDeadlineSeconds = k8sResources.Pod.ActiveDeadlineSeconds
 				spec.Pod.TerminationGracePeriodSeconds = k8sResources.Pod.TerminationGracePeriodSeconds

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -137,6 +137,7 @@ func (p podSpecLegacy) ToLatest() *specs.PodSpec {
 	}
 
 	iPodSpec := &PodSpec{
+		Annotations:                   p.k8sPodSpecLegacy.Annotations.Copy(),
 		RestartPolicy:                 p.k8sPodSpecLegacy.RestartPolicy,
 		ActiveDeadlineSeconds:         p.k8sPodSpecLegacy.ActiveDeadlineSeconds,
 		TerminationGracePeriodSeconds: p.k8sPodSpecLegacy.TerminationGracePeriodSeconds,

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -25,6 +25,8 @@ func (s *legacySpecsSuite) TestParse(c *gc.C) {
 
 	specStrBase := `
 omitServiceFrontend: true
+annotations:
+  foo: baz
 activeDeadlineSeconds: 10
 restartPolicy: OnFailure
 terminationGracePeriodSeconds: 20
@@ -290,6 +292,7 @@ echo "do some stuff here for gitlab-init container"
 		pSpecs.ProviderPod = &k8sspecs.K8sPodSpec{
 			KubernetesResources: &k8sspecs.KubernetesResources{
 				Pod: &k8sspecs.PodSpec{
+					Annotations:                   map[string]string{"foo": "baz"},
 					RestartPolicy:                 core.RestartPolicyOnFailure,
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					TerminationGracePeriodSeconds: int64Ptr(20),

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/juju/juju/caas/specs"
+	"github.com/juju/juju/core/annotations"
 )
 
 var logger = loggo.GetLogger("juju.kubernetes.provider.specs")
@@ -80,9 +81,16 @@ func (*K8sContainerSpec) Validate() error {
 	return nil
 }
 
+// PodSpecWithAnnotations wraps a k8s podspec to add annotations.
+type PodSpecWithAnnotations struct {
+	Annotations annotations.Annotation
+	core.PodSpec
+}
+
 // PodSpec is a subset of v1.PodSpec which defines
 // attributes we expose for charms to set.
 type PodSpec struct {
+	Annotations                   annotations.Annotation   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	RestartPolicy                 core.RestartPolicy       `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
 	ActiveDeadlineSeconds         *int64                   `json:"activeDeadlineSeconds,omitempty" yaml:"activeDeadlineSeconds,omitempty"`
 	TerminationGracePeriodSeconds *int64                   `json:"terminationGracePeriodSeconds,omitempty" yaml:"terminationGracePeriodSeconds,omitempty"`

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -164,6 +164,8 @@ kubernetesResources:
       verbs: ["bind"]
       resourceNames: ["admin","edit","view"]
   pod:
+    annotations:
+      foo: baz
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
     terminationGracePeriodSeconds: 20
@@ -611,6 +613,7 @@ echo "do some stuff here for gitlab-init container"
 			KubernetesResources: &k8sspecs.KubernetesResources{
 				K8sRBACResources: rbacResources,
 				Pod: &k8sspecs.PodSpec{
+					Annotations:                   map[string]string{"foo": "baz"},
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,
 					TerminationGracePeriodSeconds: int64Ptr(20),

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -229,6 +229,8 @@ kubernetesResources:
               resources: ["pods"]
               verbs: ["get", "watch", "list"]
   pod:
+    annotations:
+      foo: baz
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
     terminationGracePeriodSeconds: 20
@@ -799,6 +801,7 @@ echo "do some stuff here for gitlab-init container"
 				},
 				K8sRBACResources: rbacResources,
 				Pod: &k8sspecs.PodSpec{
+					Annotations:                   map[string]string{"foo": "baz"},
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,
 					TerminationGracePeriodSeconds: int64Ptr(20),

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -79,7 +79,7 @@ func (k *kubernetesClient) configureStatefulSet(
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels:      k.getStatefulSetLabels(appName),
-					Annotations: podAnnotations(annotations.Copy()).ToMap(),
+					Annotations: podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 			},
 			PodManagementPolicy: getPodManagementPolicy(workloadSpec.Service),
@@ -95,7 +95,7 @@ func (k *kubernetesClient) configureStatefulSet(
 	if err := k.configurePodFiles(appName, annotations, workloadSpec, containers, cfgName); err != nil {
 		return errors.Trace(err)
 	}
-	podSpec := workloadSpec.Pod
+	podSpec := workloadSpec.Pod.PodSpec
 	existingPodSpec := podSpec
 
 	handlePVC := func(pvc core.PersistentVolumeClaim, mountPath string, readOnly bool) error {


### PR DESCRIPTION
## Description of change

Allow charms to specify pod annotations in the pod spec.

```
kubernetesResources:
  pod:
    annotations:
      foo: baz
    restartPolicy: OnFailure
    activeDeadlineSeconds: 10
```

Most of the PR is white space changes in the tests.

## QA steps

deploy a k8s charm eg mariadb-k8s with a pod spec with annotations
kubectl et -o json pod/mariadb-k8s-0 | jq .metadata.annotations

