### PR TITLE
Pin the transent dependency (2.8.4)

### DIFF
--- a/caas/jujud-operator-requirements.txt
+++ b/caas/jujud-operator-requirements.txt
@@ -2,3 +2,4 @@ pip>=7.0.0,<8.2.0
 charmhelpers>=0.4.0,<1.0.0
 charms.reactive>=0.1.0,<2.0.0
 kubernetes==10.0.*
+google_auth>=1.21.0,<1.22.0


### PR DESCRIPTION
## Description of change

The following dependency google_auth changes what it installs
depending on the version of python you have. I'm unsure of the real fix
here, as multidict doesn't seem to compile on anything by amd64. So
pinning it to use an older version seems a bit bruteforce'ish and we're
not getting the latest spec/security changes from that lib.

I think someone needs to come through and audit what is being installed
here and correctly pin them so we don't get blocked on a release.



