### PR TITLE
[dev] Support per endpoint expose parameters in application state model

### DIFF
--- a/api/firewaller/application_test.go
+++ b/api/firewaller/application_test.go
@@ -53,7 +53,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Change something and check it's detected.
-	err = s.application.SetExposed(nil, nil, nil)
+	err = s.application.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
@@ -64,7 +64,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 }
 
 func (s *applicationSuite) TestIsExposed(c *gc.C) {
-	err := s.application.SetExposed(nil, nil, nil)
+	err := s.application.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	isExposed, err := s.apiApplication.IsExposed()

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2467,7 +2467,7 @@ func (s *applicationSuite) TestApplicationExpose(c *gc.C) {
 		apps[i] = s.AddTestingApplication(c, name, charm)
 		c.Assert(apps[i].IsExposed(), jc.IsFalse)
 	}
-	err = apps[1].SetExposed(nil, nil, nil)
+	err = apps[1].SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apps[1].IsExposed(), jc.IsTrue)
 	for i, t := range applicationExposeTests {
@@ -2493,7 +2493,7 @@ func (s *applicationSuite) setupApplicationExpose(c *gc.C) {
 		apps[i] = s.AddTestingApplication(c, name, charm)
 		c.Assert(apps[i].IsExposed(), jc.IsFalse)
 	}
-	err = apps[1].SetExposed(nil, nil, nil)
+	err = apps[1].SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(apps[1].IsExposed(), jc.IsTrue)
 }
@@ -2594,7 +2594,7 @@ func (s *applicationSuite) TestApplicationUnexpose(c *gc.C) {
 		c.Logf("test %d. %s", i, t.about)
 		app := s.AddTestingApplication(c, "dummy-application", charm)
 		if t.initial {
-			app.SetExposed(nil, nil, nil)
+			app.SetExposed(nil)
 		}
 		c.Assert(app.IsExposed(), gc.Equals, t.initial)
 		err := s.applicationAPI.Unexpose(params.ApplicationUnexpose{t.application})
@@ -2613,7 +2613,7 @@ func (s *applicationSuite) TestApplicationUnexpose(c *gc.C) {
 func (s *applicationSuite) setupApplicationUnexpose(c *gc.C) *state.Application {
 	charm := s.AddTestingCharm(c, "dummy")
 	app := s.AddTestingApplication(c, "dummy-application", charm)
-	app.SetExposed(nil, nil, nil)
+	app.SetExposed(nil)
 	c.Assert(app.IsExposed(), gc.Equals, true)
 	return app
 }

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -448,7 +448,7 @@ func (a stateApplicationShim) EndpointBindings() (Bindings, error) {
 func (a stateApplicationShim) SetExposed() error {
 	// TODO(achilleas): Remove this method once the required API changes
 	// for working with the additional expose parameters land.
-	return a.Application.SetExposed(nil, nil, nil)
+	return a.Application.SetExposed(nil)
 }
 
 type stateCharmShim struct {

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -343,7 +343,7 @@ func (s *firewallerBaseSuite) testGetExposed(
 	},
 ) {
 	// Set the application to exposed first.
-	err := s.application.SetExposed(nil, nil, nil)
+	err := s.application.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := addFakeEntities(params.Entities{Entities: []params.Entity{

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4133,7 +4133,7 @@ func (sse setApplicationExposed) step(c *gc.C, ctx *context) {
 	err = s.ClearExposed()
 	c.Assert(err, jc.ErrorIsNil)
 	if sse.exposed {
-		err = s.SetExposed(nil, nil, nil)
+		err = s.SetExposed(nil)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v2 v2.0.0-20200903081432-fe0d99923df9
+	github.com/juju/description/v2 v2.0.0-20200907123847-ca234e95e1e7
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c h1:m/Uo8B7nrH3K6n
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v2 v2.0.0-20200903081432-fe0d99923df9 h1:QRlYeZDE344vCHN9Qv4VEbJcX8yAWJKSCU2BEE1hFSI=
-github.com/juju/description/v2 v2.0.0-20200903081432-fe0d99923df9/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
+github.com/juju/description/v2 v2.0.0-20200907123847-ca234e95e1e7 h1:t5iftiLHHwZiKiqwH8Ud5NatyAncgVwRL9sBi08Y3PY=
+github.com/juju/description/v2 v2.0.0-20200907123847-ca234e95e1e7/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -183,7 +183,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	})
 
 	wordpress := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-	err = wordpress.SetExposed(nil, nil, nil)
+	err = wordpress.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpress.SetMinUnits(units)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2102,7 +2102,7 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			wordpress := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
-			err := wordpress.SetExposed(nil, nil, nil)
+			err := wordpress.SetExposed(nil)
 			c.Assert(err, jc.ErrorIsNil)
 			err = wordpress.SetMinUnits(42)
 			c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -843,9 +843,6 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		CharmModifiedVersion: application.doc.CharmModifiedVersion,
 		ForceCharm:           application.doc.ForceCharm,
 		Exposed:              application.doc.Exposed,
-		ExposedEndpoints:     application.doc.ExposedEndpoints,
-		ExposeToSpaceIDs:     application.doc.ExposeToSpaceIDs,
-		ExposeToCIDRs:        application.doc.ExposeToCIDRs,
 		PasswordHash:         application.doc.PasswordHash,
 		Placement:            application.doc.Placement,
 		HasResources:         application.doc.HasResources,
@@ -866,6 +863,18 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	if constraints, found := e.modelStorageConstraints[storageConstraintsKey]; found {
 		args.StorageConstraints = e.storageConstraints(constraints)
 	}
+
+	// Include exposed endpoint details
+	if len(application.doc.ExposedEndpoints) > 0 {
+		args.ExposedEndpoints = make(map[string]description.ExposedEndpointArgs)
+		for epName, details := range application.doc.ExposedEndpoints {
+			args.ExposedEndpoints[epName] = description.ExposedEndpointArgs{
+				ExposeToSpaceIDs: details.ExposeToSpaceIDs,
+				ExposeToCIDRs:    details.ExposeToCIDRs,
+			}
+		}
+	}
+
 	exApplication := e.model.AddApplication(args)
 
 	// Populate offer list

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -575,7 +575,12 @@ func (s *MigrationExportSuite) TestApplicationExposeParameters(c *gc.C) {
 		},
 	)
 
-	err = app.SetExposed([]string{"server"}, []string{serverSpace.Id()}, []string{"13.37.0.0/16"})
+	err = app.SetExposed(map[string]state.ExposedEndpoint{
+		"server": {
+			ExposeToSpaceIDs: []string{serverSpace.Id()},
+			ExposeToCIDRs:    []string{"13.37.0.0/16"},
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
@@ -584,9 +589,11 @@ func (s *MigrationExportSuite) TestApplicationExposeParameters(c *gc.C) {
 	applications := model.Applications()
 	c.Assert(applications, gc.HasLen, 1)
 
-	c.Assert(applications[0].ExposedEndpoints(), gc.DeepEquals, []string{"server"})
-	c.Assert(applications[0].ExposeToSpaceIDs(), gc.DeepEquals, []string{serverSpace.Id()})
-	c.Assert(applications[0].ExposeToCIDRs(), gc.DeepEquals, []string{"13.37.0.0/16"})
+	expEps := applications[0].ExposedEndpoints()
+	c.Assert(expEps, gc.HasLen, 1)
+	c.Assert(expEps["server"], gc.Not(gc.IsNil))
+	c.Assert(expEps["server"].ExposeToSpaceIDs(), gc.DeepEquals, []string{serverSpace.Id()})
+	c.Assert(expEps["server"].ExposeToCIDRs(), gc.DeepEquals, []string{"13.37.0.0/16"})
 }
 
 func (s *MigrationExportSuite) TestApplicationExposingOffers(c *gc.C) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1249,6 +1249,17 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 		return nil, errors.Trace(err)
 	}
 
+	var exposedEndpoints map[string]ExposedEndpoint
+	if expEps := a.ExposedEndpoints(); len(expEps) > 0 {
+		exposedEndpoints = make(map[string]ExposedEndpoint, len(expEps))
+		for epName, details := range expEps {
+			exposedEndpoints[epName] = ExposedEndpoint{
+				ExposeToSpaceIDs: details.ExposeToSpaceIDs(),
+				ExposeToCIDRs:    details.ExposeToCIDRs(),
+			}
+		}
+	}
+
 	return &applicationDoc{
 		Name:                 a.Name(),
 		Series:               a.Series(),
@@ -1263,9 +1274,7 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 		UnitCount:            len(a.Units()),
 		RelationCount:        i.relationCount(a.Name()),
 		Exposed:              a.Exposed(),
-		ExposedEndpoints:     a.ExposedEndpoints(),
-		ExposeToSpaceIDs:     a.ExposeToSpaceIDs(),
-		ExposeToCIDRs:        a.ExposeToCIDRs(),
+		ExposedEndpoints:     exposedEndpoints,
 		MinUnits:             a.MinUnits(),
 		Tools:                i.makeTools(a.Tools()),
 		MetricCredentials:    a.MetricsCredentials(),

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -526,7 +526,12 @@ func (s *MigrationImportSuite) setupSourceApplications(
 	err = application.SetMetricCredentials([]byte("sekrit"))
 	c.Assert(err, jc.ErrorIsNil)
 	// Expose the application.
-	err = application.SetExposed([]string{"admin"}, exposedSpaceIDs, []string{"13.37.0.0/16"})
+	err = application.SetExposed(map[string]state.ExposedEndpoint{
+		"admin": {
+			ExposeToSpaceIDs: exposedSpaceIDs,
+			ExposeToCIDRs:    []string{"13.37.0.0/16"},
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = testModel.SetAnnotations(application, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)
@@ -552,8 +557,6 @@ func (s *MigrationImportSuite) assertImportedApplication(
 	c.Assert(imported.Series(), gc.Equals, exported.Series())
 	c.Assert(imported.IsExposed(), gc.Equals, exported.IsExposed())
 	c.Assert(imported.ExposedEndpoints(), gc.DeepEquals, exported.ExposedEndpoints())
-	c.Assert(imported.ExposeToSpaceIDs(), gc.DeepEquals, exported.ExposeToSpaceIDs())
-	c.Assert(imported.ExposeToCIDRs(), gc.DeepEquals, exported.ExposeToCIDRs())
 	c.Assert(imported.MetricCredentials(), jc.DeepEquals, exported.MetricCredentials())
 	c.Assert(imported.PasswordValid(pwd), jc.IsTrue)
 	c.Assert(imported.CharmOrigin(), jc.DeepEquals, exported.CharmOrigin())

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -408,8 +408,6 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"ForceCharm",
 		"Exposed",
 		"ExposedEndpoints",
-		"ExposeToSpaceIDs",
-		"ExposeToCIDRs",
 		"MinUnits",
 		"MetricCredentials",
 		"PasswordHash",

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -268,7 +268,7 @@ func (s *InstanceModeSuite) TestExposedApplication(c *gc.C) {
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
 
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
@@ -297,7 +297,7 @@ func (s *InstanceModeSuite) TestMultipleExposedApplications(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.SetExposed(nil, nil, nil)
+	err := app1.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -309,7 +309,7 @@ func (s *InstanceModeSuite) TestMultipleExposedApplications(c *gc.C) {
 
 	app2 := s.AddTestingApplication(c, "mysql", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	err = app2.SetExposed(nil, nil, nil)
+	err = app2.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)
@@ -344,7 +344,7 @@ func (s *InstanceModeSuite) TestMachineWithoutInstanceId(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// add a unit but don't start its instance yet.
 	u1, m1 := s.addUnit(c, app)
@@ -374,7 +374,7 @@ func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app)
@@ -409,7 +409,7 @@ func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 
 func (s *InstanceModeSuite) TestStartWithState(c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
@@ -431,7 +431,7 @@ func (s *InstanceModeSuite) TestStartWithState(c *gc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("8080/tcp"), firewall.AllNetworksIPV4CIDR),
 	})
 
-	err = app.SetExposed(nil, nil, nil)
+	err = app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -441,7 +441,7 @@ func (s *InstanceModeSuite) TestStartWithPartialState(c *gc.C) {
 	inst := s.startInstance(c, m)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err = app.SetExposed(nil, nil, nil)
+	err = app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Starting the firewaller, no open ports.
@@ -485,7 +485,7 @@ func (s *InstanceModeSuite) TestStartWithUnexposedApplication(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// Expose service.
-	err = app.SetExposed(nil, nil, nil)
+	err = app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertPorts(c, inst, m.Id(), firewall.IngressRules{
 		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), firewall.AllNetworksIPV4CIDR),
@@ -540,7 +540,7 @@ func (s *InstanceModeSuite) TestSetClearExposedApplication(c *gc.C) {
 	s.assertPorts(c, inst, m.Id(), nil)
 
 	// SeExposed opens the ports.
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertPorts(c, inst, m.Id(), firewall.IngressRules{
@@ -560,7 +560,7 @@ func (s *InstanceModeSuite) TestRemoveUnit(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app)
@@ -599,7 +599,7 @@ func (s *InstanceModeSuite) TestRemoveApplication(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -627,7 +627,7 @@ func (s *InstanceModeSuite) TestRemoveMultipleApplications(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.SetExposed(nil, nil, nil)
+	err := app1.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -637,7 +637,7 @@ func (s *InstanceModeSuite) TestRemoveMultipleApplications(c *gc.C) {
 	})
 
 	app2 := s.AddTestingApplication(c, "mysql", s.charm)
-	err = app2.SetExposed(nil, nil, nil)
+	err = app2.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)
@@ -677,7 +677,7 @@ func (s *InstanceModeSuite) TestDeadMachine(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -711,7 +711,7 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -752,7 +752,7 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 
 func (s *InstanceModeSuite) TestStartWithStateOpenPortsBroken(c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
@@ -1332,7 +1332,7 @@ func (s *GlobalModeSuite) TestGlobalMode(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.SetExposed(nil, nil, nil)
+	err := app1.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -1344,7 +1344,7 @@ func (s *GlobalModeSuite) TestGlobalMode(c *gc.C) {
 
 	app2 := s.AddTestingApplication(c, "moinmoin", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	err = app2.SetExposed(nil, nil, nil)
+	err = app2.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)
@@ -1403,7 +1403,7 @@ func (s *GlobalModeSuite) TestStartWithUnexposedApplication(c *gc.C) {
 	s.assertEnvironPorts(c, nil)
 
 	// Expose application.
-	err = app.SetExposed(nil, nil, nil)
+	err = app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEnvironPorts(c, firewall.IngressRules{
 		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), firewall.AllNetworksIPV4CIDR),
@@ -1415,7 +1415,7 @@ func (s *GlobalModeSuite) TestRestart(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -1457,7 +1457,7 @@ func (s *GlobalModeSuite) TestRestartUnexposedApplication(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.SetExposed(nil, nil, nil)
+	err := app.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -1491,7 +1491,7 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.SetExposed(nil, nil, nil)
+	err := app1.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -1511,7 +1511,7 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	app2 := s.AddTestingApplication(c, "moinmoin", s.charm)
-	err = app2.SetExposed(nil, nil, nil)
+	err = app2.SetExposed(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)


### PR DESCRIPTION
# Description of change

Due to a change in the approach for modeling expose parameters, this PR revises the changes from #11963 so that we can specify a list of spaces and/or CIDRs that can access exposed application ports on a **per endpoint** basis.

## QA steps

None needed. The `exposed` flag is still being set as usual and that's the only thing that the firewall worker considers when generating ingress rules.