### PR TITLE
Added public-dns-address controller config option.

### DIFF
--- a/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
@@ -41,6 +41,7 @@ func (s *CrossControllerSuite) SetUpTest(c *gc.C) {
 	api, err := crosscontroller.NewCrossControllerAPI(
 		s.resources,
 		func() ([]string, string, error) { return s.localControllerInfo() },
+		func() (string, error) { return "publicDNSaddr", nil },
 		func() state.NotifyWatcher { return s.watchLocalControllerInfo() },
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -54,7 +55,7 @@ func (s *CrossControllerSuite) TestControllerInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ControllerAPIInfoResults{
 		[]params.ControllerAPIInfoResult{{
-			Addresses: []string{"addr1", "addr2"},
+			Addresses: []string{"publicDNSaddr", "addr1", "addr2"},
 			CACert:    "ca-cert",
 		}},
 	})

--- a/controller/config.go
+++ b/controller/config.go
@@ -314,6 +314,9 @@ const (
 
 	// MeteringURL is the key for the url to use for metrics
 	MeteringURL = "metering-url"
+
+	// PublicDNSAddress is the public DNS address (and port) of the controller.
+	PublicDNSAddress = "public-dns-address"
 )
 
 var (
@@ -347,6 +350,7 @@ var (
 		ModelLogsSize,
 		PruneTxnQueryCount,
 		PruneTxnSleepTime,
+		PublicDNSAddress,
 		JujuHASpace,
 		JujuManagementSpace,
 		AuditingEnabled,
@@ -398,6 +402,7 @@ var (
 		MongoMemoryProfile,
 		PruneTxnQueryCount,
 		PruneTxnSleepTime,
+		PublicDNSAddress,
 		JujuHASpace,
 		JujuManagementSpace,
 		CAASOperatorImagePath,
@@ -788,6 +793,11 @@ func (c Config) PruneTxnSleepTime() time.Duration {
 	return val
 }
 
+// PublicDNSAddress returns the DNS name of the controller.
+func (c Config) PublicDNSAddress() string {
+	return c.asString(PublicDNSAddress)
+}
+
 // JujuHASpace is the network space within which the MongoDB replica-set
 // should communicate.
 func (c Config) JujuHASpace() string {
@@ -1128,6 +1138,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ModelLogsSize:            schema.String(),
 	PruneTxnQueryCount:       schema.ForceInt(),
 	PruneTxnSleepTime:        schema.String(),
+	PublicDNSAddress:         schema.String(),
 	JujuHASpace:              schema.String(),
 	JujuManagementSpace:      schema.String(),
 	CAASOperatorImagePath:    schema.String(),
@@ -1168,6 +1179,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ModelLogsSize:            fmt.Sprintf("%vM", DefaultModelLogsSizeMB),
 	PruneTxnQueryCount:       DefaultPruneTxnQueryCount,
 	PruneTxnSleepTime:        DefaultPruneTxnSleepTime,
+	PublicDNSAddress:         schema.Omit,
 	JujuHASpace:              schema.Omit,
 	JujuManagementSpace:      schema.Omit,
 	CAASOperatorImagePath:    schema.Omit,
@@ -1304,6 +1316,10 @@ they don't have any access rights to the controller itself`,
 	PruneTxnSleepTime: {
 		Type:        environschema.Tstring,
 		Description: `The amount of time to sleep between processing each batch query`,
+	},
+	PublicDNSAddress: {
+		Type:        environschema.Tstring,
+		Description: `Public DNS address (with port) of the controller.`,
 	},
 	JujuHASpace: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -339,6 +339,12 @@ var newConfigTests = []struct {
 		controller.NonSyncedWritesToRaftLog: "I live dangerously",
 	},
 	expectError: `non-synced-writes-to-raft-log: expected bool, got string\("I live dangerously"\)`,
+}, {
+	about: "public-dns-address: expect string, got number",
+	config: controller.Config{
+		controller.PublicDNSAddress: 42,
+	},
+	expectError: `public-dns-address: expected string, got int\(42\)`,
 }, {}}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {
@@ -432,6 +438,18 @@ func (s *ConfigSuite) TestPruneTxnQueryCount(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cfg.PruneTxnQueryCount(), gc.Equals, 500)
 	c.Check(cfg.PruneTxnSleepTime(), gc.Equals, 5*time.Millisecond)
+}
+
+func (s *ConfigSuite) TestPublicDNSAddressConfigValue(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"public-dns-address": "controller.test.com:12345",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.PublicDNSAddress(), gc.Equals, "controller.test.com:12345")
 }
 
 func (s *ConfigSuite) TestNetworkSpaceConfigValues(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -56,6 +56,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MongoMemoryProfile,
 		controller.PruneTxnQueryCount,
 		controller.PruneTxnSleepTime,
+		controller.PublicDNSAddress,
 		controller.MaxCharmStateSize,
 		controller.MaxAgentStateSize,
 		controller.NonSyncedWritesToRaftLog,
@@ -96,10 +97,12 @@ func (s *ControllerSuite) TestUpdateControllerConfig(c *gc.C) {
 	// Sanity check.
 	c.Check(cfg.AuditingEnabled(), gc.Equals, false)
 	c.Check(cfg.AuditLogCaptureArgs(), gc.Equals, true)
+	c.Assert(cfg.PublicDNSAddress(), gc.Equals, "")
 
 	err = s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.AuditingEnabled:     true,
 		controller.AuditLogCaptureArgs: false,
+		controller.PublicDNSAddress:    "controller.test.com:1234",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -108,6 +111,7 @@ func (s *ControllerSuite) TestUpdateControllerConfig(c *gc.C) {
 
 	c.Assert(newCfg.AuditingEnabled(), gc.Equals, true)
 	c.Assert(newCfg.AuditLogCaptureArgs(), gc.Equals, false)
+	c.Assert(newCfg.PublicDNSAddress(), gc.Equals, "controller.test.com:1234")
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigRemoveYieldsDefaults(c *gc.C) {


### PR DESCRIPTION
### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

This PR introduces a config value for controllers - a public dns address (with port).
See  

## QA steps

- add two controllers to jimm
- set public-dns-address on both controllers
- create an offer on one controller
- consume offer on the other -> verify the CMR works.

## Documentation changes

Document the new controller configuration option: public-dns-address

## Bug reference

https://bugs.launchpad.net/juju/+bug/1895275