### PR TITLE
application Update problematic for charmhub integration and too many ways to update config

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -972,7 +972,9 @@ type forceParams struct {
 // Update updates the application attributes, including charm URL,
 // minimum number of units, charm config and constraints.
 // All parameters in params.ApplicationUpdate except the application name are optional.
-func (api *APIBase) Update(args params.ApplicationUpdate) error {
+// Note: Updating the charm-url via Update is no longer supported.  See SetCharm.
+// Note: This method is no longer supported with facade v13.  See: SetCharm, SetConfigs.
+func (api *APIv12) Update(args params.ApplicationUpdate) error {
 	if err := api.checkCanWrite(); err != nil {
 		return err
 	}
@@ -985,26 +987,10 @@ func (api *APIBase) Update(args params.ApplicationUpdate) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	// Set the charm for the given application.
 	if args.CharmURL != "" {
-		// For now we do not support changing the channel through Update().
-		// TODO(ericsnow) Support it?
-		channel := app.Channel()
-		if err = api.updateCharm(
-			setCharmParams{
-				AppName:     args.ApplicationName,
-				Application: app,
-				Channel:     channel,
-				Force: forceParams{
-					ForceSeries: args.ForceSeries,
-					ForceUnits:  args.ForceCharmURL,
-					Force:       args.Force,
-				},
-			},
-			args.CharmURL,
-		); err != nil {
-			return errors.Trace(err)
-		}
+		return errors.NotSupportedf("updating charm url, see SetCharm")
 	}
 	// Set the minimum number of units for the given application.
 	if args.MinUnits != nil {
@@ -1013,11 +999,23 @@ func (api *APIBase) Update(args params.ApplicationUpdate) error {
 		}
 	}
 
+	if err := api.setConfig(app, args.Generation, args.SettingsYAML, args.SettingsStrings); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Update application's constraints.
+	if args.Constraints != nil {
+		return app.SetConstraints(*args.Constraints)
+	}
+	return nil
+}
+
+func (api *APIBase) setConfig(app Application, generation, settingsYAML string, settingsStrings map[string]string) error {
 	// We need a guard on the API server-side for direct API callers such as
 	// python-libjuju, and for older clients.
 	// Always default to the master branch.
-	if args.Generation == "" {
-		args.Generation = model.GenerationMaster
+	if generation == "" {
+		generation = model.GenerationMaster
 	}
 
 	// Update settings for charm and/or application.
@@ -1026,14 +1024,14 @@ func (api *APIBase) Update(args params.ApplicationUpdate) error {
 		return errors.Annotate(err, "obtaining charm for this application")
 	}
 
-	appConfig, appConfigSchema, charmSettings, err := parseCharmSettings(api.modelType, ch, app.Name(), args.SettingsStrings, args.SettingsYAML)
+	appConfig, appConfigSchema, charmSettings, err := parseCharmSettings(api.modelType, ch, app.Name(), settingsStrings, settingsYAML)
 	if err != nil {
 		return errors.Annotate(err, "parsing settings for application")
 	}
 
 	var configChanged bool
 	if len(charmSettings) != 0 {
-		if err = app.UpdateCharmConfig(args.Generation, charmSettings); err != nil {
+		if err = app.UpdateCharmConfig(generation, charmSettings); err != nil {
 			return errors.Annotate(err, "updating charm config settings")
 		}
 		configChanged = true
@@ -1046,16 +1044,12 @@ func (api *APIBase) Update(args params.ApplicationUpdate) error {
 	}
 
 	// If the config change is generational, add the app to the generation.
-	if configChanged && args.Generation != model.GenerationMaster {
-		if err := api.addAppToBranch(args.Generation, args.ApplicationName); err != nil {
+	if configChanged && generation != model.GenerationMaster {
+		if err := api.addAppToBranch(generation, app.Name()); err != nil {
 			return errors.Trace(err)
 		}
 	}
 
-	// Update application's constraints.
-	if args.Constraints != nil {
-		return app.SetConstraints(*args.Constraints)
-	}
 	return nil
 }
 
@@ -2527,7 +2521,9 @@ func (u *APIv5) SetApplicationsConfig(_, _ struct{}) {}
 // SetApplicationsConfig implements the server side of Application.SetApplicationsConfig.
 // It does not unset values that are set to an empty string.
 // Unset should be used for that.
-func (api *APIBase) SetApplicationsConfig(args params.ApplicationConfigSetArgs) (params.ErrorResults, error) {
+// Note: SetApplicationsConfig is misleading, both application and charm config are set.
+// Note: For facade version 13 and higher, use SetConfig.
+func (api *APIv12) SetApplicationsConfig(args params.ApplicationConfigSetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
 	if err := api.checkCanWrite(); err != nil {
 		return result, errors.Trace(err)
@@ -2537,59 +2533,40 @@ func (api *APIBase) SetApplicationsConfig(args params.ApplicationConfigSetArgs) 
 	}
 	result.Results = make([]params.ErrorResult, len(args.Args))
 	for i, arg := range args.Args {
-		err := api.setApplicationConfig(arg)
+		app, err := api.backend.Application(arg.ApplicationName)
+		if err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		err = api.setConfig(app, arg.Generation, "", arg.Config)
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
 }
 
-func (api *APIBase) setApplicationConfig(arg params.ApplicationConfigSet) error {
-	app, err := api.backend.Application(arg.ApplicationName)
-	if err != nil {
-		return errors.Trace(err)
+// SetConfig implements the server side of Application.SetConfig.  Both
+// application and charm config are set. It does not unset values in
+// Config map that are set to an empty string. Unset should be used for that.
+func (api *APIBase) SetConfigs(args params.ConfigSetArgs) (params.ErrorResults, error) {
+	var result params.ErrorResults
+	if err := api.checkCanWrite(); err != nil {
+		return result, errors.Trace(err)
 	}
-
-	appConfigAttrs, charmConfig, err := splitApplicationAndCharmConfig(api.modelType, arg.Config)
-	if err != nil {
-		return errors.Trace(err)
+	if err := api.check.ChangeAllowed(); err != nil {
+		return result, errors.Trace(err)
 	}
-	configSchema, defaults, err := applicationConfigSchema(api.modelType)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if len(appConfigAttrs) > 0 {
-		if err := app.UpdateApplicationConfig(appConfigAttrs, nil, configSchema, defaults); err != nil {
-			return errors.Annotate(err, "updating application config values")
-		}
-	}
-	if len(charmConfig) > 0 {
-		ch, _, err := app.Charm()
+	result.Results = make([]params.ErrorResult, len(args.Args))
+	for i, arg := range args.Args {
+		app, err := api.backend.Application(arg.ApplicationName)
 		if err != nil {
-			return errors.Trace(err)
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
 		}
-		// Validate the charm and application config.
-		charmConfigChanges, err := ch.Config().ParseSettingsStrings(charmConfig)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		// We need a guard on the API server-side for direct API callers such as
-		// python-libjuju, and for older clients.
-		// Always default to the master branch.
-		if arg.Generation == "" {
-			arg.Generation = model.GenerationMaster
-		}
-		if err := app.UpdateCharmConfig(arg.Generation, charmConfigChanges); err != nil {
-			return errors.Annotate(err, "updating application charm settings")
-		}
-		if arg.Generation != model.GenerationMaster {
-			if err := api.addAppToBranch(arg.Generation, arg.ApplicationName); err != nil {
-				return errors.Trace(err)
-			}
-		}
+		err = api.setConfig(app, arg.Generation, arg.ConfigYAML, arg.Config)
+		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
-	return nil
+	return result, nil
 }
 
 func (api *APIBase) addAppToBranch(branchName string, appName string) error {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -383,8 +383,48 @@ func (s *ApplicationSuite) TestUpdateCAASApplicationSettings(c *gc.C) {
 		ApplicationName: "postgresql",
 		SettingsYAML:    "postgresql:\n  stringOption: bar\n  juju-external-hostname: foo",
 	}
-	err := s.api.Update(args)
+	api := &application.APIv12{s.api}
+	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
+
+	pgApp := s.backend.applications["postgresql"]
+	pgApp.CheckCall(c, 2, "UpdateCharmConfig", "master", charm.Settings{
+		"stringOption": "bar",
+	})
+
+	appDefaults := caas.ConfigDefaults(k8s.ConfigDefaults())
+	appCfgSchema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	c.Assert(err, jc.ErrorIsNil)
+	appCfgSchema, appDefaults, err = application.AddTrustSchemaAndDefaults(appCfgSchema, appDefaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	appCfg, err := coreapplication.NewConfig(map[string]interface{}{
+		"juju-external-hostname": "foo",
+	}, appCfgSchema, appDefaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pgApp.CheckCall(c, 3, "UpdateApplicationConfig", appCfg.Attributes(), []string(nil), appCfgSchema, schema.Defaults(nil))
+}
+
+func (s *ApplicationSuite) TestSetCAASConfigSettings(c *gc.C) {
+	s.model.modelType = state.ModelTypeCAAS
+	s.setAPIUser(c, names.NewUserTag("admin"))
+	s.backend.charm = &mockCharm{
+		meta: &charm.Meta{
+			Deployment: &charm.Deployment{
+				DeploymentMode: charm.ModeOperator,
+			},
+		},
+	}
+
+	// Update settings for the application.
+	args := params.ConfigSetArgs{Args: []params.ConfigSet{{
+		ApplicationName: "postgresql",
+		ConfigYAML:      "postgresql:\n  stringOption: bar\n  juju-external-hostname: foo",
+	}}}
+	results, err := s.api.SetConfigs(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.DeepEquals, []params.ErrorResult{{}})
 
 	pgApp := s.backend.applications["postgresql"]
 	pgApp.CheckCall(c, 2, "UpdateCharmConfig", "master", charm.Settings{
@@ -421,8 +461,35 @@ func (s *ApplicationSuite) TestUpdateCAASApplicationSettingsInIAASModelTriggersE
 		ApplicationName: "postgresql",
 		SettingsYAML:    "postgresql:\n  stringOption: bar\n  juju-external-hostname: foo",
 	}
-	err := s.api.Update(args)
+	api := &application.APIv12{s.api}
+	err := api.Update(args)
 	c.Assert(err, gc.ErrorMatches, `.*unknown option "juju-external-hostname"`, gc.Commentf("expected to get an error when attempting to set CAAS-specific app setting in IAAS model"))
+}
+
+func (s *ApplicationSuite) TestSetCAASConfigSettingsInIAASModelTriggersError(c *gc.C) {
+	s.model.modelType = state.ModelTypeIAAS
+	s.setAPIUser(c, names.NewUserTag("admin"))
+	s.backend.charm = &mockCharm{
+		meta: &charm.Meta{
+			Deployment: &charm.Deployment{
+				DeploymentMode: charm.ModeOperator,
+			},
+		},
+	}
+
+	// Update settings for the application.
+	args := params.ConfigSetArgs{Args: []params.ConfigSet{{
+		ApplicationName: "postgresql",
+		ConfigYAML:      "postgresql:\n  stringOption: bar\n  juju-external-hostname: foo",
+	}}}
+
+	results, err := s.api.SetConfigs(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.DeepEquals, []params.ErrorResult{{
+		Error: &params.Error{
+			Message: "parsing settings for application: unknown option \"juju-external-hostname\"",
+		},
+	}}, gc.Commentf("expected to get an error when attempting to set CAAS-specific app setting in IAAS model"))
 }
 
 func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
@@ -1777,7 +1844,8 @@ func (s *ApplicationSuite) TestSetApplicationConfigEmptyUsesMaster(c *gc.C) {
 
 func (s *ApplicationSuite) testSetApplicationConfig(c *gc.C, branchName string) {
 	application.SetModelType(s.api, state.ModelTypeCAAS)
-	result, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
+	api := &application.APIv12{s.api}
+	result, err := api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
 		Args: []params.ApplicationConfigSet{{
 			ApplicationName: "postgresql",
 			Config: map[string]string{
@@ -1790,17 +1858,20 @@ func (s *ApplicationSuite) testSetApplicationConfig(c *gc.C, branchName string) 
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "Application")
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "UpdateApplicationConfig", "Charm", "UpdateCharmConfig")
+	app.CheckCallNames(c, "Charm", "Name", "UpdateCharmConfig", "UpdateApplicationConfig")
 
-	schema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	appCfgSchema, err := caas.ConfigSchema(k8s.ConfigSchema())
 	c.Assert(err, jc.ErrorIsNil)
 	defaults := caas.ConfigDefaults(k8s.ConfigDefaults())
-	schema, defaults, err = application.AddTrustSchemaAndDefaults(schema, defaults)
+	appCfgSchema, defaults, err = application.AddTrustSchemaAndDefaults(appCfgSchema, defaults)
 	c.Assert(err, jc.ErrorIsNil)
 
-	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
+	appCfg, err := coreapplication.NewConfig(map[string]interface{}{
 		"juju-external-hostname": "value",
-	}, []string(nil), schema, defaults)
+	}, appCfgSchema, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app.CheckCall(c, 3, "UpdateApplicationConfig", appCfg.Attributes(), []string(nil), appCfgSchema, schema.Defaults(nil))
 	app.CheckCall(c, 2, "UpdateCharmConfig", model.GenerationMaster, charm.Settings{"stringOption": "stringVal"})
 
 	// We should never have accessed the generation.
@@ -1809,7 +1880,8 @@ func (s *ApplicationSuite) testSetApplicationConfig(c *gc.C, branchName string) 
 
 func (s *ApplicationSuite) TestSetApplicationConfigBranch(c *gc.C) {
 	application.SetModelType(s.api, state.ModelTypeCAAS)
-	result, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
+	api := &application.APIv12{s.api}
+	result, err := api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
 		Args: []params.ApplicationConfigSet{{
 			ApplicationName: "postgresql",
 			Config: map[string]string{
@@ -1822,17 +1894,54 @@ func (s *ApplicationSuite) TestSetApplicationConfigBranch(c *gc.C) {
 	c.Assert(result.OneError(), jc.ErrorIsNil)
 	s.backend.CheckCallNames(c, "Application")
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "UpdateApplicationConfig", "Charm", "UpdateCharmConfig")
+	app.CheckCallNames(c, "Charm", "Name", "UpdateCharmConfig", "UpdateApplicationConfig", "Name")
 
-	schema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	appCfgSchema, err := caas.ConfigSchema(k8s.ConfigSchema())
 	c.Assert(err, jc.ErrorIsNil)
 	defaults := caas.ConfigDefaults(k8s.ConfigDefaults())
-	schema, defaults, err = application.AddTrustSchemaAndDefaults(schema, defaults)
+	appCfgSchema, defaults, err = application.AddTrustSchemaAndDefaults(appCfgSchema, defaults)
 	c.Assert(err, jc.ErrorIsNil)
 
-	app.CheckCall(c, 0, "UpdateApplicationConfig", coreapplication.ConfigAttributes{
+	appCfg, err := coreapplication.NewConfig(map[string]interface{}{
 		"juju-external-hostname": "value",
-	}, []string(nil), schema, defaults)
+	}, appCfgSchema, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app.CheckCall(c, 3, "UpdateApplicationConfig", appCfg.Attributes(), []string(nil), appCfgSchema, schema.Defaults(nil))
+	app.CheckCall(c, 2, "UpdateCharmConfig", "new-branch", charm.Settings{"stringOption": "stringVal"})
+
+	s.backend.generation.CheckCall(c, 0, "AssignApplication", "postgresql")
+}
+
+func (s *ApplicationSuite) TestSetConfigBranch(c *gc.C) {
+	application.SetModelType(s.api, state.ModelTypeCAAS)
+	result, err := s.api.SetConfigs(params.ConfigSetArgs{
+		Args: []params.ConfigSet{{
+			ApplicationName: "postgresql",
+			Config: map[string]string{
+				"juju-external-hostname": "value",
+				"stringOption":           "stringVal",
+			},
+			Generation: "new-branch",
+		}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.OneError(), jc.ErrorIsNil)
+	s.backend.CheckCallNames(c, "Application")
+	app := s.backend.applications["postgresql"]
+	app.CheckCallNames(c, "Charm", "Name", "UpdateCharmConfig", "UpdateApplicationConfig", "Name")
+
+	appCfgSchema, err := caas.ConfigSchema(k8s.ConfigSchema())
+	c.Assert(err, jc.ErrorIsNil)
+	defaults := caas.ConfigDefaults(k8s.ConfigDefaults())
+	appCfgSchema, defaults, err = application.AddTrustSchemaAndDefaults(appCfgSchema, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	appCfg, err := coreapplication.NewConfig(map[string]interface{}{
+		"juju-external-hostname": "value",
+	}, appCfgSchema, defaults)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app.CheckCall(c, 3, "UpdateApplicationConfig", appCfg.Attributes(), []string(nil), appCfgSchema, schema.Defaults(nil))
 	app.CheckCall(c, 2, "UpdateCharmConfig", "new-branch", charm.Settings{"stringOption": "stringVal"})
 
 	s.backend.generation.CheckCall(c, 0, "AssignApplication", "postgresql")
@@ -1840,7 +1949,8 @@ func (s *ApplicationSuite) TestSetApplicationConfigBranch(c *gc.C) {
 
 func (s *ApplicationSuite) TestBlockSetApplicationConfig(c *gc.C) {
 	s.blockChecker.SetErrors(errors.New("blocked"))
-	_, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{})
+	api := &application.APIv12{s.api}
+	_, err := api.SetApplicationsConfig(params.ApplicationConfigSetArgs{})
 	c.Assert(err, gc.ErrorMatches, "blocked")
 	s.blockChecker.CheckCallNames(c, "ChangeAllowed")
 	s.relation.CheckNoCalls(c)
@@ -1848,7 +1958,8 @@ func (s *ApplicationSuite) TestBlockSetApplicationConfig(c *gc.C) {
 
 func (s *ApplicationSuite) TestSetApplicationConfigPermissionDenied(c *gc.C) {
 	s.setAPIUser(c, names.NewUserTag("fred"))
-	_, err := s.api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
+	api := &application.APIv12{s.api}
+	_, err := api.SetApplicationsConfig(params.ApplicationConfigSetArgs{
 		Args: []params.ApplicationConfigSet{{
 			ApplicationName: "postgresql",
 		}}})

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -106,10 +106,6 @@ func (s *permSuite) TestOperationPerm(c *gc.C) {
 		op:    opClientServiceUnexpose,
 		allow: []names.Tag{userAdmin, userOther},
 	}, {
-		about: "Application.Update",
-		op:    opClientServiceUpdate,
-		allow: []names.Tag{userAdmin, userOther},
-	}, {
 		about: "Application.SetCharm",
 		op:    opClientServiceSetCharm,
 		allow: []names.Tag{userAdmin, userOther},
@@ -322,21 +318,6 @@ func opClientSetAnnotations(c *gc.C, st api.Connection, mst *state.State) (func(
 		_, err := annotations.NewClient(st).Set(setParams)
 		c.Assert(err, jc.ErrorIsNil)
 	}, nil
-}
-
-func opClientServiceUpdate(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
-	args := params.ApplicationUpdate{
-		ApplicationName: "no-such-charm",
-		CharmURL:        "cs:quantal/wordpress-42",
-		ForceCharmURL:   true,
-		SettingsStrings: map[string]string{"blog-title": "foo"},
-		SettingsYAML:    `"wordpress": {"blog-title": "foo"}`,
-	}
-	err := application.NewClient(st).Update(args)
-	if params.IsCodeNotFound(err) {
-		err = nil
-	}
-	return func() {}, err
 }
 
 func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func(), error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2267,18 +2267,6 @@
                     },
                     "description": "Set implements the server side of Application.Set.\nIt does not unset values that are set to an empty string.\nUnset should be used for that."
                 },
-                "SetApplicationsConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/ApplicationConfigSetArgs"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ErrorResults"
-                        }
-                    },
-                    "description": "SetApplicationsConfig implements the server side of Application.SetApplicationsConfig.\nIt does not unset values that are set to an empty string.\nUnset should be used for that."
-                },
                 "SetCharm": {
                     "type": "object",
                     "properties": {
@@ -2287,6 +2275,18 @@
                         }
                     },
                     "description": "SetCharm sets the charm for a given for the application."
+                },
+                "SetConfigs": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ConfigSetArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetConfig implements the server side of Application.SetConfig.  Both\napplication and charm config are set. It does not unset values in\nConfig map that are set to an empty string. Unset should be used for that."
                 },
                 "SetConstraints": {
                     "type": "object",
@@ -2362,15 +2362,6 @@
                         }
                     },
                     "description": "UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig."
-                },
-                "Update": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/ApplicationUpdate"
-                        }
-                    },
-                    "description": "Update updates the application attributes, including charm URL,\nminimum number of units, charm config and constraints.\nAll parameters in params.ApplicationUpdate except the application name are optional."
                 },
                 "UpdateApplicationSeries": {
                     "type": "object",
@@ -2496,46 +2487,6 @@
                     "additionalProperties": false,
                     "required": [
                         "charm-relations"
-                    ]
-                },
-                "ApplicationConfigSet": {
-                    "type": "object",
-                    "properties": {
-                        "application": {
-                            "type": "string"
-                        },
-                        "config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "generation": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "application",
-                        "generation",
-                        "config"
-                    ]
-                },
-                "ApplicationConfigSetArgs": {
-                    "type": "object",
-                    "properties": {
-                        "Args": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ApplicationConfigSet"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "Args"
                     ]
                 },
                 "ApplicationConfigUnsetArgs": {
@@ -3158,56 +3109,6 @@
                         "options"
                     ]
                 },
-                "ApplicationUpdate": {
-                    "type": "object",
-                    "properties": {
-                        "application": {
-                            "type": "string"
-                        },
-                        "charm-url": {
-                            "type": "string"
-                        },
-                        "constraints": {
-                            "$ref": "#/definitions/Value"
-                        },
-                        "force": {
-                            "type": "boolean"
-                        },
-                        "force-charm-url": {
-                            "type": "boolean"
-                        },
-                        "force-series": {
-                            "type": "boolean"
-                        },
-                        "generation": {
-                            "type": "string"
-                        },
-                        "min-units": {
-                            "type": "integer"
-                        },
-                        "settings": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "settings-yaml": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "application",
-                        "charm-url",
-                        "force-charm-url",
-                        "force-series",
-                        "force",
-                        "settings-yaml",
-                        "generation"
-                    ]
-                },
                 "ApplicationsDeploy": {
                     "type": "object",
                     "properties": {
@@ -3321,6 +3222,50 @@
                     "additionalProperties": false,
                     "required": [
                         "config"
+                    ]
+                },
+                "ConfigSet": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "config-yaml": {
+                            "type": "string"
+                        },
+                        "generation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "generation",
+                        "config",
+                        "config-yaml"
+                    ]
+                },
+                "ConfigSetArgs": {
+                    "type": "object",
+                    "properties": {
+                        "Args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConfigSet"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Args"
                     ]
                 },
                 "Constraints": {

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -325,7 +325,7 @@ type ApplicationGetResults struct {
 	EndpointBindings  map[string]string      `json:"endpoint-bindings,omitempty"`
 }
 
-// ApplicationConfigSetArgs holds the parameters for
+// ApplicationConfigSetArgsV12 holds the parameters for
 // setting application config values for specified applications.
 type ApplicationConfigSetArgs struct {
 	Args []ApplicationConfigSet
@@ -341,6 +341,25 @@ type ApplicationConfigSet struct {
 	Generation string `json:"generation"`
 
 	Config map[string]string `json:"config"`
+}
+
+// ConfigSetArgs holds the parameters for setting application and
+// charm config values for specified applications.
+type ConfigSetArgs struct {
+	Args []ConfigSet
+}
+
+// ConfigSet holds the parameters for an application and charm
+// config set command.
+type ConfigSet struct {
+	ApplicationName string `json:"application"`
+
+	// Generation is the generation version that this request
+	// will set application configuration for.
+	Generation string `json:"generation"`
+
+	Config     map[string]string `json:"config"`
+	ConfigYAML string            `json:"config-yaml"`
 }
 
 // ApplicationConfigUnsetArgs holds the parameters for

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -135,9 +135,8 @@ type applicationAPI interface {
 	Set(application string, options map[string]string) error
 	Unset(application string, options []string) error
 	BestAPIVersion() int
-
-	// These methods are on API V6.
 	SetApplicationConfig(branchName string, application string, config map[string]string) error
+	SetConfig(branchName string, application, configYAML string, config map[string]string) error
 	UnsetApplicationConfig(branchName string, application string, options []string) error
 }
 
@@ -359,18 +358,57 @@ func (c *configCommand) resetConfig(client applicationAPI, ctx *cmd.Context) err
 // setConfig is the run action when we are setting new attribute values as args
 // or as a file passed in.
 func (c *configCommand) setConfig(client applicationAPI, ctx *cmd.Context) error {
-	if c.useFile {
-		return c.setConfigFromFile(client, ctx)
-	}
-
-	settings, err := c.validateValues(ctx)
+	settingsYAML, err := c.configYAMLFromFile(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
+	settings, err := c.configMapFromKV(client, ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Note: this is a bit of a mess based on facade versions.  Trying
+	// to consolidate to 1 method for setting application and charm config.
+	// Investigating simplifying with future versions of juju.
+	switch ver := client.BestAPIVersion(); {
+	case ver < 6:
+		if settingsYAML != "" {
+			err = c.callUpdate(client, settingsYAML)
+			break
+		}
+		err = client.Set(c.applicationName, settings)
+	case ver < 12:
+		if settingsYAML != "" {
+			err = c.callUpdate(client, settingsYAML)
+			break
+		}
+		err = client.SetApplicationConfig(c.branchName, c.applicationName, settings)
+	default:
+		err = client.SetConfig(c.branchName, c.applicationName, settingsYAML, settings)
+	}
+	return errors.Trace(block.ProcessBlockedError(err, block.BlockChange))
+}
+
+func (c *configCommand) callUpdate(client applicationAPI, settingsYAML string) error {
+	return client.Update(
+		params.ApplicationUpdate{
+			ApplicationName: c.applicationName,
+			SettingsYAML:    settingsYAML,
+			Generation:      c.branchName,
+		},
+	)
+}
+
+func (c *configCommand) configMapFromKV(client applicationAPI, ctx *cmd.Context) (map[string]string, error) {
+	settings, err := c.validateValues(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	result, err := client.Get(c.branchName, c.applicationName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for k, v := range settings {
@@ -384,18 +422,15 @@ func (c *configCommand) setConfig(client applicationAPI, ctx *cmd.Context) error
 			}
 		}
 	}
-
-	if client.BestAPIVersion() < 6 {
-		err = client.Set(c.applicationName, settings)
-	} else {
-		err = client.SetApplicationConfig(c.branchName, c.applicationName, settings)
-	}
-	return block.ProcessBlockedError(err, block.BlockChange)
+	return settings, nil
 }
 
-// setConfigFromFile sets the application configuration from settings passed
+// configYAMLFromFile sets the application and charm configuration from settings passed
 // in a YAML file.
-func (c *configCommand) setConfigFromFile(client applicationAPI, ctx *cmd.Context) error {
+func (c *configCommand) configYAMLFromFile(ctx *cmd.Context) (string, error) {
+	if !c.useFile {
+		return "", nil
+	}
 	var (
 		b   []byte
 		err error
@@ -403,23 +438,17 @@ func (c *configCommand) setConfigFromFile(client applicationAPI, ctx *cmd.Contex
 	if c.configFile.Path == "-" {
 		buf := bytes.Buffer{}
 		if _, err := buf.ReadFrom(ctx.Stdin); err != nil {
-			return errors.Trace(err)
+			return "", errors.Trace(err)
 		}
 		b = buf.Bytes()
 	} else {
 		b, err = c.configFile.Read(ctx)
 		if err != nil {
-			return errors.Trace(err)
+			return "", errors.Trace(err)
 		}
 	}
-	return errors.Trace(block.ProcessBlockedError(
-		client.Update(
-			params.ApplicationUpdate{
-				ApplicationName: c.applicationName,
-				SettingsYAML:    string(b),
-				Generation:      c.branchName,
-			},
-		), block.BlockChange))
+
+	return string(b), nil
 }
 
 // getConfig is the run action to return one or all configuration values.

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1037,7 +1037,7 @@ func (h *bundleHandler) setOptions(change *bundlechanges.SetOptionsChange) error
 		return errors.Annotatef(err, "cannot marshal options for application %q", p.Application)
 	}
 
-	if h.deployAPI.BestFacadeVersion("application") > 12 {
+	if h.deployAPI.BestFacadeVersion("Application") > 12 {
 		err = h.deployAPI.SetConfig(model.GenerationMaster, p.Application, string(cfg), nil)
 	} else {
 		err = h.deployAPI.Update(params.ApplicationUpdate{

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1037,15 +1037,16 @@ func (h *bundleHandler) setOptions(change *bundlechanges.SetOptionsChange) error
 		return errors.Annotatef(err, "cannot marshal options for application %q", p.Application)
 	}
 
-	if err := h.deployAPI.Update(params.ApplicationUpdate{
-		ApplicationName: p.Application,
-		SettingsYAML:    string(cfg),
-		Generation:      model.GenerationMaster,
-	}); err != nil {
-		return errors.Annotatef(err, "cannot update options for application %q", p.Application)
+	if h.deployAPI.BestFacadeVersion("application") > 12 {
+		err = h.deployAPI.SetConfig(model.GenerationMaster, p.Application, string(cfg), nil)
+	} else {
+		err = h.deployAPI.Update(params.ApplicationUpdate{
+			ApplicationName: p.Application,
+			SettingsYAML:    string(cfg),
+			Generation:      model.GenerationMaster,
+		})
 	}
-
-	return nil
+	return errors.Annotatef(err, "cannot update options for application %q", p.Application)
 }
 
 // setConstraints updates application constraints.

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -124,7 +124,11 @@ type ApplicationAPI interface {
 	SetAnnotation(annotations map[string]map[string]string) ([]apiparams.ErrorResult, error)
 	SetCharm(string, application.SetCharmConfig) error
 	SetConstraints(application string, constraints constraints.Value) error
+
+	// Deprecate use of Update, use SetConfig instead.
 	Update(apiparams.ApplicationUpdate) error
+	SetConfig(branchName string, application, configYAML string, config map[string]string) error
+
 	ScaleApplication(application.ScaleApplicationParams) (apiparams.ScaleApplicationResult, error)
 	Consume(arg crossmodel.ConsumeApplicationArgs) (string, error)
 }

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -517,6 +517,20 @@ func (mr *MockDeployerAPIMockRecorder) SetCharm(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharm", reflect.TypeOf((*MockDeployerAPI)(nil).SetCharm), arg0, arg1)
 }
 
+// SetConfig mocks base method
+func (m *MockDeployerAPI) SetConfig(arg0, arg1, arg2 string, arg3 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetConfig indicates an expected call of SetConfig
+func (mr *MockDeployerAPIMockRecorder) SetConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockDeployerAPI)(nil).SetConfig), arg0, arg1, arg2, arg3)
+}
+
 // SetConstraints mocks base method
 func (m *MockDeployerAPI) SetConstraints(arg0 string, arg1 constraints.Value) error {
 	m.ctrl.T.Helper()

--- a/cmd/juju/application/fakeapplication_test.go
+++ b/cmd/juju/application/fakeapplication_test.go
@@ -111,6 +111,22 @@ func (f *fakeApplicationAPI) SetApplicationConfig(branchName, application string
 	return f.Set(application, config)
 }
 
+func (f *fakeApplicationAPI) SetConfig(branchName, application, configYAML string, config map[string]string) error {
+	if branchName != f.branchName {
+		return errors.Errorf("expected branch %q, got %q", f.branchName, branchName)
+	}
+	if f.err != nil {
+		return f.err
+	}
+
+	if application != f.name {
+		return errors.NotFoundf("application %q", application)
+	}
+
+	f.config = configYAML
+	return f.Set(application, config)
+}
+
 func (f *fakeApplicationAPI) Unset(application string, options []string) error {
 	if f.err != nil {
 		return f.err


### PR DESCRIPTION

## Description of change

Update in the application facade is problematic for the CharmHub integration has it allows another way a charm to be upgraded.  Update is only used by the juju client to update charm and application config.  Its full capabilities appear to be a duplicate of SetCharm. A full duplicate of which is no longer required. Changing to only be part of the application facade prior to version 13.  Setting a charm-url via Update is now unsupported.

We update charm and application config with 1 api call if given key value pairs on the cli, and a 2nd way when deploying bundles and when a file is provided on the cli, a third way when deploying charms or upgrading them.  Too confusing.  Consolidating the first 2 ways into 1 from here forward.   The prior methods are left for client compatibility with older versions of juju.

## QA steps

There should be no change to current behavior.  Test client with old versions of juju.  Test old clients with new juju controller.

Deploy bundles with config and use the juju config command.

