### PR TITLE
Tighten up Azure dependency versions to avoid issue with deprecated 5.0.0 version

### DIFF
--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -1,9 +1,9 @@
 apache-libcloud>=2.4.0
-azure>=2.0.0rc3
+azure==4.0
 azure-batch>=0.30.0rc3
 azure-common>=1.1.3
 azure-graphrbac>=0.30.0rc3
-azure-mgmt>=0.30.0rc3
+azure-mgmt==4.0.0
 azure-mgmt-authorization>=0.30.0rc3
 azure-mgmt-batch>=0.30.0rc3
 azure-mgmt-cdn>=0.30.0rc3
@@ -20,7 +20,7 @@ azure-mgmt-web>=0.30.0rc3
 azure-nspkg>=1.0.0
 azure-servicebus>=0.20.1
 azure-servicemanagement-legacy>=0.20.3
-azure-storage>=0.31.0
+azure-storage==0.36.0
 boto>=2.48
 coverage>=3.7.1
 fixtures>=1.3.1


### PR DESCRIPTION

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

The `acceptancetests/requirements.txt` no longer installs due to https://github.com/Azure/azure-sdk-for-python/issues/10646 -- so I've pinned the relevant Azure packages to the version before the deprecation as a quick fix.

Note that this is only required when you install the deps for the first time (which we don't do every CI run, hence why this is still working in CI).

## QA steps

* Create a Python virtual environment and activate it
* `pip install -r requirements.txt`
* After this change, that should work fine. Before, it will fail with a big error message, including:

> Starting with v5.0.0, the 'azure' meta-package is deprecated and cannot be installed anymore.
> Please install the service specific packages prefixed by `azure` needed for your application.
> ...
> A more comprehensive discussion of the rationale for this decision can be found in the following issue:
> https://github.com/Azure/azure-sdk-for-python/issues/10646

## Documentation changes

N/A

## Bug reference

N/A
