### PR TITLE
Adds missing uniter name to probe worker

### DIFF
--- a/cmd/k8sagent/unit/manifolds_test.go
+++ b/cmd/k8sagent/unit/manifolds_test.go
@@ -54,6 +54,8 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"proxy-config-updater",
 		"logging-config-updater",
 		"api-address-updater",
+		"caas-prober",
+		"probe-http-server",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -181,5 +183,9 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"migration-fortress",
 		"migration-inactive-flag",
+	},
+	"probe-http-server": {},
+	"caas-prober": {
+		"probe-http-server",
 	},
 }

--- a/worker/caasprober/manifold.go
+++ b/worker/caasprober/manifold.go
@@ -9,12 +9,10 @@ import (
 	"github.com/juju/worker/v2/dependency"
 
 	"github.com/juju/juju/apiserver/apiserverhttp"
-	"github.com/juju/juju/worker/uniter"
 )
 
 type ManifoldConfig struct {
-	MuxName    string
-	UniterName string
+	MuxName string
 }
 
 func Manifold(config ManifoldConfig) dependency.Manifold {
@@ -37,26 +35,16 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 		return nil, errors.Trace(err)
 	}
 
-	var uniterProbe *uniter.Probe
-	if err := context.Get(c.UniterName, &uniterProbe); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	return NewController(&caasProbes{
 		Liveness:  &ProbeSuccess{},
 		Readiness: &ProbeSuccess{},
-		Startup: ProberFunc(func() (bool, error) {
-			return uniterProbe.HasStarted(), nil
-		}),
+		Startup:   &ProbeSuccess{},
 	}, mux)
 }
 
 func (c ManifoldConfig) Validate() error {
 	if c.MuxName == "" {
 		return errors.NotValidf("empty mux name")
-	}
-	if c.UniterName == "" {
-		return errors.NotValidf("empty uniter name")
 	}
 	return nil
 }


### PR DESCRIPTION
### Checklist

 - [x] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

k8sagent manifold was missing the uniter name to the caas prober causing it to not start. Oversight from original PR.

## QA steps

Deploy a new v3 workload using harry's cockroach charm.
