### PR TITLE
Bug 1897743, do not run the start hook when no reboot, only ErrRestart

### DIFF
--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -390,11 +390,7 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			"start hook after reboot",
 			quickStart{},
 			stopUniter{},
-			startUniter{
-				rebootQuerier: fakeRebootQuerier{
-					rebootDetected: true,
-				},
-			},
+			startUniter{},
 			// Since the unit has already been started before and
 			// a reboot was detected, we expect the uniter to
 			// queue a start hook to notify the charms about the
@@ -986,7 +982,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			"unknown local relation dir is removed",
 			quickStartRelation{},
 			stopUniter{},
-			startUniter{},
+			startUniter{rebootQuerier: &fakeRebootQuerier{rebootNotDetected}},
 			// We need some synchronisation point here to ensure that the uniter
 			// has entered the correct place in the resolving loop. Now that we are
 			// no longer always executing config-changed, we poke the config just so


### PR DESCRIPTION


## Description of change

RebootDetected needs to be determined each time the Uniter loop is started, rather than when the worker is started.  This allows for correct uniter restarts which are not worker restarts, such as during a charm upgrade.

## QA steps

Run the QA steps in #11887, to ensure no change.

```console
$ juju bootstrap lxd testme
$ juju deploy keystone-315
Located charm "cs:keystone-315".
Deploying charm "cs:keystone-315".

# wait for idle, will be blocked with missing relations
# 
$ juju show-status-log keystone/0
Time                   Type       Status       Message
...
30 Sep 2020 15:57:57Z  juju-unit  executing    running start hook
30 Sep 2020 15:57:58Z  workload   blocked      Missing relations: database, Allowed_units list provided but this unit not present
30 Sep 2020 15:57:58Z  juju-unit  idle

# upgrade the charm
$ juju upgrade-charm keystone
Looking up metadata for charm cs:keystone (channel: stable)
Added charm "cs:keystone-317" to the model.
...

# watch for "upgrade-charm" hook to be run, not "start" hook
$ juju show-status-log keystone/0
Time                   Type       Status       Message
...
30 Sep 2020 15:57:57Z  juju-unit  executing    running start hook
30 Sep 2020 15:57:58Z  workload   blocked      Missing relations: database, Allowed_units list provided but this unit not present
30 Sep 2020 15:57:58Z  juju-unit  idle
30 Sep 2020 15:58:39Z  juju-unit  executing    running upgrade-charm hook
...
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1897743
