### PR TITLE
Fix jujuc for new k8s charms.

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -829,6 +829,12 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			},
 			{
 				Name:      jujuDataDirVolumeName,
+				MountPath: "/usr/bin/jujuc",
+				SubPath:   "usr/bin/jujuc",
+				ReadOnly:  true,
+			},
+			{
+				Name:      jujuDataDirVolumeName,
 				MountPath: jujuDataDir,
 				SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
 			},

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -322,6 +322,12 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 				},
 				{
 					Name:      "juju-data-dir",
+					MountPath: "/usr/bin/jujuc",
+					SubPath:   "usr/bin/jujuc",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "juju-data-dir",
 					MountPath: jujuDataDir,
 					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
 				},

--- a/cmd/k8sagent/initialize/command.go
+++ b/cmd/k8sagent/initialize/command.go
@@ -90,21 +90,31 @@ func (c *initCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// TODO(caas): stream read/write
-	pebbleBytes, err := c.fileReaderWriter.ReadFile("/opt/pebble")
+	binary, err := c.fileReaderWriter.ReadFile("/opt/pebble")
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = c.fileReaderWriter.WriteFile("/shared/usr/bin/pebble", pebbleBytes, 0755)
+	err = c.fileReaderWriter.WriteFile("/shared/usr/bin/pebble", binary, 0755)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// TODO(caas): stream read/write
-	agentBytes, err := c.fileReaderWriter.ReadFile("/opt/k8sagent")
+	binary, err = c.fileReaderWriter.ReadFile("/opt/k8sagent")
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = c.fileReaderWriter.WriteFile("/shared/usr/bin/k8sagent", agentBytes, 0755)
+	err = c.fileReaderWriter.WriteFile("/shared/usr/bin/k8sagent", binary, 0755)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// TODO(caas): stream read/write
+	binary, err = c.fileReaderWriter.ReadFile("/opt/jujuc")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = c.fileReaderWriter.WriteFile("/shared/usr/bin/jujuc", binary, 0755)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/k8sagent/initialize/command_test.go
+++ b/cmd/k8sagent/initialize/command_test.go
@@ -95,6 +95,8 @@ apiport: 17070`[1:])
 		s.fileReaderWriter.EXPECT().WriteFile("/shared/usr/bin/pebble", pebbleBytes, os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().ReadFile("/opt/k8sagent").Times(1).Return(pebbleBytes, nil),
 		s.fileReaderWriter.EXPECT().WriteFile("/shared/usr/bin/k8sagent", pebbleBytes, os.FileMode(0755)).Return(nil),
+		s.fileReaderWriter.EXPECT().ReadFile("/opt/jujuc").Times(1).Return(pebbleBytes, nil),
+		s.fileReaderWriter.EXPECT().WriteFile("/shared/usr/bin/jujuc", pebbleBytes, os.FileMode(0755)).Return(nil),
 
 		s.applicationAPI.EXPECT().Close().Times(1).Return(nil),
 	)

--- a/cmd/k8sagent/unit/agent.go
+++ b/cmd/k8sagent/unit/agent.go
@@ -142,8 +142,8 @@ func (c *k8sUnitAgent) Init(args []string) error {
 		return errors.NotValidf("expected a unit tag; got %q", unitTag)
 	}
 
-	srcBin := path.Dir(os.Args[0])
-	if err := c.ensureToolSymlinks(srcBin, dataDir, unitTag); err != nil {
+	srcDir := path.Dir(os.Args[0])
+	if err := c.ensureToolSymlinks(srcDir, dataDir, unitTag); err != nil {
 		return errors.Annotate(err, "ensuring agent conf file")
 	}
 	return nil
@@ -162,11 +162,14 @@ func (c *k8sUnitAgent) ensureToolSymlinks(srcPath, dataDir string, unitTag names
 		jnames.K8sAgent,
 		jnames.JujuRun,
 		jnames.JujuIntrospect,
-		jnames.Jujuc,
 	} {
 		if err = c.fileReaderWriter.Symlink(path.Join(srcPath, jnames.K8sAgent), path.Join(toolsDir, link)); err != nil {
 			return errors.Annotatef(err, "ensuring symlink %q", link)
 		}
+	}
+
+	if err = c.fileReaderWriter.Symlink(path.Join(srcPath, jnames.Jujuc), path.Join(toolsDir, jnames.Jujuc)); err != nil {
+		return errors.Annotatef(err, "ensuring symlink %q", jnames.Jujuc)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of change

Hook tool symlinks now use jujuc instead of k8sagent (as it doesn't support hook tools).

## QA steps

Deploy v2 charm and `juju run app/0 status-get`

## Documentation changes

N/A

## Bug reference

N/A