### PR TITLE
Juju info add config option

### DIFF
--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -103,6 +103,9 @@ func transformChannelMap(channelMap []transport.ChannelMap) ([]string, map[strin
 	channels := make(map[string]params.Channel, len(channelMap))
 	for _, cm := range channelMap {
 		ch := cm.Channel
+		if ch.Track == "" {
+			ch.Track = "latest"
+		}
 		chName := ch.Track + "/" + ch.Risk
 		channels[chName] = params.Channel{
 			Revision:   cm.Revision.Revision,

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -103,6 +103,7 @@ func transformChannelMap(channelMap []transport.ChannelMap) ([]string, map[strin
 	channels := make(map[string]params.Channel, len(channelMap))
 	for _, cm := range channelMap {
 		ch := cm.Channel
+		// Per the charmhub/snap channel spec.
 		if ch.Track == "" {
 			ch.Track = "latest"
 		}

--- a/cmd/juju/charmhub/data.go
+++ b/cmd/juju/charmhub/data.go
@@ -10,6 +10,7 @@ import (
 )
 
 func convertCharmInfoResult(info charmhub.InfoResponse) (InfoResponse, error) {
+
 	ir := InfoResponse{
 		Type:        info.Type,
 		ID:          info.ID,

--- a/cmd/juju/charmhub/data.go
+++ b/cmd/juju/charmhub/data.go
@@ -10,7 +10,6 @@ import (
 )
 
 func convertCharmInfoResult(info charmhub.InfoResponse) (InfoResponse, error) {
-
 	ir := InfoResponse{
 		Type:        info.Type,
 		ID:          info.ID,

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -43,7 +43,7 @@ type infoCommand struct {
 
 	api InfoCommandAPI
 
-	verbose       bool
+	config        bool
 	charmOrBundle string
 }
 
@@ -63,6 +63,7 @@ func (c *infoCommand) Info() *cmd.Info {
 // It implements part of the cmd.Command interface.
 func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	f.BoolVar(&c.config, "config", false, "display config for this charm")
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
@@ -107,7 +108,6 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-
 	return c.out.Write(ctx, &view)
 }
 
@@ -138,7 +138,7 @@ func (c *infoCommand) formatter(writer io.Writer, value interface{}) error {
 		return errors.Errorf("unexpected results")
 	}
 
-	if err := makeInfoWriter(writer, c.warningLog, results).Print(); err != nil {
+	if err := makeInfoWriter(writer, c.warningLog, c.config, results).Print(); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
@@ -139,19 +138,19 @@ func (b bundleInfoWriter) Print() error {
 }
 
 type charmInfoOutput struct {
-	Name        string                  `yaml:"name,omitempty"`
-	ID          string                  `yaml:"charm-id,omitempty"`
-	Summary     string                  `yaml:"summary,omitempty"`
-	Publisher   string                  `yaml:"publisher,omitempty"`
-	Supports    string                  `yaml:"supports,omitempty"`
-	Tags        string                  `yaml:"tags,omitempty"`
-	Subordinate bool                    `yaml:"subordinate"`
-	StoreURL    string                  `yaml:"store-url,omitempty"`
-	Description string                  `yaml:"description,omitempty"`
-	Relations   relationOutput          `yaml:"relations,omitempty"`
-	Channels    string                  `yaml:"channels,omitempty"`
-	Installed   string                  `yaml:"installed,omitempty"`
-	Config      map[string]charm.Option `yaml:"settings,omitempty"`
+	Name        string                 `yaml:"name,omitempty"`
+	ID          string                 `yaml:"charm-id,omitempty"`
+	Summary     string                 `yaml:"summary,omitempty"`
+	Publisher   string                 `yaml:"publisher,omitempty"`
+	Supports    string                 `yaml:"supports,omitempty"`
+	Tags        string                 `yaml:"tags,omitempty"`
+	Subordinate bool                   `yaml:"subordinate"`
+	StoreURL    string                 `yaml:"store-url,omitempty"`
+	Description string                 `yaml:"description,omitempty"`
+	Relations   relationOutput         `yaml:"relations,omitempty"`
+	Channels    string                 `yaml:"channels,omitempty"`
+	Installed   string                 `yaml:"installed,omitempty"`
+	Config      map[string]interface{} `yaml:"config,omitempty"`
 }
 
 type relationOutput struct {
@@ -177,8 +176,9 @@ func (c charmInfoWriter) Print() error {
 	}
 	if c.in.Charm != nil {
 		out.Subordinate = c.in.Charm.Subordinate
-		if c.displayConfig {
-			out.Config = c.in.Charm.Config.Options
+		if c.displayConfig && c.in.Charm.Config != nil {
+			out.Config = make(map[string]interface{}, 1)
+			out.Config["settings"] = c.in.Charm.Config.Options
 		}
 	}
 	if rels, err := c.relations(); err == nil {

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -79,15 +79,16 @@ channels: |
   latest/candidate:  1.0.3  2019-12-16  (17)  12MB
   latest/beta:       1.0.3  2019-12-16  (17)  12MB
   latest/edge:       1.0.3  2019-12-16  (18)  12MB
-settings:
-  status:
-    type: string
-    description: temporary string for unit status
-    default: hello
-  thing:
-    type: string
-    description: A thing used by the charm.
-    default: "\U0001F381"
+config:
+  settings:
+    status:
+      type: string
+      description: temporary string for unit status
+      default: hello
+    thing:
+      type: string
+      description: A thing used by the charm.
+      default: "\U0001F381"
 `
 	c.Assert(obtained, gc.Equals, expected)
 }


### PR DESCRIPTION

## Description of change

Allow channels to be displayed again, real vs canned data issue.  Instead of latest, the tracks that are latest are an empty string, insert "latest" for display purposes.

Add the ability to display charm config options in the juju info output.  Handy to know before deploying.

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju add-model seven --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju info apitest-ubuntu-qa --config
name: apitest-ubuntu-qa
charm-id: 4HVy9HLeoMQ0eUALfsvE6ifqtL6DqUPm
summary: |
  juju-qa version of the ubuntu charm.
publisher: Heather Lanigan
supports: focal, xenial, bionic
subordinate: false
store-url: https://api.staging.snapcraft.io/v2/charms/apitest-ubuntu-qa
description: |
  juju-qa version of the ubuntu charm.
channels: |
  latest/stable:     1     (1)  250kB
  latest/candidate:  1     (1)  250kB
  latest/beta:       1     (1)  250kB
  latest/edge:       2     (2)  250kB
settings:
  status:
    type: string
    description: temporary string for unit status
    default: hello
  thing:
    type: string
    description: A thing used by the charm.
    default: "\U0001F381"

```


