### PR TITLE
Create default fields for info and find api calls.

### DIFF
--- a/charmhub/filter.go
+++ b/charmhub/filter.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"fmt"
+)
+
+func appendFilterList(value string, filters []string) []string {
+	retVals := make([]string, len(filters))
+	for i, v := range filters {
+		retVals[i] = fmt.Sprintf("%s.%s", value, v)
+	}
+	return retVals
+}
+
+// always present are: type, id, and name
+
+var defaultChannelFilter = []string{
+	"channel.name",
+	"channel.platform.architecture",
+	"channel.platform.os",
+	"channel.platform.series",
+	"channel.released-at",
+	"channel.risk",
+	"channel.track",
+}
+
+var defaultResultFilter = []string{
+	"result.bugs-url",
+	"result.categories.featured",
+	"result.categories.name",
+	"result.description",
+	"result.license",
+	"result.media.height",
+	"result.media.type",
+	"result.media.url",
+	"result.media.width",
+	"result.publisher.display-name",
+	"result.store-url",
+	"result.summary",
+	"result.used-by",
+	"result.website",
+}
+
+var defaultRevisionFilter = []string{
+	"revision.config-yaml",
+	"revision.created-at",
+	"revision.metadata-yaml",
+	"revision.platforms.architecture",
+	"revision.platforms.os",
+	"revision.platforms.series",
+	"revision.revision",
+	"revision.version",
+}
+
+var defaultDownloadFilter = []string{
+	"download.hash-sha-256",
+	"download.size",
+	"download.url",
+}

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -53,7 +53,7 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 	name := "meshuggah"
 
 	restClient := NewMockRESTClient(ctrl)
-	s.expectGetFailure(c, restClient)
+	s.expectGetFailure(restClient)
 
 	client := NewFindClient(path, restClient, &FakeLogger{})
 	_, err := client.Find(context.TODO(), name)
@@ -63,6 +63,8 @@ func (s *FindSuite) TestFindFailure(c *gc.C) {
 func (s *FindSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name string) {
 	namedPath, err := p.Query("q", name)
 	c.Assert(err, jc.ErrorIsNil)
+	namedPath, err = namedPath.Query("fields", defaultFindFilter())
+	c.Assert(err, jc.ErrorIsNil)
 
 	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, responses *transport.FindResponses) {
 		responses.Results = []transport.FindResponse{{
@@ -71,7 +73,7 @@ func (s *FindSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name
 	}).Return(nil)
 }
 
-func (s *FindSuite) expectGetFailure(c *gc.C, client *MockRESTClient) {
+func (s *FindSuite) expectGetFailure(client *MockRESTClient) {
 	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
 }
 

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -53,7 +53,7 @@ func (s *InfoSuite) TestInfoFailure(c *gc.C) {
 	name := "meshuggah"
 
 	restClient := NewMockRESTClient(ctrl)
-	s.expectGetFailure(c, restClient)
+	s.expectGetFailure(restClient)
 
 	client := NewInfoClient(path, restClient, &FakeLogger{})
 	_, err := client.Info(context.TODO(), name)
@@ -80,18 +80,22 @@ func (s *InfoSuite) TestInfoError(c *gc.C) {
 func (s *InfoSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name string) {
 	namedPath, err := p.Join(name)
 	c.Assert(err, jc.ErrorIsNil)
+	namedPath, err = namedPath.Query("fields", defaultInfoFilter())
+	c.Assert(err, jc.ErrorIsNil)
 
 	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, response *transport.InfoResponse) {
 		response.Name = name
 	}).Return(nil)
 }
 
-func (s *InfoSuite) expectGetFailure(c *gc.C, client *MockRESTClient) {
+func (s *InfoSuite) expectGetFailure(client *MockRESTClient) {
 	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
 }
 
 func (s *InfoSuite) expectGetError(c *gc.C, client *MockRESTClient, p path.Path, name string) {
 	namedPath, err := p.Join(name)
+	c.Assert(err, jc.ErrorIsNil)
+	namedPath, err = namedPath.Query("fields", defaultInfoFilter())
 	c.Assert(err, jc.ErrorIsNil)
 
 	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, response *transport.InfoResponse) {


### PR DESCRIPTION
The CharmHub info and find apis will only return the name, type and ID if no fields are provided defining what data to return.  Add all the fields necessary to fill the InfoResponse and FindResponse structures.

In the future we can look at being more specific in the fields, or using specific fields for different types of info/find calls.


## QA steps

There should be no visible change in info and find command output.

```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju add-model seven --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju info ubuntu
name: ubuntu
charm-id: S3Tu8yuXujMlsWkrpNWEommeAQOGpRWg
summary: A pristine Ubuntu Server
publisher: charmers
supports: xenial, bionic, artful, cosmic, disco, trusty, focal
subordinate: false
store-url: https://staging-api.charmhub.io/ubuntu
description: |
  This simply deploys the Ubuntu Cloud/Server image
channels: |
  latest/stable:     11     (11)  4MB
  latest/candidate:  11     (11)  4MB
  latest/beta:       11     (11)  4MB
  latest/edge:       11     (11)  4MB
$ juju find ubuntu
Name                     Bundle  Version  Supports                                        Publisher              Summary
ubuntu                   -       11       xenial,bionic,artful,cosmic,disco,trusty,focal  charmers               A pristine Ubuntu Server
ubuntu-repository-cache  -       4        xenial,trusty                                   cloud-images           Ubuntu archive caching proxy mirror
ubuntu-devenv            -       11       bionic,xenial,trusty                            kwmonroe               Simple Ubuntu development and test environment
ubuntu-qa                -       3        focal,bionic,xenial                             Canonical Juju QA Bot  juju-qa version of the ubuntu charm.
```


