### PR TITLE
Fix Azure Subnets Implementation

### DIFF
--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -80,8 +80,9 @@ func (env *azureEnviron) allSubnets() ([]network.SubnetInfo, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	results := make([]network.SubnetInfo, len(values))
-	for i, sub := range values {
+
+	var results []network.SubnetInfo
+	for _, sub := range values {
 		id := to.String(sub.ID)
 
 		// An empty CIDR is no use to us, so guard against it.
@@ -91,10 +92,10 @@ func (env *azureEnviron) allSubnets() ([]network.SubnetInfo, error) {
 			continue
 		}
 
-		results[i] = network.SubnetInfo{
+		results = append(results, network.SubnetInfo{
 			CIDR:       cidr,
 			ProviderId: network.Id(id),
-		}
+		})
 	}
 	return results, nil
 }

--- a/provider/azure/environ_network_test.go
+++ b/provider/azure/environ_network_test.go
@@ -4,11 +4,14 @@
 package azure_test
 
 import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
 )
@@ -30,12 +33,29 @@ func (s *environSuite) TestSubnetsSuccess(c *gc.C) {
 	// in the default virtual network created for every model.
 	s.sender = azuretesting.Senders{
 		makeSender("/deployments/common", s.commonDeployment),
-		makeSender("/virtualNetworks/juju-internal-network/subnets", nil),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", network.SubnetListResult{
+			Value: &[]network.Subnet{
+				{
+					ID: to.StringPtr("provider-sub-id"),
+					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+						AddressPrefix: to.StringPtr("10.0.0.0/24"),
+					},
+				},
+				{
+					// Result without an address prefix is ignored.
+					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{},
+				},
+			},
+		}),
 	}
 
 	netEnv, ok := environs.SupportsNetworking(env)
 	c.Assert(ok, jc.IsTrue)
 
-	_, err := netEnv.Subnets(s.callCtx, instance.UnknownId, nil)
+	subs, err := netEnv.Subnets(s.callCtx, instance.UnknownId, nil)
 	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(subs, gc.HasLen, 1)
+	c.Check(subs[0].ProviderId, gc.Equals, corenetwork.Id("provider-sub-id"))
+	c.Check(subs[0].CIDR, gc.Equals, "10.0.0.0/24")
 }

--- a/provider/azure/environ_network_test.go
+++ b/provider/azure/environ_network_test.go
@@ -5,12 +5,12 @@ package azure_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/provider/azure/internal/azuretesting"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/provider/azure/internal/azuretesting"
 )
 
 func (s *environSuite) TestSubnetsInstanceIDError(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch follows #11966 and corrects the subnet results packing so that we only get records for subnets with a CIDR (`AddressPrefix`).

## QA steps

Unit test covers the case; regression can be test for with the same steps as #11966.

## Documentation changes

None.

## Bug reference

N/A
