### PR TITLE
Allows mux worker to start without TLS

### DIFF
--- a/worker/muxhttpserver/manifold.go
+++ b/worker/muxhttpserver/manifold.go
@@ -54,23 +54,24 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 		return nil, errors.Trace(err)
 	}
 
-	var authority pki.Authority
-	if err := context.Get(c.AuthorityName, &authority); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	serverConfig := DefaultConfig()
 	if c.Port != "" {
 		serverConfig.Port = c.Port
+	}
+
+	if c.AuthorityName == "" {
+		return NewServerWithOutTLS(c.Logger, serverConfig)
+	}
+
+	var authority pki.Authority
+	if err := context.Get(c.AuthorityName, &authority); err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	return NewServer(authority, c.Logger, serverConfig)
 }
 
 func (c ManifoldConfig) Validate() error {
-	if c.AuthorityName == "" {
-		return errors.NotValidf("empty AuthorityName")
-	}
 	if c.Logger == nil {
 		return errors.NotValidf("nil Logger")
 	}


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

- Bug that was not allowing the mux worker to start without TLS

## QA steps

Bootstrap new k8's charm cockroach
