### PR TITLE
Create the charmhub refresher

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -543,7 +543,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 
 	var macaroon *macaroon.Macaroon
 	var charmOrigin commoncharm.Origin
-	url, macaroon, charmOrigin, err = store.AddCharmFromURL(h.deployAPI, h.authorizer, url, origin, h.force, series)
+	url, macaroon, charmOrigin, err = store.AddCharmWithAuthorizationFromURL(h.deployAPI, h.authorizer, url, origin, h.force, series)
 	if err != nil {
 		return errors.Annotatef(err, "cannot add charm %q", chParms.Charm)
 	}

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -440,7 +440,7 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// Store the charm in the controller
-	curl, csMac, csOrigin, err := store.AddCharmFromURL(deployAPI, macaroonGetter, storeCharmOrBundleURL, c.origin, c.force, series)
+	curl, csMac, csOrigin, err := store.AddCharmWithAuthorizationFromURL(deployAPI, macaroonGetter, storeCharmOrBundleURL, c.origin, c.force, series)
 	if err != nil {
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -347,14 +347,15 @@ func (s *charmHubCharmRefresherSuite) TestRefresh(c *gc.C) {
 	}
 
 	charmAdder := NewMockCharmAdder(ctrl)
-	charmAdder.EXPECT().AddCharm(newCurl, origin, false).Return(origin, nil)
+	charmAdder.EXPECT().AddCharm(newCurl, origin, false, "bionic").Return(origin, nil)
 
 	charmResolver := NewMockCharmResolver(ctrl)
 	charmResolver.EXPECT().ResolveCharm(curl, origin).Return(newCurl, origin, []string{}, nil)
 
 	cfg := RefresherConfig{
-		CharmURL: curl,
-		CharmRef: ref,
+		CharmURL:       curl,
+		CharmRef:       ref,
+		DeployedSeries: "bionic",
 	}
 
 	refresher := (&factory{}).maybeCharmHub(charmAdder, charmResolver)

--- a/cmd/juju/application/store/store.go
+++ b/cmd/juju/application/store/store.go
@@ -19,10 +19,23 @@ import (
 )
 
 // AddCharmFromURL calls the appropriate client API calls to add the
-// given charm URL to state. For non-public charm URLs, this function also
-// handles the macaroon authorization process using the given csClient.
+// given charm URL to state.
+func AddCharmFromURL(client CharmAdder, curl *charm.URL, origin commoncharm.Origin, force bool, series string) (*charm.URL, commoncharm.Origin, error) {
+	resultOrigin, err := client.AddCharm(curl, origin, force, series)
+	if err != nil {
+		if params.IsCodeUnauthorized(err) {
+			return nil, commoncharm.Origin{}, errors.Forbiddenf(err.Error())
+		}
+		return nil, commoncharm.Origin{}, errors.Trace(err)
+	}
+	return curl, resultOrigin, nil
+}
+
+// AddCharmWithAuthorizationFromURL calls the appropriate client API calls to
+// add the given charm URL to state. For non-public charm URLs, this function
+// also handles the macaroon authorization process using the given csClient.
 // The resulting charm URL of the added charm is displayed on stdout.
-func AddCharmFromURL(client CharmAdder, cs MacaroonGetter, curl *charm.URL, origin commoncharm.Origin, force bool, series string) (*charm.URL, *macaroon.Macaroon, commoncharm.Origin, error) {
+func AddCharmWithAuthorizationFromURL(client CharmAdder, cs MacaroonGetter, curl *charm.URL, origin commoncharm.Origin, force bool, series string) (*charm.URL, *macaroon.Macaroon, commoncharm.Origin, error) {
 	var csMac *macaroon.Macaroon
 	resultOrigin, err := client.AddCharm(curl, origin, force, series)
 	if err != nil {

--- a/cmd/juju/application/store/store_test.go
+++ b/cmd/juju/application/store/store_test.go
@@ -42,6 +42,7 @@ func (s *storeSuite) TestAddCharmFromURLAddCharmSuccess(c *gc.C) {
 		curl,
 		origin,
 		true,
+		"focal",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedCurl.String(), gc.Equals, curl.String())
@@ -60,6 +61,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFail(c *gc.C) {
 		curl,
 		origin,
 		true,
+		"focal",
 	)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(obtainedCurl, gc.IsNil)
@@ -81,6 +83,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFailUnauthorized(c *gc.C) {
 		curl,
 		origin,
 		true,
+		"focal",
 	)
 	c.Assert(err, jc.Satisfies, errors.IsForbidden)
 	c.Assert(obtainedCurl, gc.IsNil)
@@ -101,7 +104,7 @@ func (s *storeSuite) TestAddCharmWithAuthorizationFromURLAddCharmSuccess(c *gc.C
 		curl,
 		origin,
 		true,
-		"",
+		"focal",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedMac, gc.IsNil)
@@ -122,7 +125,7 @@ func (s *storeSuite) TestAddCharmWithAuthorizationFromURLFailAddCharmFail(c *gc.
 		curl,
 		origin,
 		true,
-		"",
+		"focal",
 	)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(obtainedMac, gc.IsNil)
@@ -148,7 +151,7 @@ func (s *storeSuite) TestAddCharmWithAuthorizationFromURLFailAddCharmFailUnautho
 		curl,
 		origin,
 		true,
-		"",
+		"focal",
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedMac, gc.IsNil)
@@ -167,7 +170,7 @@ func (s *storeSuite) expectAddCharm(err error) {
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		true,
-		"",
+		"focal",
 	).DoAndReturn(
 		func(_ *charm.URL, origin commoncharm.Origin, _ bool, _ string) (commoncharm.Origin, error) {
 			return origin, err
@@ -180,7 +183,7 @@ func (s *storeSuite) expectAddCharmWithAuthorization() {
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		gomock.AssignableToTypeOf(&macaroon.Macaroon{}),
 		true,
-		"",
+		"focal",
 	).DoAndReturn(
 		func(_ *charm.URL, origin commoncharm.Origin, _ *macaroon.Macaroon, _ bool, _ string) (commoncharm.Origin, error) {
 			return origin, nil


### PR DESCRIPTION
## Description of change

The following updates the charmhub refresher to correctly handle
charmhub vs charmstore function calls. Essentially because we don't have
macaroons then we don't want to end up falling into the
AddCharmWithAuthorization workflow. By removing the special case we can
correctly reason about what the path the charmhub refresher will take.

In an ideal world we would use a better pattern for dealing with this.
Maybe resort to a stragtegy, but generally just embedding the
functionality into two different types also resolves this.


## QA steps

Unsure here?

