### PR TITLE
Move DefaultSupportedLTS to juju

### DIFF
--- a/cmd/juju/application/deployer/series_selector.go
+++ b/cmd/juju/application/deployer/series_selector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
+	"github.com/juju/juju/version"
 )
 
 const (
@@ -111,7 +111,7 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 		return "", err
 	}
 
-	latestLTS := series.DefaultSupportedLTS()
+	latestLTS := version.DefaultSupportedLTS()
 	logger.Infof(msgLatestLTSSeries, latestLTS)
 	return latestLTS, nil
 }

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/os/series"
 	"github.com/juju/utils/v2/arch"
 
 	"github.com/juju/juju/caas"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/version"
 )
 
 func prepare(context *cmd.Context, controllerName string, store jujuclient.ClientStore) (environs.Environ, error) {
@@ -157,7 +157,7 @@ func (c *imageMetadataCommand) setParams(context *cmd.Context) error {
 		logger.Infof("no model found, creating image metadata using user supplied data")
 	}
 	if c.Series == "" {
-		c.Series = series.DefaultSupportedLTS()
+		c.Series = version.DefaultSupportedLTS()
 	}
 	if c.ImageId == "" {
 		return errors.Errorf("image id must be specified")

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/logfwd/syslog"
 	"github.com/juju/juju/network"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.environs.config")
@@ -456,7 +457,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":              series.DefaultSupportedLTS(),
+	"default-series":              jujuversion.DefaultSupportedLTS(),
 	ProvisionerHarvestModeKey:     HarvestDestroyed.String(),
 	ResourceTagsKey:               "",
 	"logging-config":              "",

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -220,7 +220,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	// we could connect to (actual live tests, rather than local-only)
 	cons := constraints.MustParse("mem=2G")
 	if t.CanOpenState {
-		_, err := sync.Upload(t.toolsStorage, "released", nil, series.DefaultSupportedLTS())
+		_, err := sync.Upload(t.toolsStorage, "released", nil, jujuversion.DefaultSupportedLTS())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	args := t.bootstrapParams()
@@ -676,7 +676,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	expectedVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.DefaultSupportedLTS(),
+		Series: jujuversion.DefaultSupportedLTS(),
 	}
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -317,7 +317,7 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := series.DefaultSupportedLTS()
+	defaultSeries := jujuversion.DefaultSupportedLTS()
 	if series.MustHostSeries() != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
+	"github.com/juju/juju/version"
 )
 
 type RepoSuite struct {
@@ -24,7 +24,7 @@ type RepoSuite struct {
 func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	// Change the environ's config to ensure we're using the one in state.
-	updateAttrs := map[string]interface{}{"default-series": series.DefaultSupportedLTS()}
+	updateAttrs := map[string]interface{}{"default-series": version.DefaultSupportedLTS()}
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	"github.com/juju/pubsub"
 	"github.com/juju/retry"
 	"github.com/juju/schema"
@@ -81,6 +80,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/lease"
 	"github.com/juju/juju/worker/modelcache"
@@ -121,7 +121,7 @@ func SampleConfig() testing.Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            series.DefaultSupportedLTS(),
+		"default-series":            jujuversion.DefaultSupportedLTS(),
 		"default-space":             "",
 		"secret":                    "pork",
 		"controller":                true,

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -8,10 +8,10 @@ import (
 	"path"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 
 	"github.com/juju/juju/cloud"
 	jujupaths "github.com/juju/juju/core/paths"
+	"github.com/juju/juju/version"
 )
 
 // ReadLegacyCloudCredentials reads cloud credentials off disk for an old
@@ -22,7 +22,7 @@ import (
 // satisfying errors.IsNotFound will be returned.
 func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
 	var (
-		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(series.DefaultSupportedLTS()))
+		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(version.DefaultSupportedLTS()))
 		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
 		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
 		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 	"github.com/juju/utils/v2"
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/paths"
+	"github.com/juju/juju/version"
 )
 
 // extractSystemId extracts the 'system_id' part from an InstanceId.
@@ -48,7 +48,7 @@ type machineInfo struct {
 	Hostname string `yaml:",omitempty"`
 }
 
-var maasDataDir = paths.MustSucceed(paths.DataDir(series.DefaultSupportedLTS()))
+var maasDataDir = paths.MustSucceed(paths.DataDir(version.DefaultSupportedLTS()))
 var _MAASInstanceFilename = path.Join(maasDataDir, "MAASmachine.txt")
 
 // cloudinitRunCmd returns the shell command that, when run, will create the

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // FakeAuthKeys holds the authorized key used for testing
@@ -34,7 +34,7 @@ func init() {
 var (
 	// FakeSupportedJujuSeries is used to provide a series of canned results
 	// of series to test bootstrap code against.
-	FakeSupportedJujuSeries = set.NewStrings("precise", "trusty", "quantal", "bionic", series.DefaultSupportedLTS())
+	FakeSupportedJujuSeries = set.NewStrings("precise", "trusty", "quantal", "bionic", jujuversion.DefaultSupportedLTS())
 )
 
 // FakeVersionNumber is a valid version number that can be used in testing.
@@ -46,7 +46,7 @@ var ModelTag = names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 // ControllerTag is a defined known valid UUID that can be used in testing.
 var ControllerTag = names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 
-// FakeControllerConfig() returns an environment configuration
+// FakeControllerConfig returns an environment configuration
 // that is expected to be found in state for a fake controller.
 func FakeControllerConfig() controller.Config {
 	return controller.Config{
@@ -66,7 +66,7 @@ func FakeControllerConfig() controller.Config {
 	}
 }
 
-// FakeConfig() returns an environment configuration for a
+// FakeConfig returns an environment configuration for a
 // fake provider with all required attributes set.
 func FakeConfig() Attrs {
 	return Attrs{
@@ -77,7 +77,7 @@ func FakeConfig() Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            series.DefaultSupportedLTS(),
+		"default-series":            jujuversion.DefaultSupportedLTS(),
 	}
 }
 

--- a/version/series.go
+++ b/version/series.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+// DefaultSupportedLTS returns the latest LTS that Juju supports and is
+// compatible with.
+func DefaultSupportedLTS() string {
+	return "bionic"
+}

--- a/version/series_test.go
+++ b/version/series_test.go
@@ -1,0 +1,20 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type seriesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&seriesSuite{})
+
+func (s *seriesSuite) TestDefaultSupportedLTS(c *gc.C) {
+	name := DefaultSupportedLTS()
+	c.Assert(name, gc.Equals, "bionic")
+}


### PR DESCRIPTION
Juju should be locked stepped with the default supported LTS and not
depend on an external package. This forces Juju to understand that when
a new LTS is updated and that we depend on that LTS then it should be
correctly updated when we do a release.

Unfortunately, we missed the default LTS for 2.8 and are instead doing it
in 2.9, with these changes, we should be in a better chance to spot that.

This PR does not update the default from bionic to focal, that will come
in a subsequent PR.

## QA steps

Only mechanical change from `juju/series` to `juju/juju`, so all tests should
pass.
