### PR TITLE
Allow bundle rewrites

### DIFF
--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -140,7 +140,7 @@ class AssessNetworkHealth:
             self.existing_series.add(info['series'])
         for series in self.existing_series:
             try:
-                client.deploy('~juju-qa/network-health', series=series,
+                client.deploy('cs:~juju-qa/network-health', series=series,
                               alias='network-health-{}'.format(series))
 
             except subprocess.CalledProcessError:
@@ -384,7 +384,7 @@ class AssessNetworkHealth:
         for app, info in apps.items():
             if 'network-health' not in app:
                 alias = 'network-health-{}'.format(app)
-                client.deploy('~juju-qa/network-health', alias=alias,
+                client.deploy('cs:~juju-qa/network-health', alias=alias,
                               series=info['series'])
                 try:
                     client.juju('add-relation', (app, alias))

--- a/acceptancetests/repository/network-health-2-machines-bind.yaml
+++ b/acceptancetests/repository/network-health-2-machines-bind.yaml
@@ -7,7 +7,7 @@ machines:
 series: xenial
 services:
   dummy-source-a:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -15,7 +15,7 @@ services:
     to:
     - '0'
   dummy-source-b:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -25,7 +25,7 @@ services:
     bindings:
       "": space-0
   dummy-source-c:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -35,7 +35,7 @@ services:
     bindings:
       "": space-0
   dummy-sink-a:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -45,7 +45,7 @@ services:
     bindings:
       "": space-0
   dummy-sink-b:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -55,7 +55,7 @@ services:
     bindings:
       "": space-0
   dummy-sink-c:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -65,7 +65,7 @@ services:
     bindings:
       "": space-0
   dummy-subordinate:
-    charm: ~juju-qa/dummy-subordinate
+    charm: cs:~juju-qa/dummy-subordinate
     expose: false
     options:
       token: 'true'

--- a/acceptancetests/repository/network-health-2-machines-vipl.yaml
+++ b/acceptancetests/repository/network-health-2-machines-vipl.yaml
@@ -9,7 +9,7 @@ machines:
 series: bionic
 services:
   dummy-source-a:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -17,7 +17,7 @@ services:
     to:
     - '0'
   dummy-source-b:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -25,7 +25,7 @@ services:
     to:
     - lxd:0
   dummy-source-c:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -33,7 +33,7 @@ services:
     to:
     - lxd:1
   dummy-sink-a:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -41,7 +41,7 @@ services:
     to:
     - lxd:0
   dummy-sink-b:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -49,7 +49,7 @@ services:
     to:
     - '1'
   dummy-sink-c:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -57,7 +57,7 @@ services:
     to:
     - lxd:1
   dummy-subordinate:
-    charm: ~juju-qa/dummy-subordinate
+    charm: cs:~juju-qa/dummy-subordinate
     expose: false
     options:
       token: 'true'

--- a/acceptancetests/repository/network-health-2-machines.yaml
+++ b/acceptancetests/repository/network-health-2-machines.yaml
@@ -7,7 +7,7 @@ machines:
 series: bionic
 services:
   dummy-source-a:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -15,7 +15,7 @@ services:
     to:
     - '0'
   dummy-source-b:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -23,7 +23,7 @@ services:
     to:
     - lxd:0
   dummy-source-c:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -31,7 +31,7 @@ services:
     to:
     - lxd:1
   dummy-sink-a:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -39,7 +39,7 @@ services:
     to:
     - lxd:0
   dummy-sink-b:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -47,7 +47,7 @@ services:
     to:
     - '1'
   dummy-sink-c:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -55,7 +55,7 @@ services:
     to:
     - lxd:1
   dummy-subordinate:
-    charm: ~juju-qa/dummy-subordinate
+    charm: cs:~juju-qa/dummy-subordinate
     expose: false
     options:
       token: 'true'

--- a/acceptancetests/repository/network-health-3-machines.yaml
+++ b/acceptancetests/repository/network-health-3-machines.yaml
@@ -9,7 +9,7 @@ machines:
 series: bionic
 services:
   dummy-source-a:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -17,7 +17,7 @@ services:
     to:
     - '0'
   dummy-source-b:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -25,7 +25,7 @@ services:
     to:
     - lxd:0
   dummy-source-c:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -33,7 +33,7 @@ services:
     to:
     - lxd:1
   dummy-source-d:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -41,7 +41,7 @@ services:
     to:
     - '2'
   dummy-source-e:
-    charm: ~juju-qa/dummy-source
+    charm: cs:~juju-qa/dummy-source
     num_units: 1
     expose: false
     options:
@@ -49,7 +49,7 @@ services:
     to:
     - lxd:2
   dummy-sink-a:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -57,7 +57,7 @@ services:
     to:
     - lxd:0
   dummy-sink-b:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -65,7 +65,7 @@ services:
     to:
     - '1'
   dummy-sink-c:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -73,7 +73,7 @@ services:
     to:
     - lxd:1
   dummy-sink-d:
-    charm: ~juju-qa/dummy-sink
+    charm: cs:~juju-qa/dummy-sink
     num_units: 1
     expose: false
     options:
@@ -81,7 +81,7 @@ services:
     to:
     - lxd:2
   dummy-subordinate:
-    charm: ~juju-qa/dummy-subordinate
+    charm: cs:~juju-qa/dummy-subordinate
     expose: false
     options:
       token: 'true'

--- a/acceptancetests/repository/scale2-lxd.yaml
+++ b/acceptancetests/repository/scale2-lxd.yaml
@@ -14,7 +14,7 @@ services:
     num_units: 0
   haproxy:
     series: trusty
-    charm: "haproxy"
+    charm: "cs:haproxy"
     num_units: 1
     to:
       - "2"

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -106,7 +106,8 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 		if applicationSpec.Plan != "" {
 			for _, step := range d.steps {
 				s := step
-				charmURL, err := charm.ParseURL(applicationSpec.Charm)
+
+				charmURL, err := resolveCharmURL(applicationSpec.Charm)
 				if err != nil {
 					return errors.Trace(err)
 				}


### PR DESCRIPTION
## Description of change

The following ensure that we correctly resolve the charm URL in a
bundle, if the bundle contains a non-canonical URL.

For example the following is a bad bundle:

```yaml
applications:
  wordpress:
      charm: wordpress
```

Instead it should be:

```yaml
applications:
  wordpress:
      charm: cs:wordpress
```

That way we always know that the wordpress correctly comes from the
right store. The code is simple and works with the charm hub
integration.

## QA steps

Attempt to deploy a bundle without a `cs:` prefix.

```sh
juju bootstrap lxd test --no-gui
juju deploy cs:~juju-qa/bundle/bundle-in-candidate-0
```
