### PR TITLE
Add deprecation warning for "juju restore-backup"

### DIFF
--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -78,7 +78,7 @@ If the provided state cannot be restored, this command will fail with
 an explanation.
 
 WARNING: This command is deprecated in favor of the stand-alone
-"juju-restore" program: https://github.com/juju/juju-restore
+"juju-restore" tool: https://github.com/juju/juju-restore
 `
 
 // Info returns the content for --help.
@@ -161,7 +161,7 @@ func (c *restoreCommand) newClient() (*backups.Client, error) {
 
 // Run is the entry point for this command.
 func (c *restoreCommand) Run(ctx *cmd.Context) error {
-	ctx.Warningf(`"juju restore-backup" is deprecated in favor of the stand-alone "juju-restore" program: https://github.com/juju/juju-restore`)
+	ctx.Warningf(`"juju restore-backup" is deprecated in favor of the stand-alone "juju-restore" tool: https://github.com/juju/juju-restore`)
 
 	if err := c.validateIaasController(c.Info().Name); err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/backups/restore.go
+++ b/cmd/juju/backups/restore.go
@@ -76,6 +76,9 @@ https://jaas.ai/docs/controller-backups for more information.
 
 If the provided state cannot be restored, this command will fail with
 an explanation.
+
+WARNING: This command is deprecated in favor of the stand-alone
+"juju-restore" program: https://github.com/juju/juju-restore
 `
 
 // Info returns the content for --help.
@@ -158,6 +161,8 @@ func (c *restoreCommand) newClient() (*backups.Client, error) {
 
 // Run is the entry point for this command.
 func (c *restoreCommand) Run(ctx *cmd.Context) error {
+	ctx.Warningf(`"juju restore-backup" is deprecated in favor of the stand-alone "juju-restore" program: https://github.com/juju/juju-restore`)
+
 	if err := c.validateIaasController(c.Info().Name); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
`juju restore-backup` is deprecated in favor of the separate [`juju-restore`](https://github.com/juju/juju-restore) program, so provide a deprecation warning (when running the command, and in the help text for it).

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
$ juju help restore-backup  # see "WARNING: ..." message at end of help text
$ juju restore-backup --file juju-backup-20201008-014905.tar.gz
WARNING "juju restore-backup" is deprecated in favor of the stand-alone "juju-restore" program: https://github.com/juju/juju-restore
...
```

## Documentation changes

N/A

## Bug reference

Related to: https://bugs.launchpad.net/juju/+bug/1893844