### PR TITLE
Initial support to wire up spaces support for Azure

### DIFF
--- a/api/firewaller/machine.go
+++ b/api/firewaller/machine.go
@@ -6,6 +6,7 @@ package firewaller
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
 	apiwatcher "github.com/juju/juju/api/watcher"
@@ -66,6 +67,9 @@ func (m *Machine) InstanceId() (instance.Id, error) {
 	}
 	result := results.Results[0]
 	if result.Error != nil {
+		if params.IsCodeNotProvisioned(result.Error) {
+			return "", errors.NotProvisionedf("machine %v", m.tag.Id())
+		}
 		return "", result.Error
 	}
 	return instance.Id(result.Result), nil

--- a/api/firewaller/machine_test.go
+++ b/api/firewaller/machine_test.go
@@ -4,6 +4,7 @@
 package firewaller_test
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -72,7 +73,7 @@ func (s *machineSuite) TestInstanceId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = apiNewMachine.InstanceId()
 	c.Assert(err, gc.ErrorMatches, "machine 3 not provisioned")
-	c.Assert(err, jc.Satisfies, params.IsCodeNotProvisioned)
+	c.Assert(err, jc.Satisfies, errors.IsNotProvisioned)
 
 	instanceId, err := s.apiMachine.InstanceId()
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -295,7 +295,7 @@ func FindSubnetIDsForAvailabilityZone(zoneName string, subnetsToZones map[Id][]s
 	matchingSubnetIDs := set.NewStrings()
 	for subnetID, zones := range subnetsToZones {
 		zonesSet := set.NewStrings(zones...)
-		if zonesSet.Contains(zoneName) {
+		if zonesSet.Size() == 0 && zoneName == "" || zonesSet.Contains(zoneName) {
 			matchingSubnetIDs.Add(string(subnetID))
 		}
 	}

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -59,6 +59,15 @@ func (*subnetSuite) TestFindSubnetIDsForAZ(c *gc.C) {
 			},
 			expected: []network.Id{"bar", "other"},
 		},
+		{
+			name:     "empty zone match",
+			zoneName: "",
+			subnetsToZones: map[network.Id][]string{
+				"bar":   {},
+				"other": {},
+			},
+			expected: []network.Id{"bar", "other"},
+		},
 	}
 
 	for i, t := range testCases {

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -5,12 +5,17 @@ package azure
 
 import (
 	stdcontext "context"
+	"fmt"
+	"math/rand"
+	"strings"
 
 	azurenetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
@@ -21,7 +26,25 @@ var _ environs.NetworkingEnviron = &azureEnviron{}
 
 // SupportsSpaces implements environs.NetworkingEnviron.
 func (env *azureEnviron) SupportsSpaces(context.ProviderCallContext) (bool, error) {
-	return false, nil
+	return true, nil
+}
+
+func (env *azureEnviron) networkInfo() (vnetRG string, vnetName string) {
+	// The virtual network to use defaults to "juju-internal-network"
+	// but may also be specified by the user.
+	vnetName = internalNetworkName
+	vnetRG = env.resourceGroup
+	if env.config.virtualNetworkName != "" {
+		// network may be "mynetwork" or "resourceGroup/mynetwork"
+		parts := strings.Split(env.config.virtualNetworkName, "/")
+		vnetName = parts[0]
+		if len(parts) > 1 {
+			vnetRG = parts[0]
+			vnetName = parts[1]
+		}
+		logger.Debugf("user specified network name %q in resource group %q", vnetName, vnetRG)
+	}
+	return
 }
 
 // Subnets implements environs.NetworkingEnviron.
@@ -29,11 +52,6 @@ func (env *azureEnviron) Subnets(
 	_ context.ProviderCallContext, instanceID instance.Id, _ []network.Id) ([]network.SubnetInfo, error) {
 	if instanceID != instance.UnknownId {
 		return nil, errors.NotSupportedf("subnets for instance")
-	}
-
-	netName := env.config.virtualNetworkName
-	if netName == "" {
-		netName = internalNetworkName
 	}
 
 	// Subnet discovery happens immediately after model creation.
@@ -46,7 +64,8 @@ func (env *azureEnviron) Subnets(
 	}
 
 	subClient := azurenetwork.SubnetsClient{BaseClient: env.network}
-	subnets, err := subClient.List(stdcontext.Background(), env.resourceGroup, netName)
+	vnetRG, vnetName := env.networkInfo()
+	subnets, err := subClient.List(stdcontext.Background(), vnetRG, vnetName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -126,4 +145,87 @@ func (env *azureEnviron) NetworkInterfaces(
 	context.ProviderCallContext, []instance.Id,
 ) ([]network.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("network interfaces")
+}
+
+// networkInfoForInstance returns the virtual network and subnet to use
+// when provisioning an instance.
+func (env *azureEnviron) networkInfoForInstance(
+	instanceConfig *instancecfg.InstanceConfig,
+	constraints constraints.Value,
+	availabilityZone string,
+	subnetsToZones []map[network.Id][]string,
+) (vnetID string, subnetIDs []string, _ error) {
+
+	// Controller and non-controller machines are assigned to separate
+	// subnets. This enables us to create controller-specific NSG rules
+	// just by targeting the controller subnet.
+	subnetName := internalSubnetName
+	if instanceConfig.Controller != nil {
+		subnetName = controllerSubnetName
+	}
+	// The subnet belongs to a virtual network.
+	vnetRG, vnetName := env.networkInfo()
+	vnetID = fmt.Sprintf(`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`, vnetName)
+	subnetID := fmt.Sprintf(
+		`[concat(resourceId('Microsoft.Network/virtualNetworks', '%s'), '/subnets/%s')]`,
+		vnetName, subnetName,
+	)
+	if vnetRG != "" {
+		vnetID = fmt.Sprintf(`[resourceId('%s', 'Microsoft.Network/virtualNetworks', '%s')]`, vnetRG, vnetName)
+		subnetID = fmt.Sprintf(
+			`[concat(resourceId('%s', 'Microsoft.Network/virtualNetworks', '%s'), '/subnets/%s')]`,
+			vnetRG, vnetName, subnetName,
+		)
+	}
+
+	// No space constraints so use the default network and subnet.
+	if !constraints.HasSpaces() {
+		return vnetID, []string{subnetID}, nil
+	}
+
+	// Attempt to filter the subnet IDs for the configured availability zone.
+	// If there is no configured zone, consider all subnet IDs.
+	az := availabilityZone
+	subnetIDsForZone := make([][]network.Id, len(subnetsToZones))
+	for i, nic := range subnetsToZones {
+		var subnetIDs []network.Id
+		if az != "" {
+			var err error
+			if subnetIDs, err = network.FindSubnetIDsForAvailabilityZone(az, nic); err != nil {
+				return "", nil, errors.Annotatef(err, "getting subnets in zone %q", az)
+			}
+			if len(subnetIDs) == 0 {
+				return "", nil, errors.Errorf("availability zone %q has no subnets satisfying space constraints", az)
+			}
+		} else {
+			for subnetID := range nic {
+				subnetIDs = append(subnetIDs, subnetID)
+			}
+		}
+
+		// Filter out any fan networks.
+		subnetIDsForZone[i] = network.FilterInFanNetwork(subnetIDs)
+	}
+	logger.Debugf("found subnet ids for zone: %#v", subnetIDsForZone)
+
+	/// For each list of subnet IDs that satisfy space and zone constraints,
+	// choose a single one at random.
+	subnetIDForZone := make([]network.Id, len(subnetIDsForZone))
+	for i, subnetIDs := range subnetIDsForZone {
+		if len(subnetIDs) == 1 {
+			subnetIDForZone[i] = subnetIDs[0]
+			continue
+		}
+
+		subnetIDForZone[i] = subnetIDs[rand.Intn(len(subnetIDs))]
+	}
+	if len(subnetIDForZone) == 0 {
+		return "", nil, errors.NotFoundf("subnet for constraint %q", constraints.String())
+	}
+
+	subnetIDs = make([]string, len(subnetIDForZone))
+	for i, id := range subnetIDForZone {
+		subnetIDs[i] = string(id)
+	}
+	return vnetID, subnetIDs, nil
 }

--- a/provider/azure/networking.go
+++ b/provider/azure/networking.go
@@ -143,29 +143,6 @@ func networkTemplateResources(
 		`[resourceId('Microsoft.Network/networkSecurityGroups', '%s')]`,
 		internalSecurityGroupName,
 	)
-	subnets := []network.Subnet{{
-		Name: to.StringPtr(internalSubnetName),
-		SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-			AddressPrefix: to.StringPtr(internalSubnetPrefix),
-			NetworkSecurityGroup: &network.SecurityGroup{
-				ID: to.StringPtr(nsgID),
-			},
-		},
-	}}
-	addressPrefixes := []string{internalSubnetPrefix}
-	if len(apiPorts) > 0 {
-		addressPrefixes = append(addressPrefixes, controllerSubnetPrefix)
-		subnets = append(subnets, network.Subnet{
-			Name: to.StringPtr(controllerSubnetName),
-			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
-				AddressPrefix: to.StringPtr(controllerSubnetPrefix),
-				NetworkSecurityGroup: &network.SecurityGroup{
-					ID: to.StringPtr(nsgID),
-				},
-			},
-		})
-	}
-
 	resources := []armtemplates.Resource{{
 		APIVersion: networkAPIVersion,
 		Type:       "Microsoft.Network/networkSecurityGroups",
@@ -178,6 +155,28 @@ func networkTemplateResources(
 	}}
 	// If no user specified virtual network, need to create it.
 	if config.virtualNetworkName == "" {
+		subnets := []network.Subnet{{
+			Name: to.StringPtr(internalSubnetName),
+			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+				AddressPrefix: to.StringPtr(internalSubnetPrefix),
+				NetworkSecurityGroup: &network.SecurityGroup{
+					ID: to.StringPtr(nsgID),
+				},
+			},
+		}}
+		addressPrefixes := []string{internalSubnetPrefix}
+		if len(apiPorts) > 0 {
+			addressPrefixes = append(addressPrefixes, controllerSubnetPrefix)
+			subnets = append(subnets, network.Subnet{
+				Name: to.StringPtr(controllerSubnetName),
+				SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+					AddressPrefix: to.StringPtr(controllerSubnetPrefix),
+					NetworkSecurityGroup: &network.SecurityGroup{
+						ID: to.StringPtr(nsgID),
+					},
+				},
+			})
+		}
 		resources = append(resources, armtemplates.Resource{
 			APIVersion: networkAPIVersion,
 			Type:       "Microsoft.Network/virtualNetworks",

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -914,7 +914,7 @@ func (fw *Firewaller) flushInstancePorts(machined *machineData, toOpen, toClose 
 	}
 	machineId := machined.tag.Id()
 	instanceId, err := m.InstanceId()
-	if params.IsCodeNotProvisioned(err) {
+	if errors.IsNotProvisioned(err) {
 		// Not provisioned yet, so nothing to do for this instance
 		return nil
 	}


### PR DESCRIPTION
## Description of change

Initial spaces support is added to the Azure provider. The main changes are:
- use subnets defined by the spaces constraint instead of the hard coded subnet "juju-internal-network"
- create a network interface per subnet, first one is primary

Drive by fix for the firewaller worker and handling not provisioned errors.

TODO: model network security group for custom networks

## QA steps

create a resource group (test-rg) and make a virtual network (test-vn) with some subnets (cidr1, cidr2)
juju bootstrap azure --no-default-model
juju add-model --config network="test-rg/test-vn"

Add some spaces to the model

juju add-space foo cidr1
juju add-space bar cidr2

Add a machine with space constraints

juju add-machine --constraints="spaces=foo,bar"

Use the Azure portal to check that machine is deployed with 2 network interfaces, one for each subnet

## Bug reference

https://bugs.launchpad.net/juju/+bug/1891650
https://bugs.launchpad.net/juju/+bug/1892490
