### PR TITLE
Implement Support for Constraint allocate-public-ip on GCE

### DIFF
--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -147,7 +147,7 @@ func (v *Value) HasCpuCores() bool {
 	return v.CpuCores != nil && *v.CpuCores > 0
 }
 
-// HasRootDisk returns true if the contraints.Value specifies a RootDisk size.
+// HasRootDisk returns true if the constraints.Value specifies a RootDisk size.
 func (v *Value) HasRootDisk() bool {
 	return v.RootDisk != nil && *v.RootDisk > 0
 }

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -158,6 +158,24 @@ func (s *environBrokerSuite) TestNewRawInstance(c *gc.C) {
 	c.Check(inst, jc.DeepEquals, s.BaseInstance)
 }
 
+func (s *environBrokerSuite) TestNewRawInstanceNoPublicIP(c *gc.C) {
+	s.FakeConn.Inst = s.BaseInstance
+	s.FakeCommon.AZInstances = []common.AvailabilityZoneInstances{{
+		ZoneName:  "home-zone",
+		Instances: []instance.Id{s.Instance.Id()},
+	}}
+
+	public := false
+	s.StartInstArgs.Constraints.AllocatePublicIP = &public
+
+	inst, err := gce.NewRawInstance(s.Env, s.CallCtx, s.StartInstArgs, s.spec)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nics := inst.NetworkInterfaces()
+	c.Assert(nics, gc.HasLen, 1)
+	c.Assert(nics[0].AccessConfigs, gc.HasLen, 0)
+}
+
 func (s *environBrokerSuite) TestNewRawInstanceZoneInvalidCredentialError(c *gc.C) {
 	s.FakeConn.Err = gce.InvalidCredentialError
 	c.Assert(s.InvalidatedCredentials, jc.IsFalse)

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -34,11 +34,10 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
-	constraints.AllocatePublicIP,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the
-// instance types.  See instancetypes.go.
+// instance types. See instancetypes.go.
 var instanceTypeConstraints = []string{
 	constraints.Arch, // Arches
 	constraints.Cores,
@@ -52,26 +51,18 @@ var instanceTypeConstraints = []string{
 func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 
-	// conflicts
-
-	// TODO(ericsnow) Are these correct?
 	validator.RegisterConflicts(
 		[]string{constraints.InstanceType},
 		instanceTypeConstraints,
 	)
 
-	// unsupported
-
 	validator.RegisterUnsupported(unsupportedConstraints)
-
-	// vocab
 
 	instTypeNames := make([]string, len(allInstanceTypes))
 	for i, itype := range allInstanceTypes {
 		instTypeNames[i] = itype.Name
 	}
 	validator.RegisterVocabulary(constraints.InstanceType, instTypeNames)
-
 	validator.RegisterVocabulary(constraints.Container, []string{vtype})
 
 	return validator, nil

--- a/provider/gce/google/export_test.go
+++ b/provider/gce/google/export_test.go
@@ -50,8 +50,8 @@ func SetInstanceSpec(inst *Instance, spec *InstanceSpec) {
 	inst.spec = spec
 }
 
-func NewNetInterface(spec NetworkSpec, name string) *compute.NetworkInterface {
-	return spec.newInterface(name)
+func NewNetInterface(spec NetworkSpec, name string, allocatePublicIP bool) *compute.NetworkInterface {
+	return spec.newInterface(name, allocatePublicIP)
 }
 
 func ConnAddInstance(conn *Connection, inst *compute.Instance, mtype string, zone string) error {

--- a/provider/gce/google/instance.go
+++ b/provider/gce/google/instance.go
@@ -52,6 +52,10 @@ type InstanceSpec struct {
 	// AvailabilityZone holds the name of the availability zone in which
 	// to create the instance.
 	AvailabilityZone string
+
+	// AllocatePublicIP is true if the instance should be assigned a public IP
+	// address, exposing it to access from outside the internal network.
+	AllocatePublicIP bool
 }
 
 func (is InstanceSpec) raw() *compute.Instance {
@@ -82,7 +86,7 @@ func (is InstanceSpec) disks() []*compute.AttachedDisk {
 func (is InstanceSpec) networkInterfaces() []*compute.NetworkInterface {
 	var result []*compute.NetworkInterface
 	for _, name := range is.NetworkInterfaces {
-		result = append(result, is.Network.newInterface(name))
+		result = append(result, is.Network.newInterface(name, is.AllocatePublicIP))
 	}
 	return result
 }

--- a/provider/gce/google/network.go
+++ b/provider/gce/google/network.go
@@ -40,6 +40,10 @@ func (ns *NetworkSpec) Path() string {
 
 // newInterface builds up all the data needed by the GCE API to create
 // a new interface connected to the network.
+// If allocatePublicIP is false the interface will not have a public IP.
+// Such interfaces can not access the public internet unless a facility like
+// Cloud NAT is recruited by the VPC where they reside.
+// See: https://cloud.google.com/nat/docs/using-nat#gcloud_11
 func (ns *NetworkSpec) newInterface(name string, allocatePublicIP bool) *compute.NetworkInterface {
 	nic := &compute.NetworkInterface{
 		Network: ns.Path(),

--- a/provider/gce/google/network.go
+++ b/provider/gce/google/network.go
@@ -40,21 +40,19 @@ func (ns *NetworkSpec) Path() string {
 
 // newInterface builds up all the data needed by the GCE API to create
 // a new interface connected to the network.
-func (ns *NetworkSpec) newInterface(name string) *compute.NetworkInterface {
-	var access []*compute.AccessConfig
-	if name != "" {
-		// This interface has an internet connection.
-		access = append(access, &compute.AccessConfig{
+func (ns *NetworkSpec) newInterface(name string, allocatePublicIP bool) *compute.NetworkInterface {
+	nic := &compute.NetworkInterface{
+		Network: ns.Path(),
+	}
+
+	if allocatePublicIP {
+		nic.AccessConfigs = []*compute.AccessConfig{{
 			Name: name,
 			Type: NetworkAccessOneToOneNAT,
-			// NatIP (only set if using a reserved public IP)
-		})
-		// TODO(ericsnow) Will we need to support more access configs?
+		}}
 	}
-	return &compute.NetworkInterface{
-		Network:       ns.Path(),
-		AccessConfigs: access,
-	}
+
+	return nic
 }
 
 // firewallSpec expands a port range set in to compute.FirewallAllowed

--- a/provider/gce/google/network_test.go
+++ b/provider/gce/google/network_test.go
@@ -33,7 +33,7 @@ func (s *networkSuite) TestNetworkSpecNewInterface(c *gc.C) {
 	spec := google.NetworkSpec{
 		Name: "spam",
 	}
-	netIF := google.NewNetInterface(spec, "eggs")
+	netIF := google.NewNetInterface(spec, "eggs", true)
 
 	c.Check(netIF, gc.DeepEquals, &compute.NetworkInterface{
 		Network: "global/networks/spam",

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -126,6 +126,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		Metadata:          s.Metadata,
 		Tags:              []string{"spam"},
 		AvailabilityZone:  "a-zone",
+		AllocatePublicIP:  true,
 	}
 	s.Instance = Instance{
 		InstanceSummary: InstanceSummary{

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -199,7 +199,6 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 		InstanceConfig: instanceConfig,
 		Tools:          tools,
 		Constraints:    cons,
-		//Placement: "",
 	}
 
 	s.InstanceType = allInstanceTypes[0]


### PR DESCRIPTION
## Description of change

This patch adds support to GCE for the `allocate-public-ip` constraint. It is done by omitting the `AccessConfig` from instance network interfaces when the constraint is `false`.

The default behaviour remains to create allocate public IPs, so no change in behaviour is manifest unless the operator explicitly passes the constraint as `false`.

Eschewing a public IP has an additional effect of removing egress to the public internet. For now this is in the hands of the operator. Google provides options to work around this via Cloud NAT; see: https://cloud.google.com/nat/docs/using-nat#gcloud_11.

## QA steps

- Bootstrap to GCE.
- `juju add-machine` and check that the machine is assigned a public IP.
- `juju add-machine --constraints allocate-public-ip=false` and check that the machine is not assigned a public IP.

## Documentation changes

Yes, accompanying he 2.9 release.

## Bug reference

https://bugs.launchpad.net/bugs/1897419
