### PR TITLE
Correct scoping in network-get to ensure public-first address sorting

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -590,7 +590,7 @@ func (n *NetworkInfo) pollForAddress(
 func spaceAddressesFromNetworkInfo(netInfos []network.NetworkInfo) corenetwork.SpaceAddresses {
 	var addrs corenetwork.SpaceAddresses
 	for _, nwInfo := range netInfos {
-		scope := corenetwork.ScopeCloudLocal
+		scope := corenetwork.ScopeUnknown
 		if strings.HasPrefix(nwInfo.InterfaceName, "fan-") {
 			scope = corenetwork.ScopeFanLocal
 		}

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -55,7 +55,7 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
 		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -66,8 +66,8 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
-	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
 func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machine, addresses ...string) {
@@ -159,7 +159,7 @@ func (s *networkInfoSuite) TestNetworksForBinding(c *gc.C) {
 func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	_ = s.setupSpace(c, "space-1", "1.2.0.0/16", false)
 	_ = s.setupSpace(c, "space-2", "2.2.0.0/16", false)
-	spaceID3 := s.setupSpace(c, "space-3", "3.2.0.0/16", false)
+	spaceID3 := s.setupSpace(c, "space-3", "10.2.0.0/16", false)
 	_ = s.setupSpace(c, "public-4", "4.2.0.0/16", true)
 
 	// We want to have all bindings set so that no actual binding is
@@ -181,13 +181,13 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	addresses := []network.SpaceAddress{
 		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
 		network.NewScopedSpaceAddress("2.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("3.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
 		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
 	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.addDevicesWithAddresses(c, machine, "1.2.3.4/16", "2.2.3.4/16", "3.2.3.4/16", "4.3.2.1/16")
+	s.addDevicesWithAddresses(c, machine, "1.2.3.4/16", "2.2.3.4/16", "10.2.3.4/16", "4.3.2.1/16")
 
 	netInfo := s.newNetworkInfo(c, prr.pu0.UnitTag(), nil)
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
@@ -195,8 +195,8 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, spaceID3)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("3.2.3.4", network.ScopeCloudLocal)})
-	c.Assert(egress, gc.DeepEquals, []string{"3.2.3.4/32"})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
 func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {


### PR DESCRIPTION
## Description of change

This patch reverts a subtle change in behaviour that was introduced way back in #10701.

When static scoping was introduced for Fan addresses, other addresses were given `local-cloud` scoping. This should have been `unknown`, which would cause scope derivation and subsequent differentiation for `local-cloud` and `public` addresses when results were sorted.

This patch makes that change and includes a red/green test that verifies the preference for public addresses.

## QA steps

This is really a test for regression, because public addresses at present are added to the machine _only_, and in space-aware providers are not factored into network-get, which looks at link-layer devices.

- Bootstrap to AWS and deploy this bundle:
```yaml
series: bionic
applications:
  easyrsa:
    charm: cs:~containers/easyrsa-325
    num_units: 1
    to:
    - "1"
  etcd:
    charm: cs:etcd-531
    num_units: 1
    to:
    - "1"
  flannel:
    charm: cs:~containers/flannel-501
  kubernetes-master:
    charm: cs:~containers/kubernetes-master-865
    num_units: 1
    to:
    - "0"
machines:
  "0": {}
  "1": {}
relations:
- - kubernetes-master:cni
  - flannel:cni
- - etcd:db
  - flannel:etcd
- - easyrsa:client
  - etcd:certificates
```
- Once it settles, ssh to machine 0 and run `systemctl restart jujud-machine-0`. This will cause link-layer devices to be updated and include `flannel.1`.
```yaml
    network-interfaces:
      ens5:
        ip-addresses:
        - 172.31.27.64
        mac-address: 0a:a9:4e:96:0a:bf
        gateway: 172.31.16.1
        space: alpha
        is-up: true
      fan-252:
        ip-addresses:
        - 252.27.64.1
        mac-address: a2:26:24:6b:6d:f9
        space: alpha
        is-up: true
      flannel.1:
        ip-addresses:
        - 10.1.89.0
        mac-address: 4a:a7:22:99:ec:6c
        is-up: true
```
- `juju run --unit kubernetes-master/0 -- network-get kube-api-endpoint` will have the 172... address first, then the fan.
```yaml
bind-addresses:
- macaddress: 0a:a9:4e:96:0a:bf
  interfacename: ens5
  addresses:
  - hostname: ""
    address: 172.31.27.64
    cidr: 172.31.16.0/20
- macaddress: a2:26:24:6b:6d:f9
  interfacename: fan-252
  addresses:
  - hostname: ""
    address: 252.27.64.1
    cidr: 252.16.0.0/12
egress-subnets:
- 172.31.27.64/32
ingress-addresses:
- 172.31.27.64
- 252.27.64.1
```

## Documentation changes

None.

## Bug reference

N/A
