### PR TITLE
API application updates

### DIFF
--- a/acceptancetests/assess_constraints.py
+++ b/acceptancetests/assess_constraints.py
@@ -158,7 +158,7 @@ class Constraints:
         instance_data = get_instance_spec(self.instance_type)
         for (key, value) in instance_data.iteritems():
             # Temperary fix until cpu-cores -> cores switch is finished.
-            if key is 'cores' and 'cpu-cores' in actual_data:
+            if key == 'cores' and 'cpu-cores' in actual_data:
                 key = 'cpu-cores'
             if key not in actual_data:
                 raise JujuAssertionError('Missing data:', key)

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -133,7 +133,7 @@ def calc_stats(prefix, values, include_count=False, test_duration=0):
     if include_count:
         stats[prefix+'count'] = len(values)
 
-    if test_duration is not 0:
+    if test_duration != 0:
         stats[prefix+'rate'] = float(len(values)) / float(test_duration)
 
     return stats

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -314,7 +314,7 @@ class AssessNetworkHealth:
         apps = client.get_status().get_applications()
         exposed = [app for app, e in apps.items() if e.get('exposed')
                    is True and 'network-health' not in app]
-        if len(exposed) is 0:
+        if len(exposed) == 0:
             nh_only = True
             log.info('No exposed units, testing with network-health '
                      'charms only.')
@@ -438,7 +438,7 @@ class AssessNetworkHealth:
             if not res:
                 error = 'Machine {} failed internet connection.'.format(unit)
                 error_string.append(error)
-        if exposed and exposed['fail'] is not ():
+        if exposed and exposed['fail'] != ():
             error = ('Application(s) {0} failed expose '
                      'test'.format(exposed['fail']))
             error_string.append(error)

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -187,8 +187,10 @@ func (c *Client) GetCharmURL(branchName, applicationName string) (*charm.URL, er
 	return charm.ParseURL(result.Result)
 }
 
-// GetCharmURLOrigin returns the charm URL the given application is
-// running at present.
+// GetCharmURLOrigin returns the charm URL along with the charm Origin for the
+// given application is running at present.
+// The charm origin gives more information about the location of the charm and
+// what revision/channel it came from.
 func (c *Client) GetCharmURLOrigin(branchName, applicationName string) (*charm.URL, apicharm.Origin, error) {
 	args := params.ApplicationGet{
 		ApplicationName: applicationName,

--- a/api/application/client.go
+++ b/api/application/client.go
@@ -188,6 +188,29 @@ func (c *Client) GetCharmURL(branchName, applicationName string) (*charm.URL, er
 	return charm.ParseURL(result.Result)
 }
 
+// GetCharmURLOrigin returns the charm URL the given application is
+// running at present.
+func (c *Client) GetCharmURLOrigin(branchName, applicationName string) (*charm.URL, apicharm.Origin, error) {
+	args := params.ApplicationGet{
+		ApplicationName: applicationName,
+		BranchName:      branchName,
+	}
+
+	var result params.CharmURLOriginResult
+	err := c.facade.FacadeCall("GetCharmURLOrigin", args, &result)
+	if err != nil {
+		return nil, apicharm.Origin{}, errors.Trace(err)
+	}
+	if result.Error != nil {
+		return nil, apicharm.Origin{}, errors.Trace(result.Error)
+	}
+	curl, err := charm.ParseURL(result.URL)
+	if err != nil {
+		return nil, apicharm.Origin{}, errors.Trace(err)
+	}
+	return curl, apicharm.APICharmOrigin(result.Origin), nil
+}
+
 // GetConfig returns the charm configuration settings for each of the
 // applications. If any of the applications are not found, an error is
 // returned.

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -20,7 +20,6 @@ import (
 	apitesting "github.com/juju/juju/api/testing"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
@@ -118,7 +117,7 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 	})
 
 	args := application.DeployArgs{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:trusty/a-charm-1"),
 		},
 		CharmOrigin: apicharm.Origin{
@@ -297,6 +296,10 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(args.ApplicationName, gc.Equals, "application")
 		c.Assert(args.CharmURL, gc.Equals, "cs:trusty/application-1")
+		c.Assert(args.CharmOrigin, gc.DeepEquals, &params.CharmOrigin{
+			Source: "charm-hub",
+			Risk:   "edge",
+		})
 		c.Assert(args.ConfigSettings, jc.DeepEquals, map[string]string{
 			"a": "b",
 			"c": "d",
@@ -316,8 +319,12 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 	})
 	cfg := application.SetCharmConfig{
 		ApplicationName: "application",
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:trusty/application-1"),
+			Origin: apicharm.Origin{
+				Source: "charm-hub",
+				Risk:   "edge",
+			},
 		},
 		ConfigSettings: map[string]string{
 			"a": "b",

--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -259,6 +259,32 @@ func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
+func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
+	var called bool
+	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
+		called = true
+		c.Assert(request, gc.Equals, "GetCharmURLOrigin")
+		args, ok := a.(params.ApplicationGet)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(args.ApplicationName, gc.Equals, "application")
+		c.Assert(args.BranchName, gc.Equals, newBranchName)
+
+		result := response.(*params.CharmURLOriginResult)
+		result.URL = "cs:curl"
+		result.Origin = params.CharmOrigin{
+			Risk: "edge",
+		}
+		return nil
+	})
+	curl, origin, err := client.GetCharmURLOrigin(newBranchName, "application")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(curl, gc.DeepEquals, charm.MustParseURL("cs:curl"))
+	c.Assert(origin, gc.DeepEquals, apicharm.Origin{
+		Risk: "edge",
+	})
+	c.Assert(called, jc.IsTrue)
+}
+
 func (s *applicationSuite) TestSetCharm(c *gc.C) {
 	var called bool
 	toUint64Ptr := func(v uint64) *uint64 {

--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -82,3 +82,24 @@ func APICharmOrigin(origin params.CharmOrigin) Origin {
 		Track:    origin.Track,
 	}
 }
+
+// CoreCharmOrigin is a helper function to convert params.CharmOrigin
+// to an Origin.
+func CoreCharmOrigin(origin corecharm.Origin) Origin {
+	var ch corecharm.Channel
+	if origin.Channel != nil {
+		ch = *origin.Channel
+	}
+	var track *string
+	if ch.Track != "" {
+		track = &ch.Track
+	}
+	return Origin{
+		Source:   OriginSource(origin.Source),
+		ID:       origin.ID,
+		Hash:     origin.Hash,
+		Revision: origin.Revision,
+		Risk:     string(ch.Risk),
+		Track:    track,
+	}
+}

--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -39,6 +39,18 @@ type Origin struct {
 	Track *string
 }
 
+// CoreChannel returns the core charm channel.
+func (o Origin) CoreChannel() corecharm.Channel {
+	var track string
+	if o.Track != nil {
+		track = *o.Track
+	}
+	return corecharm.Channel{
+		Track: track,
+		Risk:  corecharm.Risk(o.Risk),
+	}
+}
+
 // ParamsCharmOrigin is a helper method to get a params version
 // of this structure.
 func (o Origin) ParamsCharmOrigin() params.CharmOrigin {

--- a/api/common/charm/charmorigin_test.go
+++ b/api/common/charm/charmorigin_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"github.com/juju/juju/api/common/charm"
+	corecharm "github.com/juju/juju/core/charm"
+	gc "gopkg.in/check.v1"
+)
+
+type originSuite struct{}
+
+var _ = gc.Suite(&originSuite{})
+
+func (originSuite) TestCoreChannel(c *gc.C) {
+	track := "latest"
+	origin := charm.Origin{
+		Risk:  "edge",
+		Track: &track,
+	}
+	c.Assert(origin.CoreChannel(), gc.DeepEquals, corecharm.Channel{
+		Risk:  corecharm.Edge,
+		Track: "latest",
+	})
+}
+
+func (originSuite) TestCoreChannelWithEmptyTrack(c *gc.C) {
+	origin := charm.Origin{
+		Risk: "edge",
+	}
+	c.Assert(origin.CoreChannel(), gc.DeepEquals, corecharm.Channel{
+		Risk: corecharm.Edge,
+	})
+}
+
+func (originSuite) TestCoreChannelThatIsEmpty(c *gc.C) {
+	origin := charm.Origin{}
+	c.Assert(origin.CoreChannel(), gc.DeepEquals, corecharm.Channel{})
+}

--- a/api/common/charm/package_test.go
+++ b/api/common/charm/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/api/modelconfig"
 	"github.com/juju/juju/apiserver/facades/client/client"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/rpc"
@@ -323,7 +322,7 @@ func opClientSetAnnotations(c *gc.C, st api.Connection, mst *state.State) (func(
 func opClientServiceSetCharm(c *gc.C, st api.Connection, mst *state.State) (func(), error) {
 	cfg := application.SetCharmConfig{
 		ApplicationName: "nosuch",
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("local:quantal/wordpress"),
 		},
 	}

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/cmd/juju/application/bundle"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/storage"
@@ -114,7 +113,7 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 					return errors.Trace(err)
 				}
 
-				origin, err := utils.DeduceOrigin(charmURL, corecharm.Channel{})
+				origin, err := utils.DeduceOrigin(charmURL, d.origin.CoreChannel())
 				if err != nil {
 					return errors.Trace(err)
 				}

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -515,6 +515,12 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 			}
 			logger.Debugf("added charm %s", curl)
 			h.results[id] = curl.String()
+			// We know we're a local charm and local charms don't require an
+			// explicit tailored origin. Instead we can just use a placeholder
+			// to ensure correctness for later on in addApplication.
+			h.origins[*curl] = commoncharm.Origin{
+				Source: commoncharm.OriginLocal,
+			}
 			return nil
 		}
 	}

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -592,15 +592,12 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		return errors.Errorf("unexpected application charm URL %q", p.Charm)
 	}
 
-	var origin commoncharm.Origin
-	if o, ok := h.origins[*cURL]; ok {
-		origin = o
-	} else {
-		o, err := utils.DeduceOrigin(cURL, corecharm.Channel{})
-		if err != nil {
-			return errors.Trace(err)
-		}
-		origin = o
+	origin, ok := h.origins[*cURL]
+	if !ok {
+		// It is expected that the addCharm is done before addApplication.
+		// We require that order to be correct otherwise it's impossible for
+		// us to deploy an application without a charm.
+		return errors.Errorf("unexpected charm url %q, no charm found for application %q", cURL.String(), p.Application)
 	}
 
 	chID := application.CharmID{

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -730,15 +730,23 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	if h.data.Type == "kubernetes" {
 		numUnits = p.NumUnits
 	}
-	var track string
-	if h.origin.Track != nil {
-		track = *h.origin.Track
-	}
-	// A channel is needed whether the risk is valid or not.
-	channel, _ := corecharm.MakeChannel(track, h.origin.Risk, "")
-	origin, err = utils.DeduceOrigin(chID.URL, channel)
-	if err != nil {
-		return errors.Trace(err)
+
+	// For charmstore charms we require a corrected channel for deploying an
+	// application. This isn't required for any other store type (local,
+	// charmhub).
+	// We should remove this when charmstore charms are defunct and remove this
+	// specialization.
+	if charm.CharmStore.Matches(chID.URL.Schema) {
+		var track string
+		if h.origin.Track != nil {
+			track = *h.origin.Track
+		}
+		// A channel is needed whether the risk is valid or not.
+		channel, _ := corecharm.MakeChannel(track, h.origin.Risk, "")
+		origin, err = utils.DeduceOrigin(chID.URL, channel)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	// Deploy the application.

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -22,13 +22,13 @@ import (
 	apicharms "github.com/juju/juju/api/charms"
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -851,7 +851,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
 
 func (s *BundleDeployCharmStoreSuite) bundleDeploySpec() bundleDeploySpec {
 	deployResourcesFunc := func(_ string,
-		_ charmstore.CharmID,
+		_ resourceadapters.CharmID,
 		_ *macaroon.Macaroon,
 		_ map[string]string,
 		_ map[string]charmresource.Meta,

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v8"
-	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -18,10 +17,10 @@ import (
 	"gopkg.in/macaroon.v2"
 	"gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/api/application"
 	applicationapi "github.com/juju/juju/api/application"
 	commoncharm "github.com/juju/juju/api/common/charm"
 	app "github.com/juju/juju/apiserver/facades/client/application"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
@@ -43,7 +42,7 @@ type deployCharm struct {
 	devices         map[string]devices.Constraints
 	deployResources resourceadapters.DeployResourcesFunc
 	force           bool
-	id              charmstore.CharmID
+	id              application.CharmID
 	flagSet         *gnuflag.FlagSet
 	model           ModelCommand
 	numUnits        int
@@ -216,7 +215,10 @@ func (d *deployCharm) deploy(
 
 	ids, err := d.deployResources(
 		applicationName,
-		id,
+		resourceadapters.CharmID{
+			URL:     id.URL,
+			Channel: id.Origin.Risk,
+		},
 		d.csMac,
 		d.resources,
 		charmInfo.Meta.Resources,
@@ -305,12 +307,17 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		return errors.Trace(err)
 	}
 
-	d.id = charmstore.CharmID{URL: d.userCharmURL}
-	d.series = userCharmURL.Series
-	d.origin, err = utils.DeduceOrigin(userCharmURL, corecharm.Channel{})
+	origin, err := utils.DeduceOrigin(userCharmURL, corecharm.Channel{})
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	d.id = application.CharmID{
+		URL:    d.userCharmURL,
+		Origin: origin,
+	}
+	d.series = userCharmURL.Series
+	d.origin = origin
 
 	ctx.Infof("Deploying charm %q.", formattedCharmURL)
 	return d.deploy(ctx, deployAPI)
@@ -340,15 +347,18 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 		return errors.Trace(err)
 	}
 
-	l.id = charmstore.CharmID{
-		URL: curl,
-		// Local charms don't need a channel.
-	}
-	l.series = l.curl.Series
-	l.origin, err = utils.DeduceOrigin(curl, corecharm.Channel{})
+	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{})
 	if err != nil {
 		return err
 	}
+
+	l.id = application.CharmID{
+		URL:    curl,
+		Origin: origin,
+		// Local charms don't need a channel.
+	}
+	l.series = l.curl.Series
+	l.origin = origin
 
 	ctx.Infof("Deploying charm %q.", curl.String())
 	return l.deploy(ctx, deployAPI)
@@ -465,9 +475,9 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	ctx.Infof("Deploying charm %q.", formattedCharmURL)
-	c.id = charmstore.CharmID{
-		URL:     curl,
-		Channel: csparams.Channel(c.origin.Risk),
+	c.id = application.CharmID{
+		URL:    curl,
+		Origin: c.origin,
 	}
 	c.series = series
 	c.csMac = csMac

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/juju/juju/api/base"
 	commoncharm "github.com/juju/juju/api/common/charm"
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -254,7 +254,7 @@ func (s *deployerSuite) newDeployerFactory() DeployerFactory {
 	dep := DeployerDependencies{
 		DeployResources: func(
 			string,
-			charmstore.CharmID,
+			resourceadapters.CharmID,
 			*macaroon.Macaroon,
 			map[string]string,
 			map[string]charmresource.Meta,

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -118,16 +118,21 @@ type ApplicationAPI interface {
 	AddRelation(endpoints, viaCIDRs []string) (*apiparams.AddRelationResults, error)
 	AddUnits(application.AddUnitsParams) ([]string, error)
 	Expose(application string, exposedEndpoints map[string]apiparams.ExposedEndpoint) error
+
 	GetAnnotations(tags []string) ([]apiparams.AnnotationsGetResult, error)
-	GetConfig(branchName string, appNames ...string) ([]map[string]interface{}, error)
-	GetConstraints(appNames ...string) ([]constraints.Value, error)
 	SetAnnotation(annotations map[string]map[string]string) ([]apiparams.ErrorResult, error)
+
+	GetCharmURLOrigin(string, string) (*charm.URL, commoncharm.Origin, error)
 	SetCharm(string, application.SetCharmConfig) error
+
+	GetConfig(branchName string, appNames ...string) ([]map[string]interface{}, error)
+	SetConfig(branchName string, application, configYAML string, config map[string]string) error
+
+	GetConstraints(appNames ...string) ([]constraints.Value, error)
 	SetConstraints(application string, constraints constraints.Value) error
 
 	// Deprecate use of Update, use SetConfig instead.
 	Update(apiparams.ApplicationUpdate) error
-	SetConfig(branchName string, application, configYAML string, config map[string]string) error
 
 	ScaleApplication(application.ScaleApplicationParams) (apiparams.ScaleApplicationResult, error)
 	Consume(arg crossmodel.ConsumeApplicationArgs) (string, error)

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -310,6 +310,22 @@ func (mr *MockDeployerAPIMockRecorder) GetAnnotations(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnotations", reflect.TypeOf((*MockDeployerAPI)(nil).GetAnnotations), arg0)
 }
 
+// GetCharmURLOrigin mocks base method
+func (m *MockDeployerAPI) GetCharmURLOrigin(arg0, arg1 string) (*charm.URL, charm0.Origin, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharmURLOrigin", arg0, arg1)
+	ret0, _ := ret[0].(*charm.URL)
+	ret1, _ := ret[1].(charm0.Origin)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetCharmURLOrigin indicates an expected call of GetCharmURLOrigin
+func (mr *MockDeployerAPIMockRecorder) GetCharmURLOrigin(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmURLOrigin", reflect.TypeOf((*MockDeployerAPI)(nil).GetCharmURLOrigin), arg0, arg1)
+}
+
 // GetConfig mocks base method
 func (m *MockDeployerAPI) GetConfig(arg0 string, arg1 ...string) ([]map[string]interface{}, error) {
 	m.ctrl.T.Helper()

--- a/cmd/juju/application/deployer/register_test.go
+++ b/cmd/juju/application/deployer/register_test.go
@@ -16,8 +16,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
+	"github.com/juju/juju/api/application"
 	apicharms "github.com/juju/juju/api/charms"
-	"github.com/juju/juju/charmstore"
 )
 
 var _ = gc.Suite(&registrationSuite{})
@@ -58,7 +58,7 @@ func (s *registrationSuite) TearDownTest(c *gc.C) {
 func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -97,7 +97,7 @@ func (s *registrationSuite) TestMeteredCharm(c *gc.C) {
 func (s *registrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -136,7 +136,7 @@ func (s *registrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 func (s *registrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -176,7 +176,7 @@ func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
 	s.stub.SetErrors(nil, errors.New("something failed"))
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -205,7 +205,7 @@ func (s *registrationSuite) TestMeteredCharmAPIError(c *gc.C) {
 func (s *registrationSuite) TestMeteredCharmInvalidAllocation(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -230,7 +230,7 @@ func (s *registrationSuite) TestMeteredCharmInvalidAllocation(c *gc.C) {
 func (s *registrationSuite) TestMeteredCharmDefaultBudgetAllocation(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -269,7 +269,7 @@ func (s *registrationSuite) TestMeteredCharmDefaultBudgetAllocation(c *gc.C) {
 func (s *registrationSuite) TestMeteredCharmDeployError(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -301,7 +301,7 @@ func (s *registrationSuite) TestMeteredCharmDeployError(c *gc.C) {
 func (s *registrationSuite) TestMeteredLocalCharmWithPlan(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("local:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -344,7 +344,7 @@ func (s *registrationSuite) TestMeteredLocalCharmNoPlan(c *gc.C) {
 	}
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("local:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -386,7 +386,7 @@ func (s *registrationSuite) TestMeteredCharmNoPlanSet(c *gc.C) {
 		PlanURL:        s.server.URL}
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -431,7 +431,7 @@ func (s *registrationSuite) TestMeteredCharmNoDefaultPlan(c *gc.C) {
 		PlanURL:        s.server.URL}
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -461,7 +461,7 @@ func (s *registrationSuite) TestMeteredCharmNoAvailablePlan(c *gc.C) {
 		PlanURL:        s.server.URL}
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -490,7 +490,7 @@ func (s *registrationSuite) TestMeteredCharmFailToQueryDefaultCharm(c *gc.C) {
 		PlanURL:        s.server.URL}
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -513,7 +513,7 @@ func (s *registrationSuite) TestMeteredCharmFailToQueryDefaultCharm(c *gc.C) {
 func (s *registrationSuite) TestUnmeteredCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/unmetered-1"),
 		},
 		ApplicationName: "application name",
@@ -539,7 +539,7 @@ func (s *registrationSuite) TestFailedAuth(c *gc.C) {
 	s.stub.SetErrors(nil, errors.Errorf("could not authorize"))
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -624,7 +624,7 @@ func (s *registrationSuite) TestPlanArgumentPlanRequiredInteraction(c *gc.C) {
 		}
 		client := httpbakery.NewClient()
 		d := DeploymentInfo{
-			CharmID: charmstore.CharmID{
+			CharmID: application.CharmID{
 				URL: charm.MustParseURL("cs:quantal/metered-1"),
 			},
 			ApplicationName: "application name",
@@ -754,7 +754,7 @@ func (s *noPlanRegistrationSuite) TearDownTest(c *gc.C) {
 func (s *noPlanRegistrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",
@@ -777,7 +777,7 @@ func (s *noPlanRegistrationSuite) TestOptionalPlanMeteredCharm(c *gc.C) {
 func (s *noPlanRegistrationSuite) TestPlanNotSpecifiedCharm(c *gc.C) {
 	client := httpbakery.NewClient()
 	d := DeploymentInfo{
-		CharmID: charmstore.CharmID{
+		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:quantal/metered-1"),
 		},
 		ApplicationName: "application name",

--- a/cmd/juju/application/deployer/steps.go
+++ b/cmd/juju/application/deployer/steps.go
@@ -6,8 +6,8 @@ package deployer
 import (
 	"github.com/juju/romulus"
 
+	"github.com/juju/juju/api/application"
 	apicharms "github.com/juju/juju/api/charms"
-	"github.com/juju/juju/charmstore"
 )
 
 func Steps() []DeployStep {
@@ -24,7 +24,7 @@ func Steps() []DeployStep {
 // DeploymentInfo is used to maintain all deployment information for
 // deployment steps.
 type DeploymentInfo struct {
-	CharmID         charmstore.CharmID
+	CharmID         application.CharmID
 	ApplicationName string
 	ModelUUID       string
 	CharmInfo       *apicharms.CharmInfo

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/api/spaces"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/charmstore"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/application/refresher"
 	"github.com/juju/juju/cmd/juju/application/store"
@@ -396,7 +395,10 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	// If it's the charmhub, we don't upgrade any resources as they're currently
 	// not supported. For now we do our best to create a valid charm.ID, but
 	// will most likely fail.
-	chID := deduceCharmID(curl, charmID.Origin)
+	chID := application.CharmID{
+		URL:    curl,
+		Origin: commoncharm.CoreCharmOrigin(charmID.Origin),
+	}
 	resourceIDs := make(map[string]string)
 	if !charm.CharmHub.Matches(curl.Schema) {
 		// Next, upgrade resources.
@@ -530,7 +532,7 @@ func (c *refreshCommand) checkApplicationFacadeSupport(verQuerier versionQuerier
 func (c *refreshCommand) upgradeResources(
 	apiRoot base.APICallCloser,
 	resourceLister utils.ResourceLister,
-	chID charmstore.CharmID,
+	chID application.CharmID,
 	csMac *macaroon.Macaroon,
 	meta map[string]charmresource.Meta,
 ) (map[string]string, error) {
@@ -551,7 +553,10 @@ func (c *refreshCommand) upgradeResources(
 	// checked further down the stack.
 	ids, err := c.DeployResources(
 		c.ApplicationName,
-		chID,
+		resourceadapters.CharmID{
+			URL:     chID.URL,
+			Channel: chID.Origin.Risk,
+		},
 		csMac,
 		c.Resources,
 		filtered,
@@ -654,15 +659,4 @@ func (c *refreshCommand) getRefresherFactory(apiRoot api.Connection) (refresher.
 		CharmResolver: c.NewCharmResolver(apiRoot, charmStore),
 	}
 	return c.NewRefresherFactory(deps), nil
-}
-
-func deduceCharmID(curl *charm.URL, origin corecharm.Origin) charmstore.CharmID {
-	var channel csparams.Channel
-	if origin.Channel != nil {
-		channel = csparams.Channel(origin.Channel.Risk)
-	}
-	return charmstore.CharmID{
-		URL:     curl,
-		Channel: channel,
-	}
 }

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -94,7 +94,7 @@ func NewRefreshCommand() cmd.Command {
 // CharmRefreshClient defines a subset of the application facade, as required
 // by the refresh command.
 type CharmRefreshClient interface {
-	GetCharmURL(string, string) (*charm.URL, error)
+	GetCharmURLOrigin(string, string) (*charm.URL, commoncharm.Origin, error)
 	Get(string, string) (*params.ApplicationGetResults, error)
 	SetCharm(string, application.SetCharmConfig) error
 }
@@ -315,7 +315,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	charmRefreshClient := c.NewCharmRefreshClient(apiRoot)
-	oldURL, err := charmRefreshClient.GetCharmURL(generation, c.ApplicationName)
+	oldURL, _, err := charmRefreshClient.GetCharmURLOrigin(generation, c.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -315,7 +315,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	charmRefreshClient := c.NewCharmRefreshClient(apiRoot)
-	oldURL, _, err := charmRefreshClient.GetCharmURLOrigin(generation, c.ApplicationName)
+	oldURL, oldOrigin, err := charmRefreshClient.GetCharmURLOrigin(generation, c.ApplicationName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -371,6 +371,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	cfg := refresher.RefresherConfig{
 		ApplicationName: c.ApplicationName,
 		CharmURL:        oldURL,
+		CharmOrigin:     oldOrigin.CoreCharmOrigin(),
 		CharmRef:        newRef,
 		Channel:         c.Channel,
 		DeployedSeries:  applicationInfo.Series,

--- a/cmd/juju/application/refresh_resources_test.go
+++ b/cmd/juju/application/refresh_resources_test.go
@@ -16,6 +16,7 @@ import (
 	csclientparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/juju/api/charms"
+	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
-	jjcharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -136,7 +136,7 @@ func (s *RefreshStoreResourceSuite) TestDeployStarsaySuccess(c *gc.C) {
 
 	deploy := newDeployCommand()
 	deploy.DeployResources = func(applicationID string,
-		chID jjcharmstore.CharmID,
+		chID resourceadapters.CharmID,
 		csMac *macaroon.Macaroon,
 		filesAndRevisions map[string]string,
 		resources map[string]charmresource.Meta,
@@ -259,7 +259,7 @@ Deploying charm "cs:bionic/starsay-1".`
 			return charmClient
 		},
 		func(applicationID string,
-			chID jjcharmstore.CharmID,
+			chID resourceadapters.CharmID,
 			csMac *macaroon.Macaroon,
 			filesAndRevisions map[string]string,
 			resources map[string]charmresource.Meta,

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/juju/juju/api/charms"
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/apiserver/params"
-	jujucharmstore "github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/application/deployer"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
@@ -88,7 +87,7 @@ func (s *BaseRefreshSuite) SetUpTest(c *gc.C) {
 
 	s.deployResources = func(
 		applicationID string,
-		chID jujucharmstore.CharmID,
+		chID resourceadapters.CharmID,
 		csMac *macaroon.Macaroon,
 		filesAndRevisions map[string]string,
 		resources map[string]charmresource.Meta,
@@ -222,9 +221,12 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
-		CharmID: jujucharmstore.CharmID{
-			URL:     s.resolvedCharmURL,
-			Channel: csclientparams.StableChannel,
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source: "charm-store",
+				Risk:   "stable",
+			},
 		},
 		StorageConstraints: map[string]storage.Constraints{
 			"bar": {Pool: "baz", Count: 1},
@@ -272,9 +274,12 @@ func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
-		CharmID: jujucharmstore.CharmID{
-			URL:     s.resolvedCharmURL,
-			Channel: csclientparams.StableChannel,
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source: "charm-store",
+				Risk:   "stable",
+			},
 		},
 		ConfigSettingsYAML: "foo:{}",
 	})
@@ -325,9 +330,12 @@ func (s *RefreshSuite) testUpgradeWithBind(c *gc.C, expectedBindings map[string]
 
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
-		CharmID: jujucharmstore.CharmID{
-			URL:     s.resolvedCharmURL,
-			Channel: csclientparams.StableChannel,
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source: "charm-store",
+				Risk:   "stable",
+			},
 		},
 		EndpointBindings: expectedBindings,
 	})
@@ -545,9 +553,12 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
-		CharmID: jujucharmstore.CharmID{
-			URL:     s.resolvedCharmURL,
-			Channel: csclientparams.BetaChannel,
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source: "charm-store",
+				Risk:   "beta",
+			},
 		},
 	})
 }
@@ -563,9 +574,12 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
-		CharmID: jujucharmstore.CharmID{
-			URL:     s.resolvedCharmURL,
-			Channel: csclientparams.BetaChannel,
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source: "charm-store",
+				Risk:   "beta",
+			},
 		},
 	})
 }
@@ -582,9 +596,12 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",
-		CharmID: jujucharmstore.CharmID{
-			URL:     s.resolvedCharmURL,
-			Channel: csclientparams.StableChannel,
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source: "charm-store",
+				Risk:   "stable",
+			},
 		},
 	})
 	var curl *charm.URL

--- a/resource/resourceadapters/deploy.go
+++ b/resource/resourceadapters/deploy.go
@@ -6,7 +6,9 @@ package resourceadapters
 import (
 	"strconv"
 
+	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
+	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/errors"
 	"gopkg.in/macaroon.v2"
 
@@ -17,10 +19,22 @@ import (
 	"github.com/juju/juju/resource/api/client"
 )
 
+// CharmID represents the underlying charm for a given application. This
+// includes both the URL and the channel.
+type CharmID struct {
+
+	// URL of the given charm, includes the reference name and a revision.
+	// Old style charm URLs are also supported i.e. charmstore.
+	URL *charm.URL
+
+	// Channel represents the underlying channel for the resources.
+	Channel string
+}
+
 // DeployResourcesFunc is the function type of DeployResources.
 type DeployResourcesFunc func(
 	applicationID string,
-	chID charmstore.CharmID,
+	chID CharmID,
 	csMac *macaroon.Macaroon,
 	filesAndRevisions map[string]string,
 	resources map[string]charmresource.Meta,
@@ -33,7 +47,7 @@ type DeployResourcesFunc func(
 // metadata. It returns a map of resource name to pending resource IDs.
 func DeployResources(
 	applicationID string,
-	chID charmstore.CharmID,
+	chID CharmID,
 	csMac *macaroon.Macaroon,
 	filesAndRevisions map[string]string,
 	resources map[string]charmresource.Meta,
@@ -63,8 +77,11 @@ func DeployResources(
 	}
 
 	ids, err = resourcecmd.DeployResources(resourcecmd.DeployResourcesArgs{
-		ApplicationID:      applicationID,
-		CharmID:            chID,
+		ApplicationID: applicationID,
+		CharmID: charmstore.CharmID{
+			URL:     chID.URL,
+			Channel: csparams.Channel(chID.Channel),
+		},
 		CharmStoreMacaroon: csMac,
 		ResourceValues:     filenames,
 		Revisions:          revisions,


### PR DESCRIPTION
## Description of change

This moves the origin request into the command and also ensures
that we're setting the charm origin in set charm correctly.

## QA steps


### Charmstore

```sh
$ juju bootstrap lxd test --no-gui
$ juju deploy cs:logstash-4
$ juju refresh logstash
Looking up metadata for charm cs:logstash (channel: stable)
Added charm "cs:logstash-5" to the model.
Leaving endpoints in "alpha": beat, client, elasticsearch, java
```

### Charmstore with no updates

```sh
$ juju bootstrap lxd test --no-gui
$ juju deploy cs:wordpress
$ juju refresh wordpress
ERROR already running latest charm "cs:wordpress-0"
```

### Local

```sh
$ juju bootstrap lxd test --no-gui
$ juju deploy ./testcharms/charm-repo/bionic/dummy
$ juju refresh dummy --path=./testcharms/charm-repo/bionic/dummy
Added charm "local:bionic/dummy-7" to the model.
```

### Switch

```sh
$ juju bootstrap lxd test --no-gui
$ juju deploy ./testcharms/charm-repo/bionic/dummy
$ juju refresh dummy --switch=cs:wordpress
Added charm "cs:wordpress-0" to the model.
Adding endpoint "cache" to default space "alpha"
Adding endpoint "db" to default space "alpha"
Adding endpoint "loadbalancer" to default space "alpha"
Adding endpoint "nfs" to default space "alpha"
Adding endpoint "website" to default space "alpha"
```

### Switch with force series

```sh
$ juju bootstrap lxd test --no-gui
$ juju deploy ./testcharms/charm-repo/bionic/dummy
$ juju refresh dummy --switch=cs:mysql --force-series
Looking up metadata for charm cs:mysql (channel: stable)
Added charm "cs:mysql-58" to the model.
Adding endpoint "ceph" to default space "alpha"
Adding endpoint "cluster" to default space "alpha"
Adding endpoint "data" to default space "alpha"
Adding endpoint "db-admin" to default space "alpha"
Adding endpoint "ha" to default space "alpha"
Adding endpoint "local-monitors" to default space "alpha"
Adding endpoint "master" to default space "alpha"
Adding endpoint "monitors" to default space "alpha"
Adding endpoint "munin" to default space "alpha"
Adding endpoint "nrpe-external-master" to default space "alpha"
Adding endpoint "shared-db" to default space "alpha"
Adding endpoint "slave" to default space "alpha"
Leaving endpoint in "alpha": db
```

