### PR TITLE
Change "Waiting on " -> "Waiting for" in destroy-controller messages

### DIFF
--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -151,8 +151,8 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 		c.Fatal("timed out waiting for result")
 	}
 	expect := "" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 1 machine\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 1 machine\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
@@ -206,8 +206,8 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 		c.Fatal("timed out waiting for result")
 	}
 	expect := "" +
-		"Waiting on 0 model, 2 machines\n" +
-		"Waiting on 0 model, 1 machine\n" +
+		"Waiting for 0 model, 2 machines\n" +
+		"Waiting for 0 model, 1 machine\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
@@ -256,9 +256,9 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 		c.Fatal("timed out waiting for result")
 	}
 	expect := "" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
-		"Waiting on 1 model, 1 machine, will kill machines directly in 20s\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
+		"Waiting for 1 model, 1 machine, will kill machines directly in 20s\n" +
 		"All hosted models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
@@ -296,18 +296,18 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutWithNoChange(c *gc.C) {
 		c.Fatal("timed out waiting for result")
 	}
 	expect := "" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications\n" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 25s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 10s\n" +
-		"Waiting on 1 model, 2 machines, 2 applications, will kill machines directly in 5s\n"
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 25s\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 10s\n" +
+		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 5s\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
@@ -555,7 +555,7 @@ func (s *KillSuite) TestFmtControllerStatus(c *gc.C) {
 		ApplicationCount:   8,
 	}
 	out := controller.FmtCtrStatus(data)
-	c.Assert(out, gc.Equals, "Waiting on 3 models, 20 machines, 8 applications")
+	c.Assert(out, gc.Equals, "Waiting for 3 models, 20 machines, 8 applications")
 }
 
 func (s *KillSuite) TestFmtEnvironStatus(c *gc.C) {

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -194,7 +194,7 @@ func s(n int) string {
 
 func fmtCtrStatus(data ctrData) string {
 	modelNo := data.HostedModelCount
-	out := fmt.Sprintf("Waiting on %d model%s", modelNo, s(modelNo))
+	out := fmt.Sprintf("Waiting for %d model%s", modelNo, s(modelNo))
 
 	if machineNo := data.HostedMachineCount; machineNo > 0 {
 		out += fmt.Sprintf(", %d machine%s", machineNo, s(machineNo))


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Just a simple change in the grammar of the destroy-controller messaging. It pains me every time I destroy a controller. In English, "waiting on" is only for tables. The rest of the time you are "waiting for" something to happen. 

