### PR TITLE
Use 'juju.is' for k8s annotstion key prefixes

### DIFF
--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -46,8 +46,8 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -62,8 +62,8 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -179,7 +179,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreate(c *gc.C) 
 			Name:        "test-example-mutatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 	}
@@ -232,7 +232,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepName(c
 		{
 			Meta: k8sspecs.Meta{
 				Name:        "example-mutatingwebhookconfiguration",
-				Annotations: map[string]string{"juju.io/disable-name-prefix": "true"},
+				Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
 			},
 			Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 		},
@@ -243,7 +243,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepName(c
 			Name:        "example-mutatingwebhookconfiguration", // This name kept no change.
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id(), "juju.io/disable-name-prefix": "true"},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id(), "juju.is/disable-name-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 	}
@@ -304,7 +304,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdate(c *gc.C) 
 			Name:        "test-example-mutatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 	}
@@ -341,8 +341,8 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -357,8 +357,8 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -470,7 +470,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreate(c *gc.C
 			Name:        "test-example-validatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 	}
@@ -523,7 +523,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 		{
 			Meta: k8sspecs.Meta{
 				Name:        "example-validatingwebhookconfiguration",
-				Annotations: map[string]string{"juju.io/disable-name-prefix": "true"},
+				Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
 			},
 			Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 		},
@@ -534,7 +534,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 			Name:        "example-validatingwebhookconfiguration", // This name kept no change.
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id(), "juju.io/disable-name-prefix": "true"},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id(), "juju.is/disable-name-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 	}
@@ -595,7 +595,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdate(c *gc.C
 			Name:        "test-example-validatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 	}

--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -45,9 +45,9 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -62,8 +62,8 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -179,7 +179,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreate(c *gc.C) 
 			Name:        "test-example-mutatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 	}
@@ -232,7 +232,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepName(c
 		{
 			Meta: k8sspecs.Meta{
 				Name:        "example-mutatingwebhookconfiguration",
-				Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
+				Annotations: map[string]string{"model.juju.is/disable-prefix": "true"},
 			},
 			Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 		},
@@ -243,7 +243,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepName(c
 			Name:        "example-mutatingwebhookconfiguration", // This name kept no change.
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id(), "juju.is/disable-name-prefix": "true"},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id(), "model.juju.is/disable-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 	}
@@ -304,7 +304,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdate(c *gc.C) 
 			Name:        "test-example-mutatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 	}
@@ -340,9 +340,9 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -357,8 +357,8 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -470,7 +470,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreate(c *gc.C
 			Name:        "test-example-validatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 	}
@@ -523,7 +523,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 		{
 			Meta: k8sspecs.Meta{
 				Name:        "example-validatingwebhookconfiguration",
-				Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
+				Annotations: map[string]string{"model.juju.is/disable-prefix": "true"},
 			},
 			Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 		},
@@ -534,7 +534,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 			Name:        "example-validatingwebhookconfiguration", // This name kept no change.
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id(), "juju.is/disable-name-prefix": "true"},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id(), "model.juju.is/disable-prefix": "true"},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 	}
@@ -595,7 +595,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdate(c *gc.C
 			Name:        "test-example-validatingwebhookconfiguration",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Webhooks: []admissionregistration.ValidatingWebhook{webhook1},
 	}

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -366,11 +366,11 @@ func (s *BaseSuite) k8sNewFakeWatcher() *watch.RaceFreeFakeWatcher {
 
 func (s *BaseSuite) ensureJujuNamespaceAnnotations(isController bool, ns *core.Namespace) *core.Namespace {
 	annotations := map[string]string{
-		"juju.is/controller": testing.ControllerTag.Id(),
-		"juju.is/model":      s.cfg.UUID(),
+		"controller.juju.is/id": testing.ControllerTag.Id(),
+		"model.juju.is/id":      s.cfg.UUID(),
 	}
 	if isController {
-		annotations["juju.is/is-controller"] = "true"
+		annotations["controller.juju.is/is-controller"] = "true"
 	}
 	ns.SetAnnotations(annotations)
 	return ns

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -366,11 +366,11 @@ func (s *BaseSuite) k8sNewFakeWatcher() *watch.RaceFreeFakeWatcher {
 
 func (s *BaseSuite) ensureJujuNamespaceAnnotations(isController bool, ns *core.Namespace) *core.Namespace {
 	annotations := map[string]string{
-		"juju.io/controller": testing.ControllerTag.Id(),
-		"juju.io/model":      s.cfg.UUID(),
+		"juju.is/controller": testing.ControllerTag.Id(),
+		"juju.is/model":      s.cfg.UUID(),
 	}
 	if isController {
-		annotations["juju.io/is-controller"] = "true"
+		annotations["juju.is/is-controller"] = "true"
 	}
 	ns.SetAnnotations(annotations)
 	return ns

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -28,6 +28,7 @@ import (
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	providerutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig"
@@ -142,7 +143,8 @@ type controllerStacker interface {
 
 func controllerCorelation(broker *kubernetesClient) (string, error) {
 	// ensure controller specific annotations.
-	_ = broker.addAnnotations(constants.AnnotationControllerIsControllerKey, "true")
+	controllerUUIDKey := k8sutils.AnnotationControllerIsControllerKey(false)
+	_ = broker.addAnnotations(controllerUUIDKey, "true")
 
 	ns, err := broker.listNamespacesByAnnotations(broker.GetAnnotations())
 	if errors.IsNotFound(err) || ns == nil {
@@ -205,12 +207,13 @@ func newcontrollerStack(
 	selectorLabels := providerutils.SelectorLabelsForApp(stackName, false)
 	labels := providerutils.LabelsForApp(stackName, false)
 
+	controllerUUIDKey := k8sutils.AnnotationControllerUUIDKey(false)
 	cs := &controllerStack{
 		ctx:              ctx,
 		stackName:        stackName,
 		selectorLabels:   selectorLabels,
 		stackLabels:      labels,
-		stackAnnotations: map[string]string{constants.AnnotationControllerUUIDKey: pcfg.ControllerTag.Id()},
+		stackAnnotations: map[string]string{controllerUUIDKey: pcfg.ControllerTag.Id()},
 		broker:           broker,
 
 		pcfg:        pcfg,

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -123,15 +123,15 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 	existingNs := core.Namespace{}
 	existingNs.SetName("controller-1")
 	existingNs.SetAnnotations(map[string]string{
-		"juju.io/model":         s.cfg.UUID(),
-		"juju.io/controller":    testing.ControllerTag.Id(),
-		"juju.io/is-controller": "true",
+		"juju.is/model":         s.cfg.UUID(),
+		"juju.is/controller":    testing.ControllerTag.Id(),
+		"juju.is/is-controller": "true",
 	})
 
 	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.getNamespace())
 	c.Assert(s.broker.GetAnnotations().ToMap(), jc.DeepEquals, map[string]string{
-		"juju.io/model":      s.cfg.UUID(),
-		"juju.io/controller": testing.ControllerTag.Id(),
+		"juju.is/model":      s.cfg.UUID(),
+		"juju.is/controller": testing.ControllerTag.Id(),
 	})
 
 	gomock.InOrder(
@@ -145,9 +145,9 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 		// "is-controller" is set as well.
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
-			"juju.io/model":         s.cfg.UUID(),
-			"juju.io/controller":    testing.ControllerTag.Id(),
-			"juju.io/is-controller": "true",
+			"juju.is/model":         s.cfg.UUID(),
+			"juju.is/controller":    testing.ControllerTag.Id(),
+			"juju.is/is-controller": "true",
 		},
 	)
 	// controller namespace linked back(changed from 'controller' to 'controller-1')
@@ -295,13 +295,13 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	c.Assert(
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
-			"juju.io/model":      s.cfg.UUID(),
-			"juju.io/controller": testing.ControllerTag.Id(),
+			"juju.is/model":      s.cfg.UUID(),
+			"juju.is/controller": testing.ControllerTag.Id(),
 		},
 	)
 
 	// Done in broker.Bootstrap method actually.
-	s.broker.GetAnnotations().Add("juju.io/is-controller", "true")
+	s.broker.GetAnnotations().Add("juju.is/is-controller", "true")
 
 	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
 	s.pcfg.Bootstrap.ControllerExternalIPs = []string{"10.0.0.1"}
@@ -337,7 +337,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-service",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
@@ -359,7 +359,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-service",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
@@ -380,7 +380,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-secret",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 	}
@@ -389,7 +389,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-secret",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -401,7 +401,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-secret",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -415,7 +415,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-configmap",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 	}
 	bootstrapParamsContent, err := s.pcfg.Bootstrap.StateInitializationParams.Marshal()
@@ -426,7 +426,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-configmap",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Data: map[string]string{
 			"bootstrap-params": string(bootstrapParamsContent),
@@ -437,7 +437,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-configmap",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Data: map[string]string{
 			"bootstrap-params": string(bootstrapParamsContent),
@@ -452,7 +452,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apps.StatefulSetSpec{
 			ServiceName: "juju-controller-test-service",
@@ -465,7 +465,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:        "storage",
 						Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-						Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+						Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 					},
 					Spec: core.PersistentVolumeClaimSpec{
 						StorageClassName: &scName,
@@ -483,7 +483,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Name:        "controller-0",
 					Namespace:   s.getNamespace(),
 					Labels:      map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
-					Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+					Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 				},
 				Spec: core.PodSpec{
 					RestartPolicy: core.RestartPolicyAlways,

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -123,15 +123,15 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 	existingNs := core.Namespace{}
 	existingNs.SetName("controller-1")
 	existingNs.SetAnnotations(map[string]string{
-		"juju.is/model":         s.cfg.UUID(),
-		"juju.is/controller":    testing.ControllerTag.Id(),
-		"juju.is/is-controller": "true",
+		"model.juju.is/id":                 s.cfg.UUID(),
+		"controller.juju.is/id":            testing.ControllerTag.Id(),
+		"controller.juju.is/is-controller": "true",
 	})
 
 	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.getNamespace())
 	c.Assert(s.broker.GetAnnotations().ToMap(), jc.DeepEquals, map[string]string{
-		"juju.is/model":      s.cfg.UUID(),
-		"juju.is/controller": testing.ControllerTag.Id(),
+		"model.juju.is/id":      s.cfg.UUID(),
+		"controller.juju.is/id": testing.ControllerTag.Id(),
 	})
 
 	gomock.InOrder(
@@ -145,9 +145,9 @@ func (s *bootstrapSuite) TestControllerCorelation(c *gc.C) {
 		// "is-controller" is set as well.
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
-			"juju.is/model":         s.cfg.UUID(),
-			"juju.is/controller":    testing.ControllerTag.Id(),
-			"juju.is/is-controller": "true",
+			"model.juju.is/id":                 s.cfg.UUID(),
+			"controller.juju.is/id":            testing.ControllerTag.Id(),
+			"controller.juju.is/is-controller": "true",
 		},
 	)
 	// controller namespace linked back(changed from 'controller' to 'controller-1')
@@ -295,13 +295,13 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	c.Assert(
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
-			"juju.is/model":      s.cfg.UUID(),
-			"juju.is/controller": testing.ControllerTag.Id(),
+			"model.juju.is/id":      s.cfg.UUID(),
+			"controller.juju.is/id": testing.ControllerTag.Id(),
 		},
 	)
 
 	// Done in broker.Bootstrap method actually.
-	s.broker.GetAnnotations().Add("juju.is/is-controller", "true")
+	s.broker.GetAnnotations().Add("controller.juju.is/is-controller", "true")
 
 	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
 	s.pcfg.Bootstrap.ControllerExternalIPs = []string{"10.0.0.1"}
@@ -337,7 +337,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-service",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
@@ -359,7 +359,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-service",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
@@ -380,7 +380,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-secret",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 	}
@@ -389,7 +389,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-secret",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -401,7 +401,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-secret",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -415,7 +415,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-configmap",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 	}
 	bootstrapParamsContent, err := s.pcfg.Bootstrap.StateInitializationParams.Marshal()
@@ -426,7 +426,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-configmap",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Data: map[string]string{
 			"bootstrap-params": string(bootstrapParamsContent),
@@ -437,7 +437,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test-configmap",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Data: map[string]string{
 			"bootstrap-params": string(bootstrapParamsContent),
@@ -452,7 +452,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Name:        "juju-controller-test",
 			Namespace:   s.getNamespace(),
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apps.StatefulSetSpec{
 			ServiceName: "juju-controller-test-service",
@@ -465,7 +465,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					ObjectMeta: v1.ObjectMeta{
 						Name:        "storage",
 						Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "juju-controller-test"},
-						Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+						Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 					},
 					Spec: core.PersistentVolumeClaimSpec{
 						StorageClassName: &scName,
@@ -483,7 +483,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Name:        "controller-0",
 					Namespace:   s.getNamespace(),
 					Labels:      map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
-					Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+					Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 				},
 				Spec: core.PodSpec{
 					RestartPolicy: core.RestartPolicyAlways,

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -25,8 +25,8 @@ const (
 	// TemplateFileNameAgentConf is the template agent.conf file name.
 	TemplateFileNameAgentConf = "template-" + agent.AgentConfigFilename
 
-	// AnnotationPrefix of juju annotations
-	AnnotationPrefix = "juju.io"
+	// AnnotationPrefix of juju annotations.
+	AnnotationPrefix = "juju.is"
 
 	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
 	// created by applications managed by Juju. Think istio, kubeflow etc
@@ -68,6 +68,9 @@ const (
 	// describe their name.
 	LabelJujuStorageName = "storage.juju.is/name"
 
+	// LegacyAnnotationPrefix is the legacy prefix of juju annotations.
+	LegacyAnnotationPrefix = "juju.io"
+
 	// LegacyAnnotationStorageName is the legacy annotation used by Juju for
 	// dictating storage name on k8s storage objects.
 	LegacyAnnotationStorageName = "juju-storage"
@@ -102,16 +105,6 @@ const (
 	LegacyLabelStorageName = "juju-storage"
 )
 
-func AnnotationKey(name string) string {
-	return AnnotationPrefix + "/" + name
-}
-
 var (
 	DefaultPropagationPolicy = metav1.DeletePropagationForeground
-
-	AnnotationModelUUIDKey              = AnnotationKey("model")
-	AnnotationControllerUUIDKey         = AnnotationKey("controller")
-	AnnotationControllerIsControllerKey = AnnotationKey("is-controller")
-	AnnotationUnit                      = AnnotationKey("unit")
-	AnnotationCharmModifiedVersionKey   = AnnotationKey("charm-modified-version")
 )

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	// Domain is the primary TLD for juju when giving resource domains to
+	// Kubernetes
+	Domain = "juju.is"
+
 	// OperatorPodIPEnvName is the environment name for operator pod IP.
 	OperatorPodIPEnvName = "JUJU_OPERATOR_POD_IP"
 
@@ -24,9 +28,6 @@ const (
 
 	// TemplateFileNameAgentConf is the template agent.conf file name.
 	TemplateFileNameAgentConf = "template-" + agent.AgentConfigFilename
-
-	// AnnotationPrefix of juju annotations.
-	AnnotationPrefix = "juju.is"
 
 	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
 	// created by applications managed by Juju. Think istio, kubeflow etc

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -46,8 +46,8 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -62,8 +62,8 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -183,7 +183,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreate(c *gc.
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -295,7 +295,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdate(c *gc.
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -370,8 +370,8 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -386,8 +386,8 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -561,10 +561,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 	cr1 := getCR1()
 	cr1.SetLabels(map[string]string{"juju-app": "app-name"})
 	cr1.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
+	cr1.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
 	cr2 := getCR2()
 	cr2.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
+	cr2.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
 
 	crs := map[string][]unstructured.Unstructured{
 		"tfjobs.kubeflow.org": {
@@ -576,7 +576,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -679,19 +679,19 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 
 	cr1 := getCR1()
 	cr1.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
+	cr1.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
 	cr2 := getCR2()
 	cr2.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
+	cr2.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
 
 	crUpdatedResourceVersion1 := getCR1()
 	crUpdatedResourceVersion1.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	crUpdatedResourceVersion1.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
+	crUpdatedResourceVersion1.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion1.SetResourceVersion("11111")
 
 	crUpdatedResourceVersion2 := getCR2()
 	crUpdatedResourceVersion2.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	crUpdatedResourceVersion2.SetAnnotations(map[string]string{"juju.io/controller": testing.ControllerTag.Id()})
+	crUpdatedResourceVersion2.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion2.SetResourceVersion("11111")
 
 	crs := map[string][]unstructured.Unstructured{
@@ -704,7 +704,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -829,7 +829,7 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group: "kubeflow.org",
@@ -888,7 +888,7 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -985,7 +985,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -1036,7 +1036,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "scheduledworkflows.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -45,9 +45,9 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -62,8 +62,8 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -183,7 +183,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreate(c *gc.
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -295,7 +295,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdate(c *gc.
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -369,9 +369,9 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -386,8 +386,8 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -561,10 +561,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 	cr1 := getCR1()
 	cr1.SetLabels(map[string]string{"juju-app": "app-name"})
 	cr1.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr1.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
+	cr1.SetAnnotations(map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()})
 	cr2 := getCR2()
 	cr2.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr2.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
+	cr2.SetAnnotations(map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()})
 
 	crs := map[string][]unstructured.Unstructured{
 		"tfjobs.kubeflow.org": {
@@ -576,7 +576,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -679,19 +679,19 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 
 	cr1 := getCR1()
 	cr1.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr1.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
+	cr1.SetAnnotations(map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()})
 	cr2 := getCR2()
 	cr2.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	cr2.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
+	cr2.SetAnnotations(map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()})
 
 	crUpdatedResourceVersion1 := getCR1()
 	crUpdatedResourceVersion1.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	crUpdatedResourceVersion1.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
+	crUpdatedResourceVersion1.SetAnnotations(map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion1.SetResourceVersion("11111")
 
 	crUpdatedResourceVersion2 := getCR2()
 	crUpdatedResourceVersion2.SetLabels(map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"})
-	crUpdatedResourceVersion2.SetAnnotations(map[string]string{"juju.is/controller": testing.ControllerTag.Id()})
+	crUpdatedResourceVersion2.SetAnnotations(map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()})
 	crUpdatedResourceVersion2.SetResourceVersion("11111")
 
 	crs := map[string][]unstructured.Unstructured{
@@ -704,7 +704,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -829,7 +829,7 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group: "kubeflow.org",
@@ -888,7 +888,7 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -985,7 +985,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "tfjobs.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",
@@ -1036,7 +1036,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "scheduledworkflows.kubeflow.org",
 			Labels:      map[string]string{"juju-app": "app-name", "juju-model": "test"},
-			Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   "kubeflow.org",

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -39,9 +39,9 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -56,8 +56,8 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -165,7 +165,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"juju.is/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				"controller.juju.is/id":                      "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 			},
 		},
 		Spec: extensionsv1beta1.IngressSpec{
@@ -217,7 +217,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"juju.is/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				"controller.juju.is/id":                      "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 			},
 		},
 		Spec: extensionsv1beta1.IngressSpec{
@@ -273,7 +273,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/rewrite-target": "/",
-					"juju.is/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+					"controller.juju.is/id":                      "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 				},
 			},
 			Spec: extensionsv1beta1.IngressSpec{

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -40,8 +40,8 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -56,8 +56,8 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -165,7 +165,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				"juju.is/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 			},
 		},
 		Spec: extensionsv1beta1.IngressSpec{
@@ -217,7 +217,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				"juju.is/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 			},
 		},
 		Spec: extensionsv1beta1.IngressSpec{
@@ -273,7 +273,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/rewrite-target": "/",
-					"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+					"juju.is/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 				},
 			},
 			Spec: extensionsv1beta1.IngressSpec{

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -97,7 +97,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on GCE.
 			newLabelRequirements(
-				requirementParams{"juju.io/cloud", selection.Equals, []string{"gce"}},
+				requirementParams{"juju.is/cloud", selection.Equals, []string{"gce"}},
 			),
 		},
 		caas.K8sCloudEC2: {
@@ -110,7 +110,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on AWS.
 			newLabelRequirements(
-				requirementParams{"juju.io/cloud", selection.Equals, []string{"ec2"}},
+				requirementParams{"juju.is/cloud", selection.Equals, []string{"ec2"}},
 			),
 		},
 		caas.K8sCloudAzure: {
@@ -120,7 +120,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 			),
 			// CDK on Azure.
 			newLabelRequirements(
-				requirementParams{"juju.io/cloud", selection.Equals, []string{"azure"}},
+				requirementParams{"juju.is/cloud", selection.Equals, []string{"azure"}},
 			),
 		},
 		// format - cloudType: requirements.

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -674,7 +674,7 @@ var basicServiceArg = &core.Service{
 	ObjectMeta: v1.ObjectMeta{
 		Name:        "app-name",
 		Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
-		Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()}},
+		Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()}},
 	Spec: core.ServiceSpec{
 		Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
 		Type:     "nodeIP",
@@ -692,7 +692,7 @@ var basicHeadlessServiceArg = &core.Service{
 		Name:   "app-name-endpoints",
 		Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 		Annotations: map[string]string{
-			"juju.io/controller": testing.ControllerTag.Id(),
+			"juju.is/controller": testing.ControllerTag.Id(),
 			"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 		},
 	},
@@ -727,7 +727,7 @@ func (s *K8sBrokerSuite) getOCIImageSecret(c *gc.C, annotations map[string]strin
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations["juju.io/controller"] = testing.ControllerTag.Id()
+	annotations["juju.is/controller"] = testing.ControllerTag.Id()
 
 	return &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -813,7 +813,7 @@ func (s *K8sBrokerSuite) assertFileSetToVolume(c *gc.C, fs specs.FileSet, result
 
 	annotations := map[string]string{
 		"fred":               "mary",
-		"juju.io/controller": testing.ControllerTag.Id(),
+		"juju.is/controller": testing.ControllerTag.Id(),
 	}
 
 	gomock.InOrder(
@@ -845,7 +845,7 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeFiles(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Data: map[string]string{
@@ -1183,7 +1183,7 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 
 	annotations := map[string]string{
 		"fred":               "mary",
-		"juju.io/controller": testing.ControllerTag.Id(),
+		"juju.is/controller": testing.ControllerTag.Id(),
 	}
 
 	err = s.broker.ConfigurePodFiles(
@@ -1804,8 +1804,8 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -1820,8 +1820,8 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -2081,9 +2081,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2100,8 +2100,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2113,7 +2113,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 				"a":                  "b",
 			}},
@@ -2195,9 +2195,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2213,8 +2213,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2233,7 +2233,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 				"a":                  "b",
 			}},
@@ -2393,10 +2393,10 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"fred":                           "mary",
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2412,8 +2412,8 @@ password: shhhh`[1:],
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2425,7 +2425,7 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 				"a":                  "b",
 			}},
@@ -2446,7 +2446,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
-				"juju.io/controller":                  testing.ControllerTag.Id(),
+				"juju.is/controller":                  testing.ControllerTag.Id(),
 				"fred":                                "mary",
 				"cloud.google.com/load-balancer-type": "Internal",
 			}},
@@ -2469,7 +2469,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 			},
 		},
@@ -2484,7 +2484,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 			},
 		},
@@ -2510,7 +2510,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 			},
 		},
@@ -2642,10 +2642,10 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"fred":                           "mary",
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2661,8 +2661,8 @@ password: shhhh`[1:],
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2674,7 +2674,7 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 				"a":                  "b",
 			}},
@@ -2696,7 +2696,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
-				"juju.io/controller":                  testing.ControllerTag.Id(),
+				"juju.is/controller":                  testing.ControllerTag.Id(),
 				"fred":                                "mary",
 				"cloud.google.com/load-balancer-type": "Internal",
 			}},
@@ -2719,7 +2719,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 			},
 		},
@@ -2734,7 +2734,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 			},
 		},
@@ -2760,7 +2760,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 			},
 		},
@@ -2889,7 +2889,7 @@ func (s *K8sBrokerSuite) assertGetService(c *gc.C, mode caas.DeploymentMode, exp
 			Name:   "app-name",
 			Labels: labels,
 			Annotations: map[string]string{
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 				"fred":               "mary",
 				"a":                  "b",
 			}},
@@ -2972,8 +2972,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -2987,8 +2987,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3061,9 +3061,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 			Name:   appName,
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"fred":                           "mary",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3078,8 +3078,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -3139,8 +3139,8 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.DaemonSetSpec{
@@ -3154,8 +3154,8 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3212,8 +3212,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -3228,8 +3228,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3296,8 +3296,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/controller":             testing.ControllerTag.Id(),
-				"juju.io/charm-modified-version": "0",
+				"juju.is/controller":             testing.ControllerTag.Id(),
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -3312,8 +3312,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3428,9 +3428,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3446,8 +3446,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3461,7 +3461,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3482,7 +3482,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -3494,7 +3494,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -3512,7 +3512,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -3588,9 +3588,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3606,8 +3606,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3621,7 +3621,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3642,7 +3642,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -3654,7 +3654,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -3672,7 +3672,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -3786,9 +3786,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3804,8 +3804,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3819,7 +3819,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3840,7 +3840,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -3852,7 +3852,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -3870,7 +3870,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -3962,9 +3962,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3980,8 +3980,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3995,7 +3995,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4016,7 +4016,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4028,7 +4028,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4046,7 +4046,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4172,9 +4172,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -4190,8 +4190,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.io/controller":             testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version": "0",
+						"juju.is/controller":             testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -4205,7 +4205,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4226,7 +4226,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4238,7 +4238,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4256,7 +4256,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4279,7 +4279,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4291,7 +4291,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4309,7 +4309,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4430,10 +4430,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"fred":                           "mary",
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -4449,9 +4449,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.is/controller":                       testing.ControllerTag.Id(),
 						"fred":                                     "mary",
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -4465,7 +4465,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4486,7 +4486,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4498,7 +4498,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4516,7 +4516,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4539,7 +4539,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4551,7 +4551,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4579,7 +4579,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4708,10 +4708,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"fred":                           "mary",
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -4727,9 +4727,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
+						"juju.is/controller":                       testing.ControllerTag.Id(),
 						"fred":                                     "mary",
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -4743,7 +4743,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Annotations: map[string]string{
 				"fred":               "mary",
 				"a":                  "b",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4764,7 +4764,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4776,7 +4776,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4794,7 +4794,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4817,7 +4817,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4829,7 +4829,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4857,7 +4857,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4875,7 +4875,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4897,7 +4897,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":               "mary",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -5189,9 +5189,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5206,8 +5206,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5317,9 +5317,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5334,8 +5334,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5465,9 +5465,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5482,8 +5482,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5640,9 +5640,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5657,8 +5657,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 						"foo": "baz",
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5818,9 +5818,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5834,8 +5834,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5991,9 +5991,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -6007,8 +6007,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -6134,9 +6134,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -6150,8 +6150,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -6251,9 +6251,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.io/controller":             testing.ControllerTag.Id(),
+				"juju.is/controller":             testing.ControllerTag.Id(),
 				"juju-app-uuid":                  "appuuid",
-				"juju.io/charm-modified-version": "0",
+				"juju.is/charm-modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -6267,8 +6267,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.io/controller":                       testing.ControllerTag.Id(),
-						"juju.io/charm-modified-version":           "0",
+						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"juju.is/charm-modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -6820,7 +6820,7 @@ func (s *K8sBrokerSuite) TestAnnotateUnit(c *gc.C) {
 	updatePod := &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "pod-name",
-			Annotations: map[string]string{"juju.io/unit": "appname/0"},
+			Annotations: map[string]string{"juju.is/unit": "appname/0"},
 		},
 	}
 
@@ -6854,7 +6854,7 @@ func (s *K8sBrokerSuite) assertAnnotateUnitByUID(c *gc.C, mode caas.DeploymentMo
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "pod-name",
 			UID:         types.UID("uuid"),
-			Annotations: map[string]string{"juju.io/unit": "appname/0"},
+			Annotations: map[string]string{"juju.is/unit": "appname/0"},
 		},
 	}
 
@@ -6918,7 +6918,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStart(c *gc.C) {
 					{Kind: "StatefulSet"},
 				},
 				Annotations: map[string]string{
-					"juju.io/unit": "test-0",
+					"juju.is/unit": "test-0",
 				},
 			},
 			Status: core.PodStatus{
@@ -6956,7 +6956,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStart(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.io/unit": "test-0",
+				"juju.is/unit": "test-0",
 			},
 		},
 		Status: core.PodStatus{
@@ -7002,7 +7002,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartRegex(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.io/unit": "test-0",
+				"juju.is/unit": "test-0",
 			},
 		},
 		Status: core.PodStatus{
@@ -7124,7 +7124,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefault(c *gc.C) {
 					{Kind: "StatefulSet"},
 				},
 				Annotations: map[string]string{
-					"juju.io/unit": "test-0",
+					"juju.is/unit": "test-0",
 				},
 			},
 			Status: core.PodStatus{
@@ -7154,7 +7154,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefault(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.io/unit": "test-0",
+				"juju.is/unit": "test-0",
 			},
 		},
 		Status: core.PodStatus{
@@ -7243,7 +7243,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefaultWaitForUnit(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.io/unit": "test-0",
+				"juju.is/unit": "test-0",
 			},
 		},
 		Status: core.PodStatus{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -674,7 +674,7 @@ var basicServiceArg = &core.Service{
 	ObjectMeta: v1.ObjectMeta{
 		Name:        "app-name",
 		Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
-		Annotations: map[string]string{"juju.is/controller": testing.ControllerTag.Id()}},
+		Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()}},
 	Spec: core.ServiceSpec{
 		Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
 		Type:     "nodeIP",
@@ -692,7 +692,7 @@ var basicHeadlessServiceArg = &core.Service{
 		Name:   "app-name-endpoints",
 		Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 		Annotations: map[string]string{
-			"juju.is/controller": testing.ControllerTag.Id(),
+			"controller.juju.is/id":                                  testing.ControllerTag.Id(),
 			"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 		},
 	},
@@ -727,7 +727,7 @@ func (s *K8sBrokerSuite) getOCIImageSecret(c *gc.C, annotations map[string]strin
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations["juju.is/controller"] = testing.ControllerTag.Id()
+	annotations["controller.juju.is/id"] = testing.ControllerTag.Id()
 
 	return &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -812,8 +812,8 @@ func (s *K8sBrokerSuite) assertFileSetToVolume(c *gc.C, fs specs.FileSet, result
 	}
 
 	annotations := map[string]string{
-		"fred":               "mary",
-		"juju.is/controller": testing.ControllerTag.Id(),
+		"fred":                  "mary",
+		"controller.juju.is/id": testing.ControllerTag.Id(),
 	}
 
 	gomock.InOrder(
@@ -844,8 +844,8 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeFiles(c *gc.C) {
 			Name:   "configuration",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Data: map[string]string{
@@ -1182,8 +1182,8 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 	}
 
 	annotations := map[string]string{
-		"fred":               "mary",
-		"juju.is/controller": testing.ControllerTag.Id(),
+		"fred":                  "mary",
+		"controller.juju.is/id": testing.ControllerTag.Id(),
 	}
 
 	err = s.broker.ConfigurePodFiles(
@@ -1803,9 +1803,9 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -1820,8 +1820,8 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -2081,9 +2081,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2100,8 +2100,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2113,9 +2113,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"a":                  "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -2195,9 +2195,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2213,8 +2213,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2233,9 +2233,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"a":                  "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -2393,10 +2393,10 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
 				"fred":                           "mary",
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2412,8 +2412,8 @@ password: shhhh`[1:],
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2425,9 +2425,9 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"a":                  "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -2446,7 +2446,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
-				"juju.is/controller":                  testing.ControllerTag.Id(),
+				"controller.juju.is/id":               testing.ControllerTag.Id(),
 				"fred":                                "mary",
 				"cloud.google.com/load-balancer-type": "Internal",
 			}},
@@ -2469,8 +2469,8 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
 			},
 		},
 		Data: map[string]string{
@@ -2484,8 +2484,8 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
 			},
 		},
 		Type: core.SecretTypeOpaque,
@@ -2510,8 +2510,8 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
 			},
 		},
 		Type: core.SecretTypeOpaque,
@@ -2642,10 +2642,10 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
 				"fred":                           "mary",
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -2661,8 +2661,8 @@ password: shhhh`[1:],
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -2674,9 +2674,9 @@ password: shhhh`[1:],
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"a":                  "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -2696,7 +2696,7 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
-				"juju.is/controller":                  testing.ControllerTag.Id(),
+				"controller.juju.is/id":               testing.ControllerTag.Id(),
 				"fred":                                "mary",
 				"cloud.google.com/load-balancer-type": "Internal",
 			}},
@@ -2719,8 +2719,8 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
 			},
 		},
 		Data: map[string]string{
@@ -2734,8 +2734,8 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
 			},
 		},
 		Type: core.SecretTypeOpaque,
@@ -2760,8 +2760,8 @@ password: shhhh`[1:],
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
 			},
 		},
 		Type: core.SecretTypeOpaque,
@@ -2889,9 +2889,9 @@ func (s *K8sBrokerSuite) assertGetService(c *gc.C, mode caas.DeploymentMode, exp
 			Name:   "app-name",
 			Labels: labels,
 			Annotations: map[string]string{
-				"juju.is/controller": testing.ControllerTag.Id(),
-				"fred":               "mary",
-				"a":                  "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
 			}},
 		Spec: core.ServiceSpec{
 			Selector: selectorLabels,
@@ -2971,9 +2971,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 			Name:   appName,
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -2987,8 +2987,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3061,9 +3061,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 			Name:   appName,
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
 				"fred":                           "mary",
-				"juju.is/charm-modified-version": "0",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3078,8 +3078,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: podSpec,
@@ -3139,8 +3139,8 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.DaemonSetSpec{
@@ -3154,8 +3154,8 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3211,9 +3211,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -3228,8 +3228,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3295,9 +3295,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -3312,8 +3312,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -3332,7 +3332,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 		s.mockSecrets.EXPECT().Create(gomock.Any(), ociImageSecret, v1.CreateOptions{}).
 			Return(ociImageSecret, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockServices.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockServices.EXPECT().Update(gomock.Any(), &serviceArg, v1.UpdateOptions{}).
@@ -3428,9 +3428,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3446,8 +3446,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3459,9 +3459,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3481,8 +3481,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -3493,8 +3493,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -3511,8 +3511,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -3588,9 +3588,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3606,8 +3606,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3619,9 +3619,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3641,8 +3641,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -3653,8 +3653,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -3671,8 +3671,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -3786,9 +3786,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3804,8 +3804,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3817,9 +3817,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3839,8 +3839,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -3851,8 +3851,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -3869,8 +3869,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -3962,9 +3962,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -3980,8 +3980,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -3993,9 +3993,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4015,8 +4015,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4027,8 +4027,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4045,8 +4045,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4172,9 +4172,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
 				"fred":                           "mary",
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -4190,8 +4190,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 						"fred":                           "mary",
-						"juju.is/controller":             testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version": "0",
+						"controller.juju.is/id":          testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version": "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -4203,9 +4203,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4225,8 +4225,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4237,8 +4237,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4255,8 +4255,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4278,8 +4278,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4290,8 +4290,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4308,8 +4308,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4430,10 +4430,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
 				"fred":                           "mary",
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -4449,9 +4449,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
 						"fred":                                     "mary",
-						"juju.is/charm-modified-version":           "0",
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -4463,9 +4463,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4485,8 +4485,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4497,8 +4497,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4515,8 +4515,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4538,8 +4538,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4550,8 +4550,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4578,8 +4578,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4708,10 +4708,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
 				"fred":                           "mary",
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -4727,9 +4727,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
 						"fred":                                     "mary",
-						"juju.is/charm-modified-version":           "0",
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: provider.Pod(workloadSpec).PodSpec,
@@ -4741,9 +4741,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"a":                  "b",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"a":                     "b",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -4763,8 +4763,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4775,8 +4775,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4793,8 +4793,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4816,8 +4816,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -4828,8 +4828,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4856,8 +4856,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -4874,8 +4874,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -4896,8 +4896,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"fred":               "mary",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"fred":                  "mary",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -5018,7 +5018,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 		s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "test-workload-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "workload-storage", v1.GetOptions{}).
@@ -5121,7 +5121,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 		s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "test-workload-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "workload-storage", v1.GetOptions{}).
@@ -5189,9 +5189,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5206,8 +5206,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5317,9 +5317,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5334,8 +5334,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5465,9 +5465,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &numUnits,
@@ -5482,8 +5482,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5640,9 +5640,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5657,8 +5657,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 						"foo": "baz",
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5818,9 +5818,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -5834,8 +5834,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -5991,9 +5991,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -6007,8 +6007,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -6134,9 +6134,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -6150,8 +6150,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -6251,9 +6251,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
-				"juju.is/controller":             testing.ControllerTag.Id(),
-				"juju-app-uuid":                  "appuuid",
-				"juju.is/charm-modified-version": "0",
+				"controller.juju.is/id":          testing.ControllerTag.Id(),
+				"app.juju.is/uuid":               "appuuid",
+				"charm.juju.is/modified-version": "0",
 			}},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &v1.LabelSelector{
@@ -6267,8 +6267,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-						"juju.is/controller":                       testing.ControllerTag.Id(),
-						"juju.is/charm-modified-version":           "0",
+						"controller.juju.is/id":                    testing.ControllerTag.Id(),
+						"charm.juju.is/modified-version":           "0",
 					},
 				},
 				Spec: podSpec,
@@ -6370,7 +6370,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 		s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "test-workload-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "workload-storage", v1.GetOptions{}).
@@ -6451,7 +6451,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "test-workload-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "workload-storage", v1.GetOptions{}).
@@ -6539,7 +6539,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 		s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "test-workload-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "workload-storage", v1.GetOptions{}).
@@ -6619,7 +6619,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 		s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
 			Return(nil, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
-			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"juju-app-uuid": "appuuid"}}}, nil),
+			Return(&appsv1.StatefulSet{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"app.juju.is/uuid": "appuuid"}}}, nil),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "test-workload-storage", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockStorageClass.EXPECT().Get(gomock.Any(), "workload-storage", v1.GetOptions{}).
@@ -6820,7 +6820,7 @@ func (s *K8sBrokerSuite) TestAnnotateUnit(c *gc.C) {
 	updatePod := &core.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "pod-name",
-			Annotations: map[string]string{"juju.is/unit": "appname/0"},
+			Annotations: map[string]string{"unit.juju.is/id": "appname/0"},
 		},
 	}
 
@@ -6854,7 +6854,7 @@ func (s *K8sBrokerSuite) assertAnnotateUnitByUID(c *gc.C, mode caas.DeploymentMo
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "pod-name",
 			UID:         types.UID("uuid"),
-			Annotations: map[string]string{"juju.is/unit": "appname/0"},
+			Annotations: map[string]string{"unit.juju.is/id": "appname/0"},
 		},
 	}
 
@@ -6918,7 +6918,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStart(c *gc.C) {
 					{Kind: "StatefulSet"},
 				},
 				Annotations: map[string]string{
-					"juju.is/unit": "test-0",
+					"unit.juju.is/id": "test-0",
 				},
 			},
 			Status: core.PodStatus{
@@ -6956,7 +6956,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStart(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.is/unit": "test-0",
+				"unit.juju.is/id": "test-0",
 			},
 		},
 		Status: core.PodStatus{
@@ -7002,7 +7002,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartRegex(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.is/unit": "test-0",
+				"unit.juju.is/id": "test-0",
 			},
 		},
 		Status: core.PodStatus{
@@ -7124,7 +7124,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefault(c *gc.C) {
 					{Kind: "StatefulSet"},
 				},
 				Annotations: map[string]string{
-					"juju.is/unit": "test-0",
+					"unit.juju.is/id": "test-0",
 				},
 			},
 			Status: core.PodStatus{
@@ -7154,7 +7154,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefault(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.is/unit": "test-0",
+				"unit.juju.is/id": "test-0",
 			},
 		},
 		Status: core.PodStatus{
@@ -7243,7 +7243,7 @@ func (s *K8sBrokerSuite) TestWatchContainerStartDefaultWaitForUnit(c *gc.C) {
 				{Kind: "StatefulSet"},
 			},
 			Annotations: map[string]string{
-				"juju.is/unit": "test-0",
+				"unit.juju.is/id": "test-0",
 			},
 		},
 		Status: core.PodStatus{

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -91,8 +91,8 @@ func isDefaultStorageClass(sc storage.StorageClass) bool {
 }
 
 const (
-	operatorStorageClassAnnotationKey = "juju.io/operator-storage"
-	workloadStorageClassAnnotationKey = "juju.io/workload-storage"
+	operatorStorageClassAnnotationKey = "juju.is/operator-storage"
+	workloadStorageClassAnnotationKey = "juju.is/workload-storage"
 )
 
 func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner {

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -100,21 +100,21 @@ var hostRegionsTestCases = []hostRegionTestcase{
 		expectedCloud:   "gce",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju.io/cloud": "gce",
+			"juju.is/cloud": "gce",
 		}),
 	},
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju.io/cloud": "ec2",
+			"juju.is/cloud": "ec2",
 		}),
 	},
 	{
 		expectedCloud:   "azure",
 		expectedRegions: set.NewStrings(""),
 		nodes: newNodeList(map[string]string{
-			"juju.io/cloud": "azure",
+			"juju.is/cloud": "azure",
 		}),
 	},
 	{
@@ -402,7 +402,7 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadStorageClass(c *gc.C) {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "juju-preferred-workload-storage",
 					Annotations: map[string]string{
-						"juju.io/workload-storage": "true",
+						"juju.is/workload-storage": "true",
 					},
 				},
 				Provisioner: "kubernetes.io/aws-ebs",
@@ -438,7 +438,7 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadAndOperatorStorageClass(c *gc.C)
 					ObjectMeta: v1.ObjectMeta{
 						Name: "juju-preferred-workload-storage",
 						Annotations: map[string]string{
-							"juju.io/workload-storage": "true",
+							"juju.is/workload-storage": "true",
 						},
 					},
 					Provisioner: "kubernetes.io/aws-ebs",
@@ -448,7 +448,7 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadAndOperatorStorageClass(c *gc.C)
 					ObjectMeta: v1.ObjectMeta{
 						Name: "juju-preferred-operator-storage",
 						Annotations: map[string]string{
-							"juju.io/operator-storage": "true",
+							"juju.is/operator-storage": "true",
 						},
 					},
 					Provisioner: "kubernetes.io/aws-ebs",

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -20,7 +20,8 @@ import (
 )
 
 var requireAnnotationsForNameSpace = []string{
-	constants.AnnotationControllerUUIDKey, constants.AnnotationModelUUIDKey,
+	utils.AnnotationControllerUUIDKey(false),
+	utils.AnnotationModelUUIDKey(false),
 }
 
 func checkNamespaceOwnedByJuju(ns *core.Namespace, annotationMap map[string]string) error {

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -183,7 +183,7 @@ func (k *kubernetesClient) EnsureOperator(name, agentPath string, config *caas.O
 		labels = utils.LabelsMerge(selectorLabels, utils.LabelsJuju)
 	}
 
-	annotations := utils.ResourceTagsToAnnotations(config.ResourceTags).
+	annotations := utils.ResourceTagsToAnnotations(config.ResourceTags, k.IsLegacyLabels()).
 		Merge(utils.AnnotationsForVersion(config.Version.String(), k.IsLegacyLabels()))
 
 	var cleanups []func()
@@ -360,7 +360,7 @@ func (k *kubernetesClient) operatorVolumeClaim(
 	return &core.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        params.pvcName,
-			Annotations: utils.ResourceTagsToAnnotations(storageParams.ResourceTags).ToMap()},
+			Annotations: utils.ResourceTagsToAnnotations(storageParams.ResourceTags, k.IsLegacyLabels()).ToMap()},
 		Spec: *pvcSpec,
 	}, nil
 }

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -31,9 +31,9 @@ type OperatorSuite struct {
 var _ = gc.Suite(&OperatorSuite{})
 
 var operatorAnnotations = map[string]string{
-	"fred":               "mary",
-	"juju.is/version":    "2.99.0",
-	"juju.is/controller": testing.ControllerTag.Id(),
+	"fred":                  "mary",
+	"juju.is/version":       "2.99.0",
+	"controller.juju.is/id": testing.ControllerTag.Id(),
 }
 
 var operatorServiceArg = &core.Service{
@@ -41,9 +41,9 @@ var operatorServiceArg = &core.Service{
 		Name:   "test-operator",
 		Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 		Annotations: map[string]string{
-			"fred":               "mary",
-			"juju.is/version":    "2.99.0",
-			"juju.is/controller": testing.ControllerTag.Id(),
+			"fred":                  "mary",
+			"juju.is/version":       "2.99.0",
+			"controller.juju.is/id": testing.ControllerTag.Id(),
 		},
 	},
 	Spec: core.ServiceSpec{
@@ -151,9 +151,9 @@ func operatorStatefulSetArg(numUnits int32, scName, serviceAccountName string, w
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 					Annotations: map[string]string{
-						"fred":               "mary",
-						"juju.is/version":    "2.99.0",
-						"juju.is/controller": testing.ControllerTag.Id(),
+						"fred":                  "mary",
+						"juju.is/version":       "2.99.0",
+						"controller.juju.is/id": testing.ControllerTag.Id(),
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 					},
@@ -186,8 +186,8 @@ func operatorStatefulSetArg(numUnits int32, scName, serviceAccountName string, w
 
 func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
-		"fred":               "mary",
-		"juju.is/controller": testing.ControllerTag.Id(),
+		"fred":                  "mary",
+		"controller.juju.is/id": testing.ControllerTag.Id(),
 	}
 	labels := map[string]string{"operator.juju.is/name": "gitlab", "operator.juju.is/target": "application"}
 	pod, err := provider.OperatorPod("gitlab", "gitlab", "10666", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", labels, tags, "operator-service-account")
@@ -195,8 +195,8 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	c.Assert(pod.Name, gc.Equals, "gitlab")
 	c.Assert(pod.Labels, jc.DeepEquals, labels)
 	c.Assert(pod.Annotations, jc.DeepEquals, map[string]string{
-		"fred":               "mary",
-		"juju.is/controller": testing.ControllerTag.Id(),
+		"fred":                  "mary",
+		"controller.juju.is/id": testing.ControllerTag.Id(),
 		"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 		"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 	})
@@ -981,8 +981,8 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-operator",
 			Annotations: map[string]string{
-				"juju.is/version":    "2.99.0",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"juju.is/version":       "2.99.0",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Spec: core.PodSpec{
@@ -999,8 +999,8 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 	ss := apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
-				"juju.is/version":    "2.99.0",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"juju.is/version":       "2.99.0",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Spec: apps.StatefulSetSpec{
@@ -1049,8 +1049,8 @@ func (s *K8sBrokerSuite) TestOperatorNoPodFound(c *gc.C) {
 	ss := apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
-				"juju-version":       "2.99.0",
-				"juju.is/controller": testing.ControllerTag.Id(),
+				"juju-version":          "2.99.0",
+				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
 		Spec: apps.StatefulSetSpec{

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&OperatorSuite{})
 var operatorAnnotations = map[string]string{
 	"fred":               "mary",
 	"juju.is/version":    "2.99.0",
-	"juju.io/controller": testing.ControllerTag.Id(),
+	"juju.is/controller": testing.ControllerTag.Id(),
 }
 
 var operatorServiceArg = &core.Service{
@@ -43,7 +43,7 @@ var operatorServiceArg = &core.Service{
 		Annotations: map[string]string{
 			"fred":               "mary",
 			"juju.is/version":    "2.99.0",
-			"juju.io/controller": testing.ControllerTag.Id(),
+			"juju.is/controller": testing.ControllerTag.Id(),
 		},
 	},
 	Spec: core.ServiceSpec{
@@ -153,7 +153,7 @@ func operatorStatefulSetArg(numUnits int32, scName, serviceAccountName string, w
 					Annotations: map[string]string{
 						"fred":               "mary",
 						"juju.is/version":    "2.99.0",
-						"juju.io/controller": testing.ControllerTag.Id(),
+						"juju.is/controller": testing.ControllerTag.Id(),
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 						"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 					},
@@ -187,7 +187,7 @@ func operatorStatefulSetArg(numUnits int32, scName, serviceAccountName string, w
 func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	tags := map[string]string{
 		"fred":               "mary",
-		"juju.io/controller": testing.ControllerTag.Id(),
+		"juju.is/controller": testing.ControllerTag.Id(),
 	}
 	labels := map[string]string{"operator.juju.is/name": "gitlab", "operator.juju.is/target": "application"}
 	pod, err := provider.OperatorPod("gitlab", "gitlab", "10666", "/var/lib/juju", "jujusolutions/jujud-operator", "2.99.0", labels, tags, "operator-service-account")
@@ -196,7 +196,7 @@ func (s *K8sSuite) TestOperatorPodConfig(c *gc.C) {
 	c.Assert(pod.Labels, jc.DeepEquals, labels)
 	c.Assert(pod.Annotations, jc.DeepEquals, map[string]string{
 		"fred":               "mary",
-		"juju.io/controller": testing.ControllerTag.Id(),
+		"juju.is/controller": testing.ControllerTag.Id(),
 		"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 		"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
 	})
@@ -982,7 +982,7 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 			Name: "test-operator",
 			Annotations: map[string]string{
 				"juju.is/version":    "2.99.0",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Spec: core.PodSpec{
@@ -1000,7 +1000,7 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
 				"juju.is/version":    "2.99.0",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Spec: apps.StatefulSetSpec{
@@ -1050,7 +1050,7 @@ func (s *K8sBrokerSuite) TestOperatorNoPodFound(c *gc.C) {
 		ObjectMeta: v1.ObjectMeta{
 			Annotations: map[string]string{
 				"juju-version":       "2.99.0",
-				"juju.io/controller": testing.ControllerTag.Id(),
+				"juju.is/controller": testing.ControllerTag.Id(),
 			},
 		},
 		Spec: apps.StatefulSetSpec{

--- a/caas/kubernetes/provider/specs/builder_test.go
+++ b/caas/kubernetes/provider/specs/builder_test.go
@@ -111,7 +111,7 @@ func (s *builderSuite) SetUpTest(c *gc.C) {
 		map[string]string{
 			"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 			"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-			"juju.is/controller":                       testing.ControllerTag.Id(),
+			"controller.juju.is/id":                    testing.ControllerTag.Id(),
 		},
 	)
 }

--- a/caas/kubernetes/provider/specs/builder_test.go
+++ b/caas/kubernetes/provider/specs/builder_test.go
@@ -111,7 +111,7 @@ func (s *builderSuite) SetUpTest(c *gc.C) {
 		map[string]string{
 			"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
 			"seccomp.security.beta.kubernetes.io/pod":  "docker/default",
-			"juju.io/controller":                       testing.ControllerTag.Id(),
+			"juju.is/controller":                       testing.ControllerTag.Id(),
 		},
 	)
 }

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -354,7 +354,7 @@ kubernetesResources:
       labels:
         foo: bar
       annotations:
-        juju.io/disable-name-prefix: "true"
+        juju.is/disable-name-prefix: "true"
       webhooks:
         - name: "example.mutatingwebhookconfiguration.com"
           failurePolicy: Ignore
@@ -383,7 +383,7 @@ kubernetesResources:
       labels:
         foo: bar
       annotations:
-        juju.io/disable-name-prefix: "true"
+        juju.is/disable-name-prefix: "true"
       webhooks:
         - name: "pod-policy.example.com"
           rules:
@@ -970,7 +970,7 @@ password: shhhh`[1:],
 						Meta: k8sspecs.Meta{
 							Name:        "example-mutatingwebhookconfiguration",
 							Labels:      map[string]string{"foo": "bar"},
-							Annotations: map[string]string{"juju.io/disable-name-prefix": "true"},
+							Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
 						},
 						Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 					},
@@ -980,7 +980,7 @@ password: shhhh`[1:],
 						Meta: k8sspecs.Meta{
 							Name:        "pod-policy.example.com",
 							Labels:      map[string]string{"foo": "bar"},
-							Annotations: map[string]string{"juju.io/disable-name-prefix": "true"},
+							Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
 						},
 						Webhooks: []admissionregistration.ValidatingWebhook{webhook2},
 					},
@@ -1476,7 +1476,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 	appName := "app-name"
 	annotations := map[string]string{
 		"fred":               "mary",
-		"juju.io/controller": testing.ControllerTag.Id(),
+		"juju.is/controller": testing.ControllerTag.Id(),
 	}
 	prefixNameSpace := func(name string) string {
 		return fmt.Sprintf("%s-%s", namespace, name)

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -354,7 +354,7 @@ kubernetesResources:
       labels:
         foo: bar
       annotations:
-        juju.is/disable-name-prefix: "true"
+        model.juju.is/disable-prefix: "true"
       webhooks:
         - name: "example.mutatingwebhookconfiguration.com"
           failurePolicy: Ignore
@@ -383,7 +383,7 @@ kubernetesResources:
       labels:
         foo: bar
       annotations:
-        juju.is/disable-name-prefix: "true"
+        model.juju.is/disable-prefix: "true"
       webhooks:
         - name: "pod-policy.example.com"
           rules:
@@ -970,7 +970,7 @@ password: shhhh`[1:],
 						Meta: k8sspecs.Meta{
 							Name:        "example-mutatingwebhookconfiguration",
 							Labels:      map[string]string{"foo": "bar"},
-							Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
+							Annotations: map[string]string{"model.juju.is/disable-prefix": "true"},
 						},
 						Webhooks: []admissionregistration.MutatingWebhook{webhook1},
 					},
@@ -980,7 +980,7 @@ password: shhhh`[1:],
 						Meta: k8sspecs.Meta{
 							Name:        "pod-policy.example.com",
 							Labels:      map[string]string{"foo": "bar"},
-							Annotations: map[string]string{"juju.is/disable-name-prefix": "true"},
+							Annotations: map[string]string{"model.juju.is/disable-prefix": "true"},
 						},
 						Webhooks: []admissionregistration.ValidatingWebhook{webhook2},
 					},
@@ -1475,8 +1475,8 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 	namespace := "test"
 	appName := "app-name"
 	annotations := map[string]string{
-		"fred":               "mary",
-		"juju.is/controller": testing.ControllerTag.Id(),
+		"fred":                  "mary",
+		"controller.juju.is/id": testing.ControllerTag.Id(),
 	}
 	prefixNameSpace := func(name string) string {
 		return fmt.Sprintf("%s-%s", namespace, name)

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -68,7 +68,7 @@ func (k *kubernetesClient) configureStatefulSet(
 			Labels: utils.LabelsForApp(appName, k.IsLegacyLabels()),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
-				Add(annotationKeyApplicationUUID, storageUniqueID).ToMap(),
+				Add(utils.AnnotationKeyApplicationUUID(k.IsLegacyLabels()), storageUniqueID).ToMap(),
 		},
 		Spec: apps.StatefulSetSpec{
 			Replicas: replicas,

--- a/caas/kubernetes/provider/utils/annotations.go
+++ b/caas/kubernetes/provider/utils/annotations.go
@@ -4,6 +4,9 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/environs/tags"
@@ -46,47 +49,61 @@ func AnnotationVersionKey(legacy bool) string {
 	return constants.AnnotationJujuVersion
 }
 
-func annotationKey(name string, legacy bool) string {
+// MakeK8sDomain builds and returns a Kubernetes resource domain for the
+// provided components. Func is idempotent
+func MakeK8sDomain(components ...string) string {
+	return fmt.Sprintf("%s.%s", strings.Join(components, "."), constants.Domain)
+}
+
+func annotationKey(name, suffix string, legacy bool) string {
 	if legacy {
 		return constants.LegacyAnnotationPrefix + "/" + name
 	}
-	return constants.AnnotationPrefix + "/" + name
+	return MakeK8sDomain(name) + "/" + suffix
 }
 
 // AnnotationModelUUIDKey returns the key used in annotations
 // to describe the model UUID.
 func AnnotationModelUUIDKey(legacy bool) string {
-	return annotationKey("model", legacy)
+	return annotationKey("model", "id", legacy)
 }
 
 // AnnotationControllerUUIDKey returns the key used in annotations
 // to describe the controller UUID.
 func AnnotationControllerUUIDKey(legacy bool) string {
-	return annotationKey("controller", legacy)
+	return annotationKey("controller", "id", legacy)
 }
 
 // AnnotationControllerIsControllerKey returns the key used in annotations
 // to describe if this pod is a controller pod.
 func AnnotationControllerIsControllerKey(legacy bool) string {
-	return annotationKey("is-controller", legacy)
+	return annotationKey("controller", "is-controller", legacy)
 }
 
 // AnnotationUnit returns the key used in annotations
 // to describe the Juju unit.
 func AnnotationUnit(legacy bool) string {
-	return annotationKey("unit", legacy)
+	return annotationKey("unit", "id", legacy)
 }
 
 // AnnotationCharmModifiedVersionKey returns the key used in annotations
 // to describe the charm modified version.
 func AnnotationCharmModifiedVersionKey(legacy bool) string {
-	return annotationKey("charm-modified-version", legacy)
+	return annotationKey("charm", "modified-version", legacy)
 }
 
 // AnnotationDisableNameKey returns the key used in annotations
 // to describe the disabled name prefix.
 func AnnotationDisableNameKey(legacy bool) string {
-	return annotationKey("disable-name-prefix", legacy)
+	return annotationKey("model", "disable-prefix", legacy)
+}
+
+// AnnotationKeyApplicationUUID is the key of annotation for recording pvc unique ID.
+func AnnotationKeyApplicationUUID(legacy bool) string {
+	if legacy {
+		return "juju-app-uuid"
+	}
+	return MakeK8sDomain("app") + "/uuid"
 }
 
 // ResourceTagsToAnnotations creates annotations from the resource tags.

--- a/caas/kubernetes/provider/utils/annotations.go
+++ b/caas/kubernetes/provider/utils/annotations.go
@@ -36,7 +36,7 @@ func AnnotationsForVersion(vers string, legacy bool) annotations.Annotation {
 	}
 }
 
-// AnnotationVersionKey returns the key used un in annotations to describe the
+// AnnotationVersionKey returns the key used in annotations to describe the
 // Juju version. Legacy controls if the key returns is a legacy annotation key
 // or newer style.
 func AnnotationVersionKey(legacy bool) string {
@@ -46,10 +46,54 @@ func AnnotationVersionKey(legacy bool) string {
 	return constants.AnnotationJujuVersion
 }
 
-func ResourceTagsToAnnotations(in map[string]string) annotations.Annotation {
+func annotationKey(name string, legacy bool) string {
+	if legacy {
+		return constants.LegacyAnnotationPrefix + "/" + name
+	}
+	return constants.AnnotationPrefix + "/" + name
+}
+
+// AnnotationModelUUIDKey returns the key used in annotations
+// to describe the model UUID.
+func AnnotationModelUUIDKey(legacy bool) string {
+	return annotationKey("model", legacy)
+}
+
+// AnnotationControllerUUIDKey returns the key used in annotations
+// to describe the controller UUID.
+func AnnotationControllerUUIDKey(legacy bool) string {
+	return annotationKey("controller", legacy)
+}
+
+// AnnotationControllerIsControllerKey returns the key used in annotations
+// to describe if this pod is a controller pod.
+func AnnotationControllerIsControllerKey(legacy bool) string {
+	return annotationKey("is-controller", legacy)
+}
+
+// AnnotationUnit returns the key used in annotations
+// to describe the Juju unit.
+func AnnotationUnit(legacy bool) string {
+	return annotationKey("unit", legacy)
+}
+
+// AnnotationCharmModifiedVersionKey returns the key used in annotations
+// to describe the charm modified version.
+func AnnotationCharmModifiedVersionKey(legacy bool) string {
+	return annotationKey("charm-modified-version", legacy)
+}
+
+// AnnotationDisableNameKey returns the key used in annotations
+// to describe the disabled name prefix.
+func AnnotationDisableNameKey(legacy bool) string {
+	return annotationKey("disable-name-prefix", legacy)
+}
+
+// ResourceTagsToAnnotations creates annotations from the resource tags.
+func ResourceTagsToAnnotations(in map[string]string, legacy bool) annotations.Annotation {
 	tagsAnnotationsMap := map[string]string{
-		tags.JujuController: constants.AnnotationControllerUUIDKey,
-		tags.JujuModel:      constants.AnnotationModelUUIDKey,
+		tags.JujuController: AnnotationControllerUUIDKey(legacy),
+		tags.JujuModel:      AnnotationModelUUIDKey(legacy),
 	}
 
 	out := annotations.New(nil)

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -317,7 +317,7 @@ func (k *kubernetesClient) filesystemToVolumeInfo(
 	pvc = &core.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
 			Name: params.pvcName,
-			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags).
+			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags, k.IsLegacyLabels()).
 				Merge(utils.AnnotationsForStorage(fs.StorageName, k.IsLegacyLabels())).
 				ToMap(),
 			Labels: labels,

--- a/worker/caasadmission/admission.go
+++ b/worker/caasadmission/admission.go
@@ -11,7 +11,6 @@ import (
 	admission "k8s.io/api/admissionregistration/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/pki"
 )
@@ -79,7 +78,7 @@ func NewAdmissionCreator(
 				},
 				FailurePolicy: &failurePolicy,
 				MatchPolicy:   &matchPolicy,
-				Name:          provider.MakeK8sDomain(Component),
+				Name:          k8sutils.MakeK8sDomain(Component),
 				NamespaceSelector: &meta.LabelSelector{
 					MatchLabels: k8sutils.LabelsForModel(modelName, legacyLabels),
 				},


### PR DESCRIPTION
## Description of change

Instead of using "juju.io" as the prefix for annotations on k8s resources, use "juju.is" instead.
Most of the change is test fallout.

## QA steps

juju bootstrap microk8s
juju deploy mariadb

check the annotations