### PR TITLE
[wait-for] Allow unit queries

### DIFF
--- a/cmd/plugins/juju-wait-for/application_test.go
+++ b/cmd/plugins/juju-wait-for/application_test.go
@@ -67,6 +67,6 @@ func (s *applicationScopeSuite) TestGetIdentValueError(c *gc.C) {
 		ApplicationInfo: &params.ApplicationInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ApplicationInfo`)
+	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ApplicationInfo: invalid identifer`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/plugins/juju-wait-for/machine.go
+++ b/cmd/plugins/juju-wait-for/machine.go
@@ -1,0 +1,166 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/api"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/query"
+	"github.com/juju/juju/core/life"
+)
+
+func newMachineCommand() cmd.Command {
+	cmd := &machineCommand{}
+	cmd.newWatchAllAPIFunc = func() (api.WatchAllAPI, error) {
+		client, err := cmd.NewAPIClient()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return watchAllAPIShim{
+			Client: client,
+		}, nil
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+const machineCommandDoc = `
+Wait for a given machine to reach a goal state.
+
+arguments:
+name
+   machine name identifier
+
+options:
+--query (= 'life=="alive" && status=="started")
+   query represents the goal state of a given machine
+`
+
+// machineCommand defines a command for waiting for models.
+type machineCommand struct {
+	waitForCommandBase
+
+	id      string
+	query   string
+	timeout time.Duration
+	found   bool
+}
+
+// Info implements Command.Info.
+func (c *machineCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "machine",
+		Args:    "[<id>]",
+		Purpose: "wait for an machine to reach a goal state",
+		Doc:     machineCommandDoc,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *machineCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.waitForCommandBase.SetFlags(f)
+	f.StringVar(&c.query, "query", `life=="alive" && status=="started"`, "query the goal state")
+	f.DurationVar(&c.timeout, "timeout", time.Minute*10, "how long to wait, before timing out")
+}
+
+// Init implements Command.Init.
+func (c *machineCommand) Init(args []string) (err error) {
+	if len(args) == 0 {
+		return errors.New("machine id must be supplied when waiting for an machine")
+	}
+	if len(args) != 1 {
+		return errors.New("only one machine id can be supplied as an argument to this command")
+	}
+	if ok := names.IsValidMachine(args[0]); !ok {
+		return errors.Errorf("%q is not valid machine id", args[0])
+	}
+	c.id = args[0]
+
+	return nil
+}
+
+func (c *machineCommand) Run(ctx *cmd.Context) error {
+	client, err := c.newWatchAllAPIFunc()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	strategy := &Strategy{
+		Client:  client,
+		Timeout: c.timeout,
+	}
+	err = strategy.Run(c.id, c.query, c.waitFor)
+	return errors.Trace(err)
+}
+
+func (c *machineCommand) waitFor(id string, deltas []params.Delta, q query.Query) (bool, error) {
+	for _, delta := range deltas {
+		logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+
+		switch entityInfo := delta.Entity.(type) {
+		case *params.MachineInfo:
+			if entityInfo.Id == id {
+				scope := MakeMachineScope(entityInfo)
+				if res, err := q.Run(scope); query.IsInvalidIdentifierErr(err) {
+					return false, invalidIdentifierError(scope, err)
+				} else if res && err == nil {
+					return true, nil
+				}
+				c.found = entityInfo.Life != life.Dead
+			}
+			break
+		}
+	}
+
+	if !c.found {
+		logger.Infof("machine %q not found, waiting...", id)
+		return false, nil
+	}
+
+	logger.Infof("machine %q found, waiting...", id)
+	return false, nil
+}
+
+// MachineScope allows the query to introspect a model entity.
+type MachineScope struct {
+	GenericScope
+	MachineInfo *params.MachineInfo
+}
+
+// MakeMachineScope creates an MachineScope from an MachineInfo
+func MakeMachineScope(info *params.MachineInfo) MachineScope {
+	return MachineScope{
+		GenericScope: GenericScope{
+			Info: info,
+		},
+		MachineInfo: info,
+	}
+}
+
+// GetIdentValue returns the value of the identifier in a given scope.
+func (m MachineScope) GetIdentValue(name string) (query.Ord, error) {
+	switch name {
+	case "id":
+		return query.NewString(m.MachineInfo.Id), nil
+	case "life":
+		return query.NewString(string(m.MachineInfo.Life)), nil
+	case "status", "agent-status":
+		return query.NewString(string(m.MachineInfo.AgentStatus.Current)), nil
+	case "instance-status":
+		return query.NewString(string(m.MachineInfo.InstanceStatus.Current)), nil
+	case "series":
+		return query.NewString(m.MachineInfo.Series), nil
+	case "container-type":
+		return query.NewString(m.MachineInfo.ContainerType), nil
+	}
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on MachineInfo", name)
+}

--- a/cmd/plugins/juju-wait-for/machine_test.go
+++ b/cmd/plugins/juju-wait-for/machine_test.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/query"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+)
+
+type machineScopeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&machineScopeSuite{})
+
+func (s *machineScopeSuite) TestGetIdentValue(c *gc.C) {
+	tests := []struct {
+		Field       string
+		MachineInfo *params.MachineInfo
+		Expected    query.Ord
+	}{{
+		Field:       "id",
+		MachineInfo: &params.MachineInfo{Id: "0/lxd/0"},
+		Expected:    query.NewString("0/lxd/0"),
+	}, {
+		Field:       "life",
+		MachineInfo: &params.MachineInfo{Life: life.Alive},
+		Expected:    query.NewString("alive"),
+	}, {
+		Field: "status",
+		MachineInfo: &params.MachineInfo{AgentStatus: params.StatusInfo{
+			Current: status.Active,
+		}},
+		Expected: query.NewString("active"),
+	}, {
+		Field: "instance-status",
+		MachineInfo: &params.MachineInfo{InstanceStatus: params.StatusInfo{
+			Current: status.Active,
+		}},
+		Expected: query.NewString("active"),
+	}, {
+		Field:       "series",
+		MachineInfo: &params.MachineInfo{Series: "focal"},
+		Expected:    query.NewString("focal"),
+	}, {
+		Field:       "container-type",
+		MachineInfo: &params.MachineInfo{ContainerType: "lxd"},
+		Expected:    query.NewString("lxd"),
+	}}
+	for i, test := range tests {
+		c.Logf("%d: GetIdentValue %q", i, test.Field)
+		scope := MachineScope{
+			MachineInfo: test.MachineInfo,
+		}
+		result, err := scope.GetIdentValue(test.Field)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.DeepEquals, test.Expected)
+	}
+}
+
+func (s *machineScopeSuite) TestGetIdentValueError(c *gc.C) {
+	scope := MachineScope{
+		MachineInfo: &params.MachineInfo{},
+	}
+	result, err := scope.GetIdentValue("bad")
+	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on MachineInfo: invalid identifer`)
+	c.Assert(result, gc.IsNil)
+}

--- a/cmd/plugins/juju-wait-for/model_test.go
+++ b/cmd/plugins/juju-wait-for/model_test.go
@@ -60,6 +60,6 @@ func (s *modelScopeSuite) TestGetIdentValueError(c *gc.C) {
 		ModelInfo: &params.ModelUpdate{},
 	}
 	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ModelInfo`)
+	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on ModelInfo: invalid identifer`)
 	c.Assert(result, gc.IsNil)
 }

--- a/cmd/plugins/juju-wait-for/query/query.go
+++ b/cmd/plugins/juju-wait-for/query/query.go
@@ -9,6 +9,36 @@ import (
 	"github.com/juju/errors"
 )
 
+// InvalidIdentifierError creates an invalid error.
+type InvalidIdentifierError struct {
+	name string
+	err  error
+}
+
+func (e *InvalidIdentifierError) Error() string {
+	return e.err.Error()
+}
+
+// Name returns the name associated with the identifier error.
+func (e *InvalidIdentifierError) Name() string {
+	return e.name
+}
+
+// ErrInvalidIdentifier defines a sentinel error for invalid identifiers.
+func ErrInvalidIdentifier(name string) error {
+	return &InvalidIdentifierError{
+		name: name,
+		err:  errors.Errorf("invalid identifer"),
+	}
+}
+
+// IsInvalidIdentifierErr returns if the error is an ErrInvalidIdentifier error
+func IsInvalidIdentifierErr(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*InvalidIdentifierError)
+	return ok
+}
+
 // Query holds all the arguments for a given query.
 type Query struct {
 	ast *QueryExpression

--- a/cmd/plugins/juju-wait-for/strategy.go
+++ b/cmd/plugins/juju-wait-for/strategy.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 
 // StrategyFunc defines a way to change the underlying stategy function that
 // can be changed depending on the callee.
-type StrategyFunc func(string, []params.Delta, query.Query) bool
+type StrategyFunc func(string, []params.Delta, query.Query) (bool, error)
 
 // Strategy defines a series of instructions to run for a given wait for
 // plan.
@@ -61,7 +62,9 @@ func (s *Strategy) Run(name string, input string, fn StrategyFunc) error {
 			}
 		}
 
-		if done := fn(name, deltas, q); done {
+		if done, err := fn(name, deltas, q); err != nil {
+			return errors.Trace(err)
+		} else if done {
 			return nil
 		}
 	}
@@ -99,4 +102,112 @@ func (m GenericScope) GetIdentValue(name string) (query.Ord, error) {
 		}
 	}
 	return nil, errors.Errorf("Runtime Error: identifier %q not found on Info", name)
+}
+
+// GetIdents returns the identifers that are supported for a given scope.
+func (m GenericScope) GetIdents() []string {
+	var res []string
+
+	refType := reflect.TypeOf(m.Info).Elem()
+	for i := 0; i < refType.NumField(); i++ {
+		field := refType.Field(i)
+		v := strings.Split(field.Tag.Get("json"), ",")[0]
+		refValue := reflect.ValueOf(m.Info).Elem()
+
+		switch refValue.Field(i).Kind() {
+		case reflect.Int, reflect.Int64, reflect.Float64, reflect.String, reflect.Bool:
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
+// Scope defines a local scope used to get identifiers of a given scope.
+type Scope interface {
+	// GetIdents returns the identifers that are supported for a given scope.
+	GetIdents() []string
+}
+
+func invalidIdentifierError(scope Scope, err error) error {
+	if !query.IsInvalidIdentifierErr(err) {
+		return errors.Trace(err)
+	}
+
+	identErr := errors.Cause(err).(*query.InvalidIdentifierError)
+	name := identErr.Name()
+
+	idents := scope.GetIdents()
+
+	type Indexed = struct {
+		Name  string
+		Value int
+	}
+	matches := make([]Indexed, 0, len(idents))
+	for _, ident := range idents {
+		matches = append(matches, Indexed{
+			Name:  ident,
+			Value: levenshteinDistance(name, ident),
+		})
+	}
+	// Find the smallest levenshtein distance. If two values are the same,
+	// fallback to sorting on the name, which should give predictable results.
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Value < matches[j].Value {
+			return true
+		}
+		if matches[i].Value > matches[j].Value {
+			return false
+		}
+		return matches[i].Name < matches[j].Name
+	})
+	matchedName := matches[0].Name
+	matchedValue := matches[0].Value
+
+	if matchedName != "" && matchedValue <= len(matchedName)+1 {
+		additional := errors.Errorf(`%s
+
+Did you mean:
+	%s
+`, err.Error(), matchedName)
+		return errors.Wrap(err, additional)
+	}
+
+	return errors.Trace(err)
+}
+
+// levenshteinDistance
+// from https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
+// (no min, compute lengths once, 2 rows array)
+// fastest profiled
+func levenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+	d := make([]int, la+1)
+	var lastdiag, olddiag, temp int
+
+	for i := 1; i <= la; i++ {
+		d[i] = i
+	}
+	for i := 1; i <= lb; i++ {
+		d[0] = i
+		lastdiag = i - 1
+		for j := 1; j <= la; j++ {
+			olddiag = d[j]
+			min := d[j] + 1
+			if (d[j-1] + 1) < min {
+				min = d[j-1] + 1
+			}
+			if a[j-1] == b[i-1] {
+				temp = 0
+			} else {
+				temp = 1
+			}
+			if (lastdiag + temp) < min {
+				min = lastdiag + temp
+			}
+			d[j] = min
+			lastdiag = olddiag
+		}
+	}
+	return d[la]
 }

--- a/cmd/plugins/juju-wait-for/strategy_test.go
+++ b/cmd/plugins/juju-wait-for/strategy_test.go
@@ -46,10 +46,10 @@ func (s *strategySuite) TestRun(c *gc.C) {
 		Client:  client,
 		Timeout: time.Minute,
 	}
-	err := strategy.Run("generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) bool {
+	err := strategy.Run("generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
 		executed = true
 		deltas = d
-		return true
+		return true, nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(executed, jc.IsTrue)
@@ -65,9 +65,9 @@ func (s *strategySuite) TestRunWithInvalidQuery(c *gc.C) {
 		Client:  client,
 		Timeout: time.Minute,
 	}
-	err := strategy.Run("generic", `life=="ac`, func(_ string, d []params.Delta, _ query.Query) bool {
+	err := strategy.Run("generic", `life=="ac`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
 		c.FailNow()
-		return false
+		return false, nil
 	})
 	c.Assert(err, gc.ErrorMatches, `Syntax Error:<:1:7> invalid character '<UNKNOWN>' found`)
 }

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -1,0 +1,180 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/apiserver/params"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/api"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/query"
+	"github.com/juju/juju/core/life"
+)
+
+func newUnitCommand() cmd.Command {
+	cmd := &unitCommand{}
+	cmd.newWatchAllAPIFunc = func() (api.WatchAllAPI, error) {
+		client, err := cmd.NewAPIClient()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return watchAllAPIShim{
+			Client: client,
+		}, nil
+	}
+	return modelcmd.Wrap(cmd)
+}
+
+const unitCommandDoc = `
+Wait for a given unit to reach a goal state.
+
+arguments:
+name
+   unit name identifier
+
+options:
+--query (= 'life=="alive" && status=="active"')
+   query represents the goal state of a given unit
+`
+
+// unitCommand defines a command for waiting for units.
+type unitCommand struct {
+	waitForCommandBase
+
+	name    string
+	query   string
+	timeout time.Duration
+	found   bool
+}
+
+// Info implements Command.Info.
+func (c *unitCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "unit",
+		Args:    "[<name>]",
+		Purpose: "wait for an unit to reach a goal state",
+		Doc:     unitCommandDoc,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *unitCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.waitForCommandBase.SetFlags(f)
+	f.StringVar(&c.query, "query", `life=="alive" && status=="active"`, "query the goal state")
+	f.DurationVar(&c.timeout, "timeout", time.Minute*10, "how long to wait, before timing out")
+}
+
+// Init implements Command.Init.
+func (c *unitCommand) Init(args []string) (err error) {
+	if len(args) == 0 {
+		return errors.New("unit name must be supplied when waiting for an unit")
+	}
+	if len(args) != 1 {
+		return errors.New("only one unit name can be supplied as an argument to this command")
+	}
+	if ok := names.IsValidUnit(args[0]); !ok {
+		return errors.Errorf("%q is not valid unit name", args[0])
+	}
+	c.name = args[0]
+
+	return nil
+}
+
+func (c *unitCommand) Run(ctx *cmd.Context) error {
+	client, err := c.newWatchAllAPIFunc()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	strategy := &Strategy{
+		Client:  client,
+		Timeout: c.timeout,
+	}
+	err = strategy.Run(c.name, c.query, c.waitFor)
+	return errors.Trace(err)
+}
+
+func (c *unitCommand) waitFor(name string, deltas []params.Delta, q query.Query) (bool, error) {
+	for _, delta := range deltas {
+		logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+
+		switch entityInfo := delta.Entity.(type) {
+		case *params.UnitInfo:
+			if entityInfo.Name == name {
+				scope := MakeUnitScope(entityInfo)
+				if res, err := q.Run(scope); query.IsInvalidIdentifierErr(err) {
+					return false, invalidIdentifierError(scope, err)
+				} else if res && err == nil {
+					return true, nil
+				}
+				c.found = entityInfo.Life != life.Dead
+			}
+			break
+		}
+	}
+
+	if !c.found {
+		logger.Infof("unit %q not found, waiting...", name)
+		return false, nil
+	}
+
+	logger.Infof("unit %q found, waiting...", name)
+	return false, nil
+}
+
+// UnitScope allows the query to introspect a unit entity.
+type UnitScope struct {
+	GenericScope
+	UnitInfo *params.UnitInfo
+}
+
+// MakeUnitScope creates an UnitScope from an UnitInfo
+func MakeUnitScope(info *params.UnitInfo) UnitScope {
+	return UnitScope{
+		GenericScope: GenericScope{
+			Info: info,
+		},
+		UnitInfo: info,
+	}
+}
+
+// GetIdentValue returns the value of the identifier in a given scope.
+func (m UnitScope) GetIdentValue(name string) (query.Ord, error) {
+	switch name {
+	case "name":
+		return query.NewString(m.UnitInfo.Name), nil
+	case "application":
+		return query.NewString(m.UnitInfo.Application), nil
+	case "series":
+		return query.NewString(m.UnitInfo.Series), nil
+	case "charm-url":
+		return query.NewString(m.UnitInfo.CharmURL), nil
+	case "life":
+		return query.NewString(string(m.UnitInfo.Life)), nil
+	case "public-address":
+		return query.NewString(m.UnitInfo.PublicAddress), nil
+	case "private-address":
+		return query.NewString(m.UnitInfo.PrivateAddress), nil
+	case "machine-id":
+		return query.NewString(m.UnitInfo.MachineId), nil
+	case "principal":
+		return query.NewString(m.UnitInfo.Principal), nil
+	case "subordinate":
+		return query.NewBool(m.UnitInfo.Subordinate), nil
+	case "workload-status":
+		return query.NewString(string(m.UnitInfo.WorkloadStatus.Current)), nil
+	case "agent-status":
+		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
+	}
+	fmt.Println(">>", name)
+	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on UnitInfo", name)
+}

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -68,7 +68,7 @@ func (c *unitCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *unitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.waitForCommandBase.SetFlags(f)
-	f.StringVar(&c.query, "query", `life=="alive" && status=="active"`, "query the goal state")
+	f.StringVar(&c.query, "query", `life=="alive" && workload-status=="active"`, "query the goal state")
 	f.DurationVar(&c.timeout, "timeout", time.Minute*10, "how long to wait, before timing out")
 }
 

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/juju/cmd"
@@ -175,6 +174,5 @@ func (m UnitScope) GetIdentValue(name string) (query.Ord, error) {
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}
-	fmt.Println(">>", name)
 	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on UnitInfo", name)
 }

--- a/cmd/plugins/juju-wait-for/unit_test.go
+++ b/cmd/plugins/juju-wait-for/unit_test.go
@@ -1,0 +1,99 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/query"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+)
+
+type unitScopeSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&unitScopeSuite{})
+
+func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
+	tests := []struct {
+		Field    string
+		UnitInfo *params.UnitInfo
+		Expected query.Ord
+	}{{
+		Field:    "name",
+		UnitInfo: &params.UnitInfo{Name: "model name"},
+		Expected: query.NewString("model name"),
+	}, {
+		Field:    "application",
+		UnitInfo: &params.UnitInfo{Application: "app-name"},
+		Expected: query.NewString("app-name"),
+	}, {
+		Field:    "series",
+		UnitInfo: &params.UnitInfo{Series: "series-name"},
+		Expected: query.NewString("series-name"),
+	}, {
+		Field:    "charm-url",
+		UnitInfo: &params.UnitInfo{CharmURL: "charm-url-value"},
+		Expected: query.NewString("charm-url-value"),
+	}, {
+		Field:    "life",
+		UnitInfo: &params.UnitInfo{Life: life.Alive},
+		Expected: query.NewString("alive"),
+	}, {
+		Field:    "public-address",
+		UnitInfo: &params.UnitInfo{PublicAddress: "public-address-1"},
+		Expected: query.NewString("public-address-1"),
+	}, {
+		Field:    "private-address",
+		UnitInfo: &params.UnitInfo{PrivateAddress: "private-address-1"},
+		Expected: query.NewString("private-address-1"),
+	}, {
+		Field:    "machine-id",
+		UnitInfo: &params.UnitInfo{MachineId: "machine-id-1"},
+		Expected: query.NewString("machine-id-1"),
+	}, {
+		Field:    "principal",
+		UnitInfo: &params.UnitInfo{Principal: "principal-1"},
+		Expected: query.NewString("principal-1"),
+	}, {
+		Field:    "subordinate",
+		UnitInfo: &params.UnitInfo{Subordinate: true},
+		Expected: query.NewBool(true),
+	}, {
+		Field: "workload-status",
+		UnitInfo: &params.UnitInfo{WorkloadStatus: params.StatusInfo{
+			Current: status.Active,
+		}},
+		Expected: query.NewString("active"),
+	}, {
+		Field: "agent-status",
+		UnitInfo: &params.UnitInfo{AgentStatus: params.StatusInfo{
+			Current: status.Active,
+		}},
+		Expected: query.NewString("active"),
+	}}
+	for i, test := range tests {
+		c.Logf("%d: GetIdentValue %q", i, test.Field)
+		scope := UnitScope{
+			UnitInfo: test.UnitInfo,
+		}
+		result, err := scope.GetIdentValue(test.Field)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.DeepEquals, test.Expected)
+	}
+}
+
+func (s *unitScopeSuite) TestGetIdentValueError(c *gc.C) {
+	scope := UnitScope{
+		UnitInfo: &params.UnitInfo{},
+	}
+	result, err := scope.GetIdentValue("bad")
+	c.Assert(err, gc.ErrorMatches, `Runtime Error: identifier "bad" not found on UnitInfo: invalid identifer`)
+	c.Assert(result, gc.IsNil)
+}

--- a/cmd/plugins/juju-wait-for/waitfor.go
+++ b/cmd/plugins/juju-wait-for/waitfor.go
@@ -49,6 +49,7 @@ func NewSuperCommand() cmd.Command {
 
 	waitFor.Register(newApplicationCommand())
 	waitFor.Register(newModelCommand())
+	waitFor.Register(newUnitCommand())
 	return waitFor
 }
 

--- a/cmd/plugins/juju-wait-for/waitfor.go
+++ b/cmd/plugins/juju-wait-for/waitfor.go
@@ -48,6 +48,7 @@ func NewSuperCommand() cmd.Command {
 		Log:         &cmd.Log{}})
 
 	waitFor.Register(newApplicationCommand())
+	waitFor.Register(newMachineCommand())
 	waitFor.Register(newModelCommand())
 	waitFor.Register(newUnitCommand())
 	return waitFor


### PR DESCRIPTION
This allows for unit queries, but whilst testing unit querying I found
out that we drop the error if you mistype an identifier in a query and
there is no way to know why. The following code fixes that and as a 
bonus, we can check to see what you wanted as well.

The code is rather simple and quite a bit of copy and paste from a model
query. The difference is that the scope and the text for the command.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy mysql
$ juju wait-for unit mysql/0
```

To trigger the error message:

```sh
$ juju wait-for unit mysql/0 --query='nam == "mysql-0"'
ERROR Runtime Error: identifier "nam" not found on UnitInfo: invalid identifer

Did you mean:
        name
```
