### PR TITLE
Fix static-analysis

### DIFF
--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -62,7 +62,6 @@ type Backend interface {
 	OfferConnections(string) ([]OfferConnection, error)
 	SpaceByName(string) (Space, error)
 	User(names.UserTag) (User, error)
-	UserPermission(subject names.UserTag, target names.Tag) (permission.Access, error)
 
 	CreateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error
 	UpdateOfferAccess(offer names.ApplicationOfferTag, user names.UserTag, access permission.Access) error


### PR DESCRIPTION
## Description of change

The function UserPermission was duplicated in both
`commoncrossmodel.Backend` and `Backend`, which emits a warning. Static
analysis should have picked this up, but for some reason, it hasn't. This
fixes the issue, but we need to work out why it wasn't caught.

## QA steps

*Please replace with how we can verify that the change works?*

```sh
make static-analysis
```
