### PR TITLE
further along to getting juju deploy of CharmHub charms working.

### DIFF
--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -128,11 +128,12 @@ func (c *Client) CharmInfo(charmURL string) (*CharmInfo, error) {
 // If the AddCharm API call fails because of an authorization error
 // when retrieving the charm from the charm store, an error
 // satisfying params.IsCodeUnauthorized will be returned.
-func (c *Client) AddCharm(curl *charm.URL, origin apicharm.Origin, force bool) (apicharm.Origin, error) {
+func (c *Client) AddCharm(curl *charm.URL, origin apicharm.Origin, force bool, series string) (apicharm.Origin, error) {
 	args := params.AddCharmWithOrigin{
 		URL:    curl.String(),
 		Origin: origin.ParamsCharmOrigin(),
 		Force:  force,
+		Series: series,
 	}
 	var result params.CharmOriginResult
 	if err := c.facade.FacadeCall("AddCharm", args, &result); err != nil {
@@ -152,12 +153,13 @@ func (c *Client) AddCharm(curl *charm.URL, origin apicharm.Origin, force bool) (
 // an error satisfying params.IsCodeUnauthorized will be returned.
 // Force is used to overload any validation errors that could occur during
 // a deploy
-func (c *Client) AddCharmWithAuthorization(curl *charm.URL, origin apicharm.Origin, csMac *macaroon.Macaroon, force bool) (apicharm.Origin, error) {
+func (c *Client) AddCharmWithAuthorization(curl *charm.URL, origin apicharm.Origin, csMac *macaroon.Macaroon, force bool, series string) (apicharm.Origin, error) {
 	args := params.AddCharmWithAuth{
 		URL:                curl.String(),
 		Origin:             origin.ParamsCharmOrigin(),
 		CharmStoreMacaroon: csMac,
 		Force:              force,
+		Series:             series,
 	}
 	var result params.CharmOriginResult
 	if err := c.facade.FacadeCall("AddCharmWithAuthorization", args, &result); err != nil {

--- a/api/charms/client_test.go
+++ b/api/charms/client_test.go
@@ -196,6 +196,7 @@ func (s *charmsMockSuite) TestAddCharm(c *gc.C) {
 	facadeArgs := params.AddCharmWithOrigin{
 		URL:    curl.String(),
 		Origin: origin.ParamsCharmOrigin(),
+		Series: "bionic",
 	}
 	result := new(params.CharmOriginResult)
 	actualResult := params.CharmOriginResult{
@@ -206,7 +207,7 @@ func (s *charmsMockSuite) TestAddCharm(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall("AddCharm", facadeArgs, result).SetArg(2, actualResult).Return(nil)
 
 	client := charms.NewClientWithFacade(mockFacadeCaller)
-	got, err := client.AddCharm(curl, origin, false)
+	got, err := client.AddCharm(curl, origin, false, "bionic")
 	c.Assert(err, gc.IsNil)
 	c.Assert(got, gc.DeepEquals, origin)
 }
@@ -228,6 +229,7 @@ func (s *charmsMockSuite) TestAddCharmWithAuthorization(c *gc.C) {
 		URL:                curl.String(),
 		CharmStoreMacaroon: &macaroon.Macaroon{},
 		Origin:             origin.ParamsCharmOrigin(),
+		Series:             "bionic",
 	}
 	result := new(params.CharmOriginResult)
 	actualResult := params.CharmOriginResult{
@@ -238,7 +240,7 @@ func (s *charmsMockSuite) TestAddCharmWithAuthorization(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall("AddCharmWithAuthorization", facadeArgs, result).SetArg(2, actualResult).Return(nil)
 
 	client := charms.NewClientWithFacade(mockFacadeCaller)
-	got, err := client.AddCharmWithAuthorization(curl, origin, &macaroon.Macaroon{}, false)
+	got, err := client.AddCharmWithAuthorization(curl, origin, &macaroon.Macaroon{}, false, "bionic")
 	c.Assert(err, gc.IsNil)
 	c.Assert(got, gc.DeepEquals, origin)
 }

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -78,7 +78,7 @@ type Repository interface {
 	// FindDownloadURL returns a url from which a charm can be downloaded
 	// based on the given charm url and charm origin.  A charm origin
 	// updated with the ID and hash for the download is also returned.
-	FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error)
+	FindDownloadURL(curl *charm.URL, origin corecharm.Origin, series string) (*url.URL, corecharm.Origin, error)
 
 	// DownloadCharm reads the charm referenced by curl or downloadURL into
 	// a file with the given path, which will be created if needed. Note
@@ -260,7 +260,7 @@ func (c *charmRepoShim) DownloadCharm(resourceURL string, archivePath string) (*
 
 // FindDownloadURL is a placeholder required to implement the
 // Repository interface.
-func (c *charmRepoShim) FindDownloadURL(_ *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
+func (c *charmRepoShim) FindDownloadURL(_ *charm.URL, origin corecharm.Origin, _ string) (*url.URL, corecharm.Origin, error) {
 	return nil, origin, nil
 }
 

--- a/apiserver/facades/client/application/mocks/repository_mock.go
+++ b/apiserver/facades/client/application/mocks/repository_mock.go
@@ -51,9 +51,9 @@ func (mr *MockRepositoryMockRecorder) DownloadCharm(arg0, arg1 interface{}) *gom
 }
 
 // FindDownloadURL mocks base method
-func (m *MockRepository) FindDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*url.URL, charm0.Origin, error) {
+func (m *MockRepository) FindDownloadURL(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (*url.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindDownloadURL", arg0, arg1)
+	ret := m.ctrl.Call(m, "FindDownloadURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*url.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].(error)
@@ -61,9 +61,9 @@ func (m *MockRepository) FindDownloadURL(arg0 *charm.URL, arg1 charm0.Origin) (*
 }
 
 // FindDownloadURL indicates an expected call of FindDownloadURL
-func (mr *MockRepositoryMockRecorder) FindDownloadURL(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) FindDownloadURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDownloadURL", reflect.TypeOf((*MockRepository)(nil).FindDownloadURL), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDownloadURL", reflect.TypeOf((*MockRepository)(nil).FindDownloadURL), arg0, arg1, arg2)
 }
 
 // Resolve mocks base method

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -200,6 +200,7 @@ func (a *API) AddCharm(args params.AddCharmWithOrigin) (params.CharmOriginResult
 		Origin:             args.Origin,
 		CharmStoreMacaroon: nil,
 		Force:              args.Force,
+		Series:             args.Series,
 	})
 }
 
@@ -220,6 +221,10 @@ func (a *API) AddCharmWithAuthorization(args params.AddCharmWithAuth) (params.Ch
 func (a *API) addCharmWithAuthorization(args params.AddCharmWithAuth) (params.CharmOriginResult, error) {
 	if args.Origin.Source != "charm-hub" && args.Origin.Source != "charm-store" {
 		return params.CharmOriginResult{}, errors.Errorf("unknown schema for charm URL %q", args.URL)
+	}
+
+	if args.Origin.Source == "charm-hub" && args.Series == "" {
+		return params.CharmOriginResult{}, errors.BadRequestf("series required for charm-hub charms")
 	}
 
 	if err := a.checkCanWrite(); err != nil {
@@ -429,19 +434,19 @@ func (a *API) charmStrategy(args params.AddCharmWithAuth) (Strategy, error) {
 		return nil, err
 	}
 	fn := a.getStrategyFunc(args.Origin.Source)
-	return fn(repo, args.URL, args.Force)
+	return fn(repo, args.URL, args.Force, args.Series)
 }
 
-type StrategyFunc func(charmRepo corecharm.Repository, url string, force bool) (Strategy, error)
+type StrategyFunc func(charmRepo corecharm.Repository, url string, force bool, series string) (Strategy, error)
 
 func getStrategyFunc(source string) StrategyFunc {
 	if source == "charm-store" {
-		return func(charmRepo corecharm.Repository, url string, force bool) (Strategy, error) {
+		return func(charmRepo corecharm.Repository, url string, force bool, _ string) (Strategy, error) {
 			return corecharm.DownloadFromCharmStore(charmRepo, url, force)
 		}
 	}
-	return func(charmRepo corecharm.Repository, url string, force bool) (Strategy, error) {
-		return corecharm.DownloadFromCharmHub(charmRepo, url, force)
+	return func(charmRepo corecharm.Repository, url string, force bool, series string) (Strategy, error) {
+		return corecharm.DownloadFromCharmHub(charmRepo, url, force, series)
 	}
 }
 

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -428,8 +428,8 @@ func (a *API) charmStrategy(args params.AddCharmWithAuth) (Strategy, error) {
 	if err != nil {
 		return nil, err
 	}
-	strat := a.getStrategyFunc(args.Origin.Source)
-	return strat(repo, args.URL, args.Force)
+	fn := a.getStrategyFunc(args.Origin.Source)
+	return fn(repo, args.URL, args.Force)
 }
 
 type StrategyFunc func(charmRepo corecharm.Repository, url string, force bool) (Strategy, error)

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -621,7 +621,7 @@ func (s *charmsMockSuite) api(c *gc.C) *charms.API {
 		return s.repository, nil
 	}
 	stratFuc := func(source string) charms.StrategyFunc {
-		return func(charmRepo corecharm.Repository, url string, force bool) (charms.Strategy, error) {
+		return func(charmRepo corecharm.Repository, url string, force bool, series string) (charms.Strategy, error) {
 			return s.strategy, nil
 		}
 	}

--- a/apiserver/facades/client/charms/convertions.go
+++ b/apiserver/facades/client/charms/convertions.go
@@ -247,9 +247,12 @@ func convertOrigin(origin corecharm.Origin) params.CharmOrigin {
 func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 	return corecharm.Origin{
 		Source:   corecharm.Source(origin.Source),
-		ID:       "",
-		Hash:     "",
-		Revision: nil,
-		Channel:  nil,
+		ID:       origin.ID,
+		Hash:     origin.Hash,
+		Revision: origin.Revision,
+		Channel: &corecharm.Channel{
+			Track: *origin.Track,
+			Risk:  corecharm.Risk(origin.Risk),
+		},
 	}
 }

--- a/apiserver/facades/client/charms/convertions.go
+++ b/apiserver/facades/client/charms/convertions.go
@@ -245,13 +245,17 @@ func convertOrigin(origin corecharm.Origin) params.CharmOrigin {
 }
 
 func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
+	var track string
+	if origin.Track != nil {
+		track = *origin.Track
+	}
 	return corecharm.Origin{
 		Source:   corecharm.Source(origin.Source),
 		ID:       origin.ID,
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
 		Channel: &corecharm.Channel{
-			Track: *origin.Track,
+			Track: track,
 			Risk:  corecharm.Risk(origin.Risk),
 		},
 	}

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/charmrepo/v6"
@@ -83,8 +84,8 @@ func (c *chRepo) DownloadCharm(resourceURL string, archivePath string) (*charm.C
 // charm origin is also returned with the ID and hash for the charm
 // to be downloaded.  If the provided charm origin has no ID, it is
 // assumed that the charm is being installed, not refreshed.
-func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
-	cfg, err := refreshConfig(curl, origin)
+func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin, series string) (*url.URL, corecharm.Origin, error) {
+	cfg, err := refreshConfig(curl, origin, series)
 	if err != nil {
 		return nil, corecharm.Origin{}, errors.Trace(err)
 	}
@@ -108,7 +109,12 @@ func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url
 	return durl, origin, errors.Trace(err)
 }
 
-func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshConfig, error) {
+// refreshConfig creates a RefreshConfig for the given input.
+// If the origin.ID is not set, a install refresh config is returned. For
+//   install. Channel and Revision are mutually exclusive in the api, only
+//   one will be used.  Channel first, Revision is a fallback.
+// If the origin.ID is set, a refresh config is returned.
+func refreshConfig(curl *charm.URL, origin corecharm.Origin, charmSeries string) (charmhub.RefreshConfig, error) {
 	var rev int
 	if origin.Revision != nil {
 		rev = *origin.Revision
@@ -118,12 +124,15 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 		channel = origin.Channel.String()
 	}
 	var seriesOS string
-	if curl.Series != "" {
-		opSys, err := series.GetOSFromSeries(curl.Series)
+	if charmSeries != "" {
+		opSys, err := series.GetOSFromSeries(charmSeries)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		seriesOS = opSys.String()
+		// Note: 21-01-2020
+		// Values passed to the api are case sensitive: ubuntu succeeds and
+		// Ubuntu returns "code": "revision-not-found".
+		seriesOS = strings.ToLower(opSys.String())
 	}
 	var cfg charmhub.RefreshConfig
 	var err error
@@ -132,15 +141,15 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 	case origin.ID == "" && channel != "":
 		// If there is no origin ID, we haven't downloaded this charm before.
 		// Try channel first.
-		cfg, err = charmhub.InstallOneFromChannel(curl.Name, channel, seriesOS, curl.Series)
+		cfg, err = charmhub.InstallOneFromChannel(curl.Name, channel, seriesOS, charmSeries)
 	case origin.ID == "" && channel == "":
 		// If there is no origin ID, we haven't downloaded this charm before.
 		// No channel, try with revision.
-		cfg, err = charmhub.InstallOneFromRevision(curl.Name, rev, seriesOS, curl.Series)
+		cfg, err = charmhub.InstallOneFromRevision(curl.Name, rev, seriesOS, charmSeries)
 	case origin.ID != "":
 		// This must be a charm upgrade if we have an ID.  Use the refresh action
 		// for metric keeping on the CharmHub side.
-		cfg, err = charmhub.RefreshOne(origin.ID, rev, channel, seriesOS, curl.Series)
+		cfg, err = charmhub.RefreshOne(origin.ID, rev, channel, seriesOS, charmSeries)
 	default:
 		return nil, errors.NotValidf("origin %v", origin)
 	}
@@ -269,7 +278,7 @@ func (c *csRepo) DownloadCharm(resourceURL string, archivePath string) (*charm.C
 	return c.repo.Get(curl, archivePath)
 }
 
-func (c *csRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
+func (c *csRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin, _ string) (*url.URL, corecharm.Origin, error) {
 	logger.Tracef("CharmStore FindDownloadURL %q", curl)
 	return nil, origin, nil
 }

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -859,8 +859,8 @@ func (m *mockRepo) DownloadCharm(downloadURL, archivePath string) (*charm.CharmA
 	return nil, nil
 }
 
-func (m *mockRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
-	m.MethodCall(m, "FindDownloadURL", curl, origin)
+func (m *mockRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin, series string) (*url.URL, corecharm.Origin, error) {
+	m.MethodCall(m, "FindDownloadURL", curl, origin, series)
 	return nil, corecharm.Origin{}, nil
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10086,6 +10086,9 @@
                         "macaroon": {
                             "$ref": "#/definitions/Macaroon"
                         },
+                        "series": {
+                            "type": "string"
+                        },
                         "url": {
                             "type": "string"
                         }
@@ -10095,7 +10098,8 @@
                         "url",
                         "charm-origin",
                         "macaroon",
-                        "force"
+                        "force",
+                        "series"
                     ]
                 },
                 "AddCharmWithOrigin": {
@@ -10107,6 +10111,9 @@
                         "force": {
                             "type": "boolean"
                         },
+                        "series": {
+                            "type": "string"
+                        },
                         "url": {
                             "type": "string"
                         }
@@ -10115,7 +10122,8 @@
                     "required": [
                         "url",
                         "charm-origin",
-                        "force"
+                        "force",
+                        "series"
                     ]
                 },
                 "Charm": {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -186,6 +186,7 @@ type AddCharmWithOrigin struct {
 	URL    string      `json:"url"`
 	Origin CharmOrigin `json:"charm-origin"`
 	Force  bool        `json:"force"`
+	Series string      `json:"series"`
 }
 
 // AddCharmWithAuthorization holds the arguments for making an
@@ -204,6 +205,7 @@ type AddCharmWithAuth struct {
 	Origin             CharmOrigin        `json:"charm-origin"`
 	CharmStoreMacaroon *macaroon.Macaroon `json:"macaroon"`
 	Force              bool               `json:"force"`
+	Series             string             `json:"series"`
 }
 
 // CharmOriginResult holds the results of AddCharms calls where

--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -31,7 +31,7 @@ func NewFindClient(path path.Path, client RESTClient, logger Logger) *FindClient
 
 // Find searches Charm Hub and provides results matching a string.
 func (c *FindClient) Find(ctx context.Context, query string) ([]transport.FindResponse, error) {
-	c.logger.Debugf("Find(%s)", query)
+	c.logger.Tracef("Find(%s)", query)
 	path, err := c.path.Query("q", query)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -109,6 +109,15 @@ func (c *HTTPRESTClient) Get(ctx context.Context, path path.Path, result interfa
 	if err != nil {
 		return errors.Annotate(err, "can not make new request")
 	}
+
+	if c.logger.IsTraceEnabled() {
+		if data, err := httputil.DumpRequest(req, true); err == nil {
+			c.logger.Tracef("Post request %s", data)
+		} else {
+			c.logger.Tracef("Post request DumpRequest error %s", err.Error())
+		}
+	}
+
 	resp, err := c.transport.Do(req)
 	if err != nil {
 		return errors.Trace(err)
@@ -152,11 +161,27 @@ func (c *HTTPRESTClient) Post(ctx context.Context, path path.Path, body, result 
 
 	req.Header = c.composeHeaders(headers)
 
+	if c.logger.IsTraceEnabled() {
+		if data, err := httputil.DumpRequest(req, true); err == nil {
+			c.logger.Tracef("Post request %s", data)
+		} else {
+			c.logger.Tracef("Post request DumpRequest error %s", err.Error())
+		}
+	}
+
 	resp, err := c.transport.Do(req)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if c.logger.IsTraceEnabled() {
+		if data, err := httputil.DumpResponse(resp, true); err == nil {
+			c.logger.Tracef("Post response %s", data)
+		} else {
+			c.logger.Tracef("Post response DumpResponse error %s", err.Error())
+		}
+	}
 
 	// Parse the response.
 	if err := httprequest.UnmarshalJSONResponse(resp, result); err != nil {

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/kr/pretty"
 
 	"github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
@@ -31,7 +32,7 @@ func NewInfoClient(path path.Path, client RESTClient, logger Logger) *InfoClient
 // Info requests the information of a given charm. If that charm doesn't exist
 // an error stating that fact will be returned.
 func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoResponse, error) {
-	c.logger.Debugf("Info(%s)", name)
+	c.logger.Tracef("Info(%s)", name)
 	var resp transport.InfoResponse
 	path, err := c.path.Join(name)
 	if err != nil {
@@ -42,5 +43,6 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 		return resp, errors.Trace(err)
 	}
 
+	c.logger.Tracef("Info(%s) unmarshalled: %s", name, pretty.Sprint(resp))
 	return resp, resp.ErrorList.Combine()
 }

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -61,7 +61,7 @@ type RefreshConfig interface {
 
 // Refresh is used to refresh installed charms to a more suitable revision.
 func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
-	c.logger.Debugf("Refresh(%s)", pretty.Sprint(config))
+	c.logger.Tracef("Refresh(%s)", pretty.Sprint(config))
 	req, err := config.Build()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -74,7 +74,7 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 	if err := resp.ErrorList.Combine(); err != nil {
 		return nil, errors.Trace(err)
 	}
-
+	c.logger.Tracef("Refresh() unmarshalled: %s", pretty.Sprint(resp.Results))
 	return resp.Results, config.Ensure(resp.Results)
 }
 

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -4,15 +4,14 @@
 package transport
 
 type FindResponses struct {
-	Results   []FindResponse `json:"results"`
-	ErrorList APIErrors      `json:"error-list"`
+	Results   []FindResponse `json:"results,omitempty"`
+	ErrorList APIErrors      `json:"error-list,omitempty"`
 }
 
 type FindResponse struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	// TODO (stickupkid): Swap this over to the new name if it ever happens.
-	Entity         Entity     `json:"charm"`
+	Type           string     `json:"type"`
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	Entity         Entity     `json:"result,omitempty"`
 	DefaultRelease ChannelMap `json:"default-release,omitempty"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -10,5 +10,5 @@ type InfoResponse struct {
 	Entity         Entity       `json:"result"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
-	ErrorList      APIErrors    `json:"error-list"`
+	ErrorList      APIErrors    `json:"error-list,omitempty"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -4,11 +4,10 @@
 package transport
 
 type InfoResponse struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	// TODO (stickupkid): Swap this over to the new name if it ever happens.
-	Entity         Entity       `json:"charm"`
+	Type           string       `json:"type"`
+	ID             string       `json:"id"`
+	Name           string       `json:"name"`
+	Entity         Entity       `json:"result"`
 	ChannelMap     []ChannelMap `json:"channel-map"`
 	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
 	ErrorList      APIErrors    `json:"error-list"`

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -17,8 +17,8 @@ type RefreshRequestContext struct {
 	ID          string `json:"id"`
 
 	Revision        int                    `json:"revision"`
-	Platform        RefreshRequestPlatform `json:"platform"`
-	TrackingChannel string                 `json:"tracking-channel"`
+	Platform        RefreshRequestPlatform `json:"platform,omitempty"`
+	TrackingChannel string                 `json:"tracking-channel,omitempty"`
 	RefreshedDate   *time.Time             `json:"refresh-date,omitempty"`
 }
 
@@ -39,8 +39,8 @@ type RefreshRequestAction struct {
 }
 
 type RefreshResponses struct {
-	Results   []RefreshResponse `json:"results"`
-	ErrorList APIErrors         `json:"error-list"`
+	Results   []RefreshResponse `json:"results,omitempty"`
+	ErrorList APIErrors         `json:"error-list,omitempty"`
 }
 
 type RefreshResponse struct {

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -31,8 +31,8 @@ type RefreshRequestPlatform struct {
 type RefreshRequestAction struct {
 	Action      string                  `json:"action"`
 	InstanceKey string                  `json:"instance-key"`
-	ID          *string                 `json:"id"`
-	Name        *string                 `json:"name"`
+	ID          *string                 `json:"id,omitempty"`
+	Name        *string                 `json:"name,omitempty"`
 	Channel     *string                 `json:"channel,omitempty"`
 	Revision    *int                    `json:"revision,omitempty"`
 	Platform    *RefreshRequestPlatform `json:"platform,omitempty"`

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -141,16 +141,16 @@ func (a *deployAPIAdapter) GetAnnotations(tags []string) ([]apiparams.Annotation
 	return a.annotationsClient.Get(tags)
 }
 
-func (a *deployAPIAdapter) AddCharm(curl *charm.URL, origin commoncharm.Origin, force bool) (commoncharm.Origin, error) {
+func (a *deployAPIAdapter) AddCharm(curl *charm.URL, origin commoncharm.Origin, force bool, series string) (commoncharm.Origin, error) {
 	if a.charmsAPIVersion > 2 {
-		return a.charmsClient.AddCharm(curl, origin, force)
+		return a.charmsClient.AddCharm(curl, origin, force, series)
 	}
 	return origin, a.apiClient.AddCharm(curl, csparams.Channel(origin.Risk), force)
 }
 
-func (a *deployAPIAdapter) AddCharmWithAuthorization(curl *charm.URL, origin commoncharm.Origin, mac *macaroon.Macaroon, force bool) (commoncharm.Origin, error) {
+func (a *deployAPIAdapter) AddCharmWithAuthorization(curl *charm.URL, origin commoncharm.Origin, mac *macaroon.Macaroon, force bool, series string) (commoncharm.Origin, error) {
 	if a.charmsAPIVersion > 2 {
-		return a.charmsClient.AddCharmWithAuthorization(curl, origin, mac, force)
+		return a.charmsClient.AddCharmWithAuthorization(curl, origin, mac, force, series)
 	}
 	return origin, a.apiClient.AddCharmWithAuthorization(curl, csparams.Channel(origin.Risk), mac, force)
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1441,7 +1441,7 @@ func (s *DeploySuite) TestDeployWithTermsNotSigned(c *gc.C) {
 	deployURL := *curl
 	deployURL.Revision = 1
 	origin := commoncharm.Origin{Source: "charm-store"}
-	s.fakeAPI.Call("AddCharm", &deployURL, origin, false).Returns(origin, error(termsRequiredError))
+	s.fakeAPI.Call("AddCharm", &deployURL, origin, false, "bionic").Returns(origin, error(termsRequiredError))
 	deploy := s.deployCommand()
 
 	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), "cs:bionic/terms1")
@@ -1471,7 +1471,7 @@ func (s *DeploySuite) TestDeployWithChannel(c *gc.C) {
 		Series:          "bionic",
 		NumUnits:        1,
 	}).Returns(error(nil))
-	s.fakeAPI.Call("AddCharm", curl, origin, false).Returns(origin, error(nil))
+	s.fakeAPI.Call("AddCharm", curl, origin, false, "bionic").Returns(origin, error(nil))
 	withCharmDeployable(
 		s.fakeAPI, curl, "bionic",
 		&charm.Meta{Name: "dummy", Series: []string{"bionic"}},
@@ -1860,7 +1860,7 @@ func (s *FakeStoreStateSuite) setupCharmMaybeAddForce(c *gc.C, url, name, series
 		)
 	}
 	origin, _ := apputils.DeduceOrigin(deployURL, corecharm.Channel{})
-	s.fakeAPI.Call("AddCharm", resolveURL, origin, force).Returns(origin, error(nil))
+	s.fakeAPI.Call("AddCharm", resolveURL, origin, force, series).Returns(origin, error(nil))
 	var chDir charm.Charm
 	var err error
 	chDir, err = charm.ReadCharmDir(testcharms.RepoWithSeries(series).CharmDirPath(name))
@@ -2527,8 +2527,8 @@ func (f *fakeDeployAPI) AddLocalCharm(url *charm.URL, ch charm.Charm, force bool
 	return results[0].(*charm.URL), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) AddCharm(url *charm.URL, origin commoncharm.Origin, force bool) (commoncharm.Origin, error) {
-	results := f.MethodCall(f, "AddCharm", url, origin, force)
+func (f *fakeDeployAPI) AddCharm(url *charm.URL, origin commoncharm.Origin, force bool, series string) (commoncharm.Origin, error) {
+	results := f.MethodCall(f, "AddCharm", url, origin, force, series)
 	return results[0].(commoncharm.Origin), jujutesting.TypeAssertError(results[1])
 }
 
@@ -2537,8 +2537,9 @@ func (f *fakeDeployAPI) AddCharmWithAuthorization(
 	origin commoncharm.Origin,
 	macaroon *macaroon.Macaroon,
 	force bool,
+	series string,
 ) (commoncharm.Origin, error) {
-	results := f.MethodCall(f, "AddCharmWithAuthorization", url, origin, macaroon, force)
+	results := f.MethodCall(f, "AddCharmWithAuthorization", url, origin, macaroon, force, series)
 	return results[0].(commoncharm.Origin), jujutesting.TypeAssertError(results[1])
 }
 
@@ -2836,7 +2837,7 @@ func withCharmDeployableWithDevicesAndStorage(
 		}
 	}
 	origin, _ := apputils.DeduceOrigin(url, corecharm.Channel{})
-	fakeAPI.Call("AddCharm", &deployURL, origin, force).Returns(origin, error(nil))
+	fakeAPI.Call("AddCharm", &deployURL, origin, force, "bionic").Returns(origin, error(nil))
 	fakeAPI.Call("CharmInfo", deployURL.String()).Returns(
 		&charms.CharmInfo{
 			URL:     url.String(),

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -487,6 +487,14 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	}
 	id := change.Id()
 	chParms := change.Params
+
+	// Use the series specified for this charm in the bundle,
+	// fallback to the series specified for the bundle.
+	series := chParms.Series
+	if series == "" {
+		series = h.data.Series
+	}
+
 	// First attempt to interpret as a local path.
 	if h.isLocalCharm(chParms.Charm) {
 		charmPath := chParms.Charm
@@ -494,10 +502,6 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 			charmPath = filepath.Join(h.bundleDir, charmPath)
 		}
 
-		series := chParms.Series
-		if series == "" {
-			series = h.data.Series
-		}
 		ch, curl, err := charmrepo.NewCharmAtPathForceSeries(charmPath, series, h.force)
 		if err != nil && !os.IsNotExist(err) {
 			return errors.Annotatef(err, "cannot deploy local charm at %q", charmPath)
@@ -539,7 +543,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 
 	var macaroon *macaroon.Macaroon
 	var charmOrigin commoncharm.Origin
-	url, macaroon, charmOrigin, err = store.AddCharmFromURL(h.deployAPI, h.authorizer, url, origin, h.force)
+	url, macaroon, charmOrigin, err = store.AddCharmFromURL(h.deployAPI, h.authorizer, url, origin, h.force, series)
 	if err != nil {
 		return errors.Annotatef(err, "cannot add charm %q", chParms.Charm)
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -1046,8 +1046,9 @@ func (s *BundleDeployCharmStoreSuite) expectAddCharm(force bool) {
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		force,
+		gomock.Any(),
 	).DoAndReturn(
-		func(_ *charm.URL, origin commoncharm.Origin, _ bool) (commoncharm.Origin, error) {
+		func(_ *charm.URL, origin commoncharm.Origin, _ bool, _ string) (commoncharm.Origin, error) {
 			return origin, nil
 		})
 }

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -440,13 +440,15 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// Store the charm in the controller
-	curl, csMac, csOrigin, err := store.AddCharmFromURL(deployAPI, macaroonGetter, storeCharmOrBundleURL, c.origin, c.force)
+	curl, csMac, csOrigin, err := store.AddCharmFromURL(deployAPI, macaroonGetter, storeCharmOrBundleURL, c.origin, c.force, series)
 	if err != nil {
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())
 		}
 		return errors.Annotatef(err, "storing charm for URL %q", storeCharmOrBundleURL)
 	}
+	formattedCharmURL := curl.String()
+	ctx.Infof("Located charm %q.", formattedCharmURL)
 
 	// If the original series was empty, so we couldn't validate the original
 	// charm series, but the charm url wasn't nil, we can check and validate
@@ -462,10 +464,7 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		}
 	}
 
-	formattedCharmURL := curl.String()
-	ctx.Infof("Located charm %q.", formattedCharmURL)
 	ctx.Infof("Deploying charm %q.", formattedCharmURL)
-
 	c.id = charmstore.CharmID{
 		URL:     curl,
 		Channel: csparams.Channel(c.origin.Risk),

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -62,33 +62,33 @@ func (mr *MockDeployerAPIMockRecorder) APICall(arg0, arg1, arg2, arg3, arg4, arg
 }
 
 // AddCharm mocks base method
-func (m *MockDeployerAPI) AddCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool) (charm0.Origin, error) {
+func (m *MockDeployerAPI) AddCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool, arg3 string) (charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCharm", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.Origin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddCharm indicates an expected call of AddCharm
-func (mr *MockDeployerAPIMockRecorder) AddCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDeployerAPIMockRecorder) AddCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharm", reflect.TypeOf((*MockDeployerAPI)(nil).AddCharm), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharm", reflect.TypeOf((*MockDeployerAPI)(nil).AddCharm), arg0, arg1, arg2, arg3)
 }
 
 // AddCharmWithAuthorization mocks base method
-func (m *MockDeployerAPI) AddCharmWithAuthorization(arg0 *charm.URL, arg1 charm0.Origin, arg2 *macaroon.Macaroon, arg3 bool) (charm0.Origin, error) {
+func (m *MockDeployerAPI) AddCharmWithAuthorization(arg0 *charm.URL, arg1 charm0.Origin, arg2 *macaroon.Macaroon, arg3 bool, arg4 string) (charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCharmWithAuthorization", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddCharmWithAuthorization", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(charm0.Origin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddCharmWithAuthorization indicates an expected call of AddCharmWithAuthorization
-func (mr *MockDeployerAPIMockRecorder) AddCharmWithAuthorization(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDeployerAPIMockRecorder) AddCharmWithAuthorization(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmWithAuthorization", reflect.TypeOf((*MockDeployerAPI)(nil).AddCharmWithAuthorization), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmWithAuthorization", reflect.TypeOf((*MockDeployerAPI)(nil).AddCharmWithAuthorization), arg0, arg1, arg2, arg3, arg4)
 }
 
 // AddLocalCharm mocks base method

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -579,16 +579,16 @@ func (c *charmAdderShim) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bo
 	return c.api.AddLocalCharm(curl, ch, force)
 }
 
-func (c *charmAdderShim) AddCharm(curl *charm.URL, origin commoncharm.Origin, force bool) (commoncharm.Origin, error) {
+func (c *charmAdderShim) AddCharm(curl *charm.URL, origin commoncharm.Origin, force bool, series string) (commoncharm.Origin, error) {
 	if c.charms != nil {
-		return c.charms.AddCharm(curl, origin, force)
+		return c.charms.AddCharm(curl, origin, force, series)
 	}
 	return origin, c.api.AddCharm(curl, csparams.Channel(origin.Risk), force)
 }
 
-func (c *charmAdderShim) AddCharmWithAuthorization(curl *charm.URL, origin commoncharm.Origin, mac *macaroon.Macaroon, force bool) (commoncharm.Origin, error) {
+func (c *charmAdderShim) AddCharmWithAuthorization(curl *charm.URL, origin commoncharm.Origin, mac *macaroon.Macaroon, force bool, series string) (commoncharm.Origin, error) {
 	if c.charms != nil {
-		return c.charms.AddCharmWithAuthorization(curl, origin, mac, force)
+		return c.charms.AddCharmWithAuthorization(curl, origin, mac, force, series)
 	}
 	return origin, c.api.AddCharmWithAuthorization(curl, csparams.Channel(origin.Risk), mac, force)
 

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -495,9 +495,6 @@ func (s *RefreshSuccessStateSuite) SetUpTest(c *gc.C) {
 		) (store.MacaroonGetter, store.CharmrepoForDeploy) {
 			return s.fakeAPI, s.fakeAPI
 		},
-		//func(conn api.Connection) store.CharmAdder {
-		//	return &apiClient{Client: conn.Client()}
-		//},
 		newCharmAdder,
 		func(conn base.APICallCloser) utils.CharmClient {
 			return &s.charmClient
@@ -548,7 +545,7 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
 	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta})
-	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
+	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false, "")
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
@@ -566,7 +563,7 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
 	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta})
-	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
+	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false, "")
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
@@ -585,7 +582,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 	s.charmClient.CheckCall(c, 0, "CharmInfo", s.resolvedCharmURL.String())
 	s.charmAdder.CheckCallNames(c, "AddCharm")
 	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Stable})
-	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
+	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false, "")
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURL", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
@@ -907,8 +904,8 @@ type mockCharmAdder struct {
 	testing.Stub
 }
 
-func (m *mockCharmAdder) AddCharm(curl *charm.URL, origin commoncharm.Origin, force bool) (commoncharm.Origin, error) {
-	m.MethodCall(m, "AddCharm", curl, origin, force)
+func (m *mockCharmAdder) AddCharm(curl *charm.URL, origin commoncharm.Origin, force bool, series string) (commoncharm.Origin, error) {
+	m.MethodCall(m, "AddCharm", curl, origin, force, series)
 	return origin, m.NextErr()
 }
 

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -259,7 +259,7 @@ func (r *charmStoreRefresher) Refresh() (*CharmID, error) {
 		return nil, errors.Errorf("already running latest charm %q", newURL)
 	}
 
-	curl, csMac, _, err := store.AddCharmFromURL(r.charmAdder, r.authorizer, newURL, origin, r.force)
+	curl, csMac, _, err := store.AddCharmFromURL(r.charmAdder, r.authorizer, newURL, origin, r.force, r.deployedSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -251,7 +251,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefresh(c *gc.C) {
 	authorizer := NewMockMacaroonGetter(ctrl)
 
 	charmAdder := NewMockCharmAdder(ctrl)
-	charmAdder.EXPECT().AddCharm(newCurl, origin, false).Return(origin, nil)
+	charmAdder.EXPECT().AddCharm(newCurl, origin, false, "").Return(origin, nil)
 
 	charmResolver := NewMockCharmResolver(ctrl)
 	charmResolver.EXPECT().ResolveCharm(curl, origin).Return(newCurl, origin, []string{}, nil)

--- a/cmd/juju/application/refresher/store_mock_test.go
+++ b/cmd/juju/application/refresher/store_mock_test.go
@@ -73,33 +73,33 @@ func (m *MockCharmAdder) EXPECT() *MockCharmAdderMockRecorder {
 }
 
 // AddCharm mocks base method
-func (m *MockCharmAdder) AddCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool) (charm0.Origin, error) {
+func (m *MockCharmAdder) AddCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool, arg3 string) (charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCharm", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.Origin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddCharm indicates an expected call of AddCharm
-func (mr *MockCharmAdderMockRecorder) AddCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCharmAdderMockRecorder) AddCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharm", reflect.TypeOf((*MockCharmAdder)(nil).AddCharm), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharm", reflect.TypeOf((*MockCharmAdder)(nil).AddCharm), arg0, arg1, arg2, arg3)
 }
 
 // AddCharmWithAuthorization mocks base method
-func (m *MockCharmAdder) AddCharmWithAuthorization(arg0 *charm.URL, arg1 charm0.Origin, arg2 *macaroon.Macaroon, arg3 bool) (charm0.Origin, error) {
+func (m *MockCharmAdder) AddCharmWithAuthorization(arg0 *charm.URL, arg1 charm0.Origin, arg2 *macaroon.Macaroon, arg3 bool, arg4 string) (charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCharmWithAuthorization", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddCharmWithAuthorization", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(charm0.Origin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddCharmWithAuthorization indicates an expected call of AddCharmWithAuthorization
-func (mr *MockCharmAdderMockRecorder) AddCharmWithAuthorization(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCharmAdderMockRecorder) AddCharmWithAuthorization(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmWithAuthorization", reflect.TypeOf((*MockCharmAdder)(nil).AddCharmWithAuthorization), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmWithAuthorization", reflect.TypeOf((*MockCharmAdder)(nil).AddCharmWithAuthorization), arg0, arg1, arg2, arg3, arg4)
 }
 
 // AddLocalCharm mocks base method

--- a/cmd/juju/application/store/interface.go
+++ b/cmd/juju/application/store/interface.go
@@ -16,8 +16,8 @@ import (
 // charm.
 type CharmAdder interface {
 	AddLocalCharm(*charm.URL, charm.Charm, bool) (*charm.URL, error) // not used in utils
-	AddCharm(*charm.URL, commoncharm.Origin, bool) (commoncharm.Origin, error)
-	AddCharmWithAuthorization(*charm.URL, commoncharm.Origin, *macaroon.Macaroon, bool) (commoncharm.Origin, error)
+	AddCharm(*charm.URL, commoncharm.Origin, bool, string) (commoncharm.Origin, error)
+	AddCharmWithAuthorization(*charm.URL, commoncharm.Origin, *macaroon.Macaroon, bool, string) (commoncharm.Origin, error)
 }
 
 // charmrepoForDeploy is a stripped-down version of the

--- a/cmd/juju/application/store/mocks/store_mock.go
+++ b/cmd/juju/application/store/mocks/store_mock.go
@@ -38,33 +38,33 @@ func (m *MockCharmAdder) EXPECT() *MockCharmAdderMockRecorder {
 }
 
 // AddCharm mocks base method
-func (m *MockCharmAdder) AddCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool) (charm0.Origin, error) {
+func (m *MockCharmAdder) AddCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool, arg3 string) (charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCharm", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddCharm", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm0.Origin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddCharm indicates an expected call of AddCharm
-func (mr *MockCharmAdderMockRecorder) AddCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCharmAdderMockRecorder) AddCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharm", reflect.TypeOf((*MockCharmAdder)(nil).AddCharm), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharm", reflect.TypeOf((*MockCharmAdder)(nil).AddCharm), arg0, arg1, arg2, arg3)
 }
 
 // AddCharmWithAuthorization mocks base method
-func (m *MockCharmAdder) AddCharmWithAuthorization(arg0 *charm.URL, arg1 charm0.Origin, arg2 *macaroon.Macaroon, arg3 bool) (charm0.Origin, error) {
+func (m *MockCharmAdder) AddCharmWithAuthorization(arg0 *charm.URL, arg1 charm0.Origin, arg2 *macaroon.Macaroon, arg3 bool, arg4 string) (charm0.Origin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCharmWithAuthorization", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddCharmWithAuthorization", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(charm0.Origin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddCharmWithAuthorization indicates an expected call of AddCharmWithAuthorization
-func (mr *MockCharmAdderMockRecorder) AddCharmWithAuthorization(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCharmAdderMockRecorder) AddCharmWithAuthorization(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmWithAuthorization", reflect.TypeOf((*MockCharmAdder)(nil).AddCharmWithAuthorization), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmWithAuthorization", reflect.TypeOf((*MockCharmAdder)(nil).AddCharmWithAuthorization), arg0, arg1, arg2, arg3, arg4)
 }
 
 // AddLocalCharm mocks base method

--- a/cmd/juju/application/store/store.go
+++ b/cmd/juju/application/store/store.go
@@ -1,9 +1,6 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// TODO(natefinch): change the code in this file to use the
-// github.com/juju/juju/charmstore package to interact with the charmstore.
-
 package store
 
 import (
@@ -25,9 +22,9 @@ import (
 // given charm URL to state. For non-public charm URLs, this function also
 // handles the macaroon authorization process using the given csClient.
 // The resulting charm URL of the added charm is displayed on stdout.
-func AddCharmFromURL(client CharmAdder, cs MacaroonGetter, curl *charm.URL, origin commoncharm.Origin, force bool) (*charm.URL, *macaroon.Macaroon, commoncharm.Origin, error) {
+func AddCharmFromURL(client CharmAdder, cs MacaroonGetter, curl *charm.URL, origin commoncharm.Origin, force bool, series string) (*charm.URL, *macaroon.Macaroon, commoncharm.Origin, error) {
 	var csMac *macaroon.Macaroon
-	resultOrigin, err := client.AddCharm(curl, origin, force)
+	resultOrigin, err := client.AddCharm(curl, origin, force, series)
 	if err != nil {
 		if !params.IsCodeUnauthorized(err) {
 			return nil, nil, commoncharm.Origin{}, errors.Trace(err)
@@ -36,7 +33,7 @@ func AddCharmFromURL(client CharmAdder, cs MacaroonGetter, curl *charm.URL, orig
 		if err != nil {
 			return nil, nil, commoncharm.Origin{}, common.MaybeTermsAgreementError(err)
 		}
-		if resultOrigin, err = client.AddCharmWithAuthorization(curl, origin, m, force); err != nil {
+		if resultOrigin, err = client.AddCharmWithAuthorization(curl, origin, m, force, series); err != nil {
 			return nil, nil, commoncharm.Origin{}, errors.Trace(err)
 		}
 		csMac = m

--- a/cmd/juju/application/store/store_test.go
+++ b/cmd/juju/application/store/store_test.go
@@ -43,6 +43,7 @@ func (s *storeSuite) TestAddCharmFromURLAddCharmSuccess(c *gc.C) {
 		curl,
 		origin,
 		true,
+		"",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedMac, gc.IsNil)
@@ -63,6 +64,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFail(c *gc.C) {
 		curl,
 		origin,
 		true,
+		"",
 	)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(obtainedMac, gc.IsNil)
@@ -88,6 +90,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFailUnauthorized(c *gc.C) {
 		curl,
 		origin,
 		true,
+		"",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedMac, gc.IsNil)
@@ -106,8 +109,9 @@ func (s *storeSuite) expectAddCharm(err error) {
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		true,
+		"",
 	).DoAndReturn(
-		func(_ *charm.URL, origin commoncharm.Origin, _ bool) (commoncharm.Origin, error) {
+		func(_ *charm.URL, origin commoncharm.Origin, _ bool, _ string) (commoncharm.Origin, error) {
 			return origin, err
 		})
 }
@@ -118,8 +122,9 @@ func (s *storeSuite) expectAddCharmWithAuthorization() {
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		gomock.AssignableToTypeOf(&macaroon.Macaroon{}),
 		true,
+		"",
 	).DoAndReturn(
-		func(_ *charm.URL, origin commoncharm.Origin, _ *macaroon.Macaroon, _ bool) (commoncharm.Origin, error) {
+		func(_ *charm.URL, origin commoncharm.Origin, _ *macaroon.Macaroon, _ bool, _ string) (commoncharm.Origin, error) {
 			return origin, nil
 		})
 }

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -16,7 +16,7 @@ type Repository interface {
 	// FindDownloadURL returns a url from which a charm can be downloaded
 	// based on the given charm url and charm origin.  A charm origin
 	// updated with the ID and hash for the download is also returned.
-	FindDownloadURL(curl *charm.URL, origin Origin) (*url.URL, Origin, error)
+	FindDownloadURL(curl *charm.URL, origin Origin, series string) (*url.URL, Origin, error)
 
 	// DownloadCharm reads the charm referenced the resource URL or downloads
 	// into a file with the given path, which will be created if needed.


### PR DESCRIPTION
## Description of change

Update CharmHub info response json tag for Entity from charm to result.  API change has been made.

Additional debugging in the CharmHub client to facilitate request and response debugging.

Id and Name in the RefreshRequestAction as a null values results in an API error:
ERROR storing charm for URL "apitest-ubuntu-qa-1": None is not of type 'string' at /actions/0/id
ERROR storing charm for URL "apitest-ubuntu-qa-1": None is not of type 'string' at /actions/0/name 

Waiting on charmhub server bug got be able to download the provided charm via url.

## QA steps


```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju add-model seven --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy apitest-ubuntu-qa
ERROR storing charm for URL "apitest-ubuntu-qa-1": cannot retrieve "https://api.staging.charmhub.io/api/v1/charms/download/4HVy9HLeoMQ0eUALfsvE6ifqtL6DqUPm_1.charm": unable to locate archive
```

