### PR TITLE
[dev] Include expose settings in show application output

### DIFF
--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -82,6 +82,7 @@ type Application interface {
 	Destroy() error
 	DestroyOperation() *state.DestroyApplicationOperation
 	EndpointBindings() (Bindings, error)
+	ExposedEndpoints() map[string]state.ExposedEndpoint
 	Endpoints() ([]state.Endpoint, error)
 	IsExposed() bool
 	IsPrincipal() bool

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -87,22 +87,23 @@ type mockApplication struct {
 	jtesting.Stub
 	application.Application
 
-	bindings    map[string]string
-	charm       *mockCharm
-	curl        *charm.URL
-	endpoints   []state.Endpoint
-	name        string
-	scale       int
-	subordinate bool
-	series      string
-	units       []*mockUnit
-	addedUnit   mockUnit
-	config      coreapplication.ConfigAttributes
-	constraints constraints.Value
-	channel     csparams.Channel
-	exposed     bool
-	remote      bool
-	agentTools  *tools.Tools
+	bindings         map[string]string
+	charm            *mockCharm
+	curl             *charm.URL
+	endpoints        []state.Endpoint
+	exposedEndpoints map[string]state.ExposedEndpoint
+	name             string
+	scale            int
+	subordinate      bool
+	series           string
+	units            []*mockUnit
+	addedUnit        mockUnit
+	config           coreapplication.ConfigAttributes
+	constraints      constraints.Value
+	channel          csparams.Channel
+	exposed          bool
+	remote           bool
+	agentTools       *tools.Tools
 }
 
 func (m *mockApplication) Name() string {
@@ -138,6 +139,11 @@ func (m *mockApplication) Constraints() (constraints.Value, error) {
 func (m *mockApplication) Endpoints() ([]state.Endpoint, error) {
 	m.MethodCall(m, "Endpoints")
 	return m.endpoints, nil
+}
+
+func (m *mockApplication) ExposedEndpoints() map[string]state.ExposedEndpoint {
+	m.MethodCall(m, "ExposedEndpoints")
+	return m.exposedEndpoints
 }
 
 func (m *mockApplication) EndpointBindings() (application.Bindings, error) {
@@ -376,6 +382,7 @@ type mockBackend struct {
 	controllers                map[string]crossmodel.ControllerInfo
 	machines                   map[string]*mockMachine
 	generation                 *mockGeneration
+	spaceInfos                 network.SpaceInfos
 }
 
 type mockFilesystemAccess struct {
@@ -453,7 +460,11 @@ func (m *mockBackend) Machine(id string) (application.Machine, error) {
 }
 
 func (m *mockBackend) AllSpaceInfos() (network.SpaceInfos, error) {
-	return nil, nil
+	m.MethodCall(m, "AllSpaceInfos")
+	if err := m.NextErr(); err != nil {
+		return nil, err
+	}
+	return m.spaceInfos, nil
 }
 
 func (m *mockBackend) Space(_ string) (*state.Space, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1995,7 +1995,7 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv13 provides the Application API facade for version 13.\nIt adds CharmOrigin.",
+        "Description": "APIv13 provides the Application API facade for version 13.\nIt adds CharmOrigin. The ApplicationsInfo call populates the exposed\nendpoints field in its response entries.",
         "Version": 13,
         "AvailableTo": [
             "controller-machine-agent",
@@ -2987,6 +2987,14 @@
                         },
                         "exposed": {
                             "type": "boolean"
+                        },
+                        "exposed-endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ExposedEndpoint"
+                                }
+                            }
                         },
                         "principal": {
                             "type": "boolean"

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -491,15 +491,16 @@ type ScaleApplicationInfo struct {
 // ApplicationResult holds an application info.
 // NOTE: we should look to combine ApplicationResult and ApplicationInfo.
 type ApplicationResult struct {
-	Tag              string            `json:"tag"`
-	Charm            string            `json:"charm,omitempty"`
-	Series           string            `json:"series,omitempty"`
-	Channel          string            `json:"channel,omitempty"`
-	Constraints      constraints.Value `json:"constraints,omitempty"`
-	Principal        bool              `json:"principal"`
-	Exposed          bool              `json:"exposed"`
-	Remote           bool              `json:"remote"`
-	EndpointBindings map[string]string `json:"endpoint-bindings,omitempty"`
+	Tag              string                     `json:"tag"`
+	Charm            string                     `json:"charm,omitempty"`
+	Series           string                     `json:"series,omitempty"`
+	Channel          string                     `json:"channel,omitempty"`
+	Constraints      constraints.Value          `json:"constraints,omitempty"`
+	Principal        bool                       `json:"principal"`
+	Exposed          bool                       `json:"exposed"`
+	Remote           bool                       `json:"remote"`
+	EndpointBindings map[string]string          `json:"endpoint-bindings,omitempty"`
+	ExposedEndpoints map[string]ExposedEndpoint `json:"exposed-endpoints,omitempty"`
 }
 
 // ApplicationInfoResults holds an application info result or a retrieval error.

--- a/cmd/juju/application/show_test.go
+++ b/cmd/juju/application/show_test.go
@@ -153,10 +153,24 @@ func (s *ShowSuite) createTestApplicationInfo(name string, suffix string) *param
 	}
 }
 
+func (s *ShowSuite) createTestApplicationInfoWithExposedEndpoints(name string, suffix string) *params.ApplicationResult {
+	app := s.createTestApplicationInfo(name, suffix)
+	app.ExposedEndpoints = map[string]params.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs: []string{"192.168.0.0/24"},
+		},
+		"website": {
+			ExposeToSpaces: []string{"non-euclidean-geometry"},
+		},
+	}
+
+	return app
+}
+
 func (s *ShowSuite) TestShow(c *gc.C) {
 	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
 		return []params.ApplicationInfoResult{
-			{Result: s.createTestApplicationInfo("wordpress", "")},
+			{Result: s.createTestApplicationInfoWithExposedEndpoints("wordpress", "")},
 		}, nil
 	}
 	s.assertRunShow(c, showTest{
@@ -173,21 +187,29 @@ wordpress:
     root-disk: 8192
   principal: true
   exposed: false
+  exposed-endpoints:
+    "":
+      expose-to-cidrs:
+      - 192.168.0.0/24
+    website:
+      expose-to-spaces:
+      - non-euclidean-geometry
   remote: false
   endpoint-bindings:
     juju-info: myspace
 `[1:],
 	})
 }
+
 func (s *ShowSuite) TestShowJSON(c *gc.C) {
 	s.mockAPI.applicationsInfoFunc = func([]names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
 		return []params.ApplicationInfoResult{
-			{Result: s.createTestApplicationInfo("wordpress", "")},
+			{Result: s.createTestApplicationInfoWithExposedEndpoints("wordpress", "")},
 		}, nil
 	}
 	s.assertRunShow(c, showTest{
 		args:   []string{"wordpress", "--format", "json"},
-		stdout: "{\"wordpress\":{\"charm\":\"charm-wordpress\",\"series\":\"quantal\",\"channel\":\"development\",\"constraints\":{\"arch\":\"amd64\",\"cores\":1,\"mem\":4096,\"root-disk\":8192},\"principal\":true,\"exposed\":false,\"remote\":false,\"endpoint-bindings\":{\"juju-info\":\"myspace\"}}}\n",
+		stdout: "{\"wordpress\":{\"charm\":\"charm-wordpress\",\"series\":\"quantal\",\"channel\":\"development\",\"constraints\":{\"arch\":\"amd64\",\"cores\":1,\"mem\":4096,\"root-disk\":8192},\"principal\":true,\"exposed\":false,\"exposed-endpoints\":{\"\":{\"expose-to-cidrs\":[\"192.168.0.0/24\"]},\"website\":{\"expose-to-spaces\":[\"non-euclidean-geometry\"]}},\"remote\":false,\"endpoint-bindings\":{\"juju-info\":\"myspace\"}}}\n",
 	})
 }
 


### PR DESCRIPTION
## Description of change

This PR updates the `juju show application` command so that it includes information about exposed endpoints.

## QA steps

```console
# Deploy the following bundle:
$ cat bundle.yaml
series: bionic
applications:
  apache2:
    charm: cs:apache2-35
    num_units: 1
    to:
    - "0"
machines:
  "0": {}
--- # overlay.yaml
applications:
  apache2:
    exposed-endpoints:
      "":
        expose-to-cidrs:
        - 0.0.0.0/0
      website:
        expose-to-cidrs:
        - 10.0.0.0/24

$ juju deploy ./bundle.yaml
$ juju show-application apache2
apache2:
  charm: apache2
  series: bionic
  principal: true
  exposed: true
  exposed-endpoints:
    "":
      expose-to-cidrs:
      - 0.0.0.0/0
    website:
      expose-to-spaces:
      - alpha
      expose-to-cidrs:
      - 10.0.0.0/24
  remote: false
  endpoint-bindings:
    "": alpha
    apache-website: alpha
    balancer: alpha
    local-monitors: alpha
    logging: alpha
    logs: alpha
    nrpe-external-master: alpha
    reverseproxy: alpha
    vhost-config: alpha
    website: alpha
    website-cache: alpha

$ juju show-application apache2 --format json | jq .
{
  "apache2": {
    "charm": "apache2",
    "series": "bionic",
    "constraints": {},
    "principal": true,
    "exposed": true,
    "exposed-endpoints": {
      "": {
        "expose-to-cidrs": [
          "0.0.0.0/0"
        ]
      },
      "website": {
        "expose-to-spaces": [
          "alpha"
        ],
        "expose-to-cidrs": [
          "10.0.0.0/24"
        ]
      }
    },
    "remote": false,
    "endpoint-bindings": {
      "": "alpha",
      "apache-website": "alpha",
      "balancer": "alpha",
      "local-monitors": "alpha",
      "logging": "alpha",
      "logs": "alpha",
      "nrpe-external-master": "alpha",
      "reverseproxy": "alpha",
      "vhost-config": "alpha",
      "website": "alpha",
      "website-cache": "alpha"
    }
  }
}
```