### PR TITLE
[dev] Enable IPV6 CIDR firewall rule support for compliant providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d // indirect
 	google.golang.org/grpc v1.30.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/amz.v3 v3.0.0-20200811022415-7b63e5e39741
+	gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b
 	gopkg.in/goose.v2 v2.0.1
 	gopkg.in/httprequest.v1 v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1026,8 +1026,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/amz.v3 v3.0.0-20200811022415-7b63e5e39741 h1:14qKyD3LDeuWJtTnYrkB8DafjhTslYsRFcg2Ky9w3nE=
-gopkg.in/amz.v3 v3.0.0-20200811022415-7b63e5e39741/go.mod h1:cE0dCGx2UfBTjLFlzEx4EXJUmoX6BXBoX9GjKOvqha4=
+gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b h1:tdSyAzD5FHJmZAZ13d5WexAo7YJkiyGphhzFfInMnDw=
+gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b/go.mod h1:cE0dCGx2UfBTjLFlzEx4EXJUmoX6BXBoX9GjKOvqha4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -159,6 +159,16 @@ func (*Suite) TestPortsToIPPerms(c *gc.C) {
 			ToPort:    82,
 			SourceIPs: []string{"0.0.0.0/0", "192.168.1.0/24"},
 		}},
+	}, {
+		about: "mixed IPV4 and IPV6 CIDRs",
+		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80-82/tcp"), "192.168.1.0/24", "0.0.0.0/0", "::/0")},
+		expected: []amzec2.IPPerm{{
+			Protocol:      "tcp",
+			FromPort:      80,
+			ToPort:        82,
+			SourceIPs:     []string{"0.0.0.0/0", "192.168.1.0/24"},
+			SourceIPV6IPs: []string{"::/0"},
+		}},
 	}}
 
 	for i, t := range testCases {

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -371,7 +371,7 @@ func getContainerDetails(srv Server, containerID string) (*lxdapi.Container, *lx
 func isErrNotFound(err error) bool {
 	// Unfortunately the lxd client does not expose error
 	// codes so we need to match against a string here.
-	return strings.Contains(err.Error(), "not found")
+	return err != nil && strings.Contains(err.Error(), "not found")
 }
 
 // isErrMissingAPIExtension returns true if the LXD server returned back an
@@ -379,7 +379,7 @@ func isErrNotFound(err error) bool {
 func isErrMissingAPIExtension(err error, ext string) bool {
 	// Unfortunately the lxd client does not expose error
 	// codes so we need to match against a string here.
-	return strings.Contains(err.Error(), fmt.Sprintf("server is missing the required %q API extension", ext))
+	return err != nil && strings.Contains(err.Error(), fmt.Sprintf("server is missing the required %q API extension", ext))
 }
 
 // SuperSubnets returns information about aggregated subnet.

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -180,7 +180,7 @@ func (s *environNetSuite) TestSubnetDiscoveryFallbackForOlderLXDs(c *gc.C) {
 	// Even though ovs-br0 is returned by the LXD API, it is *not* bridged
 	// into the container we will be introspecting and so this subnet will
 	// not be reported back. This is a caveat of the fallback code.
-	srv.EXPECT().GetNetworkNames().Return([]string{"lo", "ovsbr0", "lxdbr0"}, nil)
+	srv.EXPECT().GetNetworkNames().Return([]string{"lo", "ovsbr0", "lxdbr0"}, nil).AnyTimes()
 
 	// This error will trigger the fallback codepath
 	srv.EXPECT().GetNetworkState("lo").Return(nil, errors.New(`server is missing the required "network_state" API extension`))
@@ -241,6 +241,13 @@ func (s *environNetSuite) TestSubnetDiscoveryFallbackForOlderLXDs(c *gc.C) {
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
 	ctx := context.NewCloudCallContext()
+
+	// Spaces should be supported
+	supportsSpaces, err := env.SupportsSpaces(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(supportsSpaces, jc.IsTrue)
+
+	// List subnets
 	subnets, err := env.Subnets(ctx, instance.UnknownId, nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/cmd/juju/interact"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/status"
@@ -2070,6 +2071,15 @@ func rulesToRuleInfo(groupId string, rules firewall.IngressRules) []neutron.Rule
 			sourceCIDRs = append(sourceCIDRs, firewall.AllNetworksIPV4CIDR)
 		}
 		for _, sr := range sourceCIDRs {
+			addrType, _ := network.CIDRAddressType(sr)
+			if addrType == network.IPv4Address {
+				ruleInfo.EthernetType = "IPv4"
+			} else if addrType == network.IPv6Address {
+				ruleInfo.EthernetType = "IPv6"
+			} else {
+				// Should never happen; ignore CIDR
+				continue
+			}
 			ruleInfo.RemoteIPPrefix = sr
 			result = append(result, ruleInfo)
 		}

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -215,6 +215,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			PortRangeMax:   80,
 			RemoteIPPrefix: "0.0.0.0/0",
 			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
 		}},
 	}, {
 		about: "multiple ports",
@@ -226,6 +227,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			PortRangeMax:   82,
 			RemoteIPPrefix: "0.0.0.0/0",
 			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
 		}},
 	}, {
 		about: "multiple port ranges",
@@ -240,6 +242,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			PortRangeMax:   82,
 			RemoteIPPrefix: "0.0.0.0/0",
 			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
 		}, {
 			Direction:      "ingress",
 			IPProtocol:     "tcp",
@@ -247,6 +250,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			PortRangeMax:   120,
 			RemoteIPPrefix: "0.0.0.0/0",
 			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
 		}},
 	}, {
 		about: "source range",
@@ -258,6 +262,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			PortRangeMax:   100,
 			RemoteIPPrefix: "192.168.1.0/24",
 			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
 		}, {
 			Direction:      "ingress",
 			IPProtocol:     "tcp",
@@ -265,6 +270,27 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			PortRangeMax:   100,
 			RemoteIPPrefix: "0.0.0.0/0",
 			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
+		}},
+	}, {
+		about: "IPV4 and IPV6 CIDRs",
+		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80-100/tcp"), "192.168.1.0/24", "2002::1234:abcd:ffff:c0a8:101/64")},
+		expected: []neutron.RuleInfoV2{{
+			Direction:      "ingress",
+			IPProtocol:     "tcp",
+			PortRangeMin:   80,
+			PortRangeMax:   100,
+			RemoteIPPrefix: "192.168.1.0/24",
+			ParentGroupId:  groupId,
+			EthernetType:   "IPv4",
+		}, {
+			Direction:      "ingress",
+			IPProtocol:     "tcp",
+			PortRangeMin:   80,
+			PortRangeMax:   100,
+			RemoteIPPrefix: "2002::1234:abcd:ffff:c0a8:101/64",
+			ParentGroupId:  groupId,
+			EthernetType:   "IPv6",
 		}},
 	}}
 
@@ -294,6 +320,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			IPProtocol:   &proto_tcp,
 			PortRangeMin: &port_80,
 			PortRangeMax: &port_80,
+			EthernetType: "IPv4",
 		},
 		expected: true,
 	}, {
@@ -303,6 +330,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			IPProtocol:   &proto_tcp,
 			PortRangeMin: &port_80,
 			PortRangeMax: &port_85,
+			EthernetType: "IPv4",
 		},
 		expected: true,
 	}, {
@@ -312,6 +340,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			IPProtocol:   nil,
 			PortRangeMin: nil,
 			PortRangeMax: nil,
+			EthernetType: "IPv4",
 		},
 		expected: false,
 	}, {
@@ -322,6 +351,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			PortRangeMin:   nil,
 			PortRangeMax:   &port_85,
 			RemoteIPPrefix: "192.168.100.0/24",
+			EthernetType:   "IPv4",
 		},
 		expected: false,
 	}, {
@@ -332,6 +362,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			PortRangeMin:   &port_85,
 			PortRangeMax:   nil,
 			RemoteIPPrefix: "192.168.100.0/24",
+			EthernetType:   "IPv4",
 		},
 		expected: false,
 	}, {
@@ -341,6 +372,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			IPProtocol:   &proto_udp,
 			PortRangeMin: &port_80,
 			PortRangeMax: &port_80,
+			EthernetType: "IPv4",
 		},
 		expected: false,
 	}, {
@@ -351,6 +383,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			PortRangeMin:   &port_80,
 			PortRangeMax:   &port_85,
 			RemoteIPPrefix: "0.0.0.0/0",
+			EthernetType:   "IPv4",
 		},
 		expected: true,
 	}, {
@@ -361,6 +394,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			PortRangeMin:   &port_80,
 			PortRangeMax:   &port_85,
 			RemoteIPPrefix: "192.168.1.0/24",
+			EthernetType:   "IPv4",
 		},
 		expected: true,
 	}, {
@@ -371,6 +405,7 @@ func (*localTests) TestSecGroupMatchesIngressRule(c *gc.C) {
 			PortRangeMin:   &port_80,
 			PortRangeMax:   &port_85,
 			RemoteIPPrefix: "192.168.100.0/24",
+			EthernetType:   "IPv4",
 		},
 		expected: false,
 	}}


### PR DESCRIPTION
## Description of change

This PR builds on top of the work introduced in #12063 and enables support for IPV6 CIDRs in firewall rules for EC2 and openstack.

In addition, the PR includes a fix for a potential null error value dereference when checking for space support in lxd that was accidentally introduced in #12068.

## QA steps

### Verify IPv6 CIDR support

Run the following on EC2 and openstack. Then check the firewall rules (for ec2 you can use the UI)
and verify that both IPV4 and IPV6 CIDRs are present.

```console
$ juju deploy apache2
$ juju run --unit apache2/0 "open-port 8080/tcp"
$ juju expose apache2 --to-cidrs 192.168.0.0/24,2002::1234:abcd:ffff:c0a8:101/64
```

### Verify LXD fix

```console
$ juju bootstrap lxd test
$ juju spaces
```