### PR TITLE
Config for whether Azure nodes get a public IP address

### DIFF
--- a/provider/azure/init.go
+++ b/provider/azure/init.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	providerType = "azure"
+	// ProviderType defines the Azure provider.
+	ProviderType = "azure"
 )
 
 // NewProvider instantiates and returns the Azure EnvironProvider using the
@@ -41,7 +42,7 @@ func init() {
 		panic(err)
 	}
 
-	environs.RegisterProvider(providerType, environProvider)
+	environs.RegisterProvider(ProviderType, environProvider)
 
 	// TODO(axw) register an image metadata data source that queries
 	// the Azure image registry, and introduce a way to disable the

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -31,6 +31,7 @@ import (
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo/utils"
+	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/state/upgrade"
 	"github.com/juju/juju/storage/provider"
 )
@@ -3165,4 +3166,45 @@ func AddCharmOriginToApplications(pool *StatePool) error {
 		}
 		return nil
 	}))
+}
+
+// AddAzureProviderNetworkConfig adds new network config attributes to any Azure models.
+func AddAzureProviderNetworkConfig(pool *StatePool) error {
+	st := pool.SystemState()
+	var ops []txn.Op
+	coll, closer := st.db().GetRawCollection(settingsC)
+	defer closer()
+	iter := coll.Find(bson.D{}).Iter()
+	defer iter.Close()
+	var doc settingsDoc
+	for iter.Next(&doc) {
+		// Is this an Azure cloud...
+		cloudType, _ := doc.Settings[config.TypeKey].(string)
+		if cloudType != azure.ProviderType {
+			continue
+		}
+		// Has this model already been upgraded, or is it new.
+		_, hasPublicIPSetting := doc.Settings[azure.ConfigAttrUsePublicIP]
+		if hasPublicIPSetting {
+			continue
+		}
+
+		defaults := azure.DefaultNetworkConfigForUpgrade()
+		for k, v := range defaults {
+			doc.Settings[k] = v
+		}
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     doc.DocID,
+			Assert: txn.DocExists,
+			Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
+		})
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runRawTransaction(ops))
+	}
+	return nil
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -88,6 +88,7 @@ type StateBackend interface {
 	RollUpAndConvertOpenedPortDocuments() error
 	AddCharmHubToModelConfig() error
 	AddCharmOriginToApplications() error
+	AddAzureProviderNetworkConfig() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -367,4 +368,8 @@ func (s stateBackend) RollUpAndConvertOpenedPortDocuments() error {
 
 func (s stateBackend) AddCharmOriginToApplications() error {
 	return state.AddCharmOriginToApplications(s.pool)
+}
+
+func (s stateBackend) AddAzureProviderNetworkConfig() error {
+	return state.AddAzureProviderNetworkConfig(s.pool)
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -40,6 +40,13 @@ func stateStepsFor29() []Step {
 				return context.State().AddCharmOriginToApplications()
 			},
 		},
+		&upgradeStep{
+			description: "add Azure provider network config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddAzureProviderNetworkConfig()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_29_test.go
+++ b/upgrades/steps_29_test.go
@@ -52,6 +52,11 @@ func (s *steps29Suite) TestAddCharmOriginToApplications(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps29Suite) TestAddAzureProviderNetworkConfig(c *gc.C) {
+	step := findStateStep(c, v290, "add Azure provider network config")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 type mergeAgents29Suite struct {
 	testing.BaseSuite
 


### PR DESCRIPTION
## Description of change

Introduce an Azure provider config (use-public-ip) to allow instances to be created without a public IP address.
This config will default to true to maintain existing behaviour.
Currently, all public clouds (ec2, google, oracle, azure) use public IP addresses. We will eventually roll out the use of this new config across all providers. And openstack which uses "use-floating-ip" can be migrated to use the new config instead.

Also, there's no need to use a static address for the node cloud local address. Private dynamic addresses are sticky and survive machine stop/start and reboot.

Finally, use the environschema capability to define the Azure config attributes.

## QA steps

juju bootstrap azure -> no change in behaviour
juju bootstrap azure --config use-public-ip=false -> tested on customer site

deploy juju 2.8 on azure
juju upgrade-controller
juju model-config use-public-ip -> true

## Bug reference

https://bugs.launchpad.net/juju/+bug/1891523
