### PR TITLE
use python binary from PATH

### DIFF
--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -485,7 +485,7 @@ fi
 
 # Select python3, else python2
 export _juju_cmd_PYTHON
-for _juju_cmd_PYTHON in /usr/bin/python{3,2};do
+for _juju_cmd_PYTHON in python{3,2};do
   [ -x ${_juju_cmd_PYTHON?} ] && break
 done
 


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ x ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ N/A ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ N/A ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ x ] Do comments answer the question of why design decisions were made?

----

## Description of change
python2 or python3 is not always under /usr/bin. Like in case of MacOS you just have python, python2.7 for Mojave
```
$ ls -la /usr/bin/python*
-rwxr-xr-x  1 root  wheel  66880 May 20 10:14 /usr/bin/python*
-rwxr-xr-x  4 root  wheel    925 Aug 18  2018 /usr/bin/python-config*
lrwxr-xr-x  1 root  wheel     75 Oct  7  2019 /usr/bin/python2.7@ -> ../../System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7
lrwxr-xr-x  1 root  wheel     82 Oct  7  2019 /usr/bin/python2.7-config@ -> ../../System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7-config
-rwxr-xr-x  1 root  wheel  66880 May 20 10:14 /usr/bin/pythonw*
lrwxr-xr-x  1 root  wheel     76 Oct  7  2019 /usr/bin/pythonw2.7@ -> ../../System/Library/Frameworks/Python.framework/Versions/2.7/bin/pythonw2.7
```

I think it would be better to check for python binary from PATH.

## QA steps

By check bash completion mechanism
```
# Select python3, else python2
export _juju_cmd_PYTHON
for _juju_cmd_PYTHON in python{3,2};do
  [ -x ${_juju_cmd_PYTHON?} ] && break
done
```
run this in basic shell on most of the systems and check whether $echo ${_juju_cmd_PYTHON} gives python2 or python3

## Documentation changes

The change is not related to documentation at all.

## Bug reference

No reference
