### PR TITLE
Change hook stderr output to be logged at WARNING level

### DIFF
--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -89,7 +89,6 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"default-series":            "bionic",
 			"firewall-mode":             "instance",
 			"ssl-hostname-verification": true,
-			"logging-config":            "<root>=DEBUG",
 			"secret":                    "pork",
 			"authorized-keys":           testing.FakeAuthKeys,
 			"type":                      "dummy",

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -89,6 +89,7 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 			"default-series":            "bionic",
 			"firewall-mode":             "instance",
 			"ssl-hostname-verification": true,
+			"logging-config":            "<root>=INFO",
 			"secret":                    "pork",
 			"authorized-keys":           testing.FakeAuthKeys,
 			"type":                      "dummy",

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -454,7 +454,7 @@ var defaultConfigValues = map[string]interface{}{
 	"default-series":              series.DefaultSupportedLTS(),
 	ProvisionerHarvestModeKey:     HarvestDestroyed.String(),
 	ResourceTagsKey:               "",
-	"logging-config":              "<root>=INFO",
+	"logging-config":              "",
 	AutomaticallyRetryHooks:       true,
 	"enable-os-refresh-update":    true,
 	"enable-os-upgrade":           true,
@@ -509,6 +509,12 @@ var defaultConfigValues = map[string]interface{}{
 	MaxActionResultsSize: DefaultActionResultsSize,
 }
 
+// defaultLoggingConfig is the default value for logging-config if it is otherwise not set.
+// We don't use the defaultConfigValues mechanism because one way to set the logging config is
+// via the JUJU_LOGGING_CONFIG environment variable, which needs to be taken into account before
+// we set the default.
+const defaultLoggingConfig = "<root>=INFO"
+
 // ConfigDefaults returns the config default values
 // to be used for any new model where there is no
 // value yet defined.
@@ -522,7 +528,9 @@ func (c *Config) setLoggingFromEnviron() error {
 	// variable, and failing that, get the config from loggo itself.
 	if loggingConfig == "" {
 		if environmentValue := os.Getenv(osenv.JujuLoggingConfigEnvKey); environmentValue != "" {
-			c.defined["logging-config"] = loggingConfig
+			c.defined["logging-config"] = environmentValue
+		} else {
+			c.defined["logging-config"] = defaultLoggingConfig
 		}
 	}
 	return nil

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -391,7 +391,7 @@ func New(withDefaults Defaulting, attrs map[string]interface{}) (*Config, error)
 		defined: defined.(map[string]interface{}),
 		unknown: make(map[string]interface{}),
 	}
-	if err := c.ensureUnitLogging(); err != nil {
+	if err := c.setLoggingFromEnviron(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -454,7 +454,7 @@ var defaultConfigValues = map[string]interface{}{
 	"default-series":              series.DefaultSupportedLTS(),
 	ProvisionerHarvestModeKey:     HarvestDestroyed.String(),
 	ResourceTagsKey:               "",
-	"logging-config":              "",
+	"logging-config":              "<root>=INFO",
 	AutomaticallyRetryHooks:       true,
 	"enable-os-refresh-update":    true,
 	"enable-os-upgrade":           true,
@@ -516,18 +516,15 @@ func ConfigDefaults() map[string]interface{} {
 	return defaultConfigValues
 }
 
-func (c *Config) ensureUnitLogging() error {
+func (c *Config) setLoggingFromEnviron() error {
 	loggingConfig := c.asString("logging-config")
 	// If the logging config hasn't been set, then look for the os environment
 	// variable, and failing that, get the config from loggo itself.
 	if loggingConfig == "" {
 		if environmentValue := os.Getenv(osenv.JujuLoggingConfigEnvKey); environmentValue != "" {
-			loggingConfig = environmentValue
-		} else {
-			loggingConfig = loggo.LoggerInfo()
+			c.defined["logging-config"] = loggingConfig
 		}
 	}
-	c.defined["logging-config"] = loggingConfig
 	return nil
 }
 

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -805,9 +805,6 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// These attributes are added if not set.
-	attrs["logging-config"] = "<root>=WARNING"
-
 	// Default firewall mode is instance
 	attrs["firewall-mode"] = string(config.FwInstance)
 	c.Assert(cfg.AllAttrs(), jc.DeepEquals, attrs)
@@ -1086,6 +1083,13 @@ func (s *ConfigSuite) TestLoggingConfig(c *gc.C) {
 	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=WARNING;juju=DEBUG")
 }
 
+func (s *ConfigSuite) TestLoggingConfigDefaults(c *gc.C) {
+	s.addJujuFiles(c)
+	s.PatchEnvironment(osenv.JujuLoggingConfigEnvKey, "")
+	config := newTestConfig(c, testing.Attrs{})
+	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO")
+}
+
 func (s *ConfigSuite) TestLoggingConfigWithUnit(c *gc.C) {
 	s.addJujuFiles(c)
 	config := newTestConfig(c, testing.Attrs{
@@ -1099,6 +1103,11 @@ func (s *ConfigSuite) TestLoggingConfigFromEnvironment(c *gc.C) {
 
 	config := newTestConfig(c, nil)
 	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO")
+
+	// But an explicit value overrides the environ
+	config = newTestConfig(c, testing.Attrs{
+		"logging-config": "<root>=WARNING"})
+	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=WARNING")
 }
 
 func (s *ConfigSuite) TestBackupDir(c *gc.C) {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -805,6 +805,9 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Set from default
+	attrs["logging-config"] = "<root>=INFO"
+
 	// Default firewall mode is instance
 	attrs["firewall-mode"] = string(config.FwInstance)
 	c.Assert(cfg.AllAttrs(), jc.DeepEquals, attrs)
@@ -1099,10 +1102,10 @@ func (s *ConfigSuite) TestLoggingConfigWithUnit(c *gc.C) {
 
 func (s *ConfigSuite) TestLoggingConfigFromEnvironment(c *gc.C) {
 	s.addJujuFiles(c)
-	s.PatchEnvironment(osenv.JujuLoggingConfigEnvKey, "<root>=INFO")
+	s.PatchEnvironment(osenv.JujuLoggingConfigEnvKey, "<root>=INFO;other=TRACE")
 
 	config := newTestConfig(c, nil)
-	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO")
+	c.Assert(config.LoggingConfig(), gc.Equals, "<root>=INFO;other=TRACE")
 
 	// But an explicit value overrides the environ
 	config = newTestConfig(c, testing.Attrs{

--- a/featuretests/api_logger_test.go
+++ b/featuretests/api_logger_test.go
@@ -23,7 +23,7 @@ func (s *apiLoggerSuite) TestLoggingConfig(c *gc.C) {
 
 	obtained, err := logging.LoggingConfig(machine.Tag())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtained, gc.Equals, "<root>=DEBUG")
+	c.Assert(obtained, gc.Equals, "<root>=INFO")
 }
 
 func (s *apiLoggerSuite) TestWatchLoggingConfig(c *gc.C) {

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -148,6 +148,8 @@ func (s *ModelConfigSuite) TestComposeNewModelConfig(c *gc.C) {
 	expected["whimsy-key"] = "whimsy-value"
 	expected["image-stream"] = "dummy-image-stream"
 	expected["no-proxy"] = "dummy-proxy"
+	// config.New() adds logging-config so remove it.
+	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 
@@ -171,6 +173,8 @@ func (s *ModelConfigSuite) TestComposeNewModelConfigRegionMisses(c *gc.C) {
 	expected["whimsy-key"] = "whimsy-value"
 	expected["no-proxy"] = "dummy-proxy"
 	expected["image-stream"] = "dummy-image-stream"
+	// config.New() adds logging-config so remove it.
+	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 
@@ -192,6 +196,8 @@ func (s *ModelConfigSuite) TestComposeNewModelConfigRegionInherits(c *gc.C) {
 	expected["no-proxy"] = "nether-proxy"
 	expected["apt-mirror"] = "http://nether-region-mirror"
 	expected["providerAttrdummy"] = "vulch"
+	// config.New() adds logging-config so remove it.
+	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 
@@ -394,7 +400,7 @@ func (s *ModelConfigSourceSuite) assertModelConfigValues(c *gc.C, modelCfg *conf
 func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
 	modelCfg, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	modelAttributes := set.NewStrings("name", "apt-mirror", "authorized-keys", "resource-tags")
+	modelAttributes := set.NewStrings("name", "apt-mirror", "logging-config", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("http-proxy"))
 }
 
@@ -407,7 +413,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	modelCfg, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	modelAttributes := set.NewStrings("name", "http-proxy", "authorized-keys", "resource-tags")
+	modelAttributes := set.NewStrings("name", "http-proxy", "logging-config", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("apt-mirror"))
 }
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -148,8 +148,6 @@ func (s *ModelConfigSuite) TestComposeNewModelConfig(c *gc.C) {
 	expected["whimsy-key"] = "whimsy-value"
 	expected["image-stream"] = "dummy-image-stream"
 	expected["no-proxy"] = "dummy-proxy"
-	// config.New() adds logging-config so remove it.
-	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 
@@ -173,8 +171,6 @@ func (s *ModelConfigSuite) TestComposeNewModelConfigRegionMisses(c *gc.C) {
 	expected["whimsy-key"] = "whimsy-value"
 	expected["no-proxy"] = "dummy-proxy"
 	expected["image-stream"] = "dummy-image-stream"
-	// config.New() adds logging-config so remove it.
-	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 
@@ -196,8 +192,6 @@ func (s *ModelConfigSuite) TestComposeNewModelConfigRegionInherits(c *gc.C) {
 	expected["no-proxy"] = "nether-proxy"
 	expected["apt-mirror"] = "http://nether-region-mirror"
 	expected["providerAttrdummy"] = "vulch"
-	// config.New() adds logging-config so remove it.
-	expected["logging-config"] = ""
 	c.Assert(cfgAttrs, jc.DeepEquals, expected)
 }
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -394,7 +394,7 @@ func (s *ModelConfigSourceSuite) assertModelConfigValues(c *gc.C, modelCfg *conf
 func (s *ModelConfigSourceSuite) TestModelConfigValues(c *gc.C) {
 	modelCfg, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	modelAttributes := set.NewStrings("name", "apt-mirror", "logging-config", "authorized-keys", "resource-tags")
+	modelAttributes := set.NewStrings("name", "apt-mirror", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("http-proxy"))
 }
 
@@ -407,7 +407,7 @@ func (s *ModelConfigSourceSuite) TestModelConfigUpdateSource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	modelCfg, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	modelAttributes := set.NewStrings("name", "http-proxy", "logging-config", "authorized-keys", "resource-tags")
+	modelAttributes := set.NewStrings("name", "http-proxy", "authorized-keys", "resource-tags")
 	s.assertModelConfigValues(c, modelCfg, modelAttributes, set.NewStrings("apt-mirror"))
 }
 

--- a/worker/common/charmrunner/logger.go
+++ b/worker/common/charmrunner/logger.go
@@ -63,6 +63,12 @@ func (l *HookLogger) Run() {
 	}
 }
 
+func (l *HookLogger) AddReceiver(receiver MessageReceiver) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.receivers = append(l.receivers, receiver)
+}
+
 // Stopper instances can be stopped.
 type Stopper interface {
 	Stop()

--- a/worker/common/charmrunner/logger.go
+++ b/worker/common/charmrunner/logger.go
@@ -63,6 +63,7 @@ func (l *HookLogger) Run() {
 	}
 }
 
+// AddReceiver adds an additional receiver to get messages
 func (l *HookLogger) AddReceiver(receiver MessageReceiver) {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -476,6 +476,7 @@ type loggerAdaptor struct {
 	level loggo.Level
 }
 
+// Messagef implements the charmrunner MessageReceiver interface
 func (l *loggerAdaptor) Messagef(isPrefix bool, message string, args ...interface{}) {
 	l.Logf(l.level, message, args...)
 }
@@ -491,12 +492,14 @@ type bufferAdaptor struct {
 	outCopy bytes.Buffer
 }
 
+// Read implements the io.Reader interface
 func (b *bufferAdaptor) Read(p []byte) (n int, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.outCopy.Read(p)
 }
 
+// Messagef implements the charmrunner MessageReceiver interface
 func (b *bufferAdaptor) Messagef(isPrefix bool, message string, args ...interface{}) {
 	formattedMessage := message
 	if len(args) > 0 {
@@ -511,6 +514,7 @@ func (b *bufferAdaptor) Messagef(isPrefix bool, message string, args ...interfac
 	b.outCopy.WriteString(formattedMessage)
 }
 
+// Bytes exposes the underlying buffered bytes.
 func (b *bufferAdaptor) Bytes() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -550,7 +550,7 @@ func (runner *runner) runCharmProcessOnRemote(hook, hookName, charmDir string, e
 
 		actionErr = &bufferAdaptor{ReadWriter: errWriter}
 		hookErrLogger = charmrunner.NewHookLogger(errReader,
-			&loggerAdaptor{runner.getLogger(hookName), loggo.WARNING},
+			&loggerAdaptor{Logger: runner.getLogger(hookName), level: loggo.WARNING},
 			actionErr,
 		)
 		defer hookErrLogger.Stop()
@@ -598,7 +598,7 @@ func (runner *runner) runCharmProcessOnLocal(hook, hookName, charmDir string, en
 
 	ps.Stdout = outWriter
 	hookOutLogger := charmrunner.NewHookLogger(outReader,
-		&loggerAdaptor{runner.getLogger(hookName), loggo.DEBUG},
+		&loggerAdaptor{Logger: runner.getLogger(hookName), level: loggo.DEBUG},
 	)
 	go hookOutLogger.Run()
 	defer hookOutLogger.Stop()
@@ -611,7 +611,7 @@ func (runner *runner) runCharmProcessOnLocal(hook, hookName, charmDir string, en
 
 	ps.Stderr = errWriter
 	hookErrLogger := charmrunner.NewHookLogger(errReader,
-		&loggerAdaptor{runner.getLogger(hookName), loggo.WARNING},
+		&loggerAdaptor{Logger: runner.getLogger(hookName), level: loggo.WARNING},
 	)
 	defer hookErrLogger.Stop()
 	go hookErrLogger.Run()

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -136,8 +136,22 @@ var runHookTests = []struct {
 	},
 }
 
+type RestrictedWriter struct {
+	Module string // what Module should be included in the log buffer
+	Buffer bytes.Buffer
+}
+
+func (r *RestrictedWriter) Write(entry loggo.Entry) {
+	if strings.HasPrefix(entry.Module, r.Module) {
+		fmt.Fprintf(&r.Buffer, "%s %s %s\n", entry.Level.String(), entry.Module, entry.Message)
+	}
+}
+
 func (s *RunHookSuite) TestRunHook(c *gc.C) {
+	writer := &RestrictedWriter{Module: "unit.u/0.something-happened"}
+	c.Assert(loggo.RegisterWriter("test", writer), jc.ErrorIsNil)
 	for i, t := range runHookTests {
+		writer.Buffer.Reset()
 		c.Logf("\ntest %d of %d: %s; perm %v", i, len(runHookTests)+1, t.summary, t.spec.perm)
 		ctx, err := s.contextFactory.HookContext(hook.Info{Kind: hooks.ConfigChanged})
 		c.Assert(err, jc.ErrorIsNil)
@@ -166,6 +180,19 @@ func (s *RunHookSuite) TestRunHook(c *gc.C) {
 			c.Errorf("background process holding up hook execution")
 		}
 		c.Assert(hookType, gc.Equals, t.hookType)
+		if t.spec.stdout != "" {
+			if len(t.spec.stdout) < lineBufferSize {
+				c.Check(writer.Buffer.String(), jc.Contains,
+					fmt.Sprintf("DEBUG unit.u/0.something-happened %s\n", t.spec.stdout))
+			} else {
+				c.Check(writer.Buffer.String(), jc.Contains,
+					fmt.Sprintf("DEBUG unit.u/0.something-happened %s\n", t.spec.stdout[:lineBufferSize]))
+			}
+		}
+		if t.spec.stderr != "" {
+			c.Check(writer.Buffer.String(), jc.Contains,
+				fmt.Sprintf("WARNING unit.u/0.something-happened %s\n", t.spec.stderr))
+		}
 	}
 }
 

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -185,8 +185,11 @@ func (s *RunHookSuite) TestRunHook(c *gc.C) {
 				c.Check(writer.Buffer.String(), jc.Contains,
 					fmt.Sprintf("DEBUG unit.u/0.something-happened %s\n", t.spec.stdout))
 			} else {
+				// Lines longer than lineBufferSize get split into multiple log messages
 				c.Check(writer.Buffer.String(), jc.Contains,
 					fmt.Sprintf("DEBUG unit.u/0.something-happened %s\n", t.spec.stdout[:lineBufferSize]))
+				c.Check(writer.Buffer.String(), jc.Contains,
+					fmt.Sprintf("DEBUG unit.u/0.something-happened %s\n", t.spec.stdout[lineBufferSize:]))
 			}
 		}
 		if t.spec.stderr != "" {


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

We have been logging both stdout and stderr for units at DEBUG, but that
leaves everything at debug. And while we want to stop including DEBUG by default, we do want to include things like Tracebacks by default. However those are written to stderr.
So we can split the logging, and log all of stdout to DEBUG and stderr to
WARNING.
This also fixes the default logging level, which had been "logger.LoggerInfo()"
which defaults to `<root>=WARNING` and sets it to what we intended it to be
`<root>=INFO`.

## QA steps

```sh
$ juju bootstrap lxd lxd
$ juju model-config logging-config
<root>=INFO
$ juju model-config -m controller logging-config
<root>=INFO
# Edit a charm to inject a python exception
$ juju deploy broken-charm
$ juju debug-log --include broken-charm/0 --replay
```

That should show lines something like:
```unit-uo-0: 01:12:30 INFO juju.worker.uniter awaiting error resolution for "install" hook
unit-uo-0: 01:13:54 INFO juju.worker.uniter awaiting error resolution for "install" hook
unit-uo-0: 01:13:54 WARNING unit.uo/0.install Traceback (most recent call last):
unit-uo-0: 01:13:54 WARNING unit.uo/0.install   File "/var/lib/juju/agents/unit-uo-0/charm/dispatch", line 14,in <module>
unit-uo-0: 01:13:54 WARNING unit.uo/0.install     import broken
unit-uo-0: 01:13:54 WARNING unit.uo/0.install ModuleNotFoundError: No module named 'broken'
unit-uo-0: 01:13:54 ERROR juju.worker.uniter.operation hook "install" (via hook dispatching script: dispatch) f
```

## Documentation changes

We should note the change in behavior for logging.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1893993