### PR TITLE
Make `juju status` error a bit more helpful if bootstrap is ongoing

### DIFF
--- a/juju/api.go
+++ b/juju/api.go
@@ -58,7 +58,7 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 		return nil, errors.Annotatef(err, "cannot work out how to connect")
 	}
 	if len(apiInfo.Addrs) == 0 {
-		return nil, errors.New("no API addresses")
+		return nil, errors.New("no controller API addresses; is bootstrap still in progress?")
 	}
 	// Copy the cache so we'll know whether it's changed so that
 	// we'll update the entry correctly.

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -161,7 +161,7 @@ func (s *NewAPIClientSuite) TestWithInfoNoAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	st, err := newAPIConnectionFromNames(c, "noconfig", "", store, panicAPIOpen)
-	c.Assert(err, gc.ErrorMatches, "no API addresses")
+	c.Assert(err, gc.ErrorMatches, "no controller API addresses; is bootstrap still in progress\\?")
 	c.Assert(st, gc.IsNil)
 }
 


### PR DESCRIPTION

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

I was confused by this terse error message from `juju status` when I started. When a bootstrap is in progress on another terminal tab, it just says "no API addresses". So I've expanded that a bit.

It's possible it'd be better to add a special `NoAPIAddresses` error type which the CLI looks for, instead of changing the message directly in `juju/api.go` -- please comment if so.

## QA steps

Run a bootstrap, and while it's running type `juju status` in another terminal window. It should say "ERROR: no API addresses" before this change and "ERROR: no controller API addresses; is bootstrap still in progress?" after.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1896566