### PR TITLE
Handle errors in the info response

### DIFF
--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -5,7 +5,6 @@ package charmhub
 
 import (
 	"context"
-	"strings"
 
 	"github.com/juju/errors"
 
@@ -40,15 +39,5 @@ func (c *FindClient) Find(ctx context.Context, query string) ([]transport.FindRe
 		return nil, errors.Trace(err)
 	}
 
-	if len(resp.ErrorList) > 0 {
-		var combined []string
-		for _, err := range resp.ErrorList {
-			if err.Message != "" {
-				combined = append(combined, err.Message)
-			}
-		}
-		return nil, errors.Errorf(strings.Join(combined, "\n"))
-	}
-
-	return resp.Results, nil
+	return resp.Results, resp.ErrorList.Combine()
 }

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -5,6 +5,7 @@ package charmhub
 
 import (
 	"context"
+	"strings"
 
 	"github.com/juju/errors"
 
@@ -38,5 +39,16 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 	if err := c.client.Get(ctx, path, &resp); err != nil {
 		return resp, errors.Trace(err)
 	}
+
+	if len(resp.ErrorList) > 0 {
+		var combined []string
+		for _, err := range resp.ErrorList {
+			if err.Message != "" {
+				combined = append(combined, err.Message)
+			}
+		}
+		return resp, errors.Errorf(strings.Join(combined, "\n"))
+	}
+
 	return resp, nil
 }

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -5,7 +5,6 @@ package charmhub
 
 import (
 	"context"
-	"strings"
 
 	"github.com/juju/errors"
 
@@ -40,15 +39,5 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 		return resp, errors.Trace(err)
 	}
 
-	if len(resp.ErrorList) > 0 {
-		var combined []string
-		for _, err := range resp.ErrorList {
-			if err.Message != "" {
-				combined = append(combined, err.Message)
-			}
-		}
-		return resp, errors.Errorf(strings.Join(combined, "\n"))
-	}
-
-	return resp, nil
+	return resp, resp.ErrorList.Combine()
 }

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -5,7 +5,6 @@ package charmhub
 
 import (
 	"context"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
@@ -68,14 +67,8 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 		return nil, errors.Trace(err)
 	}
 
-	if len(resp.ErrorList) > 0 {
-		var combined []string
-		for _, err := range resp.ErrorList {
-			if err.Message != "" {
-				combined = append(combined, err.Message)
-			}
-		}
-		return nil, errors.Errorf(strings.Join(combined, "\n"))
+	if err := resp.ErrorList.Combine(); err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	return resp.Results, config.Ensure(resp.Results)

--- a/charmhub/transport/error.go
+++ b/charmhub/transport/error.go
@@ -3,8 +3,31 @@
 
 package transport
 
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
 // APIError represents the error from the CharmHub API.
 type APIError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+// APIErrors represents a slice of APIError's
+type APIErrors []APIError
+
+// Combine will combine any errors into one error.
+func (a APIErrors) Combine() error {
+	if len(a) > 0 {
+		var combined []string
+		for _, err := range a {
+			if err.Message != "" {
+				combined = append(combined, err.Message)
+			}
+		}
+		return errors.Errorf(strings.Join(combined, "\n"))
+	}
+	return nil
 }

--- a/charmhub/transport/error_test.go
+++ b/charmhub/transport/error_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transport
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type ErrorSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ErrorSuite{})
+
+func (ErrorSuite) TestNoErrors(c *gc.C) {
+	var errors APIErrors
+	err := errors.Combine()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (ErrorSuite) TestNoErrorsWithEmptySlice(c *gc.C) {
+	errors := make(APIErrors, 0)
+	err := errors.Combine()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (ErrorSuite) TestWithOneError(c *gc.C) {
+	errors := APIErrors{{
+		Message: "one",
+	}}
+	err := errors.Combine()
+	c.Assert(err, gc.ErrorMatches, `one`)
+}
+
+func (ErrorSuite) TestWithMultipleErrors(c *gc.C) {
+	errors := APIErrors{
+		{Message: "one"},
+		{Message: "two"},
+	}
+	err := errors.Combine()
+	c.Assert(err, gc.ErrorMatches, `one
+two`)
+}

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -5,7 +5,7 @@ package transport
 
 type FindResponses struct {
 	Results   []FindResponse `json:"results"`
-	ErrorList []APIError     `json:"error-list"`
+	ErrorList APIErrors      `json:"error-list"`
 }
 
 type FindResponse struct {

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -11,5 +11,5 @@ type InfoResponse struct {
 	Entity         Entity       `json:"charm"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
-	ErrorList      []APIError   `json:"error-list"`
+	ErrorList      APIErrors    `json:"error-list"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -11,4 +11,5 @@ type InfoResponse struct {
 	Entity         Entity       `json:"charm"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
+	ErrorList      []APIError   `json:"error-list"`
 }

--- a/charmhub/transport/package_test.go
+++ b/charmhub/transport/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+package transport
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -40,7 +40,7 @@ type RefreshRequestAction struct {
 
 type RefreshResponses struct {
 	Results   []RefreshResponse `json:"results"`
-	ErrorList []APIError        `json:"error-list"`
+	ErrorList APIErrors         `json:"error-list"`
 }
 
 type RefreshResponse struct {


### PR DESCRIPTION
## Description of change

When the info API returns an error, we should correctly handle it to
highlight the issue to a user of juju.

## QA steps


```sh
$ juju bootstrap lxd test --no-gui
$ juju deploy bad
ERROR No charm or bundle with name 'bad'.
```