### PR TITLE
Add bootstrap support for setting up storage pools

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -141,6 +141,7 @@ func InitializeState(
 			StorageProviderRegistry: args.StorageProviderRegistry,
 			EnvironVersion:          args.ControllerModelEnvironVersion,
 		},
+		StoragePools:              args.StoragePools,
 		Cloud:                     args.ControllerCloud,
 		CloudCredentials:          cloudCreds,
 		ControllerConfig:          args.ControllerConfig,

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -186,7 +186,7 @@ LXC_BRIDGE="ignored"`[1:])
 			ModelConstraints:              expectModelConstraints,
 			ControllerInheritedConfig:     controllerInheritedConfig,
 			HostedModelConfig:             hostedModelConfigAttrs,
-			StoragePools: map[string]map[string]interface{}{
+			StoragePools: map[string]storage.Attrs{
 				"spool": {
 					"type": "loop",
 					"foo":  "bar",

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -163,6 +165,7 @@ LXC_BRIDGE="ignored"`[1:])
 			"no-proxy": "a-value",
 		},
 	}
+	registry := provider.CommonStorageProviders()
 	var envProvider fakeProvider
 	args := agentbootstrap.InitializeStateParams{
 		StateInitializationParams: instancecfg.StateInitializationParams{
@@ -183,6 +186,12 @@ LXC_BRIDGE="ignored"`[1:])
 			ModelConstraints:              expectModelConstraints,
 			ControllerInheritedConfig:     controllerInheritedConfig,
 			HostedModelConfig:             hostedModelConfigAttrs,
+			StoragePools: map[string]map[string]interface{}{
+				"spool": {
+					"type": "loop",
+					"foo":  "bar",
+				},
+			},
 		},
 		BootstrapMachineAddresses: initialAddrs,
 		BootstrapMachineJobs:      []model.MachineJob{model.JobManageModel},
@@ -191,7 +200,7 @@ LXC_BRIDGE="ignored"`[1:])
 			c.Assert(t, gc.Equals, "dummy")
 			return &envProvider, nil
 		},
-		StorageProviderRegistry: provider.CommonStorageProviders(),
+		StorageProviderRegistry: registry,
 	}
 
 	adminUser := names.NewLocalUserTag("agent-admin")
@@ -313,6 +322,14 @@ LXC_BRIDGE="ignored"`[1:])
 		SharedSecret:   "abc123",
 		SystemIdentity: "def456",
 	})
+
+	// Check the initial storage pool.
+	pm := poolmanager.New(state.NewStateSettings(st), registry)
+	storageCfg, err := pm.Get("spool")
+	c.Assert(err, jc.ErrorIsNil)
+	expectedStorageCfg, err := storage.NewConfig("spool", "loop", map[string]interface{}{"foo": "bar"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(storageCfg, jc.DeepEquals, expectedStorageCfg)
 
 	// Check that the machine agent's config has been written
 	// and that we can use it to connect to mongo.

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -41,7 +41,7 @@ func (s *storageSuite) TestValidateConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = p.ValidateConfig(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.Attrs(), jc.DeepEquals, map[string]interface{}{
+	c.Assert(cfg.Attrs(), jc.DeepEquals, storage.Attrs{
 		"storage-class":       "my-storage",
 		"storage-provisioner": "aws-storage",
 		"storage-label":       "storage-fred",

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
+	"github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
 )
 
@@ -342,7 +343,7 @@ type StateInitializationParams struct {
 
 	// StoragePools is one or more named storage pools to create
 	// in the controller model.
-	StoragePools map[string]map[string]interface{}
+	StoragePools map[string]storage.Attrs
 }
 
 type stateInitializationParamsInternal struct {
@@ -352,7 +353,7 @@ type stateInitializationParamsInternal struct {
 	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
 	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
-	StoragePools                            map[string]map[string]interface{} `yaml:"storage-pools,omitempty"`
+	StoragePools                            map[string]storage.Attrs          `yaml:"storage-pools,omitempty"`
 	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id,omitempty"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
 	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics `yaml:"bootstrap-machine-hardware,omitempty"`

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -339,6 +339,10 @@ type StateInitializationParams struct {
 	// to store in environment storage at bootstrap time. This is ignored
 	// in non-bootstrap instances.
 	CustomImageMetadata []*imagemetadata.ImageMetadata
+
+	// StoragePools is one or more named storage pools to create
+	// in the controller model.
+	StoragePools map[string]map[string]interface{}
 }
 
 type stateInitializationParamsInternal struct {
@@ -348,6 +352,7 @@ type stateInitializationParamsInternal struct {
 	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
 	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
+	StoragePools                            map[string]map[string]interface{} `yaml:"storage-pools,omitempty"`
 	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id,omitempty"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
 	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics `yaml:"bootstrap-machine-hardware,omitempty"`
@@ -376,6 +381,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		p.ControllerInheritedConfig,
 		p.RegionInheritedConfig,
 		p.HostedModelConfig,
+		p.StoragePools,
 		p.BootstrapMachineInstanceId,
 		p.BootstrapMachineConstraints,
 		p.BootstrapMachineHardwareCharacteristics,
@@ -415,6 +421,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		RegionInheritedConfig:                   internal.RegionInheritedConfig,
 		HostedModelConfig:                       internal.HostedModelConfig,
+		StoragePools:                            internal.StoragePools,
 		BootstrapMachineInstanceId:              internal.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             internal.BootstrapMachineConstraints,
 		BootstrapMachineHardwareCharacteristics: internal.BootstrapMachineHardwareCharacteristics,

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1250,7 +1250,7 @@ type bootstrapConfigs struct {
 	bootstrap                bootstrap.Config
 	inheritedControllerAttrs map[string]interface{}
 	userConfigAttrs          map[string]interface{}
-	storagePools             map[string]map[string]interface{}
+	storagePools             map[string]storage.Attrs
 }
 
 func (c *bootstrapCommand) bootstrapConfigs(
@@ -1314,7 +1314,7 @@ func (c *bootstrapCommand) bootstrapConfigs(
 	if err != nil {
 		return bootstrapConfigs{}, errors.Trace(err)
 	}
-	var storagePools map[string]map[string]interface{}
+	var storagePools map[string]storage.Attrs
 	if len(storagePoolAttrs) > 0 {
 		poolName, _ := storagePoolAttrs[poolmanager.Name].(string)
 		if poolName == "" {
@@ -1324,7 +1324,7 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		if poolType == "" {
 			return bootstrapConfigs{}, errors.NewNotValid(nil, "storage pool requires a type")
 		}
-		storagePools = make(map[string]map[string]interface{})
+		storagePools = make(map[string]storage.Attrs)
 		storagePools[poolName] = storagePoolAttrs
 	}
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -49,6 +49,9 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/lxd/lxdnames"
+	"github.com/juju/juju/state/stateenvirons"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -127,7 +130,10 @@ agent stream is 'released' (default), then a 2.3.1 client can bootstrap:
     * 2.3.1 controller by running '... bootstrap ...';
     * 2.3.2 controller by running 'bootstrap --auto-upgrade'.
 However, if this client has a copy of codebase, then a local copy of Juju
-will be built and bootstrapped - 2.3.1.1.`
+will be built and bootstrapped - 2.3.1.1.
+
+If a storage pool is specified using --storage-pool, this will be created
+in the controller model.`
 
 var usageBootstrapConfigTxt = `
 
@@ -145,6 +151,7 @@ Examples:
     juju bootstrap --config=~/config-rs.yaml rackspace joe-syd
     juju bootstrap --agent-version=2.2.4 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
+    juju bootstrap aws --storage-pool name=secret --storage-pool type=ebs --storage-pool encrypted=true
 
 See also:
     add-credentials
@@ -192,6 +199,7 @@ type bootstrapCommand struct {
 	AgentVersion             *version.Number
 	config                   common.ConfigFlag
 	modelDefaults            common.ConfigFlag
+	storagePool              common.ConfigFlag
 
 	showClouds          bool
 	showRegionsForCloud string
@@ -272,6 +280,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.CredentialName, "credential", "", "Credentials to use when bootstrapping")
 	f.Var(&c.config, "config", "Specify a controller configuration file, or one or more configuration\n    options\n    (--config config.yaml [--config key=value ...])")
 	f.Var(&c.modelDefaults, "model-default", "Specify a configuration file, or one or more configuration\n    options to be set for all models, unless otherwise specified\n    (--model-default config.yaml [--model-default key=value ...])")
+	f.Var(&c.storagePool, "storage-pool", "Specify options for an initial storage pool\n    'name' and 'type' are required, plus any additional attributes\n    (--storage-pool pool-config.yaml [--storage-pool key=value ...])")
 	f.StringVar(&c.hostedModelName, "d", defaultHostedModelName, "Name of the default hosted model for the controller")
 	f.StringVar(&c.hostedModelName, "default-model", defaultHostedModelName, "Name of the default hosted model for the controller")
 	f.BoolVar(&c.showClouds, "clouds", false, "Print the available clouds which can be used to bootstrap a Juju environment")
@@ -726,6 +735,18 @@ to create a new model to deploy %sworkloads.
 		return errors.Trace(err)
 	}
 
+	// Validate the storage provider config.
+	registry := stateenvirons.NewStorageProviderRegistry(environ)
+	m := poolmanager.MemSettings{make(map[string]map[string]interface{})}
+	pm := poolmanager.New(m, registry)
+	for poolName, cfg := range bootstrapCfg.storagePools {
+		poolType, _ := cfg[poolmanager.Type].(string)
+		_, err = pm.Create(poolName, storage.ProviderType(poolType), cfg)
+		if err != nil {
+			return errors.NewNotValid(err, "invalid storage provider config")
+		}
+	}
+
 	bootstrapParams := bootstrap.BootstrapParams{
 		ControllerName:            c.controllerName,
 		BootstrapSeries:           c.BootstrapSeries,
@@ -747,6 +768,7 @@ to create a new model to deploy %sworkloads.
 		ControllerExternalIPs:     append([]string(nil), bootstrapCfg.bootstrap.ControllerExternalIPs...),
 		JujuDbSnapPath:            c.JujuDbSnapPath,
 		JujuDbSnapAssertionsPath:  c.JujuDbSnapAssertionsPath,
+		StoragePools:              bootstrapCfg.storagePools,
 		DialOpts: environs.BootstrapDialOpts{
 			Timeout:        bootstrapCfg.bootstrap.BootstrapTimeout,
 			RetryDelay:     bootstrapCfg.bootstrap.BootstrapRetryDelay,
@@ -1228,6 +1250,7 @@ type bootstrapConfigs struct {
 	bootstrap                bootstrap.Config
 	inheritedControllerAttrs map[string]interface{}
 	userConfigAttrs          map[string]interface{}
+	storagePools             map[string]map[string]interface{}
 }
 
 func (c *bootstrapCommand) bootstrapConfigs(
@@ -1285,6 +1308,24 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		} else {
 			providerAttrs = coercedAttrs.(map[string]interface{})
 		}
+	}
+
+	storagePoolAttrs, err := c.storagePool.ReadAttrs(ctx)
+	if err != nil {
+		return bootstrapConfigs{}, errors.Trace(err)
+	}
+	var storagePools map[string]map[string]interface{}
+	if len(storagePoolAttrs) > 0 {
+		poolName, _ := storagePoolAttrs[poolmanager.Name].(string)
+		if poolName == "" {
+			return bootstrapConfigs{}, errors.NewNotValid(nil, "storage pool requires a name")
+		}
+		poolType, _ := storagePoolAttrs[poolmanager.Type].(string)
+		if poolType == "" {
+			return bootstrapConfigs{}, errors.NewNotValid(nil, "storage pool requires a type")
+		}
+		storagePools = make(map[string]map[string]interface{})
+		storagePools[poolName] = storagePoolAttrs
 	}
 
 	bootstrapConfigAttrs := make(map[string]interface{})
@@ -1416,6 +1457,7 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		bootstrap:                bootstrapConfig,
 		inheritedControllerAttrs: inheritedControllerAttrs,
 		userConfigAttrs:          userConfigAttrs,
+		storagePools:             storagePools,
 	}
 	return configs, nil
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/ec2"
 	"github.com/juju/juju/provider/openstack"
+	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -951,7 +952,7 @@ func (s *BootstrapSuite) TestBootstrapWithStoragePool(c *gc.C) {
 		"--storage-pool", "foo=bar",
 	)
 
-	c.Assert(bootstrapFuncs.args.StoragePools, jc.DeepEquals, map[string]map[string]interface{}{
+	c.Assert(bootstrapFuncs.args.StoragePools, jc.DeepEquals, map[string]storage.Attrs{
 		"test": {
 			"name": "test",
 			"type": "loop",

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -41,6 +41,10 @@ type BootstrapParams struct {
 	// will not be stored in state for the environment.
 	BootstrapConstraints constraints.Value
 
+	// StoragePools is one or more named storage pools to create
+	// in the controller model.
+	StoragePools map[string]map[string]interface{}
+
 	// BootstrapSeries, if specified, is the series to use for the
 	// initial bootstrap machine.
 	BootstrapSeries string

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
 )
 
@@ -43,7 +44,7 @@ type BootstrapParams struct {
 
 	// StoragePools is one or more named storage pools to create
 	// in the controller model.
-	StoragePools map[string]map[string]interface{}
+	StoragePools map[string]storage.Attrs
 
 	// BootstrapSeries, if specified, is the series to use for the
 	// initial bootstrap machine.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/pki"
+	corestorage "github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -168,7 +169,7 @@ type BootstrapParams struct {
 
 	// StoragePools is one or more named storage pools to create
 	// in the controller model.
-	StoragePools map[string]map[string]interface{}
+	StoragePools map[string]corestorage.Attrs
 
 	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -166,6 +166,10 @@ type BootstrapParams struct {
 	// will be used to test the contents of the .snap at JujuDbSnap.
 	JujuDbSnapAssertionsPath string
 
+	// StoragePools is one or more named storage pools to create
+	// in the controller model.
+	StoragePools map[string]map[string]interface{}
+
 	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 
@@ -618,6 +622,7 @@ func Bootstrap(
 		CloudRegion:                args.CloudRegion,
 		ControllerConfig:           args.ControllerConfig,
 		ModelConstraints:           args.ModelConstraints,
+		StoragePools:               args.StoragePools,
 		BootstrapSeries:            args.BootstrapSeries,
 		SupportedBootstrapSeries:   args.SupportedBootstrapSeries,
 		Placement:                  args.Placement,
@@ -704,6 +709,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
 	icfg.Bootstrap.RegionInheritedConfig = args.Cloud.RegionConfig
 	icfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
+	icfg.Bootstrap.StoragePools = args.StoragePools
 	icfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	icfg.Bootstrap.GUI = guiArchive(args.GUIDataSourceBaseURL, cfg.GUIStream(), vers.Major, vers.Minor, true, func(msg string) {
 		ctx.Infof(msg)
@@ -789,6 +795,7 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerConfig = args.ControllerConfig
 	pcfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
 	pcfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
+	pcfg.Bootstrap.StoragePools = args.StoragePools
 	pcfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType
 	pcfg.Bootstrap.ControllerExternalName = args.ControllerExternalName

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -194,6 +194,32 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedConstraints(c *gc.C) {
 	c.Assert(env.args.ModelConstraints, gc.DeepEquals, modelCons)
 }
 
+func (s *bootstrapSuite) TestBootstrapWithStoragePools(c *gc.C) {
+	env := newEnviron("foo", useDefaultKeys, nil)
+	s.setDummyStorage(c, env)
+	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:         coretesting.FakeControllerConfig(),
+			AdminSecret:              "admin-secret",
+			CAPrivateKey:             coretesting.CAKey,
+			SupportedBootstrapSeries: supportedJujuSeries,
+			StoragePools: map[string]map[string]interface{}{
+				"spool": {
+					"type": "loop",
+					"foo":  "bar",
+				},
+			},
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.bootstrapCount, gc.Equals, 1)
+	c.Assert(env.args.StoragePools, gc.DeepEquals, map[string]map[string]interface{}{
+		"spool": {
+			"type": "loop",
+			"foo":  "bar",
+		},
+	})
+}
+
 func (s *bootstrapSuite) TestBootstrapSpecifiedBootstrapSeries(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/dummy"
+	corestorage "github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -203,7 +204,7 @@ func (s *bootstrapSuite) TestBootstrapWithStoragePools(c *gc.C) {
 			AdminSecret:              "admin-secret",
 			CAPrivateKey:             coretesting.CAKey,
 			SupportedBootstrapSeries: supportedJujuSeries,
-			StoragePools: map[string]map[string]interface{}{
+			StoragePools: map[string]corestorage.Attrs{
 				"spool": {
 					"type": "loop",
 					"foo":  "bar",
@@ -212,7 +213,7 @@ func (s *bootstrapSuite) TestBootstrapWithStoragePools(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env.bootstrapCount, gc.Equals, 1)
-	c.Assert(env.args.StoragePools, gc.DeepEquals, map[string]map[string]interface{}{
+	c.Assert(env.args.StoragePools, gc.DeepEquals, map[string]corestorage.Attrs{
 		"spool": {
 			"type": "loop",
 			"foo":  "bar",

--- a/provider/azure/disk.go
+++ b/provider/azure/disk.go
@@ -44,12 +44,13 @@ func (env *azureEnviron) diskEncryptionInfo(
 		return "", nil
 	}
 	logger.Debugf("creating root disk encryption with parameters: %#v", *rootDisk)
+	// The "encrypted" value may arrive as a bool or a string.
 	encryptedStr, ok := rootDisk.Attributes[encryptedKey].(string)
-	encrypted := false
-	if ok {
+	encrypted, _ := rootDisk.Attributes[encryptedKey].(bool)
+	if !encrypted && ok {
 		encrypted, _ = strconv.ParseBool(encryptedStr)
 	}
-	if !ok || !encrypted {
+	if !encrypted {
 		logger.Debugf("encryption not enabled for root disk")
 		return "", nil
 	}

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -38,6 +38,8 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
 	coretools "github.com/juju/juju/tools"
 )
 
@@ -208,6 +210,21 @@ func BootstrapInstance(
 		StatusCallback:  instanceStatus,
 		CleanupCallback: statusCleanup,
 	}
+
+	// If a root disk constraint is specified, see if it matches any
+	// storage pools scheduled to be added to the controller model and
+	// set up the root disk accordingly.
+	if args.BootstrapConstraints.HasRootDiskSource() {
+		sp, ok := args.StoragePools[*args.BootstrapConstraints.RootDiskSource]
+		if ok {
+			pType, _ := sp[poolmanager.Type].(string)
+			startInstanceArgs.RootDisk = &storage.VolumeParams{
+				Provider:   storage.ProviderType(pType),
+				Attributes: sp,
+			}
+		}
+	}
+
 	zones, err := startInstanceZones(env, callCtx, startInstanceArgs)
 	if errors.IsNotImplemented(err) {
 		// No zone support, so just call StartInstance with

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -531,7 +531,7 @@ func (s *BootstrapSuite) TestStartInstanceRootDisk(c *gc.C) {
 		AvailableTools:           availableTools,
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 		BootstrapConstraints:     constraints.MustParse("root-disk-source=spool"),
-		StoragePools: map[string]map[string]interface{}{
+		StoragePools: map[string]corestorage.Attrs{
 			"spool": {
 				"type": "dummy",
 				"foo":  "bar",

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/common"
+	corestorage "github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -500,6 +501,45 @@ func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot start bootstrap instance: no usable availability zones`)
+}
+
+func (s *BootstrapSuite) TestStartInstanceRootDisk(c *gc.C) {
+	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+		instances.Instance,
+		*instance.HardwareCharacteristics,
+		network.InterfaceInfos,
+		error,
+	) {
+		c.Assert(args.RootDisk, jc.DeepEquals, &corestorage.VolumeParams{
+			Provider: "dummy",
+			Attributes: map[string]interface{}{
+				"type": "dummy",
+				"foo":  "bar",
+			},
+		})
+		hw := instance.MustParseHardware("arch=ppc64el")
+		return &mockInstance{}, &hw, nil, nil
+	}
+	env := &mockEnviron{
+		startInstance: startInstance,
+		config:        fakeMinimalConfig(c),
+	}
+	ctx := envtesting.BootstrapContext(c)
+	availableTools := fakeAvailableTools()
+	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+		ControllerConfig:         coretesting.FakeControllerConfig(),
+		AvailableTools:           availableTools,
+		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		BootstrapConstraints:     constraints.MustParse("root-disk-source=spool"),
+		StoragePools: map[string]map[string]interface{}{
+			"spool": {
+				"type": "dummy",
+				"foo":  "bar",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Arch, gc.Equals, "ppc64el")
 }
 
 func (s *BootstrapSuite) TestSuccess(c *gc.C) {

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -33,7 +33,7 @@ type InitializeParams struct {
 
 	// StoragePools is one or more named storage pools to create
 	// in the controller model.
-	StoragePools map[string]map[string]interface{}
+	StoragePools map[string]storage.Attrs
 
 	// Cloud contains the properties of the cloud that the
 	// controller runs in.
@@ -440,7 +440,7 @@ func (st *State) createDefaultStoragePoolsOps(registry storage.ProviderRegistry)
 	return ops, nil
 }
 
-func (st *State) createCustomStoragePoolsOps(registry storage.ProviderRegistry, storagePools map[string]map[string]interface{}) ([]txn.Op, error) {
+func (st *State) createCustomStoragePoolsOps(registry storage.ProviderRegistry, storagePools map[string]storage.Attrs) ([]txn.Op, error) {
 	m := poolmanager.MemSettings{make(map[string]map[string]interface{})}
 	pm := poolmanager.New(m, registry)
 	for name, attrs := range storagePools {
@@ -455,8 +455,6 @@ func (st *State) createCustomStoragePoolsOps(registry storage.ProviderRegistry, 
 			)
 		}
 	}
-
-	logger.Criticalf("SP: %#v", m.Settings)
 
 	var ops []txn.Op
 	for key, settings := range m.Settings {

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -31,6 +31,10 @@ type InitializeParams struct {
 	// the controller model.
 	ControllerModelArgs ModelArgs
 
+	// StoragePools is one or more named storage pools to create
+	// in the controller model.
+	StoragePools map[string]map[string]interface{}
+
 	// Cloud contains the properties of the cloud that the
 	// controller runs in.
 	Cloud cloud.Cloud
@@ -193,6 +197,10 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	storagePoolOps, err := st.createCustomStoragePoolsOps(args.ControllerModelArgs.StorageProviderRegistry, args.StoragePools)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	salt, err := utils.RandomSalt()
 	if err != nil {
 		return nil, err
@@ -276,6 +284,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 		ops = append(ops, createCloudCredentialOp(tag, cred))
 	}
 	ops = append(ops, modelOps...)
+	ops = append(ops, storagePoolOps...)
 
 	if err := st.db().RunTransaction(ops); err != nil {
 		return nil, errors.Trace(err)
@@ -423,6 +432,31 @@ func (st *State) createDefaultStoragePoolsOps(registry storage.ProviderRegistry)
 			)
 		}
 	}
+
+	var ops []txn.Op
+	for key, settings := range m.Settings {
+		ops = append(ops, createSettingsOp(settingsC, key, settings))
+	}
+	return ops, nil
+}
+
+func (st *State) createCustomStoragePoolsOps(registry storage.ProviderRegistry, storagePools map[string]map[string]interface{}) ([]txn.Op, error) {
+	m := poolmanager.MemSettings{make(map[string]map[string]interface{})}
+	pm := poolmanager.New(m, registry)
+	for name, attrs := range storagePools {
+		pType, _ := attrs[poolmanager.Type].(string)
+		if pType == "" {
+			return nil, errors.Errorf("missing provider type for storage pool %q", name)
+		}
+		providerType := storage.ProviderType(pType)
+		if _, err := pm.Create(name, providerType, attrs); err != nil {
+			return nil, errors.Annotatef(
+				err, "adding custom storage pool %q", name,
+			)
+		}
+	}
+
+	logger.Criticalf("SP: %#v", m.Settings)
 
 	var ops []txn.Op
 	for key, settings := range m.Settings {

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -698,7 +698,7 @@ func (s *InitializeSuite) TestInitializeWithStoragePool(c *gc.C) {
 		},
 		MongoSession:  s.Session,
 		AdminPassword: "dummy-secret",
-		StoragePools: map[string]map[string]interface{}{
+		StoragePools: map[string]storage.Attrs{
 			"spool": {
 				"type": "dummy",
 				"foo":  "bar",

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2216,7 +2216,7 @@ func (s *MigrationImportSuite) TestStoragePools(c *gc.C) {
 	pool := pools[0]
 	c.Assert(pool.Name(), gc.Equals, "test-pool")
 	c.Assert(pool.Provider(), gc.Equals, provider.LoopProviderType)
-	c.Assert(pool.Attrs(), jc.DeepEquals, map[string]interface{}{
+	c.Assert(pool.Attrs(), jc.DeepEquals, storage.Attrs{
 		"value": 42,
 	})
 }

--- a/storage/config.go
+++ b/storage/config.go
@@ -21,11 +21,14 @@ const (
 	ConfigStorageDir = "storage-dir"
 )
 
+// Attrs defines storage attributes.
+type Attrs map[string]interface{}
+
 // Config defines the configuration for a storage source.
 type Config struct {
 	name     string
 	provider ProviderType
-	attrs    map[string]interface{}
+	attrs    Attrs
 }
 
 var fields = schema.Fields{}
@@ -36,7 +39,7 @@ var configChecker = schema.FieldMap(
 )
 
 // NewConfig creates a new Config for instantiating a storage source.
-func NewConfig(name string, provider ProviderType, attrs map[string]interface{}) (*Config, error) {
+func NewConfig(name string, provider ProviderType, attrs Attrs) (*Config, error) {
 	_, err := configChecker.Coerce(attrs, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "validating common storage config")
@@ -60,11 +63,11 @@ func (c *Config) Provider() ProviderType {
 }
 
 // Attrs returns the configuration attributes for a storage source.
-func (c *Config) Attrs() map[string]interface{} {
+func (c *Config) Attrs() Attrs {
 	if c.attrs == nil {
 		return nil
 	}
-	attrs := make(map[string]interface{})
+	attrs := make(Attrs)
 	for k, v := range c.attrs {
 		attrs[k] = v
 	}

--- a/storage/poolmanager/poolmanager_test.go
+++ b/storage/poolmanager/poolmanager_test.go
@@ -53,7 +53,7 @@ func (s *poolSuite) TestList(c *gc.C) {
 	pools, err := s.poolManager.List()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(pools, gc.HasLen, 1)
-	c.Assert(pools[0].Attrs(), gc.DeepEquals, map[string]interface{}{"foo": "bar", "bleep": "bloop"})
+	c.Assert(pools[0].Attrs(), gc.DeepEquals, storage.Attrs{"foo": "bar", "bleep": "bloop"})
 	c.Assert(pools[0].Name(), gc.Equals, "testpool")
 	c.Assert(pools[0].Provider(), gc.Equals, storage.ProviderType("loop"))
 }
@@ -87,36 +87,36 @@ func (s *poolSuite) TestPool(c *gc.C) {
 	s.createSettings(c)
 	p, err := s.poolManager.Get("testpool")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(p.Attrs(), gc.DeepEquals, map[string]interface{}{"foo": "bar", "bleep": "bloop"})
+	c.Assert(p.Attrs(), gc.DeepEquals, storage.Attrs{"foo": "bar", "bleep": "bloop"})
 	c.Assert(p.Name(), gc.Equals, "testpool")
 	c.Assert(p.Provider(), gc.Equals, storage.ProviderType("loop"))
 }
 
 func (s *poolSuite) TestCreate(c *gc.C) {
-	created, err := s.poolManager.Create("testpool", storage.ProviderType("loop"), map[string]interface{}{"foo": "bar"})
+	created, err := s.poolManager.Create("testpool", storage.ProviderType("loop"), storage.Attrs{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 	p, err := s.poolManager.Get("testpool")
 	c.Assert(created, gc.DeepEquals, p)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(p.Attrs(), gc.DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(p.Attrs(), gc.DeepEquals, storage.Attrs{"foo": "bar"})
 	c.Assert(p.Name(), gc.Equals, "testpool")
 	c.Assert(p.Provider(), gc.Equals, storage.ProviderType("loop"))
 }
 
 func (s *poolSuite) TestCreateAlreadyExists(c *gc.C) {
-	_, err := s.poolManager.Create("testpool", storage.ProviderType("loop"), map[string]interface{}{"foo": "bar"})
+	_, err := s.poolManager.Create("testpool", storage.ProviderType("loop"), storage.Attrs{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.poolManager.Create("testpool", storage.ProviderType("loop"), map[string]interface{}{"foo": "bar"})
+	_, err = s.poolManager.Create("testpool", storage.ProviderType("loop"), storage.Attrs{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, ".*cannot overwrite.*")
 }
 
 func (s *poolSuite) TestCreateMissingName(c *gc.C) {
-	_, err := s.poolManager.Create("", "loop", map[string]interface{}{"foo": "bar"})
+	_, err := s.poolManager.Create("", "loop", storage.Attrs{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "pool name is missing")
 }
 
 func (s *poolSuite) TestCreateMissingType(c *gc.C) {
-	_, err := s.poolManager.Create("testpool", "", map[string]interface{}{"foo": "bar"})
+	_, err := s.poolManager.Create("testpool", "", storage.Attrs{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "provider type is missing")
 }
 
@@ -132,28 +132,28 @@ func (s *poolSuite) TestCreateInvalidConfig(c *gc.C) {
 
 func (s *poolSuite) TestReplace(c *gc.C) {
 	s.createSettings(c)
-	err := s.poolManager.Replace("testpool", "", map[string]interface{}{"zip": "zap"})
+	err := s.poolManager.Replace("testpool", "", storage.Attrs{"zip": "zap"})
 	c.Assert(err, jc.ErrorIsNil)
 	p, err := s.poolManager.Get("testpool")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(p.Attrs(), gc.DeepEquals, map[string]interface{}{"zip": "zap"})
+	c.Assert(p.Attrs(), gc.DeepEquals, storage.Attrs{"zip": "zap"})
 	c.Assert(p.Name(), gc.Equals, "testpool")
 	c.Assert(p.Provider(), gc.Equals, storage.ProviderType("loop"))
 }
 
 func (s *poolSuite) TestReplaceMissingName(c *gc.C) {
-	err := s.poolManager.Replace("", "", map[string]interface{}{"foo": "bar"})
+	err := s.poolManager.Replace("", "", storage.Attrs{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "pool name is missing")
 }
 
 func (s *poolSuite) TestReplaceNewProvider(c *gc.C) {
 	s.registry.Providers["notebook"] = &dummystorage.StorageProvider{}
 	s.createSettings(c)
-	err := s.poolManager.Replace("testpool", "notebook", map[string]interface{}{"handwritten": "true"})
+	err := s.poolManager.Replace("testpool", "notebook", storage.Attrs{"handwritten": "true"})
 	c.Assert(err, jc.ErrorIsNil)
 	p, err := s.poolManager.Get("testpool")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(p.Attrs(), gc.DeepEquals, map[string]interface{}{"handwritten": "true"})
+	c.Assert(p.Attrs(), gc.DeepEquals, storage.Attrs{"handwritten": "true"})
 	c.Assert(p.Name(), gc.Equals, "testpool")
 	c.Assert(p.Provider(), gc.Equals, storage.ProviderType("notebook"))
 }
@@ -165,12 +165,12 @@ func (s *poolSuite) TestReplaceInvalidConfig(c *gc.C) {
 		},
 	}
 	s.createSettings(c)
-	err := s.poolManager.Replace("testpool", "invalid", map[string]interface{}{"zip": "zap"})
+	err := s.poolManager.Replace("testpool", "invalid", storage.Attrs{"zip": "zap"})
 	c.Assert(err, gc.ErrorMatches, "validating storage provider config: no good")
 }
 
 func (s *poolSuite) TestReplaceNotFound(c *gc.C) {
-	err := s.poolManager.Replace("deadpool", "", map[string]interface{}{"zip": "zap"})
+	err := s.poolManager.Replace("deadpool", "", storage.Attrs{"zip": "zap"})
 	c.Assert(err, gc.ErrorMatches, "pool \"deadpool\" not found")
 }
 


### PR DESCRIPTION
A previous PR #12096 added support for creating Azure encrypted disks from a storage pool and root-disk-source constraint.
However, there was no way to do this for the controller as the storage pool did not exist yet.
This PR allows the creation of a named storage pool at bootstrap, and wires up the controller instance creation to configure the root disk volume params from that storage pool definition. Allowance is made for multiple storage pools, even though right now the CLI can just support the one.
The same arg handling as is used for `--config` is used here. Either a YAML file or multiple cmd args can be used.

## QA steps

```
juju bootstrap azure/australiasoutheast test \
  --no-default-model \
  --storage-pool name=foo \
  --storage-pool type=azure \
  --storage-pool encrypted=true \
  --storage-pool vault-name-prefix=secret \
  --bootstrap-constraints="root-disk-source=foo"
```

Check that the Azure controller VM uses disk encryption.
Check that the controller model has the storage pool created.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892485
