### PR TITLE
[dev] Include per-endpoint expose settings in exported bundles

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
@@ -494,10 +495,23 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 			return nil, errors.Trace(err)
 		}
 
+		// For security purposes we do not allow both the expose flag
+		// and the exposed endpoints fields to be populated in exported
+		// bundles. Otherwise, exporting a bundle from a 2.9 controller
+		// (with per-endpoint expose settings) and deploying it to a
+		// 2.8 controller would result in all application ports to be
+		// made accessible from 0.0.0.0/0.
+		exposedEndpoints, err := mapExposedEndpoints(application.ExposedEndpoints(), allSpacesInfoLookup)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		exposedFlag := application.Exposed() && len(exposedEndpoints) == 0
+
 		if application.Subordinate() {
 			newApplication = &charm.ApplicationSpec{
 				Charm:            application.CharmURL(),
-				Expose:           application.Exposed(),
+				Expose:           exposedFlag,
+				ExposedEndpoints: exposedEndpoints,
 				Options:          application.CharmConfig(),
 				Annotations:      application.Annotations(),
 				EndpointBindings: endpointsWithSpaceNames,
@@ -539,7 +553,8 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 				Scale_:           scale,
 				Placement_:       placement,
 				To:               ut,
-				Expose:           application.Exposed(),
+				Expose:           exposedFlag,
+				ExposedEndpoints: exposedEndpoints,
 				Options:          application.CharmConfig(),
 				Annotations:      application.Annotations(),
 				EndpointBindings: endpointsWithSpaceNames,
@@ -647,6 +662,62 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 	}
 
 	return data, nil
+}
+
+// mapExposedEndpoints converts the description package representation of the
+// exposed endpoint settings into a format that can be included in the exported
+// bundle output.  The provided spaceInfos list is used to convert space IDs
+// into space names.
+func mapExposedEndpoints(exposedEndpoints map[string]description.ExposedEndpoint, spaceInfos network.SpaceInfos) (map[string]charm.ExposedEndpointSpec, error) {
+	if len(exposedEndpoints) == 0 {
+		return nil, nil
+	} else if allEndpointParams, found := exposedEndpoints[""]; found && len(exposedEndpoints) == 1 {
+		// We have a single entry for the wildcard endpoint; check if
+		// it only includes an expose to all networks CIDR.
+		if len(allEndpointParams.ExposeToSpaceIDs()) == 0 &&
+			len(allEndpointParams.ExposeToCIDRs()) == 1 &&
+			allEndpointParams.ExposeToCIDRs()[0] == firewall.AllNetworksIPV4CIDR {
+			return nil, nil // equivalent to using non-granular expose like pre 2.9 juju
+		}
+	}
+
+	res := make(map[string]charm.ExposedEndpointSpec, len(exposedEndpoints))
+	for endpointName, exposeDetails := range exposedEndpoints {
+		exposeToCIDRs := exposeDetails.ExposeToCIDRs()
+		exposeToSpaceNames, err := mapSpaceIDsToNames(spaceInfos, exposeDetails.ExposeToSpaceIDs())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		// Ensure consistent ordering of results
+		sort.Strings(exposeToSpaceNames)
+		sort.Strings(exposeToCIDRs)
+
+		res[endpointName] = charm.ExposedEndpointSpec{
+			ExposeToSpaces: exposeToSpaceNames,
+			ExposeToCIDRs:  exposeToCIDRs,
+		}
+	}
+
+	return res, nil
+}
+
+func mapSpaceIDsToNames(spaceInfos network.SpaceInfos, spaceIDs []string) ([]string, error) {
+	if len(spaceIDs) == 0 {
+		return nil, nil
+	}
+
+	spaceNames := make([]string, len(spaceIDs))
+	for i, spaceID := range spaceIDs {
+		sp := spaceInfos.GetByID(spaceID)
+		if sp == nil {
+			return nil, errors.NotFoundf("space with ID %q", spaceID)
+		}
+
+		spaceNames[i] = string(sp.Name)
+	}
+
+	return spaceNames, nil
 }
 
 func (b *BundleAPI) printSpaceNamesInEndpointBindings(apps []description.Application) bool {


### PR DESCRIPTION
## Description of change

This PR updates the bundle export code to include per-endpoint expose settings which get rendered in the overlay section of the exported bundle.

If no per-endpoint expose settings have been specified, or a single expose entry for the wildcard ("") endpoint exists that only contains a 0.0.0.0/0 CIDR (i.e. no expose-to-space-ids values), then the output will match what a pre 2.9 controller would emit with the `exposed` flag will be set to true.

On the other hand, if we do have expose settings present, the `exposed` flag will be **omitted** and **only** the expose settings will be included as part of the overlay part of the exported bundle.

This is an intentional move to prevent operators from accidentally exposing their entire application to _0.0.0.0/0_ if they export a bundle from a 2.9 controller that includes an exposed application + endpoint-specific expose settings and then attempt to deploy it to a 2.8 (or earlier) controller that does not recognize the expose settings section. By omitting the expose flag, we prevent the application from being exposed at all by the 2.8 controller and provide the operator with an opportunity to audit the expose change and apply it manually if required.

Admittedly, it's not the most elegant solution but it does follow the principle of least surprise...

## QA steps

```console
$ juju bootstrap lxd test
$ juju deploy apache2
# Run this or the equivalent (more verbose): juju expose apache2 --to-cidrs 0.0.0.0/0
$ juju expose apache2 

# At this point, the exported bundle will match what you would get from a pre-2.9 controller.
$ juju export-bundle
series: bionic
applications:
  apache2:
    charm: cs:apache2-35
    num_units: 1
    to:
    - "0"
    expose: true   <----- look for this
machines:
  "0": {}

# Switch to granular expose mode
$ juju expose apache2 --endpoints website --to-cidrs 10.0.0.0/24

# This time, the exported bundle will lack the "expose:true" flag and
# include an overlay section with expose settings
$ juju export-bundle
series: bionic
applications:
  apache2:
    charm: cs:apache2-35
    num_units: 1
    to:
    - "0"
machines:
  "0": {}
--- # overlay.yaml
applications:
  apache2:
    exposed-endpoints:
      "":
        expose-to-cidrs:
        - 0.0.0.0/0
      website:
        expose-to-cidrs:
        - 10.0.0.0/24
```