### PR TITLE
When calculating Bindings updateOps, only 1 op per space doc is necessary.

### DIFF
--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -239,16 +239,21 @@ func (b *Bindings) updateOps(txnRevno int64, newMap map[string]string, newMeta *
 	}
 
 	// Ensure that the spaceIDs needed for the bindings exist.
+	spIdMap := set.NewStrings()
 	for _, spID := range b.Map() {
 		sp, err := b.st.Space(spID)
 		if err != nil {
 			return ops, errors.Trace(err)
+		}
+		if spIdMap.Contains(spID) {
+			continue
 		}
 		ops = append(ops, txn.Op{
 			C:      spacesC,
 			Id:     sp.doc.DocId,
 			Assert: txn.DocExists,
 		})
+		spIdMap.Add(spID)
 	}
 
 	// To avoid a potential race where units may suddenly appear on a new


### PR DESCRIPTION

## Description of change

While helping to debug an upgrade-charm failure due to txn issues, found that there were 12 ops to verify the alpha space doc with the openstack-dashboard charm.  Only need 1.

## QA steps

```console
# bootstrap and deploy the charm, chosen for the endpoints, 
$ juju bootstrap guimaas testme
$ juju deploy openstack-dashboard

$ juju bind  openstack-dashboard ha=default public=default website=default cluster=default

# helpful to find the txn db.txns.find({'s': 6}).sort({'_id': -1}).pretty(), latest successful txn on top.
# look at the bind txn in the db, should have only 1 of:
              {
                        "c" : "spaces",
                        "d" : "<model-uuid>6:1",
                        "a" : "d+"
              },

```


