### PR TITLE
Make CLI error a bit more helpful if bootstrap is in progress

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -184,7 +184,7 @@ type RedirectError struct {
 }
 
 func (e *RedirectError) Error() string {
-	return fmt.Sprintf("redirection to alternative server required")
+	return "redirection to alternative server required"
 }
 
 // Open establishes a connection to the API server using the Info

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -249,6 +249,9 @@ func (c *CommandBase) NewAPIRoot(
 	if redirErr, ok := errors.Cause(err).(*api.RedirectError); ok {
 		return nil, newModelMigratedError(store, modelName, redirErr)
 	}
+	if _, ok := errors.Cause(err).(*juju.NoAddressesError); ok {
+		return nil, errors.New("no controller API addresses; is bootstrap still in progress?")
+	}
 	return conn, errors.Trace(err)
 }
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -249,7 +249,7 @@ func (c *CommandBase) NewAPIRoot(
 	if redirErr, ok := errors.Cause(err).(*api.RedirectError); ok {
 		return nil, newModelMigratedError(store, modelName, redirErr)
 	}
-	if _, ok := errors.Cause(err).(*juju.NoAddressesError); ok {
+	if juju.IsNoAddressesError(err) {
 		return nil, errors.New("no controller API addresses; is bootstrap still in progress?")
 	}
 	return conn, errors.Trace(err)

--- a/juju/api.go
+++ b/juju/api.go
@@ -46,6 +46,14 @@ type NewAPIConnectionParams struct {
 	ModelUUID string
 }
 
+// NoAddressesError is returned from NewAPIConnection when the controller has
+// no API addresses yet (likely because a bootstrap is still in progress).
+type NoAddressesError struct{}
+
+func (e *NoAddressesError) Error() string {
+	return "no API addresses"
+}
+
 // NewAPIConnection returns an api.Connection to the specified Juju controller,
 // with specified account credentials, optionally scoped to the specified model
 // name.
@@ -58,7 +66,7 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 		return nil, errors.Annotatef(err, "cannot work out how to connect")
 	}
 	if len(apiInfo.Addrs) == 0 {
-		return nil, errors.New("no API addresses")
+		return nil, &NoAddressesError{}
 	}
 	// Copy the cache so we'll know whether it's changed so that
 	// we'll update the entry correctly.

--- a/juju/api.go
+++ b/juju/api.go
@@ -46,12 +46,13 @@ type NewAPIConnectionParams struct {
 	ModelUUID string
 }
 
-// NoAddressesError is returned from NewAPIConnection when the controller has
-// no API addresses yet (likely because a bootstrap is still in progress).
-type NoAddressesError struct{}
+var errNoAddresses = errors.New("no API addresses")
 
-func (e *NoAddressesError) Error() string {
-	return "no API addresses"
+// IsNoAddressesError reports whether the error (from NewAPIConnection) is an
+// error due to the controller having no API addresses yet (likely because a
+// bootstrap is still in progress).
+func IsNoAddressesError(err error) bool {
+	return errors.Cause(err) == errNoAddresses
 }
 
 // NewAPIConnection returns an api.Connection to the specified Juju controller,
@@ -66,7 +67,7 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 		return nil, errors.Annotatef(err, "cannot work out how to connect")
 	}
 	if len(apiInfo.Addrs) == 0 {
-		return nil, &NoAddressesError{}
+		return nil, errNoAddresses
 	}
 	// Copy the cache so we'll know whether it's changed so that
 	// we'll update the entry correctly.

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -162,7 +162,7 @@ func (s *NewAPIClientSuite) TestWithInfoNoAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	st, err := newAPIConnectionFromNames(c, "noconfig", "", store, panicAPIOpen)
-	c.Assert(errors.Cause(err), gc.DeepEquals, &juju.NoAddressesError{})
+	c.Assert(err, jc.Satisfies, juju.IsNoAddressesError)
 	c.Assert(st, gc.IsNil)
 }
 

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -162,7 +162,7 @@ func (s *NewAPIClientSuite) TestWithInfoNoAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	st, err := newAPIConnectionFromNames(c, "noconfig", "", store, panicAPIOpen)
-	c.Assert(err, gc.ErrorMatches, "no API addresses")
+	c.Assert(errors.Cause(err), gc.DeepEquals, &juju.NoAddressesError{})
 	c.Assert(st, gc.IsNil)
 }
 


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

I was confused by this terse error message from `juju status` when I started. When a bootstrap is in progress on another terminal tab, it just says "no API addresses". So I've expanded that a bit (via a new error type which the CLI looks for).

Previous closed PR: https://github.com/juju/juju/pull/12034 (that's against 2.8 and uses an approach that changed the API layer message, which we don't want).

Also a drive-by fix to `RedirectError.Error()` removing an unnecessary `fmt.Sprintf`.

## QA steps

Run a bootstrap, and while it's running type `juju status` in another terminal window. It should say "ERROR: no API addresses" before this change and "ERROR: no controller API addresses; is bootstrap still in progress?" after.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1896566