### PR TITLE
Azure Subnet Discovery

### DIFF
--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -4,6 +4,10 @@
 package azure
 
 import (
+	stdcontext "context"
+
+	azurenetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -16,44 +20,86 @@ import (
 var _ environs.NetworkingEnviron = &azureEnviron{}
 
 // SupportsSpaces implements environs.NetworkingEnviron.
-func (e *azureEnviron) SupportsSpaces(context.ProviderCallContext) (bool, error) {
+func (env *azureEnviron) SupportsSpaces(context.ProviderCallContext) (bool, error) {
 	return false, nil
 }
 
 // Subnets implements environs.NetworkingEnviron.
-func (e *azureEnviron) Subnets(context.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error) {
-	return nil, errors.NotSupportedf("subnets")
+func (env *azureEnviron) Subnets(
+	_ context.ProviderCallContext, instanceID instance.Id, _ []network.Id) ([]network.SubnetInfo, error) {
+	if instanceID != instance.UnknownId {
+		return nil, errors.NotSupportedf("subnets for instance")
+	}
+
+	netName := env.config.virtualNetworkName
+	if netName == "" {
+		netName = internalNetworkName
+	}
+
+	// Subnet discovery happens immediately after model creation.
+	// We need to ensure that the asynchronously invoked resource creation has
+	// completed and added our networking assets.
+	if err := env.waitCommonResourcesCreated(); err != nil {
+		return nil, errors.Annotate(
+			err, "waiting for common resources to be created",
+		)
+	}
+
+	subClient := azurenetwork.SubnetsClient{BaseClient: env.network}
+	subnets, err := subClient.List(stdcontext.Background(), env.resourceGroup, netName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	values := subnets.Values()
+	results := make([]network.SubnetInfo, len(values))
+	for i, sub := range values {
+		id := to.String(sub.ID)
+
+		// An empty CIDR is no use to us, so guard against it.
+		cidr := to.String(sub.AddressPrefix)
+		if cidr == "" {
+			logger.Debugf("ignoring subnet %q with empty address prefix", id)
+			continue
+		}
+
+		results[i] = network.SubnetInfo{
+			CIDR:       cidr,
+			ProviderId: network.Id(id),
+		}
+	}
+	return results, nil
 }
 
 // SuperSubnets implements environs.NetworkingEnviron.
-func (e *azureEnviron) SuperSubnets(context.ProviderCallContext) ([]string, error) {
+func (env *azureEnviron) SuperSubnets(context.ProviderCallContext) ([]string, error) {
 	return nil, errors.NotSupportedf("super subnets")
 }
 
 // SupportsSpaceDiscovery implements environs.NetworkingEnviron.
-func (e *azureEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
+func (env *azureEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
 	return false, nil
 }
 
 // Spaces implements environs.NetworkingEnviron.
-func (e *azureEnviron) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (env *azureEnviron) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
 	return nil, errors.NotSupportedf("spaces")
 }
 
 // SupportsContainerAddresses implements environs.NetworkingEnviron.
-func (e *azureEnviron) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
+func (env *azureEnviron) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
 	return false, nil
 }
 
 // AllocateContainerAddresses implements environs.NetworkingEnviron.
-func (e *azureEnviron) AllocateContainerAddresses(
+func (env *azureEnviron) AllocateContainerAddresses(
 	context.ProviderCallContext, instance.Id, names.MachineTag, network.InterfaceInfos,
 ) (network.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("container addresses")
 }
 
 // ReleaseContainerAddresses implements environs.NetworkingEnviron.
-func (e *azureEnviron) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
+func (env *azureEnviron) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container addresses")
 }
 
@@ -76,7 +122,7 @@ func (*azureEnviron) SSHAddresses(
 }
 
 // NetworkInterfaces implements environs.NetworkingEnviron.
-func (e *azureEnviron) NetworkInterfaces(
+func (env *azureEnviron) NetworkInterfaces(
 	context.ProviderCallContext, []instance.Id,
 ) ([]network.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("network interfaces")

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -1,0 +1,83 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+)
+
+var _ environs.NetworkingEnviron = &azureEnviron{}
+
+// SupportsSpaces implements environs.NetworkingEnviron.
+func (e *azureEnviron) SupportsSpaces(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// Subnets implements environs.NetworkingEnviron.
+func (e *azureEnviron) Subnets(context.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error) {
+	return nil, errors.NotSupportedf("subnets")
+}
+
+// SuperSubnets implements environs.NetworkingEnviron.
+func (e *azureEnviron) SuperSubnets(context.ProviderCallContext) ([]string, error) {
+	return nil, errors.NotSupportedf("super subnets")
+}
+
+// SupportsSpaceDiscovery implements environs.NetworkingEnviron.
+func (e *azureEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// Spaces implements environs.NetworkingEnviron.
+func (e *azureEnviron) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
+	return nil, errors.NotSupportedf("spaces")
+}
+
+// SupportsContainerAddresses implements environs.NetworkingEnviron.
+func (e *azureEnviron) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// AllocateContainerAddresses implements environs.NetworkingEnviron.
+func (e *azureEnviron) AllocateContainerAddresses(
+	context.ProviderCallContext, instance.Id, names.MachineTag, network.InterfaceInfos,
+) (network.InterfaceInfos, error) {
+	return nil, errors.NotSupportedf("container addresses")
+}
+
+// ReleaseContainerAddresses implements environs.NetworkingEnviron.
+func (e *azureEnviron) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
+	return errors.NotSupportedf("container addresses")
+}
+
+// ProviderSpaceInfo implements environs.NetworkingEnviron.
+func (*azureEnviron) ProviderSpaceInfo(
+	context.ProviderCallContext, *network.SpaceInfo,
+) (*environs.ProviderSpaceInfo, error) {
+	return nil, errors.NotSupportedf("provider space info")
+}
+
+// AreSpacesRoutable implements environs.NetworkingEnviron.
+func (*azureEnviron) AreSpacesRoutable(_ context.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
+	return false, nil
+}
+
+// SSHAddresses implements environs.NetworkingEnviron.
+func (*azureEnviron) SSHAddresses(
+	_ context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
+	return addresses, nil
+}
+
+// NetworkInterfaces implements environs.NetworkingEnviron.
+func (e *azureEnviron) NetworkInterfaces(
+	context.ProviderCallContext, []instance.Id,
+) ([]network.InterfaceInfos, error) {
+	return nil, errors.NotSupportedf("network interfaces")
+}

--- a/provider/azure/environ_network_test.go
+++ b/provider/azure/environ_network_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package azure_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/provider/azure/internal/azuretesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/environs"
+)
+
+func (s *environSuite) TestSubnetsInstanceIDError(c *gc.C) {
+	env := s.openEnviron(c)
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, jc.IsTrue)
+
+	_, err := netEnv.Subnets(s.callCtx, "some-ID", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
+func (s *environSuite) TestSubnetsSuccess(c *gc.C) {
+	env := s.openEnviron(c)
+
+	// We wait for common resource creation, then query subnets
+	// in the default virtual network created for every model.
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", nil),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, jc.IsTrue)
+
+	_, err := netEnv.Subnets(s.callCtx, instance.UnknownId, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
## Description of change

This patch adds an implementation of `NetworkingEnviron` to the Azure provider.

At this stage, only `Subnets` has a non-stub implementation. It is anticipated that `SupportsSpaces` will return true in a following patch.

## QA steps

- Bootstrap to Azure.
- `juju subnets` should return results like:
```
subnets:
  192.168.0.0/20:
    type: ipv4
    provider-id: /subscriptions/2eebf55a-1e02-45d8-a299-02aed8aea00b/resourceGroups/juju-default-53435127/providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet
    status: in-use
    space: alpha
    zones: []
```

## Documentation changes

None yet. When we turn space support on, that fact will need to be added to the documentation.

## Bug reference

N/A
