### PR TITLE
[dev] Use dedicated payloads for the uniter/firewaller OpenedMachinePortRanges calls

### DIFF
--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -8,11 +8,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/firewaller"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/state"
@@ -188,107 +186,4 @@ func mustClosePortRanges(c *gc.C, st *state.State, u *state.Unit, endpointName s
 	}
 
 	c.Assert(st.ApplyOperation(unitPortRanges.Changes()), jc.ErrorIsNil)
-}
-
-func (s *machineSuite) TestOpenedPortRanges(c *gc.C) {
-	mockResponse := params.OpenMachinePortRangesResults{
-		Results: []params.OpenMachinePortRangesResult{
-			{
-				GroupKey: "cidr",
-				UnitPortRanges: []params.OpenUnitPortRanges{
-					{
-						UnitTag: "unit-mysql-0",
-						PortRangeGroups: map[string][]params.PortRange{
-							// The subnet CIDRs for space "42" that "foo"
-							// is bound to.
-							"192.168.0.0/24": {
-								params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
-							},
-							"192.168.1.0/24": {
-								params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
-							},
-						},
-					},
-					{
-						UnitTag: "unit-wordpress-0",
-						PortRangeGroups: map[string][]params.PortRange{
-							// Wordpress has opened port 80 to
-							// all bound spaces (alpha and 42). We should
-							// get an entry in each subnet
-							"10.0.0.0/24": {
-								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-							},
-							"10.0.1.0/24": {
-								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-							},
-							"192.168.0.0/24": {
-								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-							},
-							"192.168.1.0/24": {
-								params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	apiCaller := basetesting.BestVersionCaller{
-		BestVersion: 6, // we need V6+ to use this API
-		APICallerFunc: func(objType string, version int, id, request string, arg, result interface{}) error {
-			c.Assert(objType, gc.Equals, "Firewaller")
-
-			// When we access the machine, the client checks that it's alive
-			if request == "Life" {
-				c.Assert(result, gc.FitsTypeOf, &params.LifeResults{})
-				*(result.(*params.LifeResults)) = params.LifeResults{
-					Results: []params.LifeResult{
-						{Life: life.Alive},
-					},
-				}
-				return nil
-			}
-
-			// This is the actual call we are testing.
-			c.Assert(request, gc.Equals, "OpenedMachinePortRanges")
-			c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: s.machines[0].MachineTag().String()}}})
-			c.Assert(result, gc.FitsTypeOf, &params.OpenMachinePortRangesResults{})
-			*(result.(*params.OpenMachinePortRangesResults)) = mockResponse
-			return nil
-		},
-	}
-
-	client, err := firewaller.NewClient(apiCaller)
-	c.Assert(err, jc.ErrorIsNil)
-
-	mach, err := client.Machine(s.machines[0].MachineTag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	portsRangesByCIDR, err := mach.OpenedMachinePortRanges()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(portsRangesByCIDR, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
-		names.NewUnitTag("mysql/0"): {
-			"192.168.0.0/24": []network.PortRange{
-				network.MustParsePortRange("3306/tcp"),
-			},
-			"192.168.1.0/24": []network.PortRange{
-				network.MustParsePortRange("3306/tcp"),
-			},
-		},
-		names.NewUnitTag("wordpress/0"): {
-			"10.0.0.0/24": []network.PortRange{
-				network.MustParsePortRange("80/tcp"),
-			},
-			"10.0.1.0/24": []network.PortRange{
-				network.MustParsePortRange("80/tcp"),
-			},
-			"192.168.0.0/24": []network.PortRange{
-				network.MustParsePortRange("80/tcp"),
-			},
-			"192.168.1.0/24": []network.PortRange{
-				network.MustParsePortRange("80/tcp"),
-			},
-		},
-	})
 }

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -81,7 +81,7 @@ func (s *stateSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 			Results: []params.OpenMachinePortRangesByEndpointResult{
 				{
 					UnitPortRanges: map[string][]params.OpenUnitPortRangesByEndpoint{
-						"unit-mysql-0": []params.OpenUnitPortRangesByEndpoint{
+						"unit-mysql-0": {
 							{
 								Endpoint:   "",
 								PortRanges: []params.PortRange{{100, 200, "tcp"}},
@@ -91,7 +91,7 @@ func (s *stateSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 								PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
 							},
 						},
-						"unit-wordpress-0": []params.OpenUnitPortRangesByEndpoint{
+						"unit-wordpress-0": {
 							{
 								Endpoint:   "monitoring-port",
 								PortRanges: []params.PortRange{{1337, 1337, "udp"}},

--- a/api/uniter/state_test.go
+++ b/api/uniter/state_test.go
@@ -71,34 +71,30 @@ func (s *stateSuite) TestAllMachinePorts(c *gc.C) {
 	})
 }
 
-func (s *stateSuite) TestOpenedMachinePortRanges(c *gc.C) {
+func (s *stateSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
-		c.Assert(request, gc.Equals, "OpenedMachinePortRanges")
+		c.Assert(request, gc.Equals, "OpenedMachinePortRangesByEndpoint")
 		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "machine-42"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.OpenMachinePortRangesResults{})
-		*(result.(*params.OpenMachinePortRangesResults)) = params.OpenMachinePortRangesResults{
-			Results: []params.OpenMachinePortRangesResult{
+		c.Assert(result, gc.FitsTypeOf, &params.OpenMachinePortRangesByEndpointResults{})
+		*(result.(*params.OpenMachinePortRangesByEndpointResults)) = params.OpenMachinePortRangesByEndpointResults{
+			Results: []params.OpenMachinePortRangesByEndpointResult{
 				{
-					GroupKey: "endpoint",
-					UnitPortRanges: []params.OpenUnitPortRanges{
-						{
-							UnitTag: "unit-mysql-0",
-							PortRangeGroups: map[string][]params.PortRange{
-								"": {
-									{100, 200, "tcp"},
-								},
-								"server": {
-									{3306, 3306, "tcp"},
-								},
+					UnitPortRanges: map[string][]params.OpenUnitPortRangesByEndpoint{
+						"unit-mysql-0": []params.OpenUnitPortRangesByEndpoint{
+							{
+								Endpoint:   "",
+								PortRanges: []params.PortRange{{100, 200, "tcp"}},
+							},
+							{
+								Endpoint:   "server",
+								PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
 							},
 						},
-						{
-							UnitTag: "unit-wordpress-0",
-							PortRangeGroups: map[string][]params.PortRange{
-								"monitoring-port": {
-									{1337, 1337, "udp"},
-								},
+						"unit-wordpress-0": []params.OpenUnitPortRangesByEndpoint{
+							{
+								Endpoint:   "monitoring-port",
+								PortRanges: []params.PortRange{{1337, 1337, "udp"}},
 							},
 						},
 					},
@@ -110,7 +106,7 @@ func (s *stateSuite) TestOpenedMachinePortRanges(c *gc.C) {
 	caller := testing.BestVersionCaller{apiCaller, 17}
 	client := uniter.NewState(caller, names.NewUnitTag("mysql/0"))
 
-	portRangesMap, err := client.OpenedMachinePortRanges(names.NewMachineTag("42"))
+	portRangesMap, err := client.OpenedMachinePortRangesByEndpoint(names.NewMachineTag("42"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(portRangesMap, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3446,13 +3446,13 @@ func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 		{Tag: "application-wordpress"},
 	}}
 	expectPortRanges := map[string][]params.OpenUnitPortRangesByEndpoint{
-		"unit-mysql-1": []params.OpenUnitPortRangesByEndpoint{
+		"unit-mysql-1": {
 			{
 				Endpoint:   "server",
 				PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
 			},
 		},
-		"unit-wordpress-0": []params.OpenUnitPortRangesByEndpoint{
+		"unit-wordpress-0": {
 			{
 				Endpoint:   "",
 				PortRanges: []params.PortRange{{100, 200, "tcp"}},

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3414,7 +3414,7 @@ func (s *uniterSuite) TestAssignedMachine(c *gc.C) {
 	})
 }
 
-func (s *uniterSuite) TestOpenedMachinePortRanges(c *gc.C) {
+func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 	// Verify no ports are opened yet on the machine (or unit).
 	machinePortRanges, err := s.machine0.OpenedPortRanges()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3445,29 +3445,30 @@ func (s *uniterSuite) TestOpenedMachinePortRanges(c *gc.C) {
 		{Tag: "machine-42"},
 		{Tag: "application-wordpress"},
 	}}
-	expectPortRanges := []params.OpenUnitPortRanges{
-		// Result list is always sorted by unit name.
-		{
-			UnitTag: "unit-mysql-1",
-			PortRangeGroups: map[string][]params.PortRange{
-				"server": {{3306, 3306, "tcp"}},
+	expectPortRanges := map[string][]params.OpenUnitPortRangesByEndpoint{
+		"unit-mysql-1": []params.OpenUnitPortRangesByEndpoint{
+			{
+				Endpoint:   "server",
+				PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
 			},
 		},
-		{
-			UnitTag: "unit-wordpress-0",
-			PortRangeGroups: map[string][]params.PortRange{
-				"":                {{100, 200, "tcp"}},
-				"monitoring-port": {{10, 20, "udp"}},
+		"unit-wordpress-0": []params.OpenUnitPortRangesByEndpoint{
+			{
+				Endpoint:   "",
+				PortRanges: []params.PortRange{{100, 200, "tcp"}},
+			},
+			{
+				Endpoint:   "monitoring-port",
+				PortRanges: []params.PortRange{{10, 20, "udp"}},
 			},
 		},
 	}
-	result, err := s.uniter.OpenedMachinePortRanges(args)
+	result, err := s.uniter.OpenedMachinePortRangesByEndpoint(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.OpenMachinePortRangesResults{
-		Results: []params.OpenMachinePortRangesResult{
+	c.Assert(result, gc.DeepEquals, params.OpenMachinePortRangesByEndpointResults{
+		Results: []params.OpenMachinePortRangesByEndpointResult{
 			{Error: apiservertesting.ErrUnauthorized},
 			{
-				GroupKey:       "endpoint",
 				UnitPortRanges: expectPortRanges,
 			},
 			{Error: apiservertesting.ErrUnauthorized},

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -226,40 +226,22 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 	c.Assert(res.Results, gc.HasLen, 1)
 
 	c.Assert(res.Results[0].Error, gc.IsNil)
-	c.Assert(res.Results[0].GroupKey, gc.Equals, "cidr", gc.Commentf("expected group key to be cidr; got %q", res.Results[0].GroupKey))
-	c.Assert(res.Results[0].UnitPortRanges, gc.DeepEquals, []params.OpenUnitPortRanges{
-		// NOTE: results are sorted by unit tag (each port ranges list
-		// is sorted as well).
-		{
-			UnitTag: "unit-mysql-0",
-			PortRangeGroups: map[string][]params.PortRange{
-				// The subnet CIDRs for space "42" that "foo"
-				// is bound to.
-				"192.168.0.0/24": {
-					params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
-				},
-				"192.168.1.0/24": {
-					params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
+	c.Assert(res.Results[0].UnitPortRanges, gc.DeepEquals, map[string][]params.OpenUnitPortRanges{
+		"unit-wordpress-0": []params.OpenUnitPortRanges{
+			{
+				Endpoint:    "",
+				SubnetCIDRs: []string{"10.0.0.0/24", "10.0.1.0/24", "192.168.0.0/24", "192.168.1.0/24"},
+				PortRanges: []params.PortRange{
+					params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
 				},
 			},
 		},
-		{
-			UnitTag: "unit-wordpress-0",
-			PortRangeGroups: map[string][]params.PortRange{
-				// Wordpress has opened port 80 to
-				// all bound spaces (alpha and 42). We should
-				// get an entry in each subnet
-				"10.0.0.0/24": {
-					params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-				},
-				"10.0.1.0/24": {
-					params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-				},
-				"192.168.0.0/24": {
-					params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
-				},
-				"192.168.1.0/24": {
-					params.FromNetworkPortRange(network.MustParsePortRange("80/tcp")),
+		"unit-mysql-0": []params.OpenUnitPortRanges{
+			{
+				Endpoint:    "foo",
+				SubnetCIDRs: []string{"192.168.0.0/24", "192.168.1.0/24"},
+				PortRanges: []params.PortRange{
+					params.FromNetworkPortRange(network.MustParsePortRange("3306/tcp")),
 				},
 			},
 		},

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -227,7 +227,7 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 
 	c.Assert(res.Results[0].Error, gc.IsNil)
 	c.Assert(res.Results[0].UnitPortRanges, gc.DeepEquals, map[string][]params.OpenUnitPortRanges{
-		"unit-wordpress-0": []params.OpenUnitPortRanges{
+		"unit-wordpress-0": {
 			{
 				Endpoint:    "",
 				SubnetCIDRs: []string{"10.0.0.0/24", "10.0.1.0/24", "192.168.0.0/24", "192.168.1.0/24"},
@@ -236,7 +236,7 @@ func (s *OpenedMachinePortsSuite) TestOpenedMachinePortRanges(c *gc.C) {
 				},
 			},
 		},
-		"unit-mysql-0": []params.OpenUnitPortRanges{
+		"unit-mysql-0": {
 			{
 				Endpoint:    "foo",
 				SubnetCIDRs: []string{"192.168.0.0/24", "192.168.1.0/24"},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18029,7 +18029,7 @@
                             "$ref": "#/definitions/OpenMachinePortRangesResults"
                         }
                     },
-                    "description": "OpenedMachinePortRanges returns a list of the opened port ranges for the\nspecified machines where each result is broken down by unit and by subnet\nCIDR."
+                    "description": "OpenedMachinePortRanges returns a list of the opened port ranges for the\nspecified machines where each result is broken down by unit. The list of\nopened ports for each unit is further grouped by endpoint name and includes\nthe subnet CIDRs that belong to the space that each endpoint is bound to."
                 },
                 "SetRelationsStatus": {
                     "type": "object",
@@ -18673,19 +18673,20 @@
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
-                        "group-key": {
-                            "type": "string"
-                        },
                         "unit-port-ranges": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/OpenUnitPortRanges"
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/OpenUnitPortRanges"
+                                    }
+                                }
                             }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "group-key",
                         "unit-port-ranges"
                     ]
                 },
@@ -18707,25 +18708,27 @@
                 "OpenUnitPortRanges": {
                     "type": "object",
                     "properties": {
-                        "port-range-groups": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/definitions/PortRange"
-                                    }
-                                }
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "port-ranges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PortRange"
                             }
                         },
-                        "unit-tag": {
-                            "type": "string"
+                        "subnet-cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "unit-tag",
-                        "port-range-groups"
+                        "endpoint",
+                        "port-ranges",
+                        "subnet-cidrs"
                     ]
                 },
                 "PortRange": {
@@ -38873,17 +38876,17 @@
                         }
                     }
                 },
-                "OpenedMachinePortRanges": {
+                "OpenedMachinePortRangesByEndpoint": {
                     "type": "object",
                     "properties": {
                         "Params": {
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/OpenMachinePortRangesResults"
+                            "$ref": "#/definitions/OpenMachinePortRangesByEndpointResults"
                         }
                     },
-                    "description": "OpenedMachinePortRanges returns the port ranges opened by each unit on the\nprovided machines grouped by application endpoint."
+                    "description": "OpenedMachinePortRangesByEndpoint returns the port ranges opened by each\nunit on the provided machines grouped by application endpoint."
                 },
                 "PrivateAddress": {
                     "type": "object",
@@ -40799,35 +40802,36 @@
                         "results"
                     ]
                 },
-                "OpenMachinePortRangesResult": {
+                "OpenMachinePortRangesByEndpointResult": {
                     "type": "object",
                     "properties": {
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
-                        "group-key": {
-                            "type": "string"
-                        },
                         "unit-port-ranges": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/OpenUnitPortRanges"
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/OpenUnitPortRangesByEndpoint"
+                                    }
+                                }
                             }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "group-key",
                         "unit-port-ranges"
                     ]
                 },
-                "OpenMachinePortRangesResults": {
+                "OpenMachinePortRangesByEndpointResults": {
                     "type": "object",
                     "properties": {
                         "results": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/OpenMachinePortRangesResult"
+                                "$ref": "#/definitions/OpenMachinePortRangesByEndpointResult"
                             }
                         }
                     },
@@ -40836,28 +40840,23 @@
                         "results"
                     ]
                 },
-                "OpenUnitPortRanges": {
+                "OpenUnitPortRangesByEndpoint": {
                     "type": "object",
                     "properties": {
-                        "port-range-groups": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/definitions/PortRange"
-                                    }
-                                }
-                            }
-                        },
-                        "unit-tag": {
+                        "endpoint": {
                             "type": "string"
+                        },
+                        "port-ranges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PortRange"
+                            }
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "unit-tag",
-                        "port-range-groups"
+                        "endpoint",
+                        "port-ranges"
                     ]
                 },
                 "PodSpec": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -795,32 +795,26 @@ type MachinePortsResults struct {
 	Results []MachinePortsResult `json:"results"`
 }
 
-// OpenMachinePortRangesResults holds the results of a request to the uniter's
-// OpenedMachinePortRanges API.
-type OpenMachinePortRangesResults struct {
-	Results []OpenMachinePortRangesResult `json:"results"`
+// OpenMachinePortRangesByEndpointResults holds the results of a request to the
+// uniter's OpenedMachinePortRangesByEndpoint API.
+type OpenMachinePortRangesByEndpointResults struct {
+	Results []OpenMachinePortRangesByEndpointResult `json:"results"`
 }
 
-// OpenMachinePortRangesResult holds a single result of a request to the
-// uniter's or the firewaller's OpenedMachinePortRanges API. It provides
-// information about the set of open port ranges by each one of the units
-// deployed to the machine.
-type OpenMachinePortRangesResult struct {
+// OpenMachinePortRangesByEndpointResult holds a single result of a request to
+// the uniter's OpenedMachinePortRangesByEndpoint API.
+type OpenMachinePortRangesByEndpointResult struct {
 	Error *Error `json:"error,omitempty"`
 
-	// GroupKey defines the attribute used to group the opened port ranges.
-	// This is set either to "endpoint" or to "cidr".
-	GroupKey string `json:"group-key"`
-
-	UnitPortRanges []OpenUnitPortRanges `json:"unit-port-ranges"`
+	// The set of opened port ranges grouped by unit tag.
+	UnitPortRanges map[string][]OpenUnitPortRangesByEndpoint `json:"unit-port-ranges"`
 }
 
-// OpenUnitPortRanges describes the set of port ranges (grouped by a particular
-// attribute, eg. endpoint, or subnet CIDR) that have been opened by a unit on
-// the machine it is deployed to.
-type OpenUnitPortRanges struct {
-	UnitTag         string                 `json:"unit-tag"`
-	PortRangeGroups map[string][]PortRange `json:"port-range-groups"`
+// OpenUnitPortRangesByEndpoint describes the set of port ranges that have been
+// opened by a unit on the machine it is deployed to for an endpoint.
+type OpenUnitPortRangesByEndpoint struct {
+	Endpoint   string      `json:"endpoint"`
+	PortRanges []PortRange `json:"port-ranges"`
 }
 
 // APIHostPortsResult holds the result of an APIHostPorts

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -817,6 +817,32 @@ type OpenUnitPortRangesByEndpoint struct {
 	PortRanges []PortRange `json:"port-ranges"`
 }
 
+// OpenMachinePortRangesResults holds the results of a request to the
+// firewaller's OpenedMachinePortRanges API.
+type OpenMachinePortRangesResults struct {
+	Results []OpenMachinePortRangesResult `json:"results"`
+}
+
+// OpenMachinePortRangesResult holds a single result of a request to
+// the firewaller's OpenedMachinePortRanges API.
+type OpenMachinePortRangesResult struct {
+	Error *Error `json:"error,omitempty"`
+
+	// The set of opened port ranges grouped by unit tag.
+	UnitPortRanges map[string][]OpenUnitPortRanges `json:"unit-port-ranges"`
+}
+
+// OpenUnitPortRanges describes the set of port ranges that have been
+// opened by a unit on the machine it is deployed to for an endpoint.
+type OpenUnitPortRanges struct {
+	Endpoint   string      `json:"endpoint"`
+	PortRanges []PortRange `json:"port-ranges"`
+
+	// The CIDRs that correspond to the subnets assigned to the space that
+	// this endpoint is bound to.
+	SubnetCIDRs []string `json:"subnet-cidrs"`
+}
+
 // APIHostPortsResult holds the result of an APIHostPorts
 // call. Each element in the top level slice holds
 // the addresses for one API server.

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -338,7 +338,7 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 
 	var machPortRanges map[names.UnitTag]network.GroupedPortRanges
 	if f.modelType == model.IAAS {
-		if machPortRanges, err = f.state.OpenedMachinePortRanges(f.machineTag); err != nil {
+		if machPortRanges, err = f.state.OpenedMachinePortRangesByEndpoint(f.machineTag); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -70,7 +70,7 @@ func NewHookContext(hcParams HookContextParams) (*HookContext, error) {
 	if err != nil {
 		return nil, err
 	}
-	machPorts, err := hcParams.State.OpenedMachinePortRanges(ctx.assignedMachineTag)
+	machPorts, err := hcParams.State.OpenedMachinePortRangesByEndpoint(ctx.assignedMachineTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description of change

Note: this PR supersedes #11953 and incorporates the review comments from that PR.

Prior to this PR, the `OpenedMachinePortRanges` call for the uniter and the firewaller facades used the same response payload (see #11882 for the firewaller implementation). To support the "expose application endpoints" work, the firewaller needs information about the per-unit opened port ranges per endpoint _and_ the subnet CIDRs that correspond to the space that each endpoint is bound to. As a result, the shared response payload for these calls proved to be inadequate.

This PR introduces the following changes:
- the uniter call has been renamed to `OpenedMachinePortRangesByEndpoint` to better indicate its purpose. It
now has its own dedicated payload type with one less level of indirection.
- the firewaller also gets its own dedicated payload which also includes the required CIDR details.
- the client for the `OpenedMachinePortRanges` firewaller API call has been removed as it was targeting a single machine at a time (something that will change with the upcoming firewaller changes). It will be re-introduced in a future PR with a signature that allows us to receive this information for a list of machine tags.

# QA steps
Not required, the changed API is not wired yet.