### PR TITLE
Merge 2.8 branch

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -590,7 +590,7 @@ func (n *NetworkInfo) pollForAddress(
 func spaceAddressesFromNetworkInfo(netInfos []network.NetworkInfo) corenetwork.SpaceAddresses {
 	var addrs corenetwork.SpaceAddresses
 	for _, nwInfo := range netInfos {
-		scope := corenetwork.ScopeCloudLocal
+		scope := corenetwork.ScopeUnknown
 		if strings.HasPrefix(nwInfo.InterfaceName, "fan-") {
 			scope = corenetwork.ScopeFanLocal
 		}

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -40,10 +40,15 @@ func fileSetsV2ToFileSets(fs []specs.FileSetV2) (out []specs.FileSet) {
 			Name:      f.Name,
 			MountPath: f.MountPath,
 		}
-		for k, v := range f.Files {
+
+		// We sort the keys of the files here to get a deterministic ordering.
+		// See lp:1895598
+		keys := specs.SortKeysForFiles(f.Files)
+
+		for _, k := range keys {
 			newf.Files = append(newf.Files, specs.File{
 				Path:    k,
-				Content: v,
+				Content: f.Files[k],
 			})
 		}
 		out = append(out, newf)

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -91,6 +91,9 @@ containers:
           file1: |
             [config]
             foo: bar
+          file: |
+            [config]
+            foo: bar
   - name: gitlab-helper
     image: gitlab-helper/latest
     ports:
@@ -401,6 +404,7 @@ echo "do some stuff here for gitlab container"
 						MountPath: "/var/lib/foo",
 						VolumeSource: specs.VolumeSource{
 							Files: []specs.File{
+								{Path: "file", Content: expectedFileContent},
 								{Path: "file1", Content: expectedFileContent},
 							},
 						},
@@ -495,7 +499,6 @@ echo "do some stuff here for gitlab-init container"
 						AutomountServiceAccountToken: boolPtr(true),
 						Roles: []specs.Role{
 							{
-								Name:   "k8sServiceAccount1",
 								Global: true,
 								Rules: []specs.PolicyRule{
 									{
@@ -870,7 +873,7 @@ serviceAccount:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `rules is required`)
+	c.Assert(err, gc.ErrorMatches, `invalid primary service account: rules is required`)
 }
 
 func (s *v2SpecsSuite) TestValidateCustomResourceDefinitions(c *gc.C) {

--- a/caas/requirements.txt
+++ b/caas/requirements.txt
@@ -2,3 +2,4 @@ pip>=7.0.0,<8.2.0
 charmhelpers>=0.20.15,<1.0.0
 charms.reactive>=0.1.0,<2.0.0
 kubernetes==10.0.*
+google_auth>=1.21.0,<1.22.0

--- a/caas/specs/filesets.go
+++ b/caas/specs/filesets.go
@@ -6,6 +6,7 @@ package specs
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/juju/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -52,6 +53,17 @@ func (fs FileSet) EqualVolume(another FileSet) bool {
 		return false
 	}
 	return true
+}
+
+// SortKeysForFiles returns a slice of all the keys for a given files map
+// sorted in increasing order as per sort.String
+func SortKeysForFiles(f map[string]string) []string {
+	keys := make([]string, 0, len(f))
+	for k := range f {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // Validate validates FileSet.

--- a/caas/specs/filesets_test.go
+++ b/caas/specs/filesets_test.go
@@ -4,6 +4,7 @@
 package specs_test
 
 import (
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas/specs"
@@ -310,5 +311,32 @@ func (s *typesSuite) TestValidateFileSetVolumeSource(c *gc.C) {
 	} {
 		c.Logf("#%d: testing VolumeSource.Validate", i)
 		c.Check(tc.spec.Validate("fakeFileSet"), gc.ErrorMatches, tc.errStr)
+	}
+}
+
+func (s *typesSuite) TestSortKeysForFiles(c *gc.C) {
+	tests := []struct {
+		Files        map[string]string
+		ExpectedKeys []string
+	}{
+		{
+			Files: map[string]string{
+				"foo": "bar",
+				"tt":  "ff",
+			},
+			ExpectedKeys: []string{"foo", "tt"},
+		},
+		{
+			Files: map[string]string{
+				"tt":  "ff",
+				"foo": "bar",
+			},
+			ExpectedKeys: []string{"foo", "tt"},
+		},
+	}
+
+	for _, test := range tests {
+		keys := specs.SortKeysForFiles(test.Files)
+		c.Assert(keys, jc.DeepEquals, test.ExpectedKeys)
 	}
 }

--- a/caas/specs/v3.go
+++ b/caas/specs/v3.go
@@ -23,7 +23,6 @@ func (spec *PodSpecV3) Validate() error {
 		return errors.Trace(err)
 	}
 	if spec.ServiceAccount != nil {
-		// TODO: do we want to restrict the prime sa can only have 1 role/clusterrole???????
 		return errors.Trace(spec.ServiceAccount.Validate())
 	}
 	return nil

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -102,6 +102,7 @@ func (c *Client) lister(ref types.ManagedObjectReference) *list.Lister {
 // return the pointer for the same folder, and should also deal with
 // the case where folderPath is nil or empty.
 func (c *Client) FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error) {
+	c.logger.Tracef("FindFolder() path=%q", folderPath)
 	if strings.Contains(folderPath, "..") {
 		// ".." not supported as per:
 		// https://github.com/vmware/govmomi/blob/master/find/finder.go#L114
@@ -155,6 +156,7 @@ func (c *Client) finder(ctx context.Context) (*find.Finder, *object.Datacenter, 
 // RemoveVirtualMachines removes VMs matching the given path from the
 // system. The path may include wildcards, to match multiple VMs.
 func (c *Client) RemoveVirtualMachines(ctx context.Context, path string) error {
+	c.logger.Tracef("RemoveVirtualMachines() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -215,6 +217,7 @@ func (c *Client) RemoveVirtualMachines(ctx context.Context, path string) error {
 
 // VirtualMachines return list of all VMs in the system matching the given path.
 func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.VirtualMachine, error) {
+	c.logger.Tracef("VirtualMachines() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -242,6 +245,7 @@ func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.Virtua
 // ComputeResources returns a slice of all compute resources in the datacenter,
 // along with a slice of each compute resource's full path.
 func (c *Client) ComputeResources(ctx context.Context) ([]ComputeResource, error) {
+	c.logger.Tracef("ComputeResources()")
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -294,6 +298,7 @@ func (c *Client) computeResourcesFromRef(ctx context.Context, ref types.ManagedO
 
 // Folders returns the datacenter's folders object.
 func (c *Client) Folders(ctx context.Context) (*object.DatacenterFolders, error) {
+	c.logger.Tracef("Folders()")
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -307,6 +312,7 @@ func (c *Client) Folders(ctx context.Context) (*object.DatacenterFolders, error)
 
 // Datastores returns list of all datastores in the system.
 func (c *Client) Datastores(ctx context.Context) ([]mo.Datastore, error) {
+	c.logger.Tracef("Datastores()")
 	finder, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -344,6 +350,7 @@ func (c *Client) Datastores(ctx context.Context) ([]mo.Datastore, error) {
 // ResourcePools returns a list of all of the resource pools (possibly
 // nested) under the given path.
 func (c *Client) ResourcePools(ctx context.Context, path string) ([]*object.ResourcePool, error) {
+	c.logger.Tracef("ResourcePools() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -365,7 +372,7 @@ func (c *Client) ResourcePools(ctx context.Context, path string) ([]*object.Reso
 // whereas parentFolderName is the subfolder in DC's root-folder.
 // The parentFolderName will fallback to DC's root-folder if it's an empty string.
 func (c *Client) EnsureVMFolder(ctx context.Context, parentFolderName string, relativeFolderPath string) (*object.Folder, error) {
-
+	c.logger.Tracef("EnsureVMFolder() parent=%q, rel=%q", parentFolderName, relativeFolderPath)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -409,6 +416,7 @@ func (c *Client) EnsureVMFolder(ctx context.Context, parentFolderName string, re
 
 // DestroyVMFolder destroys a folder(folderPath could be either relative path of vmfolder of datacenter or full path).
 func (c *Client) DestroyVMFolder(ctx context.Context, folderPath string) error {
+	c.logger.Tracef("DestroyVMFolder() path=%q", folderPath)
 	folder, err := c.FindFolder(ctx, folderPath)
 	if errors.IsNotFound(err) {
 		return nil
@@ -430,6 +438,7 @@ func (c *Client) DestroyVMFolder(ctx context.Context, folderPath string) error {
 
 // MoveVMFolderInto moves one VM folder into another.
 func (c *Client) MoveVMFolderInto(ctx context.Context, parentPath, childPath string) error {
+	c.logger.Tracef("MoveVMFolderInto() parent=%q, child=%q", parentPath, childPath)
 	parent, err := c.FindFolder(ctx, parentPath)
 	if err != nil {
 		return errors.Trace(err)
@@ -455,6 +464,7 @@ func (c *Client) MoveVMsInto(
 	folderPath string,
 	vms ...types.ManagedObjectReference,
 ) error {
+	c.logger.Tracef("MoveVMsInto() path=%q, vms=%v", folderPath, vms)
 	folder, err := c.FindFolder(ctx, folderPath)
 	if err != nil {
 		return errors.Trace(err)
@@ -479,6 +489,8 @@ func (c *Client) UpdateVirtualMachineExtraConfig(
 	vmInfo *mo.VirtualMachine,
 	metadata map[string]string,
 ) error {
+	c.logger.Tracef("UpdateVirtualMachineExtraConfig() vmInfo.Name=%q, metadata=%v",
+		vmInfo.Name, metadata)
 	var spec types.VirtualMachineConfigSpec
 	for k, v := range metadata {
 		opt := &types.OptionValue{Key: k, Value: v}
@@ -497,6 +509,7 @@ func (c *Client) UpdateVirtualMachineExtraConfig(
 
 // DeleteDatastoreFile deletes a file or directory in the datastore.
 func (c *Client) DeleteDatastoreFile(ctx context.Context, datastorePath string) error {
+	c.logger.Tracef("DeleteDatastoreFile() path=%q", datastorePath)
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -724,6 +737,7 @@ func isManagedObjectNotFound(err error) bool {
 // UserHasRootLevelPrivilege returns whether the connected user has the
 // specified privilege on the root-level object.
 func (c *Client) UserHasRootLevelPrivilege(ctx context.Context, privilege string) (bool, error) {
+	c.logger.Tracef("UserHasRootLevelPrivilege() privilege=%q", privilege)
 	session, err := c.client.SessionManager.UserSession(ctx)
 	if err != nil {
 		return false, errors.Annotate(err, "getting user session")

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -168,7 +168,6 @@ func (c *Client) ensureTemplateVM(
 	datastore *object.Datastore,
 	args CreateVirtualMachineParams,
 ) (vm *object.VirtualMachine, err error) {
-
 	templateFolder, err := c.FindFolder(ctx, path.Join(args.RootVMFolder, vmTemplatePath(args)))
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
@@ -309,6 +308,7 @@ func (c *Client) CreateVirtualMachine(
 	ctx context.Context,
 	args CreateVirtualMachineParams,
 ) (_ *mo.VirtualMachine, err error) {
+	c.logger.Tracef("CreateVirtualMachine() args.Name=%q", args.Name)
 	_, datacenter, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -422,20 +422,28 @@ func (c *Client) createImportSpec(
 	args CreateVirtualMachineParams,
 	datastore *object.Datastore,
 ) (*types.OvfCreateImportSpecResult, error) {
-	c.logger.Debugf("Creating import spec")
 	cisp := types.OvfCreateImportSpecParams{
 		EntityName: vmTemplateName(args),
 	}
+	c.logger.Debugf("Creating import spec: pool=%q, datastore=%q, entity=%q",
+		args.ResourcePool, datastore, cisp.EntityName)
 
 	c.logger.Debugf("Fetching OVF manager")
 	ovfManager := ovf.NewManager(c.client.Client)
 	spec, err := ovfManager.CreateImportSpec(ctx, UbuntuOVF, args.ResourcePool, datastore, cisp)
-	c.logger.Debugf("ImportSpec built")
 	if err != nil {
+		c.logger.Debugf("CreateImportSpec error: err=%v", err)
 		return nil, errors.Trace(err)
-	} else if spec.Error != nil {
-		return nil, errors.New(spec.Error[0].LocalizedMessage)
+	} else if len(spec.Error) > 0 {
+		messages := make([]string, len(spec.Error))
+		for i, e := range spec.Error {
+			messages[i] = e.LocalizedMessage
+		}
+		message := strings.Join(messages, "\n")
+		c.logger.Debugf("CreateImportSpec fault: messages=%s", message)
+		return nil, errors.New(message)
 	}
+	c.logger.Debugf("CreateImportSpec succeeded")
 	return spec, nil
 }
 

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1253,6 +1253,10 @@ func (s *backingStatus) updateApplicationWorkload(ctx *allWatcherContext, unit *
 		Name:      unit.Application,
 	}
 	info0 := ctx.store.Get(appInfo.EntityID())
+	if info0 == nil {
+		// The parent info doesn't exist. Ignore the workload until it does.
+		return
+	}
 	appInfo = info0.(*multiwatcher.ApplicationInfo)
 	updated := *appInfo
 	updated.WorkloadVersion = s.StatusInfo
@@ -1332,7 +1336,7 @@ func (c *backingConstraints) updated(ctx *allWatcherContext) error {
 	info0 := ctx.store.Get(parentID)
 	switch info := info0.(type) {
 	case nil:
-		// The parent info doesn't exist. Ignore the status until it does.
+		// The parent info doesn't exist. Ignore the constraints until it does.
 		return nil
 	case *multiwatcher.UnitInfo, *multiwatcher.MachineInfo:
 		// We don't (yet) publish unit or machine constraints.

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2240,6 +2240,34 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 		},
 		func(c *gc.C, st *State) changeTestCase {
 			app := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
+			unit, err := app.AddUnit(AddUnitParams{})
+			c.Assert(err, jc.ErrorIsNil)
+			err = unit.SetWorkloadVersion("42.47")
+			c.Assert(err, jc.ErrorIsNil)
+			return changeTestCase{
+				about: "workload version is ignored if there is no application info",
+				initialContents: []multiwatcher.EntityInfo{
+					&multiwatcher.UnitInfo{
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+					},
+				},
+				change: watcher.Change{
+					C:  "statuses",
+					Id: st.docID("u#" + unit.Name() + "#charm#sat#workload-version"),
+				},
+				expectContents: []multiwatcher.EntityInfo{
+					&multiwatcher.UnitInfo{
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress/0",
+						Application: "wordpress",
+					},
+				},
+			}
+		},
+		func(c *gc.C, st *State) changeTestCase {
+			app := AddTestingApplication(c, st, "wordpress", AddTestingCharm(c, st, "wordpress"))
 			setApplicationConfigAttr(c, app, "blog-title", "boring")
 
 			return changeTestCase{

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -239,16 +239,21 @@ func (b *Bindings) updateOps(txnRevno int64, newMap map[string]string, newMeta *
 	}
 
 	// Ensure that the spaceIDs needed for the bindings exist.
+	spIdMap := set.NewStrings()
 	for _, spID := range b.Map() {
 		sp, err := b.st.Space(spID)
 		if err != nil {
 			return ops, errors.Trace(err)
+		}
+		if spIdMap.Contains(spID) {
+			continue
 		}
 		ops = append(ops, txn.Op{
 			C:      spacesC,
 			Id:     sp.doc.DocId,
 			Assert: txn.DocExists,
 		})
+		spIdMap.Add(spID)
 	}
 
 	// To avoid a potential race where units may suddenly appear on a new

--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -25,7 +25,7 @@ import (
 type LeadershipContextFunc func(accessor context.LeadershipSettingsAccessor, tracker leadership.Tracker, unitName string) context.LeadershipContext
 
 // RelationStateTrackerConfig contains configuration values for creating a new
-// RlationStateTracker instance.
+// RelationStateTracker instance.
 type RelationStateTrackerConfig struct {
 	State                *uniter.State
 	Unit                 *uniter.Unit

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
@@ -28,6 +29,7 @@ var logger interface{}
 // Logger represents the logging methods used in this package.
 type Logger interface {
 	Errorf(string, ...interface{})
+	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
 }
 
@@ -67,6 +69,13 @@ func Loop(cfg LoopConfig, localState *LocalState) error {
 
 	// Initialize charmdir availability before entering the loop in case we're recovering from a restart.
 	err := updateCharmDir(cfg.Executor.State(), cfg.CharmDirGuard, cfg.Abort, cfg.Logger)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// If we're restarting the loop, ensure any pending charm upgrade is run
+	// before continuing.
+	err = checkCharmUpgrade(cfg.Logger, cfg.Watcher.Snapshot(), rf, cfg.Executor)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -166,4 +175,54 @@ func updateCharmDir(opState operation.State, guard fortress.Guard, abort fortres
 	} else {
 		return guard.Lockdown(abort)
 	}
+}
+
+func checkCharmUpgrade(logger Logger, remote remotestate.Snapshot, rf *resolverOpFactory, ex operation.Executor) error {
+	// If we restarted due to error with a pending charm upgrade available,
+	// do the upgrade now.  There are cases (lp:1895040) where the error was
+	// caused because not all units were upgraded before relation-created
+	// hooks were attempted for peer relations.  Do this before the remote
+	// state watcher is started.  It will not trigger an upgrade, until the
+	// next applicationChanged event.  Could get stuck in an error loop.
+
+	local := rf.LocalState
+	local.State = ex.State()
+
+	// If the unit isn't started or already upgrading, no need to start an upgrade.
+	if !local.State.Started || local.State.Kind == operation.Upgrade ||
+		(local.State.Hook != nil && local.State.Hook.Kind == hooks.UpgradeCharm) ||
+		remote.CharmURL == nil {
+		return nil
+	}
+
+	if *local.CharmURL == *remote.CharmURL {
+		return nil
+	}
+
+	if remote.CharmProfileRequired {
+		if remote.LXDProfileName == "" {
+			return nil
+		}
+		rev, err := lxdprofile.ProfileRevision(remote.LXDProfileName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if rev != remote.CharmURL.Revision {
+			logger.Tracef("Charm profile required: current revision %d does not match new revision %d", rev, remote.CharmURL.Revision)
+			return nil
+		}
+	}
+
+	logger.Debugf("execute pending upgrade from %s to %s after uniter loop restart", local.CharmURL, remote.CharmURL)
+	op, err := rf.NewUpgrade(remote.CharmURL)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err = ex.Run(op, nil); err != nil {
+		return errors.Trace(err)
+	}
+	if local.Restart {
+		return ErrRestart
+	}
+	return nil
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -271,7 +271,6 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 }
 
 func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
-
 	defer func() {
 		// If this is a CAAS unit, then dead errors are fairly normal ways to exit
 		// the uniter main loop, but the parent operator agent needs to keep running.
@@ -302,48 +301,9 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	}
 	u.logger.Infof("unit %q started", u.unit)
 
-	// Install is a special case, as it must run before there
-	// is any remote state, and before the remote state watcher
-	// is started.
-	var charmURL *corecharm.URL
-	var charmModifiedVersion int
-	var canApplyCharmProfile bool
-	opState := u.operationExecutor.State()
-	if opState.Kind == operation.Install {
-		u.logger.Infof("resuming charm install")
-		canApplyCharmProfile, err = u.unit.CanApplyLXDProfile()
-		if err != nil {
-			return err
-		}
-		if canApplyCharmProfile {
-			// Note: canApplyCharmProfile will be false for a CAAS model.
-			// Verify the charm profile before proceeding.
-			if err := u.verifyCharmProfile(opState.CharmURL); err != nil {
-				return err
-			}
-		}
-		op, err := u.operationFactory.NewInstall(opState.CharmURL)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if err := u.operationExecutor.Run(op, nil); err != nil {
-			return errors.Trace(err)
-		}
-		charmURL = opState.CharmURL
-	} else {
-		curl, err := u.unit.CharmURL()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		charmURL = curl
-		app, err := u.unit.Application()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		charmModifiedVersion, err = app.CharmModifiedVersion()
-		if err != nil {
-			return errors.Trace(err)
-		}
+	canApplyCharmProfile, charmURL, charmModifiedVersion, err := u.charmState()
+	if err != nil {
+		return err
 	}
 
 	var watcher *remotestate.RemoteStateWatcher
@@ -376,7 +336,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	restartWatcher := func() error {
 		if watcher != nil {
 			// watcher added to catacomb, will kill uniter if there's an error.
-			worker.Stop(watcher)
+			_ = worker.Stop(watcher)
 		}
 		var err error
 		watcher, err = remotestate.NewWatcher(
@@ -424,12 +384,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		return nil
 	}
 
-	var rebootDetected bool
-	if u.modelType == model.IAAS {
-		if rebootDetected, err = u.rebootQuerier.Query(unitTag); err != nil {
-			return errors.Annotatef(err, "could not check reboot status for %q", unitTag)
-		}
-	} else if u.modelType == model.CAAS && u.isRemoteUnit {
+	if u.modelType == model.CAAS && u.isRemoteUnit {
 		if u.containerRunningStatusChannel == nil {
 			return errors.NotValidf("ContainerRunningStatusChannel missing for CAAS remote unit")
 		}
@@ -438,10 +393,18 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		}
 	}
 
+	var rebootDetected bool
+
 	for {
 		if err = restartWatcher(); err != nil {
 			err = errors.Annotate(err, "(re)starting watcher")
 			break
+		}
+
+		if u.modelType == model.IAAS {
+			if rebootDetected, err = u.rebootQuerier.Query(unitTag); err != nil {
+				return errors.Annotatef(err, "could not check reboot status for %q", unitTag)
+			}
 		}
 
 		cfg := ResolverConfig{
@@ -496,6 +459,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			// CAAS remote units should trigger remote update of the charm every start.
 			OutdatedRemoteCharm: u.isRemoteUnit,
 		}
+
 		for err == nil {
 			err = resolver.Loop(resolver.LoopConfig{
 				Resolver:      uniterResolver,
@@ -528,6 +492,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				// creating LocalState.
 				charmURL = localState.CharmURL
 				charmModifiedVersion = localState.CharmModifiedVersion
+
 				// leave err assigned, causing loop to break
 			default:
 				// We need to set conflicted from here, because error
@@ -592,6 +557,65 @@ func (u *Uniter) verifyCharmProfile(curl *corecharm.URL) error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// charmState returns data for the local state setup.
+// While gathering the data, look for interrupted Install or pending
+// charm upgrade, execute if found.
+func (u *Uniter) charmState() (bool, *corecharm.URL, int, error) {
+	// Install is a special case, as it must run before there
+	// is any remote state, and before the remote state watcher
+	// is started.
+	var charmURL *corecharm.URL
+	var charmModifiedVersion int
+
+	canApplyCharmProfile, err := u.unit.CanApplyLXDProfile()
+	if err != nil {
+		return canApplyCharmProfile, charmURL, charmModifiedVersion, err
+	}
+
+	opState := u.operationExecutor.State()
+	if opState.Kind == operation.Install {
+		u.logger.Infof("resuming charm install")
+		if canApplyCharmProfile {
+			// Note: canApplyCharmProfile will be false for a CAAS model.
+			// Verify the charm profile before proceeding.
+			if err := u.verifyCharmProfile(opState.CharmURL); err != nil {
+				return canApplyCharmProfile, charmURL, charmModifiedVersion, err
+			}
+		}
+		op, err := u.operationFactory.NewInstall(opState.CharmURL)
+		if err != nil {
+			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
+		}
+		if err := u.operationExecutor.Run(op, nil); err != nil {
+			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
+		}
+		charmURL = opState.CharmURL
+		return canApplyCharmProfile, charmURL, charmModifiedVersion, nil
+	}
+
+	// No install needed, find the curl and start.
+	curl, err := u.unit.CharmURL()
+	if err != nil {
+		return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
+	}
+	charmURL = curl
+	app, err := u.unit.Application()
+	if err != nil {
+		return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
+	}
+
+	// TODO (hml) 25-09-2020 - investigate
+	// This assumes that the uniter is not restarting after an application
+	// changed notification, with changes to CharmModifiedVersion, but before
+	// it could be acted on.
+	charmModifiedVersion, err = app.CharmModifiedVersion()
+	if err != nil {
+		return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
+	}
+
+	return canApplyCharmProfile, charmURL, charmModifiedVersion, nil
 }
 
 func (u *Uniter) terminate() error {

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -390,11 +390,7 @@ func (s *UniterSuite) TestUniterStartHook(c *gc.C) {
 			"start hook after reboot",
 			quickStart{},
 			stopUniter{},
-			startUniter{
-				rebootQuerier: fakeRebootQuerier{
-					rebootDetected: true,
-				},
-			},
+			startUniter{},
 			// Since the unit has already been started before and
 			// a reboot was detected, we expect the uniter to
 			// queue a start hook to notify the charms about the
@@ -986,7 +982,7 @@ func (s *UniterSuite) TestUniterRelations(c *gc.C) {
 			"unknown local relation dir is removed",
 			quickStartRelation{},
 			stopUniter{},
-			startUniter{},
+			startUniter{rebootQuerier: &fakeRebootQuerier{rebootNotDetected}},
 			// We need some synchronisation point here to ensure that the uniter
 			// has entered the correct place in the resolving loop. Now that we are
 			// no longer always executing config-changed, we poke the config just so


### PR DESCRIPTION
Merge 2.8 bringing in these PRs:

#12046 handle no application info for workload status
#12049 k8s service account roles
#12050 better vsphere logging
#12062 run upgrade-charm after uniter restart if one is pending
#12073 for bindings updateOps, only 1 per space is necessary
#12070 fix rotation of k8s charms due to pod spec map ordering issue
#12093 fix validation of model upgrade
#12067 correct scoping of network-get to ensure public ip first
#12083 pin transient dependency in operator image
#12069 do not run start hook when no reboot

## QA steps

See individual PRs