### PR TITLE
Small fixes for golang 1.15 compatibility

### DIFF
--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -84,7 +84,7 @@ func (s *ShowOutputSuite) TestRun(c *gc.C) {
 	}{{
 		should:         "handle wait-time formatting errors",
 		withClientWait: "not-a-duration-at-all",
-		expectedErr:    `time: invalid duration not-a-duration-at-all`,
+		expectedErr:    `time: invalid duration "?not-a-duration-at-all"?`,
 	}, {
 		should:            "timeout if result never comes",
 		withClientWait:    "2s",

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -242,7 +242,7 @@ func (f *fakeAddMachineAPI) AddMachines(args []params.AddMachineParams) ([]param
 			})
 		} else {
 			results = append(results, params.AddMachinesResult{
-				Machine: string(i),
+				Machine: string(rune(i)),
 				Error:   &params.Error{Message: "something went wrong", Code: "1"},
 			})
 		}

--- a/cmd/jujud/agent/caasunitinit_test.go
+++ b/cmd/jujud/agent/caasunitinit_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -132,7 +133,7 @@ func (s *CAASUnitInitSuite) TestInitUnit(c *gc.C) {
 }
 
 func (s *CAASUnitInitSuite) TestInitUnitWaitSend(c *gc.C) {
-	socketName := "@" + string(rand.Int63())
+	socketName := "@" + strconv.FormatInt(rand.Int63(), 10)
 	listening := make(chan struct{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -196,7 +196,7 @@ func deviceID(i int) (string, error) {
 	if i < 0 || i > 25 {
 		return "", errors.Errorf("got %d but only support devices 0-25", i)
 	}
-	return fmt.Sprintf("vd%s", string('a'+i)), nil
+	return fmt.Sprintf("vd%s", string(rune('a'+i))), nil
 }
 
 // Domain describes a libvirt domain. A domain is an instance of an operating

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -235,7 +235,7 @@ var newConfigTests = []struct {
 	config: controller.Config{
 		controller.PruneTxnSleepTime: "15",
 	},
-	expectError: `prune-txn-sleep-time must be a valid duration \(eg "10ms"\): time: missing unit in duration 15`,
+	expectError: `prune-txn-sleep-time must be a valid duration \(eg "10ms"\): time: missing unit in duration "?15"?`,
 }, {
 	about: "mongo-memory-profile not valid",
 	config: controller.Config{
@@ -277,7 +277,7 @@ var newConfigTests = []struct {
 	config: controller.Config{
 		controller.AgentRateLimitRate: "150",
 	},
-	expectError: `agent-ratelimit-rate: conversion to duration: time: missing unit in duration 150`,
+	expectError: `agent-ratelimit-rate: conversion to duration: time: missing unit in duration "?150"?`,
 }, {
 	about: "agent-ratelimit-rate bad type, int",
 	config: controller.Config{
@@ -687,7 +687,7 @@ func (s *ConfigSuite) TestMaxDebugLogDurationSchemaCoerce(c *gc.C) {
 			"max-debug-log-duration": "12",
 		},
 	)
-	c.Assert(err.Error(), gc.Equals, "max-debug-log-duration: conversion to duration: time: missing unit in duration 12")
+	c.Assert(err, gc.ErrorMatches, `max-debug-log-duration: conversion to duration: time: missing unit in duration "?12"?`)
 }
 
 func (s *ConfigSuite) TestDefaults(c *gc.C) {

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -1008,9 +1008,9 @@ func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err 
 		if letter > deviceLetterMax {
 			return "", "", errTooManyVolumes
 		}
-		deviceName := devicePrefix + string(letter)
+		deviceName := devicePrefix + string(rune(letter))
 		if numbers {
-			deviceName += string('1' + (n % deviceNumMax))
+			deviceName += string(rune('1' + (n % deviceNumMax)))
 		}
 		n++
 		realDeviceName := renamedDevicePrefix + deviceName[len(devicePrefix):]


### PR DESCRIPTION
A few small tweaks to handle differences between go 1.14 and 1.15
There's a couple of more major worker test failures in the worker/httpserver package but these tweaks cover most things.

## QA steps

run the unit tests

