### PR TITLE
Remove Unused "linklayerdevicesrefs" Collection

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -387,9 +387,8 @@ func allCollections() CollectionSchema {
 				{Key: []string{"model-uuid", "name"}},
 			},
 		},
-		subnetsC:              {},
-		linkLayerDevicesC:     {},
-		linkLayerDevicesRefsC: {},
+		subnetsC:          {},
+		linkLayerDevicesC: {},
 		ipAddressesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machine-id", "device-name"},
@@ -618,7 +617,6 @@ const (
 	storageInstancesC          = "storageinstances"
 	subnetsC                   = "subnets"
 	linkLayerDevicesC          = "linklayerdevices"
-	linkLayerDevicesRefsC      = "linklayerdevicesrefs"
 	ipAddressesC               = "ip.addresses"
 	toolsmetadataC             = "toolsmetadata"
 	txnLogC                    = "txns.log"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -172,7 +172,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// These are recreated whilst migrating other network entities.
 		providerIDsC,
-		linkLayerDevicesRefsC,
 
 		// Recreated whilst migrating actions.
 		actionNotificationsC,

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3225,3 +3225,17 @@ func ExposeWildcardEndpointForExposedApplications(pool *StatePool) error {
 		return nil
 	}))
 }
+
+func RemoveLinkLayerDevicesRefsCollection(pool *StatePool) error {
+	st := pool.SystemState()
+	col, closer := st.db().GetRawCollection("linklayerdevicesrefs")
+	defer closer()
+
+	// We can't test with errors.IsNotFound here.
+	err := col.DropCollection()
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+
+	return errors.Trace(err)
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -89,6 +89,7 @@ type StateBackend interface {
 	AddCharmHubToModelConfig() error
 	AddCharmOriginToApplications() error
 	ExposeWildcardEndpointForExposedApplications() error
+	RemoveLinkLayerDevicesRefsCollection() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -372,4 +373,8 @@ func (s stateBackend) AddCharmOriginToApplications() error {
 
 func (s stateBackend) ExposeWildcardEndpointForExposedApplications() error {
 	return state.ExposeWildcardEndpointForExposedApplications(s.pool)
+}
+
+func (s stateBackend) RemoveLinkLayerDevicesRefsCollection() error {
+	return state.RemoveLinkLayerDevicesRefsCollection(s.pool)
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -47,6 +47,13 @@ func stateStepsFor29() []Step {
 				return context.State().ExposeWildcardEndpointForExposedApplications()
 			},
 		},
+		&upgradeStep{
+			description: "remove unused linklayerdevicesrefs collection",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveLinkLayerDevicesRefsCollection()
+			},
+		},
 	}
 }
 

--- a/upgrades/steps_29_test.go
+++ b/upgrades/steps_29_test.go
@@ -57,6 +57,11 @@ func (s *steps29Suite) TestExposeWildcardEndpointForExposedApplications(c *gc.C)
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 
+func (s *steps29Suite) TestRemoveLinkLayerDevicesRefsCollection(c *gc.C) {
+	step := findStateStep(c, v290, "remove unused linklayerdevicesrefs collection")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}
+
 type mergeAgents29Suite struct {
 	testing.BaseSuite
 


### PR DESCRIPTION
Removes `linklayerdevicesrefs` from the Juju collection list and adds an upgrade step to remove it from MongoDB when upgrading. 

Usage of this collection was removed some time ago.

## QA steps

- Using 2.8 `juju bootstrap lxd test`.
- With this patch `juju upgrade-controller --build-agent`.
- Connect to Mongo and run `show collections` and ensure that the collection is absent.

## Documentation changes

None.

## Bug reference

N/A
