### PR TITLE
[dev] Remove wildcard CIDR fallback from firewall worker

### DIFF
--- a/api/application/client.go
+++ b/api/application/client.go
@@ -806,9 +806,15 @@ func hasGranularExposeParameters(exposedEndpoints map[string]params.ExposedEndpo
 	} else if allEndpointParams, found := exposedEndpoints[""]; found && len(exposedEndpoints) == 1 {
 		// We have a single entry for the wildcard endpoint; check if
 		// it only includes an expose to all networks CIDR.
+		var allNetworkCIDRCount int
+		for _, cidr := range allEndpointParams.ExposeToCIDRs {
+			if cidr == firewall.AllNetworksIPV4CIDR || cidr == firewall.AllNetworksIPV6CIDR {
+				allNetworkCIDRCount++
+			}
+		}
+
 		if len(allEndpointParams.ExposeToSpaces) == 0 &&
-			len(allEndpointParams.ExposeToCIDRs) == 1 &&
-			allEndpointParams.ExposeToCIDRs[0] == firewall.AllNetworksIPV4CIDR {
+			len(allEndpointParams.ExposeToCIDRs) == allNetworkCIDRCount {
 			return false // equivalent to using non-granular expose like pre 2.9 juju
 		}
 	}

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -1739,6 +1739,16 @@ func (s *applicationSuite) TestExposeVersionChecks(c *gc.C) {
 			expErr: "",
 		},
 		{
+			descr:         "use expose parameters with pre 2.9 controller but expose all endpoints to 0.0.0.0/0 and ::/0",
+			facadeVersion: 12,
+			exposedEndpoints: map[string]params.ExposedEndpoint{
+				"": {
+					ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
+				},
+			},
+			expErr: "",
+		},
+		{
 			descr:            "don't use expose parameters",
 			facadeVersion:    12,
 			exposedEndpoints: nil,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1525,7 +1525,7 @@ func (api *APIBase) Expose(args params.ApplicationExpose) error {
 	if len(mappedExposeParams) == 0 {
 		mappedExposeParams = map[string]state.ExposedEndpoint{
 			"": {
-				ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR},
+				ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR},
 			},
 		}
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2510,7 +2510,7 @@ func (s *applicationSuite) TestApplicationExposeEndpoints(c *gc.C) {
 		ApplicationName: app.Name(),
 		ExposedEndpoints: map[string]params.ExposedEndpoint{
 			// Exposing an endpoint with no expose options implies
-			// expose to 0.0.0.0/0.
+			// expose to 0.0.0.0/0 and ::/0.
 			"monitoring-port": {},
 		},
 	})
@@ -2521,7 +2521,7 @@ func (s *applicationSuite) TestApplicationExposeEndpoints(c *gc.C) {
 	c.Assert(got.IsExposed(), gc.Equals, true)
 	c.Assert(got.ExposedEndpoints(), gc.DeepEquals, map[string]state.ExposedEndpoint{
 		"monitoring-port": {
-			ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR},
+			ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR},
 		},
 	})
 }
@@ -2535,7 +2535,7 @@ func (s *applicationSuite) TestApplicationExposeEndpointsWithPre29Client(c *gc.C
 		ApplicationName: app.Name(),
 		// If no endpoint-specific expose params are provided, the call
 		// will emulate the behavior of a pre 2.9 controller where all
-		// ports are exposed to 0.0.0.0/0.
+		// ports are exposed to 0.0.0.0/0 and ::/0.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2544,7 +2544,7 @@ func (s *applicationSuite) TestApplicationExposeEndpointsWithPre29Client(c *gc.C
 	c.Assert(got.IsExposed(), gc.Equals, true)
 	c.Assert(got.ExposedEndpoints(), gc.DeepEquals, map[string]state.ExposedEndpoint{
 		"": {
-			ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR},
+			ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR},
 		},
 	})
 }
@@ -2583,7 +2583,7 @@ var applicationExposeTests = []struct {
 		expExposed:  true,
 		expExposedEndpoints: map[string]state.ExposedEndpoint{
 			"": {
-				ExposeToCIDRs: []string{"0.0.0.0/0"},
+				ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
 			},
 		},
 	},
@@ -2593,7 +2593,7 @@ var applicationExposeTests = []struct {
 		expExposed:  true,
 		expExposedEndpoints: map[string]state.ExposedEndpoint{
 			"": {
-				ExposeToCIDRs: []string{"0.0.0.0/0"},
+				ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"},
 			},
 		},
 	},
@@ -2715,7 +2715,7 @@ var applicationUnexposeTests = []struct {
 		// The server-admin (and hence the app) should remain exposed
 		expExposed: true,
 		expExposedEndpoints: map[string]state.ExposedEndpoint{
-			"server-admin": {ExposeToCIDRs: []string{"0.0.0.0/0"}},
+			"server-admin": {ExposeToCIDRs: []string{"0.0.0.0/0", "::/0"}},
 		},
 	},
 	{

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -674,9 +674,15 @@ func mapExposedEndpoints(exposedEndpoints map[string]description.ExposedEndpoint
 	} else if allEndpointParams, found := exposedEndpoints[""]; found && len(exposedEndpoints) == 1 {
 		// We have a single entry for the wildcard endpoint; check if
 		// it only includes an expose to all networks CIDR.
+		var allNetworkCIDRCount int
+		for _, cidr := range allEndpointParams.ExposeToCIDRs() {
+			if cidr == firewall.AllNetworksIPV4CIDR || cidr == firewall.AllNetworksIPV6CIDR {
+				allNetworkCIDRCount++
+			}
+		}
+
 		if len(allEndpointParams.ExposeToSpaceIDs()) == 0 &&
-			len(allEndpointParams.ExposeToCIDRs()) == 1 &&
-			allEndpointParams.ExposeToCIDRs()[0] == firewall.AllNetworksIPV4CIDR {
+			len(allEndpointParams.ExposeToCIDRs()) == allNetworkCIDRCount {
 			return nil, nil // equivalent to using non-granular expose like pre 2.9 juju
 		}
 	}

--- a/cmd/juju/application/expose.go
+++ b/cmd/juju/application/expose.go
@@ -140,7 +140,16 @@ func (c *exposeCommand) buildExposedEndpoints() map[string]params.ExposedEndpoin
 	if len(endpoints)+len(spaces)+len(cidrs) == 0 {
 		// No granular expose params required
 		return nil
-	} else if len(endpoints) == 0 && len(spaces) == 0 && len(cidrs) == 1 && cidrs[0] == firewall.AllNetworksIPV4CIDR {
+	}
+
+	var allNetworkCIDRCount int
+	for _, cidr := range cidrs {
+		if cidr == firewall.AllNetworksIPV4CIDR || cidr == firewall.AllNetworksIPV6CIDR {
+			allNetworkCIDRCount++
+		}
+	}
+
+	if len(endpoints) == 0 && len(spaces) == 0 && len(cidrs) == allNetworkCIDRCount {
 		// No granular expose params required; this is equivalent
 		// to "juju expose <application>"
 		return nil

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -583,12 +583,14 @@ func (c *upgradeJujuCommand) validateModelUpgrade() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO (stickupkid): Define force for validation of model upgrade.
-	if err := client.ValidateModelUpgrade(names.NewModelTag(details.ModelUUID), false); err != nil {
-		return errors.Trace(err)
-	}
 
-	return nil
+	// TODO (stickupkid): Define force for validation of model upgrade.
+	// If the model to upgrade does not implement the minimum facade version
+	// for validating, we return nil.
+	if err = client.ValidateModelUpgrade(names.NewModelTag(details.ModelUUID), false); errors.IsNotImplemented(err) {
+		return nil
+	}
+	return errors.Trace(err)
 }
 
 // environConfigGetter implements environs.EnvironConfigGetter for use

--- a/core/network/firewall/rule.go
+++ b/core/network/firewall/rule.go
@@ -191,6 +191,7 @@ func (rules IngressRules) cidrsByPortRange() map[network.PortRange]set.Strings {
 		}
 		if rule.SourceCIDRs.IsEmpty() {
 			cidrs.Add(AllNetworksIPV4CIDR)
+			cidrs.Add(AllNetworksIPV6CIDR)
 			continue
 		}
 		for cidr := range rule.SourceCIDRs {

--- a/state/application.go
+++ b/state/application.go
@@ -56,7 +56,7 @@ type ExposedEndpoint struct {
 // include the 0.0.0.0/0 CIDR.
 func (exp ExposedEndpoint) AllowTrafficFromAnyNetwork() bool {
 	for _, cidr := range exp.ExposeToCIDRs {
-		if cidr == firewall.AllNetworksIPV4CIDR {
+		if cidr == firewall.AllNetworksIPV4CIDR || cidr == firewall.AllNetworksIPV6CIDR {
 			return true
 		}
 	}
@@ -774,7 +774,7 @@ func (a *Application) MergeExposeSettings(exposedEndpoints map[string]ExposedEnd
 		// 0.0.0.0/0 CIDR. This matches the "expose to the entire
 		// world" behavior in juju controllers prior to 2.9.
 		if len(exposeParams.ExposeToSpaceIDs)+len(exposeParams.ExposeToCIDRs) == 0 {
-			exposeParams.ExposeToCIDRs = []string{firewall.AllNetworksIPV4CIDR}
+			exposeParams.ExposeToCIDRs = []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR}
 		}
 
 		mergedExposedEndpoints[endpoint] = exposeParams

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2468,10 +2468,10 @@ func (s *ApplicationSuite) TestApplicationExposeWithoutSpaceAndCIDR(c *gc.C) {
 
 	exp := map[string]state.ExposedEndpoint{
 		"server": {
-			ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR},
+			ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR},
 		},
 	}
-	c.Assert(s.mysql.ExposedEndpoints(), gc.DeepEquals, exp, gc.Commentf("expected the implicit 0.0.0.0/0 CIDR to be added when an empty ExposedEndpoint value is provided to MergeExposeSettings"))
+	c.Assert(s.mysql.ExposedEndpoints(), gc.DeepEquals, exp, gc.Commentf("expected the implicit 0.0.0.0/0 and ::/0 CIDRs to be added when an empty ExposedEndpoint value is provided to MergeExposeSettings"))
 }
 
 func (s *ApplicationSuite) TestApplicationUnsetExposeEndpoints(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3185,7 +3185,7 @@ func ExposeWildcardEndpointForExposedApplications(pool *StatePool) error {
 
 		var implicitExposedEndpoints = map[string]ExposedEndpoint{
 			"": {
-				ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR},
+				ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR},
 			},
 		}
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4765,6 +4765,59 @@ func (s *upgradesSuite) TestAddCharmOriginToApplication(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestExposeWildcardEndpointForExposedApplication(c *gc.C) {
+	model1 := s.makeModel(c, "model-1", coretesting.Attrs{})
+	model2 := s.makeModel(c, "model-2", coretesting.Attrs{})
+	defer func() {
+		_ = model1.Close()
+		_ = model2.Close()
+	}()
+
+	uuid1 := model1.ModelUUID()
+	uuid2 := model2.ModelUUID()
+
+	coll, closer := s.state.db().GetRawCollection(applicationsC)
+	defer closer()
+
+	err := coll.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid1, "app1"),
+		"model-uuid": uuid1,
+		"charmurl":   charm.MustParseURL("cs:test").String(),
+		"exposed":    true, // exposed application
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = coll.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app2"),
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("local:test").String(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := bsonMById{
+		{
+			"_id":        ensureModelUUID(uuid1, "app1"),
+			"model-uuid": uuid1,
+			"charmurl":   "cs:test",
+			"exposed":    true,
+			"exposed-endpoints": bson.M{
+				"": bson.M{
+					"to-cidrs": []interface{}{"0.0.0.0/0"},
+				},
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app2"),
+			"model-uuid": uuid2,
+			"charmurl":   "local:test",
+		},
+	}
+
+	sort.Sort(expected)
+	s.assertUpgradedData(c, ExposeWildcardEndpointForExposedApplications,
+		upgradedData(coll, expected),
+	)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4801,7 +4801,7 @@ func (s *upgradesSuite) TestExposeWildcardEndpointForExposedApplication(c *gc.C)
 			"exposed":    true,
 			"exposed-endpoints": bson.M{
 				"": bson.M{
-					"to-cidrs": []interface{}{"0.0.0.0/0"},
+					"to-cidrs": []interface{}{"0.0.0.0/0", "::/0"},
 				},
 			},
 		},

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -88,6 +88,7 @@ type StateBackend interface {
 	RollUpAndConvertOpenedPortDocuments() error
 	AddCharmHubToModelConfig() error
 	AddCharmOriginToApplications() error
+	ExposeWildcardEndpointForExposedApplications() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -367,4 +368,8 @@ func (s stateBackend) RollUpAndConvertOpenedPortDocuments() error {
 
 func (s stateBackend) AddCharmOriginToApplications() error {
 	return state.AddCharmOriginToApplications(s.pool)
+}
+
+func (s stateBackend) ExposeWildcardEndpointForExposedApplications() error {
+	return state.ExposeWildcardEndpointForExposedApplications(s.pool)
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -40,6 +40,13 @@ func stateStepsFor29() []Step {
 				return context.State().AddCharmOriginToApplications()
 			},
 		},
+		&upgradeStep{
+			description: `add explicit "expose all endpoints to 0.0.0.0/0" entry for already exposed applications`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().ExposeWildcardEndpointForExposedApplications()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_29_test.go
+++ b/upgrades/steps_29_test.go
@@ -52,6 +52,11 @@ func (s *steps29Suite) TestAddCharmOriginToApplications(c *gc.C) {
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps29Suite) TestExposeWildcardEndpointForExposedApplications(c *gc.C) {
+	step := findStateStep(c, v290, `add explicit "expose all endpoints to 0.0.0.0/0" entry for already exposed applications`)
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 type mergeAgents29Suite struct {
 	testing.BaseSuite
 

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -956,6 +956,7 @@ func (fw *Firewaller) updateForRemoteRelationIngress(appTag names.ApplicationTag
 		// No relevant firewall rule exists, so go public.
 		if cidrs.Size() == 0 {
 			cidrs.Add(firewall.AllNetworksIPV4CIDR)
+			cidrs.Add(firewall.AllNetworksIPV6CIDR)
 		}
 	}
 

--- a/worker/firewaller/firewaller.go
+++ b/worker/firewaller/firewaller.go
@@ -846,18 +846,6 @@ func (fw *Firewaller) ingressRulesForExposedMachineUnit(machine *machineData, un
 		rules            firewall.IngressRules
 	)
 
-	// Emulate pre 2.9 behavior: expose all ports to 0.0.0.0/0.
-	if len(exposedEndpoints) == 0 {
-		for _, portRange := range openUnitPortRanges.UniquePortRanges() {
-			rules = append(rules, firewall.NewIngressRule(portRange, firewall.AllNetworksIPV4CIDR))
-		}
-
-		// De-dup and sort rules before returning them back.
-		rules = rules.UniqueRules()
-		sort.Slice(rules, func(i, j int) bool { return rules[i].LessThan(rules[j]) })
-		return rules
-	}
-
 	for exposedEndpoint, exposeDetails := range exposedEndpoints {
 		// Collect the operator-provided CIDRs that should be able to
 		// access the port ranges opened for this endpoint; then resolve
@@ -871,9 +859,20 @@ func (fw *Firewaller) ingressRulesForExposedMachineUnit(machine *machineData, un
 				continue
 			}
 
+			if len(sp.Subnets) == 0 {
+				if exposedEndpoint == "" {
+					fw.logger.Warningf("all endpoints of application %q are exposed to space %q which contains no subnets", unit.applicationd.application.Name(), sp.Name)
+				} else {
+					fw.logger.Warningf("endpoint %q application %q are exposed to space %q which contains no subnets", exposedEndpoint, unit.applicationd.application.Name(), sp.Name)
+				}
+			}
 			for _, subnet := range sp.Subnets {
 				srcCIDRs.Add(subnet.CIDR)
 			}
+		}
+
+		if len(srcCIDRs) == 0 {
+			continue // no rules required
 		}
 
 		// If this is a named (i.e. not the wildcard) endpoint, look up

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -1269,7 +1269,7 @@ func (s *InstanceModeSuite) TestRemoteRelationIngressFallbackToPublic(c *gc.C) {
 	for i := 1; i < 30; i++ {
 		ingress = append(ingress, fmt.Sprintf("10.%d.0.1/32", i))
 	}
-	s.assertIngressCidrs(c, ingress, []string{"0.0.0.0/0"})
+	s.assertIngressCidrs(c, ingress, []string{"0.0.0.0/0", "::/0"})
 }
 
 func (s *InstanceModeSuite) TestRemoteRelationIngressFallbackToWhitelist(c *gc.C) {

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -269,7 +269,9 @@ func (s *InstanceModeSuite) TestExposedApplication(c *gc.C) {
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
 
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
@@ -298,7 +300,9 @@ func (s *InstanceModeSuite) TestMultipleExposedApplications(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.MergeExposeSettings(nil)
+	err := app1.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -310,7 +314,9 @@ func (s *InstanceModeSuite) TestMultipleExposedApplications(c *gc.C) {
 
 	app2 := s.AddTestingApplication(c, "mysql", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	err = app2.MergeExposeSettings(nil)
+	err = app2.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)
@@ -345,7 +351,9 @@ func (s *InstanceModeSuite) TestMachineWithoutInstanceId(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	// add a unit but don't start its instance yet.
 	u1, m1 := s.addUnit(c, app)
@@ -375,7 +383,9 @@ func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app)
@@ -410,7 +420,9 @@ func (s *InstanceModeSuite) TestMultipleUnits(c *gc.C) {
 
 func (s *InstanceModeSuite) TestStartWithState(c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
@@ -442,7 +454,9 @@ func (s *InstanceModeSuite) TestStartWithPartialState(c *gc.C) {
 	inst := s.startInstance(c, m)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err = app.MergeExposeSettings(nil)
+	err = app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Starting the firewaller, no open ports.
@@ -486,7 +500,9 @@ func (s *InstanceModeSuite) TestStartWithUnexposedApplication(c *gc.C) {
 	s.assertIngressRules(c, inst, m.Id(), nil)
 
 	// Expose service.
-	err = app.MergeExposeSettings(nil)
+	err = app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertIngressRules(c, inst, m.Id(), firewall.IngressRules{
 		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), firewall.AllNetworksIPV4CIDR),
@@ -541,7 +557,9 @@ func (s *InstanceModeSuite) TestSetClearExposedApplication(c *gc.C) {
 	s.assertIngressRules(c, inst, m.Id(), nil)
 
 	// SeExposed opens the ports.
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertIngressRules(c, inst, m.Id(), firewall.IngressRules{
@@ -561,7 +579,9 @@ func (s *InstanceModeSuite) TestRemoveUnit(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app)
@@ -600,7 +620,9 @@ func (s *InstanceModeSuite) TestRemoveApplication(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -628,7 +650,9 @@ func (s *InstanceModeSuite) TestRemoveMultipleApplications(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.MergeExposeSettings(nil)
+	err := app1.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -638,7 +662,9 @@ func (s *InstanceModeSuite) TestRemoveMultipleApplications(c *gc.C) {
 	})
 
 	app2 := s.AddTestingApplication(c, "mysql", s.charm)
-	err = app2.MergeExposeSettings(nil)
+	err = app2.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)
@@ -678,7 +704,9 @@ func (s *InstanceModeSuite) TestDeadMachine(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -712,7 +740,9 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -753,7 +783,9 @@ func (s *InstanceModeSuite) TestRemoveMachine(c *gc.C) {
 
 func (s *InstanceModeSuite) TestStartWithStateOpenPortsBroken(c *gc.C) {
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	u, m := s.addUnit(c, app)
 	inst := s.startInstance(c, m)
@@ -1418,9 +1450,122 @@ func (s *InstanceModeSuite) TestExposedApplicationWithExposedEndpointsWhenSpaceT
 
 	// Check that worker picked up the change and updated the rules
 	s.assertIngressRules(c, inst, m.Id(), firewall.IngressRules{
-		// We expect to see port 80 use subnter-{1,2} CIDRs
+		// We expect to see port 80 use subnet-{1,2} CIDRs
 		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), "192.168.0.0/24", "192.168.1.0/24"),
 	})
+}
+
+func (s *InstanceModeSuite) TestExposedApplicationWithExposedEndpointsWhenSpaceDeleted(c *gc.C) {
+	// Create two spaces and add a subnet to each one
+	sp1, err := s.State.AddSpace("space1", "sp-1", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	sub1, err := s.State.AddSubnet(network.SubnetInfo{
+		ID:        "subnet-1",
+		CIDR:      "192.168.0.0/24",
+		SpaceID:   sp1.Id(),
+		SpaceName: sp1.Name(),
+		IsPublic:  false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	sp2, err := s.State.AddSpace("space2", "sp-2", nil, true)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddSubnet(network.SubnetInfo{
+		ID:        "subnet-2",
+		CIDR:      "192.168.1.0/24",
+		SpaceID:   sp2.Id(),
+		SpaceName: sp2.Name(),
+		IsPublic:  false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	fw := s.newFirewaller(c)
+	defer statetesting.AssertKillAndWait(c, fw)
+
+	app := s.AddTestingApplication(c, "wordpress", s.charm)
+
+	u, m := s.addUnit(c, app)
+	inst := s.startInstance(c, m)
+	// Open port 80 for all endpoints
+	mustOpenPortRanges(c, s.State, u, allEndpoints, []network.PortRange{
+		network.MustParsePortRange("80/tcp"),
+	})
+
+	// Expose app to space-1
+	err = app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {
+			ExposeToSpaceIDs: []string{sp1.Id()},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertIngressRules(c, inst, m.Id(), firewall.IngressRules{
+		// We expect to see port 80 use the subnet-1 CIDR
+		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), "192.168.0.0/24"),
+	})
+
+	// Simulate the deletion of a space, with subnets moving back to alpha.
+	moveOps := sub1.UpdateSpaceOps(network.AlphaSpaceId)
+	deleteOps := sp1.RemoveSpaceOps()
+	c.Assert(s.State.ApplyOperation(modelOp{append(moveOps, deleteOps...)}), jc.ErrorIsNil)
+
+	// We expect to see NO ingress rules as the referenced space does not exist.
+	s.assertIngressRules(c, inst, m.Id(), nil)
+}
+
+func (s *InstanceModeSuite) TestExposedApplicationWithExposedEndpointsWhenSpaceHasNoSubnets(c *gc.C) {
+	// Create a space with a single subnet
+	sp1, err := s.State.AddSpace("space1", "sp-1", nil, false)
+	c.Assert(err, jc.ErrorIsNil)
+	sub1, err := s.State.AddSubnet(network.SubnetInfo{
+		ID:        "subnet-1",
+		CIDR:      "192.168.0.0/24",
+		SpaceID:   sp1.Id(),
+		SpaceName: sp1.Name(),
+		IsPublic:  false,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	fw := s.newFirewaller(c)
+	defer statetesting.AssertKillAndWait(c, fw)
+
+	app := s.AddTestingApplication(c, "wordpress", s.charm)
+
+	u, m := s.addUnit(c, app)
+	inst := s.startInstance(c, m)
+	// Open port 80 for all endpoints and 1337 for the "url" endpoint
+	mustOpenPortRanges(c, s.State, u, allEndpoints, []network.PortRange{
+		network.MustParsePortRange("80/tcp"),
+	})
+	mustOpenPortRanges(c, s.State, u, "url", []network.PortRange{
+		network.MustParsePortRange("1337/tcp"),
+	})
+
+	// Expose app to space-1
+	err = app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {
+			ExposeToSpaceIDs: []string{sp1.Id()},
+		},
+		"url": {
+			ExposeToSpaceIDs: []string{sp1.Id()},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.assertIngressRules(c, inst, m.Id(), firewall.IngressRules{
+		// We expect to see port 80 and 1337 use the subnet-1 CIDR
+		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), "192.168.0.0/24"),
+		firewall.NewIngressRule(network.MustParsePortRange("1337/tcp"), "192.168.0.0/24"),
+	})
+
+	// Move endpoint back to alpha space. This will leave space-1 with no
+	// endpoints.
+	moveOps := sub1.UpdateSpaceOps(network.AlphaSpaceId)
+	c.Assert(s.State.ApplyOperation(modelOp{moveOps}), jc.ErrorIsNil)
+
+	// We expect to see NO ingress rules (and warnings in the logs) as
+	// there are no CIDRs to access the exposed application.
+	s.assertIngressRules(c, inst, m.Id(), nil)
 }
 
 type modelOp struct {
@@ -1477,7 +1622,9 @@ func (s *GlobalModeSuite) TestGlobalMode(c *gc.C) {
 	defer statetesting.AssertKillAndWait(c, fw)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.MergeExposeSettings(nil)
+	err := app1.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -1489,7 +1636,9 @@ func (s *GlobalModeSuite) TestGlobalMode(c *gc.C) {
 
 	app2 := s.AddTestingApplication(c, "moinmoin", s.charm)
 	c.Assert(err, jc.ErrorIsNil)
-	err = app2.MergeExposeSettings(nil)
+	err = app2.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)
@@ -1548,7 +1697,9 @@ func (s *GlobalModeSuite) TestStartWithUnexposedApplication(c *gc.C) {
 	s.assertEnvironPorts(c, nil)
 
 	// Expose application.
-	err = app.MergeExposeSettings(nil)
+	err = app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEnvironPorts(c, firewall.IngressRules{
 		firewall.NewIngressRule(network.MustParsePortRange("80/tcp"), firewall.AllNetworksIPV4CIDR),
@@ -1560,7 +1711,9 @@ func (s *GlobalModeSuite) TestRestart(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -1602,7 +1755,9 @@ func (s *GlobalModeSuite) TestRestartUnexposedApplication(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app.MergeExposeSettings(nil)
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u, m := s.addUnit(c, app)
@@ -1636,7 +1791,9 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	fw := s.newFirewaller(c)
 
 	app1 := s.AddTestingApplication(c, "wordpress", s.charm)
-	err := app1.MergeExposeSettings(nil)
+	err := app1.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u1, m1 := s.addUnit(c, app1)
@@ -1656,7 +1813,9 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	app2 := s.AddTestingApplication(c, "moinmoin", s.charm)
-	err = app2.MergeExposeSettings(nil)
+	err = app2.MergeExposeSettings(map[string]state.ExposedEndpoint{
+		allEndpoints: {ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR}},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	u2, m2 := s.addUnit(c, app2)


### PR DESCRIPTION
## Description of change

This PR is a followup to #12001. It introduces an upgrade step for iterating the exposed applications and injecting an exposed endpoint entry for the wildcard endpoint and the 0.0.0.0/0 and ::/1 CIDRs.

This change makes it easy to figure out the CIDRs that should be able to access the application by inspecting the application documents in the DB.

After the upgrade, all applications with exposed endpoints will include at least one source CIDR that should be able to access the opened port ranges. As a result, we can remove the extra logic from the firewall worker that used to fall back to a 0.0.0.0/0 CIDR if none was specified.

In addition, the PR addresses an issue found with the previous PR where the firewall worker would incorrectly fall back to the wildcard CIDR, if an endpoint was exposed to a space that got either removed OR had all its subnets moved to another space. The PR includes extra tests to cover both these cases.

## QA steps

### Testing the upgrade step

```console
# Bootstrap a 2.8.x controller using juju from snap
$ /snap/bin/juju bootstrap lxd test --no-gui
$ /snap/bin/juju deploy apache2
$ /snap/bin/juju run --unit apache2/0 "open-port 80/tcp"
$ /snap/bin/juju expose apache2

# Check the database contents for the app
> db.applications.find({},{"exposed":1,"exposed-endpoints":1}).pretty()
{ "_id" : "7cf98dfc-ca9a-44b0-8157-0ab42e25fbff:apache2", "exposed" : true }

# Now upgrade to the 2.9 beta from this PR
$ juju upgrade-controller --build-agent
$ juju upgrade-model 

# Inspect the database contents again and verify that an entry has been added for the
# wildcard ("") endpoint with a `to-cidrs` field that includes 0.0.0.0/0 and ::/0
```

### Testing the space gone/no-subnet fix

Try this on a provider with space support

```console
$ juju expose apache2 --to-spaces space1
$ juju expose apache2 --endpoints website --to-spaces space2

# TODO:
# - Move the space1 subnets to the alpha space
# - Delete space 2
# - Check the firewaller logs for warnings about the missing space and the space with no subnets
# - Verify that NO ingress rules are used; the app is exposed but nothing can reach its ports
```