### PR TITLE
Use testing clock instead of wallclock for exec tests;

### DIFF
--- a/caas/kubernetes/provider/exec/exec_test.go
+++ b/caas/kubernetes/provider/exec/exec_test.go
@@ -363,7 +363,7 @@ func (s *execSuite) TestExec(c *gc.C) {
 	select {
 	case err := <-errChan:
 		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(coretesting.LongWait):
+	case <-time.After(coretesting.ShortWait):
 		c.Fatalf("timed out waiting for Exec return")
 	}
 }
@@ -453,11 +453,8 @@ func (s *execSuite) TestExecCancel(c *gc.C) {
 		switch currentCall {
 		case 0:
 			close(cancel)
-			select {
-			case <-wait:
-			case <-time.After(waitTime):
-				c.Fatalf("timed out waiting for exit")
-			}
+			err := s.clock.WaitAdvance(waitTime, coretesting.LongWait, 1)
+			c.Assert(err, jc.ErrorIsNil)
 		case 1:
 		case 2:
 		case 3:
@@ -474,7 +471,7 @@ func (s *execSuite) TestExecCancel(c *gc.C) {
 	select {
 	case err := <-errChan:
 		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(waitTime):
+	case <-time.After(coretesting.ShortWait):
 		c.Fatalf("timed out waiting for Exec return")
 	}
 }


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Use the testing clock instead of wallclock for exec tests;

