### PR TITLE
Application status shouldn't use model cache

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -185,7 +185,7 @@ func (aw *SrvAllWatcher) translateApplication(info multiwatcher.EntityInfo) para
 	// correctly interpret the unknown status from the unit status. If the unit
 	// status is not found, then fall back to unknown.
 	// If a charm author has set the application status, then show that instead.
-	applicationStatus := multiwatcher.StatusInfo{Current: status.Unknown}
+	applicationStatus := multiwatcher.StatusInfo{Current: status.Unset}
 	if orig.Status.Current != status.Unset {
 		applicationStatus = orig.Status
 	}

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -180,16 +180,13 @@ func (aw *SrvAllWatcher) translateApplication(info multiwatcher.EntityInfo) para
 		return nil
 	}
 
-	// Get the application status from the cache if it is unset.
+	// If the application status is unset, then set it to unknown. It is
+	// expected that downstream clients (model cache, pylibjuju, jslibjuju)
+	// correctly interpret the unknown status from the unit status. If the unit
+	// status is not found, then fall back to unknown.
+	// If a charm author has set the application status, then show that instead.
 	applicationStatus := multiwatcher.StatusInfo{Current: status.Unknown}
-	if orig.Status.Current == status.Unset {
-		if model, err := aw.controller.Model(orig.ModelUUID); err == nil {
-			cachedApp, err := model.Application(orig.Name)
-			if err == nil {
-				applicationStatus = multiwatcher.NewStatusInfo(cachedApp.Status(), nil)
-			}
-		}
-	} else {
+	if orig.Status.Current != status.Unset {
 		applicationStatus = orig.Status
 	}
 

--- a/apiserver/watcher_internal_test.go
+++ b/apiserver/watcher_internal_test.go
@@ -4,13 +4,9 @@
 package apiserver
 
 import (
-	"time"
-
-	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/status"
@@ -39,87 +35,6 @@ func (s *allWatcherSuite) TestTranslateApplicationWithStatus(c *gc.C) {
 		Life:      life.Alive,
 		Status: multiwatcher.StatusInfo{
 			Current: status.Active,
-		},
-	}
-	output := w.translateApplication(input)
-	c.Assert(output, jc.DeepEquals, &params.ApplicationInfo{
-		ModelUUID: input.ModelUUID,
-		Name:      input.Name,
-		CharmURL:  input.CharmURL,
-		Life:      input.Life,
-		Status: params.StatusInfo{
-			Current: status.Active,
-		},
-	})
-}
-
-func (s *allWatcherSuite) setupCache(c *gc.C) *cache.Controller {
-	changes := make(chan interface{})
-	handled := make(chan interface{})
-	notify := func(evt interface{}) {
-		c.Logf("%#v", evt)
-		select {
-		case handled <- evt:
-		case <-time.After(testing.LongWait):
-			c.Fatalf("handled notify not retrieved")
-		}
-	}
-	sendEvent := func(event interface{}) {
-		select {
-		case changes <- event:
-		case <-time.After(testing.LongWait):
-			c.Fatal("cache did not accept event")
-		}
-		select {
-		case <-handled:
-		case <-time.After(testing.LongWait):
-			c.Fatal("cache did not handle event")
-		}
-	}
-
-	controller, err := cache.NewController(cache.ControllerConfig{
-		Changes: changes,
-		Notify:  notify,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, controller) })
-
-	sendEvent(cache.ModelChange{
-		ModelUUID: testing.ModelTag.Id(),
-		// Defaults for everything else.
-	})
-	sendEvent(cache.ApplicationChange{
-		ModelUUID: testing.ModelTag.Id(),
-		Name:      "test-app",
-		Status: status.StatusInfo{
-			Status: status.Unset,
-		},
-		// Defaults for everything else.
-	})
-	sendEvent(cache.UnitChange{
-		ModelUUID:   testing.ModelTag.Id(),
-		Name:        "test-app/0",
-		Application: "test-app",
-		WorkloadStatus: status.StatusInfo{
-			Status: status.Active,
-		},
-		// Defaults for everything else.
-	})
-
-	return controller
-}
-
-func (s *allWatcherSuite) TestTranslateApplicationStatusUnset(c *gc.C) {
-	controller := s.setupCache(c)
-	w := s.watcher()
-	w.controller = controller
-	input := &multiwatcher.ApplicationInfo{
-		ModelUUID: testing.ModelTag.Id(),
-		Name:      "test-app",
-		CharmURL:  "test-app",
-		Life:      life.Alive,
-		Status: multiwatcher.StatusInfo{
-			Current: status.Unset,
 		},
 	}
 	output := w.translateApplication(input)


### PR DESCRIPTION
## Description of change

This fix is very subtle because it highlights a problem with how the
all watcher is consumed by different clients (model cache, pylibjuju,
jslibjuju).

When you connect to the allwatcher you're given a series of deltas and
is expected that the client consumes that as verbatim. There is a
problem though, with the insert of the previous derivation status it
causes problems where it's impossible to know what the status of an
application is right now.

At the application delta is dispatched once at the start of signing on
to the allwatcher, you get what it was at the time of sign-on, which is
inconsistent.

With the changes to getting the application status from the model cache
then depends if the units have primed the model cache in time to get
that information.

If we assume the diagram below we can see that depending on when you
join the allwatcher defines what application status.

If you're AllWatcher (A, B, C) you'll never see that the unit status is
blocked.

In order for pylibjuju the *only* way to get the right information is to
do it in pylibjuju.

```
 ALLWATCHER  ALLWATCHER  ALLWATCHER
     (A)         (B)         (C)
      +           +           +
      |           |           |
      |           |           |
      |           |           |
      |           |           |
      |           |           |
---+--+-----------+-+---------+------+-----------> TIME
   ^                ^                ^
   |                |                |
   |                |                |
   |                |                |
   +                +                +

APP STATUS      UNIT STATUS      UNIT STATUS
 (UNSET)          (WAITING)        (BLOCKED)
```
## QA steps

### Juju

Pylibjuju is required here, but first bootstrap Juju.

```sh
juju bootstrap lxd test --no-gui
```

### Pylibjuju

Set up pylibjuju correctly with the following [commit](https://github.com/juju/python-libjuju/commit/fd531e88db9dbae64f0690fe37a0fc1986573e19) and run the 
following code snippet.

```python
import asyncio
from juju import loop
from juju.controller import Controller
from juju.model import Model
from juju.errors import JujuEntityNotFoundError
from juju.client import client

async def main():
    controller = Controller()
    model = Model()

    await controller.connect_current()
    await model.connect_current()

    try:
        # Create
        application = await model.deploy("cs:~davigar15/simple-0")
        while True:
            print(application.status)
            await asyncio.sleep(5)
    except JujuEntityNotFoundError as e:
        print(e.entity_name)
    finally:
        await model.disconnect()


if __name__ == '__main__':
    loop.run(main())
```

It is expected that the output should be something similar to:

```sh
waiting
waiting
waiting
waiting
waiting
waiting
waiting
waiting
waiting
waiting
waiting
maintenance
blocked
blocked
```

## Bug reference

https://github.com/juju/python-libjuju/issues/441