### PR TITLE
Ensure embedded commands do not exec commands

### DIFF
--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -23,40 +23,56 @@ func Test(t *stdtesting.T) {
 	gc.TestingT(t)
 }
 
-var disallowedCalls = set.NewStrings(
-	"Chdir",
-	"Chmod",
-	"Chown",
-	"Create",
-	"Lchown",
-	"Lstat",
-	"Mkdir",
-	"Open",
-	"OpenFile",
-	"Remove",
-	"RemoveAll",
-	"Rename",
-	"TempDir",
-	"Stat",
-	"Symlink",
-	"UserCacheDir",
-	"UserConfigDir",
-	"UserHomeDir",
-)
+var disallowedCalls = map[string]set.Strings{
+	"os": set.NewStrings(
+		"Chdir",
+		"Chmod",
+		"Chown",
+		"Create",
+		"Lchown",
+		"Lstat",
+		"Mkdir",
+		"Open",
+		"OpenFile",
+		"Remove",
+		"RemoveAll",
+		"Rename",
+		"TempDir",
+		"Stat",
+		"Symlink",
+		"UserCacheDir",
+		"UserConfigDir",
+		"UserHomeDir",
+	),
+	"exec": set.NewStrings(
+		"Command",
+		"LookPath",
+	),
+	"net": set.NewStrings(
+		"Dial",
+	),
+	"utils": set.NewStrings(
+		"RunCommands",
+	),
+}
 
 var allowedCalls = map[string]set.Strings{
 	// Used for checking for new Juju 2 installs.
-	"juju/commands/main.go": set.NewStrings("Stat"),
+	"juju/commands/main.go": set.NewStrings("os.Stat"),
+	// plugins are not enabled for embedded CLI commands.
+	"juju/commands/plugin.go": set.NewStrings("exec.Command"),
 	// upgrade-model is not a whitelisted embedded CLI command.
-	"juju/commands/upgrademodel.go": set.NewStrings("Open", "RemoveAll"),
+	"juju/commands/upgrademodel.go": set.NewStrings("os.Open", "os.RemoveAll"),
 	// ssh is not a whitelisted embedded CLI command.
-	"juju/commands/ssh_machine.go": set.NewStrings("Remove"),
+	"juju/commands/ssh_machine.go": set.NewStrings("os.Remove"),
 	// upgrade-gui is not a whitelisted embedded CLI command.
-	"juju/gui/upgradegui.go": set.NewStrings("Remove"),
+	"juju/gui/upgradegui.go": set.NewStrings("os.Remove"),
+	// agree is not a whitelisted embedded CLI command.
+	"juju/romulus/agree/agree.go": set.NewStrings("exec.Command", "exec.LookPath"),
 	// Ignore the actual os calls.
 	"modelcmd/filesystem.go": set.NewStrings("*"),
 	// signmetadata is not a whitelisted embedded CLI command.
-	"plugins/juju-metadata/signmetadata.go": set.NewStrings("Open"),
+	"plugins/juju-metadata/signmetadata.go": set.NewStrings("os.Open"),
 }
 
 var ignoredPackages = set.NewStrings(
@@ -66,11 +82,13 @@ type OSCallTest struct{}
 
 var _ = gc.Suite(&OSCallTest{})
 
-// TestNoDirectFilesystemAccess ensures Juju CLI commands do
-// not directly access the filesystem va the "os" package.
+// TestNoRestrictedCalls ensures Juju CLI commands do
+// not make restricted os level calls, namely:
+// - directly access the filesystem via the "os" package
+// - directly execute commands via the "exec" package
 // This ensures embedded commands do not accidentally bypass
-// the restrictions to filesystem access.
-func (s *OSCallTest) TestNoDirectFilesystemAccess(c *gc.C) {
+// the restrictions to filesystem or exec access.
+func (s *OSCallTest) TestNoRestrictedCalls(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("not needed on Windows, checking for imports on Ubuntu sufficient")
 	}
@@ -92,6 +110,12 @@ func (s *OSCallTest) TestNoDirectFilesystemAccess(c *gc.C) {
 	c.Assert(calls, gc.HasLen, 0)
 }
 
+type callCheckContext struct {
+	pkgName         string
+	disallowedCalls set.Strings
+	calls           map[string]set.Strings
+}
+
 func (s *OSCallTest) parseDir(fset *token.FileSet, calls map[string]set.Strings, dir string) {
 	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
@@ -103,22 +127,33 @@ func (s *OSCallTest) parseDir(fset *token.FileSet, calls map[string]set.Strings,
 
 	for _, pkg := range pkgs {
 		for fName, f := range pkg.Files {
-			osImportAliases := set.NewStrings("os")
-			// Ensure we also capture os calls where the import tis aliased.
-			for _, imp := range f.Imports {
-				if imp.Name == nil {
-					continue
+			for pkgName, funcs := range disallowedCalls {
+				ctx := &callCheckContext{
+					pkgName:         pkgName,
+					disallowedCalls: funcs,
+					calls:           calls,
 				}
-				if imp.Name.Name != "" && imp.Path.Value == `"os"` {
-					osImportAliases.Add(imp.Name.Name)
-				}
+				s.parsePackageFunctions(ctx, fName, f)
 			}
-			s.parseFile(f, fName, osImportAliases, calls)
 		}
 	}
 }
 
-func (*OSCallTest) parseFile(f *ast.File, fName string, osImportAliases set.Strings, calls map[string]set.Strings) {
+func (s *OSCallTest) parsePackageFunctions(ctx *callCheckContext, fName string, f *ast.File) {
+	osImportAliases := set.NewStrings(ctx.pkgName)
+	// Ensure we also capture os calls where the import is aliased.
+	for _, imp := range f.Imports {
+		if imp.Name == nil {
+			continue
+		}
+		if imp.Name.Name != "" && imp.Path.Value == fmt.Sprintf(`%q`, ctx.pkgName) {
+			osImportAliases.Add(imp.Name.Name)
+		}
+	}
+	s.parseFile(ctx, fName, f, osImportAliases)
+}
+
+func (*OSCallTest) parseFile(ctx *callCheckContext, fName string, f *ast.File, osImportAliases set.Strings) {
 	for _, decl := range f.Decls {
 		if decl, ok := decl.(*ast.FuncDecl); ok {
 			ast.Inspect(decl.Body, func(n ast.Node) bool {
@@ -136,11 +171,11 @@ func (*OSCallTest) parseFile(f *ast.File, fName string, osImportAliases set.Stri
 					return false
 				}
 
-				if !disallowedCalls.Contains(expr.Sel.Name) {
+				if !ctx.disallowedCalls.Contains(expr.Sel.Name) {
 					return false
 				}
 				if allowed, ok := allowedCalls[fName]; ok {
-					if allowed.Contains("*") || allowed.Contains(expr.Sel.Name) {
+					if allowed.Contains("*") || allowed.Contains(ctx.pkgName+"."+expr.Sel.Name) {
 						return false
 					}
 				}
@@ -150,12 +185,12 @@ func (*OSCallTest) parseFile(f *ast.File, fName string, osImportAliases set.Stri
 				}
 				exprIdent := expr.X.(*ast.Ident)
 				if osImportAliases.Contains(exprIdent.Name) {
-					funcs := calls[fName]
+					funcs := ctx.calls[fName]
 					if funcs == nil {
 						funcs = set.NewStrings()
 					}
 					funcs.Add(fmt.Sprintf("%v.%v()", exprIdent.Name, expr.Sel.Name))
-					calls[fName] = funcs
+					ctx.calls[fName] = funcs
 				}
 				return false
 			})


### PR DESCRIPTION
## Description of change

Update the unit test to check that CLI commands do not directly exec things.
Adjust the super command set up to not run plugins in embedded mode.

## QA steps

From the CLI, run a plugin, eg juju metadata

