### PR TITLE
Manual Spaces Integration Test

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -9,8 +9,6 @@ test_deploy_manual() {
 
         cd .. || exit
 
-        # TODO (stickupkid): We currently only support LXD in this test
-        # currently, future tests should run on aws.
         case "${BOOTSTRAP_PROVIDER:-}" in
             "lxd")
                 export BOOTSTRAP_PROVIDER="manual"
@@ -25,7 +23,7 @@ test_deploy_manual() {
                 run "run_deploy_manual_aws"
                 ;;
             *)
-                echo "==> TEST SKIPPED: deploy manual - tests for LXD only"
+                echo "==> TEST SKIPPED: deploy manual - tests for LXD and AWS"
                 ;;
         esac
     )

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -135,24 +135,3 @@ EOF
     manual_deploy "${cloud_name}" "${name}" "${addr_m1}" "${addr_m2}"
 }
 
-run_cleanup_deploy_manual_aws() {
-    set +e
-
-    if [ -f "${TEST_DIR}/ec2-instances" ]; then
-        echo "====> Cleaning up EC2 instances"
-        while read -r ec2_instance; do
-            aws ec2 terminate-instances --instance-ids="${ec2_instance}" >>"${TEST_DIR}/aws_cleanup"
-        done < "${TEST_DIR}/ec2-instances"
-    fi
-
-    if [ -f "${TEST_DIR}/ec2-key-pairs" ]; then
-        echo "====> Cleaning up EC2 key-pairs"
-        while read -r ec2_keypair; do
-            aws ec2 delete-key-pair --key-name="${ec2_keypair}" >>"${TEST_DIR}/aws_cleanup"
-        done < "${TEST_DIR}/ec2-key-pairs"
-    fi
-
-    set_verbosity
-
-    echo "====> Completed cleaning up aws"
-}

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -85,6 +85,8 @@ run_deploy_manual_aws() {
     chmod 400 ~/.ssh/"${name}".pem
     echo "${name}" >> "${TEST_DIR}/ec2-key-pairs"
 
+    local addr_c addr_m1 addr_m2
+
     launch_and_wait_addr_ec2 "${name}" "${controller}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_c
     launch_and_wait_addr_ec2 "${name}" "${model1}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_m1
     launch_and_wait_addr_ec2 "${name}" "${model2}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_m2

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -89,33 +89,7 @@ run_deploy_manual_aws() {
     launch_and_wait_addr_ec2 "${name}" "${model1}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_m1
     launch_and_wait_addr_ec2 "${name}" "${model2}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_m2
 
-    # shellcheck disable=SC2154
-    for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
-        ssh-keygen -f "${HOME}/.ssh/known_hosts" -R ubuntu@"${addr}"
-
-        attempt=0
-        while [ ${attempt} -lt 10 ]; do
-            OUT=$(ssh -T -n -i ~/.ssh/"${name}".pem \
-                -o IdentitiesOnly=yes \
-                -o StrictHostKeyChecking=no \
-                -o AddKeysToAgent=yes \
-                -o UserKnownHostsFile="${HOME}/.ssh/known_hosts" \
-                ubuntu@"${addr}" 2>&1 || true)
-            if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
-                echo "Adding ssh key to ${addr}"
-                break
-            fi
-
-            sleep 1
-            attempt=$((attempt+1))
-        done
-
-        if [ "${attempt}" -ge 10 ]; then
-            echo "Failed to add key to ${addr}"
-            exit 1
-        fi
-    done
-
+    ensure_valid_ssh_hosts "${addr_c}" "${addr_m1}" "${addr_m2}"
 
     cloud_name="cloud-${name}"
 

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -1,4 +1,4 @@
-create_priveleged_profile() {
+create_privileged_profile() {
     PROFILE=$(cat <<'EOF'
 config:
   security.nesting: "true"
@@ -72,7 +72,7 @@ run_deploy_manual_lxd() {
         -C "ubuntu@${name}.com" \
         -N ""
 
-    create_priveleged_profile
+    create_privileged_profile
     create_user_profile "${name}"
 
     series="bionic"

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -81,6 +81,8 @@ run_spaces_manual_aws() {
     chmod 400 ~/.ssh/"${name}".pem
     echo "${name}" >> "${TEST_DIR}/ec2-key-pairs"
 
+    local addr_c addr_m1 addr_m2 addr_m3
+
     launch_and_wait_addr_ec2 "${name}" "${controller}" "${image_id}" "$(echo "${subs}" | sed -n 1p)" "${sg_id}" addr_c
     launch_and_wait_addr_ec2 "${name}" "${machine1}" "${image_id}" "$(echo "${subs}" | sed -n 1p)" "${sg_id}" addr_m1
     launch_and_wait_addr_ec2 "${name}" "${machine2}" "${image_id}" "$(echo "${subs}" | sed -n 2p)" "${sg_id}" addr_m2

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -1,0 +1,120 @@
+test_spaces_manual() {
+    if [ "$(skip 'test_spaces_manual')" ]; then
+        echo "==> TEST SKIPPED: spaces manual"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        case "${BOOTSTRAP_PROVIDER:-}" in
+            "aws")
+                export BOOTSTRAP_PROVIDER="manual"
+                run "run_spaces_manual_aws"
+                ;;
+            *)
+                echo "==> TEST SKIPPED: deploy manual - tests for LXD and AWS"
+                ;;
+        esac
+    )
+}
+
+run_spaces_manual_aws() {
+    echo
+
+    echo "==> Checking for dependencies"
+    check_dependencies aws
+
+    name="tests-$(petname)"
+
+    controller="${name}-controller"
+    machine1="${name}-m1"
+    machine2="${name}-m2"
+    machine3="${name}-m3"
+
+    set -eux
+
+    add_clean_func "run_cleanup_deploy_manual_aws"
+
+    # Eventually we should use BOOTSTRAP_SERIES.
+    series="bionic"
+
+    OUT=$(aws ec2 describe-images \
+            --owners 099720109477 \
+            --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-${series}-?????-amd64-server-????????" 'Name=state,Values=available' \
+            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
+            --output text)
+    if [ -z "${OUT}" ]; then
+        echo "No image available: unknown state."
+        exit 1
+    fi
+    image_id="${OUT}"
+
+    # Get each subnet ID from the default VPC.
+    # These should represent the VPC 172.31.0.0/16 carved into 3 /20 ranges.
+    # See https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html#default-vpc-components
+    OUT=$(aws ec2 describe-subnets | jq -r '.Subnets[] | select(.DefaultForAz==true) | .SubnetId')
+    len=$(echo "$OUT" | wc -w)
+    if [ "${len}" -ne "3" ]; then
+        echo "Expected 3 subnets from default VPC; got: ${OUT}"
+        exit 1
+    fi
+    subs="${OUT}"
+
+    # Ensure we have a security group allowing SSH access.
+    OUT=$(aws ec2 describe-security-groups | jq ".SecurityGroups[] | select(.GroupName==\"ci-spaces-manual-ssh\")" || true)
+    if [ -z "${OUT}" ]; then
+        sg_id=$(aws ec2 create-security-group --group-name "ci-spaces-manual-ssh" --description "SSH access for manual spaces test" --query 'GroupId' --output text)
+        aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 22 --cidr 0.0.0.0/0
+    else
+        sg_id=$(echo "${OUT}" | jq -r '.GroupId')
+    fi
+
+    # Create a key-pair so that we can provision machines via SSH.
+    aws ec2 create-key-pair --key-name "${name}" --query 'KeyMaterial' --output text > ~/.ssh/"${name}".pem
+    chmod 400 ~/.ssh/"${name}".pem
+    echo "${name}" >> "${TEST_DIR}/ec2-key-pairs"
+
+    launch_and_wait_addr_ec2 "${name}" "${controller}" "${image_id}" "$(echo "${subs}" | sed -n 1p)" "${sg_id}" addr_c
+    launch_and_wait_addr_ec2 "${name}" "${machine1}" "${image_id}" "$(echo "${subs}" | sed -n 1p)" "${sg_id}" addr_m1
+    launch_and_wait_addr_ec2 "${name}" "${machine2}" "${image_id}" "$(echo "${subs}" | sed -n 2p)" "${sg_id}" addr_m2
+    launch_and_wait_addr_ec2 "${name}" "${machine3}" "${image_id}" "$(echo "${subs}" | sed -n 3p)" "${sg_id}" addr_m3
+
+    ensure_valid_ssh_hosts "${addr_c}" "${addr_m1}" "${addr_m2}" "${addr_m3}"
+
+    cloud_name="cloud-${name}"
+
+    CLOUD=$(cat <<EOF
+clouds:
+  ${cloud_name}:
+    type: manual
+    endpoint: "ubuntu@${addr_c}"
+    regions:
+      default:
+        endpoint: "ubuntu@${addr_c}"
+EOF
+)
+
+    echo "${CLOUD}" > "${TEST_DIR}/cloud_name.yaml"
+
+    juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    bootstrap "${cloud_name}" "test-${name}" "${file}"
+
+    # Each machine is in a different subnet,
+    # which will be discovered when the agent starts.
+    #juju add-machine ssh:ubuntu@"${addr_m1}" >"${TEST_DIR}/add-machine-1.log" 2>&1
+    #juju add-machine ssh:ubuntu@"${addr_m2}" >"${TEST_DIR}/add-machine-2.log" 2>&1
+    #juju add-machine ssh:ubuntu@"${addr_m3}" >"${TEST_DIR}/add-machine-3.log" 2>&1
+
+    #juju add-space space-1 172.31.0.0/20
+    #juju add-space space-2 172.31.16.0/20
+    #juju add-space space-3 172.31.32.0/20
+
+}
+
+

--- a/tests/suites/manual/task.sh
+++ b/tests/suites/manual/task.sh
@@ -10,4 +10,5 @@ test_manual() {
     check_dependencies juju petname
 
     test_deploy_manual
+    test_spaces_manual
 }

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -31,3 +31,24 @@ launch_and_wait_addr_ec2() {
     eval $addr_result="'${address}'"
 }
 
+run_cleanup_deploy_manual_aws() {
+    set +e
+
+    if [ -f "${TEST_DIR}/ec2-instances" ]; then
+        echo "====> Cleaning up EC2 instances"
+        while read -r ec2_instance; do
+            aws ec2 terminate-instances --instance-ids="${ec2_instance}" >>"${TEST_DIR}/aws_cleanup"
+        done < "${TEST_DIR}/ec2-instances"
+    fi
+
+    if [ -f "${TEST_DIR}/ec2-key-pairs" ]; then
+        echo "====> Cleaning up EC2 key-pairs"
+        while read -r ec2_keypair; do
+            aws ec2 delete-key-pair --key-name="${ec2_keypair}" >>"${TEST_DIR}/aws_cleanup"
+        done < "${TEST_DIR}/ec2-key-pairs"
+    fi
+
+    set_verbosity
+
+    echo "====> Completed cleaning up aws"
+}

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -1,0 +1,33 @@
+launch_and_wait_addr_ec2() {
+    local name instance_name addr_result
+
+    name=${1}
+    instance_name=${2}
+    instance_image_id=${3}
+    subnet_id=${4}
+    sg_id=${5}
+    addr_result=${6}
+
+    tags="ResourceType=instance,Tags=[{Key=Name,Value=${instance_name}}]"
+    instance_id=$(aws ec2 run-instances --image-id "${instance_image_id}" \
+        --count 1 \
+        --instance-type t2.medium \
+        --associate-public-ip-address \
+        --tag-specifications "${tags}" \
+        --key-name "${name}" \
+        --subnet-id "${subnet_id}" \
+        --security-group-ids "${sg_id}" \
+        --query 'Instances[0].InstanceId' \
+        --output text)
+
+    echo "${instance_id}" >> "${TEST_DIR}/ec2-instances"
+
+    aws ec2 wait instance-running --instance-ids "${instance_id}"
+    sleep 10
+
+    address=$(aws ec2 describe-instances --instance-ids "${instance_id}" --query 'Reservations[0].Instances[0].PublicDnsName' --output text)
+
+    # shellcheck disable=SC2086
+    eval $addr_result="'${address}'"
+}
+


### PR DESCRIPTION
## Description of change

Adds an integration test to verify progressing subnet discovery and space definition with the manual provider.

Machines are provisioned on AWS so that we get access to multiple subnets.

Some assets from the current manual HA tests have been made common in order that they can be shared.

## QA steps

Run it: `BOOTSTRAP_PROVIDER=aws ./main.sh -v manual`

## Documentation changes

None

## Bug reference

N/A
