### PR TITLE
Fix the validate model upgrade from a facade

### DIFF
--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -583,11 +583,10 @@ func (c *upgradeJujuCommand) validateModelUpgrade() error {
 		return errors.Trace(err)
 	}
 	// TODO (stickupkid): Define force for validation of model upgrade.
-	if err := client.ValidateModelUpgrade(names.NewModelTag(details.ModelUUID), false); err != nil {
-		return errors.Trace(err)
+	if err = client.ValidateModelUpgrade(names.NewModelTag(details.ModelUUID), false); errors.IsNotImplemented(err) {
+		return nil
 	}
-
-	return nil
+	return errors.Trace(err)
 }
 
 // environConfigGetter implements environs.EnvironConfigGetter for use

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -914,6 +914,19 @@ func (s *UpgradeJujuSuite) TestUpgradeValidateModel(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `a message from the server about the problem`)
 }
 
+func (s *UpgradeJujuSuite) TestUpgradeValidateModelNotImplementedNoError(c *gc.C) {
+	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
+
+	fakeAPI.setUpgradeErr = errors.NotImplementedf("")
+
+	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+	err := cmdtesting.InitCommand(command, []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = command.Run(cmdtesting.Context(c))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *UpgradeJujuSuite) TestUpgradeInProgress(c *gc.C) {
 	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
 	fakeAPI.setVersionErr = &params.Error{


### PR DESCRIPTION
## Description of change

This was fixed originally in develop, but actually needed to be fixed in
the 2.8 branch. Essentially this makes upgrading to 2.8 invalid because
it expects that you already have the facade available.

## QA steps

*Please replace with how we can verify that the change works?*

```sh
$ git checkout ab69570b38fbc746e54184e4c3274612bcbb8327 # 2.8.3 tag
$ make go-install
$ juju bootstrap lxd test --build-agent

$ git checkout 2.8
$ make go-install
$ juju upgrade-model --build-agent
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1895963
