### PR TITLE
Link-layer Processing by Device Name

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -200,24 +200,24 @@ func (o *MachineLinkLayerOp) PopulateExistingAddresses() error {
 	return errors.Trace(err)
 }
 
-// MatchingIncoming returns the first incoming interface that matches
-// the input known device, based on name and hardware address.
+// MatchingIncoming returns the first incoming interface
+// that matches the input known device based on name.
 // Nil is returned if there is no match.
 func (o *MachineLinkLayerOp) MatchingIncoming(dev LinkLayerDevice) *network.InterfaceInfo {
-	if matches := o.incoming.GetByNameAndHardwareAddress(dev.Name(), dev.MACAddress()); len(matches) > 0 {
+	if matches := o.incoming.GetByName(dev.Name()); len(matches) > 0 {
 		return &matches[0]
 	}
 	return nil
 }
 
 // MatchingIncomingAddrs finds all the primary addresses on devices matching
-// the input name and hardware address, and returns them as state args.
+// the input name, and returns them as state args.
 // TODO (manadart 2020-07-15): We should investigate making an enhanced
 // core/network address type instead of this state type.
 // It would embed ProviderAddress and could be obtained directly via a method
 // or property of InterfaceInfos.
-func (o *MachineLinkLayerOp) MatchingIncomingAddrs(name, hwAddress string) []state.LinkLayerDeviceAddress {
-	return networkAddressStateArgsForDevice(o.Incoming(), name, hwAddress)
+func (o *MachineLinkLayerOp) MatchingIncomingAddrs(name string) []state.LinkLayerDeviceAddress {
+	return networkAddressStateArgsForDevice(o.Incoming(), name)
 }
 
 // DeviceAddresses returns all currently known
@@ -238,36 +238,34 @@ func (o *MachineLinkLayerOp) AssertAliveOp() txn.Op {
 	return o.machine.AssertAliveOp()
 }
 
-// MarkDevProcessed indicates that the input hardware address was present in
-// the incoming data and its updates have been handled by the build step.
-func (o *MachineLinkLayerOp) MarkDevProcessed(name, hwAddr string) {
-	o.processedDevs.Add(deviceKey(name, hwAddr))
+// MarkDevProcessed indicates that the input device name was present in the
+// incoming data and its updates have been handled by the build step.
+func (o *MachineLinkLayerOp) MarkDevProcessed(name string) {
+	o.processedDevs.Add(name)
 }
 
 // IsDevProcessed returns a boolean indicating whether the input incoming
 // device matches a known device that was marked as processed by the method
 // above.
 func (o *MachineLinkLayerOp) IsDevProcessed(dev network.InterfaceInfo) bool {
-	return o.processedDevs.Contains(deviceKey(dev.InterfaceName, dev.MACAddress))
+	return o.processedDevs.Contains(dev.InterfaceName)
 }
 
 // MarkAddrProcessed indicates that the input (known) IP address was present in
 // the incoming data for the device with input hardware address.
-func (o *MachineLinkLayerOp) MarkAddrProcessed(name, hwAddr, ipAddr string) {
-	key := deviceKey(name, hwAddr)
-
-	if _, ok := o.processedAddrs[key]; !ok {
-		o.processedAddrs[key] = set.NewStrings(ipAddr)
+func (o *MachineLinkLayerOp) MarkAddrProcessed(name, ipAddr string) {
+	if _, ok := o.processedAddrs[name]; !ok {
+		o.processedAddrs[name] = set.NewStrings(ipAddr)
 	} else {
-		o.processedAddrs[key].Add(ipAddr)
+		o.processedAddrs[name].Add(ipAddr)
 	}
 }
 
 // IsAddrProcessed returns a boolean indicating whether the input incoming
 // device/address pair matches an entry that was marked as processed by the
 // method above.
-func (o *MachineLinkLayerOp) IsAddrProcessed(name, hwAddr, ipAddr string) bool {
-	if addrs, ok := o.processedAddrs[deviceKey(name, hwAddr)]; ok {
+func (o *MachineLinkLayerOp) IsAddrProcessed(name, ipAddr string) bool {
+	if addrs, ok := o.processedAddrs[name]; ok {
 		return addrs.Contains(ipAddr)
 	}
 	return false
@@ -276,8 +274,4 @@ func (o *MachineLinkLayerOp) IsAddrProcessed(name, hwAddr, ipAddr string) bool {
 // Done (state.ModelOperation) returns the result of running the operation.
 func (o *MachineLinkLayerOp) Done(err error) error {
 	return err
-}
-
-func deviceKey(name, hwAddr string) string {
-	return name + hwAddr
 }

--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -155,11 +155,16 @@ func NewMachineLinkLayerOp(machine LinkLayerMachine, incoming network.InterfaceI
 	logger.Infof("processing link-layer devices for machine %q", machine.Id())
 
 	return &MachineLinkLayerOp{
-		machine:        machine,
-		incoming:       incoming,
-		processedDevs:  set.NewStrings(),
-		processedAddrs: make(map[string]set.Strings),
+		machine:  machine,
+		incoming: incoming,
 	}
+}
+
+// ClearProcessed ensures that any record of processed devices and addresses is
+// effectively zeroed. This should be called before each transaction attempt.
+func (o *MachineLinkLayerOp) ClearProcessed() {
+	o.processedDevs = set.NewStrings()
+	o.processedAddrs = make(map[string]set.Strings)
 }
 
 // Incoming is a property accessor for the link-layer data we are processing.

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -178,7 +178,6 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpMultipleAddressSuccess(
 	// It will be unchanged and generate no update ops.
 	lbDev := mocks.NewMockLinkLayerDevice(ctrl)
 	lbExp := lbDev.EXPECT()
-	lbExp.MACAddress().Return("").MinTimes(1)
 	lbExp.Name().Return("lo").MinTimes(1)
 	lbExp.UpdateOps(state.LinkLayerDeviceArgs{
 		Name:        "lo",
@@ -201,7 +200,6 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpMultipleAddressSuccess(
 	ethMAC := "aa:bb:cc:dd:ee:f0"
 	ethDev := mocks.NewMockLinkLayerDevice(ctrl)
 	ethExp := ethDev.EXPECT()
-	ethExp.MACAddress().Return(ethMAC).MinTimes(1)
 	ethExp.Name().Return("eth0").MinTimes(1)
 	ethExp.UpdateOps(state.LinkLayerDeviceArgs{
 		Name:        "eth0",
@@ -373,7 +371,6 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpBridgedDeviceMovesAddre
 	// Device eth0 exists with an address.
 	childDev := mocks.NewMockLinkLayerDevice(ctrl)
 	childExp := childDev.EXPECT()
-	childExp.MACAddress().Return(hwAddr).MinTimes(1)
 	childExp.Name().Return("eth0").MinTimes(1)
 
 	// We expect an update with the bridge as parent.

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -212,13 +212,11 @@ func networkDeviceToStateArgs(dev corenetwork.InterfaceInfo) state.LinkLayerDevi
 // configuration is sometimes supplied with a duplicated device for each
 // address.
 // This is a normalisation that returns state args for all primary addresses
-// of interfaces with the input name and hardware address.
-func networkAddressStateArgsForDevice(
-	devs corenetwork.InterfaceInfos, name, hwAddr string,
-) []state.LinkLayerDeviceAddress {
+// of interfaces with the input name.
+func networkAddressStateArgsForDevice(devs corenetwork.InterfaceInfos, name string) []state.LinkLayerDeviceAddress {
 	var res []state.LinkLayerDeviceAddress
 
-	for _, dev := range devs.GetByNameAndHardwareAddress(name, hwAddr) {
+	for _, dev := range devs.GetByName(name) {
 		if dev.PrimaryAddress().Value == "" {
 			continue
 		}

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -430,10 +430,10 @@ func (s *TypesSuite) TestAddressMatchingFromObservedConfig(c *gc.C) {
 	}
 
 	interfaces := params.InterfaceInfoFromNetworkConfig(cfg)
-	breno38 := interfaces.GetByNameAndHardwareAddress("br-eno3-8", "ac:1f:6b:65:66:46")
+	breno38 := interfaces.GetByName("br-eno3-8")
 	c.Check(breno38, gc.HasLen, 2)
 
-	stateAddr := networkAddressStateArgsForDevice(interfaces, "br-eno3-8", "ac:1f:6b:65:66:46")
+	stateAddr := networkAddressStateArgsForDevice(interfaces, "br-eno3-8")
 	c.Check(stateAddr, gc.DeepEquals, []state.LinkLayerDeviceAddress{{
 		DeviceName:       "br-eno3-8",
 		ConfigMethod:     "static",

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -173,7 +173,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 	// TODO (manadart 2020-07-15): We also need to set shadow addresses.
 	// These are sent where appropriate by the provider,
 	// but we do not yet process them.
-	incomingAddrs := o.MatchingIncomingAddrs(dev.Name(), dev.MACAddress())
+	incomingAddrs := o.MatchingIncomingAddrs(dev.Name())
 
 	for _, addr := range o.DeviceAddresses(dev) {
 		addrOps, err := o.processExistingDeviceAddress(dev, addr, incomingAddrs)
@@ -185,7 +185,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDevice(dev networkingcommon.Lin
 
 	// TODO (manadart 2020-07-15): Process (log) new addresses on the device.
 
-	o.MarkDevProcessed(dev.Name(), dev.MACAddress())
+	o.MarkDevProcessed(dev.Name())
 	return ops, nil
 }
 
@@ -213,14 +213,13 @@ func (o *mergeMachineLinkLayerOp) processExistingDeviceAddress(
 	incomingAddrs []state.LinkLayerDeviceAddress,
 ) ([]txn.Op, error) {
 	addrValue := addr.Value()
-	hwAddr := dev.MACAddress()
 	name := dev.Name()
 
 	// If one of the incoming addresses matches the existing one,
 	// return ops for setting the incoming provider IDs.
 	for _, incomingAddr := range incomingAddrs {
 		if strings.HasPrefix(incomingAddr.CIDRAddress, addrValue) {
-			if o.IsAddrProcessed(name, hwAddr, addrValue) {
+			if o.IsAddrProcessed(name, addrValue) {
 				continue
 			}
 
@@ -229,7 +228,7 @@ func (o *mergeMachineLinkLayerOp) processExistingDeviceAddress(
 				return nil, errors.Trace(err)
 			}
 
-			o.MarkAddrProcessed(name, hwAddr, addrValue)
+			o.MarkAddrProcessed(name, addrValue)
 
 			return append(ops, addr.SetProviderNetIDsOps(
 				incomingAddr.ProviderNetworkID, incomingAddr.ProviderSubnetID)...), nil

--- a/apiserver/facades/controller/instancepoller/merge.go
+++ b/apiserver/facades/controller/instancepoller/merge.go
@@ -38,7 +38,9 @@ func newMergeMachineLinkLayerOp(
 
 // Build (state.ModelOperation) returns the transaction operations used to
 // merge incoming provider link-layer data with that in state.
-func (o *mergeMachineLinkLayerOp) Build(_ int) ([]txn.Op, error) {
+func (o *mergeMachineLinkLayerOp) Build(attempt int) ([]txn.Op, error) {
+	o.ClearProcessed()
+
 	if err := o.PopulateExistingDevices(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -52,7 +54,9 @@ func (o *mergeMachineLinkLayerOp) Build(_ int) ([]txn.Op, error) {
 		return nil, jujutxn.ErrNoOperations
 	}
 
-	o.normaliseIncoming()
+	if attempt == 0 {
+		o.normaliseIncoming()
+	}
 
 	if err := o.PopulateExistingAddresses(); err != nil {
 		return nil, errors.Trace(err)

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -266,16 +266,12 @@ func (s InterfaceInfos) Validate() error {
 	return nil
 }
 
-// GetByNameAndHardwareAddress returns a new collection containing any
-// interfaces with the input device name and hardware (MAC) address.
-// This is intended to uniquely identify devices, accommodating the following
-// knowledge:
-// - Bridges have the same MAC address as their child devices.
-// - AWS does not supply device names, but does supply HW address.
-func (s InterfaceInfos) GetByNameAndHardwareAddress(name, hwAddr string) InterfaceInfos {
+// GetByName returns a new collection containing
+// any interfaces with the input device name.
+func (s InterfaceInfos) GetByName(name string) InterfaceInfos {
 	var res InterfaceInfos
 	for _, dev := range s {
-		if dev.InterfaceName == name && dev.MACAddress == hwAddr {
+		if dev.InterfaceName == name {
 			res = append(res, dev)
 		}
 	}

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -130,24 +130,12 @@ func (*nicSuite) TestInterfaceInfosValidate(c *gc.C) {
 	c.Check(getInterFaceInfos().Validate(), jc.ErrorIsNil)
 }
 
-func (s *nicSuite) TestInterfaceInfosGetByNameAndHardwareAddress(c *gc.C) {
-	name := "eth0"
-	hwAddr := "00:16:3e:aa:bb:cc"
-
-	devs := s.info.GetByNameAndHardwareAddress("wrong-name", hwAddr)
+func (s *nicSuite) TestInterfaceInfosGetByName(c *gc.C) {
+	devs := s.info.GetByName("wrong-name")
 	c.Assert(devs, gc.IsNil)
 
-	devs = s.info.GetByNameAndHardwareAddress(name, "wrong-MAC")
-	c.Assert(devs, gc.IsNil)
-
-	devs = s.info.GetByNameAndHardwareAddress(name, hwAddr)
+	devs = s.info.GetByName("eth0")
 	c.Assert(devs, gc.HasLen, 1)
-
-	devs = append(s.info, network.InterfaceInfo{
-		InterfaceName: name,
-		MACAddress:    hwAddr,
-	}).GetByNameAndHardwareAddress(name, hwAddr)
-	c.Assert(devs, gc.HasLen, 2)
 }
 
 func getInterFaceInfos() network.InterfaceInfos {


### PR DESCRIPTION
## Description of change

This patch comes full-circle back to reasoning about link-layer devices based on name.

Prior patches attempted to do matching based on hardware address due to providers such as EC2, which know the MAC, but not the device name. Those changes failed to accommodate the fact that:
- Bridging an Ethernet device will result in the both the NIC and the bridge device having the same MAC address.
- Bridging a VLAN tag will result in a different bridge MAC address if it is performed multiple times.
- Bonding NICs will cause the bonded NICs and the bond device to share the same MAC, effectively changing the MAC of one or more Ethernet devices *despite* MAAS thinking the MAC has not changed.

The last of the items above is addressed here, by assuming that device name can uniquely identify a device. This is possible due to the addition of the `normaliseIncoming` method added under #11921.

In addition, a fix is added so that the tracking of processed devices and addresses is cleared each time we attempt to build the update model operation. 

## QA steps

### MAAS

For this, I used my local virtual MAAS.
- Ensure one of the KVMs has at least 3 NICs and re-commission it in MAAS.
- Bond 2 of the NICs *not* used for PXE, leave the device unconfigured.
- Add a new space. _space-siksiksix_ to the fabric with MAAS DHCP.
- Add a new VLAN, _vlan-666_ to this space/fabric.
- Add a new subnet with some unused /24 CIDR to the VLAN/space.
- Enable DHCP relay via the untagged VLAN on the same fabric.
- Add this VLAN/subnet as a tag to the bond device created above, with auto-assigned IP.
- Now bootstrap, ensuring that a different machine is the controller.
- Deploy this bundle:
```yaml
description: Test bundle for bridging VLANs
series: bionic
machines:
  '0':
    constraints: spaces=space-siksiksix
    series: bionic
applications:
    postgres:
        charm: "cs:postgresql-208"
        num_units: 2
        to: ["lxd:0", "lxd:0"]
        constraints: spaces=space-default,space-siksiksix
        bindings:
            "": space-siksiksix
    mysql:
        charm: "cs:percona-cluster-291"
        num_units: 2
        to: ["lxd:0", "lxd:0"]
        constraints: spaces=space-default,space-siksiksix
        bindings:
            "": space-siksiksix
    mongo:
        charm: "cs:mongodb-56"
        num_units: 2
        to: ["lxd:0", "lxd:0"]
        constraints: spaces=space-default,space-siksiksix
        bindings:
            "": space-siksiksix
```
- The bundle should quiesce without errors:
```
Model    Controller  Cloud/Region  Version  SLA          Timestamp
default  test        localmaas     2.8.2.1  unsupported  15:58:38+02:00

App       Version  Status  Scale  Charm            Store       Rev  OS      Notes
mongo     3.6.3    active      2  mongodb          jujucharms   56  ubuntu
mysql     5.7.20   active      2  percona-cluster  jujucharms  291  ubuntu
postgres  10.14    active      2  postgresql       jujucharms  208  ubuntu

Unit         Workload  Agent  Machine  Public address  Ports                                    Message
mongo/0*     active    idle   0/lxd/0  172.16.0.2      27017/tcp,27019/tcp,27021/tcp,28017/tcp  Unit is ready as PRIMARY
mongo/1      active    idle   0/lxd/1  172.16.0.5      27017/tcp,27019/tcp,27021/tcp,28017/tcp  Unit is ready as SECONDARY
mysql/0*     active    idle   0/lxd/2  172.16.0.6      3306/tcp                                 Unit is ready
mysql/1      active    idle   0/lxd/3  172.16.0.3      3306/tcp                                 Unit is ready
postgres/0*  active    idle   0/lxd/4  172.16.0.7      5432/tcp                                 Live master (10.14)
postgres/1   active    idle   0/lxd/5  172.16.0.4      5432/tcp                                 Live secondary (10.14)

Machine  State    DNS         Inst id              Series  AZ       Message
0        started  172.16.0.1  kvm-01               bionic  default  Deployed
0/lxd/0  started  172.16.0.2  juju-18c04f-0-lxd-0  bionic  default  Container started
0/lxd/1  started  172.16.0.5  juju-18c04f-0-lxd-1  bionic  default  Container started
0/lxd/2  started  172.16.0.6  juju-18c04f-0-lxd-2  bionic  default  Container started
0/lxd/3  started  172.16.0.3  juju-18c04f-0-lxd-3  bionic  default  Container started
0/lxd/4  started  172.16.0.7  juju-18c04f-0-lxd-4  bionic  default  Container started
0/lxd/5  started  172.16.0.4  juju-18c04f-0-lxd-5  bionic  default  Container started
```

### AWS (Regression)

- Bootstrap to AWS.
- Once complete, check the collections `linklayerdevices` and `ip.addresses`. The Ethernet device and its address should both have a provider [subnet] ID, and no duplicate devices or addresses should be present.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1893629
