### PR TITLE
Allow Changing NIC Provider IDs

### DIFF
--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -185,14 +185,6 @@ func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
 		return nil, nil
 	}
 
-	// If the incoming provider ID is not empty, we will only set it on the
-	// device if it is currently empty.
-	// TODO (manadart 2020-06-30): This is a preservation of prior behaviour
-	// and probably bares re-evaluation.
-	if id != "" && currentID != "" {
-		return nil, nil
-	}
-
 	// If removing the provider ID from the device,
 	// also remove the ID from the global collection.
 	if id == "" {
@@ -207,8 +199,7 @@ func (dev *LinkLayerDevice) SetProviderIDOps(id network.Id) ([]txn.Op, error) {
 		}, nil
 	}
 
-	// Since we assume that we are now setting the ID for the first time,
-	// ensure that it has not already been used to identify another device.
+	// Ensure that it is not currently used to identify another device.
 	exists, err := dev.st.networkEntityGlobalKeyExists("linklayerdevice", id)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -662,7 +662,7 @@ func (s *linkLayerDevicesStateSuite) TestSetProviderIDOps(c *gc.C) {
 	c.Assert(dev1.ProviderID().String(), gc.Equals, "p1")
 
 	// No-op if already set.
-	ops, err = dev1.SetProviderIDOps("p2")
+	ops, err = dev1.SetProviderIDOps("p1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ops, gc.HasLen, 0)
 
@@ -682,6 +682,11 @@ func (s *linkLayerDevicesStateSuite) TestSetProviderIDOps(c *gc.C) {
 
 	// The global ID is unregistered, so we should be able to reset it.
 	ops, err = dev1.SetProviderIDOps("p1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.Not(gc.HasLen), 0)
+
+	// We should be able to change the ID, provided the new ID is unused.
+	ops, err = dev1.SetProviderIDOps("p2")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ops, gc.Not(gc.HasLen), 0)
 }


### PR DESCRIPTION
Old behaviour for processing link-layer devices from the instance-poller had a lot of "bug out" logic, including preventing device provider IDs from changing.

This patch continues refinement of that logic allowing provider IDs to change if the new ID is not currently referring to another device. A warning is logged when a device's provider ID is changing.

## QA steps

Using a MAAS with which you have access to the database:
- Bootstrap.
- `juju add-machine` ensuring that the provisioned machine has a plain ethernet device that is *not* the PXE boot interface.
- Connect to Mongo and note the provider ID of one of that device:
```
{
        "_id" : "24e9fb87-622e-4cfe-8348-af6a0a0a2416:m#2#d#ens7",
        "name" : "ens7",
        "model-uuid" : "24e9fb87-622e-4cfe-8348-af6a0a0a2416",
        "mtu" : 1500,
        "providerid" : "396",
        "machine-id" : "2",
        "type" : "ethernet",
        "mac-address" : "52:54:00:5f:1c:15",
        "is-auto-start" : true,
        "is-up" : true,
        "parent-name" : "",
        "virtual-port-type" : "",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f806ae4cda7630d3360d7eb_48e4543b"
        ]
}
```
- Connect to the MAAS Postrgres DB using `sudo -u postgres psql maasdb`.
- Hack an update to the device ID:
```
maasdb=# select * from maasserver_interface_ip_addresses;
maasdb=# delete from maasserver_interface_ip_addresses where interface_id='396';
DELETE 2
maasdb=# update maasserver_interface set id=nextval('maasserver_interface_id_seq'::regclass) where mac_address='52:54:00:5f:1c:15';
UPDATE 1
```
- When the instance-poller runs, we should see a log line like this:
```
machine-0: 16:00:06 WARNING juju.apiserver.instancepoller changing provider ID for device "ens7" from "396" to "398"
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1897330
