### PR TITLE
K8s labels dev

### DIFF
--- a/caas/kubernetes/provider/admissionregistration.go
+++ b/caas/kubernetes/provider/admissionregistration.go
@@ -25,6 +25,7 @@ func (k *kubernetesClient) getAdmissionControllerLabels(appName string) map[stri
 		utils.LabelsForApp(appName, k.IsLegacyLabels()),
 		utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
 	)
+
 	if !k.IsLegacyLabels() {
 		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
@@ -173,7 +174,7 @@ func (k *kubernetesClient) ensureValidatingWebhookConfigurations(
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        decideNameForGlobalResource(v.Meta, k.namespace),
 				Namespace:   k.namespace,
-				Labels:      k8slabels.Merge(v.Labels, k.getAdmissionControllerLabels(appName)),
+				Labels:      utils.LabelsMerge(v.Labels, k.getAdmissionControllerLabels(appName)),
 				Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
 			},
 			Webhooks: v.Webhooks,

--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
@@ -42,8 +43,11 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Name: "app-name",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -53,12 +57,12 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: utils.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: utils.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -176,9 +180,13 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreate(c *gc.C) 
 
 	cfg1 := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-mutatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-mutatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
@@ -240,9 +248,13 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepName(c
 
 	cfg1 := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "example-mutatingwebhookconfiguration", // This name kept no change.
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "example-mutatingwebhookconfiguration", // This name kept no change.
+			Namespace: "test",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id(), "juju.io/disable-name-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
@@ -301,9 +313,13 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdate(c *gc.C) 
 
 	cfg1 := &admissionregistration.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-mutatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-mutatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
@@ -313,7 +329,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdate(c *gc.C) 
 		c, cfgs,
 		s.mockMutatingWebhookConfiguration.EXPECT().Create(gomock.Any(), cfg1, metav1.CreateOptions{}).Return(cfg1, s.k8sAlreadyExistsError()),
 		s.mockMutatingWebhookConfiguration.EXPECT().
-			List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-app=app-name,juju-model=test"}).
+			List(gomock.Any(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
 			Return(&admissionregistration.MutatingWebhookConfigurationList{Items: []admissionregistration.MutatingWebhookConfiguration{*cfg1}}, nil),
 		s.mockMutatingWebhookConfiguration.EXPECT().
 			Get(gomock.Any(), "test-example-mutatingwebhookconfiguration", metav1.GetOptions{}).
@@ -337,8 +353,11 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Name: "app-name",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -348,12 +367,12 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: utils.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: utils.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -467,9 +486,13 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreate(c *gc.C
 
 	cfg1 := &admissionregistration.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-validatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-validatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
@@ -531,9 +554,13 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 
 	cfg1 := &admissionregistration.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "example-validatingwebhookconfiguration", // This name kept no change.
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "example-validatingwebhookconfiguration", // This name kept no change.
+			Namespace: "test",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id(), "juju.io/disable-name-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
@@ -592,9 +619,13 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdate(c *gc.C
 
 	cfg1 := &admissionregistration.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-example-validatingwebhookconfiguration",
-			Namespace:   "test",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name:      "test-example-validatingwebhookconfiguration",
+			Namespace: "test",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
@@ -604,7 +635,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdate(c *gc.C
 		c, cfgs,
 		s.mockValidatingWebhookConfiguration.EXPECT().Create(gomock.Any(), cfg1, metav1.CreateOptions{}).Return(cfg1, s.k8sAlreadyExistsError()),
 		s.mockValidatingWebhookConfiguration.EXPECT().
-			List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-app=app-name,juju-model=test"}).
+			List(gomock.Any(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
 			Return(&admissionregistration.ValidatingWebhookConfigurationList{Items: []admissionregistration.ValidatingWebhookConfiguration{*cfg1}}, nil),
 		s.mockValidatingWebhookConfiguration.EXPECT().
 			Get(gomock.Any(), "test-example-validatingwebhookconfiguration", metav1.GetOptions{}).

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -187,6 +187,7 @@ func (s *BaseSuite) getNamespace() string {
 
 func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
+
 	newK8sClientFunc, newK8sRestFunc := s.setupK8sRestClient(c, ctrl, s.getNamespace())
 	randomPrefixFunc := func() (string, error) {
 		return "appuuid", nil

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -191,6 +191,10 @@ func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
 	randomPrefixFunc := func() (string, error) {
 		return "appuuid", nil
 	}
+
+	s.mockNamespaces.EXPECT().Get(gomock.Any(), s.getNamespace(), v1.GetOptions{}).
+		Return(nil, s.k8sNotFoundError())
+
 	return s.setupBroker(c, ctrl, newK8sClientFunc, newK8sRestFunc, randomPrefixFunc)
 }
 

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -28,6 +28,7 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	providerutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig"
 	"github.com/juju/juju/cloudconfig/podcfg"
@@ -108,6 +109,7 @@ type controllerStack struct {
 	ctx environs.BootstrapContext
 
 	stackName        string
+	selectorLabels   map[string]string
 	stackLabels      map[string]string
 	stackAnnotations map[string]string
 	broker           *kubernetesClient
@@ -200,10 +202,17 @@ func newcontrollerStack(
 	agentConfig.SetStateServingInfo(si)
 	pcfg.Bootstrap.StateServingInfo = si
 
+	selectorLabels := providerutils.LabelsForApp(stackName, false)
+	labels := providerutils.LabelsMerge(
+		selectorLabels,
+		providerutils.LabelsJuju,
+	)
+
 	cs := &controllerStack{
 		ctx:              ctx,
 		stackName:        stackName,
-		stackLabels:      map[string]string{constants.LabelApplication: stackName},
+		selectorLabels:   selectorLabels,
+		stackLabels:      labels,
 		stackAnnotations: map[string]string{constants.AnnotationControllerUUIDKey: pcfg.ControllerTag.Id()},
 		broker:           broker,
 
@@ -409,7 +418,7 @@ func (c *controllerStack) createControllerService() error {
 			Annotations: c.stackAnnotations,
 		},
 		Spec: core.ServiceSpec{
-			Selector: c.stackLabels,
+			Selector: c.selectorLabels,
 			Type:     controllerSvcSpec.ServiceType,
 			Ports: []core.ServicePort{
 				{
@@ -465,6 +474,7 @@ func (c *controllerStack) createControllerService() error {
 			logger.Debugf("polling k8s controller svc DNS, in %d attempt, %v", attempt, err)
 		},
 	}
+
 	return errors.Trace(retry.Call(retryCallArgs))
 }
 
@@ -574,11 +584,11 @@ func (c *controllerStack) createControllerStatefulset() error {
 			ServiceName: c.resourceNameService,
 			Replicas:    &numberOfPods,
 			Selector: &v1.LabelSelector{
-				MatchLabels: c.stackLabels,
+				MatchLabels: c.selectorLabels,
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels:      c.stackLabels,
+					Labels:      c.selectorLabels,
 					Name:        c.pcfg.GetPodName(), // This really should not be set.
 					Namespace:   c.broker.GetCurrentNamespace(),
 					Annotations: c.stackAnnotations,

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -18,9 +18,11 @@ import (
 )
 
 func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: appName,
+	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
+	return labels
 }
 
 func (k *kubernetesClient) ensureConfigMaps(

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -28,17 +28,78 @@ const (
 	// AnnotationPrefix of juju annotations
 	AnnotationPrefix = "juju.io"
 
-	LabelOperator      = "juju-operator"
-	LabelStorage       = "juju-storage"
-	LabelVersion       = "juju-version"
-	LabelApplication   = "juju-app"
-	LabelModel         = "juju-model"
-	LabelModelOperator = "juju-modeloperator"
-
 	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
 	// created by applications managed by Juju. Think istio, kubeflow etc
 	// See https://bugs.launchpad.net/juju/+bug/1892285
 	LabelJujuAppCreatedBy = "app.juju.is/created-by"
+
+	// AnnotationJujuStorageName is the Juju annotation that represents a
+	// storage objects associated Juju name.
+	AnnotationJujuStorageName = "storage.juju.is/name"
+
+	// AnnotationJujuVersion is the version annotation used on operator
+	// deployments.
+	AnnotationJujuVersion = "juju.is/version"
+
+	// LabelKubernetesAppName is the common meta key for kubernetes app names.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+	LabelKubernetesAppName = "app.kubernetes.io/name"
+
+	// LabelKubernetesAppManaged is the common meta key for kubernetes apps
+	// that are managed by a non k8s process (such as Juju).
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+	LabelKubernetesAppManaged = "app.kubernetes.io/managed-by"
+
+	// LabelJujuModelName is the juju label applied for juju models.
+	LabelJujuModelName = "model.juju.is/name"
+
+	// LabelJujuOperatorName is the juju label applied to Juju operators to
+	// identify their name. Operator names are generally named after the thing
+	// the operator is controlling. i.e an operator name for a model test would be
+	// "test"
+	LabelJujuOperatorName = "operator.juju.is/name"
+
+	// LabelJujuOperatorTarget is the juju label applied to Juju operators to
+	// describe the modeling paradigm they target. For example model,
+	// application
+	LabelJujuOperatorTarget = "operator.juju.is/target"
+
+	// LabelJujuStorageName is the juju label applied to Juju storage objects to
+	// describe their name.
+	LabelJujuStorageName = "storage.juju.is/name"
+
+	// LegacyAnnotationStorageName is the legacy annotation used by Juju for
+	// dictating storage name on k8s storage objects.
+	LegacyAnnotationStorageName = "juju-storage"
+
+	// LegacyAnnotationVersion is the legacy annotation used by Juju for
+	// dictating juju agent version on operators.
+	LegacyAnnotationVersion = "juju-version"
+
+	// LegacyLabelKubernetesAppName is the legacy label key used for juju app
+	// identification. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	LegacyLabelKubernetesAppName = "juju-app"
+
+	// LegacyLabelModelName is the legacy label key used for juju models. This
+	// purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	LegacyLabelModelName = "juju-model"
+
+	// LegacyLabelModelOperator is the legacy label key used for juju model
+	// operators. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	LegacyLabelModelOperator = "juju-modeloperator"
+
+	// LegacyLabelKubernetesOperatorName is the legacy label key used for juju
+	// operators. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	LegacyLabelKubernetesOperatorName = "juju-operator"
+
+	// LegacyLabelJujuStorageName is the legacy label key used for juju storage
+	// pvc. This purely exists to maintain backwards functionality.
+	// See https://bugs.launchpad.net/juju/+bug/1888513
+	LegacyLabelStorageName = "juju-storage"
 )
 
 func AnnotationKey(name string) string {

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -100,11 +100,6 @@ const (
 	// pvc. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
 	LegacyLabelStorageName = "juju-storage"
-
-	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
-	// created by applications managed by Juju. Think istio, kubeflow etc
-	// See https://bugs.launchpad.net/juju/+bug/1892285
-	LabelJujuAppCreatedBy = "app.juju.is/created-by"
 )
 
 func AnnotationKey(name string) string {

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -100,6 +100,11 @@ const (
 	// pvc. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
 	LegacyLabelStorageName = "juju-storage"
+
+	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
+	// created by applications managed by Juju. Think istio, kubeflow etc
+	// See https://bugs.launchpad.net/juju/+bug/1892285
+	LabelJujuAppCreatedBy = "app.juju.is/created-by"
 )
 
 func AnnotationKey(name string) string {

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -42,6 +42,10 @@ func (d *dummyUpgradeCAASController) Namespace() string {
 	return "test"
 }
 
+func (d *dummyUpgradeCAASController) IsLegacyLabels() bool {
+	return false
+}
+
 func (s *ControllerUpgraderSuite) SetUpTest(c *gc.C) {
 	s.broker = &dummyUpgradeCAASController{
 		client: fake.NewSimpleClientset(),
@@ -86,8 +90,8 @@ func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ss.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 
-	c.Assert(ss.Annotations[constants.LabelVersion], gc.Equals, version.MustParse("9.9.9").String())
-	c.Assert(ss.Spec.Template.Annotations[constants.LabelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Annotations[constants.AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Spec.Template.Annotations[constants.AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
 }
 
 func (s *ControllerUpgraderSuite) TestControllerDoesNotExist(c *gc.C) {

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -38,12 +38,12 @@ func (d *dummyUpgradeCAASController) Client() kubernetes.Interface {
 	return d.client
 }
 
-func (d *dummyUpgradeCAASController) Namespace() string {
-	return "test"
-}
-
 func (d *dummyUpgradeCAASController) IsLegacyLabels() bool {
 	return false
+}
+
+func (d *dummyUpgradeCAASController) Namespace() string {
+	return "test"
 }
 
 func (s *ControllerUpgraderSuite) SetUpTest(c *gc.C) {

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -65,8 +65,12 @@ func (k *kubernetesClient) ensureCustomResourceDefinitions(
 	for _, v := range crdSpecs {
 		crd := &apiextensionsv1beta1.CustomResourceDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				Name:        v.Name,
-				Labels:      k8slabels.Merge(v.Labels, k.getAPIExtensionLabelsGlobal(appName)),
+				Name: v.Name,
+				Labels: utils.LabelsMerge(
+					v.Labels,
+					k.getAPIExtensionLabelsGlobal(appName),
+					utils.LabelsJuju,
+				),
 				Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
 			},
 			Spec: v.Spec,
@@ -257,7 +261,10 @@ func (k *kubernetesClient) ensureCustomResources(
 				return cleanUps, errors.Trace(err)
 			}
 			crSpec.SetLabels(
-				k8slabels.Merge(crSpec.GetLabels(), k.getCRLabels(appName, crd.Spec.Scope)),
+				utils.LabelsMerge(
+					crSpec.GetLabels(),
+					k.getCRLabels(appName, crd.Spec.Scope),
+					utils.LabelsJuju),
 			)
 			crSpec.SetAnnotations(
 				k8sannotations.New(crSpec.GetAnnotations()).

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -31,16 +31,22 @@ import (
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/crd_getter_mock.go github.com/juju/juju/caas/kubernetes/provider CRDGetterInterface
 
 func (k *kubernetesClient) getAPIExtensionLabelsGlobal(appName string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: appName,
-		constants.LabelModel:       k.namespace,
+	labels := utils.LabelsMerge(
+		utils.LabelsForApp(appName, k.IsLegacyLabels()),
+		utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
+	)
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
+	return labels
 }
 
 func (k *kubernetesClient) getAPIExtensionLabelsNamespaced(appName string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: appName,
+	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
+	return labels
 }
 
 func (k *kubernetesClient) getCRLabels(appName string, scope apiextensionsv1beta1.ResourceScope) map[string]string {

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/caas/kubernetes/provider/mocks"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
@@ -42,8 +43,11 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Name: "app-name",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -53,12 +57,12 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: utils.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: utils.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -181,8 +185,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreate(c *gc.
 
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "tfjobs.kubeflow.org",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
@@ -293,8 +301,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdate(c *gc.
 
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "tfjobs.kubeflow.org",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
@@ -366,8 +378,11 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Name: "app-name",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -377,12 +392,12 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: utils.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: utils.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -560,9 +575,16 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 
 	cr1 := getCR1()
 	cr1.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr1.SetLabels(utils.LabelsMerge(
+		utils.LabelsForApp("app-name", false),
+		utils.LabelsJuju,
+	))
 	cr1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	cr2 := getCR2()
-	cr2.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr2.SetLabels(utils.LabelsMerge(
+		utils.LabelsForApp("app-name", false),
+		utils.LabelsJuju,
+	))
 	cr2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 
 	crs := map[string][]unstructured.Unstructured{
@@ -573,8 +595,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "tfjobs.kubeflow.org",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
@@ -677,19 +703,31 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 	crRaw2 := getCR2()
 
 	cr1 := getCR1()
-	cr1.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr1.SetLabels(utils.LabelsMerge(
+		utils.LabelsForApp("app-name", false),
+		utils.LabelsJuju,
+	))
 	cr1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	cr2 := getCR2()
-	cr2.SetLabels(map[string]string{"juju-app": "app-name"})
+	cr2.SetLabels(utils.LabelsMerge(
+		utils.LabelsForApp("app-name", false),
+		utils.LabelsJuju,
+	))
 	cr2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 
 	crUpdatedResourceVersion1 := getCR1()
-	crUpdatedResourceVersion1.SetLabels(map[string]string{"juju-app": "app-name"})
+	crUpdatedResourceVersion1.SetLabels(utils.LabelsMerge(
+		utils.LabelsForApp("app-name", false),
+		utils.LabelsJuju,
+	))
 	crUpdatedResourceVersion1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion1.SetResourceVersion("11111")
 
 	crUpdatedResourceVersion2 := getCR2()
-	crUpdatedResourceVersion2.SetLabels(map[string]string{"juju-app": "app-name"})
+	crUpdatedResourceVersion2.SetLabels(utils.LabelsMerge(
+		utils.LabelsForApp("app-name", false),
+		utils.LabelsJuju,
+	))
 	crUpdatedResourceVersion2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion2.SetResourceVersion("11111")
 
@@ -701,8 +739,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "tfjobs.kubeflow.org",
-			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{

--- a/caas/kubernetes/provider/daemonset.go
+++ b/caas/kubernetes/provider/daemonset.go
@@ -17,9 +17,7 @@ import (
 )
 
 func (k *kubernetesClient) getDaemonSetLabels(appName string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: appName,
-	}
+	return utils.LabelsForApp(appName, k.IsLegacyLabels())
 }
 
 func (k *kubernetesClient) ensureDaemonSet(spec *apps.DaemonSet) (func(), error) {
@@ -94,10 +92,15 @@ func (k *kubernetesClient) listDaemonSets(labels map[string]string) ([]apps.Daem
 }
 
 func (k *kubernetesClient) deleteDaemonSets(appName string) error {
+	labels := k.getDaemonSetLabels(appName)
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
+	}
+
 	err := k.client().AppsV1().DaemonSets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: &constants.DefaultPropagationPolicy,
 	}, v1.ListOptions{
-		LabelSelector: utils.LabelSetToSelector(k.getDaemonSetLabels(appName)).String(),
+		LabelSelector: utils.LabelSetToSelector(labels).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/caas/kubernetes/provider/exec/exec_test.go
+++ b/caas/kubernetes/provider/exec/exec_test.go
@@ -488,7 +488,7 @@ func (s *execSuite) TestModelNameToNameSpace(c *gc.C) {
 	defer ctrl.Finish()
 
 	gomock.InOrder(
-		s.mockNamespaces.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-model=controller"}).
+		s.mockNamespaces.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "model.juju.is/name=controller"}).
 			Return(&core.NamespaceList{Items: []core.Namespace{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "controller-k1"},
@@ -496,7 +496,7 @@ func (s *execSuite) TestModelNameToNameSpace(c *gc.C) {
 			}}, nil),
 	)
 
-	nsName, err := exec.ModelNameToNameSpace("controller", s.mockNamespaces)
+	nsName, err := exec.ModelNameToNameSpace("controller", false, s.mockNamespaces)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(nsName, gc.DeepEquals, "controller-k1")
 }

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -21,9 +21,11 @@ import (
 )
 
 func (k *kubernetesClient) getIngressLabels(appName string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: appName,
+	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
+	return labels
 }
 
 // TODO(caas): should we overwrite the existing `juju expose` created ingress if user runs upgrade-charm with new ingress podspec v2.

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
@@ -36,8 +37,11 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "app-name",
-			Labels: map[string]string{"juju-app": "app-name"},
+			Name: "app-name",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+			),
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
 				"juju.io/controller":             testing.ControllerTag.Id(),
@@ -47,12 +51,12 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
 			Selector: &v1.LabelSelector{
-				MatchLabels: map[string]string{"juju-app": "app-name"},
+				MatchLabels: utils.LabelsForApp("app-name", false),
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"juju-app": "app-name"},
+					Labels: utils.LabelsForApp("app-name", false),
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
@@ -162,10 +166,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
 	ingress := &extensionsv1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-ingress",
-			Labels: map[string]string{
-				"foo":      "bar",
-				"juju-app": "app-name",
-			},
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+				utils.LabelForKeyValue("foo", "bar"),
+			),
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
 				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
@@ -217,10 +222,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
 	ingress := &extensionsv1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-ingress",
-			Labels: map[string]string{
-				"foo":      "bar",
-				"juju-app": "app-name",
-			},
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsJuju,
+				utils.LabelForKeyValue("foo", "bar"),
+			),
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
 				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
@@ -276,10 +282,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 		return &extensionsv1beta1.Ingress{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "test-ingress",
-				Labels: map[string]string{
-					"foo":      "bar",
-					"juju-app": "app-name",
-				},
+				Labels: utils.LabelsMerge(
+					utils.LabelsForApp("app-name", false),
+					utils.LabelsJuju,
+					utils.LabelForKeyValue("foo", "bar"),
+				),
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/rewrite-target": "/",
 					"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -131,6 +131,10 @@ type kubernetesClient struct {
 	// informerFactoryUnlocked informer factory setup for tracking this model
 	informerFactoryUnlocked informers.SharedInformerFactory
 
+	// isLegacyLabels describes if this client should use and implement legacy
+	// labels or new ones
+	isLegacyLabels bool
+
 	// randomPrefix generates an annotation for stateful sets.
 	randomPrefix RandomPrefixFunc
 }
@@ -187,6 +191,14 @@ func newK8sBroker(
 		return nil, errors.NotValidf("modelUUID is required")
 	}
 
+	isLegacy, err := utils.IsLegacyModelLabels(
+		newCfg.Config.Name(), k8sClient.CoreV1().Namespaces())
+	if err != nil {
+		logger.Warningf("determining legacy label status for model %s: %v",
+			newCfg.Config.Name(), err)
+		isLegacy = true
+	}
+
 	client := &kubernetesClient{
 		clock:                       clock,
 		clientUnlocked:              k8sClient,
@@ -208,6 +220,7 @@ func newK8sBroker(
 		randomPrefix:      randomPrefix,
 		annotations: k8sannotations.New(nil).
 			Add(constants.AnnotationModelUUIDKey, modelUUID),
+		isLegacyLabels: isLegacy,
 	}
 	if controllerUUID != "" {
 		// controllerUUID could be empty in add-k8s without -c because there might be no controller yet.
@@ -608,9 +621,18 @@ func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.Provide
 // GetService returns the service for the specified application.
 func (k *kubernetesClient) GetService(appName string, mode caas.DeploymentMode, includeClusterIP bool) (*caas.Service, error) {
 	services := k.client().CoreV1().Services(k.namespace)
+	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	if mode == caas.ModeOperator {
+		labels = utils.LabelsForOperator(appName, OperatorAppTarget, k.IsLegacyLabels())
+	}
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
+	}
+
 	servicesList, err := services.List(context.TODO(), v1.ListOptions{
-		LabelSelector: applicationSelector(appName, mode),
+		LabelSelector: utils.LabelSetToSelector(labels).String(),
 	})
+
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -880,7 +902,14 @@ func (k *kubernetesClient) applyRawK8sSpec(
 	}
 
 	labelGetter := func(isNamespaced bool) map[string]string {
-		return k.getlabelsForApp(appName, isNamespaced)
+		labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+		if !isNamespaced {
+			labels = utils.LabelsMerge(
+				labels,
+				utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
+			)
+		}
+		return labels
 	}
 	annotations := utils.ResourceTagsToAnnotations(params.ResourceTags)
 
@@ -1474,10 +1503,17 @@ func (k *kubernetesClient) configureDaemonSet(
 	if err != nil {
 		return cleanUps, errors.Trace(err)
 	}
+
+	selectorLabels := k.getDaemonSetLabels(appName)
+	labels := selectorLabels
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
+	}
+
 	daemonSet := &apps.DaemonSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   deploymentName,
-			Labels: k.getDaemonSetLabels(appName),
+			Labels: labels,
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
 				Add(annotationKeyApplicationUUID, storageUniqueID).ToMap(),
@@ -1485,13 +1521,13 @@ func (k *kubernetesClient) configureDaemonSet(
 		Spec: apps.DaemonSetSpec{
 			// TODO(caas): DaemonSetUpdateStrategy support.
 			Selector: &v1.LabelSelector{
-				MatchLabels: k.getDaemonSetLabels(appName),
+				MatchLabels: selectorLabels,
 			},
 			RevisionHistoryLimit: int32Ptr(daemonsetRevisionHistoryLimit),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
-					Labels:       k.getDaemonSetLabels(appName),
+					Labels:       selectorLabels,
 					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 				Spec: workloadSpec.Pod.PodSpec,
@@ -1574,8 +1610,11 @@ func (k *kubernetesClient) configureDeployment(
 	}
 	deployment := &apps.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   deploymentName,
-			Labels: utils.LabelsForApp(appName),
+			Name: deploymentName,
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp(appName, k.IsLegacyLabels()),
+				utils.LabelsJuju,
+			),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
 				Add(annotationKeyApplicationUUID, storageUniqueID).ToMap(),
@@ -1585,12 +1624,12 @@ func (k *kubernetesClient) configureDeployment(
 			Replicas:             replicas,
 			RevisionHistoryLimit: int32Ptr(deploymentRevisionHistoryLimit),
 			Selector: &v1.LabelSelector{
-				MatchLabels: utils.LabelsForApp(appName),
+				MatchLabels: utils.LabelsForApp(appName, k.IsLegacyLabels()),
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
-					Labels:       utils.LabelsForApp(appName),
+					Labels:       utils.LabelsForApp(appName, k.IsLegacyLabels()),
 					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 				Spec: workloadSpec.Pod.PodSpec,
@@ -1677,7 +1716,8 @@ func (k *kubernetesClient) deleteDeployments(appName string) error {
 	err := k.client().AppsV1().Deployments(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: &constants.DefaultPropagationPolicy,
 	}, v1.ListOptions{
-		LabelSelector: utils.LabelSetToSelector(utils.LabelsForApp(appName)).String(),
+		LabelSelector: utils.LabelSetToSelector(
+			utils.LabelsForApp(appName, k.IsLegacyLabels())).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -1789,12 +1829,15 @@ func (k *kubernetesClient) configureService(
 	}
 	service := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        deploymentName,
-			Labels:      utils.LabelsForApp(appName),
+			Name: deploymentName,
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp(appName, k.IsLegacyLabels()),
+				utils.LabelsJuju,
+			),
 			Annotations: annotations,
 		},
 		Spec: core.ServiceSpec{
-			Selector:                 utils.LabelsForApp(appName),
+			Selector:                 utils.LabelsForApp(appName, k.IsLegacyLabels()),
 			Type:                     serviceType,
 			Ports:                    ports,
 			ExternalIPs:              config.Get(serviceExternalIPsConfigKey, []string(nil)).([]string),
@@ -1813,14 +1856,17 @@ func (k *kubernetesClient) configureHeadlessService(
 	logger.Debugf("creating/updating headless service for %s", appName)
 	service := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   headlessServiceName(deploymentName),
-			Labels: utils.LabelsForApp(appName),
+			Name: headlessServiceName(deploymentName),
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp(appName, k.IsLegacyLabels()),
+				utils.LabelsJuju,
+			),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
 				Add("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true").ToMap(),
 		},
 		Spec: core.ServiceSpec{
-			Selector:                 utils.LabelsForApp(appName),
+			Selector:                 utils.LabelsForApp(appName, k.IsLegacyLabels()),
 			Type:                     core.ServiceTypeClusterIP,
 			ClusterIP:                "None",
 			PublishNotReadyAddresses: true,
@@ -1896,19 +1942,12 @@ func (k *kubernetesClient) UnexposeService(appName string) error {
 	return errors.Trace(k.deleteIngress(deploymentName, ""))
 }
 
-func operatorSelector(appName string) string {
-	return utils.LabelSetToSelector(map[string]string{
-		constants.LabelOperator: appName,
-	}).String()
-}
-
-func applicationSelector(appName string, mode caas.DeploymentMode) string {
+func (k *kubernetesClient) applicationSelector(appName string, mode caas.DeploymentMode) string {
 	if mode == caas.ModeOperator {
-		return operatorSelector(appName)
+		return operatorSelector(appName, k.IsLegacyLabels())
 	}
-	return utils.LabelSetToSelector(map[string]string{
-		constants.LabelApplication: appName,
-	}).String()
+	return utils.LabelSetToSelector(
+		utils.LabelsForApp(appName, k.IsLegacyLabels())).String()
 }
 
 // AnnotateUnit annotates the specified pod (name or uid) with a unit tag.
@@ -1921,7 +1960,7 @@ func (k *kubernetesClient) AnnotateUnit(appName string, mode caas.DeploymentMode
 			return errors.Trace(err)
 		}
 		pods, err := pods.List(context.TODO(), v1.ListOptions{
-			LabelSelector: applicationSelector(appName, mode),
+			LabelSelector: k.applicationSelector(appName, mode),
 		})
 		// TODO(caas): remove getting pod by Id (a bit expensive) once we started to store podName in cloudContainer doc.
 		if err != nil {
@@ -1958,12 +1997,12 @@ func (k *kubernetesClient) AnnotateUnit(appName string, mode caas.DeploymentMode
 // WatchUnits returns a watcher which notifies when there
 // are changes to units of the specified application.
 func (k *kubernetesClient) WatchUnits(appName string, mode caas.DeploymentMode) (watcher.NotifyWatcher, error) {
-	selector := applicationSelector(appName, mode)
-	logger.Debugf("selecting units %q to watch", selector)
+	selector := utils.LabelSetToSelector(utils.LabelsForApp(appName, k.IsLegacyLabels()))
+	logger.Debugf("selecting units %q to watch", selector.String())
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
 		informers.WithTweakListOptions(func(o *v1.ListOptions) {
-			o.LabelSelector = selector
+			o.LabelSelector = selector.String()
 		}),
 	)
 	return k.newWatcher(factory.Core().V1().Pods().Informer(), appName, k.clock)
@@ -1975,7 +2014,7 @@ func (k *kubernetesClient) WatchUnits(appName string, mode caas.DeploymentMode) 
 // is used.
 func (k *kubernetesClient) WatchContainerStart(appName string, containerName string) (watcher.StringsWatcher, error) {
 	pods := k.client().CoreV1().Pods(k.namespace)
-	selector := applicationSelector(appName, caas.ModeWorkload)
+	selector := k.applicationSelector(appName, caas.ModeWorkload)
 	logger.Debugf("selecting units %q to watch", selector)
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
@@ -2068,7 +2107,7 @@ func (k *kubernetesClient) WatchService(appName string, mode caas.DeploymentMode
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
 		informers.WithTweakListOptions(func(o *v1.ListOptions) {
-			o.LabelSelector = applicationSelector(appName, mode)
+			o.LabelSelector = k.applicationSelector(appName, mode)
 		}),
 	)
 
@@ -2097,7 +2136,7 @@ var jujuPVNameRegexp = regexp.MustCompile(`^(?P<storageName>\D+)-\w+$`)
 func (k *kubernetesClient) Units(appName string, mode caas.DeploymentMode) ([]caas.Unit, error) {
 	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: applicationSelector(appName, mode),
+		LabelSelector: k.applicationSelector(appName, mode),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -194,9 +194,7 @@ func newK8sBroker(
 	isLegacy, err := utils.IsLegacyModelLabels(
 		newCfg.Config.Name(), k8sClient.CoreV1().Namespaces())
 	if err != nil {
-		logger.Warningf("determining legacy label status for model %s: %v",
-			newCfg.Config.Name(), err)
-		isLegacy = true
+		return nil, errors.Trace(err)
 	}
 
 	client := &kubernetesClient{

--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -3,6 +3,7 @@
 
 package provider
 
+// IsLegacyLabels indicates if this provider is operating on a legacy label schema
 func (k *kubernetesClient) IsLegacyLabels() bool {
 	return k.isLegacyLabels
 }

--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -3,14 +3,6 @@
 
 package provider
 
-import (
-	"github.com/juju/juju/caas/kubernetes/provider/utils"
-)
-
-func (k *kubernetesClient) getlabelsForApp(appName string, isNamespaced bool) map[string]string {
-	labels := utils.LabelsForApp(appName)
-	if !isNamespaced {
-		labels = utils.AppendLabels(labels, utils.LabelsForModel(k.CurrentModel()))
-	}
-	return labels
+func (k *kubernetesClient) IsLegacyLabels() bool {
+	return k.isLegacyLabels
 }

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -109,7 +109,7 @@ func (m *modelOperatorBrokerBridge) Namespace() string {
 
 func (m *modelOperatorBrokerBridge) IsLegacyLabels() bool {
 	if m.isLegacyLabels == nil {
-		return false
+		return true
 	}
 	return m.isLegacyLabels()
 }

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -15,6 +15,7 @@ import (
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/juju/juju/agent"
@@ -45,6 +46,9 @@ type ModelOperatorBroker interface {
 
 	// Namespace returns the current default namespace targeted by this broker.
 	Namespace() string
+
+	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
+	IsLegacyLabels() bool
 }
 
 // modelOperatorBrokerBridge provides a pluggable struct of funcs to implement
@@ -54,6 +58,7 @@ type modelOperatorBrokerBridge struct {
 	ensureDeployment func(*apps.Deployment) error
 	ensureService    func(*core.Service) error
 	namespace        func() string
+	isLegacyLabels   func() bool
 }
 
 const (
@@ -62,6 +67,8 @@ const (
 	EnvModelAgentCAASServiceName      = "SERVICE_NAME"
 	EnvModelAgentCAASServiceNamespace = "SERVICE_NAMESPACE"
 	EnvModelAgentHTTPPort             = "HTTP_PORT"
+
+	OperatorModelTarget = "model"
 )
 
 var (
@@ -100,6 +107,13 @@ func (m *modelOperatorBrokerBridge) Namespace() string {
 	return m.namespace()
 }
 
+func (m *modelOperatorBrokerBridge) IsLegacyLabels() bool {
+	if m.isLegacyLabels == nil {
+		return false
+	}
+	return m.isLegacyLabels()
+}
+
 func ensureModelOperator(
 	modelUUID,
 	agentPath string,
@@ -109,10 +123,16 @@ func ensureModelOperator(
 	operatorName := modelOperatorName
 	modelTag := names.NewModelTag(modelUUID)
 
+	selectorLabels := modelOperatorLabels(operatorName, broker.IsLegacyLabels())
+	labels := selectorLabels
+	if !broker.IsLegacyLabels() {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
+	}
+
 	configMap := modelOperatorConfigMap(
 		broker.Namespace(),
 		operatorName,
-		map[string]string{},
+		labels,
 		config.AgentConf)
 
 	if err := broker.EnsureConfigMap(configMap); err != nil {
@@ -145,7 +165,7 @@ func ensureModelOperator(
 	}
 
 	service := modelOperatorService(
-		operatorName, broker.Namespace(), map[string]string{}, config.Port)
+		operatorName, broker.Namespace(), labels, selectorLabels, config.Port)
 	if err := broker.EnsureService(service); err != nil {
 		return errors.Annotate(err, "ensuring model operater service")
 	}
@@ -153,7 +173,8 @@ func ensureModelOperator(
 	deployment, err := modelOperatorDeployment(
 		operatorName,
 		broker.Namespace(),
-		map[string]string{},
+		labels,
+		selectorLabels,
 		config.OperatorImagePath,
 		config.Port,
 		modelUUID,
@@ -184,7 +205,8 @@ func (k *kubernetesClient) EnsureModelOperator(
 			_, err := k.ensureK8sService(svc)
 			return err
 		},
-		namespace: func() string { return k.namespace },
+		namespace:      func() string { return k.namespace },
+		isLegacyLabels: k.IsLegacyLabels,
 	}
 
 	return ensureModelOperator(modelUUID, agentPath, config, bridge)
@@ -223,13 +245,12 @@ func modelOperatorConfigMap(
 	labels map[string]string,
 	agentConf []byte,
 ) *core.ConfigMap {
-	moLabels := modelOperatorLabels(operatorName)
 
 	return &core.ConfigMap{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
 			Namespace: namespace,
-			Labels:    utils.AppendLabels(labels, moLabels),
+			Labels:    labels,
 		},
 		Data: map[string]string{
 			modelOperatorConfigMapAgentConfKey(operatorName): string(agentConf),
@@ -240,7 +261,8 @@ func modelOperatorConfigMap(
 func modelOperatorDeployment(
 	operatorName,
 	namespace string,
-	labels map[string]string,
+	labels,
+	selectorLabels map[string]string,
 	operatorImagePath string,
 	port int32,
 	modelUUID string,
@@ -248,8 +270,6 @@ func modelOperatorDeployment(
 	volumes []core.Volume,
 	volumeMounts []core.VolumeMount,
 ) (*apps.Deployment, error) {
-
-	moLabels := modelOperatorLabels(operatorName)
 
 	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud model --model-uuid=%s", modelUUID)
 	jujuDataDir, err := paths.DataDir("kubernetes")
@@ -261,16 +281,16 @@ func modelOperatorDeployment(
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
 			Namespace: namespace,
-			Labels:    utils.AppendLabels(labels, moLabels),
+			Labels:    labels,
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: int32Ptr(1),
 			Selector: &meta.LabelSelector{
-				MatchLabels: moLabels,
+				MatchLabels: selectorLabels,
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: meta.ObjectMeta{
-					Labels: moLabels,
+					Labels: selectorLabels,
 				},
 				Spec: core.PodSpec{
 					Containers: []core.Container{{
@@ -344,28 +364,28 @@ func (k *kubernetesClient) modelOperatorDeploymentExists(operatorName string) (b
 	return true, nil
 }
 
-func modelOperatorLabels(operatorName string) map[string]string {
-	return map[string]string{
-		constants.LabelModelOperator: operatorName,
+func modelOperatorLabels(operatorName string, legacy bool) labels.Set {
+	if legacy {
+		return utils.LabelForKeyValue(constants.LegacyLabelModelOperator, operatorName)
 	}
+	return utils.LabelsForOperator(operatorName, OperatorModelTarget, legacy)
 }
 
 func modelOperatorService(
 	operatorName,
 	namespace string,
-	labels map[string]string,
+	labels,
+	selectorLabels map[string]string,
 	port int32,
 ) *core.Service {
-	moLabels := modelOperatorLabels(operatorName)
-
 	return &core.Service{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
 			Namespace: namespace,
-			Labels:    moLabels,
+			Labels:    labels,
 		},
 		Spec: core.ServiceSpec{
-			Selector: moLabels,
+			Selector: selectorLabels,
 			Type:     core.ServiceTypeClusterIP,
 			Ports: []core.ServicePort{
 				{

--- a/caas/kubernetes/provider/modeloperator_upgrade.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade.go
@@ -12,12 +12,16 @@ import (
 type upgradeCAASModelOperatorBridge struct {
 	clientFn    func() kubernetes.Interface
 	namespaceFn func() string
+	isLegacyFn  func() bool
 }
 
 type UpgradeCAASModelOperatorBroker interface {
 	// Client returns a Kubernetes client associated with the current broker's
 	// cluster
 	Client() kubernetes.Interface
+
+	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
+	IsLegacyLabels() bool
 
 	// Namespace returns the targeted Kubernetes namespace for this broker
 	Namespace() string
@@ -27,11 +31,19 @@ func (u *upgradeCAASModelOperatorBridge) Client() kubernetes.Interface {
 	return u.clientFn()
 }
 
+func (u *upgradeCAASModelOperatorBridge) IsLegacyLabels() bool {
+	return u.isLegacyFn()
+}
+
 func modelOperatorUpgrade(
 	operatorName string,
 	vers version.Number,
 	broker UpgradeCAASModelOperatorBroker) error {
-	return upgradeDeployment(operatorName, "", vers,
+	return upgradeDeployment(
+		operatorName,
+		"",
+		vers,
+		broker.IsLegacyLabels(),
 		broker.Client().AppsV1().Deployments(broker.Namespace()))
 }
 
@@ -43,6 +55,7 @@ func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version
 	broker := &upgradeCAASModelOperatorBridge{
 		clientFn:    k.client,
 		namespaceFn: k.GetCurrentNamespace,
+		isLegacyFn:  k.IsLegacyLabels,
 	}
 	return modelOperatorUpgrade(modelOperatorName, vers, broker)
 }

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -39,6 +39,10 @@ func (d *dummyUpgradeCAASModel) Namespace() string {
 	return "test"
 }
 
+func (d *dummyUpgradeCAASModel) IsLegacyLabels() bool {
+	return false
+}
+
 func (s *modelUpgraderSuite) SetUpTest(c *gc.C) {
 	s.broker = &dummyUpgradeCAASModel{
 		client: fake.NewSimpleClientset(),
@@ -83,6 +87,6 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(de.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 
-	c.Assert(de.Annotations[constants.LabelVersion], gc.Equals, version.MustParse("9.9.9").String())
-	c.Assert(de.Spec.Template.Annotations[constants.LabelVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Annotations[constants.AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Spec.Template.Annotations[constants.AnnotationJujuVersion], gc.Equals, version.MustParse("9.9.9").String())
 }

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -35,12 +35,12 @@ func (d *dummyUpgradeCAASModel) Client() kubernetes.Interface {
 	return d.client
 }
 
-func (d *dummyUpgradeCAASModel) Namespace() string {
-	return "test"
-}
-
 func (d *dummyUpgradeCAASModel) IsLegacyLabels() bool {
 	return false
+}
+
+func (d *dummyUpgradeCAASModel) Namespace() string {
+	return "test"
 }
 
 func (s *modelUpgraderSuite) SetUpTest(c *gc.C) {

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -121,7 +121,10 @@ func (k *kubernetesClient) ensureNamespaceAnnotations(ns *core.Namespace) error 
 // createNamespace creates a named namespace.
 func (k *kubernetesClient) createNamespace(name string) error {
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: name}}
-	ns.SetLabels(utils.AppendLabels(ns.GetLabels(), utils.LabelsForModel(k.CurrentModel())))
+	ns.SetLabels(utils.LabelsMerge(
+		ns.GetLabels(),
+		utils.LabelsForModel(k.CurrentModel(), false),
+		utils.LabelsJuju))
 	if err := k.ensureNamespaceAnnotations(ns); err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/version"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
+	rbac "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,14 +32,24 @@ import (
 	"github.com/juju/juju/core/watcher"
 )
 
-func operatorLabels(appName string) map[string]string {
-	return map[string]string{constants.LabelOperator: appName}
-}
+const (
+	OperatorAppTarget = "application"
+)
 
 // GetOperatorPodName returns operator pod name for an application.
-func GetOperatorPodName(api typedcorev1.PodInterface, appName string) (string, error) {
-	podsList, err := api.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName),
+func GetOperatorPodName(
+	podAPI typedcorev1.PodInterface,
+	nsAPI typedcorev1.NamespaceInterface,
+	appName string,
+	namespace string,
+) (string, error) {
+	legacyLabels, err := utils.IsLegacyModelLabels(namespace, nsAPI)
+	if err != nil {
+		return "", errors.Annotatef(err, "determining legacy label status for namespace %s", namespace)
+	}
+
+	podsList, err := podAPI.List(context.TODO(), v1.ListOptions{
+		LabelSelector: operatorSelector(appName, legacyLabels),
 	})
 	if err != nil {
 		return "", errors.Trace(err)
@@ -50,8 +60,11 @@ func GetOperatorPodName(api typedcorev1.PodInterface, appName string) (string, e
 	return podsList.Items[0].GetName(), nil
 }
 
-func (k *kubernetesClient) deleteOperatorRBACResources(appName string) error {
-	selector := utils.LabelSetToSelector(operatorLabels(appName))
+func (k *kubernetesClient) deleteOperatorRBACResources(operatorName string) error {
+	selector := utils.LabelsToSelector(
+		utils.LabelsForOperator(operatorName, OperatorAppTarget, k.IsLegacyLabels()),
+	)
+
 	if err := k.deleteRoleBindings(selector); err != nil {
 		return errors.Trace(err)
 	}
@@ -64,7 +77,11 @@ func (k *kubernetesClient) deleteOperatorRBACResources(appName string) error {
 	return nil
 }
 
-func (k *kubernetesClient) ensureOperatorRBACResources(operatorName string, labels, annotations map[string]string) (sa *core.ServiceAccount, cleanUps []func(), err error) {
+func (k *kubernetesClient) ensureOperatorRBACResources(
+	operatorName string,
+	labels,
+	annotations map[string]string,
+) (sa *core.ServiceAccount, cleanUps []func(), err error) {
 	defer func() {
 		// ensure cleanup in reversed order.
 		i := 0
@@ -93,14 +110,14 @@ func (k *kubernetesClient) ensureOperatorRBACResources(operatorName string, labe
 		return nil, cleanUps, errors.Trace(err)
 	}
 	// ensure role.
-	r, rCleanups, err := k.ensureRole(&rbacv1.Role{
+	r, rCleanups, err := k.ensureRole(&rbac.Role{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        operatorName,
 			Namespace:   k.namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Rules: []rbacv1.PolicyRule{
+		Rules: []rbac.PolicyRule{
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
@@ -123,20 +140,20 @@ func (k *kubernetesClient) ensureOperatorRBACResources(operatorName string, labe
 		return nil, cleanUps, errors.Trace(err)
 	}
 	// ensure rolebinding.
-	_, rBCleanups, err := k.ensureRoleBinding(&rbacv1.RoleBinding{
+	_, rBCleanups, err := k.ensureRoleBinding(&rbac.RoleBinding{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        operatorName,
 			Namespace:   k.namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		RoleRef: rbacv1.RoleRef{
+		RoleRef: rbac.RoleRef{
 			Name: r.GetName(),
 			Kind: "Role",
 		},
-		Subjects: []rbacv1.Subject{
+		Subjects: []rbac.Subject{
 			{
-				Kind:      rbacv1.ServiceAccountKind,
+				Kind:      rbac.ServiceAccountKind,
 				Name:      sa.GetName(),
 				Namespace: sa.GetNamespace(),
 			},
@@ -151,13 +168,20 @@ func (k *kubernetesClient) ensureOperatorRBACResources(operatorName string, labe
 
 // EnsureOperator creates or updates an operator pod with the given application
 // name, agent path, and operator config.
-func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caas.OperatorConfig) (err error) {
-	logger.Debugf("creating/updating %s operator", appName)
+func (k *kubernetesClient) EnsureOperator(name, agentPath string, config *caas.OperatorConfig) (err error) {
+	logger.Debugf("creating/updating %s operator", name)
 
-	operatorName := k.operatorName(appName)
-	labels := operatorLabels(appName)
+	operatorName := k.operatorName(name)
+
+	selectorLabels := utils.LabelsForOperator(name, OperatorAppTarget, k.IsLegacyLabels())
+	labels := selectorLabels
+
+	if !k.IsLegacyLabels() {
+		labels = utils.LabelsMerge(selectorLabels, utils.LabelsJuju)
+	}
+
 	annotations := utils.ResourceTagsToAnnotations(config.ResourceTags).
-		Add(constants.LabelVersion, config.Version.String())
+		Merge(utils.AnnotationsForVersion(config.Version.String(), k.IsLegacyLabels()))
 
 	var cleanups []func()
 	defer func() {
@@ -176,7 +200,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 			Annotations: annotations,
 		},
 		Spec: core.ServiceSpec{
-			Selector: map[string]string{constants.LabelOperator: appName},
+			Selector: selectorLabels,
 			Type:     core.ServiceTypeClusterIP,
 			Ports: []core.ServicePort{
 				{
@@ -188,7 +212,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		},
 	}
 	if _, err := k.ensureK8sService(service); err != nil {
-		return errors.Annotatef(err, "creating or updating service for %v operator", appName)
+		return errors.Annotatef(err, "creating or updating service for %v operator", name)
 	}
 	cleanups = append(cleanups, func() { _ = k.deleteService(operatorName) })
 	services := k.client().CoreV1().Services(k.namespace)
@@ -209,11 +233,15 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		// We expect that the config map already exists,
 		// so make sure it does.
 		if _, err := k.getConfigMap(cmName); err != nil {
-			return errors.Annotatef(err, "config map for %q should already exist", appName)
+			return errors.Annotatef(err, "config map for %q should already exist", name)
 		}
 	} else {
+		configMapLabels := labels
+		if k.IsLegacyLabels() {
+			configMapLabels = k.getConfigMapLabels(name)
+		}
 		cmCleanUp, err := k.ensureConfigMapLegacy(
-			operatorConfigMap(appName, cmName, k.getConfigMapLabels(appName), annotations, config))
+			operatorConfigMap(name, cmName, configMapLabels, annotations, config))
 		cleanups = append(cleanups, cmCleanUp)
 		if err != nil {
 			return errors.Annotate(err, "creating or updating ConfigMap")
@@ -223,11 +251,12 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	// Set up the parameters for creating charm storage (if required).
 	pod, err := operatorPod(
 		operatorName,
-		appName,
+		name,
 		svc.Spec.ClusterIP,
 		agentPath,
 		config.OperatorImagePath,
 		config.Version.String(),
+		selectorLabels,
 		annotations.Copy(),
 		sa.GetName(),
 	)
@@ -238,7 +267,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	podWithoutStorage := pod
 
 	numPods := int32(1)
-	operatorPvc, err := k.operatorVolumeClaim(appName, operatorName, config.CharmStorage)
+	operatorPvc, err := k.operatorVolumeClaim(name, operatorName, config.CharmStorage)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -250,11 +279,11 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		Spec: apps.StatefulSetSpec{
 			Replicas: &numPods,
 			Selector: &v1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: selectorLabels,
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels:      labels,
+					Labels:      selectorLabels,
 					Annotations: pod.Annotations,
 				},
 			},
@@ -262,7 +291,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		},
 	}
 	if operatorPvc != nil {
-		logger.Debugf("using persistent volume claim for operator %s: %+v", appName, operatorPvc)
+		logger.Debugf("using persistent volume claim for operator %s: %+v", name, operatorPvc)
 		statefulset.Spec.VolumeClaimTemplates = []core.PersistentVolumeClaim{*operatorPvc}
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, core.VolumeMount{
 			Name:      operatorPvc.Name,
@@ -271,10 +300,20 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	}
 	statefulset.Spec.Template.Spec = pod.Spec
 	err = k.ensureStatefulSet(statefulset, podWithoutStorage.Spec)
-	return errors.Annotatef(err, "creating or updating %v operator StatefulSet", appName)
+	return errors.Annotatef(err, "creating or updating %v operator StatefulSet", name)
 }
 
-func (k *kubernetesClient) operatorVolumeClaim(appName, operatorName string, storageParams *caas.CharmStorageParams) (*core.PersistentVolumeClaim, error) {
+func operatorSelector(appName string, legacyLabels bool) string {
+	return utils.LabelSetToSelector(
+		utils.LabelsForOperator(appName, OperatorAppTarget, legacyLabels)).
+		String()
+}
+
+func (k *kubernetesClient) operatorVolumeClaim(
+	appName,
+	operatorName string,
+	storageParams *caas.CharmStorageParams,
+) (*core.PersistentVolumeClaim, error) {
 	// We may no longer need storage for charms, but if the charm has previously been deployed
 	// with storage, we need to retain that.
 	operatorVolumeClaim := "charm"
@@ -334,9 +373,9 @@ func (k *kubernetesClient) validateOperatorStorage() (string, error) {
 
 // OperatorExists indicates if the operator for the specified
 // application exists, and whether the operator is terminating.
-func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, error) {
-	operatorName := k.operatorName(appName)
-	exists, terminating, err := k.operatorStatefulSetExists(appName, operatorName)
+func (k *kubernetesClient) OperatorExists(name string) (caas.OperatorState, error) {
+	operatorName := k.operatorName(name)
+	exists, terminating, err := k.operatorStatefulSetExists(operatorName)
 	if err != nil {
 		return caas.OperatorState{}, errors.Trace(err)
 	}
@@ -350,18 +389,17 @@ func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, e
 	}
 	checks := []struct {
 		label string
-		check func(appName string, operatorName string) (bool, bool, error)
+		check func(operatorName string) (bool, bool, error)
 	}{
 		{"rbac", k.operatorRBACResourcesRemaining},
 		{"config map", k.operatorConfigMapExists},
-		{"configurations config map", k.operatorConfigurationsConfigMapExists},
+		{"configurations config map", func(on string) (bool, bool, error) { return k.operatorConfigurationsConfigMapExists(name, on) }},
 		{"service", k.operatorServiceExists},
-		{"secret", k.operatorSecretExists},
+		{"secret", func(on string) (bool, bool, error) { return k.operatorSecretExists(name, on) }},
 		{"deployment", k.operatorDeploymentExists},
-		{"pods", k.operatorPodExists},
 	}
 	for _, c := range checks {
-		exists, _, err := c.check(appName, operatorName)
+		exists, _, err := c.check(operatorName)
 		if err != nil {
 			return caas.OperatorState{}, errors.Annotatef(err, "%s resource check", c.label)
 		}
@@ -375,7 +413,7 @@ func (k *kubernetesClient) OperatorExists(appName string) (caas.OperatorState, e
 	return caas.OperatorState{}, nil
 }
 
-func (k *kubernetesClient) operatorStatefulSetExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
+func (k *kubernetesClient) operatorStatefulSetExists(operatorName string) (exists bool, terminating bool, err error) {
 	statefulSets := k.client().AppsV1().StatefulSets(k.namespace)
 	operator, err := statefulSets.Get(context.TODO(), operatorName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
@@ -387,7 +425,7 @@ func (k *kubernetesClient) operatorStatefulSetExists(appName string, operatorNam
 	return true, operator.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorRBACResourcesRemaining(appName string, operatorName string) (exists bool, terminating bool, err error) {
+func (k *kubernetesClient) operatorRBACResourcesRemaining(operatorName string) (exists bool, terminating bool, err error) {
 	sa, err := k.getServiceAccount(operatorName)
 	if errors.IsNotFound(err) {
 		// continue
@@ -415,7 +453,7 @@ func (k *kubernetesClient) operatorRBACResourcesRemaining(appName string, operat
 	return false, false, nil
 }
 
-func (k *kubernetesClient) operatorConfigMapExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
+func (k *kubernetesClient) operatorConfigMapExists(operatorName string) (exists bool, terminating bool, err error) {
 	configMaps := k.client().CoreV1().ConfigMaps(k.namespace)
 	configMapName := operatorConfigMapName(operatorName)
 	cm, err := configMaps.Get(context.TODO(), configMapName, v1.GetOptions{})
@@ -443,7 +481,7 @@ func (k *kubernetesClient) operatorConfigurationsConfigMapExists(appName string,
 	return true, cm.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorServiceExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
+func (k *kubernetesClient) operatorServiceExists(operatorName string) (exists bool, terminating bool, err error) {
 	services := k.client().CoreV1().Services(k.namespace)
 	s, err := services.Get(context.TODO(), operatorName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
@@ -470,7 +508,7 @@ func (k *kubernetesClient) operatorSecretExists(appName string, operatorName str
 	return true, s.DeletionTimestamp != nil, nil
 }
 
-func (k *kubernetesClient) operatorDeploymentExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
+func (k *kubernetesClient) operatorDeploymentExists(operatorName string) (exists bool, terminating bool, err error) {
 	deployments := k.client().AppsV1().Deployments(k.namespace)
 	operator, err := deployments.Get(context.TODO(), operatorName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
@@ -479,17 +517,6 @@ func (k *kubernetesClient) operatorDeploymentExists(appName string, operatorName
 		return false, false, errors.Trace(err)
 	}
 	return true, operator.DeletionTimestamp != nil, nil
-}
-
-func (k *kubernetesClient) operatorPodExists(appName string, operatorName string) (exists bool, terminating bool, err error) {
-	pods := k.client().CoreV1().Pods(k.namespace)
-	podList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName),
-	})
-	if err != nil {
-		return false, false, errors.Trace(err)
-	}
-	return len(podList.Items) != 0, false, nil
 }
 
 // DeleteOperator deletes the specified operator.
@@ -535,7 +562,7 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 	}
 	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName),
+		LabelSelector: operatorSelector(appName, k.IsLegacyLabels()),
 	})
 	if err != nil {
 		return errors.Trace(err)
@@ -580,7 +607,7 @@ func (k *kubernetesClient) WatchOperator(appName string) (watcher.NotifyWatcher,
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
 		informers.WithTweakListOptions(func(o *v1.ListOptions) {
-			o.LabelSelector = operatorSelector(appName)
+			o.LabelSelector = operatorSelector(appName, k.IsLegacyLabels())
 		}),
 	)
 	return k.newWatcher(factory.Core().V1().Pods().Informer(), appName, k.clock)
@@ -600,7 +627,7 @@ func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 
 	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName),
+		LabelSelector: operatorSelector(appName, k.IsLegacyLabels()),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -617,7 +644,7 @@ func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 	}
 
 	cfg := caas.OperatorConfig{}
-	if ver, ok := opPod.Annotations[constants.LabelVersion]; ok {
+	if ver, ok := opPod.Annotations[utils.AnnotationVersionKey(k.IsLegacyLabels())]; ok {
 		cfg.Version, err = version.Parse(ver)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -665,6 +692,7 @@ func operatorPod(
 	agentPath,
 	operatorImagePath,
 	version string,
+	selectorLabels map[string]string,
 	annotations k8sannotations.Annotation,
 	serviceAccountName string,
 ) (*core.Pod, error) {
@@ -684,10 +712,9 @@ func operatorPod(
 	mountToken := true
 	return &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
-			Name: podName,
-			Annotations: podAnnotations(annotations.Copy()).
-				Add(constants.LabelVersion, version).ToMap(),
-			Labels: operatorLabels(appName),
+			Name:        podName,
+			Annotations: podAnnotations(annotations.Copy()).ToMap(),
+			Labels:      selectorLabels,
 		},
 		Spec: core.PodSpec{
 			ServiceAccountName:           serviceAccountName,

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -33,6 +33,9 @@ import (
 )
 
 const (
+	// OperatorAppTarget is the constant used to describe the operator's target
+	// in kubernetes. This allows us to differentiate between different
+	// operators that would possible have the same labels otherwise
 	OperatorAppTarget = "application"
 )
 

--- a/caas/kubernetes/provider/operator_upgrade.go
+++ b/caas/kubernetes/provider/operator_upgrade.go
@@ -29,6 +29,7 @@ type upgradeCAASOperatorBridge struct {
 	clientFn         func() kubernetes.Interface
 	clockFn          func() clock.Clock
 	deploymentNameFn func(string, bool) string
+	isLegacyFn       func() bool
 	namespaceFn      func() string
 	operatorFn       func(string) (*caas.Operator, error)
 	operatorNameFn   func(string) string
@@ -45,6 +46,9 @@ type UpgradeCAASOperatorBroker interface {
 	// Returns the deployment name use for the given application name, supports
 	// finding legacy deployment names if set to True.
 	DeploymentName(string, bool) string
+
+	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
+	IsLegacyLabels() bool
 
 	Namespace() string
 
@@ -70,6 +74,10 @@ func (u *upgradeCAASOperatorBridge) DeploymentName(n string, l bool) string {
 	return u.deploymentNameFn(n, l)
 }
 
+func (u *upgradeCAASOperatorBridge) IsLegacyLabels() bool {
+	return u.isLegacyFn()
+}
+
 func (u *upgradeCAASOperatorBridge) Operator(n string) (*caas.Operator, error) {
 	return u.operatorFn(n)
 }
@@ -92,7 +100,7 @@ func operatorInitUpgrade(appName, imagePath string, broker UpgradeCAASOperatorBr
 		broker UpgradeCAASOperatorBroker) func() (bool, error) {
 
 		return func() (done bool, err error) {
-			labelSelector := utils.LabelSetToSelector(labelSet).String()
+			labelSelector := utils.LabelsToSelector(labelSet).String()
 			podList, err := broker.Client().CoreV1().Pods(broker.Namespace()).
 				List(context.TODO(), meta.ListOptions{
 					LabelSelector: labelSelector,
@@ -173,7 +181,11 @@ func operatorInitUpgrade(appName, imagePath string, broker UpgradeCAASOperatorBr
 	return nil, errors.NotFoundf("deployment %q init containers", deploymentName)
 }
 
-func operatorUpgrade(appName string, vers version.Number, broker UpgradeCAASOperatorBroker) error {
+func operatorUpgrade(
+	appName string,
+	vers version.Number,
+	broker UpgradeCAASOperatorBroker,
+) error {
 	operator, err := broker.Operator(appName)
 	if err != nil {
 		return errors.Trace(err)
@@ -207,6 +219,7 @@ func operatorUpgrade(appName string, vers version.Number, broker UpgradeCAASOper
 					broker.OperatorName(appName),
 					operatorImagePath,
 					vers,
+					broker.IsLegacyLabels(),
 					broker.Client().AppsV1().StatefulSets(broker.Namespace())))
 			}
 		}
@@ -218,6 +231,7 @@ func (k *kubernetesClient) upgradeOperator(agentTag names.Tag, vers version.Numb
 		clientFn:         k.client,
 		clockFn:          func() clock.Clock { return k.clock },
 		deploymentNameFn: k.deploymentName,
+		isLegacyFn:       k.IsLegacyLabels,
 		namespaceFn:      k.GetCurrentNamespace,
 		operatorFn:       k.Operator,
 		operatorNameFn:   k.operatorName,

--- a/caas/kubernetes/provider/operator_upgrade_test.go
+++ b/caas/kubernetes/provider/operator_upgrade_test.go
@@ -46,6 +46,10 @@ func (d *DummyUpgradeCAASOperator) DeploymentName(n string, _ bool) string {
 	return n
 }
 
+func (d *DummyUpgradeCAASOperator) IsLegacyLabels() bool {
+	return false
+}
+
 func (d *DummyUpgradeCAASOperator) Namespace() string {
 	return "test"
 }
@@ -59,10 +63,6 @@ func (d *DummyUpgradeCAASOperator) Operator(n string) (*caas.Operator, error) {
 
 func (d *DummyUpgradeCAASOperator) OperatorName(n string) string {
 	return n
-}
-
-func (d *DummyUpgradeCAASOperator) IsLegacyLabels() bool {
-	return false
 }
 
 func (o *OperatorUpgraderSuite) SetUpTest(c *gc.C) {

--- a/caas/kubernetes/provider/operator_upgrade_test.go
+++ b/caas/kubernetes/provider/operator_upgrade_test.go
@@ -61,6 +61,10 @@ func (d *DummyUpgradeCAASOperator) OperatorName(n string) string {
 	return n
 }
 
+func (d *DummyUpgradeCAASOperator) IsLegacyLabels() bool {
+	return false
+}
+
 func (o *OperatorUpgraderSuite) SetUpTest(c *gc.C) {
 	o.broker = &DummyUpgradeCAASOperator{
 		client: fake.NewSimpleClientset(),

--- a/caas/kubernetes/provider/provider_test.go
+++ b/caas/kubernetes/provider/provider_test.go
@@ -74,16 +74,6 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 	c.Assert(provider, gc.NotNil)
 }
 
-func (s *providerSuite) TestOpen(c *gc.C) {
-	config := fakeConfig(c)
-	broker, err := s.provider.Open(environs.OpenParams{
-		Cloud:  fakeCloudSpec(),
-		Config: config,
-	})
-	c.Check(err, jc.ErrorIsNil)
-	c.Assert(broker, gc.NotNil)
-}
-
 func (s *providerSuite) TestOpenInvalidCloudSpec(c *gc.C) {
 	spec := fakeCloudSpec()
 	spec.Name = ""

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -20,10 +20,12 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 )
 
-func (k *kubernetesClient) getSecretLabels(appName string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: appName,
+func getSecretLabels(appName string, legacy bool) map[string]string {
+	labels := utils.LabelsForApp(appName, legacy)
+	if !legacy {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
+	return labels
 }
 
 func processSecretData(in map[string]string) (_ map[string][]byte, err error) {
@@ -42,7 +44,7 @@ func (k *kubernetesClient) ensureSecrets(appName string, annotations k8sannotati
 			ObjectMeta: v1.ObjectMeta{
 				Name:        v.Name,
 				Namespace:   k.namespace,
-				Labels:      k.getSecretLabels(appName),
+				Labels:      getSecretLabels(appName, k.IsLegacyLabels()),
 				Annotations: annotations.Merge(v.Annotations),
 			},
 			Type:       v.Type,
@@ -81,7 +83,7 @@ func (k *kubernetesClient) ensureOCIImageSecret(
 		ObjectMeta: v1.ObjectMeta{
 			Name:        imageSecretName,
 			Namespace:   k.namespace,
-			Labels:      k.getSecretLabels(appName),
+			Labels:      getSecretLabels(appName, k.IsLegacyLabels()),
 			Annotations: annotations.ToMap()},
 		Type: core.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
@@ -175,7 +177,8 @@ func (k *kubernetesClient) deleteSecrets(appName string) error {
 	err := k.client().CoreV1().Secrets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: &constants.DefaultPropagationPolicy,
 	}, v1.ListOptions{
-		LabelSelector: utils.LabelSetToSelector(k.getSecretLabels(appName)).String(),
+		LabelSelector: utils.LabelSetToSelector(
+			getSecretLabels(appName, k.IsLegacyLabels())).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/caas/kubernetes/provider/services.go
+++ b/caas/kubernetes/provider/services.go
@@ -10,7 +10,6 @@ import (
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
 
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
@@ -18,8 +17,12 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 )
 
-func getServiceLabels(appName string) map[string]string {
-	return utils.LabelsForApp(appName)
+func getServiceLabels(appName string, legacy bool) map[string]string {
+	labels := utils.LabelsForApp(appName, legacy)
+	if !legacy {
+		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
+	}
+	return labels
 }
 
 func (k *kubernetesClient) ensureServicesForApp(appName string, annotations k8sannotations.Annotation, services []k8sspecs.K8sService) (cleanUps []func(), err error) {
@@ -28,7 +31,7 @@ func (k *kubernetesClient) ensureServicesForApp(appName string, annotations k8sa
 			ObjectMeta: v1.ObjectMeta{
 				Name:        v.Name,
 				Namespace:   k.namespace,
-				Labels:      k8slabels.Merge(v.Labels, getServiceLabels(appName)),
+				Labels:      utils.LabelsMerge(v.Labels, getServiceLabels(appName, k.IsLegacyLabels())),
 				Annotations: annotations.Copy().Merge(v.Annotations),
 			},
 			Spec: v.Spec,
@@ -81,7 +84,8 @@ func (k *kubernetesClient) deleteServices(appName string) error {
 	api := k.client().CoreV1().Services(k.namespace)
 	services, err := api.List(context.TODO(),
 		v1.ListOptions{
-			LabelSelector: utils.LabelSetToSelector(getServiceLabels(appName)).String(),
+			LabelSelector: utils.LabelSetToSelector(
+				getServiceLabels(appName, k.IsLegacyLabels())).String(),
 		},
 	)
 	if err != nil {

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -13,16 +13,14 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 
-	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/core/watcher"
 )
 
 func (k *kubernetesClient) deleteClusterScopeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
 	defer wg.Done()
 
-	labels := map[string]string{
-		constants.LabelModel: k.namespace,
-	}
+	labels := utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels())
 	selector := k8slabels.NewSelector().Add(
 		labelSetToRequirements(labels)...,
 	)

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -142,29 +142,29 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	}
 
 	// timer +1.
-	s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-model=test"}).
+	s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
 		Return(&rbacv1.ClusterRoleBindingList{}, nil).
 		After(
 			s.mockClusterRoleBindings.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
-				v1.ListOptions{LabelSelector: "juju-model=test"},
+				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockClusterRoles.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-model=test"}).
+	s.mockClusterRoles.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
 		Return(&rbacv1.ClusterRoleList{}, nil).
 		After(
 			s.mockClusterRoles.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
-				v1.ListOptions{LabelSelector: "juju-model=test"},
+				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
 	s.mockNamespaceableResourceClient.EXPECT().List(gomock.Any(),
 		// list all custom resources for crd "v1alpha2".
-		v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+		v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 	).Return(&unstructured.UnstructuredList{}, nil).After(
 		s.mockDynamicClient.EXPECT().Resource(
 			schema.GroupVersionResource{
@@ -176,7 +176,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	).After(
 		// list all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().List(gomock.Any(),
-			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+			v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 		).Return(&unstructured.UnstructuredList{}, nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -194,7 +194,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 		// delete all custom resources for crd "v1alpha2".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(gomock.Any(),
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+			v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -208,7 +208,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 		// delete all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(gomock.Any(),
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+			v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -225,42 +225,42 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	)
 
 	// timer +1.
-	s.mockCustomResourceDefinition.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"}).AnyTimes().
+	s.mockCustomResourceDefinition.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"}).AnyTimes().
 		Return(&apiextensionsv1beta1.CustomResourceDefinitionList{}, nil).
 		After(
 			s.mockCustomResourceDefinition.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
-				v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+				v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockMutatingWebhookConfiguration.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-model=test"}).
+	s.mockMutatingWebhookConfiguration.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
 		Return(&admissionregistrationv1beta1.MutatingWebhookConfigurationList{}, nil).
 		After(
 			s.mockMutatingWebhookConfiguration.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
-				v1.ListOptions{LabelSelector: "juju-model=test"},
+				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockValidatingWebhookConfiguration.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-model=test"}).
+	s.mockValidatingWebhookConfiguration.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
 		Return(&admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}, nil).
 		After(
 			s.mockValidatingWebhookConfiguration.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
-				v1.ListOptions{LabelSelector: "juju-model=test"},
+				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-model=test"}).
+	s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
 		Return(&storagev1.StorageClassList{}, nil).
 		After(
 			s.mockStorageClass.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
-				v1.ListOptions{LabelSelector: "juju-model=test"},
+				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(nil),
 		)
 
@@ -407,18 +407,18 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 
 	s.mockClusterRoleBindings.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
 	s.mockClusterRoles.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
 	// delete all custom resources for crd "v1alpha2".
 	s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+		v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 	).Return(nil).After(
 		s.mockDynamicClient.EXPECT().Resource(
 			schema.GroupVersionResource{
@@ -431,7 +431,7 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 		// delete all custom resources for crd "v1".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(gomock.Any(),
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
-			v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+			v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 		).Return(nil),
 	).After(
 		s.mockDynamicClient.EXPECT().Resource(
@@ -449,22 +449,22 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 
 	s.mockCustomResourceDefinition.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test,juju-resource-lifecycle notin (persistent)"},
+		v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
 	s.mockMutatingWebhookConfiguration.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
 	s.mockValidatingWebhookConfiguration.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
 	s.mockStorageClass.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
-		v1.ListOptions{LabelSelector: "juju-model=test"},
+		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(nil)
 
 	var wg sync.WaitGroup

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8swatchertest "github.com/juju/juju/caas/kubernetes/provider/watcher/test"
 	"github.com/juju/juju/testing"
 )
@@ -33,8 +34,11 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	// CRs of this Cluster scope CRD will get deleted.
 	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "tfjobs.kubeflow.org",
-			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+			),
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -88,8 +92,11 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	// CRs of this namespaced scope CRD will be skipped.
 	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "tfjobs.kubeflow.org",
-			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+			),
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -297,8 +304,11 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 	// CRs of this Cluster scope CRD will get deleted.
 	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "tfjobs.kubeflow.org",
-			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+			),
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -352,8 +362,11 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 	// CRs of this namespaced scope CRD will be skipped.
 	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   "tfjobs.kubeflow.org",
-			Labels: map[string]string{"juju-app": "app-name", "juju-model": "test"},
+			Name: "tfjobs.kubeflow.org",
+			Labels: utils.LabelsMerge(
+				utils.LabelsForApp("app-name", false),
+				utils.LabelsForModel("test", false),
+			),
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -14,7 +14,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
 
-	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	k8sannotations "github.com/juju/juju/core/annotations"
 )
@@ -39,7 +39,13 @@ func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
 	return errors.NotImplementedf("k8s upgrade for agent tag %q", agentTag)
 }
 
-func upgradeDeployment(name, imagePath string, vers version.Number, broker appstyped.DeploymentInterface) error {
+func upgradeDeployment(
+	name,
+	imagePath string,
+	vers version.Number,
+	legacyLabels bool,
+	broker appstyped.DeploymentInterface,
+) error {
 	de, err := broker.Get(context.TODO(), name, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return errors.NotFoundf(
@@ -60,11 +66,11 @@ func upgradeDeployment(name, imagePath string, vers version.Number, broker appst
 	// just ensure juju-version to current version for now.
 	de.SetAnnotations(
 		k8sannotations.New(de.GetAnnotations()).
-			Add(constants.LabelVersion, vers.String()).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
 	)
 	de.Spec.Template.SetAnnotations(
 		k8sannotations.New(de.Spec.Template.GetAnnotations()).
-			Add(constants.LabelVersion, vers.String()).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
 	)
 
 	if _, err := broker.Update(context.TODO(), de, meta.UpdateOptions{}); err != nil {
@@ -74,7 +80,13 @@ func upgradeDeployment(name, imagePath string, vers version.Number, broker appst
 	return nil
 }
 
-func upgradeStatefulSet(name, imagePath string, vers version.Number, broker appstyped.StatefulSetInterface) error {
+func upgradeStatefulSet(
+	name,
+	imagePath string,
+	vers version.Number,
+	legacyLabels bool,
+	broker appstyped.StatefulSetInterface,
+) error {
 	ss, err := broker.Get(context.TODO(), name, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return errors.NotFoundf(
@@ -95,11 +107,11 @@ func upgradeStatefulSet(name, imagePath string, vers version.Number, broker apps
 	// just ensure juju-version to current version for now.
 	ss.SetAnnotations(
 		k8sannotations.New(ss.GetAnnotations()).
-			Add(constants.LabelVersion, vers.String()).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
 	)
 	ss.Spec.Template.SetAnnotations(
 		k8sannotations.New(ss.Spec.Template.GetAnnotations()).
-			Add(constants.LabelVersion, vers.String()).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
 	)
 
 	if _, err := broker.Update(context.TODO(), ss, meta.UpdateOptions{}); err != nil {

--- a/caas/kubernetes/provider/utils/annotations.go
+++ b/caas/kubernetes/provider/utils/annotations.go
@@ -9,6 +9,43 @@ import (
 	"github.com/juju/juju/environs/tags"
 )
 
+type AnnotationKeySupplier func() string
+
+// AnnotationsForStorage provides the annotations that should be placed on a
+// storage object. The annotations returned by this function are storage
+// specific only and should be combined with other annotations where
+// appropriate.
+func AnnotationsForStorage(name string, legacy bool) annotations.Annotation {
+	if legacy {
+		return annotations.Annotation{
+			constants.LegacyAnnotationStorageName: name,
+		}
+	}
+	return annotations.Annotation{
+		constants.AnnotationJujuStorageName: name,
+	}
+}
+
+// AnnotationsForVersion provides the annotations that should be placed on an
+// object that requires juju version information. The annotations returned by
+// this function are version specific and may need to be combined with other
+// annotations for a complete set.
+func AnnotationsForVersion(vers string, legacy bool) annotations.Annotation {
+	return annotations.Annotation{
+		AnnotationVersionKey(legacy): vers,
+	}
+}
+
+// AnnotationVersionKey returns the key used un in annotations to describe the
+// Juju version. Legacy controls if the key returns is a legacy annotation key
+// or newer style.
+func AnnotationVersionKey(legacy bool) string {
+	if legacy {
+		return constants.LegacyAnnotationVersion
+	}
+	return constants.AnnotationJujuVersion
+}
+
 func ResourceTagsToAnnotations(in map[string]string) annotations.Annotation {
 	tagsAnnotationsMap := map[string]string{
 		tags.JujuController: constants.AnnotationControllerUUIDKey,

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -4,52 +4,131 @@
 package utils
 
 import (
-	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"context"
+
+	"github.com/juju/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	core "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 )
 
-func LabelSetToSelector(labels k8slabels.Set) k8slabels.Selector {
-	return k8slabels.SelectorFromValidatedSet(labels)
-}
+var (
+	// LabelsJuju is a common set
+	LabelsJuju = map[string]string{
+		constants.LabelKubernetesAppManaged: "juju",
+	}
+)
 
-// AppendLabels adds the labels defined in src to dest returning the result.
-// Overlapping keys in sources maps are overwritten by the very last defined
-// value for a duplicate key.
-func AppendLabels(dest map[string]string, sources ...map[string]string) map[string]string {
-	if dest == nil {
-		dest = map[string]string{}
-	}
-	if sources == nil {
-		return dest
-	}
-	for _, s := range sources {
-		for k, v := range s {
-			dest[k] = v
+// HasLabels returns true if the src contains the labels in has
+func HasLabels(src, has labels.Set) bool {
+	for k, v := range has {
+		if src[k] != v {
+			return false
 		}
 	}
-	return dest
+	return true
+}
+
+// IsLegacyModelLabels checks to see if the provided model is running on an older
+// labeling scheme or a newer one.
+func IsLegacyModelLabels(model string, namespaceI core.NamespaceInterface) (bool, error) {
+	ns, err := namespaceI.Get(context.TODO(), model, meta.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return true, errors.Annotatef(err, "unable to determine legacy status for namespace %s", model)
+	}
+
+	return !HasLabels(ns.Labels, LabelsForModel(model, false)), nil
+}
+
+// LabelSetToSelector converts a set of Kubernetes labels
+func LabelSetToSelector(l labels.Set) labels.Selector {
+	return labels.SelectorFromValidatedSet(l)
 }
 
 // LabelsForApp returns the labels that should be on a k8s object for a given
 // application name
-func LabelsForApp(name string) map[string]string {
-	return map[string]string{
-		constants.LabelApplication: name,
+func LabelsForApp(name string, legacy bool) labels.Set {
+	if legacy {
+		return labels.Set{
+			constants.LegacyLabelKubernetesAppName: name,
+		}
+	}
+	return labels.Set{
+		constants.LabelKubernetesAppName: name,
 	}
 }
 
 // LabelForKeyValue returns a Kubernetes label set for the supplied key value.
-func LabelForKeyValue(key, value string) k8slabels.Set {
-	return k8slabels.Set{
+func LabelForKeyValue(key, value string) labels.Set {
+	return labels.Set{
 		key: value,
 	}
 }
 
+// LabelsMerge
+func LabelsMerge(a labels.Set, merges ...labels.Set) labels.Set {
+	for _, merge := range merges {
+		a = labels.Merge(a, merge)
+	}
+	return a
+}
+
 // LabelsForModel returns the labels that should be on a k8s object for a given
 // model name
-func LabelsForModel(name string) map[string]string {
-	return map[string]string{
-		constants.LabelModel: name,
+func LabelsForModel(name string, legacy bool) labels.Set {
+	if legacy {
+		return map[string]string{
+			constants.LegacyLabelModelName: name,
+		}
 	}
+	return map[string]string{
+		constants.LabelJujuModelName: name,
+	}
+}
+
+// LabelsForOperator returns the labels that should be placed on a juju operator
+// Takes the operator name, type and a legacy flag to indicate these labels are
+// being used on a model that is operating in "legacy" label mode
+func LabelsForOperator(name, target string, legacy bool) labels.Set {
+	if legacy {
+		return map[string]string{
+			constants.LegacyLabelKubernetesOperatorName: name,
+		}
+	}
+	return map[string]string{
+		constants.LabelJujuOperatorName:   name,
+		constants.LabelJujuOperatorTarget: target,
+	}
+}
+
+// LabelsForStorage return the labels that should be placed on a k8s storage
+// object. Takes the storage name and a legacy flat.
+func LabelsForStorage(name string, legacy bool) labels.Set {
+	if legacy {
+		return map[string]string{
+			constants.LegacyLabelStorageName: name,
+		}
+	}
+	return map[string]string{
+		constants.LabelJujuStorageName: name,
+	}
+}
+
+// LabelsToSelector transforms the supplied label set to a valid Kubernetes
+// label selector
+func LabelsToSelector(ls labels.Set) labels.Selector {
+	return labels.SelectorFromValidatedSet(ls)
+}
+
+func StorageNameFromLabels(labels labels.Set) string {
+	if labels[constants.LabelJujuStorageName] != "" {
+		return labels[constants.LabelJujuStorageName]
+	}
+	return labels[constants.LegacyLabelStorageName]
 }

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -71,7 +71,8 @@ func LabelForKeyValue(key, value string) labels.Set {
 	}
 }
 
-// LabelsMerge
+// LabelsMerge merges one or more sets of labels together into a new set. For
+// duplicate keys the last key found is used.
 func LabelsMerge(a labels.Set, merges ...labels.Set) labels.Set {
 	for _, merge := range merges {
 		a = labels.Merge(a, merge)

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -1,0 +1,51 @@
+package utils_test
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
+)
+
+type LabelSuite struct {
+	client *fake.Clientset
+}
+
+var _ = gc.Suite(&LabelSuite{})
+
+func (l *LabelSuite) SetUpTest(c *gc.C) {
+	l.client = fake.NewSimpleClientset()
+}
+
+func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
+	tests := []struct {
+		IsLegacy  bool
+		Model     string
+		Namespace *core.Namespace
+	}{
+		{
+			IsLegacy: false,
+			Model:    "legacy-model-label-test-1",
+			Namespace: &core.Namespace{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   "legacy-model-label-test-1",
+					Labels: utils.LabelsForModel("legacy-model-label-test-1", false),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		_, err := l.client.CoreV1().Namespaces().Create(context.TODO(), test.Namespace, meta.CreateOptions{})
+		c.Assert(err, jc.ErrorIsNil)
+
+		legacy, err := utils.IsLegacyModelLabels(test.Model, l.client.CoreV1().Namespaces())
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(legacy, gc.Equals, test.IsLegacy)
+	}
+}

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package utils_test
 
 import (
@@ -7,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
@@ -20,6 +24,40 @@ var _ = gc.Suite(&LabelSuite{})
 
 func (l *LabelSuite) SetUpTest(c *gc.C) {
 	l.client = fake.NewSimpleClientset()
+}
+
+func (l *LabelSuite) TestHasLabels(c *gc.C) {
+	tests := []struct {
+		Src    labels.Set
+		Has    labels.Set
+		Result bool
+	}{
+		{
+			Src: labels.Set{
+				"foo":  "bar",
+				"test": "test",
+			},
+			Has: labels.Set{
+				"foo": "bar",
+			},
+			Result: true,
+		},
+		{
+			Src: labels.Set{
+				"foo":  "bar",
+				"test": "test",
+			},
+			Has: labels.Set{
+				"doesnot": "exist",
+			},
+			Result: false,
+		},
+	}
+
+	for _, test := range tests {
+		res := utils.HasLabels(test.Src, test.Has)
+		c.Assert(res, gc.Equals, test.Result)
+	}
 }
 
 func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
@@ -48,4 +86,82 @@ func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(legacy, gc.Equals, test.IsLegacy)
 	}
+}
+
+func (l *LabelSuite) TestLabelSetToSelector(c *gc.C) {
+	tests := []struct {
+		Labels   labels.Set
+		Selector string
+	}{
+		{
+			Labels: labels.Set{
+				"foo": "bar",
+			},
+			Selector: "foo=bar",
+		},
+		{
+			Labels: labels.Set{
+				"foo":  "bar",
+				"test": "mctest",
+			},
+			Selector: "foo=bar,test=mctest",
+		},
+	}
+
+	for _, test := range tests {
+		rval := utils.LabelSetToSelector(test.Labels)
+		c.Assert(test.Selector, gc.Equals, rval.String())
+	}
+}
+
+func (l *LabelSuite) TestLabelsForApp(c *gc.C) {
+	tests := []struct {
+		AppName        string
+		ExpectedLabels labels.Set
+		Legacy         bool
+	}{
+		{
+			AppName: "tlm-boom",
+			ExpectedLabels: labels.Set{
+				"app.kubernetes.io/name": "tlm-boom",
+			},
+			Legacy: false,
+		},
+		{
+			AppName: "tlm-boom",
+			ExpectedLabels: labels.Set{
+				"juju-app": "tlm-boom",
+			},
+			Legacy: true,
+		},
+	}
+
+	for _, test := range tests {
+		rval := utils.LabelsForApp(test.AppName, test.Legacy)
+		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
+	}
+}
+
+func (l *LabelSuite) TestLabelForKeyValue(c *gc.C) {
+	tests := []struct {
+		Key            string
+		Value          string
+		ExpectedLabels labels.Set
+	}{
+		{
+			Key:   "foo",
+			Value: "bar",
+			ExpectedLabels: labels.Set{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		rval := utils.LabelForKeyValue(test.Key, test.Value)
+		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
+	}
+}
+
+func (l *LabelSuite) TestLabelMerge(c *gc.C) {
 }

--- a/caas/kubernetes/provider/utils/package_test.go
+++ b/caas/kubernetes/provider/utils/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -179,7 +179,7 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner)
 		sc.VolumeBindingMode = &bindMode
 	}
 	if cfg.Namespace != "" {
-		sc.Labels = map[string]string{constants.LabelModel: k.namespace}
+		sc.Labels = utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels())
 	}
 	_, err = k.client().StorageV1().StorageClasses().Create(context.TODO(), sc, v1.CreateOptions{})
 	if err != nil {
@@ -310,11 +310,17 @@ func (k *kubernetesClient) filesystemToVolumeInfo(
 		return nil, nil, errors.Annotatef(err, "finding volume for %s", fs.StorageName)
 	}
 
+	labels := utils.LabelsMerge(
+		utils.LabelsForStorage(fs.StorageName, k.IsLegacyLabels()),
+		utils.LabelsJuju)
+
 	pvc = &core.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
 			Name: params.pvcName,
 			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags).
-				Add(constants.LabelStorage, fs.StorageName).ToMap(),
+				Merge(utils.AnnotationsForStorage(fs.StorageName, k.IsLegacyLabels())).
+				ToMap(),
+			Labels: labels,
 		},
 		Spec: *pvcSpec,
 	}
@@ -363,7 +369,7 @@ func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.Volum
 		return nil, nil
 	}
 
-	storageName := pvc.Labels[constants.LabelStorage]
+	storageName := utils.StorageNameFromLabels(pvc.Labels)
 	if storageName == "" {
 		if valid := legacyJujuPVNameRegexp.MatchString(volMount.Name); valid {
 			storageName = legacyJujuPVNameRegexp.ReplaceAllString(volMount.Name, "$storageName")

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -167,7 +167,14 @@ func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 		}
 		// We don't want to introduce CaaS broker here, but only use exec client.
 		podAPI := c.execClient.RawClient().CoreV1().Pods(c.execClient.NameSpace())
-		if providerID, err = k8sprovider.GetOperatorPodName(podAPI, appName); err != nil {
+		providerID, err = k8sprovider.GetOperatorPodName(
+			podAPI,
+			c.execClient.RawClient().CoreV1().Namespaces(),
+			c.execClient.NameSpace(),
+			appName,
+		)
+
+		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		if len(providerID) == 0 {

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -14,7 +14,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/apiserver/params"
@@ -35,6 +37,7 @@ type sshContainerSuite struct {
 	applicationAPI     *mocks.MockApplicationAPI
 	execClient         *mocks.MockExecutor
 	mockPods           *k8smocks.MockPodInterface
+	mockNamespaces     *k8smocks.MockNamespaceInterface
 
 	sshC commands.SSHContainerInterfaceForTest
 }
@@ -53,6 +56,7 @@ func (s *sshContainerSuite) TearDownTest(c *gc.C) {
 	s.applicationAPI = nil
 	s.execClient = nil
 	s.mockPods = nil
+	s.mockNamespaces = nil
 }
 
 func (s *sshContainerSuite) setUpController(c *gc.C, remote bool, containerName string) *gomock.Controller {
@@ -64,12 +68,14 @@ func (s *sshContainerSuite) setUpController(c *gc.C, remote bool, containerName 
 	s.execClient = mocks.NewMockExecutor(ctrl)
 
 	s.mockPods = k8smocks.NewMockPodInterface(ctrl)
+	s.mockNamespaces = k8smocks.NewMockNamespaceInterface(ctrl)
 	mockCoreV1 := k8smocks.NewMockCoreV1Interface(ctrl)
 
 	k8sClient := k8smocks.NewMockInterface(ctrl)
 	s.execClient.EXPECT().RawClient().AnyTimes().Return(k8sClient)
 	k8sClient.EXPECT().CoreV1().AnyTimes().Return(mockCoreV1)
 	mockCoreV1.EXPECT().Pods(gomock.Any()).AnyTimes().Return(s.mockPods)
+	mockCoreV1.EXPECT().Namespaces().AnyTimes().Return(s.mockNamespaces)
 
 	s.sshC = commands.NewSSHContainer(
 		s.modelUUID,
@@ -116,7 +122,11 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPod(c *gc.C) {
 
 	gomock.InOrder(
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-operator=mariadb-k8s"}).AnyTimes().
+
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
+			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
+
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "mariadb-k8s-operator-0"}},
 			}}, nil),
@@ -132,7 +142,11 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPodNoProviderID(c *gc.C)
 
 	gomock.InOrder(
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-operator=mariadb-k8s"}).AnyTimes().
+
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
+			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
+
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: ""}},
 			}}, nil),
@@ -429,7 +443,11 @@ func (s *sshContainerSuite) TestCopyToOperator(c *gc.C) {
 
 	gomock.InOrder(
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-operator=mariadb-k8s"}).AnyTimes().
+
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
+			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
+
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "mariadb-k8s-operator-0"}},
 			}}, nil),
@@ -456,7 +474,11 @@ func (s *sshContainerSuite) TestCopyFromOperator(c *gc.C) {
 
 	gomock.InOrder(
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "juju-operator=mariadb-k8s"}).AnyTimes().
+
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
+			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
+
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "mariadb-k8s-operator-0"}},
 			}}, nil),

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -22,7 +22,7 @@ metadata:
   name: $name
   namespace: $namespace
   labels:
-    juju-app: test-app
+    app.kubernetes.io/name: test-app
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -89,7 +89,7 @@ metadata:
   name: $name
   namespace: $namespace
   labels:
-    juju-app: test-app
+    app.kubernetes.io/name: test-app
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/worker/caasadmission/admission.go
+++ b/worker/caasadmission/admission.go
@@ -47,6 +47,7 @@ func (a AdmissionCreatorFunc) EnsureMutatingWebhookConfiguration() (func(), erro
 func NewAdmissionCreator(
 	authority pki.Authority,
 	namespace, modelName string,
+	legacyLabels bool,
 	ensureConfig func(*admission.MutatingWebhookConfiguration) (func(), error),
 	service *admission.ServiceReference) (AdmissionCreator, error) {
 
@@ -65,7 +66,7 @@ func NewAdmissionCreator(
 	// MutatingWebjook Obj
 	obj := admission.MutatingWebhookConfiguration{
 		ObjectMeta: meta.ObjectMeta{
-			Labels:    k8sutils.LabelsForModel(modelName),
+			Labels:    k8sutils.LabelsForModel(modelName, legacyLabels),
 			Name:      fmt.Sprintf("juju-model-admission-%s", namespace),
 			Namespace: namespace,
 		},
@@ -80,7 +81,7 @@ func NewAdmissionCreator(
 				MatchPolicy:   &matchPolicy,
 				Name:          provider.MakeK8sDomain(Component),
 				NamespaceSelector: &meta.LabelSelector{
-					MatchLabels: k8sutils.LabelsForModel(modelName),
+					MatchLabels: k8sutils.LabelsForModel(modelName, legacyLabels),
 				},
 				Rules: []admission.RuleWithOperations{
 					{

--- a/worker/caasadmission/admission_test.go
+++ b/worker/caasadmission/admission_test.go
@@ -57,7 +57,7 @@ func (a *AdmissionSuite) TestAdmissionCreatorObject(c *gc.C) {
 	}
 
 	admissionCreator, err := caasadmission.NewAdmissionCreator(
-		authority, "testns", "testmodel",
+		authority, "testns", "testmodel", false,
 		func(obj *admission.MutatingWebhookConfiguration) (func(), error) {
 			ensureWebhookCalled = true
 

--- a/worker/caasadmission/controller.go
+++ b/worker/caasadmission/controller.go
@@ -31,6 +31,7 @@ func NewController(
 	logger Logger,
 	mux Mux,
 	path string,
+	legacyLabels bool,
 	admissionCreator AdmissionCreator,
 	rbacMapper RBACMapper) (*Controller, error) {
 
@@ -41,7 +42,8 @@ func NewController(
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &c.catacomb,
 		Work: c.makeLoop(admissionCreator,
-			admissionHandler(logger, rbacMapper), logger, mux, path),
+			admissionHandler(logger, rbacMapper, legacyLabels),
+			logger, mux, path),
 	}); err != nil {
 		return c, errors.Trace(err)
 	}

--- a/worker/caasadmission/controller_test.go
+++ b/worker/caasadmission/controller_test.go
@@ -66,7 +66,7 @@ func (s *ControllerSuite) TestControllerStartup(c *gc.C) {
 		},
 	}
 
-	ctrl, err := caasadmission.NewController(logger, mux, path, creator, rbacMapper)
+	ctrl, err := caasadmission.NewController(logger, mux, path, false, creator, rbacMapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitGroup.Wait()
@@ -98,7 +98,7 @@ func (s *ControllerSuite) TestControllerStartupMuxError(c *gc.C) {
 	}
 	creator := &dummyAdmissionCreator{}
 
-	ctrl, err := caasadmission.NewController(logger, mux, path, creator, rbacMapper)
+	ctrl, err := caasadmission.NewController(logger, mux, path, false, creator, rbacMapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitGroup.Wait()
@@ -124,7 +124,7 @@ func (s *ControllerSuite) TestControllerStartupAdmissionError(c *gc.C) {
 		},
 	}
 
-	ctrl, err := caasadmission.NewController(logger, mux, path, creator, rbacMapper)
+	ctrl, err := caasadmission.NewController(logger, mux, path, false, creator, rbacMapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitGroup.Wait()

--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -51,7 +51,7 @@ var (
 	}
 )
 
-func admissionHandler(logger Logger, rbacMapper RBACMapper) http.Handler {
+func admissionHandler(logger Logger, rbacMapper RBACMapper, legacyLabels bool) http.Handler {
 	codecFactory := serializer.NewCodecFactory(runtime.NewScheme())
 
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -140,7 +140,7 @@ func admissionHandler(logger Logger, rbacMapper RBACMapper) http.Handler {
 		}
 
 		patchJSON, err := json.Marshal(
-			patchForLabels(metaObj.Labels, appName))
+			patchForLabels(metaObj.Labels, appName, legacyLabels))
 		if err != nil {
 			http.Error(res,
 				fmt.Sprintf("marshalling patch object to json: %v", err),
@@ -177,7 +177,10 @@ func patchEscape(s string) string {
 	return r
 }
 
-func patchForLabels(labels map[string]string, appName string) []patchOperation {
+func patchForLabels(
+	labels map[string]string,
+	appName string,
+	legacyLabels bool) []patchOperation {
 	patches := []patchOperation{}
 
 	neededLabels := providerutils.LabelForKeyValue(

--- a/worker/caasadmission/handler_test.go
+++ b/worker/caasadmission/handler_test.go
@@ -90,7 +90,7 @@ func (h *HandlerSuite) TestEmptyBodyFails(c *gc.C) {
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	recorder := httptest.NewRecorder()
 
-	admissionHandler(h.logger, &rbacmappertest.Mapper{}).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacmappertest.Mapper{}, false).ServeHTTP(recorder, req)
 
 	c.Assert(recorder.Code, gc.Equals, http.StatusBadRequest)
 }
@@ -100,7 +100,7 @@ func (h *HandlerSuite) TestUnknownContentType(c *gc.C) {
 	req.Header.Set("junk", "junk")
 	recorder := httptest.NewRecorder()
 
-	admissionHandler(h.logger, &rbacmappertest.Mapper{}).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacmappertest.Mapper{}, false).ServeHTTP(recorder, req)
 
 	c.Assert(recorder.Code, gc.Equals, http.StatusUnsupportedMediaType)
 }
@@ -122,7 +122,7 @@ func (h *HandlerSuite) TestUnknownServiceAccount(c *gc.C) {
 	req.Header.Set(HeaderContentType, ExpectedContentType)
 	recorder := httptest.NewRecorder()
 
-	admissionHandler(h.logger, &rbacmappertest.Mapper{}).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacmappertest.Mapper{}, false).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 
@@ -157,7 +157,7 @@ func (h *HandlerSuite) TestRBACMapperFailure(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusInternalServerError)
 }
 
@@ -196,7 +196,7 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 
@@ -217,6 +217,7 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 
 	expectedLabels := providerutils.LabelForKeyValue(
 		providerconst.LabelJujuAppCreatedBy, appName)
+
 	for k, v := range expectedLabels {
 		found := false
 		for _, patchOp := range patchOperations[1:] {
@@ -283,7 +284,7 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 

--- a/worker/caasadmission/manifold.go
+++ b/worker/caasadmission/manifold.go
@@ -32,6 +32,10 @@ type K8sBroker interface {
 	// when called and a subsequent error if there was a problem. If error is
 	// not nil then no other return values should be considered valid.
 	EnsureMutatingWebhookConfiguration(*admission.MutatingWebhookConfiguration) (func(), error)
+
+	// IsLegacyLabels reports if the k8s broker requires legacy labels to be
+	// used for the broker model/namespace
+	IsLegacyLabels() bool
 }
 
 // Logger represents the methods used by the worker to log details
@@ -124,6 +128,7 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 	admissionPath := AdmissionPathForModel(currentConfig.Model().Id())
 	admissionCreator, err := NewAdmissionCreator(authority,
 		broker.GetCurrentNamespace(), broker.CurrentModel(),
+		broker.IsLegacyLabels(),
 		broker.EnsureMutatingWebhookConfiguration,
 		&admission.ServiceReference{
 			Name:      c.ServiceName,
@@ -140,6 +145,7 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 		c.Logger,
 		mux,
 		AdmissionPathForModel(currentConfig.Model().Id()),
+		broker.IsLegacyLabels(),
 		admissionCreator,
 		rbacMapper)
 }

--- a/worker/caasrbacmapper/mapper_test.go
+++ b/worker/caasrbacmapper/mapper_test.go
@@ -72,7 +72,7 @@ func (m *MapperSuite) TestMapperAdditionSync(c *gc.C) {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    provider.RBACLabels(appName, "test-model", false),
+			Labels:    provider.RBACLabels(appName, "test-model", false, false),
 			UID:       uid,
 		},
 	}
@@ -121,7 +121,7 @@ func (m *MapperSuite) TestRBACMapperUpdateSync(c *gc.C) {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    provider.RBACLabels(appName, "test-model", false),
+			Labels:    provider.RBACLabels(appName, "test-model", false, false),
 			UID:       uid,
 		},
 	}
@@ -145,7 +145,7 @@ func (m *MapperSuite) TestRBACMapperUpdateSync(c *gc.C) {
 	// Update SA with a new app name to check propagation
 	appName = "test-2"
 	sa2 := sa.DeepCopy()
-	sa2.ObjectMeta.Labels = provider.RBACLabels(appName, "test-model", false)
+	sa2.ObjectMeta.Labels = provider.RBACLabels(appName, "test-model", false, false)
 	waitGroup.Add(1)
 	m.mockSANamespaceLister.EXPECT().Get(gomock.Eq(name)).
 		DoAndReturn(func(_ string) (*core.ServiceAccount, error) {
@@ -189,7 +189,7 @@ func (m *MapperSuite) TestRBACMapperDeleteSync(c *gc.C) {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    provider.RBACLabels(appName, "test-model", false),
+			Labels:    provider.RBACLabels(appName, "test-model", false, false),
 			UID:       uid,
 		},
 	}


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Changes the labels used by Juju for Kubernetes.

Juju now adopts more idiomatic way of adding Kubernetes labels as per k8s docs https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

We are adopting k8s standard labels and also adding juju.is labels such as model.juju.is/name

This change will not retroactively change labels for existing models

## QA steps

Need to perform a lot of bootstrapping and upgrading older controllers.

- We are wanting to make sure that model's pre this change continue to use the older style of kubernetes labeling.
- Need to make sure that newly created models use the new style of labels
- All created objects are correctly labels include a managed-by: juju label

```sh
#Run Unit Tests
cd caas/kubernetes/provider
go test .
```

## Documentation changes

- Needs a discourse post explaining the change

## Bug reference

https://bugs.launchpad.net/juju/+bug/1888513
