### PR TITLE
Cleanup EC2 key-pairs for manual integration tests

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -50,7 +50,7 @@ manual_deploy() {
 
     juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
 
-    juju deploy percona-cluster
+    juju deploy cs:percona-cluster
 
     wait_for "percona-cluster" "$(idle_condition "percona-cluster" 0 0)"
 


### PR DESCRIPTION
## Description of change

For manual provider tests running on EC2 VMs, we add a key-pair so that we can SSH to the machines. We have been creating a key-pair per test without cleaning them up.

This patch ensures that the test key-pair is removed during test clean-up.

## QA steps

From the _tests_ directory:
    `BOOTSTRAP_PROVIDER=aws ./main.sh -v manual`

Check that after the completes, the key-pair with the same name as the test has been removed.
Example:
    https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#KeyPairs:

## Documentation changes

None.

## Bug reference

N/A
