### PR TITLE
K8s SA roles

### DIFF
--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -495,7 +495,6 @@ echo "do some stuff here for gitlab-init container"
 						AutomountServiceAccountToken: boolPtr(true),
 						Roles: []specs.Role{
 							{
-								Name:   "k8sServiceAccount1",
 								Global: true,
 								Rules: []specs.PolicyRule{
 									{
@@ -870,7 +869,7 @@ serviceAccount:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `rules is required`)
+	c.Assert(err, gc.ErrorMatches, `invalid primary service account: rules is required`)
 }
 
 func (s *v2SpecsSuite) TestValidateCustomResourceDefinitions(c *gc.C) {

--- a/caas/specs/v3.go
+++ b/caas/specs/v3.go
@@ -23,7 +23,6 @@ func (spec *PodSpecV3) Validate() error {
 		return errors.Trace(err)
 	}
 	if spec.ServiceAccount != nil {
-		// TODO: do we want to restrict the prime sa can only have 1 role/clusterrole???????
 		return errors.Trace(spec.ServiceAccount.Validate())
 	}
 	return nil


### PR DESCRIPTION
## Description of change

We were restricting the primary k8s service account for a workload pod to only have one role.
This PR removes that restriction.
The common validation code is moved so that it is shared between the primary service account struct and the additional service account struct, ie ServiceAccountSpecV3
Also, setting the primary service account name no longer sets the role name - the user can specify their own or it defaults to the service account name. ie the same behaviour as for additional service accounts.

## QA steps

Deploy a k8s charm with a primary service account with > 1 role like in the bug.
Use kubectl to check the roles and role bindings.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1896076
