### PR TITLE
Add support for bootstrapping a controller in a vSphere cluster that is nested under the folder

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -35,6 +35,7 @@ type Client interface {
 	VirtualMachines(context.Context, string) ([]*mo.VirtualMachine, error)
 	UserHasRootLevelPrivilege(context.Context, string) (bool, error)
 	FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error)
+	GetComputeResourcePath(context.Context, *mo.ComputeResource) (string, error)
 }
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/client_mock.go github.com/juju/juju/provider/vsphere Client

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -63,12 +63,11 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (zones ne
 
 // AvailabilityZones is part of the common.ZonedEnviron interface.
 func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
-	logger.Debugf("LP #1894236: AvailabilityZones() env.zones: %+v", env.zones)
+	logger.Tracef("AvailabilityZones() env.zones: %+v", env.zones)
 
-	// if env.zones == nil {  // LP #1894236
 	if len(env.zones) == 0 {
 		computeResources, err := env.client.ComputeResources(env.ctx)
-		logger.Debugf("LP #1894236: AvailabilityZones() computeResources: %+v", computeResources)
+		logger.Tracef("AvailabilityZones() computeResources: %+v", computeResources)
 		if err != nil {
 			HandleCredentialError(err, env, ctx)
 			return nil, errors.Trace(err)
@@ -80,8 +79,8 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) (n
 				continue
 			}
 
-			logger.Debugf("LP #1894236: AvailabilityZones() cr.Name: %v", cr.Name)
-			logger.Debugf("LP #1894236: AvailabilityZones() cr.Parent: %+v", cr.Parent)
+			logger.Tracef("AvailabilityZones() cr.Name: %v", cr.Name)
+			logger.Tracef("AvailabilityZones() cr.Parent: %+v", cr.Parent)
 
 			// Construct path for ResourcePools function call
 			path, err := env.client.GetComputeResourcePath(env.ctx, cr)
@@ -90,7 +89,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) (n
 			}
 
 			pools, err := env.client.ResourcePools(env.ctx, path+"/...")
-			logger.Debugf("LP #1894236: AvailabilityZones() pools: %+v", pools)
+			logger.Tracef("AvailabilityZones() pools: %+v", pools)
 			if err != nil {
 				HandleCredentialError(err, env, ctx)
 				return nil, errors.Trace(err)
@@ -104,10 +103,10 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) (n
 				zones = append(zones, zone)
 			}
 		}
-		logger.Debugf("LP #1894236: AvailabilityZones() zones: %+v", zones)
+		logger.Tracef("AvailabilityZones() zones: %+v", zones)
 		env.zones = zones
 	}
-	logger.Debugf("LP #1894236: AvailabilityZones() return value: %+v", env.zones)
+	logger.Tracef("AvailabilityZones() return value: %+v", env.zones)
 	return env.zones, nil
 }
 

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -83,16 +83,13 @@ func (env *sessionEnviron) AvailabilityZones(ctx context.ProviderCallContext) (n
 			logger.Debugf("LP #1894236: AvailabilityZones() cr.Name: %v", cr.Name)
 			logger.Debugf("LP #1894236: AvailabilityZones() cr.Parent: %+v", cr.Parent)
 
-			if "Folder" == cr.Parent.Type {
-				logger.Debugf("LP #1894236: AvailabilityZones() cr.Parent.Type == 'Folder'")
-				// TODO: retrieve folder's full path, merge it with cr.Name  and pass it to
-				// ResourcePools() below
-
-				// folderFullPath = TODO
-				// path = folderFullPath+"/"+cr.Name+"/..."
+			// Construct path for ResourcePools function call
+			path, err := env.client.GetComputeResourcePath(env.ctx, cr)
+			if err != nil {
+				return nil, errors.Trace(err)
 			}
 
-			pools, err := env.client.ResourcePools(env.ctx, cr.Name+"/...")
+			pools, err := env.client.ResourcePools(env.ctx, path+"/...")
 			logger.Debugf("LP #1894236: AvailabilityZones() pools: %+v", pools)
 			if err != nil {
 				HandleCredentialError(err, env, ctx)

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -244,9 +244,9 @@ func (c *Client) ComputeResources(ctx context.Context) ([]*mo.ComputeResource, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	c.logger.Tracef("LP #1894236: ComputeResources(): folders: %+v", folders)
+	c.logger.Tracef("ComputeResources(): folders: %+v", folders)
 
-	c.logger.Tracef("LP #1894236: ComputeResources(): folders.HostFolder: %+v", folders.HostFolder)
+	c.logger.Tracef("ComputeResources(): folders.HostFolder: %+v", folders.HostFolder)
 	es, err := c.lister(folders.HostFolder.Reference()).List(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -260,7 +260,7 @@ func (c *Client) ComputeResources(ctx context.Context) ([]*mo.ComputeResource, e
 		case mo.ComputeResource:
 			cprs = append(cprs, &o)
 		case mo.Folder:
-			c.logger.Tracef("LP #1894236: ComputeResources(): handling mo.Folder, o.Name: %+v", o.Name)
+			c.logger.Tracef("ComputeResources(): handling mo.Folder, o.Name: %+v", o.Name)
 
 			// Get finder
 			finder, _, err := c.finder(ctx)
@@ -270,14 +270,14 @@ func (c *Client) ComputeResources(ctx context.Context) ([]*mo.ComputeResource, e
 
 			// Find folder
 			fd, err := finder.Folder(ctx, o.Name)
-			c.logger.Tracef("LP #1894236: ComputeResources(): finder.Folder() return value: %+v", fd)
+			c.logger.Tracef("ComputeResources(): finder.Folder() return value: %+v", fd)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 
 			// List the contents of the folder
 			folderContents, err := c.lister(fd.Reference()).List(ctx)
-			c.logger.Tracef("LP #1894236: ComputeResources(): folderContents: %+v", folderContents)
+			c.logger.Tracef("ComputeResources(): folderContents: %+v", folderContents)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -286,15 +286,15 @@ func (c *Client) ComputeResources(ctx context.Context) ([]*mo.ComputeResource, e
 			for _, element := range folderContents {
 				switch obj := element.Object.(type) {
 				case mo.ClusterComputeResource:
-					c.logger.Tracef("LP #1894236: ComputeResources(): appending to cprs: %v", obj.ComputeResource.Name)
+					c.logger.Tracef("ComputeResources(): appending to cprs: %v", obj.ComputeResource.Name)
 					cprs = append(cprs, &obj.ComputeResource)
 				case mo.ComputeResource:
-					c.logger.Tracef("LP #1894236: ComputeResources(): appending to cprs: %v", obj.Name)
+					c.logger.Tracef("ComputeResources(): appending to cprs: %v", obj.Name)
 					cprs = append(cprs, &obj)
 				case mo.Folder:
-					c.logger.Tracef("LP #1894236: ComputeResources(): ignoring nested mo.Folder, obj.Name: %v", obj.Name)
+					c.logger.Tracef("ComputeResources(): WARNING: ignoring nested mo.Folder, obj.Name: %v", obj.Name)
 				default:
-					c.logger.Tracef("LP #1894236: ComputeResources(): skipping type: %v", reflect.TypeOf(o).String())
+					c.logger.Tracef("ComputeResources(): skipping type: %v", reflect.TypeOf(o).String())
 				}
 			}
 		}
@@ -364,7 +364,7 @@ func (c *Client) GetComputeResourcePath(ctx context.Context, cr *mo.ComputeResou
 
 	// Retrieve absolute path if ComputeResoure's parent s a Folder
 	if "Folder" == cr.Parent.Type {
-		c.logger.Debugf("cr.Parent.Type is a Folder")
+		c.logger.Tracef("GetComputeResourcePath() cr.Parent.Type is a Folder")
 
 		// Retrieve parent folder
 		pc := property.DefaultCollector(c.client.Client)
@@ -374,7 +374,7 @@ func (c *Client) GetComputeResourcePath(ctx context.Context, cr *mo.ComputeResou
 		if err != nil {
 			return path, errors.Trace(err)
 		}
-		c.logger.Tracef("retrieved folder: %+v", folder)
+		c.logger.Tracef("GetComputeResourcePath(): retrieved folder: %+v", folder)
 
 		// Get finder
 		finder, _, err := c.finder(ctx)
@@ -387,13 +387,13 @@ func (c *Client) GetComputeResourcePath(ctx context.Context, cr *mo.ComputeResou
 		if err != nil {
 			return path, errors.Trace(err)
 		}
-		c.logger.Tracef("found folder: %+v", fd)
-		c.logger.Tracef("folder's full path: %+v", fd.InventoryPath)
+		c.logger.Tracef("GetComputeResourcePath(): found folder: %+v", fd)
+		c.logger.Tracef("GetComputeResourcePath(): folder's full path: %+v", fd.InventoryPath)
 
 		path = fd.InventoryPath+"/"+path
 	}
 
-	c.logger.Tracef("returning path: %v", path)
+	c.logger.Tracef("GetComputeResourcePath(): returning path: %v", path)
 	return path, nil
 }
 


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

This PR adds support for a specific vSphere folder structure, where the cluster's parent is a folder. Without the patch, juju is unable to bootstrap the controller to the specified zone (that maps to cluster) because it is not able to find this zone. 

## QA steps

1. Set up a vSphere structure so that the cluster's parent is a folder

```
Datacenter
+- FolderName
   +- ClusterName
```

2. Bootstrap a controller
```sh
juju bootstrap \
  --config bootstrap-timeout=1800 \
  --to zone=ClusterName/Resources \
  --constraints 'zone=ClusterName/Resources cores=8 mem=24G root-disk=100G' \
  --model-default /home/ubuntu/deploy/generated/model_defaults.yaml \
  vsphere foundation_vsphere
```

## Documentation changes

No change.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1894236
