### PR TITLE
Add openstack support for the allocate-public-ip constraint

### DIFF
--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -17,6 +17,7 @@ var unsupportedConstraints = []string{
 	constraints.Arch,
 	constraints.InstanceType,
 	constraints.Spaces,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/caas/kubernetes/provider/precheck.go
+++ b/caas/kubernetes/provider/precheck.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 )

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -843,6 +843,14 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		return errors.Trace(err)
 	}
 	logger.Infof("combined bootstrap constraints: %v", bootstrapParams.BootstrapConstraints)
+	unsupported, err := constraintsValidator.Validate(bootstrapParams.BootstrapConstraints)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(unsupported) > 0 {
+		logger.Warningf(
+			"unsupported constraints: %v", strings.Join(unsupported, ","))
+	}
 
 	bootstrapParams.ModelConstraints = c.Constraints
 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -780,23 +780,23 @@ func (s *BootstrapSuite) TestBootstrapAttributesInheritedOverDefaults(c *gc.C) {
 	bootstrapCmd := bootstrapCommand{}
 	ctx := cmdtesting.Context(c)
 
-	// The OpenStack provider has a default of "use-floating-ip": false, so we
+	// The OpenStack provider has a default of "use-default-secgroup": false, so we
 	// use that to test against.
 	env := &openstack.Environ{}
 	provider := env.Provider()
 
-	// First test that use-floating-ip defaults to false
+	// First test that use-default-secgroup defaults to false
 	testCloud, err := cloud.CloudByName("dummy-cloud")
 	c.Assert(err, jc.ErrorIsNil)
 
-	key := "use-floating-ip"
+	key := "use-default-secgroup"
 	checkConfigs(c, bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
 		"bootstrapModelConfig":     {key: false},
 		"inheritedControllerAttrs": {},
 		"userConfigAttrs":          {},
 	})
 
-	// Second test that use-floating-ip in the cloud config overwrites the
+	// Second test that use-default-secgroup in the cloud config overwrites the
 	// provider default of false with true
 	testCloud, err = cloud.CloudByName("dummy-cloud-with-config")
 	c.Assert(err, jc.ErrorIsNil)
@@ -865,25 +865,25 @@ func (s *BootstrapSuite) TestBootstrapAttributesCLIOverDefaults(c *gc.C) {
 
 	ctx := cmdtesting.Context(c)
 
-	// The OpenStack provider has a default of "use-floating-ip": false, so we
+	// The OpenStack provider has a default of "use-default-secgroup": false, so we
 	// use that to test against.
 	env := &openstack.Environ{}
 	provider := env.Provider()
 
-	// First test that use-floating-ip defaults to false
+	// First test that use-default-secgroup defaults to false
 	testCloud, err := cloud.CloudByName("dummy-cloud")
 	c.Assert(err, jc.ErrorIsNil)
 
-	key := "use-floating-ip"
+	key := "use-default-secgroup"
 	checkConfigs(c, s.bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
 		"bootstrapModelConfig":     {key: false},
 		"inheritedControllerAttrs": {},
 		"userConfigAttrs":          {},
 	})
 
-	// Second test that use-floating-ip passed on the command line overwrites the
+	// Second test that use-default-secgroup passed on the command line overwrites the
 	// provider default of false with true
-	s.bootstrapCmd.config.Set("use-floating-ip=true")
+	s.bootstrapCmd.config.Set("use-default-secgroup=true")
 	checkConfigs(c, s.bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
 		"bootstrapModelConfig":     {key: true},
 		"inheritedControllerAttrs": {},
@@ -899,27 +899,27 @@ func (s *BootstrapSuite) TestBootstrapAttributesCLIOverInherited(c *gc.C) {
 
 	ctx := cmdtesting.Context(c)
 
-	// The OpenStack provider has a default of "use-floating-ip": false, so we
+	// The OpenStack provider has a default of "use-default-secgroup": false, so we
 	// use that to test against.
 	env := &openstack.Environ{}
 	provider := env.Provider()
 
-	// First test that use-floating-ip defaults to false
+	// First test that use-default-secgroup defaults to false
 	testCloud, err := cloud.CloudByName("dummy-cloud")
 	c.Assert(err, jc.ErrorIsNil)
 
-	key := "use-floating-ip"
+	key := "use-default-secgroup"
 	checkConfigs(c, s.bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
 		"bootstrapModelConfig":     {key: false},
 		"inheritedControllerAttrs": {},
 		"userConfigAttrs":          {},
 	})
 
-	// Second test that use-floating-ip passed on the command line overwrites the
+	// Second test that use-default-secgroup passed on the command line overwrites the
 	// inherited attribute
 	testCloud, err = cloud.CloudByName("dummy-cloud-with-config")
 	c.Assert(err, jc.ErrorIsNil)
-	s.bootstrapCmd.config.Set("use-floating-ip=false")
+	s.bootstrapCmd.config.Set("use-default-secgroup=false")
 	checkConfigs(c, s.bootstrapCmd, key, ctx, testCloud, provider, map[string]map[string]interface{}{
 		"bootstrapModelConfig":     {key: false},
 		"inheritedControllerAttrs": {key: true},
@@ -2209,7 +2209,7 @@ clouds:
         config:
             broken: Bootstrap
             controller: not-a-bool
-            use-floating-ip: true
+            use-default-secgroup: true
     many-credentials-no-auth-types:
         type: many-credentials
 `[1:]), 0644)

--- a/provider/cloudsigma/environcaps.go
+++ b/provider/cloudsigma/environcaps.go
@@ -13,6 +13,7 @@ var unsupportedConstraints = []string{
 	constraints.InstanceType,
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator returns a Validator instance which

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -171,6 +171,7 @@ var unsupportedConstraints = []string{
 	// TODO(anastasiamac 2016-03-16) LP#1557874
 	// use virt-type in StartInstances
 	constraints.VirtType,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -34,6 +34,7 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.AllocatePublicIP,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -23,6 +23,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
 	constraints.Container,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/schema"
 	"github.com/juju/utils"
 	"gopkg.in/juju/environschema.v1"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/container/lxd"

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -21,6 +21,7 @@ var unsupportedConstraints = []string{
 	constraints.CpuPower,
 	constraints.InstanceType,
 	constraints.VirtType,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -332,6 +332,7 @@ var unsupportedConstraints = []string{
 	constraints.InstanceType,
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -332,6 +332,7 @@ func (e *Environ) ConstraintsValidator(ctx envcontext.ProviderCallContext) (cons
 		constraints.Container,
 		constraints.VirtType,
 		constraints.Tags,
+		constraints.AllocatePublicIP,
 	}
 
 	validator := constraints.NewValidator()

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -399,6 +399,14 @@ func (s *localServerSuite) TestBootstrapFailsWhenPublicIPError(c *gc.C) {
 }
 
 func (s *localServerSuite) TestAddressesWithPublicIP(c *gc.C) {
+	s.assertAddressesWithPublicIP(c, constraints.Value{}, true)
+}
+
+func (s *localServerSuite) TestAddressesWithPublicIPConstraintsOverride(c *gc.C) {
+	s.assertAddressesWithPublicIP(c, constraints.MustParse("allocate-public-ip=true"), false)
+}
+
+func (s *localServerSuite) assertAddressesWithPublicIP(c *gc.C, cons constraints.Value, useFloatingIP bool) {
 	// Floating IP address is 10.0.0.1
 	bootstrapFinished := false
 	s.PatchValue(&common.FinishBootstrap, func(
@@ -425,14 +433,22 @@ func (s *localServerSuite) TestAddressesWithPublicIP(c *gc.C) {
 
 	env := s.openEnviron(c, coretesting.Attrs{
 		"network":         "private_999",
-		"use-floating-ip": true,
+		"use-floating-ip": useFloatingIP,
 	})
-	err := bootstrapEnv(c, env)
+	err := bootstrapEnvWithConstraints(c, env, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrapFinished, jc.IsTrue)
 }
 
 func (s *localServerSuite) TestAddressesWithoutPublicIP(c *gc.C) {
+	s.assertAddressesWithoutPublicIP(c, constraints.Value{}, false)
+}
+
+func (s *localServerSuite) TestAddressesWithoutPublicIPConstraintsOverride(c *gc.C) {
+	s.assertAddressesWithoutPublicIP(c, constraints.MustParse("allocate-public-ip=false"), true)
+}
+
+func (s *localServerSuite) assertAddressesWithoutPublicIP(c *gc.C, cons constraints.Value, useFloatingIP bool) {
 	bootstrapFinished := false
 	s.PatchValue(&common.FinishBootstrap, func(
 		ctx environs.BootstrapContext,
@@ -455,8 +471,8 @@ func (s *localServerSuite) TestAddressesWithoutPublicIP(c *gc.C) {
 		return nil
 	})
 
-	env := s.openEnviron(c, coretesting.Attrs{"use-floating-ip": false})
-	err := bootstrapEnv(c, env)
+	env := s.openEnviron(c, coretesting.Attrs{"use-floating-ip": useFloatingIP})
+	err := bootstrapEnvWithConstraints(c, env, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(bootstrapFinished, jc.IsTrue)
 }
@@ -3144,8 +3160,11 @@ func newNovaNetworkingOpenstackService(cred *identity.Credentials, auth identity
 	service.SetupHTTP(nil)
 	return service, logMsg
 }
-
 func bootstrapEnv(c *gc.C, env environs.Environ) error {
+	return bootstrapEnvWithConstraints(c, env, constraints.Value{})
+}
+
+func bootstrapEnvWithConstraints(c *gc.C, env environs.Environ, cons constraints.Value) error {
 	return bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
 		context.NewCloudCallContext(),
 		bootstrap.BootstrapParams{
@@ -3153,5 +3172,6 @@ func bootstrapEnv(c *gc.C, env environs.Environ) error {
 			AdminSecret:              testing.AdminSecret,
 			CAPrivateKey:             coretesting.CAKey,
 			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			BootstrapConstraints:     cons,
 		})
 }

--- a/provider/openstack/provider_configurator.go
+++ b/provider/openstack/provider_configurator.go
@@ -42,7 +42,7 @@ func (c *defaultConfigurator) GetCloudConfig(args environs.StartInstanceParams) 
 // GetConfigDefaults implements ProviderConfigurator interface.
 func (c *defaultConfigurator) GetConfigDefaults() schema.Defaults {
 	return schema.Defaults{
-		"use-floating-ip":      false,
+		"use-floating-ip":      schema.Omit,
 		"use-default-secgroup": false,
 		"network":              "",
 		"external-network":     "",

--- a/provider/oracle/environ.go
+++ b/provider/oracle/environ.go
@@ -662,6 +662,7 @@ func (o *OracleEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (c
 		constraints.CpuPower,
 		constraints.RootDisk,
 		constraints.VirtType,
+		constraints.AllocatePublicIP,
 	}
 
 	// we choose to use the default validator implementation

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -76,6 +76,7 @@ func (env *sessionEnviron) checkDatastore(ctx context.ProviderCallContext, datas
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.AllocatePublicIP,
 }
 
 // ConstraintsValidator returns a Validator value which is used to


### PR DESCRIPTION
## Description of change

The openstack provider supports the allocate-public-ip constraint.
The now deprecated use-floating-ip model config is still supported, but if the new constraint is specified, that take precedence.
With this new constraint, we can now provision openstack machines with/without public IP as needed, rather than having to have a global, model wide setting for all machines.

The openstack provider used to use the value of use-floating-ip to determine whether any public IP addresses should be queried when getting instances. This is no longer possible since it can't be known on a per machine basis at the time of query whether to do that or not, especially when AllInstances() is called. So now we always attempt to fetch any public IP address for each instance.

The other providers which don't yet support this constraint have had it added to the unsupported list. Sadly, we don't surface this to the user if they try and deploy an app or add a machine; we just log a WARNING on the controller. ie unsupported constraints are not considered an error. For bootstrap, we actually have the constraint validator to use so I've added a WARNING there which the user sees written to their terminal when bootstrapping. But it will require invasive API changes to surface anything to the user when deploying or adding a machine.

## QA steps

juju bootstrap lxd --bootstrap-constraints="allocate-public-ip=true"
Creating Juju controller "ian3" on lxd/localhost
WARNING unsupported constraints: allocate-public-ip
...

juju bootstrap microstack --config use-floating-ip=true
WARNING Config attribute "use-floating-ip" is deprecated.
You can instead use the constraint "allocate-public-ip".
,,,

juju bootstrap microstack --bootstrap-constraints="allocate-public-ip=true"
...

In both cases confirm that a floating ip is used.