### PR TITLE
Fix HardwareCharacteristic.Clone() when strings have spaces in them

### DIFF
--- a/core/instance/hardwarecharacteristics.go
+++ b/core/instance/hardwarecharacteristics.go
@@ -74,7 +74,12 @@ func (hc *HardwareCharacteristics) Clone() *HardwareCharacteristics {
 	if hc == nil {
 		return nil
 	}
-	clone := MustParseHardware(hc.String())
+	clone := *hc
+	if hc.Tags != nil {
+		tags := make([]string, len(*hc.Tags))
+		copy(tags, *hc.Tags)
+		clone.Tags = &tags
+	}
 	return &clone
 }
 

--- a/core/instance/hardwarecharacteristics_test.go
+++ b/core/instance/hardwarecharacteristics_test.go
@@ -302,3 +302,21 @@ func (s HardwareSuite) TestClone(c *gc.C) {
 	hc2 := hc.Clone()
 	c.Assert(hc, jc.DeepEquals, *hc2)
 }
+
+// Regression test for https://bugs.launchpad.net/juju/+bug/1895756
+func (s HardwareSuite) TestCloneSpace(c *gc.C) {
+	az := "a -"
+	hc := &instance.HardwareCharacteristics{AvailabilityZone: &az}
+	clone := hc.Clone()
+	c.Assert(hc, jc.DeepEquals, clone)
+}
+
+// Ensure fields like the Tags slice are deep-copied
+func (s HardwareSuite) TestCloneDeep(c *gc.C) {
+	tags := []string{"a"}
+	hc := &instance.HardwareCharacteristics{Tags: &tags}
+	clone := hc.Clone()
+	c.Assert(hc, jc.DeepEquals, clone)
+	tags[0] = "z"
+	c.Assert((*clone.Tags)[0], gc.Equals, "a")
+}


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

## Description of change

The .Clone() method currently clones by round-tripping via .String() and then re-parsing using MustParseHardware(), but this panics if any of the string fields in HardwareCharacteristic contain a space.

I've fixed by cloning the object directly, and added test cases to cover this.

NOTE: it's possible we don't support spaces in some of these fields in other parts of the codebase, but this will at least fix the panic, and probably fix this issue.

## QA steps

See https://bugs.launchpad.net/juju/+bug/1895756 -- you can create a storage device name with a space in it like `Foo - Bar` and then a bootstrap should fail as per the bug. With this fix it should succeed.

## Documentation changes

N/A

## Bug reference

Fixes: https://bugs.launchpad.net/juju/+bug/1895756
