### PR TITLE
Lp 1895598 k8s rotation

### DIFF
--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -40,10 +40,15 @@ func fileSetsV2ToFileSets(fs []specs.FileSetV2) (out []specs.FileSet) {
 			Name:      f.Name,
 			MountPath: f.MountPath,
 		}
-		for k, v := range f.Files {
+
+		// We sort the keys of the files here to get a deterministic ordering.
+		// See lp:1895598
+		keys := specs.SortKeysForFiles(f.Files)
+
+		for _, k := range keys {
 			newf.Files = append(newf.Files, specs.File{
 				Path:    k,
-				Content: v,
+				Content: f.Files[k],
 			})
 		}
 		out = append(out, newf)

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -91,6 +91,9 @@ containers:
           file1: |
             [config]
             foo: bar
+          file: |
+            [config]
+            foo: bar
   - name: gitlab-helper
     image: gitlab-helper/latest
     ports:
@@ -401,6 +404,7 @@ echo "do some stuff here for gitlab container"
 						MountPath: "/var/lib/foo",
 						VolumeSource: specs.VolumeSource{
 							Files: []specs.File{
+								{Path: "file", Content: expectedFileContent},
 								{Path: "file1", Content: expectedFileContent},
 							},
 						},

--- a/caas/specs/filesets.go
+++ b/caas/specs/filesets.go
@@ -6,6 +6,7 @@ package specs
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/juju/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -52,6 +53,17 @@ func (fs FileSet) EqualVolume(another FileSet) bool {
 		return false
 	}
 	return true
+}
+
+// SortKeysForFiles returns a slice of all the keys for a given files map
+// sorted in increasing order as per sort.String
+func SortKeysForFiles(f map[string]string) []string {
+	keys := make([]string, 0, len(f))
+	for k := range f {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // Validate validates FileSet.

--- a/caas/specs/filesets_test.go
+++ b/caas/specs/filesets_test.go
@@ -4,6 +4,7 @@
 package specs_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas/specs"
@@ -310,5 +311,32 @@ func (s *typesSuite) TestValidateFileSetVolumeSource(c *gc.C) {
 	} {
 		c.Logf("#%d: testing VolumeSource.Validate", i)
 		c.Check(tc.spec.Validate("fakeFileSet"), gc.ErrorMatches, tc.errStr)
+	}
+}
+
+func (s *typesSuite) TestSortKeysForFiles(c *gc.C) {
+	tests := []struct {
+		Files        map[string]string
+		ExpectedKeys []string
+	}{
+		{
+			Files: map[string]string{
+				"foo": "bar",
+				"tt":  "ff",
+			},
+			ExpectedKeys: []string{"foo", "tt"},
+		},
+		{
+			Files: map[string]string{
+				"tt":  "ff",
+				"foo": "bar",
+			},
+			ExpectedKeys: []string{"foo", "tt"},
+		},
+	}
+
+	for _, test := range tests {
+		keys := specs.SortKeysForFiles(test.Files)
+		c.Assert(keys, jc.DeepEquals, test.ExpectedKeys)
 	}
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

   Fixes file set ordering bug for caas spec

    v2 container spec file set ordering is non deterministic because of go
    maps unmarshalling. This make us generate different kubernetes volume
    specs for v2 deployments potentially.

    See lp:1895598

    This change introduces into the v2 -> v3 conversion a deterministic
    ordering on the map keys using string.Sort()

## QA steps

See unit test changes. They reliably failed every so often due to unpacking.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1895598
