### PR TITLE
Fixes label bug in the addmission worker.

### DIFF
--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -3,6 +3,17 @@
 
 package provider
 
+import (
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
+	// created by applications managed by Juju. Think istio, kubeflow etc
+	// See https://bugs.launchpad.net/juju/+bug/1892285
+	LabelJujuAppCreatedBy = "app.juju.is/created-by"
+)
+
 // AppendLabels adds the labels defined in src to dest returning the result.
 // Overlapping keys in sources maps are overwritten by the very last defined
 // value for a duplicate key.
@@ -42,5 +53,12 @@ func LabelsForApp(name string) map[string]string {
 func LabelsForModel(name string) map[string]string {
 	return map[string]string{
 		labelModel: name,
+	}
+}
+
+// LabelForKeyValue returns a Kubernetes label set for the supplied key value.
+func LabelForKeyValue(key, value string) labels.Set {
+	return labels.Set{
+		key: value,
 	}
 }

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -68,7 +68,7 @@ data:
   test: test
 EOF
 
-juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.app\.juju\.is\/created-by}')
   check_contains "${juju_app}" "test-app"
 
   echo "$juju_app" | check test-app
@@ -134,7 +134,7 @@ data:
   test: test
 EOF
 
-juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.juju-app}')
+juju_app=$(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get cm -n "${namespace}" "${name}" -o=jsonpath='{.metadata.labels.app\.juju\.is\/created-by}')
   check_contains "${juju_app}" "test-app"
 
   echo "$juju_app" | check test-app

--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -171,15 +171,16 @@ func errToAdmissionResponse(err error) *admission.AdmissionResponse {
 }
 
 func patchEscape(s string) string {
-	r := strings.Replace(s, "/", "~1", -1)
-	r = strings.Replace(r, "~", "~0", -1)
+	r := strings.Replace(s, "~", "~0", -1)
+	r = strings.Replace(r, "/", "~1", -1)
 	return r
 }
 
 func patchForLabels(labels map[string]string, appName string) []patchOperation {
 	patches := []patchOperation{}
 
-	neededLabels := provider.LabelsForApp(appName)
+	neededLabels := provider.LabelForKeyValue(
+		provider.LabelJujuAppCreatedBy, appName)
 
 	if len(labels) == 0 {
 		patches = append(patches, patchOperation{

--- a/worker/caasadmission/handler_test.go
+++ b/worker/caasadmission/handler_test.go
@@ -214,18 +214,19 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 	c.Assert(patchOperations[0].Op, gc.Equals, "add")
 	c.Assert(patchOperations[0].Path, gc.Equals, "/metadata/labels")
 
-	expectedLabels := provider.LabelsForApp(appName)
+	expectedLabels := provider.LabelForKeyValue(
+		provider.LabelJujuAppCreatedBy, appName)
 	for k, v := range expectedLabels {
 		found := false
 		for _, patchOp := range patchOperations[1:] {
-			if patchOp.Path == fmt.Sprintf("/metadata/labels/%s", k) {
+			if patchOp.Path == fmt.Sprintf("/metadata/labels/%s", patchEscape(k)) {
 				c.Assert(patchOp.Op, gc.Equals, "add")
 				c.Assert(patchOp.Value, jc.DeepEquals, v)
 				found = true
 				break
 			}
 		}
-		c.Assert(found, gc.Equals, true)
+		c.Assert(found, jc.IsTrue)
 	}
 
 	for k, v := range expectedLabels {
@@ -246,8 +247,10 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 	pod := core.Pod{
 		ObjectMeta: meta.ObjectMeta{
-			Name:   "pod",
-			Labels: provider.LabelsForApp("replace-app"),
+			Name: "pod",
+			Labels: provider.LabelForKeyValue(
+				provider.LabelJujuAppCreatedBy, "replace-app",
+			),
 		},
 	}
 	podBytes, err := json.Marshal(&pod)
@@ -295,18 +298,19 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(patchOperations), gc.Equals, 1)
 
-	expectedLabels := provider.LabelsForApp(appName)
+	expectedLabels := provider.LabelForKeyValue(
+		provider.LabelJujuAppCreatedBy, appName)
 	for k, v := range expectedLabels {
 		found := false
 		for _, patchOp := range patchOperations {
-			if patchOp.Path == fmt.Sprintf("/metadata/labels/%s", k) {
+			if patchOp.Path == fmt.Sprintf("/metadata/labels/%s", patchEscape(k)) {
 				c.Assert(patchOp.Op, gc.Equals, "replace")
 				c.Assert(patchOp.Value, jc.DeepEquals, v)
 				found = true
 				break
 			}
 		}
-		c.Assert(found, gc.Equals, true)
+		c.Assert(found, jc.IsTrue)
 	}
 
 	for k, v := range expectedLabels {


### PR DESCRIPTION


LP: 1892285

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The admission worker has been adding juju-app labels to created objects
from deploy objects. This has been causing K8's selector to incorrectly
target the wrong pods.

The fix here is to change the label we use so that selectors don't
break.

This change doesn't require any upgrade work.

## QA steps

```sh
cd tests
./main.sh caasadmission
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892285
