### PR TITLE
Add an explicit user to the consume offer params

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -266,7 +266,17 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 
 	found := params.ConsumeOfferDetailsResults{}
 
-	err = c.facade.FacadeCall("GetConsumeDetails", params.OfferURLs{[]string{urlStr}, bakery.LatestVersion}, &found)
+	offerURLs := params.OfferURLs{[]string{urlStr}, bakery.LatestVersion}
+	var args interface{}
+	if c.facade.BestAPIVersion() < 3 {
+		args = offerURLs
+	} else {
+		args = params.ConsumeOfferDetailsArg{
+			OfferURLs: offerURLs,
+		}
+	}
+
+	err = c.facade.FacadeCall("GetConsumeDetails", args, &found)
 	if err != nil {
 		return params.ConsumeOfferDetails{}, errors.Trace(err)
 	}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -19,7 +19,7 @@ var facadeVersions = map[string]int{
 	"AllWatcher":                   1,
 	"Annotations":                  2,
 	"Application":                  13,
-	"ApplicationOffers":            2,
+	"ApplicationOffers":            3,
 	"ApplicationScaler":            1,
 	"Backups":                      2,
 	"Block":                        2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -160,6 +160,7 @@ func AllFacades() *facade.Registry {
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)
+	reg("ApplicationOffers", 3, applicationoffers.NewOffersAPIV3) // Add user to consume offers details  args.
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)
 	reg("Backups", 2, backups.NewFacadeV2)

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -62,6 +62,7 @@ type Backend interface {
 	OfferConnections(string) ([]OfferConnection, error)
 	SpaceByName(string) (Space, error)
 	User(names.UserTag) (User, error)
+	UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error)
 
 	CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
 	UpdateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
@@ -84,6 +85,10 @@ var GetStateAccess = func(st *state.State) Backend {
 type stateShim struct {
 	commoncrossmodel.Backend
 	st *state.State
+}
+
+func (s stateShim) UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error) {
+	return s.st.UserPermission(subject, target)
 }
 
 func (s stateShim) CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4242,8 +4242,8 @@
     },
     {
         "Name": "ApplicationOffers",
-        "Description": "OffersAPIV2 implements the cross model interface V2.",
-        "Version": 2,
+        "Description": "OffersAPIV3 implements the cross model interface V3.",
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -4293,13 +4293,13 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/OfferURLs"
+                            "$ref": "#/definitions/ConsumeOfferDetailsArg"
                         },
                         "Result": {
                             "$ref": "#/definitions/ConsumeOfferDetailsResults"
                         }
                     },
-                    "description": "GetConsumeDetails returns the details necessary to pass to another model to\nconsume the specified offers represented by the urls."
+                    "description": "GetConsumeDetails returns the details necessary to pass to another model\nto allow the specified args user to consume the offers represented by the args URLs."
                 },
                 "ListApplicationOffers": {
                     "type": "object",
@@ -4563,6 +4563,21 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "ConsumeOfferDetailsArg": {
+                    "type": "object",
+                    "properties": {
+                        "offer-urls": {
+                            "$ref": "#/definitions/OfferURLs"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "offer-urls"
+                    ]
                 },
                 "ConsumeOfferDetailsResult": {
                     "type": "object",

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -600,6 +600,13 @@ type ConsumeOfferDetails struct {
 	ControllerInfo *ExternalControllerInfo  `json:"external-controller,omitempty"`
 }
 
+// ConsumeOfferDetailsArg holds arguments for querying the
+// details used for consuming offers.
+type ConsumeOfferDetailsArg struct {
+	OfferURLs OfferURLs `json:"offer-urls"`
+	UserTag   string    `json:"user-tag,omitempty"`
+}
+
 // ConsumeOfferDetailsResult contains the details necessary to
 // consume an application offer or an error.
 type ConsumeOfferDetailsResult struct {


### PR DESCRIPTION
## Description of change

The "ApplicationOffers" facade is a controller facade which uses the authenticated user to determine who is performing an api call. For JAAS, the JIMM proxy connects to the controller as admin and so needs to pass in the user as a parameter. The first place where this has become an issue is the ConsumeOfferDetails API call.

This PR adds the user as an explicit arg to the ConsumeOfferDetails call and weaves that user through all the underlying facade methods. Other API calls like Offer() etc will likely need to be migrated in the future.

## QA steps

bootstrap a controller
offer an application
add a new user and grant access to the offer
as that user, with both a new juju client and an old juju client, consume the offer
