### PR TITLE
Mention shellcheck dependency in README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -44,6 +44,12 @@ echo "failed" | grep -q "passes"   # fails
 
 ## Getting started
 
+Before running tests, you'll need to install `shellcheck`:
+
+```sh
+sudo snap install shellcheck
+```
+
 To get started, it's best to quickly look at the help command from the runner.
 
 ```sh


### PR DESCRIPTION
Minor tweak to tests/README to mention installing required dependency (shellcheck).
