### PR TITLE
Fix juju ssh for k8s operators

### DIFF
--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -170,8 +170,8 @@ func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 		providerID, err = k8sprovider.GetOperatorPodName(
 			podAPI,
 			c.execClient.RawClient().CoreV1().Namespaces(),
-			c.execClient.NameSpace(),
 			appName,
+			c.execClient.NameSpace(),
 		)
 
 		if err != nil {

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -126,7 +126,7 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPod(c *gc.C) {
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "mariadb-k8s-operator-0"}},
 			}}, nil),
@@ -146,7 +146,7 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPodNoProviderID(c *gc.C)
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: ""}},
 			}}, nil),
@@ -447,7 +447,7 @@ func (s *sshContainerSuite) TestCopyToOperator(c *gc.C) {
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "mariadb-k8s-operator-0"}},
 			}}, nil),
@@ -478,7 +478,7 @@ func (s *sshContainerSuite) TestCopyFromOperator(c *gc.C) {
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
-		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=test-ns,operator.juju.is/target=application"}).AnyTimes().
+		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
 			Return(&core.PodList{Items: []core.Pod{
 				{ObjectMeta: metav1.ObjectMeta{Name: "mariadb-k8s-operator-0"}},
 			}}, nil),


### PR DESCRIPTION
juju ssh to k8s operator pods was broken due to 2 parameters being swapped.
And the unit tests tested the wrong behaviour.

## QA steps

Deploy a k8s charm
juju ssh mariadb-k8s/0

(would fail previously)

