### PR TITLE
SetCharm now includes CharmOrigin 

### DIFF
--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -312,6 +312,9 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	app := s.backend.applications["postgresql"]
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-store",
+		},
 		StorageConstraints: map[string]state.StorageConstraints{
 			"a": {},
 			"b": {Pool: "radiant"},
@@ -433,7 +436,10 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	s.backend.charm.CheckCallNames(c, "Config")
 	app := s.backend.applications["postgresql"]
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
-		Charm:          &state.Charm{},
+		Charm: &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-store",
+		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
 }
@@ -452,7 +458,10 @@ postgresql:
 	s.backend.charm.CheckCallNames(c, "Config")
 	app := s.backend.applications["postgresql"]
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
-		Charm:          &state.Charm{},
+		Charm: &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-store",
+		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
 }
@@ -469,7 +478,10 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 	app := s.backend.applications["postgresql"]
 	app.CheckCallNames(c, "Charm", "AgentTools", "SetCharm")
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
-		Charm:          &state.Charm{},
+		Charm: &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-store",
+		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
 }
@@ -507,7 +519,10 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 	app := s.backend.applications["postgresql"]
 	app.CheckCallNames(c, "Charm", "AgentTools", "SetCharm")
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
-		Charm:          &state.Charm{},
+		Charm: &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-store",
+		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3043,6 +3043,9 @@
                         "channel": {
                             "type": "string"
                         },
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
                         "charm-url": {
                             "type": "string"
                         },
@@ -3152,9 +3155,6 @@
                     "properties": {
                         "application": {
                             "type": "string"
-                        },
-                        "charm-origin": {
-                            "$ref": "#/definitions/CharmOrigin"
                         },
                         "charm-url": {
                             "type": "string"

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -135,7 +135,6 @@ type ApplicationDeployV6 struct {
 type ApplicationUpdate struct {
 	ApplicationName string             `json:"application"`
 	CharmURL        string             `json:"charm-url"`
-	CharmOrigin     *CharmOrigin       `json:"charm-origin,omitempty"`
 	ForceCharmURL   bool               `json:"force-charm-url"`
 	ForceSeries     bool               `json:"force-series"`
 	Force           bool               `json:"force"`
@@ -149,6 +148,58 @@ type ApplicationUpdate struct {
 	Generation string `json:"generation"`
 }
 
+// ApplicationSetCharmV12 sets the charm for a given application
+// for application facades older than v12. Missing the newer CharmOrigin.
+type ApplicationSetCharmV12 struct {
+	// ApplicationName is the name of the application to set the charm on.
+	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this
+	// request will set the application charm for.
+	Generation string `json:"generation"`
+
+	// CharmURL is the new url for the charm.
+	CharmURL string `json:"charm-url"`
+
+	// Channel is the charm store channel from which the charm came.
+	Channel string `json:"channel"`
+
+	// ConfigSettings is the charm settings to set during the upgrade.
+	// This field is only understood by Application facade version 2
+	// and greater.
+	ConfigSettings map[string]string `json:"config-settings,omitempty"`
+
+	// ConfigSettingsYAML is the charm settings in YAML format to set
+	// during the upgrade. If this is non-empty, it will take precedence
+	// over ConfigSettings. This field is only understood by Application
+	// facade version 2
+	ConfigSettingsYAML string `json:"config-settings-yaml,omitempty"`
+
+	// Force forces the lxd profile validation overriding even if it's fails.
+	Force bool `json:"force"`
+
+	// ForceUnits forces the upgrade on units in an error state.
+	ForceUnits bool `json:"force-units"`
+
+	// ForceSeries forces the use of the charm even if it doesn't match the
+	// series of the unit.
+	ForceSeries bool `json:"force-series"`
+
+	// ResourceIDs is a map of resource names to resource IDs to activate during
+	// the upgrade.
+	ResourceIDs map[string]string `json:"resource-ids,omitempty"`
+
+	// StorageConstraints is a map of storage names to storage constraints to
+	// update during the upgrade. This field is only understood by Application
+	// facade version 2 and greater.
+	StorageConstraints map[string]StorageConstraints `json:"storage-constraints,omitempty"`
+
+	// EndpointBindings is a map of operator-defined endpoint names to
+	// space names to be merged with any existing endpoint bindings. This
+	// field is only understood by Application facade version 10 and greater.
+	EndpointBindings map[string]string `json:"endpoint-bindings,omitempty"`
+}
+
 // ApplicationSetCharm sets the charm for a given application.
 type ApplicationSetCharm struct {
 	// ApplicationName is the name of the application to set the charm on.
@@ -160,6 +211,9 @@ type ApplicationSetCharm struct {
 
 	// CharmURL is the new url for the charm.
 	CharmURL string `json:"charm-url"`
+
+	// CharmOrigin is the charm origin
+	CharmOrigin *CharmOrigin `json:"charm-origin,omitempty"`
 
 	// Channel is the charm store channel from which the charm came.
 	Channel string `json:"channel"`

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -109,6 +109,52 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(force, jc.IsTrue)
 }
 
+func (s *ApplicationSuite) TestSetCharmCharmOrigin(c *gc.C) {
+	// Add a compatible charm.
+	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
+	rev := sch.Revision()
+	origin := &state.CharmOrigin{
+		Source:   "charm-store",
+		Revision: &rev,
+	}
+	cfg := state.SetCharmConfig{
+		Charm:       sch,
+		CharmOrigin: origin,
+	}
+	err := s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.mysql.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedOrigin := s.mysql.CharmOrigin()
+	c.Assert(obtainedOrigin, gc.DeepEquals, origin)
+}
+
+func (s *ApplicationSuite) TestSetCharmCharmOriginNoChange(c *gc.C) {
+	// Add a compatible charm.
+	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
+	rev := sch.Revision()
+	origin := &state.CharmOrigin{
+		Source:   "charm-store",
+		Revision: &rev,
+	}
+	cfg := state.SetCharmConfig{
+		Charm:       sch,
+		CharmOrigin: origin,
+	}
+	err := s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	cfg = state.SetCharmConfig{
+		Charm:      sch,
+		ForceUnits: true,
+	}
+	err = s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.mysql.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedOrigin := s.mysql.CharmOrigin()
+	c.Assert(obtainedOrigin, gc.DeepEquals, origin)
+}
+
 func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	charm := s.AddTestingCharm(c, "lxd-profile")
 	app := s.AddTestingApplication(c, "lxd-profile", charm)


### PR DESCRIPTION
## Description of change

As part of new charm refresh (formerly upgrade-charm), add CharmOrigin to SetCharm.

A follow on is necessary to update Update() in the application facade.  

## QA steps


```console
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju bootstrap localhost testme
$ juju deploy cs:ubuntu-12
Located charm "cs:ubuntu-12".
Deploying charm "cs:ubuntu-12".
$ juju-db.bash
juju:PRIMARY> db.applications.find().pretty()
{
...
	"charmurl" : "cs:ubuntu-12",
	"cs-channel" : "stable",
	"charm-origin" : {
		"source" : "charm-store",
		"id" : "",
		"hash" : "",
		"revision" : 12,
		"channel" : {
			"risk" : "stable"
		}
	},
...
juju:PRIMARY> quit
$ juju upgrade-charm ubuntu
Looking up metadata for charm cs:ubuntu (channel: stable)
Added charm "cs:ubuntu-15" to the model.
$ juju-db.bash
juju:PRIMARY> db.applications.find().pretty()
{
	...
	"charmurl" : "cs:ubuntu-15",
	"cs-channel" : "stable",
	"charm-origin" : {
		"source" : "charm-store",
		"id" : "",
		"hash" : "",
		"revision" : 15,
		"channel" : {
			"risk" : "stable"
		}
	},
```
