### PR TITLE
fix download of a CharmHub charm to the controller

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -89,6 +89,7 @@ func (h *charmsHandler) ServeUnsupported(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error {
+	logger.Child("charmsHandler").Tracef("ServePost(%s)", r.URL)
 	if r.Method != "POST" {
 		return errors.Trace(emitUnsupportedMethodErr(r.Method))
 	}
@@ -108,6 +109,7 @@ func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error 
 }
 
 func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
+	logger.Child("charmsHandler").Tracef("ServeGet(%s)", r.URL)
 	if r.Method != "GET" {
 		return errors.Trace(emitUnsupportedMethodErr(r.Method))
 	}
@@ -515,6 +517,7 @@ func sendBundleContent(
 	archivePath string,
 	sender bundleContentSenderFunc,
 ) error {
+	logger.Child("charmhttp").Tracef("sendBundleContent %q", archivePath)
 	bundle, err := charm.ReadCharmArchive(archivePath)
 	if err != nil {
 		return errors.Annotatef(err, "unable to read archive in %q", archivePath)

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -110,7 +110,7 @@ func AddCharmWithAuthorizationAndRepo(st State, args params.AddCharmWithAuthoriz
 
 	// TODO (stickupkid): This should be abstracted out in the future to
 	// accommodate the charmhub adapter.
-	strategy, err := corecharm.DownloadFromCharmStore(repo, args.URL, args.Force)
+	strategy, err := corecharm.DownloadFromCharmStore(logger.Child("strategy"), repo, args.URL, args.Force)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -165,7 +165,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
@@ -217,7 +217,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				ConfigYAML: entityConfig,
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -442,11 +442,11 @@ type StrategyFunc func(charmRepo corecharm.Repository, url string, force bool, s
 func getStrategyFunc(source string) StrategyFunc {
 	if source == "charm-store" {
 		return func(charmRepo corecharm.Repository, url string, force bool, _ string) (Strategy, error) {
-			return corecharm.DownloadFromCharmStore(charmRepo, url, force)
+			return corecharm.DownloadFromCharmStore(logger.Child("strategy"), charmRepo, url, force)
 		}
 	}
 	return func(charmRepo corecharm.Repository, url string, force bool, series string) (Strategy, error) {
-		return corecharm.DownloadFromCharmHub(charmRepo, url, force, series)
+		return corecharm.DownloadFromCharmHub(logger.Child("strategy"), charmRepo, url, force, series)
 	}
 }
 

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -97,14 +97,13 @@ func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin, serie
 		return nil, corecharm.Origin{}, errors.Errorf("More than 1 result found")
 	}
 	findResult := result[0]
-	logger.Tracef("FindDownloadURL received %+v", findResult)
 	if findResult.Error != nil {
 		// TODO: (hml) 4-sep-2020
 		// When list of error codes available, create real error for them.
 		return nil, corecharm.Origin{}, errors.Errorf("%s: %s", findResult.Error.Code, findResult.Error.Message)
 	}
 	origin.ID = findResult.Entity.ID
-	origin.Hash = findResult.Entity.Download.HashSHA265
+	origin.Hash = findResult.Entity.Download.HashSHA256
 	durl, err := url.Parse(findResult.Entity.Download.URL)
 	return durl, origin, errors.Trace(err)
 }

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -120,7 +120,7 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 					Download: transport.Download{
-						HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+						HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 						Size:       12042240,
 						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 					},

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -122,7 +122,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
@@ -175,7 +175,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
-					HashSHA265: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -36,7 +36,7 @@ type Revision struct {
 }
 
 type Download struct {
-	HashSHA265 string `json:"hash-sha-265"`
+	HashSHA256 string `json:"hash-sha-256"`
 	Size       int    `json:"size"`
 	URL        string `json:"url"`
 }

--- a/core/charm/strategies_test.go
+++ b/core/charm/strategies_test.go
@@ -35,6 +35,7 @@ func (s strategySuite) TestValidate(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	err := strategy.Validate()
 	c.Assert(err, jc.ErrorIsNil)
@@ -52,6 +53,7 @@ func (s strategySuite) TestValidateWithError(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	err := strategy.Validate()
 	c.Assert(err, gc.ErrorMatches, "boom")
@@ -65,7 +67,7 @@ func (s strategySuite) TestDownloadResult(c *gc.C) {
 	err = file.Sync()
 	c.Assert(err, jc.ErrorIsNil)
 
-	strategy := &Strategy{}
+	strategy := &Strategy{logger: &fakeLogger{}}
 	result, err := strategy.downloadResult(file.Name(), AlwaysMatchChecksum)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.SHA256, gc.Equals, "4e97ed7423be2ea12939e8fdd592cfb3dcd4d0097d7d193ef998ab6b4db70461")
@@ -96,6 +98,7 @@ func (s strategySuite) TestRunWithCharmAlreadyUploaded(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	_, alreadyExists, _, err := strategy.Run(mockState, mockVersionValidator, Origin{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,6 +120,7 @@ func (s strategySuite) TestRunWithPrepareUploadError(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	_, alreadyExists, _, err := strategy.Run(mockState, mockVersionValidator, Origin{})
 	c.Assert(err, gc.ErrorMatches, "boom")
@@ -154,6 +158,7 @@ func (s strategySuite) TestRun(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	_, alreadyExists, _, err := strategy.Run(mockState, mockVersionValidator, Origin{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -196,6 +201,7 @@ func (s strategySuite) TestRunWithInvalidLXDProfile(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	_, alreadyExists, _, err := strategy.Run(mockState, mockVersionValidator, Origin{})
 	c.Assert(err, gc.ErrorMatches, `cannot add charm: invalid lxd-profile.yaml: contains config value "boot"`)
@@ -237,6 +243,7 @@ func (s strategySuite) TestFinishAfterRun(c *gc.C) {
 	strategy := &Strategy{
 		charmURL: curl,
 		store:    mockStore,
+		logger:   &fakeLogger{},
 	}
 	_, alreadyExists, _, err := strategy.Run(mockState, mockVersionValidator, Origin{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -256,4 +263,14 @@ func mustWriteToTempFile(c *gc.C, mockCharm *MockStoreCharm) func(*charm.URL, st
 
 		return mockCharm, AlwaysMatchChecksum, origin, nil
 	}
+}
+
+type fakeLogger struct {
+}
+
+func (l *fakeLogger) Errorf(_ string, _ ...interface{}) {}
+func (l *fakeLogger) Debugf(_ string, _ ...interface{}) {}
+func (l *fakeLogger) Tracef(_ string, _ ...interface{}) {}
+func (l *fakeLogger) Child(string) Logger {
+	return &fakeLogger{}
 }


### PR DESCRIPTION
## Description of change

Fix 2 small bugs in downloading a CharmHub charm to the controller:

In the json and naming in the charmhub Download structure, 5 & 6 were transposed.  Should have been HashSHA256, "hash-she-256".

Finding this bug was hampered by the sha check failure annotated a nil error instead of creating a new one.  Thus this deploy got much further along than it should have, as we saved a tar ball of size 0 to the blobstore.

This allows both deploy and refresh to work with CharmHub charms.  There may still be fine tuning to do with each.

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju add-model charmhub --config charm-hub-url="https://api.staging.snapcraft.io"

# deploy a charm, deploy with revisions, deploy with channel
# 
$ juju deploy ubuntu-qa
Located charm "ubuntu-qa-1".
Deploying charm "ubuntu-qa-1".
$ juju deploy ubuntu-qa-3 ubuntu-qa-rev
Located charm "ubuntu-qa-3".
Deploying charm "ubuntu-qa-3".
$ juju deploy ubuntu-qa --channel 1.0/edge ubuntu-qa-channel
Located charm "ubuntu-qa-2".
Deploying charm "ubuntu-qa-2".
$ juju status
Model     Controller  Cloud/Region         Version      SLA          Timestamp
charmhub  friday      localhost/localhost  2.9-beta1.1  unsupported  20:51:47Z

App                Version  Status  Scale  Charm      Store    Rev  OS      Message
ubuntu-qa                   active      1  ubuntu-qa  unknown    1  ubuntu  hello
ubuntu-qa-channel           active      1  ubuntu-qa  unknown    2  ubuntu  hello
ubuntu-qa-rev               active      1  ubuntu-qa  unknown    3  ubuntu  hello

Unit                  Workload  Agent  Machine  Public address  Ports  Message
ubuntu-qa-channel/0*  active    idle   0        10.217.94.134          hello
ubuntu-qa-rev/0*      active    idle   1        10.217.94.161          hello
ubuntu-qa/0*          active    idle   2        10.217.94.110          hello

Machine  State    DNS            Inst id        Series  AZ  Message
0        started  10.217.94.134  juju-6bf6c0-0  bionic      Running
1        started  10.217.94.161  juju-6bf6c0-1  bionic      Running
2        started  10.217.94.110  juju-6bf6c0-2  bionic      Running

# refresh a charm via channel
# 
$ juju refresh ubuntu-qa --channel 2.0/edge
Added charm "ubuntu-qa-3" to the model.
juju status
Model     Controller  Cloud/Region         Version      SLA          Timestamp
charmhub  friday      localhost/localhost  2.9-beta1.1  unsupported  20:56:31Z

App                Version  Status  Scale  Charm      Store    Rev  OS      Message
ubuntu-qa                   active      1  ubuntu-qa  unknown    3  ubuntu  hello
ubuntu-qa-channel           active      1  ubuntu-qa  unknown    2  ubuntu  it is now: 10/02/2020, 20:55:52
ubuntu-qa-rev               active      1  ubuntu-qa  unknown    3  ubuntu  it is now: 10/02/2020, 20:55:46

Unit                  Workload  Agent  Machine  Public address  Ports  Message
ubuntu-qa-channel/0*  active    idle   0        10.217.94.134          it is now: 10/02/2020, 20:55:52
ubuntu-qa-rev/0*      active    idle   1        10.217.94.161          it is now: 10/02/2020, 20:55:46
ubuntu-qa/0*          active    idle   2        10.217.94.110          hello

Machine  State    DNS            Inst id        Series  AZ  Message
0        started  10.217.94.134  juju-6bf6c0-0  bionic      Running
1        started  10.217.94.161  juju-6bf6c0-1  bionic      Running
2        started  10.217.94.110  juju-6bf6c0-2  bionic      Running
```

