### PR TITLE
[dev] Check if provider supports IPV6 CIDRs before applying ingress deltas

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -807,3 +807,25 @@ func MergedAddresses(machineAddresses, providerAddresses []SpaceAddress) []Space
 	}
 	return merged
 }
+
+// CIDRAddressType returns back an AddressType to indicate whether the supplied
+// CIDR corresponds to an IPV4 or IPV6 range. An error will be returned if a
+// non-valid CIDR is provided.
+//
+// Caveat: if the provided CIDR corresponds to an IPV6 range with a 4in6
+// prefix, the function will classify it as an IPV4 address. This is a known
+// limitation of the go stdlib IP parsing code but it's not something that we
+// are likely to encounter in the wild so there is no need to add extra logic
+// to work around it.
+func CIDRAddressType(cidr string) (AddressType, error) {
+	_, netIP, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	if netIP.IP.To4() != nil {
+		return IPv4Address, nil
+	}
+
+	return IPv6Address, nil
+}

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -874,3 +874,46 @@ func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 		c.Check(got, gc.Equals, t.exp)
 	}
 }
+
+func (s *AddressSuite) TestCIDRAddressType(c *gc.C) {
+	tests := []struct {
+		descr  string
+		CIDR   string
+		exp    network.AddressType
+		expErr string
+	}{
+		{
+			descr: "IPV4 CIDR",
+			CIDR:  "10.0.0.0/24",
+			exp:   network.IPv4Address,
+		},
+		{
+			descr: "IPV6 CIDR",
+			CIDR:  "2002::1234:abcd:ffff:c0a8:101/64",
+			exp:   network.IPv6Address,
+		},
+		{
+			descr: "IPV6 with 4in6 prefix",
+			CIDR:  "0:0:0:0:0:ffff:c0a8:2a00/120",
+			// The Go stdlib interprets this as an IPV4
+			exp: network.IPv4Address,
+		},
+		{
+			descr:  "bogus CIDR",
+			CIDR:   "catastrophe",
+			expErr: ".*invalid CIDR address.*",
+		},
+	}
+
+	for i, t := range tests {
+		c.Logf("test %d: %s", i, t.descr)
+		got, err := network.CIDRAddressType(t.CIDR)
+		if t.expErr != "" {
+			c.Check(got, gc.Equals, network.AddressType(""))
+			c.Check(err, gc.ErrorMatches, t.expErr)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(got, gc.Equals, t.exp)
+		}
+	}
+}

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -490,6 +490,14 @@ type Firewaller interface {
 	IngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error)
 }
 
+// FirewallFeatureQuerier exposes methods for detecting what features the
+// environment firewall supports.
+type FirewallFeatureQuerier interface {
+	// SupportsRulesWithIPV6CIDRs returns true if the environment supports
+	// ingress rules containing IPV6 CIDRs.
+	SupportsRulesWithIPV6CIDRs(ctx context.ProviderCallContext) (bool, error)
+}
+
 // InstanceTagger is an interface that can be used for tagging instances.
 type InstanceTagger interface {
 	// TagInstance tags the given instance with the specified tags.

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2343,3 +2343,10 @@ func (*Environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space
 func (*Environ) SSHAddresses(ctx context.ProviderCallContext, addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddresses, error) {
 	return addresses, nil
 }
+
+// SupportsRulesWithIPV6CIDRs returns true if the environment supports ingress
+// rules containing IPV6 CIDRs. It is part of the FirewallFeatureQuerier
+// interface.
+func (e *Environ) SupportsRulesWithIPV6CIDRs(ctx context.ProviderCallContext) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
## Description of change

Some of the provider implementations do not support IPV6 CIDRs when Opening/Closing ports on the global/instance firewalls. From juju 2.9, when an application is exposed without any additional arguments juju assumes that the application is exposed to the world and uses the wildcard IPV4 **and IPV6** CIDRs `0.0.0.0/0` and `::/0` when constructing ingress rules.

Passing IPV6 CIDRs to some providers (e.g. ec2 or gce) causes validation issues thus preventing the firewall rules from being correctly applied.

To address this issue in a generic way, this PR introduces a new interface in the `environs` package called `FirewallFeatureQuerier`. This interface allows the firewall worker to query the list of features supported by the firewall implementation. Currently, the interface contains a single method `SupportsRulesWithIPV6CIDRs` which returns a boolean to indicate whether the firewall supports IPV6 CIDRs.

The firewall worker uses this information to drop IPV6 CIDRs from the generated rules when the provider does not support IPV6 CIDRs.

Currently, the interface is only implemented by the **openstack** (returns true) and **dummy** providers. A followup PR will implement this interface for EC2.

## QA steps

Try the following on openstack and ec2 (or azure, gce). Openstack should apply both the IPV4 and IPV6 ingress rules whereas the other providers will only apply the IPV4 ones (without any errors).

```console
$ juju deploy apache2
$ juju run --unit apache2/0 "open-port 8080/tcp"
$ juju expose apache2 --to-cidrs 192.168.0.0/24,2002::1234:abcd:ffff:c0a8:101/64

# Check the ingress rules using the provider's UI or CLI tools
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1897564