### PR TITLE
Add GetCharmURLOrigin to application facade

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1329,6 +1329,9 @@ func (api *APIBase) GetCharmURL(args params.ApplicationGet) (params.StringResult
 	return params.StringResult{Result: charmURL.String()}, nil
 }
 
+// GetCharmURLOrigin isn't on the V12 API.
+func (api *APIv12) GetCharmURLOrigin(_ struct{}) {}
+
 // GetCharmURLOrigin returns the charm URL and charm origin the given
 // application is running at present.
 func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmURLOriginResult, error) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1329,6 +1329,50 @@ func (api *APIBase) GetCharmURL(args params.ApplicationGet) (params.StringResult
 	return params.StringResult{Result: charmURL.String()}, nil
 }
 
+// GetCharmURLOrigin returns the charm URL and charm origin the given
+// application is running at present.
+func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmURLOriginResult, error) {
+	if err := api.checkCanWrite(); err != nil {
+		return params.CharmURLOriginResult{}, errors.Trace(err)
+	}
+	oneApplication, err := api.backend.Application(args.ApplicationName)
+	if err != nil {
+		return params.CharmURLOriginResult{Error: apiservererrors.ServerError(err)}, nil
+	}
+	charmURL, _ := oneApplication.CharmURL()
+	result := params.CharmURLOriginResult{URL: charmURL.String()}
+	chOrigin := oneApplication.CharmOrigin()
+	if chOrigin == nil {
+		result.Error = apiservererrors.ServerError(errors.NotFoundf("charm origin for %q", args.ApplicationName))
+		return result, nil
+	}
+	result.Origin = makeParamsCharmOrigin(chOrigin)
+	return result, nil
+}
+
+func makeParamsCharmOrigin(origin *state.CharmOrigin) params.CharmOrigin {
+	var rev *int
+	if origin.Revision != nil {
+		rev = origin.Revision
+	}
+	var track *string
+	var risk string
+	if origin.Channel != nil {
+		risk = origin.Channel.Risk
+		if origin.Channel.Track != "" {
+			track = &origin.Channel.Track
+		}
+	}
+	return params.CharmOrigin{
+		Source:   origin.Source,
+		ID:       origin.ID,
+		Hash:     origin.Hash,
+		Risk:     risk,
+		Revision: rev,
+		Track:    track,
+	}
+}
+
 // Set implements the server side of Application.Set.
 // It does not unset values that are set to an empty string.
 // Unset should be used for that.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -965,6 +965,33 @@ func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
 	c.Assert(result.Result, gc.Equals, "local:quantal/wordpress-3")
 }
 
+func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	rev := ch.Revision()
+	// Technically this charm origin is impossible, a local
+	// charm cannot have a channel.  Done just for testing.
+	expectedOrigin := state.CharmOrigin{
+		Source:   "local",
+		Revision: &rev,
+		Channel: &state.Channel{
+			Track: "latest",
+			Risk:  "stable",
+		},
+	}
+	s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
+	result, err := s.applicationAPI.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "wordpress"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.URL, gc.Equals, "local:quantal/wordpress-3")
+	latest := "latest"
+	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
+		Source:   "local",
+		Risk:     "stable",
+		Revision: &rev,
+		Track:    &latest,
+	})
+}
+
 func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 	curl, _ := s.UploadCharm(c, "cs:precise/dummy-0", "dummy")
 	err := application.AddCharmWithAuthorization(application.NewStateShim(s.State), params.AddCharmWithAuthorization{

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -75,6 +75,7 @@ type Application interface {
 	Charm() (Charm, bool, error)
 	CharmURL() (*charm.URL, bool)
 	Channel() csparams.Channel
+	CharmOrigin() *state.CharmOrigin
 	ClearExposed() error
 	CharmConfig(string) (charm.Settings, error)
 	Constraints() (constraints.Value, error)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2186,6 +2186,18 @@
                     },
                     "description": "GetCharmURL returns the charm URL the given application is\nrunning at present."
                 },
+                "GetCharmURLOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationGet"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmURLOriginResult"
+                        }
+                    },
+                    "description": "GetCharmURLOrigin returns the charm URL and charm origin the given\napplication is running at present."
+                },
                 "GetConfig": {
                     "type": "object",
                     "properties": {
@@ -3261,6 +3273,25 @@
                         "optional",
                         "limit",
                         "scope"
+                    ]
+                },
+                "CharmURLOriginResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url",
+                        "charm-origin"
                     ]
                 },
                 "ConfigResult": {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -213,6 +213,13 @@ type CharmOriginResult struct {
 	Error  *Error      `json:"error,omitempty"`
 }
 
+// CharmURLOriginResult holds the results of the charm's url and origin.
+type CharmURLOriginResult struct {
+	URL    string      `json:"url"`
+	Origin CharmOrigin `json:"charm-origin"`
+	Error  *Error      `json:"error,omitempty"`
+}
+
 // AddMachineParams encapsulates the parameters used to create a new machine.
 type AddMachineParams struct {
 	// The following fields hold attributes that will be given to the

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -901,7 +901,17 @@ func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Ch
 	app, err := s.State.AddApplication(state.AddApplicationArgs{Name: name, Charm: ch, Series: ch.URL().Series})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
+}
 
+func (s *JujuConnSuite) AddTestingApplicationWithOrigin(c *gc.C, name string, ch *state.Charm, origin *state.CharmOrigin) *state.Application {
+	app, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:        name,
+		Charm:       ch,
+		Series:      ch.URL().Series,
+		CharmOrigin: origin,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return app
 }
 
 func (s *JujuConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Application {


### PR DESCRIPTION
## Description of change

Variation on GetCharmURL to use for charm refresh.  Get the charm URL and the charm's origin.  Required for CharmHub integration.

When refreshing (upgrading) a charm, it is necessary to know the current origin which holds an ID required by the CharmHub.  It also contains the channel track data required to properly update to the correct channel if the channel was specified during Refresh.  If only a Risk specified with --channel, it applies to the Charm's current track.  Track/Risk would be required in --channel to change the track also.

The application facade version has already been rev'd for 2.9.

## QA steps

Not used yet.  Test when wired up with an api and caller.
