### PR TITLE
Allow external users to consume offers

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -424,7 +424,7 @@ func (api *OffersAPI) FindApplicationOffers(filters params.OfferFilters) (params
 			defer release()
 			modelFilter := filters.Filters[0]
 			modelFilter.ModelName = m.Name()
-			modelFilter.OwnerName = m.Owner().Name()
+			modelFilter.OwnerName = m.Owner().Id()
 			filtersToUse.Filters = append(filtersToUse.Filters, modelFilter)
 		}
 	} else {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -213,7 +213,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error, expected
 	filter := params.OfferFilters{
 		Filters: []params.OfferFilter{
 			{
-				OwnerName:       "fred",
+				OwnerName:       "fred@external",
 				ModelName:       "prod",
 				OfferName:       "hosted-db2",
 				ApplicationName: "test",
@@ -234,7 +234,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error, expected
 				ApplicationDescription: "description",
 				OfferName:              "hosted-db2",
 				OfferUUID:              "hosted-db2-uuid",
-				OfferURL:               "fred/prod.hosted-db2",
+				OfferURL:               "fred@external/prod.hosted-db2",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 				Bindings:               map[string]string{"db2": "myspace"},
 				Spaces: []params.RemoteSpace{
@@ -255,7 +255,7 @@ func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error, expected
 				SourceModelTag: testing.ModelTag.String(),
 				RelationId:     1,
 				Endpoint:       "db",
-				Username:       "fred",
+				Username:       "fred@external",
 				Status:         params.EntityStatus{Status: "joined"},
 				IngressSubnets: expectedCIDRS,
 			}},
@@ -316,7 +316,7 @@ func (s *applicationOffersSuite) TestListError(c *gc.C) {
 	filter := params.OfferFilters{
 		Filters: []params.OfferFilter{
 			{
-				OwnerName:       "fred",
+				OwnerName:       "fred@external",
 				ModelName:       "prod",
 				OfferName:       "hosted-db2",
 				ApplicationName: "test",
@@ -387,7 +387,7 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
-				OfferURL:               "fred/prod.hosted-db2",
+				OfferURL:               "fred@external/prod.hosted-db2",
 				OfferName:              "hosted-db2",
 				OfferUUID:              "hosted-db2-uuid",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
@@ -400,7 +400,7 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 					},
 				},
 				Users: []params.OfferUserDetails{
-					{UserName: "fred", DisplayName: "", Access: "admin"},
+					{UserName: "fred@external", DisplayName: "", Access: "admin"},
 					{UserName: "mary", DisplayName: "mary", Access: "consume"},
 				},
 			},
@@ -408,7 +408,7 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 			CharmURL:        "cs:db2-2",
 			Connections: []params.OfferConnection{{
 				SourceModelTag: "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-				RelationId:     1, Username: "fred", Endpoint: "db",
+				RelationId:     1, Username: "fred@external", Endpoint: "db",
 				Status:         params.EntityStatus{Status: "joined"},
 				IngressSubnets: []string{"192.168.1.0/32", "10.0.0.0/8"},
 			}},
@@ -416,11 +416,11 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 	}}
 	s.authorizer.Tag = names.NewUserTag("admin")
 	expected[0].Result.Users[0].UserName = "admin"
-	s.assertShow(c, "fred/prod.hosted-db2", expected)
+	s.assertShow(c, "fred@external/prod.hosted-db2", expected)
 	// Again with an unqualified model path.
-	s.authorizer.AdminTag = names.NewUserTag("fred")
+	s.authorizer.AdminTag = names.NewUserTag("fred@external")
 	s.authorizer.Tag = s.authorizer.AdminTag
-	expected[0].Result.Users[0].UserName = "fred"
+	expected[0].Result.Users[0].UserName = "fred@external"
 	s.applicationOffers.ResetCalls()
 	s.assertShow(c, "prod.hosted-db2", expected)
 }
@@ -434,9 +434,9 @@ func (s *applicationOffersSuite) TestShowNoPermission(c *gc.C) {
 
 	s.authorizer.Tag = user
 	expected := []params.ApplicationOfferResult{{
-		Error: common.ServerError(errors.NotFoundf("application offer %q", "fred/prod.hosted-db2")),
+		Error: common.ServerError(errors.NotFoundf("application offer %q", "fred@external/prod.hosted-db2")),
 	}}
-	s.assertShow(c, "fred/prod.hosted-db2", expected)
+	s.assertShow(c, "fred@external/prod.hosted-db2", expected)
 }
 
 func (s *applicationOffersSuite) TestShowPermission(c *gc.C) {
@@ -447,7 +447,7 @@ func (s *applicationOffersSuite) TestShowPermission(c *gc.C) {
 			ApplicationOfferDetails: params.ApplicationOfferDetails{
 				SourceModelTag:         testing.ModelTag.String(),
 				ApplicationDescription: "description",
-				OfferURL:               "fred/prod.hosted-db2",
+				OfferURL:               "fred@external/prod.hosted-db2",
 				OfferName:              "hosted-db2",
 				OfferUUID:              "hosted-db2-uuid",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
@@ -466,18 +466,18 @@ func (s *applicationOffersSuite) TestShowPermission(c *gc.C) {
 		}}}
 	s.mockState.users[user.Name()] = &mockUser{user.Name()}
 	s.mockState.CreateOfferAccess(names.NewApplicationOfferTag("hosted-db2"), user, permission.ReadAccess)
-	s.assertShow(c, "fred/prod.hosted-db2", expected)
+	s.assertShow(c, "fred@external/prod.hosted-db2", expected)
 }
 
 func (s *applicationOffersSuite) TestShowError(c *gc.C) {
-	url := "fred/prod.hosted-db2"
+	url := "fred@external/prod.hosted-db2"
 	filter := params.OfferURLs{[]string{url}, bakery.LatestVersion}
 	msg := "fail"
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, errors.New(msg)
 	}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 
 	_, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
@@ -485,41 +485,41 @@ func (s *applicationOffersSuite) TestShowError(c *gc.C) {
 }
 
 func (s *applicationOffersSuite) TestShowNotFound(c *gc.C) {
-	urls := []string{"fred/prod.hosted-db2"}
+	urls := []string{"fred@external/prod.hosted-db2"}
 	filter := params.OfferURLs{urls, bakery.LatestVersion}
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, nil
 	}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred/prod.hosted-db2" not found`)
+	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred@external/prod.hosted-db2" not found`)
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall)
 }
 
 func (s *applicationOffersSuite) TestShowRejectsEndpoints(c *gc.C) {
-	urls := []string{"fred/prod.hosted-db2:db"}
+	urls := []string{"fred@external/prod.hosted-db2:db"}
 	filter := params.OfferURLs{urls, bakery.LatestVersion}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Error.Message, gc.Equals, `remote application "fred/prod.hosted-db2:db" shouldn't include endpoint`)
+	c.Assert(found.Results[0].Error.Message, gc.Equals, `remote application "fred@external/prod.hosted-db2:db" shouldn't include endpoint`)
 }
 
 func (s *applicationOffersSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
-	urls := []string{"fred/prod.hosted-mysql", "fred/test.hosted-db2"}
+	urls := []string{"fred@external/prod.hosted-mysql", "fred@external/test.hosted-db2"}
 	filter := params.OfferURLs{urls, bakery.LatestVersion}
 
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, nil
 	}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
-	anotherModel := &mockModel{uuid: "uuid2", name: "test", owner: "fred", modelType: state.ModelTypeIAAS}
+	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
+	anotherModel := &mockModel{uuid: "uuid2", name: "test", owner: "fred@external", modelType: state.ModelTypeIAAS}
 	s.mockStatePool.st["uuid2"] = &mockState{
 		modelUUID: "uuid2",
 		model:     anotherModel,
@@ -529,14 +529,14 @@ func (s *applicationOffersSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 2)
-	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred/prod.hosted-mysql" not found`)
-	c.Assert(found.Results[1].Error.Error(), gc.Matches, `application offer "fred/test.hosted-db2" not found`)
+	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred@external/prod.hosted-mysql" not found`)
+	c.Assert(found.Results[1].Error.Error(), gc.Matches, `application offer "fred@external/test.hosted-db2" not found`)
 	s.applicationOffers.CheckCallNames(c, listOffersBackendCall, listOffersBackendCall)
 }
 
 func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 	name := "test"
-	url := "fred/prod.hosted-" + name
+	url := "fred@external/prod.hosted-" + name
 	anOffer := jujucrossmodel.ApplicationOffer{
 		ApplicationName:        name,
 		ApplicationDescription: "description",
@@ -570,7 +570,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 			charm: ch, curl: charm.MustParseURL("db2-2"), bindings: map[string]string{"db": "myspace"}},
 	}
 
-	model := &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	model := &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 	anotherModel := &mockModel{uuid: "uuid2", name: "test", owner: "mary", modelType: state.ModelTypeIAAS}
 
 	s.mockState.model = model
@@ -708,7 +708,7 @@ func (s *applicationOffersSuite) TestFid(c *gc.C) {
 				ApplicationDescription: "description",
 				OfferName:              "hosted-db2",
 				OfferUUID:              "hosted-db2-uuid",
-				OfferURL:               "fred/prod.hosted-db2",
+				OfferURL:               "fred@external/prod.hosted-db2",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 				Bindings:               map[string]string{"db2": "myspace"},
 				Spaces: []params.RemoteSpace{
@@ -725,7 +725,7 @@ func (s *applicationOffersSuite) TestFid(c *gc.C) {
 			CharmURL:        "cs:db2-2",
 			Connections: []params.OfferConnection{{
 				SourceModelTag: "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-				RelationId:     1, Username: "fred", Endpoint: "db",
+				RelationId:     1, Username: "fred@external", Endpoint: "db",
 				Status:         params.EntityStatus{Status: "joined"},
 				IngressSubnets: []string{"192.168.1.0/32", "10.0.0.0/8"},
 			}},
@@ -757,7 +757,7 @@ func (s *applicationOffersSuite) TestFindPermission(c *gc.C) {
 				ApplicationDescription: "description",
 				OfferName:              "hosted-db2",
 				OfferUUID:              "hosted-db2-uuid",
-				OfferURL:               "fred/prod.hosted-db2",
+				OfferURL:               "fred@external/prod.hosted-db2",
 				Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 				Bindings:               map[string]string{"db2": "myspace"},
 				Spaces: []params.RemoteSpace{
@@ -850,7 +850,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 			name:  "db2",
 			charm: ch, curl: charm.MustParseURL("db2-2"), bindings: map[string]string{"db2": "myspace"}},
 	}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 	s.mockState.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
 		providerId: "juju-space-myspace",
@@ -911,7 +911,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 	}
 	s.mockState.connections = []applicationoffers.OfferConnection{
 		&mockOfferConnection{
-			username:    "fred",
+			username:    "fred@external",
 			modelUUID:   testing.ModelTag.Id(),
 			relationKey: "hosted-db2:db wordpress:db",
 			relationId:  1,
@@ -930,7 +930,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 		Filters: []params.OfferFilter{
 			{
 				OfferName: "hosted-db2",
-				OwnerName: "fred",
+				OwnerName: "fred@external",
 				ModelName: "prod",
 			},
 			{
@@ -960,7 +960,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 					ApplicationDescription: "db2 description",
 					OfferName:              "hosted-db2",
 					OfferUUID:              "hosted-db2-uuid",
-					OfferURL:               "fred/prod.hosted-db2",
+					OfferURL:               "fred@external/prod.hosted-db2",
 					Endpoints:              []params.RemoteEndpoint{{Name: "db"}},
 					Bindings:               map[string]string{"db2": "myspace"},
 					Spaces: []params.RemoteSpace{
@@ -1021,7 +1021,7 @@ func (s *applicationOffersSuite) TestFindError(c *gc.C) {
 	s.applicationOffers.listOffers = func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error) {
 		return nil, errors.New(msg)
 	}
-	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	s.mockState.model = &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 
 	_, err := s.api.FindApplicationOffers(filter)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
@@ -1085,12 +1085,12 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 
 func (s *consumeSuite) TestConsumeDetailsRejectsEndpoints(c *gc.C) {
 	results, err := s.api.GetConsumeDetails(params.OfferURLs{
-		OfferURLs: []string{"fred/prod.application:db"},
+		OfferURLs: []string{"fred@external/prod.application:db"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error != nil, jc.IsTrue)
-	c.Assert(results.Results[0].Error.Message, gc.Equals, `remote application "fred/prod.application:db" shouldn't include endpoint`)
+	c.Assert(results.Results[0].Error.Message, gc.Equals, `remote application "fred@external/prod.application:db" shouldn't include endpoint`)
 }
 
 func (s *consumeSuite) TestConsumeDetailsNoPermission(c *gc.C) {
@@ -1104,11 +1104,11 @@ func (s *consumeSuite) TestConsumeDetailsNoPermission(c *gc.C) {
 
 	s.authorizer.Tag = apiUser
 	results, err := s.api.GetConsumeDetails(params.OfferURLs{
-		OfferURLs: []string{"fred/prod.hosted-mysql"},
+		OfferURLs: []string{"fred@external/prod.hosted-mysql"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []params.ConsumeOfferDetailsResult{{
-		Error: common.ServerError(errors.NotFoundf("application offer %q", "fred/prod.hosted-mysql")),
+		Error: common.ServerError(errors.NotFoundf("application offer %q", "fred@external/prod.hosted-mysql")),
 	}}
 	c.Assert(results.Results, jc.DeepEquals, expected)
 }
@@ -1124,14 +1124,14 @@ func (s *consumeSuite) TestConsumeDetailsWithPermission(c *gc.C) {
 
 	s.authorizer.Tag = apiUser
 	results, err := s.api.GetConsumeDetails(params.OfferURLs{
-		OfferURLs: []string{"fred/prod.hosted-mysql"},
+		OfferURLs: []string{"fred@external/prod.hosted-mysql"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOfferDetails{
 		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		OfferURL:               "fred/prod.hosted-mysql",
+		OfferURL:               "fred@external/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
 		OfferUUID:              "hosted-mysql-uuid",
 		ApplicationDescription: "a database",
@@ -1182,14 +1182,14 @@ func (s *consumeSuite) TestConsumeDetailsDefaultEndpoint(c *gc.C) {
 
 	s.authorizer.Tag = apiUser
 	results, err := s.api.GetConsumeDetails(params.OfferURLs{
-		OfferURLs: []string{"fred/prod.hosted-mysql"},
+		OfferURLs: []string{"fred@external/prod.hosted-mysql"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	c.Assert(results.Results[0].Offer, jc.DeepEquals, &params.ApplicationOfferDetails{
 		SourceModelTag:         "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		OfferURL:               "fred/prod.hosted-mysql",
+		OfferURL:               "fred@external/prod.hosted-mysql",
 		OfferName:              "hosted-mysql",
 		OfferUUID:              "hosted-mysql-uuid",
 		ApplicationDescription: "a database",
@@ -1205,7 +1205,7 @@ func (s *consumeSuite) setupOffer() {
 	modelUUID := testing.ModelTag.Id()
 	offerName := "hosted-mysql"
 
-	model := &mockModel{uuid: modelUUID, name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+	model := &mockModel{uuid: modelUUID, name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 	s.mockState.allmodels = []applicationoffers.Model{model}
 	st := &mockState{
 		modelUUID:         modelUUID,
@@ -1270,7 +1270,7 @@ func (s *consumeSuite) TestRemoteApplicationInfo(c *gc.C) {
 
 	s.authorizer.Tag = user
 	results, err := s.api.RemoteApplicationInfo(params.OfferURLs{
-		OfferURLs: []string{"fred/prod.hosted-mysql", "fred/prod.unknown"},
+		OfferURLs: []string{"fred@external/prod.hosted-mysql", "fred@external/prod.unknown"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
@@ -1280,7 +1280,7 @@ func (s *consumeSuite) TestRemoteApplicationInfo(c *gc.C) {
 			ModelTag:         testing.ModelTag.String(),
 			Name:             "hosted-mysql",
 			Description:      "a database",
-			OfferURL:         "fred/prod.hosted-mysql",
+			OfferURL:         "fred@external/prod.hosted-mysql",
 			SourceModelLabel: "prod",
 			IconURLPath:      "rest/1.0/remote-application/hosted-mysql/icon",
 			Endpoints: []params.RemoteEndpoint{
@@ -1320,7 +1320,7 @@ func (s *consumeSuite) assertDestroyOffersNoForce(c *gc.C, api destroyOffers) {
 	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 	st.(*mockState).connections = []applicationoffers.OfferConnection{
 		&mockOfferConnection{
-			username:    "fred",
+			username:    "fred@external",
 			modelUUID:   testing.ModelTag.Id(),
 			relationKey: "hosted-db2:db wordpress:db",
 			relationId:  1,
@@ -1330,7 +1330,7 @@ func (s *consumeSuite) assertDestroyOffersNoForce(c *gc.C, api destroyOffers) {
 	s.authorizer.Tag = names.NewUserTag("admin")
 	results, err := s.api.DestroyOffers(params.DestroyApplicationOffers{
 		OfferURLs: []string{
-			"fred/prod.hosted-mysql"},
+			"fred@external/prod.hosted-mysql"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -1340,12 +1340,12 @@ func (s *consumeSuite) assertDestroyOffersNoForce(c *gc.C, api destroyOffers) {
 		},
 	})
 
-	urls := []string{"fred/prod.hosted-db2"}
+	urls := []string{"fred@external/prod.hosted-db2"}
 	filter := params.OfferURLs{urls, bakery.LatestVersion}
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred/prod.hosted-db2" not found`)
+	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred@external/prod.hosted-db2" not found`)
 }
 
 func (s *consumeSuite) TestDestroyOffersForce(c *gc.C) {
@@ -1354,7 +1354,7 @@ func (s *consumeSuite) TestDestroyOffersForce(c *gc.C) {
 	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 	st.(*mockState).connections = []applicationoffers.OfferConnection{
 		&mockOfferConnection{
-			username:    "fred",
+			username:    "fred@external",
 			modelUUID:   testing.ModelTag.Id(),
 			relationKey: "hosted-db2:db wordpress:db",
 			relationId:  1,
@@ -1365,7 +1365,7 @@ func (s *consumeSuite) TestDestroyOffersForce(c *gc.C) {
 	results, err := s.api.DestroyOffers(params.DestroyApplicationOffers{
 		Force: true,
 		OfferURLs: []string{
-			"fred/prod.hosted-mysql", "fred/prod.unknown", "garbage/badmodel.someoffer", "badmodel.someoffer"},
+			"fred@external/prod.hosted-mysql", "fred@external/prod.unknown", "garbage/badmodel.someoffer", "badmodel.someoffer"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 4)
@@ -1381,12 +1381,12 @@ func (s *consumeSuite) TestDestroyOffersForce(c *gc.C) {
 		},
 	})
 
-	urls := []string{"fred/prod.hosted-db2"}
+	urls := []string{"fred@external/prod.hosted-db2"}
 	filter := params.OfferURLs{urls, bakery.LatestVersion}
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred/prod.hosted-db2" not found`)
+	c.Assert(found.Results[0].Error.Error(), gc.Matches, `application offer "fred@external/prod.hosted-db2" not found`)
 }
 
 func (s *consumeSuite) TestDestroyOffersPermission(c *gc.C) {
@@ -1396,7 +1396,7 @@ func (s *consumeSuite) TestDestroyOffersPermission(c *gc.C) {
 	st.(*mockState).users["foobar"] = &mockUser{"foobar"}
 
 	results, err := s.api.DestroyOffers(params.DestroyApplicationOffers{
-		OfferURLs: []string{"fred/prod.hosted-mysql"},
+		OfferURLs: []string{"fred@external/prod.hosted-mysql"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -385,7 +385,7 @@ func (api *BaseAPI) getApplicationOffersDetails(
 		model := models[modelUUID]
 
 		for _, offerDetails := range offers {
-			offerDetails.OfferURL = jujucrossmodel.MakeURL(model.Owner().Name(), model.Name(), offerDetails.OfferName, "")
+			offerDetails.OfferURL = jujucrossmodel.MakeURL(model.Owner().Id(), model.Name(), offerDetails.OfferName, "")
 			result = append(result, offerDetails)
 		}
 	}

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -107,7 +107,7 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string, filterWithEndpoin
 		},
 	}
 	s.mockState.model = &mockModel{
-		uuid: coretesting.ModelTag.Id(), name: "prod", owner: "fred", modelType: state.ModelTypeIAAS}
+		uuid: coretesting.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
 	s.mockState.relations["hosted-db2:db wordpress:db"] = &mockRelation{
 		id: 1,
 		endpoint: state.Endpoint{
@@ -121,7 +121,7 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string, filterWithEndpoin
 	}
 	s.mockState.connections = []applicationoffers.OfferConnection{
 		&mockOfferConnection{
-			username:    "fred",
+			username:    "fred@external",
 			modelUUID:   coretesting.ModelTag.Id(),
 			relationKey: "hosted-db2:db wordpress:db",
 			relationId:  1,

--- a/cmd/juju/crossmodel/list.go
+++ b/cmd/juju/crossmodel/list.go
@@ -160,7 +160,7 @@ func (c *listCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Trace(err)
 	}
 	c.filters = []crossmodel.ApplicationOfferFilter{{
-		OwnerName:       ownerTag.Name(),
+		OwnerName:       ownerTag.Id(),
 		ModelName:       unqualifiedModelName,
 		ApplicationName: c.applicationName,
 	}}

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -114,13 +114,13 @@ func (s *ListSuite) TestListSummary(c *gc.C) {
 		c,
 		[]string{"--format", "summary"},
 		`
-Offer       Application     Charm     Connected  Store           URL                                  Endpoint  Interface  Role
-adiff-db2   app-adiff-db2   cs:db2-5  0/2        vendor          vendor:fred/model.adiff-db2          log       http       provider
-                                                                                                      mysql     db2        requirer
-hosted-db2  app-hosted-db2  cs:db2-5  0/0        myctrl          myctrl:fred/model.hosted-db2         log       http       provider
-                                                                                                      mysql     db2        requirer
-zdiff-db2   app-zdiff-db2   cs:db2-5  1/3        differentstore  differentstore:fred/model.zdiff-db2  log       http       provider
-                                                                                                      mysql     db2        requirer
+Offer       Application     Charm     Connected  Store           URL                                           Endpoint  Interface  Role
+adiff-db2   app-adiff-db2   cs:db2-5  0/2        vendor          vendor:fred@external/model.adiff-db2          log       http       provider
+                                                                                                               mysql     db2        requirer
+hosted-db2  app-hosted-db2  cs:db2-5  0/0        myctrl          myctrl:fred@external/model.hosted-db2         log       http       provider
+                                                                                                               mysql     db2        requirer
+zdiff-db2   app-zdiff-db2   cs:db2-5  1/3        differentstore  differentstore:fred@external/model.zdiff-db2  log       http       provider
+                                                                                                               mysql     db2        requirer
 
 `[1:],
 		"",
@@ -253,7 +253,7 @@ hosted-db2:
   application: app-hosted-db2
   store: myctrl
   charm: cs:db2-5
-  offer-url: myctrl:fred/model.hosted-db2
+  offer-url: myctrl:fred@external/model.hosted-db2
   endpoints:
     mysql:
       interface: db2
@@ -288,7 +288,7 @@ func (s *ListSuite) createOfferItem(name, store string, connections []model.Offe
 	return &model.ApplicationOfferDetails{
 		ApplicationName: "app-" + name,
 		OfferName:       name,
-		OfferURL:        fmt.Sprintf("%s:%s.%s", store, "fred/model", name),
+		OfferURL:        fmt.Sprintf("%s:%s.%s", store, "fred@external/model", name),
 		CharmURL:        "cs:db2-5",
 		Endpoints:       s.endpoints,
 		Connections:     connections,

--- a/cmd/juju/crossmodel/offer.go
+++ b/cmd/juju/crossmodel/offer.go
@@ -163,7 +163,7 @@ func (c *offerCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	url := jujucrossmodel.MakeURL(ownerTag.Name(), unqualifiedModelName, c.OfferName, "")
+	url := jujucrossmodel.MakeURL(ownerTag.Id(), unqualifiedModelName, c.OfferName, "")
 	ep := strings.Join(c.Endpoints, ", ")
 	ctx.Infof("Application %q endpoints [%s] available at %q", c.Application, ep, url)
 	return nil

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -183,7 +183,7 @@ func makeURLFromCurrentModel(urlStr, offerSource, currentModel string) (*crossmo
 			return nil, errors.Trace(err)
 		}
 		modelName = baseName
-		userName = userTag.Name()
+		userName = userTag.Id()
 	}
 	derivedUrl := crossmodel.MakeURL(userName, modelName, urlStr, offerSource)
 	return crossmodel.ParseOfferURL(derivedUrl)

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -43,11 +43,11 @@ func (s *removeSuite) TestRemoveURLError(c *gc.C) {
 }
 
 func (s *removeSuite) TestRemoveURLWithEndpoints(c *gc.C) {
-	_, err := s.runRemove(c, "fred/model.db2:db")
+	_, err := s.runRemove(c, "fred@external/model.db2:db")
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `
 These offers contain endpoints. Only specify the offer name itself.
- -fred/model.db2:db`[1:])
+ -fred@external/model.db2:db`[1:])
 }
 
 func (s *removeSuite) TestRemoveInconsistentControllers(c *gc.C) {
@@ -62,8 +62,8 @@ func (s *removeSuite) TestRemoveApiError(c *gc.C) {
 }
 
 func (s *removeSuite) TestRemove(c *gc.C) {
-	s.mockAPI.expectedURLs = []string{"fred/model.db2", "mary/model.db2"}
-	_, err := s.runRemove(c, "fred/model.db2", "mary/model.db2", "-y")
+	s.mockAPI.expectedURLs = []string{"fred@external/model.db2", "mary/model.db2"}
+	_, err := s.runRemove(c, "fred@external/model.db2", "mary/model.db2", "-y")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -404,18 +404,6 @@ func setUnsetUsers(c accountDetailsGetter, offerURLs []*crossmodel.OfferURL) err
 	return nil
 }
 
-// offersForModel group the offer URLs per model.
-func offersForModel(offerURLs []*crossmodel.OfferURL) map[string][]string {
-	offersForModel := make(map[string][]string)
-	for _, url := range offerURLs {
-		fullName := jujuclient.JoinOwnerModelName(names.NewUserTag(url.User), url.ModelName)
-		offers := offersForModel[fullName]
-		offers = append(offers, url.ApplicationName)
-		offersForModel[fullName] = offers
-	}
-	return offersForModel
-}
-
 func (c *revokeCommand) runForOffers() error {
 	client, err := c.getOfferAPI()
 	if err != nil {


### PR DESCRIPTION
## Description of change

Tweak how offer URLs are constructed and back end filtering done to allow external users to make offers and have them consumable.

## QA steps

See bug for reproduction scenario.
```sh
$ juju bootstrap localhost localhost --config identity-url=https://api.jujucharms.com/identity
$ juju add-model test-1 --owner martin-hilton@external --credential localhost
$ juju grant admin admin martin-hilton@external/test-1
$ juju switch martin-hilton@external/test-1
$ juju deploy postgresql
$ juju offer postgresql:db

$ juju show-offer martin-hilton/test-1.postgresql
$ juju show-offer martin-hilton@external/test-1.postgresql
$ juju offers
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1893940
