### PR TITLE
fix lp:1895040, run upgrade-charm operation after uniter loop restart if one is pending

### DIFF
--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -25,7 +25,7 @@ import (
 type LeadershipContextFunc func(accessor context.LeadershipSettingsAccessor, tracker leadership.Tracker, unitName string) context.LeadershipContext
 
 // RelationStateTrackerConfig contains configuration values for creating a new
-// RlationStateTracker instance.
+// RelationStateTracker instance.
 type RelationStateTrackerConfig struct {
 	State                *uniter.State
 	Unit                 *uniter.Unit

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -8,12 +8,16 @@ import (
 	"time"
 
 	"github.com/juju/charm/v7"
+	"github.com/juju/charm/v7/hooks"
 	"github.com/juju/loggo"
+
+	envtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
@@ -43,7 +47,7 @@ func (s *LoopSuite) SetUpTest(c *gc.C) {
 	}
 	s.opFactory = &mockOpFactory{}
 	s.executor = &mockOpExecutor{}
-	s.charmURL = charm.MustParseURL("cs:trusty/mysql")
+	s.charmURL = charm.MustParseURL("cs:trusty/mysql-1")
 	s.abort = make(chan struct{})
 }
 
@@ -177,9 +181,9 @@ func (s *LoopSuite) TestLoop(c *gc.C) {
 	_, err := s.loop()
 	c.Assert(err, gc.Equals, resolver.ErrLoopAborted)
 	c.Assert(resolverCalls, gc.Equals, 3)
-	s.executor.CheckCallNames(c, "State", "State", "Run", "State", "State")
+	s.executor.CheckCallNames(c, "State", "State", "State", "Run", "State", "State")
 
-	runArgs := s.executor.Calls()[2].Args
+	runArgs := s.executor.Calls()[3].Args
 	c.Assert(runArgs, gc.HasLen, 2)
 	c.Assert(runArgs[0], gc.DeepEquals, theOp)
 	c.Assert(runArgs[1], gc.NotNil)
@@ -238,7 +242,7 @@ func (s *LoopSuite) TestLoopWithChange(c *gc.C) {
 	_, err := s.loop()
 	c.Assert(err, gc.Equals, resolver.ErrLoopAborted)
 	c.Assert(resolverCalls, gc.Equals, 4)
-	s.executor.CheckCallNames(c, "State", "State", "Run", "State", "State", "State")
+	s.executor.CheckCallNames(c, "State", "State", "State", "Run", "State", "State", "State")
 
 	c.Assert(remoteStateSnapshotCount, gc.Equals, 5)
 	select {
@@ -248,7 +252,7 @@ func (s *LoopSuite) TestLoopWithChange(c *gc.C) {
 	default:
 	}
 
-	runArgs := s.executor.Calls()[2].Args
+	runArgs := s.executor.Calls()[3].Args
 	c.Assert(runArgs, gc.HasLen, 2)
 	c.Assert(runArgs[0], gc.DeepEquals, theOp)
 	c.Assert(runArgs[1], gc.NotNil)
@@ -277,6 +281,135 @@ func (s *LoopSuite) TestNextOpFails(c *gc.C) {
 	})
 	_, err := s.loop()
 	c.Assert(err, gc.ErrorMatches, "NextOp fails")
+}
+
+func (s *LoopSuite) TestCheckCharmUpgradeUpgradeCharmHook(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Started: true,
+			Kind:    operation.Continue,
+			Hook:    &hook.Info{Kind: hooks.UpgradeCharm},
+		},
+		run: nil,
+	}
+	s.testCheckCharmUpgradeDoesNothing(c)
+}
+
+func (s *LoopSuite) TestCheckCharmUpgradeSameURL(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Started: true,
+			Kind:    operation.Continue,
+		},
+		run: nil,
+	}
+	s.watcher = &mockRemoteStateWatcher{
+		snapshot: remotestate.Snapshot{
+			CharmURL: charm.MustParseURL("cs:trusty/mysql-1"),
+		},
+	}
+	s.testCheckCharmUpgradeDoesNothing(c)
+}
+
+func (s *LoopSuite) TestCheckCharmUpgradeIncorrectLXDProfile(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Started: true,
+			Kind:    operation.Continue,
+		},
+		run: nil,
+	}
+	s.watcher = &mockRemoteStateWatcher{
+		snapshot: remotestate.Snapshot{
+			CharmURL:             charm.MustParseURL("cs:trusty/mysql-2"),
+			CharmProfileRequired: true,
+			LXDProfileName:       "juju-test-mysql-1",
+		},
+	}
+	s.testCheckCharmUpgradeDoesNothing(c)
+}
+
+func (s *LoopSuite) testCheckCharmUpgradeDoesNothing(c *gc.C) {
+	s.resolver = resolver.ResolverFunc(func(
+		_ resolver.LocalState,
+		_ remotestate.Snapshot,
+		_ operation.Factory,
+	) (operation.Operation, error) {
+		return nil, resolver.ErrWaiting
+	})
+	close(s.abort)
+	_, err := s.loop()
+	c.Assert(err, gc.Equals, resolver.ErrLoopAborted)
+
+	// Run not called
+	c.Assert(s.executor.Calls(), gc.HasLen, 3)
+	s.executor.CheckCallNames(c, "State", "State", "State")
+}
+
+func (s *LoopSuite) TestCheckCharmUpgrade(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Started: true,
+			Kind:    operation.Continue,
+		},
+		run: nil,
+	}
+	s.watcher = &mockRemoteStateWatcher{
+		snapshot: remotestate.Snapshot{
+			CharmURL: charm.MustParseURL("cs:trusty/mysql-2"),
+		},
+	}
+	s.testCheckCharmUpgradeCallsRun(c)
+}
+
+func (s *LoopSuite) TestCheckCharmUpgradeLXDProfile(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Started: true,
+			Kind:    operation.Continue,
+		},
+		run: nil,
+	}
+	s.watcher = &mockRemoteStateWatcher{
+		snapshot: remotestate.Snapshot{
+			CharmURL:             charm.MustParseURL("cs:trusty/mysql-2"),
+			CharmProfileRequired: true,
+			LXDProfileName:       "juju-test-mysql-2",
+		},
+	}
+	s.testCheckCharmUpgradeCallsRun(c)
+}
+
+func (s *LoopSuite) testCheckCharmUpgradeCallsRun(c *gc.C) {
+	s.opFactory = &mockOpFactory{
+		Factory: nil,
+		Stub:    envtesting.Stub{},
+		op:      mockOp{},
+	}
+	s.resolver = resolver.ResolverFunc(func(
+		_ resolver.LocalState,
+		_ remotestate.Snapshot,
+		_ operation.Factory,
+	) (operation.Operation, error) {
+		return nil, resolver.ErrWaiting
+	})
+	close(s.abort)
+	_, err := s.loop()
+	c.Assert(err, gc.Equals, resolver.ErrLoopAborted)
+
+	// Run not called
+	c.Assert(s.executor.Calls(), gc.HasLen, 4)
+	s.executor.CheckCallNames(c, "State", "State", "Run", "State")
 }
 
 func waitChannel(c *gc.C, ch <-chan interface{}, activity string) interface{} {


### PR DESCRIPTION
## Description of change

During SetCharm, if there are new peer relations, they are added to the relation collection at the same time as the new charm URL is updated in the applications collection.  There is a race between these two events reaching the unit to be handled.  If the new peer relation is received, or acted upon, before the upgrade charm event, the unit will start an error loop.  The peer relation isn't found in the local copy read from disk of the charm's metadata.yaml.  

Upgrade charm is usually done when there is a lull in charm activity.  To not drastically change behavior, check to see if upgrade charm is in the queue when the uniter loop starts up.  If so run upgrade charm before continuing.  Other conditions for running upgrade-charm are: one is not already in progress, the unit has been started.

The verifyCharmProfileResolver cannot be used here as it creates an import circle.

## QA steps

```console
# run twice, once with an lxdprofile and once without.

# setup charms for test
$ cd /tmp
$ charm pull cs:~jameinel/ubuntu-lite-7
$ charm pull cs:~jameinel/ubuntu-lite

# Add the following text to the end of /tmp/ubuntu-lite-7/metadata.yaml
peers:
  peer:
    interface: ubuntu-peer

# 
$ juju bootstrap localhost testme
$ juju deploy -n 5 /tmp/ubutu-lite

# wait for units to be up and running
$ juju upgrade-charm --path /tmp/ubutu-lite-7 ubuntu-lite
```

Run these steps on a prior version of 2.8, see the error, upgrade to this patch, the error should resolve.

Run charm upgrade with other charms, there should be no change in current behavior.
## Bug reference

https://bugs.launchpad.net/juju/+bug/1895040
