### PR TITLE
Fix a typo in k8s units watcher

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -770,14 +770,14 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 	watchers := []k8swatcher.KubernetesNotifyWatcher{podWatcher, eventWatcher}
 	watchCallCount := 0
 
-	s.k8sWatcherFn = k8swatcher.NewK8sWatcherFunc(func(_ cache.SharedIndexInformer, n string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
+	s.k8sWatcherFn = func(_ cache.SharedIndexInformer, n string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
 		if watchCallCount >= len(watchers) {
 			return nil, errors.NotFoundf("no watcher available for index %d", watchCallCount)
 		}
 		w := watchers[watchCallCount]
 		watchCallCount++
 		return w, nil
-	})
+	}
 
 	gomock.InOrder(
 		// create namespace.

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1984,12 +1984,12 @@ func (k *kubernetesClient) AnnotateUnit(appName string, mode caas.DeploymentMode
 // WatchUnits returns a watcher which notifies when there
 // are changes to units of the specified application.
 func (k *kubernetesClient) WatchUnits(appName string, mode caas.DeploymentMode) (watcher.NotifyWatcher, error) {
-	selector := utils.LabelSetToSelector(utils.LabelsForApp(appName, k.IsLegacyLabels()))
-	logger.Debugf("selecting units %q to watch", selector.String())
+	selector := k.applicationSelector(appName, mode)
+	logger.Debugf("selecting units %q to watch", selector)
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
 		informers.WithTweakListOptions(func(o *v1.ListOptions) {
-			o.LabelSelector = selector.String()
+			o.LabelSelector = selector
 		}),
 	)
 	return k.newWatcher(factory.Core().V1().Pods().Informer(), appName, k.clock)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -6872,22 +6872,43 @@ func (s *K8sBrokerSuite) assertAnnotateUnitByUID(c *gc.C, mode caas.DeploymentMo
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *K8sBrokerSuite) TestWatchUnits(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	podWatcher, podFirer := k8swatchertest.NewKubernetesTestWatcher()
+	s.k8sWatcherFn = func(si cache.SharedIndexInformer, n string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
+		c.Assert(n, gc.Equals, "test")
+		return podWatcher, nil
+	}
+
+	w, err := s.broker.WatchUnits("test", caas.ModeWorkload)
+	c.Assert(err, jc.ErrorIsNil)
+
+	podFirer()
+
+	select {
+	case _, ok := <-w.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for event")
+	}
+}
+
 func (s *K8sBrokerSuite) TestWatchContainerStart(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
 	podWatcher, podFirer := k8swatchertest.NewKubernetesTestStringsWatcher()
 	var filter k8swatcher.K8sStringsWatcherFilterFunc
-	s.k8sStringsWatcherFn = k8swatcher.NewK8sStringsWatcherFunc(
-		func(_ cache.SharedIndexInformer,
-			_ string,
-			_ jujuclock.Clock,
-			_ []string,
-			ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
-			filter = ff
-			return podWatcher, nil
-		},
-	)
+	s.k8sStringsWatcherFn = func(_ cache.SharedIndexInformer,
+		_ string,
+		_ jujuclock.Clock,
+		_ []string,
+		ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
+		filter = ff
+		return podWatcher, nil
+	}
 
 	podList := &core.PodList{
 		Items: []core.Pod{{
@@ -6965,16 +6986,14 @@ func (s *K8sBrokerSuite) TestWatchContainerStartRegex(c *gc.C) {
 
 	podWatcher, podFirer := k8swatchertest.NewKubernetesTestStringsWatcher()
 	var filter k8swatcher.K8sStringsWatcherFilterFunc
-	s.k8sStringsWatcherFn = k8swatcher.NewK8sStringsWatcherFunc(
-		func(_ cache.SharedIndexInformer,
-			_ string,
-			_ jujuclock.Clock,
-			_ []string,
-			ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
-			filter = ff
-			return podWatcher, nil
-		},
-	)
+	s.k8sStringsWatcherFn = func(_ cache.SharedIndexInformer,
+		_ string,
+		_ jujuclock.Clock,
+		_ []string,
+		ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
+		filter = ff
+		return podWatcher, nil
+	}
 
 	pod := core.Pod{
 		ObjectMeta: v1.ObjectMeta{
@@ -7088,16 +7107,14 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefault(c *gc.C) {
 
 	podWatcher, podFirer := k8swatchertest.NewKubernetesTestStringsWatcher()
 	var filter k8swatcher.K8sStringsWatcherFilterFunc
-	s.k8sStringsWatcherFn = k8swatcher.NewK8sStringsWatcherFunc(
-		func(_ cache.SharedIndexInformer,
-			_ string,
-			_ jujuclock.Clock,
-			_ []string,
-			ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
-			filter = ff
-			return podWatcher, nil
-		},
-	)
+	s.k8sStringsWatcherFn = func(_ cache.SharedIndexInformer,
+		_ string,
+		_ jujuclock.Clock,
+		_ []string,
+		ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
+		filter = ff
+		return podWatcher, nil
+	}
 
 	podList := &core.PodList{
 		Items: []core.Pod{{
@@ -7176,16 +7193,14 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefaultWaitForUnit(c *gc.C) {
 
 	podWatcher, podFirer := k8swatchertest.NewKubernetesTestStringsWatcher()
 	var filter k8swatcher.K8sStringsWatcherFilterFunc
-	s.k8sStringsWatcherFn = k8swatcher.NewK8sStringsWatcherFunc(
-		func(_ cache.SharedIndexInformer,
-			_ string,
-			_ jujuclock.Clock,
-			_ []string,
-			ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
-			filter = ff
-			return podWatcher, nil
-		},
-	)
+	s.k8sStringsWatcherFn = func(_ cache.SharedIndexInformer,
+		_ string,
+		_ jujuclock.Clock,
+		_ []string,
+		ff k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
+		filter = ff
+		return podWatcher, nil
+	}
 
 	podList := &core.PodList{
 		Items: []core.Pod{{


### PR DESCRIPTION
## Description of change

There was a mistake in the k8s units watcher introduced by the recent PR to change k8s labels.
As a driveby, remove some unnecessary function casts.

## QA steps

juju bootstrap microk8s
juju deploy mariadb-k8s

