### PR TITLE
2.8 upgrade panic placeholder charms 1895954

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Juju"
-#define MyAppVersion "2.8.2"
+#define MyAppVersion "2.8.3"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://jujucharms.com/"
 #define MyAppExeName "juju.exe"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.8.2
+version: 2.8.3
 summary: juju client
 description: Through the use of charms, juju provides you with shareable, re-usable, and repeatable expressions of devops best practices.
 confinement: classic

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2972,8 +2972,9 @@ func ResetDefaultRelationLimitInCharmMetadata(pool *StatePool) (err error) {
 		var ops []txn.Op
 		for _, charmDoc := range docs {
 			if charmDoc.Meta == nil {
-				if !charmDoc.Placeholder {
-					logger.Warningf("charmDoc has nil Meta and is not a placeholder: %# v",
+				if !(charmDoc.Placeholder || charmDoc.PendingUpload) {
+					logger.Warningf(
+						"charmDoc has nil Meta and is not a placeholder/pending upload: %# v",
 						pretty.Formatter(charmDoc))
 				}
 				continue

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2970,6 +2970,10 @@ func ResetDefaultRelationLimitInCharmMetadata(pool *StatePool) (err error) {
 
 		var ops []txn.Op
 		for _, charmDoc := range docs {
+			if charmDoc.Meta == nil {
+				logger.Warningf("charmDoc has nil Meta (invalid charm): %v", charmDoc)
+				continue
+			}
 			for epName, rel := range charmDoc.Meta.Requires {
 				rel.Limit = 0
 				charmDoc.Meta.Requires[epName] = rel

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4484,7 +4484,7 @@ func (s *upgradesSuite) TestLimitHandlesPlaceholderCharms(c *gc.C) {
 		"placeholder":   true,
 		"bundlesha256":  "",
 		"storagepath":   "",
-		"macaroon":      bson.Binary{},
+		"macaroon":      []uint8{},
 		"meta":          nil,
 		"config":        nil,
 		"actions":       nil,

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.8.2"
+const version = "2.8.3"
 
 const (
 	// TreeStateDirty when the build was made with a dirty checkout.


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

The upgrade step to fix charm Meta 'limits' field didn't handle charms that weren't fully downloaded. When recording a new charm, we start by adding a placeholder (with no Meta), and then we populate that meta by downloading the charm.
This just checks for a nil value, and we know there is no upgrade that we need to do.

## QA steps

I'm not sure how to force one of these into actual data. I suppose you could block traffic from your controller to the charm store, and then try to deploy a charm. You could do that with 2.8.1 and then upgrade to 2.8.2, and see that it panics, but with this patch, it won't panic. (The unit test covers the data that we've seen in the wild.)

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1895954