### PR TITLE
Remove Azure public ip config and use a constraint instead

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4189,6 +4189,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },
@@ -9484,6 +9487,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },
@@ -13158,6 +13164,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },
@@ -14308,6 +14317,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },
@@ -19116,6 +19128,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },
@@ -23023,6 +23038,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },
@@ -31127,6 +31145,9 @@
                 "Value": {
                     "type": "object",
                     "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
                         "arch": {
                             "type": "string"
                         },

--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -23,17 +23,18 @@ const (
 	Arch      = "arch"
 	Container = "container"
 	// cpuCores is an alias for Cores.
-	cpuCores       = "cpu-cores"
-	Cores          = "cores"
-	CpuPower       = "cpu-power"
-	Mem            = "mem"
-	RootDisk       = "root-disk"
-	RootDiskSource = "root-disk-source"
-	Tags           = "tags"
-	InstanceType   = "instance-type"
-	Spaces         = "spaces"
-	VirtType       = "virt-type"
-	Zones          = "zones"
+	cpuCores         = "cpu-cores"
+	Cores            = "cores"
+	CpuPower         = "cpu-power"
+	Mem              = "mem"
+	RootDisk         = "root-disk"
+	RootDiskSource   = "root-disk-source"
+	Tags             = "tags"
+	InstanceType     = "instance-type"
+	Spaces           = "spaces"
+	VirtType         = "virt-type"
+	Zones            = "zones"
+	AllocatePublicIP = "allocate-public-ip"
 )
 
 // Value describes a user's requirements of the hardware on which units
@@ -97,6 +98,12 @@ type Value struct {
 	// Zones, if not nil, holds a list of availability zones limiting where
 	// the machine can be located.
 	Zones *[]string `json:"zones,omitempty" yaml:"zones,omitempty"`
+
+	// AllocatePublicIP, if nil or true, signals that machines should be
+	// created with a public IP address instead of a cloud local one.
+	// The default behaviour if the value is not specified is to allocate
+	// a public IP so that public cloud behaviour works out of the box.
+	AllocatePublicIP *bool `json:"allocate-public-ip,omitempty" yaml:"allocate-public-ip,omitempty"`
 }
 
 var rawAliases = map[string]string{
@@ -208,6 +215,11 @@ func (v *Value) HasZones() bool {
 	return v.Zones != nil && len(*v.Zones) > 0
 }
 
+// HasAllocatePublicIP returns whether the allocate-public-ip constraint was specified.
+func (v *Value) HasAllocatePublicIP() bool {
+	return v.AllocatePublicIP != nil
+}
+
 // String expresses a constraints.Value in the language in which it was specified.
 func (v Value) String() string {
 	var strs []string
@@ -258,6 +270,9 @@ func (v Value) String() string {
 	if v.Zones != nil {
 		s := strings.Join(*v.Zones, ",")
 		strs = append(strs, "zones="+s)
+	}
+	if v.AllocatePublicIP != nil {
+		strs = append(strs, "allocate-public-ip="+boolStr(*v.AllocatePublicIP))
 	}
 
 	// Ensure constraint values with spaces are properly escaped
@@ -311,6 +326,9 @@ func (v Value) GoString() string {
 	} else if v.Zones != nil {
 		values = append(values, "Zones: (*[]string)(nil)")
 	}
+	if v.AllocatePublicIP != nil {
+		values = append(values, fmt.Sprintf("AllocatePublicIP: %v", *v.AllocatePublicIP))
+	}
 	return fmt.Sprintf("{%s}", strings.Join(values, ", "))
 }
 
@@ -319,6 +337,10 @@ func uintStr(i uint64) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", i)
+}
+
+func boolStr(b bool) string {
+	return fmt.Sprintf("%v", b)
 }
 
 // Parse constructs a constraints.Value from the supplied arguments,
@@ -476,6 +498,8 @@ func (v *Value) setRaw(name, str string) error {
 		err = v.setVirtType(str)
 	case Zones:
 		err = v.setZones(str)
+	case AllocatePublicIP:
+		err = v.setAllocatePublicIP(str)
 	default:
 		return errors.Errorf("unknown constraint %q", name)
 	}
@@ -543,6 +567,8 @@ func (v *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			v.VirtType = &vstr
 		case Zones:
 			v.Zones, err = parseYamlStrings("zones", val)
+		case AllocatePublicIP:
+			v.AllocatePublicIP, err = parseBool(vstr)
 		default:
 			return errors.Errorf("unknown constraint value: %v", k)
 		}
@@ -681,6 +707,29 @@ func (v *Value) setZones(str string) error {
 	}
 	v.Zones = parseCommaDelimited(str)
 	return nil
+}
+
+func (v *Value) setAllocatePublicIP(str string) (err error) {
+	if str == "" {
+		return nil
+	}
+	if v.AllocatePublicIP != nil {
+		return errors.Errorf("already set")
+	}
+	v.AllocatePublicIP, err = parseBool(str)
+	return
+}
+
+func parseBool(str string) (*bool, error) {
+	var value bool
+	if str != "" {
+		val, err := strconv.ParseBool(str)
+		if err != nil {
+			return nil, errors.Errorf("must be 'true' or 'false'")
+		}
+		value = val
+	}
+	return &value, nil
 }
 
 func parseUint64(str string) (*uint64, error) {

--- a/provider/azure/config.go
+++ b/provider/azure/config.go
@@ -18,10 +18,6 @@ import (
 )
 
 const (
-	// ConfigAttrUsePublicIP is true if a public IP should be used for each provisioned node.
-	// Exported as it is used in an upgrade step.
-	ConfigAttrUsePublicIP = "use-public-ip"
-
 	// configAttrStorageAccountType mirrors the storage SKU name in the Azure SDK
 	//
 	// The term "storage account" has been replaced with "SKU name" in recent
@@ -48,11 +44,6 @@ const (
 )
 
 var configSchema = environschema.Fields{
-	ConfigAttrUsePublicIP: {
-		Description: "Whether provisioned nodes get a public IP address.",
-		Type:        environschema.Tbool,
-		Immutable:   true,
-	},
 	configAttrStorageAccountType: {
 		Type:      environschema.Tstring,
 		Immutable: true,
@@ -76,19 +67,10 @@ var configSchema = environschema.Fields{
 }
 
 var configDefaults = schema.Defaults{
-	ConfigAttrUsePublicIP:         true,
 	configAttrStorageAccountType:  string(storage.StandardLRS),
 	configAttrLoadBalancerSkuName: string(network.LoadBalancerSkuNameStandard),
 	configAttrResourceGroupName:   schema.Omit,
 	configAttrNetwork:             schema.Omit,
-}
-
-// DefaultNetworkConfigForUpgrade is used to set the config for an Azure
-// model created before this config existed.
-func DefaultNetworkConfigForUpgrade() map[string]interface{} {
-	return map[string]interface{}{
-		ConfigAttrUsePublicIP: true,
-	}
 }
 
 // Schema returns the configuration schema for an environment.
@@ -124,7 +106,6 @@ type azureModelConfig struct {
 	*config.Config
 
 	// Azure specific config.
-	usePublicIP         bool
 	storageAccountType  string
 	loadBalancerSkuName string
 	resourceGroupName   string
@@ -259,12 +240,10 @@ Please choose a model name of no more than %d characters.`,
 		loadBalancerSkuName = string(network.LoadBalancerSkuNameStandard)
 	}
 
-	usePublicIP, _ := validated[ConfigAttrUsePublicIP].(bool)
 	networkName, _ := validated[configAttrNetwork].(string)
 
 	azureConfig := &azureModelConfig{
 		Config:              newCfg,
-		usePublicIP:         usePublicIP,
 		storageAccountType:  storageAccountType,
 		loadBalancerSkuName: loadBalancerSkuName,
 		resourceGroupName:   userSpecifiedResourceGroup,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -617,7 +617,7 @@ func (s *environSuite) TestStartInstanceRootDiskLargerThanMin(c *gc.C) {
 }
 
 func (s *environSuite) assertStartInstance(c *gc.C, wantedRootDisk *int, publicIP bool) {
-	env := s.openEnviron(c, testing.Attrs{"use-public-ip": publicIP})
+	env := s.openEnviron(c)
 	s.sender = s.startInstanceSenders(false)
 	s.requests = nil
 	args := makeStartInstanceParams(c, s.controllerUUID, "bionic")
@@ -630,6 +630,9 @@ func (s *environSuite) assertStartInstance(c *gc.C, wantedRootDisk *int, publicI
 			expectedRootDisk = uint64(*wantedRootDisk * 1024)
 			expectedDiskSize = *wantedRootDisk + 2
 		}
+	}
+	if !publicIP {
+		args.Constraints.AllocatePublicIP = &publicIP
 	}
 	result, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1360,7 +1363,7 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 	defer envtesting.DisableFinishBootstrap()()
 
 	ctx := envtesting.BootstrapContext(c)
-	env := prepareForBootstrap(c, ctx, s.provider, &s.sender, testing.Attrs{"use-public-ip": false})
+	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
 	s.sender = append(s.sender, s.startInstanceSenders(true)...)
@@ -1370,7 +1373,7 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 			ControllerConfig:         testing.FakeControllerConfig(),
 			AvailableTools:           makeToolsList("bionic"),
 			BootstrapSeries:          "bionic",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
+			BootstrapConstraints:     constraints.MustParse("mem=3.5G allocate-public-ip=false"),
 			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
 		},
 	)

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -17,55 +17,58 @@ import (
 
 // constraintsDoc is the Mongo DB representation of a constraints.Value.
 type constraintsDoc struct {
-	DocID          string `bson:"_id,omitempty"`
-	ModelUUID      string `bson:"model-uuid"`
-	Arch           *string
-	CpuCores       *uint64
-	CpuPower       *uint64
-	Mem            *uint64
-	RootDisk       *uint64
-	RootDiskSource *string
-	InstanceType   *string
-	Container      *instance.ContainerType
-	Tags           *[]string
-	Spaces         *[]string
-	VirtType       *string
-	Zones          *[]string
+	DocID            string `bson:"_id,omitempty"`
+	ModelUUID        string `bson:"model-uuid"`
+	Arch             *string
+	CpuCores         *uint64
+	CpuPower         *uint64
+	Mem              *uint64
+	RootDisk         *uint64
+	RootDiskSource   *string
+	InstanceType     *string
+	Container        *instance.ContainerType
+	Tags             *[]string
+	Spaces           *[]string
+	VirtType         *string
+	Zones            *[]string
+	AllocatePublicIP *bool
 }
 
 func newConstraintsDoc(cons constraints.Value, id string) constraintsDoc {
 	result := constraintsDoc{
-		DocID:          id,
-		Arch:           cons.Arch,
-		CpuCores:       cons.CpuCores,
-		CpuPower:       cons.CpuPower,
-		Mem:            cons.Mem,
-		RootDisk:       cons.RootDisk,
-		RootDiskSource: cons.RootDiskSource,
-		InstanceType:   cons.InstanceType,
-		Container:      cons.Container,
-		Tags:           cons.Tags,
-		Spaces:         cons.Spaces,
-		VirtType:       cons.VirtType,
-		Zones:          cons.Zones,
+		DocID:            id,
+		Arch:             cons.Arch,
+		CpuCores:         cons.CpuCores,
+		CpuPower:         cons.CpuPower,
+		Mem:              cons.Mem,
+		RootDisk:         cons.RootDisk,
+		RootDiskSource:   cons.RootDiskSource,
+		InstanceType:     cons.InstanceType,
+		Container:        cons.Container,
+		Tags:             cons.Tags,
+		Spaces:           cons.Spaces,
+		VirtType:         cons.VirtType,
+		Zones:            cons.Zones,
+		AllocatePublicIP: cons.AllocatePublicIP,
 	}
 	return result
 }
 
 func (doc constraintsDoc) value() constraints.Value {
 	result := constraints.Value{
-		Arch:           doc.Arch,
-		CpuCores:       doc.CpuCores,
-		CpuPower:       doc.CpuPower,
-		Mem:            doc.Mem,
-		RootDisk:       doc.RootDisk,
-		RootDiskSource: doc.RootDiskSource,
-		InstanceType:   doc.InstanceType,
-		Container:      doc.Container,
-		Tags:           doc.Tags,
-		Spaces:         doc.Spaces,
-		VirtType:       doc.VirtType,
-		Zones:          doc.Zones,
+		Arch:             doc.Arch,
+		CpuCores:         doc.CpuCores,
+		CpuPower:         doc.CpuPower,
+		Mem:              doc.Mem,
+		RootDisk:         doc.RootDisk,
+		RootDiskSource:   doc.RootDiskSource,
+		InstanceType:     doc.InstanceType,
+		Container:        doc.Container,
+		Tags:             doc.Tags,
+		Spaces:           doc.Spaces,
+		VirtType:         doc.VirtType,
+		Zones:            doc.Zones,
+		AllocatePublicIP: doc.AllocatePublicIP,
 	}
 	return result
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -583,6 +583,7 @@ func (s *MigrationSuite) TestConstraintsDocFields(c *gc.C) {
 		"Spaces",
 		"VirtType",
 		"Zones",
+		"AllocatePublicIP",
 	)
 	s.AssertExportedFields(c, constraintsDoc{}, fields)
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4765,53 +4765,6 @@ func (s *upgradesSuite) TestAddCharmOriginToApplication(c *gc.C) {
 	)
 }
 
-func (s *upgradesSuite) TestAddAzureProviderNetworkConfig(c *gc.C) {
-	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
-	defer settingsCloser()
-	_, err := settingsColl.RemoveAll(nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = settingsColl.Insert(bson.M{
-		// already upgraded
-		"_id": "foo",
-		"settings": bson.M{
-			"type":          "azure",
-			"use-public-ip": false},
-	}, bson.M{
-		// non azure model
-		"_id": "bar",
-		"settings": bson.M{
-			"type": "ec2"},
-	}, bson.M{
-		"_id": "baz",
-		"settings": bson.M{
-			"type": "azure"},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	expectedSettings := bsonMById{
-		{
-			"_id": "bar",
-			"settings": bson.M{
-				"type": "ec2"},
-		}, {
-			"_id": "baz",
-			"settings": bson.M{
-				"type":          "azure",
-				"use-public-ip": true,
-			},
-		}, {
-			"_id": "foo",
-			"settings": bson.M{
-				"type":          "azure",
-				"use-public-ip": false},
-		}}
-
-	//sort.Sort(expectedSettings)
-	s.assertUpgradedData(c, AddAzureProviderNetworkConfig,
-		upgradedData(settingsColl, expectedSettings),
-	)
-}
-
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -88,7 +88,6 @@ type StateBackend interface {
 	RollUpAndConvertOpenedPortDocuments() error
 	AddCharmHubToModelConfig() error
 	AddCharmOriginToApplications() error
-	AddAzureProviderNetworkConfig() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -368,8 +367,4 @@ func (s stateBackend) RollUpAndConvertOpenedPortDocuments() error {
 
 func (s stateBackend) AddCharmOriginToApplications() error {
 	return state.AddCharmOriginToApplications(s.pool)
-}
-
-func (s stateBackend) AddAzureProviderNetworkConfig() error {
-	return state.AddAzureProviderNetworkConfig(s.pool)
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -40,13 +40,6 @@ func stateStepsFor29() []Step {
 				return context.State().AddCharmOriginToApplications()
 			},
 		},
-		&upgradeStep{
-			description: "add Azure provider network config",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return context.State().AddAzureProviderNetworkConfig()
-			},
-		},
 	}
 }
 

--- a/upgrades/steps_29_test.go
+++ b/upgrades/steps_29_test.go
@@ -52,11 +52,6 @@ func (s *steps29Suite) TestAddCharmOriginToApplications(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
-func (s *steps29Suite) TestAddAzureProviderNetworkConfig(c *gc.C) {
-	step := findStateStep(c, v290, "add Azure provider network config")
-	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
-}
-
 type mergeAgents29Suite struct {
 	testing.BaseSuite
 


### PR DESCRIPTION
## Description of change

Azure had a "use-public-ip" configuration attribute.
Remove that (plus associated upgrade steps).
Instead, introduce a new "allocate-public-ip" constraint.

## QA steps

juju bootstrap azure
ensure controller starts with public ip (the default)

juju set-model-constraints "mem=1G allocate-public-ip=true"
juju get-model-constraints
(ensure constraints are correct)

juju add-machine
juju show-machine 2
(ensure constraints on machine are correct)

