### PR TITLE
Download charm/bundle refinements

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -214,7 +214,7 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 		revision, found = info.DefaultRelease.Revision, true
 	} else if serie := info.DefaultRelease.Channel.Platform.Series; serie != c.series {
 		// Define a specialized message for when the default release is
-		return errors.Errorf("%s %q not found for the default release %q using %s", info.Type, c.charmOrBundle, serie, c.series)
+		return errors.Errorf("%s %q not found for the default release series %q matching %q", info.Type, c.charmOrBundle, serie, c.series)
 	}
 
 	if !found {

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -158,17 +158,22 @@ func (s *downloadSuite) expectInfo(charmHubURL string) {
 	s.charmHubClient.EXPECT().Info(gomock.Any(), "test").Return(transport.InfoResponse{
 		Type: "charm",
 		Name: "test",
-		DefaultRelease: transport.ChannelMap{
+		ChannelMap: []transport.ChannelMap{{
 			Channel: transport.Channel{
+				Name:  "a",
 				Track: "latest",
 				Risk:  "stable",
+				Platform: transport.Platform{
+					Series: "xenial",
+				},
 			},
 			Revision: transport.Revision{
+				Revision: 1,
 				Download: transport.Download{
 					URL: charmHubURL,
 				},
 			},
-		},
+		}},
 	}, nil)
 }
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -159,6 +159,10 @@ func (s *downloadSuite) expectInfo(charmHubURL string) {
 		Type: "charm",
 		Name: "test",
 		DefaultRelease: transport.ChannelMap{
+			Channel: transport.Channel{
+				Track: "latest",
+				Risk:  "stable",
+			},
 			Revision: transport.Revision{
 				Download: transport.Download{
 					URL: charmHubURL,

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -70,6 +70,15 @@ func MakeChannel(track, risk, branch string) (Channel, error) {
 	}, nil
 }
 
+// MustParseChannel parses a given string or returns a panic.
+func MustParseChannel(s string) Channel {
+	c, err := ParseChannel(s)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
 // ParseChannel parses a string representing a store channel.
 // The returned channel's track, risk and name are normalized.
 func ParseChannel(s string) (Channel, error) {

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438
+	github.com/juju/os v0.0.0-20201007123315-6372fe69ac0a
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
+github.com/juju/os v0.0.0-20201007123315-6372fe69ac0a h1:ZcagY5abiUiq9nUXbbzI000CQxLkF8QrhCsmXHZfkOc=
+github.com/juju/os v0.0.0-20201007123315-6372fe69ac0a/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=


### PR DESCRIPTION
Update the new charmhub download charm/bundle with the following
two features:

#### Pipe to stdout

Allow a charm to be piped to stdout if an additional hyphen argument is
passed. This follows the same pattern as config and other UNIX type
commands.

The code is really simple as we can use the FileSystem interface to
inject a new `*os.File` that points to the stdout pointer. Using that then
allows us to use

#### Download a charm by either the channel or series

The following allows you to download a charm via a channel or series.
It's rather complicated to work out the right series by default and how
to correctly order them. Essentially we needed to order the controller
series (which essentially is all ubuntu releases) by the order of the
release (focal, bionic, xenial, etc). Then we order the resulting
channel map so that it aligns with that ordering, so that if no series
is defined, then you get an expected outcome.

## QA steps

#### Download a charm to stdout.

```sh
$ juju bootstrap lxd test
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju download ubuntu-qa - > /tmp/charm.zip
Fetching charm "ubuntu-qa"
```

#### Download a charm via channel/series

```sh
$ juju bootstrap lxd test
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"
```

##### Full channel

```
$ juju download --channel=latest/stable ubuntu-qa
Fetching charm "ubuntu-qa"
Install the "ubuntu-qa" charm with:
    juju deploy ./ubuntu-qa.charm
```

##### Track channel

```sh
$ juju download --channel=latest ubuntu-qa
Fetching charm "ubuntu-qa"
Install the "ubuntu-qa" charm with:
    juju deploy ./ubuntu-qa.charm
```

##### Risk channel

```sh
$ juju download --channel=stable ubuntu-qa
Fetching charm "ubuntu-qa"
Install the "ubuntu-qa" charm with:
    juju deploy ./ubuntu-qa.charm
```

##### Invalid channel

```sh
juju download --channel=other/bad ubuntu-qa
ERROR risk in channel "other/bad" not valid
```

##### No track for channel

```sh
$ juju download --channel=other ubuntu-qa
ERROR charm "ubuntu-qa" not found with in the channel "other"
```

##### Default release series with no channel

This is a bit weird because we don't specify a channel, I don't
know which one to use, so I'm using the default release here.

```sh
$ juju download --series=xenial ubuntu-qa
Fetching charm "ubuntu-qa"
Install the "ubuntu-qa" charm with:
    juju deploy ./ubuntu-qa.charm
```

##### Default release series with no channel with no match

If we try and specify a series for the default release then it will
complain.

```sh
$ juju download --series=focal ubuntu-qa
ERROR charm "ubuntu-qa" not found for "latest/stable" channel matching "trusty" series
```

##### Series with channel

So you can download focal if you specify the channel.

```sh
$ juju download --channel=latest/stable --series=focal ubuntu-qa
Fetching charm "ubuntu-qa"
Install the "ubuntu-qa" charm with:
    juju deploy ./ubuntu-qa.charm
```
