### PR TITLE
Azure extra network config

### DIFF
--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -35,6 +35,10 @@ const (
 	// rather than Juju creating it.
 	configAttrResourceGroupName = "resource-group-name"
 
+	// configNetwork is the virtual network each machine's primary NIC
+	// is attached to.
+	configAttrNetwork = "network"
+
 	// The below bits are internal book-keeping things, rather than
 	// configuration. Config is just what we have to work with.
 
@@ -64,6 +68,11 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Immutable:   true,
 	},
+	configAttrNetwork: {
+		Description: "If set, use the specified virtual network for all model machines instead of creating one.",
+		Type:        environschema.Tstring,
+		Immutable:   true,
+	},
 }
 
 var configDefaults = schema.Defaults{
@@ -71,6 +80,7 @@ var configDefaults = schema.Defaults{
 	configAttrStorageAccountType:  string(storage.StandardLRS),
 	configAttrLoadBalancerSkuName: string(network.LoadBalancerSkuNameStandard),
 	configAttrResourceGroupName:   schema.Omit,
+	configAttrNetwork:             schema.Omit,
 }
 
 // DefaultNetworkConfigForUpgrade is used to set the config for an Azure
@@ -118,6 +128,7 @@ type azureModelConfig struct {
 	storageAccountType  string
 	loadBalancerSkuName string
 	resourceGroupName   string
+	virtualNetworkName  string
 }
 
 // knownStorageAccountTypes returns a list of valid storage SKU names.
@@ -249,6 +260,7 @@ Please choose a model name of no more than %d characters.`,
 	}
 
 	usePublicIP, _ := validated[ConfigAttrUsePublicIP].(bool)
+	networkName, _ := validated[configAttrNetwork].(string)
 
 	azureConfig := &azureModelConfig{
 		Config:              newCfg,
@@ -256,6 +268,7 @@ Please choose a model name of no more than %d characters.`,
 		storageAccountType:  storageAccountType,
 		loadBalancerSkuName: loadBalancerSkuName,
 		resourceGroupName:   userSpecifiedResourceGroup,
+		virtualNetworkName:  networkName,
 	}
 	return azureConfig, nil
 }

--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -109,6 +109,16 @@ func (s *configSuite) TestValidateResourceGroupNameCantChange(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot change immutable "resource-group-name" config \(foo -> bar\)`)
 }
 
+func (s *configSuite) TestValidateVirtualNetworkNameCantChange(c *gc.C) {
+	cfgOld := makeTestModelConfig(c, testing.Attrs{"network": "foo"})
+	_, err := s.provider.Validate(cfgOld, cfgOld)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfgNew := makeTestModelConfig(c, testing.Attrs{"network": "bar"})
+	_, err = s.provider.Validate(cfgNew, cfgOld)
+	c.Assert(err, gc.ErrorMatches, `cannot change immutable "network" config \(foo -> bar\)`)
+}
+
 func (s *configSuite) assertConfigValid(c *gc.C, attrs testing.Attrs) {
 	cfg := makeTestModelConfig(c, attrs)
 	_, err := s.provider.Validate(cfg, nil)


### PR DESCRIPTION
## Description of change

Introduce a "network" model config attribute for the Azure provider.
If set, do not create a new virtual network - the expectation is that there's one there already with subnets. New instances are configured to use this existing subnet.

As a driveby, add the network security group to the template dependencies.

This won't work yet because subnet discovery is not done, but it's the first piece.
If unset, bootstrap behaves as normal.

## QA steps

regression test bootstrap
juju bootstrap azure

