### PR TITLE
[dev] Add field for the OVS-related payload to netplan.Bridge

### DIFF
--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -78,9 +78,10 @@ type BridgeParameters struct {
 }
 
 type Bridge struct {
-	Interfaces []string `yaml:"interfaces,omitempty,flow"`
-	Interface  `yaml:",inline"`
-	Parameters BridgeParameters `yaml:"parameters,omitempty"`
+	Interfaces    []string `yaml:"interfaces,omitempty,flow"`
+	Interface     `yaml:",inline"`
+	Parameters    BridgeParameters       `yaml:"parameters,omitempty"`
+	OVSParameters map[string]interface{} `yaml:"openvswitch,omitempty"`
 }
 
 type Route struct {

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -99,6 +99,25 @@ network:
     br0:
       interfaces: [wlp1s0, switchports]
       dhcp4: false
+    ovs0:
+      interfaces: [patch0-1, eth0, bond0]
+      addresses:
+      - 10.5.48.11/20
+      openvswitch:
+        controller:
+          addresses:
+          - unix:/var/run/openvswitch/ovs0.mgmt
+          connection-mode: out-of-band
+        external-ids:
+          iface-id: myhostname
+        fail-mode: secure
+        mcast-snooping: true
+        other-config:
+          disable-in-band: true
+        protocols:
+        - OpenFlow10
+        - OpenFlow11
+        - OpenFlow12
   routes:
   - to: 0.0.0.0/0
     via: 11.0.0.1


### PR DESCRIPTION
## Description of change

Juju unmarshals the yaml payload obtained from netplan in strict mode. As a result, an error due to an unknown field is raised if netplan includes OVS-related information about a bridge in its output.

This PR augments the `netplan.Bridge` type with a new field for keeping track of OVS-related details.

## QA steps

To run these steps you will need to use the `latest/edge` maas snap and also to have maas download the 20.10 (groovy) image. 

Then, set up 2 KVM nodes with dual NICs. 
- The first KVM node will be used for the controller. Assign the first NIC to space1 and the second NIC to space2.
- The second KVM node will be used for workloads. Assign the first NIC to space 1 and create an OVS bridge using the second NIC assigned to space 2.
 
```console
$ juju bootstrap vmaas test-maas --no-gui 
$ juju add-machine --constraints spaces=space1,space2 --series=groovy

# Inspect NICs on the added machine
$ juju ssh 0 'ip a'
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 52:54:00:a6:56:6f brd ff:ff:ff:ff:ff:ff
    altname enp0s4
    inet 10.0.0.19/24 brd 10.0.0.255 scope global ens4
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fea6:566f/64 scope link
       valid_lft forever preferred_lft forever
3: ens7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master ovs-system state UP group default qlen 1000
    link/ether 08:3d:01:91:ff:5e brd ff:ff:ff:ff:ff:ff
    altname enp0s7
4: ovs-system: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether ee:0f:fa:9c:28:7c brd ff:ff:ff:ff:ff:ff
5: ovsbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 08:3d:01:91:ff:5e brd ff:ff:ff:ff:ff:ff
    inet 10.42.0.3/24 brd 10.42.0.255 scope global ovsbr0
       valid_lft forever preferred_lft forever
    inet6 fe80::c819:12ff:fece:8e4f/64 scope link
       valid_lft forever preferred_lft forever

#---------
# SSH into machine and verify connectivity, e.g. by curling a URL
# and change the default route if you cannot reach the outside world
# via the default bridge (the OVS bridge in my deployment)
#
# Important: if this doesn't work, lxd will not be able to pull images!
#---------

# Deploy an lxd workload bound to the space with the OVS bridge (space2 in this example)
$ juju deploy cs:~jameinel/ubuntu-lite-7 --to lxd:0 --bind space2 --series=bionic

# Check that the container's eth0 device has the ovs bridge as its parent
$ juju ssh 0 'sudo lxc config show $(sudo lxc list| grep juju | cut -d"|" -f2) | egrep "^devices:" -A8'
devices:
  eth0:
    host_name: 0lxd0-0
    hwaddr: 00:16:3e:6c:00:24
    mtu: "1500"
    name: eth0
    nictype: bridged
    parent: ovsbr0 <---- the OVS bridge is used due to the space constraint
    type: nic

# Deploy an lxd workload bound to the other space (space1 in this example)
$ juju deploy apache2 --to lxd:0 --bind space1 --series=bionic

# 
$ juju ssh 0 'sudo lxc config show $(sudo lxc list| grep juju | cut -d"|" -f2 | tail -1) | egrep "^devices:" -A8'
devices:
  eth0:
    host_name: 0lxd1-0
    hwaddr: 00:16:3e:61:38:56
    mtu: "1500"
    name: eth0
    nictype: bridged
    parent: br-ens4 <--- a new bridge has been created
    type: nic

# Finally, check juju status 
$  juju status | egrep "^Machine" -A 10
Machine  State    DNS        Inst id              Series  AZ       Message
0        started  10.0.0.19  kvm-1                groovy  default  Deployed
0/lxd/0  started  10.42.0.4  juju-868a23-0-lxd-0  bionic  default  Container started
0/lxd/1  started  10.0.0.20  juju-868a23-0-lxd-1  bionic  default  Container started

# Note that machine 0 and 0/lxd/1 have an IP in space 1 and that 0/lxd/0 has an IP in space 2
# and that both workloads show up as started (i.e. agents can talk to the controller fine).
```