### PR TITLE
Handle no application info for workload status

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1284,6 +1284,10 @@ func (s *backingStatus) updateApplicationWorkload(ctx *allWatcherContext, unit *
 		Name:      unit.Application,
 	}
 	info0 := ctx.store.Get(appInfo.EntityID())
+	if info0 == nil {
+		// The parent info doesn't exist. Ignore the workload until it does.
+		return
+	}
 	appInfo = info0.(*multiwatcher.ApplicationInfo)
 	updated := *appInfo
 	updated.WorkloadVersion = s.StatusInfo
@@ -1363,7 +1367,7 @@ func (c *backingConstraints) updated(ctx *allWatcherContext) error {
 	info0 := ctx.store.Get(parentID)
 	switch info := info0.(type) {
 	case nil:
-		// The parent info doesn't exist. Ignore the status until it does.
+		// The parent info doesn't exist. Ignore the constraints until it does.
 		return nil
 	case *multiwatcher.UnitInfo, *multiwatcher.MachineInfo:
 		// We don't (yet) publish unit or machine constraints.

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2247,6 +2247,34 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			app := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
+			unit, err := app.AddUnit(AddUnitParams{})
+			c.Assert(err, jc.ErrorIsNil)
+			err = unit.SetWorkloadVersion("42.47")
+			c.Assert(err, jc.ErrorIsNil)
+			return changeTestCase{
+				about: "workload version is ignored if there is no application info",
+				initialContents: []multiwatcher.EntityInfo{
+					&multiwatcher.UnitInfo{
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+					},
+				},
+				change: watcher.Change{
+					C:  "statuses",
+					Id: st.docID("u#" + unit.Name() + "#charm#sat#workload-version"),
+				},
+				expectContents: []multiwatcher.EntityInfo{
+					&multiwatcher.UnitInfo{
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+					},
+				},
+			}
+		},
+		func(c *gc.C, st *State) changeTestCase {
+			app := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			setApplicationConfigAttr(c, app, "blog-title", "boring")
 
 			return changeTestCase{


### PR DESCRIPTION
## Description of change

Although theoretically impossible in a normal workload setup, it has
shown up in tests. The idea that an application wouldn't exist, but have
a unit seems very implausible.
How ever implausible it's shown up in testing and if it can happen in
testing, it can show up in the wild.

The fix is really simple, if no application exists, we can safely ignore
the workload status and move on.

## QA steps

Remove the if nil check and the tests will fail.

## Bugs

https://bugs.launchpad.net/juju/+bug/1896658
