### PR TITLE
make --channel a string

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -306,7 +307,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 
 	d.id = charmstore.CharmID{URL: d.userCharmURL}
 	d.series = userCharmURL.Series
-	d.origin, err = utils.DeduceOrigin(userCharmURL, "")
+	d.origin, err = utils.DeduceOrigin(userCharmURL, corecharm.Channel{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -344,7 +345,7 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 		// Local charms don't need a channel.
 	}
 	l.series = l.curl.Series
-	l.origin, err = utils.DeduceOrigin(curl, "")
+	l.origin, err = utils.DeduceOrigin(curl, corecharm.Channel{})
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
 	"github.com/juju/charmrepo/v6"
-	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/featureflag"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -122,7 +122,7 @@ type DeployerConfig struct {
 	BundleMachines       map[string]string
 	BundleOverlayFile    []string
 	BundleStorage        map[string]map[string]storage.Constraints
-	Channel              csparams.Channel
+	Channel              corecharm.Channel
 	CharmOrBundle        string
 	ConfigOptions        common.ConfigFlag
 	ConstraintsStr       string
@@ -156,7 +156,7 @@ type factory struct {
 	attachStorage     []string
 	charmOrBundle     string
 	bundleOverlayFile []string
-	channel           csparams.Channel
+	channel           corecharm.Channel
 	series            string
 	force             bool
 	dryRun            bool

--- a/cmd/juju/application/store/store_test.go
+++ b/cmd/juju/application/store/store_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
-	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/store/mocks"
 	"github.com/juju/juju/cmd/juju/application/utils"
+	corecharm "github.com/juju/juju/core/charm"
 )
 
 type storeSuite struct {
@@ -34,7 +34,7 @@ func (s *storeSuite) TestAddCharmFromURLAddCharmSuccess(c *gc.C) {
 
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, csparams.BetaChannel)
+	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, obtainedMac, _, err := store.AddCharmFromURL(
@@ -54,7 +54,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFail(c *gc.C) {
 	s.expectAddCharm(errors.NotFoundf("testing"))
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, csparams.BetaChannel)
+	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, obtainedMac, _, err := store.AddCharmFromURL(
@@ -77,7 +77,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFailUnauthorized(c *gc.C) {
 	})
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, csparams.BetaChannel)
+	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta})
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectGet("/delegatable-macaroon?id=" + url.QueryEscape(curl.String()))
 	s.expectAddCharmWithAuthorization()

--- a/cmd/juju/application/upgradecharm_test.go
+++ b/cmd/juju/application/upgradecharm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -546,7 +547,7 @@ func (s *UpgradeCharmSuite) TestUpgradeWithChannel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, csclientparams.BetaChannel)
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -564,7 +565,7 @@ func (s *UpgradeCharmSuite) TestUpgradeCharmShouldRespectDeployedChannelByDefaul
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, csclientparams.BetaChannel)
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -583,7 +584,7 @@ func (s *UpgradeCharmSuite) TestSwitch(c *gc.C) {
 	s.charmClient.CheckCallNames(c, "CharmInfo")
 	s.charmClient.CheckCall(c, 0, "CharmInfo", s.resolvedCharmURL.String())
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, csclientparams.StableChannel)
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Stable})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -5,14 +5,13 @@ package utils
 
 import (
 	"github.com/juju/charm/v8"
-	"github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/errors"
 
 	commoncharm "github.com/juju/juju/api/common/charm"
 	corecharm "github.com/juju/juju/core/charm"
 )
 
-func DeduceOrigin(url *charm.URL, channel params.Channel) (commoncharm.Origin, error) {
+func DeduceOrigin(url *charm.URL, channel corecharm.Channel) (commoncharm.Origin, error) {
 	if url == nil {
 		return commoncharm.Origin{}, errors.NotValidf("charm url")
 	}
@@ -21,24 +20,21 @@ func DeduceOrigin(url *charm.URL, channel params.Channel) (commoncharm.Origin, e
 	case "cs":
 		return commoncharm.Origin{
 			Source: commoncharm.OriginCharmStore,
-			Risk:   string(channel),
+			Risk:   string(channel.Risk),
 		}, nil
 	case "local":
 		return commoncharm.Origin{
 			Source: commoncharm.OriginLocal,
 		}, nil
 	default:
-		if channel == "" {
-			return commoncharm.Origin{Source: commoncharm.OriginCharmHub}, nil
-		}
-		chChannel, err := corecharm.MakeChannel("", string(channel), "")
-		if err != nil {
-			return commoncharm.Origin{}, errors.Trace(err)
+		var track *string
+		if channel.Track != "" {
+			track = &channel.Track
 		}
 		return commoncharm.Origin{
 			Source: commoncharm.OriginCharmHub,
-			Risk:   string(chChannel.Risk),
-			Track:  &chChannel.Track,
+			Risk:   string(channel.Risk),
+			Track:  track,
 		}, nil
 	}
 }

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -96,7 +96,7 @@ func ParseChannel(s string) (Channel, error) {
 	case 3:
 		track, risk, branch = &p[0], &p[1], &p[2]
 	default:
-		return Channel{}, errors.Errorf("channel is malformed and has to many components %q", s)
+		return Channel{}, errors.Errorf("channel is malformed and has too many components %q", s)
 	}
 
 	ch := Channel{}

--- a/core/charm/channel_test.go
+++ b/core/charm/channel_test.go
@@ -33,7 +33,7 @@ func (s channelSuite) TestParseChannel(c *gc.C) {
 	}, {
 		Name:        "too many components",
 		Value:       "////",
-		ExpectedErr: `channel is malformed and has to many components "////"`,
+		ExpectedErr: `channel is malformed and has too many components "////"`,
 	}, {
 		Name:        "invalid risk",
 		Value:       "track/meshuggah",


### PR DESCRIPTION
## Description of change

The csparams.Channel currently used it too limiting, as it takes a channel risk only.  For CharmHub we need to allow for track/risk values.  The values will be validated during command Init().

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju bootstrap lxd test --no-gui

## Deploy remote charm from a specific channel
$ juju deploy --channel edge cs:~juju-qa/bionic/dummy-in-edge
Located charm "cs:~juju-qa/bionic/dummy-in-edge-0".
Deploying charm "cs:~juju-qa/bionic/dummy-in-edge-0".

## Deploy local bundle with different channels per charm
$ cat > charm-channels.yaml << EOT
applications:
  dummy-in-edge:
    charm: cs:~juju-qa/bionic/dummy-in-edge
    channel: edge
  other-dummy-in-beta:
    charm: cs:~juju-qa/bionic/other-dummy-in-beta
    channel: beta
  wordpress:
    charm: wordpress
EOT

$ juju deploy ./charm-channels.yaml  --dry-run
Resolving charm via charmstore: cs:~juju-qa/bionic/other-dummy-in-beta from channel: beta
Resolving charm via charmstore: cs:~juju-qa/bionic/dummy-in-edge from channel: edge
Resolving charm via charmstore: cs:wordpress
Changes to deploy bundle:
- upload charm cs:~juju-qa/bionic/other-dummy-in-beta-0 for series bionic from channel beta
- deploy application in-beta on bionic using cs:~juju-qa/bionic/other-dummy-in-beta-0
- upload charm cs:~juju-qa/bionic/dummy-in-edge-0 for series bionic from channel edge
- deploy application in-edge on bionic using cs:~juju-qa/bionic/dummy-in-edge-0
- upload charm cs:wordpress-0
- deploy application wordpress using cs:wordpress-0
- add unit in-beta/0 to new machine 0
- add unit in-edge/0 to new machine 1
- add unit wordpress/0 to new machine 2

## channel not found 
$ juju deploy wordpress --channel testing/edge
ERROR channel "testing/edge" not found
```


