### PR TITLE
vsphere: Improve createImportSpec logging, sprinkle trace logging

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -102,6 +102,7 @@ func (c *Client) lister(ref types.ManagedObjectReference) *list.Lister {
 // return the pointer for the same folder, and should also deal with
 // the case where folderPath is nil or empty.
 func (c *Client) FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error) {
+	c.logger.Tracef("FindFolder() path=%q", folderPath)
 	if strings.Contains(folderPath, "..") {
 		// ".." not supported as per:
 		// https://github.com/vmware/govmomi/blob/master/find/finder.go#L114
@@ -155,6 +156,7 @@ func (c *Client) finder(ctx context.Context) (*find.Finder, *object.Datacenter, 
 // RemoveVirtualMachines removes VMs matching the given path from the
 // system. The path may include wildcards, to match multiple VMs.
 func (c *Client) RemoveVirtualMachines(ctx context.Context, path string) error {
+	c.logger.Tracef("RemoveVirtualMachines() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -215,6 +217,7 @@ func (c *Client) RemoveVirtualMachines(ctx context.Context, path string) error {
 
 // VirtualMachines return list of all VMs in the system matching the given path.
 func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.VirtualMachine, error) {
+	c.logger.Tracef("VirtualMachines() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -242,6 +245,7 @@ func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.Virtua
 // ComputeResources returns a slice of all compute resources in the datacenter,
 // along with a slice of each compute resource's full path.
 func (c *Client) ComputeResources(ctx context.Context) ([]ComputeResource, error) {
+	c.logger.Tracef("ComputeResources()")
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -294,6 +298,7 @@ func (c *Client) computeResourcesFromRef(ctx context.Context, ref types.ManagedO
 
 // Folders returns the datacenter's folders object.
 func (c *Client) Folders(ctx context.Context) (*object.DatacenterFolders, error) {
+	c.logger.Tracef("Folders()")
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -307,6 +312,7 @@ func (c *Client) Folders(ctx context.Context) (*object.DatacenterFolders, error)
 
 // Datastores returns list of all datastores in the system.
 func (c *Client) Datastores(ctx context.Context) ([]mo.Datastore, error) {
+	c.logger.Tracef("Datastores()")
 	finder, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -344,6 +350,7 @@ func (c *Client) Datastores(ctx context.Context) ([]mo.Datastore, error) {
 // ResourcePools returns a list of all of the resource pools (possibly
 // nested) under the given path.
 func (c *Client) ResourcePools(ctx context.Context, path string) ([]*object.ResourcePool, error) {
+	c.logger.Tracef("ResourcePools() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -365,7 +372,7 @@ func (c *Client) ResourcePools(ctx context.Context, path string) ([]*object.Reso
 // whereas parentFolderName is the subfolder in DC's root-folder.
 // The parentFolderName will fallback to DC's root-folder if it's an empty string.
 func (c *Client) EnsureVMFolder(ctx context.Context, parentFolderName string, relativeFolderPath string) (*object.Folder, error) {
-
+	c.logger.Tracef("EnsureVMFolder() parent=%q, rel=%q", parentFolderName, relativeFolderPath)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -409,6 +416,7 @@ func (c *Client) EnsureVMFolder(ctx context.Context, parentFolderName string, re
 
 // DestroyVMFolder destroys a folder(folderPath could be either relative path of vmfolder of datacenter or full path).
 func (c *Client) DestroyVMFolder(ctx context.Context, folderPath string) error {
+	c.logger.Tracef("DestroyVMFolder() path=%q", folderPath)
 	folder, err := c.FindFolder(ctx, folderPath)
 	if errors.IsNotFound(err) {
 		return nil
@@ -430,6 +438,7 @@ func (c *Client) DestroyVMFolder(ctx context.Context, folderPath string) error {
 
 // MoveVMFolderInto moves one VM folder into another.
 func (c *Client) MoveVMFolderInto(ctx context.Context, parentPath, childPath string) error {
+	c.logger.Tracef("MoveVMFolderInto() parent=%q, child=%q", parentPath, childPath)
 	parent, err := c.FindFolder(ctx, parentPath)
 	if err != nil {
 		return errors.Trace(err)
@@ -455,6 +464,7 @@ func (c *Client) MoveVMsInto(
 	folderPath string,
 	vms ...types.ManagedObjectReference,
 ) error {
+	c.logger.Tracef("MoveVMsInto() path=%q, vms=%v", folderPath, vms)
 	folder, err := c.FindFolder(ctx, folderPath)
 	if err != nil {
 		return errors.Trace(err)
@@ -479,6 +489,8 @@ func (c *Client) UpdateVirtualMachineExtraConfig(
 	vmInfo *mo.VirtualMachine,
 	metadata map[string]string,
 ) error {
+	c.logger.Tracef("UpdateVirtualMachineExtraConfig() vmInfo.Name=%q, metadata=%v",
+		vmInfo.Name, metadata)
 	var spec types.VirtualMachineConfigSpec
 	for k, v := range metadata {
 		opt := &types.OptionValue{Key: k, Value: v}
@@ -497,6 +509,7 @@ func (c *Client) UpdateVirtualMachineExtraConfig(
 
 // DeleteDatastoreFile deletes a file or directory in the datastore.
 func (c *Client) DeleteDatastoreFile(ctx context.Context, datastorePath string) error {
+	c.logger.Tracef("DeleteDatastoreFile() path=%q", datastorePath)
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -724,6 +737,7 @@ func isManagedObjectNotFound(err error) bool {
 // UserHasRootLevelPrivilege returns whether the connected user has the
 // specified privilege on the root-level object.
 func (c *Client) UserHasRootLevelPrivilege(ctx context.Context, privilege string) (bool, error) {
+	c.logger.Tracef("UserHasRootLevelPrivilege() privilege=%q", privilege)
 	session, err := c.client.SessionManager.UserSession(ctx)
 	if err != nil {
 		return false, errors.Annotate(err, "getting user session")

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -168,7 +168,6 @@ func (c *Client) ensureTemplateVM(
 	datastore *object.Datastore,
 	args CreateVirtualMachineParams,
 ) (vm *object.VirtualMachine, err error) {
-
 	templateFolder, err := c.FindFolder(ctx, path.Join(args.RootVMFolder, vmTemplatePath(args)))
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
@@ -309,6 +308,7 @@ func (c *Client) CreateVirtualMachine(
 	ctx context.Context,
 	args CreateVirtualMachineParams,
 ) (_ *mo.VirtualMachine, err error) {
+	c.logger.Tracef("CreateVirtualMachine() args.Name=%q", args.Name)
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -422,20 +422,28 @@ func (c *Client) createImportSpec(
 	args CreateVirtualMachineParams,
 	datastore *object.Datastore,
 ) (*types.OvfCreateImportSpecResult, error) {
-	c.logger.Debugf("Creating import spec")
 	cisp := types.OvfCreateImportSpecParams{
 		EntityName: vmTemplateName(args),
 	}
+	c.logger.Debugf("Creating import spec: pool=%q, datastore=%q, entity=%q",
+		args.ResourcePool, datastore, cisp.EntityName)
 
 	c.logger.Debugf("Fetching OVF manager")
 	ovfManager := ovf.NewManager(c.client.Client)
 	spec, err := ovfManager.CreateImportSpec(ctx, UbuntuOVF, args.ResourcePool, datastore, cisp)
-	c.logger.Debugf("ImportSpec built")
 	if err != nil {
+		c.logger.Debugf("CreateImportSpec error: err=%v", err)
 		return nil, errors.Trace(err)
-	} else if spec.Error != nil {
-		return nil, errors.New(spec.Error[0].LocalizedMessage)
+	} else if len(spec.Error) > 0 {
+		messages := make([]string, len(spec.Error))
+		for i, e := range spec.Error {
+			messages[i] = e.LocalizedMessage
+		}
+		message := strings.Join(messages, "; ")
+		c.logger.Debugf("CreateImportSpec fault: messages=%s", message)
+		return nil, errors.New(message)
 	}
+	c.logger.Debugf("CreateImportSpec succeeded")
 	return spec, nil
 }
 

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -439,7 +439,7 @@ func (c *Client) createImportSpec(
 		for i, e := range spec.Error {
 			messages[i] = e.LocalizedMessage
 		}
-		message := strings.Join(messages, "; ")
+		message := strings.Join(messages, "\n")
 		c.logger.Debugf("CreateImportSpec fault: messages=%s", message)
 		return nil, errors.New(message)
 	}


### PR DESCRIPTION

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Improved the debug logging for `createImportSpec`, which may have helped us debug https://bugs.launchpad.net/juju/+bug/1895815 a bit more quickly. Also sprinkle a few more trace logs of vSphere client methods.

I did a proof of concept locally of trace-logging *all* vSphere API requests and responses, but it's a **huge** amount of data, screeds of XML. Plus, the govmomi library we're using only has a global debug logging hook (`debug.SetProvider` is a global function instead of per client). So I decided to just tweak and improve what we have.

## QA steps

Deploy to a vSphere cluster with TRACE-level logging turned on for the vsphere provider, for example:

```sh
$ juju bootstrap vsphere vs --config datastore=datastore1 --show-log \
    --logging-config="<root>=DEBUG;juju.provider.vmware=TRACE"
```

## Documentation changes

N/A

## Bug reference

Related to: https://bugs.launchpad.net/juju/+bug/1895815
