### PR TITLE
Add Priority and PriorityClassName to podspce v2 and v3;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2490,6 +2490,8 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 				spec.Pod.DNSPolicy = k8sResources.Pod.DNSPolicy
 				spec.Pod.HostNetwork = k8sResources.Pod.HostNetwork
 				spec.Pod.HostPID = k8sResources.Pod.HostPID
+				spec.Pod.PriorityClassName = k8sResources.Pod.PriorityClassName
+				spec.Pod.Priority = k8sResources.Pod.Priority
 			}
 			spec.ServiceAccounts = append(spec.ServiceAccounts, &k8sResources.K8sRBACResources)
 		}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -150,9 +150,11 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 				ReadinessGates: []core.PodReadinessGate{
 					{ConditionType: core.PodInitialized},
 				},
-				DNSPolicy:   core.DNSClusterFirst,
-				HostNetwork: true,
-				HostPID:     true,
+				DNSPolicy:         core.DNSClusterFirst,
+				HostNetwork:       true,
+				HostPID:           true,
+				PriorityClassName: "system-cluster-critical",
+				Priority:          int32Ptr(2000000000),
 			},
 		},
 	}
@@ -201,6 +203,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 			DNSPolicy:                    core.DNSClusterFirst,
 			HostNetwork:                  true,
 			HostPID:                      true,
+			PriorityClassName:            "system-cluster-critical",
+			Priority:                     int32Ptr(2000000000),
 			ServiceAccountName:           "app-name",
 			AutomountServiceAccountToken: boolPtr(true),
 			InitContainers:               initContainers(),

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -99,6 +99,8 @@ type PodSpec struct {
 	DNSPolicy                     core.DNSPolicy           `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
 	HostNetwork                   bool                     `json:"hostNetwork,omitempty" yaml:"hostNetwork,omitempty"`
 	HostPID                       bool                     `json:"hostPID,omitempty" yaml:"hostPID,omitempty"`
+	PriorityClassName             string                   `json:"priorityClassName,omitempty"`
+	Priority                      *int32                   `json:"priority,omitempty"`
 }
 
 // IsEmpty checks if PodSpec is empty or not.

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -176,6 +176,9 @@ kubernetesResources:
       - conditionType: PodScheduled
     dnsPolicy: ClusterFirstWithHostNet
     hostNetwork: true
+    hostPID: true
+    priorityClassName: system-cluster-critical
+    priority: 2000000000
   secrets:
     - name: build-robot-secret
       type: Opaque
@@ -624,8 +627,11 @@ echo "do some stuff here for gitlab-init container"
 					ReadinessGates: []core.PodReadinessGate{
 						{ConditionType: core.PodScheduled},
 					},
-					DNSPolicy:   "ClusterFirstWithHostNet",
-					HostNetwork: true,
+					DNSPolicy:         "ClusterFirstWithHostNet",
+					HostNetwork:       true,
+					HostPID:           true,
+					PriorityClassName: "system-cluster-critical",
+					Priority:          int32Ptr(2000000000),
 				},
 				Secrets: []k8sspecs.K8sSecret{
 					{

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -242,6 +242,8 @@ kubernetesResources:
     dnsPolicy: ClusterFirstWithHostNet
     hostNetwork: true
     hostPID: true
+    priorityClassName: system-cluster-critical
+    priority: 2000000000
   secrets:
     - name: build-robot-secret
       type: Opaque
@@ -812,9 +814,11 @@ echo "do some stuff here for gitlab-init container"
 					ReadinessGates: []core.PodReadinessGate{
 						{ConditionType: core.PodScheduled},
 					},
-					DNSPolicy:   "ClusterFirstWithHostNet",
-					HostNetwork: true,
-					HostPID:     true,
+					DNSPolicy:         "ClusterFirstWithHostNet",
+					HostNetwork:       true,
+					HostPID:           true,
+					PriorityClassName: "system-cluster-critical",
+					Priority:          int32Ptr(2000000000),
 				},
 				Secrets: []k8sspecs.K8sSecret{
 					{


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Add `Priority` and `PriorityClassName` to podspce v2 and v3;

Driveby: tested `updateStrategy`;

## QA steps

```console
## deploy k8s app with priority and priorityclassname set in k8s spec;
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateless",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/2  pod-spec-get | yml2json | jq '{service: .service, pod: .kubernetesResources.pod}'
{
  "service": {
    "updateStrategy": {
      "rollingUpdate": {
        "maxUnavailable": 10
      },
      "type": "RollingUpdate"
    }
  },
  "pod": {
    "priorityClassName": "system-cluster-critical",
    "priority": 2000000000
  }
}

$ mkubectl get deployment.apps/mariadb-k8s -nt1 -o json | jq '{strategy: .spec.strategy,priority: .spec.template.spec.priority,priorityClassName: .spec.template.spec.priorityClassName}'
{
  "strategy": {
    "rollingUpdate": {
      "maxSurge": "25%",
      "maxUnavailable": 10
    },
    "type": "RollingUpdate"
  },
  "priority": 2000000000,
  "priorityClassName": "system-cluster-critical"
}

```

## Documentation changes

No(this is already documented)

## Bug reference

No
