### PR TITLE
Operations/tasks support machines as receivers

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -566,6 +566,12 @@
                         "limit": {
                             "type": "integer"
                         },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "offset": {
                             "type": "integer"
                         },

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -126,6 +126,7 @@ type FindActionsByNames struct {
 type OperationQueryArgs struct {
 	Applications []string `json:"applications,omitempty"`
 	Units        []string `json:"units,omitempty"`
+	Machines     []string `json:"machines,omitempty"`
 	ActionNames  []string `json:"actions,omitempty"`
 	Status       []string `json:"status,omitempty"`
 

--- a/cmd/juju/action/listoperations_test.go
+++ b/cmd/juju/action/listoperations_test.go
@@ -44,6 +44,10 @@ func (s *ListOperationsSuite) TestInit(c *gc.C) {
 		args:        []string{"--units", "valid/0," + invalidUnitId},
 		expectedErr: "invalid unit name \"" + invalidUnitId + "\"",
 	}, {
+		should:      "fail with invalid machine id",
+		args:        []string{"--machines", "0," + invalidMachineId},
+		expectedErr: "invalid machine id \"" + invalidMachineId + "\"",
+	}, {
 		should:      "fail with invalid status value",
 		args:        []string{"--status", "pending," + "error"},
 		expectedErr: `"error" is not a valid task status, want one of \[pending running completed failed cancelled aborting aborted\]`,
@@ -82,6 +86,7 @@ func (s *ListOperationsSuite) TestRunQueryArgs(c *gc.C) {
 	args := []string{
 		"--apps", "mysql,mediawiki",
 		"--units", "mysql/1,mediawiki/0",
+		"--machines", "0,1",
 		"--actions", "backup",
 		"--status", "completed,pending",
 	}
@@ -94,6 +99,7 @@ func (s *ListOperationsSuite) TestRunQueryArgs(c *gc.C) {
 		c.Assert(fakeClient.operationQueryArgs, jc.DeepEquals, params.OperationQueryArgs{
 			Applications: []string{"mysql", "mediawiki"},
 			Units:        []string{"mysql/1", "mediawiki/0"},
+			Machines:     []string{"0", "1"},
 			ActionNames:  []string{"backup"},
 			Status:       []string{"completed", "pending"},
 		})
@@ -133,8 +139,8 @@ var listOperationResults = []params.OperationResult{
 		Actions: []params.ActionResult{{
 			Action: &params.Action{
 				Tag:      "action-6",
-				Receiver: "unit-mysql-1",
-				Name:     "vacuum",
+				Receiver: "machine-1",
+				Name:     "juju-run",
 			},
 		}},
 		Summary:      "operation 5",
@@ -296,13 +302,13 @@ func (s *ListOperationsSuite) TestRunYaml(c *gc.C) {
   summary: operation 5
   status: pending
   action:
-    name: vacuum
+    name: juju-run
     parameters: {}
   timing:
     enqueued: 2013-02-14 06:06:06 +0000 UTC
   tasks:
     "6":
-      host: mysql/1
+      host: "1"
       status: ""
 "7":
   summary: operation 7

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -33,6 +33,7 @@ const (
 	validUnitId            = "mysql/0"
 	validUnitId2           = "mysql/1"
 	invalidUnitId          = "something-strange-"
+	invalidMachineId       = "fred"
 	validApplicationId     = "mysql"
 	invalidApplicationId   = "something-strange-"
 )

--- a/cmd/juju/action/showoutput.go
+++ b/cmd/juju/action/showoutput.go
@@ -325,9 +325,9 @@ func fetchResult(api APIClient, requestedId string, compat bool) (params.ActionR
 func FormatActionResult(id string, result params.ActionResult, utc, compat bool) map[string]interface{} {
 	response := map[string]interface{}{"id": id, "status": result.Status}
 	if result.Action != nil {
-		ut, err := names.ParseUnitTag(result.Action.Receiver)
+		rt, err := names.ParseTag(result.Action.Receiver)
 		if err == nil {
-			response["unit"] = ut.Id()
+			response[rt.Kind()] = rt.Id()
 		}
 	}
 	if result.Message != "" {
@@ -359,6 +359,14 @@ func FormatActionResult(id string, result params.ActionResult, utc, compat bool)
 	if unit, ok := response["unit"]; ok && compat {
 		delete(response, "unit")
 		response["UnitId"] = unit
+	}
+	if machine, ok := response["MachineId"]; ok && !compat {
+		delete(response, "MachineId")
+		response["machine"] = machine
+	}
+	if machine, ok := response["machine"]; ok && compat {
+		delete(response, "machine")
+		response["MachineId"] = machine
 	}
 
 	if result.Enqueued.IsZero() && result.Started.IsZero() && result.Completed.IsZero() {

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -84,7 +84,7 @@ func (s *ShowOutputSuite) TestRun(c *gc.C) {
 	}{{
 		should:         "handle wait-time formatting errors",
 		withClientWait: "not-a-duration-at-all",
-		expectedErr:    "time: invalid duration not-a-duration-at-all",
+		expectedErr:    `time: invalid duration not-a-duration-at-all`,
 	}, {
 		should:            "timeout if result never comes",
 		withClientWait:    "2s",

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -214,6 +214,22 @@ func (c *execCommand) Init(args []string) error {
 func ConvertActionResults(result params.ActionResult, query actionQuery, compat bool) map[string]interface{} {
 	values := make(map[string]interface{})
 	values[query.receiver.receiverType] = query.receiver.tag.Id()
+	if unit, ok := values["UnitId"]; ok && !compat {
+		delete(values, "UnitId")
+		values["unit"] = unit
+	}
+	if unit, ok := values["unit"]; ok && compat {
+		delete(values, "unit")
+		values["UnitId"] = unit
+	}
+	if machine, ok := values["MachineId"]; ok && !compat {
+		delete(values, "MachineId")
+		values["machine"] = machine
+	}
+	if machine, ok := values["machine"]; ok && compat {
+		delete(values, "machine")
+		values["MachineId"] = machine
+	}
 	if result.Error != nil {
 		values["Error"] = result.Error.Error()
 		values["Action"] = query.actionTag.Id()
@@ -239,14 +255,6 @@ func ConvertActionResults(result params.ActionResult, query actionQuery, compat 
 	val := action.ConvertActionOutput(result.Output, compat, true)
 	for k, v := range val {
 		values[k] = v
-	}
-	if unit, ok := values["UnitId"]; ok && !compat {
-		delete(values, "UnitId")
-		values["unit"] = unit
-	}
-	if unit, ok := values["unit"]; ok && compat {
-		delete(values, "unit")
-		values["UnitId"] = unit
 	}
 	return values
 }

--- a/cmd/juju/commands/exec_test.go
+++ b/cmd/juju/commands/exec_test.go
@@ -257,34 +257,34 @@ func (s *ExecSuite) TestConvertRunResults(c *gc.C) {
 		}, ""),
 		query: makeActionQuery(validUUID, "MachineId", names.NewMachineTag("1")),
 		expected: map[string]interface{}{
-			"Error":     "whoops",
-			"MachineId": "1",
-			"Action":    validUUID,
+			"Error":   "whoops",
+			"machine": "1",
+			"Action":  validUUID,
 		},
 	}, {
 		message: "different action tag from query tag",
 		results: makeActionResult(mockResponse{machineTag: "not-a-tag"}, "invalid"),
 		query:   makeActionQuery(validUUID, "MachineId", names.NewMachineTag("1")),
 		expected: map[string]interface{}{
-			"Error":     `expected action tag "action-` + validUUID + `", got "invalid"`,
-			"MachineId": "1",
-			"Action":    validUUID,
+			"Error":   `expected action tag "action-` + validUUID + `", got "invalid"`,
+			"machine": "1",
+			"Action":  validUUID,
 		},
 	}, {
 		message: "different response tag from query tag",
 		results: makeActionResult(mockResponse{machineTag: "not-a-tag"}, "action-"+validUUID),
 		query:   makeActionQuery(validUUID, "MachineId", names.NewMachineTag("1")),
 		expected: map[string]interface{}{
-			"Error":     `expected action receiver "machine-1", got "not-a-tag"`,
-			"MachineId": "1",
-			"Action":    validUUID,
+			"Error":   `expected action receiver "machine-1", got "not-a-tag"`,
+			"machine": "1",
+			"Action":  validUUID,
 		},
 	}, {
 		message: "minimum is machine id",
 		results: makeActionResult(mockResponse{machineTag: "machine-1"}, "action-"+validUUID),
 		query:   makeActionQuery(validUUID, "MachineId", names.NewMachineTag("1")),
 		expected: map[string]interface{}{
-			"MachineId": "1",
+			"machine": "1",
 		},
 	}, {
 		message: "other fields are copied if there",
@@ -391,9 +391,9 @@ func (s *ExecSuite) TestAllMachines(c *gc.C) {
 		ConvertActionResults(machine0Result, machine0Query, false),
 		ConvertActionResults(machine1Result, machine1Query, false),
 		map[string]interface{}{
-			"Action":    mock.receiverIdMap["2"],
-			"MachineId": "2",
-			"Error":     "action not found",
+			"Action":  mock.receiverIdMap["2"],
+			"machine": "2",
+			"Error":   "action not found",
 		},
 	}
 

--- a/state/action.go
+++ b/state/action.go
@@ -542,13 +542,8 @@ func IsNewActionIDSupported(ver version.Number) bool {
 // newActionDoc builds the actionDoc with the given name and parameters.
 func newActionDoc(mb modelBackend, operationID string, receiverTag names.Tag, actionName string, parameters map[string]interface{}, modelAgentVersion version.Number) (actionDoc, actionNotificationDoc, error) {
 	prefix := ensureActionMarker(receiverTag.Id())
-	// For actions run on units, we want to use a user friendly action id.
-	// Theoretically, an action receiver could also be a machine, but for
-	// now we'll continue to use a UUID for that case, since I don't think
-
-	// we support machine actions anymore.
 	var actionId string
-	if receiverTag.Kind() == names.UnitTagKind && IsNewActionIDSupported(modelAgentVersion) {
+	if IsNewActionIDSupported(modelAgentVersion) {
 		id, err := sequenceWithMin(mb, "task", 1)
 		if err != nil {
 			return actionDoc{}, actionNotificationDoc{}, err

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -745,7 +745,16 @@ func (s *ActionSuite) TestComplete(c *gc.C) {
 	c.Assert(len(actions), gc.Equals, 0)
 }
 
-func (s *ActionSuite) TestFindActionTagsById(c *gc.C) {
+func (s *ActionSuite) TestFindUnitActionTagsById(c *gc.C) {
+	s.assertFindActionTagsById(c, s.unit.Tag())
+}
+
+func (s *ActionSuite) TestFindMachineActionTagsById(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{})
+	s.assertFindActionTagsById(c, machine.Tag())
+}
+
+func (s *ActionSuite) assertFindActionTagsById(c *gc.C, receiver names.Tag) {
 	s.toSupportNewActionID(c)
 
 	actions := []struct {
@@ -761,7 +770,7 @@ func (s *ActionSuite) TestFindActionTagsById(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 	for _, action := range actions {
-		_, err := s.model.EnqueueAction(operationID, s.unit.Tag(), action.Name, action.Parameters)
+		_, err := s.model.EnqueueAction(operationID, receiver, action.Name, action.Parameters)
 		c.Check(err, gc.Equals, nil)
 	}
 


### PR DESCRIPTION
## Description of change

The new opt-in action UX did not handle listing operations, show task etc for juju run actions, since for those the receiver is a machine, and only a unit receiver was supported.

Add support for either unit or machine receivers for processing operations/tasks. Also enhance the operations query to support machines. Usage is opt-in using a feature flag and new "machines" query parameter is optional so no facade bump needed.

## QA steps

juju exec --machine 1 hostname
juju operations --machine 1
juju show-task 2 --format yaml

