### PR TITLE
use provided store-url from charmhub

### DIFF
--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -90,7 +90,7 @@ func (api *CharmHubAPI) Info(arg params.Entity) (params.CharmHubEntityInfoResult
 	if err != nil {
 		return params.CharmHubEntityInfoResult{}, errors.Trace(err)
 	}
-	return params.CharmHubEntityInfoResult{Result: convertCharmInfoResult(info, api.client.URL())}, nil
+	return params.CharmHubEntityInfoResult{Result: convertCharmInfoResult(info)}, nil
 }
 
 // Find queries the CharmHub API with a given entity ID.
@@ -102,7 +102,7 @@ func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubEntityFindResult,
 	if err != nil {
 		return params.CharmHubEntityFindResult{}, errors.Trace(err)
 	}
-	return params.CharmHubEntityFindResult{Results: convertCharmFindResults(results, api.client.URL())}, nil
+	return params.CharmHubEntityFindResult{Results: convertCharmFindResults(results)}, nil
 }
 
 type charmHubClientFactory struct{}

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -84,12 +84,10 @@ func (s *charmHubAPISuite) expectClient() {
 }
 
 func (s *charmHubAPISuite) expectInfo() {
-	s.client.EXPECT().URL().Return("https://someurl.com")
 	s.client.EXPECT().Info(gomock.Any(), "wordpress").Return(getCharmHubInfoResponse(), nil)
 }
 
 func (s *charmHubAPISuite) expectFind() {
-	s.client.EXPECT().URL().Return("https://someurl.com")
 	s.client.EXPECT().Find(gomock.Any(), "wordpress").Return(getCharmHubFindResponses(), nil)
 }
 
@@ -195,7 +193,8 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 			Publisher: map[string]string{
 				"display-name": "Wordress Charmers",
 			},
-			Summary: "WordPress is a full featured web blogging tool, this charm deploys it.",
+			Summary:  "WordPress is a full featured web blogging tool, this charm deploys it.",
+			StoreURL: "https://someurl.com/wordpress",
 			UsedBy: []string{
 				"wordpress-everlast",
 				"wordpress-jorge",

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -5,8 +5,6 @@ package charmhub
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
@@ -16,7 +14,7 @@ import (
 	"github.com/juju/juju/charmhub/transport"
 )
 
-func convertCharmInfoResult(info transport.InfoResponse, clientURL string) params.InfoResponse {
+func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 	ir := params.InfoResponse{
 		Type:        info.Type,
 		ID:          info.ID,
@@ -25,7 +23,7 @@ func convertCharmInfoResult(info transport.InfoResponse, clientURL string) param
 		Publisher:   publisher(info.Entity),
 		Summary:     info.Entity.Summary,
 		Tags:        categories(info.Entity.Categories),
-		StoreURL:    transformStoreURL(clientURL, info.Name),
+		StoreURL:    info.Entity.StoreURL,
 	}
 	switch ir.Type {
 	case "bundle":
@@ -51,15 +49,15 @@ func categories(cats []transport.Category) []string {
 	return result
 }
 
-func convertCharmFindResults(responses []transport.FindResponse, clientURL string) []params.FindResponse {
+func convertCharmFindResults(responses []transport.FindResponse) []params.FindResponse {
 	results := make([]params.FindResponse, len(responses))
 	for k, response := range responses {
-		results[k] = convertCharmFindResult(response, clientURL)
+		results[k] = convertCharmFindResult(response)
 	}
 	return results
 }
 
-func convertCharmFindResult(resp transport.FindResponse, clientURL string) params.FindResponse {
+func convertCharmFindResult(resp transport.FindResponse) params.FindResponse {
 	return params.FindResponse{
 		Type:      resp.Type,
 		ID:        resp.ID,
@@ -68,22 +66,13 @@ func convertCharmFindResult(resp transport.FindResponse, clientURL string) param
 		Summary:   resp.Entity.Summary,
 		Version:   resp.DefaultRelease.Revision.Version,
 		Series:    transformSeries(resp.DefaultRelease),
-		StoreURL:  transformStoreURL(clientURL, resp.Name),
+		StoreURL:  resp.Entity.StoreURL,
 	}
 }
 
 func publisher(ch transport.Entity) string {
 	publisher, _ := ch.Publisher["display-name"]
 	return publisher
-}
-
-// transformStoreURL converts the store url into something we can use in the
-// output.
-// TODO (stickupkid): The API should provide this URL or at least guidance on
-// how to construct it.
-func transformStoreURL(clientURL, name string) string {
-	url := strings.TrimSuffix(clientURL, "/")
-	return fmt.Sprintf("%s/%s", url, name)
 }
 
 // transformSeries returns a slice of supported series for that revision.

--- a/charmhub/client_integration_test.go
+++ b/charmhub/client_integration_test.go
@@ -28,9 +28,9 @@ func (s *ClientSuite) TestLiveInfoRequest(c *gc.C) {
 	client, err := charmhub.NewClient(config)
 	c.Assert(err, jc.ErrorIsNil)
 
-	response, err := client.Info(context.TODO(), "wordpress")
+	response, err := client.Info(context.TODO(), "ubuntu")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(response.Name, gc.Equals, "wordpress")
+	c.Assert(response.Name, gc.Equals, "ubuntu")
 }
 
 func (s *ClientSuite) TestLiveFindRequest(c *gc.C) {
@@ -40,7 +40,8 @@ func (s *ClientSuite) TestLiveFindRequest(c *gc.C) {
 	client, err := charmhub.NewClient(config)
 	c.Assert(err, jc.ErrorIsNil)
 
-	responses, err := client.Find(context.TODO(), "wordpress")
+	responses, err := client.Find(context.TODO(), "ubuntu")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(responses[0].Name, gc.Equals, "wordpress")
+	c.Assert(len(responses), jc.GreaterThan, 1)
+	c.Assert(responses[0].Name, gc.Equals, "ubuntu")
 }

--- a/charmhub/find_integration_test.go
+++ b/charmhub/find_integration_test.go
@@ -34,8 +34,8 @@ func (s *FindClientSuite) TestLiveFindRequest(c *gc.C) {
 	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
 	client := charmhub.NewFindClient(findPath, restClient, &charmhub.FakeLogger{})
-	responses, err := client.Find(context.TODO(), "wordpress")
+	responses, err := client.Find(context.TODO(), "ubuntu")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), jc.GreaterThan, 1)
-	c.Assert(responses[0].Name, gc.Equals, "wordpress")
+	c.Assert(responses[0].Name, gc.Equals, "ubuntu")
 }

--- a/charmhub/info_integration_test.go
+++ b/charmhub/info_integration_test.go
@@ -34,7 +34,7 @@ func (s *InfoClientSuite) TestLiveInfoRequest(c *gc.C) {
 	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil, &charmhub.FakeLogger{})
 
 	client := charmhub.NewInfoClient(infoPath, restClient, &charmhub.FakeLogger{})
-	response, err := client.Info(context.TODO(), "wordpress")
+	response, err := client.Info(context.TODO(), "ubuntu")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(response.Name, gc.Equals, "wordpress")
+	c.Assert(response.Name, gc.Equals, "ubuntu")
 }

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -49,6 +49,7 @@ type Entity struct {
 	Publisher   map[string]string `json:"publisher"`
 	Summary     string            `json:"summary"`
 	UsedBy      []string          `json:"used-by"`
+	StoreURL    string            `json:"store-url"`
 }
 
 type Category struct {


### PR DESCRIPTION


## Description of change

Use the store-url provided by the charmhub api instead of making one up.  It was previously empty.

## QA steps

Verify store-url is not the same as the Charmhub-url with name appended.
```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju info ubuntu
name: ubuntu
charm-id: rf7Gsh1SEvKQ3nOzjtpleWxStMMkEhl9
summary: A pristine Ubuntu Server
publisher: charmers
supports: xenial, bionic, artful, cosmic, disco, trusty, focal
tags: misc
subordinate: false
store-url: https://charmhub.io/ubuntu
description: |
  This simply deploys the Ubuntu Cloud/Server image
channels: |
  latest/stable:     11     (11)  4MB
  latest/candidate:  11     (11)  4MB
  latest/beta:       11     (11)  4MB
  latest/edge:       11     (11)  4MB

```

Verify integration tests succeed.
```sh
go test -v ./charmhub/... -check.v -tags="integration"
```

