### PR TITLE
Tighten up PR template a bit

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,17 @@
-## Please provide the following details to expedite Pull Request review:
+## Please provide the following details to expedite review (and delete this heading)
 
-### Checklist
+*Replace with a description about why this change is needed, along with a description of what changed.*
 
- - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
- - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
- - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
- - [ ] Do comments answer the question of why design decisions were made?
+## Checklist
 
-----
-
-## Description of change
-
-*Please replace with a description about why this change is needed, along with a description of what changed?*
+ - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
+ - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
+ - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
+ - [ ] Comments answer the question of why design decisions were made
 
 ## QA steps
 
-*Please replace with how we can verify that the change works?*
+*Please replace with how we can verify that the change works.*
 
 ```sh
 QA steps here
@@ -23,8 +19,8 @@ QA steps here
 
 ## Documentation changes
 
-*Please replace with any notes about how it affects current user workflow? CLI? API?*
+*Please replace with any notes about how it affects current user workflow, CLI, or API.*
 
 ## Bug reference
 
-*Please add a link to any bugs that this change is related to.*
+*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*


### PR DESCRIPTION
Mainly moving the "description of change" section to the top, as (IMO) that's bar far the most important section. It will also improve the PR snippet/widget when you paste a PR link into GitHub or Trello, rather than having the checklist text in the way.

I've also made some minor tweaks to the text/punctuation for consistency.