### PR TITLE
Fix bug #1887549: Check args.AgentVersion in bootstrapCAAS

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -271,7 +271,9 @@ func bootstrapCAAS(
 	}
 
 	jujuVersion := jujuversion.Current
-
+	if args.AgentVersion != nil {
+		jujuVersion = *args.AgentVersion
+	}
 	// set agent version before finalizing bootstrap config
 	if err := setBootstrapAgentVersion(environ, jujuVersion); err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
## Please provide the following details to expedite Pull Request review:

### Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [ ] Do comments answer the question of why design decisions were made?

----

## Description of change

This change is needed to fix the bug lp#1887549, that prevents the juju controller from being bootstrapped using a pinned version. In other words, the `--agent-version` option when bootstrapping is ignored.

## QA steps

```sh
# Setup microk8s
sudo snap install microk8s --classic
microk8s.status --wait-ready
microk8s.enable storage dns

# Check juju version
juju version  # p.e. 2.8.4-focal-amd64

# Bootstrap controllers
juju bootstrap microk8s one --agent-version 2.8.1
juju status  # Version==2.8.1

juju bootstrap microk8s two --agent-version 2.8.2
juju status  # Version==2.8.2

juju bootstrap microk8s current
juju status  # Version==2.8.4
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1887549
