### PR TITLE
Debug msgs charmhub client

### DIFF
--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -108,12 +108,13 @@ func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubEntityFindResult,
 type charmHubClientFactory struct{}
 
 func (charmHubClientFactory) Client(url string) (Client, error) {
-	cfg := charmhub.CharmHubConfigFromURL(url)
-	cfg.Logger = logger.Child("client")
+	cfg, err := charmhub.CharmHubConfigFromURL(url, logger.Child("client"))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	client, err := charmhub.NewClient(cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	return client, nil
 }

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -108,7 +108,9 @@ func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubEntityFindResult,
 type charmHubClientFactory struct{}
 
 func (charmHubClientFactory) Client(url string) (Client, error) {
-	client, err := charmhub.NewClient(charmhub.CharmHubConfigFromURL(url))
+	cfg := charmhub.CharmHubConfigFromURL(url)
+	cfg.Logger = logger.Child("client")
+	client, err := charmhub.NewClient(cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -480,11 +480,13 @@ func (a *API) charmHubRepository() (corecharm.Repository, error) {
 	var chCfg charmhub.Config
 	chURL, ok := cfg.CharmHubURL()
 	if ok {
-		chCfg = charmhub.CharmHubConfigFromURL(chURL)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"))
 	} else {
-		chCfg = charmhub.CharmHubConfig()
+		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"))
 	}
-	chCfg.Logger = logger.Child("client")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	chClient, err := charmhub.NewClient(chCfg)
 	if err != nil {

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -484,6 +484,8 @@ func (a *API) charmHubRepository() (corecharm.Repository, error) {
 	} else {
 		chCfg = charmhub.CharmHubConfig()
 	}
+	chCfg.Logger = logger.Child("client")
+
 	chClient, err := charmhub.NewClient(chCfg)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
-
 	charmhubpath "github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/version"
@@ -78,13 +76,17 @@ type Config struct {
 
 // CharmHubConfig defines a charmHub client configuration for targeting the
 // snapcraft API.
-func CharmHubConfig() Config {
-	return CharmHubConfigFromURL(CharmHubServerURL)
+func CharmHubConfig(logger Logger) (Config, error) {
+	return CharmHubConfigFromURL(CharmHubServerURL, logger)
 }
 
 // CharmHubConfigFromURL defines a charmHub client configuration with a given
 // URL for targeting the API.
-func CharmHubConfigFromURL(url string) Config {
+func CharmHubConfigFromURL(url string, logger Logger) (Config, error) {
+	if logger == nil {
+		return Config{}, errors.NotValidf("nil logger")
+	}
+
 	// By default we want to specify a default user-agent here. In the future
 	// we should ensure this probably contains model UUID and cloud.
 	headers := make(http.Header)
@@ -95,7 +97,8 @@ func CharmHubConfigFromURL(url string) Config {
 		Version: CharmHubServerVersion,
 		Entity:  CharmHubServerEntity,
 		Headers: headers,
-	}
+		Logger:  logger,
+	}, nil
 }
 
 // BasePath returns the base configuration path for speaking to the server API.
@@ -141,27 +144,23 @@ func NewClient(config Config) (*Client, error) {
 		return nil, errors.Annotate(err, "constructing refresh path")
 	}
 
-	logger := config.Logger
-	if logger == nil {
-		logger = loggo.GetLogger("juju.charmhubclient")
-	}
-	logger.Tracef("NewClient to %q", config.URL)
+	config.Logger.Tracef("NewClient to %q", config.URL)
 
 	httpClient := DefaultHTTPTransport()
 	apiRequester := NewAPIRequester(httpClient)
-	restClient := NewHTTPRESTClient(apiRequester, config.Headers, logger)
+	restClient := NewHTTPRESTClient(apiRequester, config.Headers, config.Logger)
 	fileSystem := DefaultFileSystem()
 
 	return &Client{
 		url:           base.String(),
-		infoClient:    NewInfoClient(infoPath, restClient, logger),
-		findClient:    NewFindClient(findPath, restClient, logger),
-		refreshClient: NewRefreshClient(refreshPath, restClient, logger),
+		infoClient:    NewInfoClient(infoPath, restClient, config.Logger),
+		findClient:    NewFindClient(findPath, restClient, config.Logger),
+		refreshClient: NewRefreshClient(refreshPath, restClient, config.Logger),
 		// download client doesn't require a path here, as the download could
 		// be from any server in theory. That information is found from the
 		// refresh response.
-		downloadClient: NewDownloadClient(httpClient, fileSystem, logger),
-		logger:         logger,
+		downloadClient: NewDownloadClient(httpClient, fileSystem, config.Logger),
+		logger:         config.Logger,
 	}, nil
 }
 

--- a/charmhub/client_integration_test.go
+++ b/charmhub/client_integration_test.go
@@ -22,7 +22,8 @@ type ClientSuite struct {
 var _ = gc.Suite(&ClientSuite{})
 
 func (s *ClientSuite) TestLiveInfoRequest(c *gc.C) {
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 
 	client, err := charmhub.NewClient(config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -33,7 +34,8 @@ func (s *ClientSuite) TestLiveInfoRequest(c *gc.C) {
 }
 
 func (s *ClientSuite) TestLiveFindRequest(c *gc.C) {
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 
 	client, err := charmhub.NewClient(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/charmhub/download.go
+++ b/charmhub/download.go
@@ -39,13 +39,15 @@ func (fileSystem) Create(name string) (*os.File, error) {
 type DownloadClient struct {
 	transport  Transport
 	fileSystem FileSystem
+	logger     Logger
 }
 
 // NewDownloadClient creates a DownloadClient for requesting
-func NewDownloadClient(transport Transport, fileSystem FileSystem) *DownloadClient {
+func NewDownloadClient(transport Transport, fileSystem FileSystem, logger Logger) *DownloadClient {
 	return &DownloadClient{
 		transport:  transport,
 		fileSystem: fileSystem,
+		logger:     logger,
 	}
 }
 

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -54,7 +54,7 @@ func (s *DownloadSuite) TestDownload(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := NewDownloadClient(transport, fileSystem, &fakeLogger{})
+	client := NewDownloadClient(transport, fileSystem, &FakeLogger{})
 	_, err = client.Download(context.TODO(), serverURL, tmpFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -84,7 +84,7 @@ func (s *DownloadSuite) TestDownloadWithNotFoundStatusCode(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := NewDownloadClient(transport, fileSystem, &fakeLogger{})
+	client := NewDownloadClient(transport, fileSystem, &FakeLogger{})
 	_, err = client.Download(context.TODO(), serverURL, tmpFile.Name())
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": archive not found`)
 }
@@ -114,7 +114,7 @@ func (s *DownloadSuite) TestDownloadWithFailedStatusCode(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := NewDownloadClient(transport, fileSystem, &fakeLogger{})
+	client := NewDownloadClient(transport, fileSystem, &FakeLogger{})
 	_, err = client.Download(context.TODO(), serverURL, tmpFile.Name())
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive`)
 }

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -54,7 +54,7 @@ func (s *DownloadSuite) TestDownload(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := NewDownloadClient(transport, fileSystem)
+	client := NewDownloadClient(transport, fileSystem, &fakeLogger{})
 	_, err = client.Download(context.TODO(), serverURL, tmpFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -84,7 +84,7 @@ func (s *DownloadSuite) TestDownloadWithNotFoundStatusCode(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := NewDownloadClient(transport, fileSystem)
+	client := NewDownloadClient(transport, fileSystem, &fakeLogger{})
 	_, err = client.Download(context.TODO(), serverURL, tmpFile.Name())
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": archive not found`)
 }
@@ -114,7 +114,7 @@ func (s *DownloadSuite) TestDownloadWithFailedStatusCode(c *gc.C) {
 	serverURL, err := url.Parse("http://meshuggah.rocks")
 	c.Assert(err, jc.ErrorIsNil)
 
-	client := NewDownloadClient(transport, fileSystem)
+	client := NewDownloadClient(transport, fileSystem, &fakeLogger{})
 	_, err = client.Download(context.TODO(), serverURL, tmpFile.Name())
 	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive`)
 }

--- a/charmhub/fake_test.go
+++ b/charmhub/fake_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+type fakeLogger struct {
+}
+
+func (l *fakeLogger) IsTraceEnabled() bool {
+	return false
+}
+
+func (l *fakeLogger) Debugf(format string, args ...interface{}) {}
+
+func (l *fakeLogger) Tracef(format string, args ...interface{}) {}

--- a/charmhub/fake_test.go
+++ b/charmhub/fake_test.go
@@ -3,13 +3,13 @@
 
 package charmhub
 
-type fakeLogger struct {
+type FakeLogger struct {
 }
 
-func (l *fakeLogger) IsTraceEnabled() bool {
+func (l *FakeLogger) IsTraceEnabled() bool {
 	return false
 }
 
-func (l *fakeLogger) Debugf(format string, args ...interface{}) {}
+func (l *FakeLogger) Debugf(format string, args ...interface{}) {}
 
-func (l *fakeLogger) Tracef(format string, args ...interface{}) {}
+func (l *FakeLogger) Tracef(format string, args ...interface{}) {}

--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -17,18 +17,21 @@ import (
 type FindClient struct {
 	path   path.Path
 	client RESTClient
+	logger Logger
 }
 
 // NewFindClient creates a FindClient for querying charm or bundle information.
-func NewFindClient(path path.Path, client RESTClient) *FindClient {
+func NewFindClient(path path.Path, client RESTClient, logger Logger) *FindClient {
 	return &FindClient{
 		path:   path,
 		client: client,
+		logger: logger,
 	}
 }
 
 // Find searches Charm Hub and provides results matching a string.
 func (c *FindClient) Find(ctx context.Context, query string) ([]transport.FindResponse, error) {
+	c.logger.Debugf("Find(%s)", query)
 	path, err := c.path.Query("q", query)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/charmhub/find_integration_test.go
+++ b/charmhub/find_integration_test.go
@@ -22,7 +22,8 @@ type FindClientSuite struct {
 var _ = gc.Suite(&FindClientSuite{})
 
 func (s *FindClientSuite) TestLiveFindRequest(c *gc.C) {
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -30,9 +31,9 @@ func (s *FindClientSuite) TestLiveFindRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport())
-	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil)
+	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
-	client := charmhub.NewFindClient(findPath, restClient)
+	client := charmhub.NewFindClient(findPath, restClient, &charmhub.FakeLogger{})
 	responses, err := client.Find(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), jc.GreaterThan, 1)

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -36,7 +36,7 @@ func (s *FindSuite) TestFind(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, path, name)
 
-	client := NewFindClient(path, restClient)
+	client := NewFindClient(path, restClient, &fakeLogger{})
 	responses, err := client.Find(context.TODO(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -55,7 +55,7 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(c, restClient)
 
-	client := NewFindClient(path, restClient)
+	client := NewFindClient(path, restClient, &fakeLogger{})
 	_, err := client.Find(context.TODO(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -158,9 +158,9 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil)
+	restClient := NewHTTPRESTClient(apiRequester, nil, &fakeLogger{})
 
-	client := NewFindClient(findPath, restClient)
+	client := NewFindClient(findPath, restClient, &fakeLogger{})
 	responses, err := client.Find(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(responses, gc.DeepEquals, findResponses.Results)
@@ -195,9 +195,9 @@ func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil)
+	restClient := NewHTTPRESTClient(apiRequester, nil, &fakeLogger{})
 
-	client := NewFindClient(findPath, restClient)
+	client := NewFindClient(findPath, restClient, &fakeLogger{})
 	_, err = client.Find(context.TODO(), "wordpress")
 	c.Assert(err, gc.ErrorMatches, "not found error code")
 }

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -36,7 +36,7 @@ func (s *FindSuite) TestFind(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, path, name)
 
-	client := NewFindClient(path, restClient, &fakeLogger{})
+	client := NewFindClient(path, restClient, &FakeLogger{})
 	responses, err := client.Find(context.TODO(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -55,7 +55,7 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(c, restClient)
 
-	client := NewFindClient(path, restClient, &fakeLogger{})
+	client := NewFindClient(path, restClient, &FakeLogger{})
 	_, err := client.Find(context.TODO(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -158,9 +158,9 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil, &fakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
 
-	client := NewFindClient(findPath, restClient, &fakeLogger{})
+	client := NewFindClient(findPath, restClient, &FakeLogger{})
 	responses, err := client.Find(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(responses, gc.DeepEquals, findResponses.Results)
@@ -195,9 +195,9 @@ func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil, &fakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
 
-	client := NewFindClient(findPath, restClient, &fakeLogger{})
+	client := NewFindClient(findPath, restClient, &FakeLogger{})
 	_, err = client.Find(context.TODO(), "wordpress")
 	c.Assert(err, gc.ErrorMatches, "not found error code")
 }

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -98,7 +98,7 @@ func (s *RESTSuite) TestGet(c *gc.C) {
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
-	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
 
 	var result interface{}
 	err := client.Get(context.TODO(), base, &result)
@@ -111,7 +111,7 @@ func (s *RESTSuite) TestGetWithInvalidContext(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockTransport := NewMockTransport(ctrl)
-	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
@@ -127,7 +127,7 @@ func (s *RESTSuite) TestGetWithFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(gomock.Any()).Return(emptyResponse(), errors.Errorf("boom"))
 
-	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
@@ -143,7 +143,7 @@ func (s *RESTSuite) TestGetWithUnmarshalFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(gomock.Any()).Return(invalidResponse(), nil)
 
-	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
 
 	base := MustMakePath(c, "http://api.foo.bar")
 

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -98,7 +98,7 @@ func (s *RESTSuite) TestGet(c *gc.C) {
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
-	client := NewHTTPRESTClient(mockTransport, nil)
+	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
 
 	var result interface{}
 	err := client.Get(context.TODO(), base, &result)
@@ -111,7 +111,7 @@ func (s *RESTSuite) TestGetWithInvalidContext(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockTransport := NewMockTransport(ctrl)
-	client := NewHTTPRESTClient(mockTransport, nil)
+	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
@@ -127,7 +127,7 @@ func (s *RESTSuite) TestGetWithFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(gomock.Any()).Return(emptyResponse(), errors.Errorf("boom"))
 
-	client := NewHTTPRESTClient(mockTransport, nil)
+	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
@@ -143,7 +143,7 @@ func (s *RESTSuite) TestGetWithUnmarshalFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(gomock.Any()).Return(invalidResponse(), nil)
 
-	client := NewHTTPRESTClient(mockTransport, nil)
+	client := NewHTTPRESTClient(mockTransport, nil, &fakeLogger{})
 
 	base := MustMakePath(c, "http://api.foo.bar")
 

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -16,19 +16,22 @@ import (
 type InfoClient struct {
 	path   path.Path
 	client RESTClient
+	logger Logger
 }
 
 // NewInfoClient creates a InfoClient for requesting
-func NewInfoClient(path path.Path, client RESTClient) *InfoClient {
+func NewInfoClient(path path.Path, client RESTClient, logger Logger) *InfoClient {
 	return &InfoClient{
 		path:   path,
 		client: client,
+		logger: logger,
 	}
 }
 
 // Info requests the information of a given charm. If that charm doesn't exist
 // an error stating that fact will be returned.
 func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoResponse, error) {
+	c.logger.Debugf("Info(%s)", name)
 	var resp transport.InfoResponse
 	path, err := c.path.Join(name)
 	if err != nil {

--- a/charmhub/info_integration_test.go
+++ b/charmhub/info_integration_test.go
@@ -22,7 +22,8 @@ type InfoClientSuite struct {
 var _ = gc.Suite(&InfoClientSuite{})
 
 func (s *InfoClientSuite) TestLiveInfoRequest(c *gc.C) {
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -30,9 +31,9 @@ func (s *InfoClientSuite) TestLiveInfoRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport())
-	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil)
+	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
-	client := charmhub.NewInfoClient(infoPath, restClient)
+	client := charmhub.NewInfoClient(infoPath, restClient, &charmhub.FakeLogger{})
 	response, err := client.Info(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, "wordpress")

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -72,7 +72,7 @@ func (s *InfoSuite) TestInfoError(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetError(c, restClient, path, name)
 
-	client := NewInfoClient(path, restClient)
+	client := NewInfoClient(path, restClient, &FakeLogger{})
 	_, err := client.Info(context.TODO(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -37,7 +37,7 @@ func (s *InfoSuite) TestInfo(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, path, name)
 
-	client := NewInfoClient(path, restClient)
+	client := NewInfoClient(path, restClient, &fakeLogger{})
 	response, err := client.Info(context.TODO(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, name)
@@ -55,7 +55,7 @@ func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(c, restClient)
 
-	client := NewInfoClient(path, restClient)
+	client := NewInfoClient(path, restClient, &fakeLogger{})
 	_, err := client.Info(context.TODO(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -212,9 +212,9 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil)
+	restClient := NewHTTPRESTClient(apiRequester, nil, &fakeLogger{})
 
-	client := NewInfoClient(infoPath, restClient)
+	client := NewInfoClient(infoPath, restClient, &fakeLogger{})
 	response, err := client.Info(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response, gc.DeepEquals, infoResponse)

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -37,7 +37,7 @@ func (s *InfoSuite) TestInfo(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGet(c, restClient, path, name)
 
-	client := NewInfoClient(path, restClient, &fakeLogger{})
+	client := NewInfoClient(path, restClient, &FakeLogger{})
 	response, err := client.Info(context.TODO(), name)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, name)
@@ -55,7 +55,7 @@ func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectGetFailure(c, restClient)
 
-	client := NewInfoClient(path, restClient, &fakeLogger{})
+	client := NewInfoClient(path, restClient, &FakeLogger{})
 	_, err := client.Info(context.TODO(), name)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -212,9 +212,9 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil, &fakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
 
-	client := NewInfoClient(infoPath, restClient, &fakeLogger{})
+	client := NewInfoClient(infoPath, restClient, &FakeLogger{})
 	response, err := client.Info(context.TODO(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response, gc.DeepEquals, infoResponse)

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils"
+	"github.com/kr/pretty"
 
 	"github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
@@ -37,13 +38,15 @@ const (
 type RefreshClient struct {
 	path   path.Path
 	client RESTClient
+	logger Logger
 }
 
 // NewRefreshClient creates a RefreshClient for requesting
-func NewRefreshClient(path path.Path, client RESTClient) *RefreshClient {
+func NewRefreshClient(path path.Path, client RESTClient, logger Logger) *RefreshClient {
 	return &RefreshClient{
 		path:   path,
 		client: client,
+		logger: logger,
 	}
 }
 
@@ -58,6 +61,7 @@ type RefreshConfig interface {
 
 // Refresh is used to refresh installed charms to a more suitable revision.
 func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
+	c.logger.Debugf("Refresh(%s)", pretty.Sprint(config))
 	req, err := config.Build()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/charmhub/refresh_integration_test.go
+++ b/charmhub/refresh_integration_test.go
@@ -24,7 +24,8 @@ var _ = gc.Suite(&RefreshClientSuite{})
 func (s *RefreshClientSuite) TestLiveRefreshRequest(c *gc.C) {
 	c.Skip("install is not currently wired up, so the test fails")
 
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -32,9 +33,9 @@ func (s *RefreshClientSuite) TestLiveRefreshRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport())
-	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil)
+	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
-	client := charmhub.NewRefreshClient(refreshPath, restClient)
+	client := charmhub.NewRefreshClient(refreshPath, restClient, &charmhub.FakeLogger{})
 
 	charmConfig, err := charmhub.RefreshOne("wordpress", 17, "latest/stable", "ubuntu", "focal")
 	c.Assert(err, jc.ErrorIsNil)
@@ -48,7 +49,8 @@ func (s *RefreshClientSuite) TestLiveRefreshRequest(c *gc.C) {
 func (s *RefreshClientSuite) TestLiveRefreshManyRequest(c *gc.C) {
 	c.Skip("install is not currently wired up, so the test fails")
 
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -56,9 +58,9 @@ func (s *RefreshClientSuite) TestLiveRefreshManyRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport())
-	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil)
+	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
-	client := charmhub.NewRefreshClient(refreshPath, restClient)
+	client := charmhub.NewRefreshClient(refreshPath, restClient, &charmhub.FakeLogger{})
 
 	wordpressConfig, err := charmhub.RefreshOne("wordpress", 16, "latest/stable", "ubuntu", "focal")
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,7 +80,8 @@ func (s *RefreshClientSuite) TestLiveRefreshManyRequest(c *gc.C) {
 func (s *RefreshClientSuite) TestLiveInstallRequest(c *gc.C) {
 	c.Skip("install is not currently wired up, so the test fails")
 
-	config := charmhub.CharmHubConfig()
+	config, err := charmhub.CharmHubConfig(&charmhub.FakeLogger{})
+	c.Assert(err, jc.ErrorIsNil)
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -86,9 +89,9 @@ func (s *RefreshClientSuite) TestLiveInstallRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport())
-	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil)
+	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
-	client := charmhub.NewRefreshClient(refreshPath, restClient)
+	client := charmhub.NewRefreshClient(refreshPath, restClient, &charmhub.FakeLogger{})
 
 	charmConfig, err := charmhub.InstallOneFromRevision("wordpress", 16, "ubuntu", "focal")
 	c.Assert(err, jc.ErrorIsNil)

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -57,7 +57,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPost(c, restClient, path, name, body)
 
-	client := NewRefreshClient(path, restClient)
+	client := NewRefreshClient(path, restClient, &fakeLogger{})
 	responses, err := client.Refresh(context.TODO(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -81,7 +81,7 @@ func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPostFailure(c, restClient)
 
-	client := NewRefreshClient(path, restClient)
+	client := NewRefreshClient(path, restClient, &fakeLogger{})
 	_, err = client.Refresh(context.TODO(), config)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -57,7 +57,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPost(c, restClient, path, name, body)
 
-	client := NewRefreshClient(path, restClient, &fakeLogger{})
+	client := NewRefreshClient(path, restClient, &FakeLogger{})
 	responses, err := client.Refresh(context.TODO(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
@@ -81,7 +81,7 @@ func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPostFailure(c, restClient)
 
-	client := NewRefreshClient(path, restClient, &fakeLogger{})
+	client := NewRefreshClient(path, restClient, &FakeLogger{})
 	_, err = client.Refresh(context.TODO(), config)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }


### PR DESCRIPTION


## Description of change

Add debug and trace logging to the charmhub client.  Pass in a logger via the config to create the client.

## QA steps

```sh
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju add-model seven --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju model-config -m controller logging-config="juju.apiserver.charmhub.client=TRACE;<root>=DEBUG;<unit>=DEBUG;juju.apiserver.charms.client=TRACE"
$ juju deploy verterok-apache2
$ juju debug-log -m controller --include-module juju.apiserver.charmhub.client --include-module juju.apiserver.charms.client
machine-0: 21:46:29 TRACE juju.apiserver.charms.client NewClient to "https://api.staging.snapcraft.io"
machine-0: 21:46:29 DEBUG juju.apiserver.charms.client Info(verterok-apache2)
machine-0: 21:46:29 TRACE juju.apiserver.charms.client Get response HTTP/1.1 200 OK
Content-Length: 133
Content-Type: application/json
Date: Wed, 16 Sep 2020 21:46:29 GMT
Server: gunicorn/19.7.1
Snap-Store-Version: 24
X-Request-Id: 6C5B8BE0C4000A324F5701BB5F6287B55612
X-Vcs-Revision: f3f6a5d
X-View-Name: snapdevicegw.webapi_info_charm.charm_info

{"channel-map":[],"default-release":{},"id":"K64RpNGzMfoSYHLhbovbizXDwueZzQFZ","name":"verterok-apache2","result":{},"type":"charm"}
```

