### PR TITLE
Cache environ ("checker") on environStatePolicy to reduce AWS calls

### DIFF
--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -112,7 +112,7 @@ func CloudSpec(
 	return environs.MakeCloudSpec(modelCloud, regionName, cloudCredential)
 }
 
-// NewEnvironFunc defines the type of a function that, given a state.State,
+// NewEnvironFunc defines the type of a function that, given a stateenvirons.Model,
 // returns a new Environ.
 type NewEnvironFunc func(Model) (environs.Environ, error)
 

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -112,7 +112,7 @@ func CloudSpec(
 	return environs.MakeCloudSpec(modelCloud, regionName, cloudCredential)
 }
 
-// NewEnvironFunc defines the type of a function that, given a stateenvirons.Model,
+// NewEnvironFunc defines the type of a function that, given a Model,
 // returns a new Environ.
 type NewEnvironFunc func(Model) (environs.Environ, error)
 


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

## Description of change

In Adam Stoke's test case of deploying medium-sized model
"cs:~containers/charmed-kubernetes", we're down from 35 instances of the
Environ to 2 (each of them does 20 AWS API calls for fetching instance
type info).

Summary of improvements (last one is this PR):

```
Instances   Calls/Instance   Total  Description
-----------------------------------------------
       35 *             39 =  1365  before
       35 *             25 =   875  after reducing DescribeInstanceTypeOfferings calls
       35 *             20 =   700  after reducing DescribeSpotPriceHistory calls
        2 *             20 =    40  after sharing (subset of) Environ between API requests
```

This is for each bootstrap. Adam Stokes, who reported the
RequestLimitExceeded issue, was doing parallel juju bootstraps/deploys,
which multiplied these numbers by a further 4x.

## QA steps

Hard to QA without logging AWS API calls -- I tested locally by turning on AWS request logging in `provider/ec2/instancetypes.go` and grepping/counting the occurrences (in the controller logs).

I wonder if we should add a log setting to log AWS API calls, or even just log them at debug level always?

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1888409
