### PR TITLE
Always show app status message; rename app Notes column to Message

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -131,9 +131,9 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Message")
 	} else {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Notes")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Message")
 	}
 	tw.SetColumnAlignRight(3)
 	tw.SetColumnAlignRight(6)
@@ -150,17 +150,6 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		// Don't let a long version push out the version column.
 		if len(version) > maxVersionWidth {
 			version = version[:truncatedWidth] + ellipsis
-		}
-		// Notes may well contain other things later.
-		notes := ""
-		if app.Exposed {
-			notes = "exposed"
-		}
-		// Expose any operator messages.
-		if fs.Model.Type == caasModelType {
-			if app.StatusInfo.Message != "" {
-				notes = app.StatusInfo.Message
-			}
 		}
 		w.Print(appName, version)
 		w.PrintStatus(app.StatusInfo.Current)
@@ -179,7 +168,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.Print(app.Address)
 		}
 
-		w.Println(notes)
+		w.Println(app.StatusInfo.Message)
 		for un, u := range app.Units {
 			units[un] = u
 			if u.MeterStatus != nil {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4996,10 +4996,10 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
 
-App        Version          Status       Scale  Charm      Store       Rev  OS      Notes
-logging    a bit too lo...  error            2  logging    jujucharms    1  ubuntu  exposed
-mysql      5.7.13           maintenance    1/2  mysql      jujucharms    1  ubuntu  exposed
-wordpress  4.5.3            active           1  wordpress  jujucharms    3  ubuntu  exposed
+App        Version          Status       Scale  Charm      Store       Rev  OS      Message
+logging    a bit too lo...  error            2  logging    jujucharms    1  ubuntu  somehow lost in all those logs
+mysql      5.7.13           maintenance    1/2  mysql      jujucharms    1  ubuntu  installing all the things
+wordpress  4.5.3            active           1  wordpress  jujucharms    3  ubuntu  
 
 Unit          Workload     Agent  Machine  Public address  Ports  Message
 mysql/0*      maintenance  idle   2        10.0.2.1               installing all the things
@@ -5104,7 +5104,7 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
+App  Version  Status  Scale  Charm  Store  Rev  OS  Message
 foo                       2                  0      
 
 Unit   Workload     Agent      Machine  Public address  Ports  Message
@@ -5152,7 +5152,7 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Notes
+App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Message
 foo                     1/2                  0      54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
@@ -5161,7 +5161,7 @@ foo/1  active    running     10.0.0.1  80/TCP
 `[1:])
 }
 
-func (s *StatusSuite) TestFormatTabularStatusNotes(c *gc.C) {
+func (s *StatusSuite) TestFormatTabularStatusMessage(c *gc.C) {
 	fStatus := formattedStatus{
 		Model: modelStatus{
 			Type: "caas",
@@ -5195,49 +5195,11 @@ func (s *StatusSuite) TestFormatTabularStatusNotes(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Notes
+App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Message
 foo                     0/1                  0      54.32.1.2  Error: ImagePullBackOff
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  waiting   allocating  10.0.0.1  80/TCP  
-`[1:])
-}
-
-func (s *StatusSuite) TestFormatTabularStatusNotesIAAS(c *gc.C) {
-	status := formattedStatus{
-		Applications: map[string]applicationStatus{
-			"foo": {
-				Address: "54.32.1.2",
-				StatusInfo: statusInfoContents{
-					Message: "Error: ImagePullBackOff",
-				},
-				Units: map[string]unitStatus{
-					"foo/0": {
-						Address:     "10.0.0.1",
-						OpenedPorts: []string{"80/TCP"},
-						JujuStatusInfo: statusInfoContents{
-							Current: status.Idle,
-						},
-						WorkloadStatusInfo: statusInfoContents{
-							Current: status.Waiting,
-						},
-					},
-				},
-			},
-		},
-	}
-	out := &bytes.Buffer{}
-	err := FormatTabular(out, false, status)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out.String(), gc.Equals, `
-Model  Controller  Cloud/Region  Version
-                                 
-
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
-foo                       1                  0      
-
-Unit   Workload  Agent  Machine  Public address  Ports   Message
-foo/0  waiting   idle                            80/TCP  
 `[1:])
 }
 
@@ -5297,7 +5259,7 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Notes
+App  Version  Status  Scale  Charm  Store  Rev  OS  Message
 foo                     0/2                  0      
 
 Unit   Workload  Agent  Machine  Public address  Ports  Message

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -165,10 +165,10 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 
 	context := s.run(c, "status")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Notes
-another             waiting    0/1  mysql      jujucharms    5  ubuntu  
-mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  
-wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  
+App        Version  Status   Scale  Charm      Store       Rev  OS      Message
+another             waiting    0/1  mysql      jujucharms    5  ubuntu  waiting for machine
+mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  waiting for machine
+wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 another/0    waiting   allocating  1                               waiting for machine
@@ -182,9 +182,9 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 	context = s.run(c, "status", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Notes
-mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  
-wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  
+App        Version  Status   Scale  Charm      Store       Rev  OS      Message
+mysql               waiting    0/1  mysql      jujucharms    1  ubuntu  waiting for machine
+wordpress           waiting    0/1  wordpress  jujucharms    3  ubuntu  waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	google.golang.org/grpc v1.30.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/amz.v3 v3.0.0-20191122063134-7ba11a47c789
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b
 	gopkg.in/goose.v2 v2.0.1
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -1025,6 +1025,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v1 v1.0.0-20151007153157-66cb46252b94/go.mod h1:u0ALmqvLRxLI95fkdCEWrE6mhWYZW1aMOJHp5YXLHTg=
 gopkg.in/errgo.v1 v1.0.0/go.mod h1:CxwszS/Xz1C49Ucd2i6Zil5UToP1EmyrFhKaMVbg1mk=

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -96,7 +96,7 @@ func BootstrapInstance(
 		}
 		return nil, "", nil, errors.Annotatef(err, "use --force to override")
 	}
-	// The series we're attemptting to bootstrap is empty, show a friendly
+	// The series we're attempting to bootstrap is empty, show a friendly
 	// error message, rather than the more cryptic error messages that follow
 	// onwards.
 	if selectedSeries == "" {


### PR DESCRIPTION
## Description of change

Previously the application status message was only shown for CAAS models, but we'd like to show it all the time for consistency and to address the issue in this bug.

This also removes display of "exposed" in the notes field (which was overwritten when a message was present in any case) as that is being revamped as we speak.

Updated go-check to the latest version, which pulls in [this minor
documentation fix](https://github.com/go-check/check/commit/038fdea0a05bc030b0bfda479dc2e08d2220ec74).

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

## QA steps

Example steps shown in linked bug.

## Documentation changes

I will scour the Discourse documentation and replace "Notes" with "Message".

## Bug reference

https://bugs.launchpad.net/juju/+bug/1850268
