### PR TITLE
[dev] Add integration tests for expose-application endpoints feature

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -32,19 +32,23 @@ import_subdir_files includes
 
 # If adding a test suite, then ensure to add it here to be picked up!
 TEST_NAMES="static_analysis \
+            agents \
             appdata \
             branches \
             caasadmission \
             cli \
             controller \
             deploy \
+            expose_ec2 \
             hooks \
-            hook_tools \
+            hooktools \
             machine \
             manual \
+            model \
+            network \
             relations \
             smoke \
-            model"
+            spaces_ec2"
 
 # Show test suites, can be used to test if a test suite is available or not.
 show_test_suites() {
@@ -100,7 +104,7 @@ show_help() {
         # shellcheck disable=SC2086
         output="${output}\n    $(green ${test})|Runs the ${name} tests"
     done
-    echo -e "${output}" | column -t -s "|"
+    echo "${output}" | column -t -s "|"
 
     echo ""
     echo "Examples:"

--- a/tests/suites/expose_ec2/bundle_with_exposed_endpoints.sh
+++ b/tests/suites/expose_ec2/bundle_with_exposed_endpoints.sh
@@ -1,0 +1,34 @@
+run_bundle_with_exposed_endpoints() {
+    echo
+
+    file="${TEST_DIR}/test-bundle-with-exposed-endpoints.log"
+
+    ensure "bundle-with-exposed-endpoints" "${file}"
+
+    assert_deploy_bundle_with_expose_flag_and_exposed_endpoints_fails
+
+    destroy_model "bundle-with-exposed-endpoints"
+}
+
+assert_deploy_bundle_with_expose_flag_and_exposed_endpoints_fails() {
+    echo "==> Checking that deploying a bundle with both the expose flag and exposed endpoint sections is not allowed"
+
+    bundle=./tests/suites/expose_ec2/bundles/invalid.yaml
+    got=$(juju deploy ${bundle} 2>&1 || true)
+    check_contains "${got}" 'exposed-endpoints cannot be specified together with "exposed:true" in application "ubuntu-lite" as this poses a security risk when deploying bundles to older controllers'
+}
+
+test_bundle_with_exposed_endpoints() {
+    if [ "$(skip 'test_bundle_with_exposed_endpoints')" ]; then
+        echo "==> TEST SKIPPED: juju bundle_with_exposed_endpoints"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_bundle_with_exposed_endpoints" "$@"
+    )
+}

--- a/tests/suites/expose_ec2/bundles/invalid.yaml
+++ b/tests/suites/expose_ec2/bundles/invalid.yaml
@@ -1,0 +1,25 @@
+# This bundle is invalid because it contains both an
+# "expose: true" field and a list of exposed endpoint
+# parameters in its overlay section
+series: bionic
+applications:
+  ubuntu-lite:
+    charm: cs:~jameinel/ubuntu-lite-7
+    num_units: 1
+    to:
+    - "0"
+    expose: true
+machines:
+  "0": {}
+--- # overlay.yaml
+applications:
+  ubuntu-lite:
+    exposed-endpoints:
+      "":
+        expose-to-cidrs:
+        - 10.0.0.0/24
+        - 192.168.0.0/24
+      ubuntu:
+        expose-to-cidrs:
+        - 10.42.0.0/16
+        - 2002:0:0:1234::/64

--- a/tests/suites/expose_ec2/expose_app.sh
+++ b/tests/suites/expose_ec2/expose_app.sh
@@ -1,0 +1,156 @@
+run_expose_app_ec2() {
+    echo
+
+    file="${TEST_DIR}/test-expose-app-ec2.log"
+
+    ensure "expose-app" "${file}"
+
+    # Deploy test charm
+    juju deploy cs:~jameinel/ubuntu-lite-7
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+
+    # Open ports and verify hook tool behavior
+    assert_opened_ports_output
+
+    # Ensure that CIDRs are correctly generated
+    assert_ingress_cidrs_for_exposed_app
+
+    # Ensure that the per-endpoint rules are included in exported bundles
+    assert_export_bundle_output_includes_exposed_endpoints
+
+    destroy_model "expose-app"
+}
+
+assert_opened_ports_output() {
+    echo "==> Checking open/opened-ports hook tools work as expected"
+
+    juju run --unit ubuntu-lite/0 "open-port 1337-1339/tcp"
+    juju run --unit ubuntu-lite/0 "open-port 1234/tcp --endpoints ubuntu"
+
+    # Test the backwards-compatible version of opened-ports where the output
+    # includes the unique set of opened ports for all endpoints.
+    # Note that 'juju run' injects a trailing line-feed tot he command output
+    # so we need to use echo to generate our expectation string.
+    exp=$(echo "1234/tcp 1337-1339/tcp" | tr '\n' ' ')
+    got=$(juju run --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ')
+    if [ "$got" != "$exp" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected opened-ports output to be:\n${exp}\nGOT:\n${got}")
+      exit 1
+    fi
+
+    # Try the new version where we group by endpoint.
+    # Note that 'juju run' injects a trailing line-feed tot he command output
+    # so we need to use echo to generate our expectation string.
+    exp=$(echo "1234/tcp (ubuntu) 1337-1339/tcp (*)" | tr '\n' ' ')
+    got=$(juju run --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ')
+    if [ "$got" != "$exp" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected opened-ports output when using --endpoints to be:\n${exp}\nGOT:\n${got}")
+      exit 1
+    fi
+}
+
+assert_ingress_cidrs_for_exposed_app() {
+    echo "==> Checking that expose --to-cidrs works as expected"
+
+    juju expose ubuntu-lite --to-cidrs 10.0.0.0/24,192.168.0.0/24
+    juju expose ubuntu-lite --endpoints ubuntu # expose to the world
+    # overwrite previous command
+    juju expose ubuntu-lite --endpoints ubuntu --to-cidrs 10.42.0.0/16,2002:0:0:1234::/64
+    sleep 2 # wait for firewall worker to detect and apply the changes
+
+    # Range 1337-1339 is opened for all endpoints. We expect it to be reachable
+    # by the expose-all CIDR list plus the CIDR for the ubuntu endpoint.
+    assert_ipv4_ingress_cidrs_for_port_range "1337" "1339" "10.0.0.0/24,10.42.0.0/16,192.168.0.0/24"
+
+    # Port 1234 should only be opened for the CIDR specified for the ubuntu endpoint
+    assert_ipv4_ingress_cidrs_for_port_range "1234" "1234" "10.42.0.0/16"
+    assert_ipv6_ingress_cidrs_for_port_range "1234" "1234" "2002:0:0:1234::/64"
+}
+
+# assert_ipv4_ingress_cidrs_for_port_range $from_port, $to_port $exp_cidrs
+assert_ipv4_ingress_cidrs_for_port_range() {
+  assert_ingress_cidrs_for_port_range "$1" "$2" "$3" "ipv4"
+}
+
+# assert_ipv6_ingress_cidrs_for_port_range $from_port, $to_port $exp_cidrs
+assert_ipv6_ingress_cidrs_for_port_range() {
+  assert_ingress_cidrs_for_port_range "$1" "$2" "$3" "ipv6"
+}
+
+assert_ingress_cidrs_for_port_range() {
+    local from_port to_port exp_cidrs cidr_type
+
+    from_port=${1}
+    to_port=${2}
+    exp_cidrs=${3}
+    cidr_type=${4}
+
+    # shellcheck disable=SC2086
+    secgrp_list=$(aws ec2 describe-security-groups --filters Name=ip-permission.from-port,Values=${from_port} Name=ip-permission.to-port,Values=${to_port})
+    if [ "$cidr_type" = "ipv4" ]; then
+      # shellcheck disable=SC2086
+      got_cidrs=$(echo ${secgrp_list} | jq -r ".SecurityGroups[0].IpPermissions | .[] | select(.FromPort == ${from_port} and .ToPort == ${to_port}) | .IpRanges | .[] | .CidrIp" | sort | paste -sd, -)
+    else
+      # shellcheck disable=SC2086
+      got_cidrs=$(echo ${secgrp_list} | jq -r ".SecurityGroups[0].IpPermissions | .[] | select(.FromPort == ${from_port} and .ToPort == ${to_port}) | .Ipv6Ranges | .[] | .CidrIpv6" | sort | paste -sd, -)
+    fi
+
+    if [ "$got_cidrs" != "$exp_cidrs" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected generated EC2 ${cidr_type} ingress CIDRs for range [${from_port}, ${to_port}] to be:\n${exp_cidrs}\nGOT:\n${got_cidrs}")
+      exit 1
+    fi
+}
+
+assert_export_bundle_output_includes_exposed_endpoints() {
+    echo "==> Checking that export-bundle output contains the exposed endpoint settings"
+
+    got=$(juju export-bundle)
+    exp=$(cat <<-EOF
+series: bionic
+applications:
+  ubuntu-lite:
+    charm: cs:~jameinel/ubuntu-lite-7
+    num_units: 1
+    to:
+    - "0"
+machines:
+  "0": {}
+--- # overlay.yaml
+applications:
+  ubuntu-lite:
+    exposed-endpoints:
+      "":
+        expose-to-cidrs:
+        - 10.0.0.0/24
+        - 192.168.0.0/24
+      ubuntu:
+        expose-to-cidrs:
+        - 10.42.0.0/16
+        - 2002:0:0:1234::/64
+EOF
+)
+
+    if [ "$got" != "$exp" ]; then
+      # shellcheck disable=SC2046
+      echo $(red "expected exported bundle to be:\n${exp}\nGOT:\n${got}")
+      exit 1
+    fi
+}
+
+test_expose_app_ec2() {
+    if [ "$(skip 'test_expose_app_ec2')" ]; then
+        echo "==> TEST SKIPPED: juju expose_app_ec2"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_expose_app_ec2" "$@"
+    )
+}

--- a/tests/suites/expose_ec2/task.sh
+++ b/tests/suites/expose_ec2/task.sh
@@ -1,0 +1,20 @@
+test_expose_ec2() {
+    if [ "$(skip 'test_expose_ec2')" ]; then
+      echo "==> TEST SKIPPED: expose application tests (EC2)"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju aws
+
+    file="${TEST_DIR}/test-expose-ec2.log"
+
+    bootstrap "test-expose-ec2" "${file}"
+
+    test_expose_app_ec2
+    test_bundle_with_exposed_endpoints
+
+    destroy_controller "test-expose-ec2"
+}


### PR DESCRIPTION
## Description of change

This PR adds two integration tests to verify that the _expose application endpoints_ feature works as expected. More specifically, the tests are designed to verify:
- that the `open-ports` and `opened-ports` hook tools work correctly when the `--endpoints` argument is provided or missing.
- that expose application `--to-cidrs` invocations work as expected (i.e. additive for different endpoints and last write wins when targeting specific endpoints multiple times)
- the juju cli emits an error when attempting to deploy a bundle containing both the `expose: true` flag and a list of endpoint-specific expose settings in an overlay.

These tests target ec2 specifically because that's one of the providers that supports ingress rules with IPV6 CIDRs. This allows us to additionally verify that the IPV6 rules are properly handled by ec2.

## QA steps

```console
$ ./main.sh -p aws expose_ec2
```