### PR TITLE
[dev] Revise response payload for OpenedMachinePortRanges API call

### DIFF
--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -80,24 +80,28 @@ func (s *stateSuite) TestOpenedMachinePortRanges(c *gc.C) {
 		*(result.(*params.OpenMachinePortRangesResults)) = params.OpenMachinePortRangesResults{
 			Results: []params.OpenMachinePortRangesResult{
 				{
-					GroupKey: "endpoint",
-					UnitPortRanges: []params.OpenUnitPortRanges{
+					Groups: []params.OpenUnitPortRangeGroup{
 						{
-							UnitTag: "unit-mysql-0",
-							PortRangeGroups: map[string][]params.PortRange{
-								"": {
-									{100, 200, "tcp"},
+							GroupKey: "endpoint",
+							UnitPortRanges: []params.OpenUnitPortRanges{
+								{
+									UnitTag: "unit-mysql-0",
+									PortRangeGroups: map[string][]params.PortRange{
+										"": {
+											{100, 200, "tcp"},
+										},
+										"server": {
+											{3306, 3306, "tcp"},
+										},
+									},
 								},
-								"server": {
-									{3306, 3306, "tcp"},
-								},
-							},
-						},
-						{
-							UnitTag: "unit-wordpress-0",
-							PortRangeGroups: map[string][]params.PortRange{
-								"monitoring-port": {
-									{1337, 1337, "udp"},
+								{
+									UnitTag: "unit-wordpress-0",
+									PortRangeGroups: map[string][]params.PortRange{
+										"monitoring-port": {
+											{1337, 1337, "udp"},
+										},
+									},
 								},
 							},
 						},

--- a/api/uniter/uniter.go
+++ b/api/uniter/uniter.go
@@ -416,12 +416,14 @@ func (st *State) OpenedMachinePortRanges(machineTag names.MachineTag) (map[names
 	result := results.Results[0]
 	if result.Error != nil {
 		return nil, result.Error
-	} else if result.GroupKey != "endpoint" {
-		return nil, fmt.Errorf("expected open unit port ranges to be grouped by endpoint, got %s", result.GroupKey)
+	} else if groupLen := len(result.Groups); groupLen != 1 {
+		return nil, fmt.Errorf("expected a single group for the unit port ranges; got %d", groupLen)
+	} else if result.Groups[0].GroupKey != "endpoint" {
+		return nil, fmt.Errorf("expected open unit port ranges to be grouped by endpoint, got %s", result.Groups[0].GroupKey)
 	}
 
 	portRangeMap := make(map[names.UnitTag]network.GroupedPortRanges)
-	for _, unitPortRanges := range result.UnitPortRanges {
+	for _, unitPortRanges := range result.Groups[0].UnitPortRanges {
 		unitTag, err := names.ParseUnitTag(unitPortRanges.UnitTag)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -430,7 +430,9 @@ func (u *UniterAPI) OpenedMachinePortRanges(args params.Entities) (params.OpenMa
 			continue
 		}
 
-		result.Results[i].GroupKey = "endpoint"
+		unitPortRangeGroup := params.OpenUnitPortRangeGroup{
+			GroupKey: "endpoint",
+		}
 
 		for unitName, unitPortRanges := range machPortRanges.ByUnit() {
 			byEp := make(map[string][]params.PortRange)
@@ -439,16 +441,18 @@ func (u *UniterAPI) OpenedMachinePortRanges(args params.Entities) (params.OpenMa
 					byEp[endpointName] = append(byEp[endpointName], params.FromNetworkPortRange(pr))
 				}
 			}
-			result.Results[i].UnitPortRanges = append(result.Results[i].UnitPortRanges, params.OpenUnitPortRanges{
+			unitPortRangeGroup.UnitPortRanges = append(unitPortRangeGroup.UnitPortRanges, params.OpenUnitPortRanges{
 				UnitTag:         names.NewUnitTag(unitName).String(),
 				PortRangeGroups: byEp,
 			})
 		}
 
-		// Sort result list by endpoint name to yield consistent results.
-		sort.Slice(result.Results[i].UnitPortRanges, func(a, b int) bool {
-			return result.Results[i].UnitPortRanges[a].UnitTag < result.Results[i].UnitPortRanges[b].UnitTag
+		// Sort result list by unit tag to yield consistent results.
+		sort.Slice(unitPortRangeGroup.UnitPortRanges, func(a, b int) bool {
+			return unitPortRangeGroup.UnitPortRanges[a].UnitTag < unitPortRangeGroup.UnitPortRanges[b].UnitTag
 		})
+
+		result.Results[i].Groups = []params.OpenUnitPortRangeGroup{unitPortRangeGroup}
 	}
 	return result, nil
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3467,8 +3467,12 @@ func (s *uniterSuite) TestOpenedMachinePortRanges(c *gc.C) {
 		Results: []params.OpenMachinePortRangesResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{
-				GroupKey:       "endpoint",
-				UnitPortRanges: expectPortRanges,
+				Groups: []params.OpenUnitPortRangeGroup{
+					{
+						GroupKey:       "endpoint",
+						UnitPortRanges: expectPortRanges,
+					},
+				},
 			},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -226,8 +226,34 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 	c.Assert(res.Results, gc.HasLen, 1)
 
 	c.Assert(res.Results[0].Error, gc.IsNil)
-	c.Assert(res.Results[0].GroupKey, gc.Equals, "cidr", gc.Commentf("expected group key to be cidr; got %q", res.Results[0].GroupKey))
-	c.Assert(res.Results[0].UnitPortRanges, gc.DeepEquals, []params.OpenUnitPortRanges{
+	c.Assert(res.Results[0].Groups, gc.HasLen, 2, gc.Commentf("expected response to include two groups for the unit port ranges"))
+
+	group0 := res.Results[0].Groups[0]
+	c.Assert(group0.GroupKey, gc.Equals, "endpoint", gc.Commentf("expected group key to be cidr; got %q", group0.GroupKey))
+	c.Assert(group0.UnitPortRanges, gc.DeepEquals, []params.OpenUnitPortRanges{
+		// NOTE: results are sorted by unit tag (each port ranges list
+		// is sorted as well).
+		{
+			UnitTag: "unit-mysql-0",
+			PortRangeGroups: map[string][]params.PortRange{
+				"foo": {
+					params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
+				},
+			},
+		},
+		{
+			UnitTag: "unit-wordpress-0",
+			PortRangeGroups: map[string][]params.PortRange{
+				"": {
+					params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
+				},
+			},
+		},
+	})
+
+	group1 := res.Results[0].Groups[1]
+	c.Assert(group1.GroupKey, gc.Equals, "cidr", gc.Commentf("expected group key to be cidr; got %q", group1.GroupKey))
+	c.Assert(group1.UnitPortRanges, gc.DeepEquals, []params.OpenUnitPortRanges{
 		// NOTE: results are sorted by unit tag (each port ranges list
 		// is sorted as well).
 		{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18673,20 +18673,16 @@
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
-                        "group-key": {
-                            "type": "string"
-                        },
-                        "unit-port-ranges": {
+                        "unit-port-range-group": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/OpenUnitPortRanges"
+                                "$ref": "#/definitions/OpenUnitPortRangeGroup"
                             }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "group-key",
-                        "unit-port-ranges"
+                        "unit-port-range-group"
                     ]
                 },
                 "OpenMachinePortRangesResults": {
@@ -18702,6 +18698,25 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "OpenUnitPortRangeGroup": {
+                    "type": "object",
+                    "properties": {
+                        "group-key": {
+                            "type": "string"
+                        },
+                        "unit-port-ranges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OpenUnitPortRanges"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "group-key",
+                        "unit-port-ranges"
                     ]
                 },
                 "OpenUnitPortRanges": {
@@ -40805,20 +40820,16 @@
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
-                        "group-key": {
-                            "type": "string"
-                        },
-                        "unit-port-ranges": {
+                        "unit-port-range-group": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/OpenUnitPortRanges"
+                                "$ref": "#/definitions/OpenUnitPortRangeGroup"
                             }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "group-key",
-                        "unit-port-ranges"
+                        "unit-port-range-group"
                     ]
                 },
                 "OpenMachinePortRangesResults": {
@@ -40834,6 +40845,25 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "OpenUnitPortRangeGroup": {
+                    "type": "object",
+                    "properties": {
+                        "group-key": {
+                            "type": "string"
+                        },
+                        "unit-port-ranges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OpenUnitPortRanges"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "group-key",
+                        "unit-port-ranges"
                     ]
                 },
                 "OpenUnitPortRanges": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -808,6 +808,13 @@ type OpenMachinePortRangesResults struct {
 type OpenMachinePortRangesResult struct {
 	Error *Error `json:"error,omitempty"`
 
+	Groups []OpenUnitPortRangeGroup `json:"unit-port-range-group"`
+}
+
+// OpenUnitPortRangeGroup is a list of per-unit opened port ranges where the
+// per-unit ports are grouped by a particular feature (e.g. by endpoint name or
+// subnet CIDR).
+type OpenUnitPortRangeGroup struct {
 	// GroupKey defines the attribute used to group the opened port ranges.
 	// This is set either to "endpoint" or to "cidr".
 	GroupKey string `json:"group-key"`


### PR DESCRIPTION
## Description of change

This response payload was recently introduced (in #11882) to support the "open-ports for endpoints" work and would initially group the port ranges for each unit by either endpoint name or resolved subnet CIDR (for the bound space) depending on whether the response was generated by the uniter facade or the firewaller facade.

However, for the "expose application endpoints" work, the firewaller must be able to access this information using *both* grouping modes. To this end, the response payload had to be modified so that it can include multiple groupings. In addition, the firewaller facade implementation has been changed to populate its response with types of groupings.
