### PR TITLE
add contains-charms to InfoResult and weave thru to juju info output.

### DIFF
--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -176,6 +176,6 @@ type Bundle struct {
 }
 
 type BundleCharm struct {
-	Name     string `json:"name"`
-	Revision int    `json:"revision"`
+	Name      string `json:"name"`
+	PackageID string `json:"package-id"`
 }

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -27,7 +27,7 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 	}
 	switch ir.Type {
 	case "bundle":
-		ir.Bundle = convertBundle()
+		ir.Bundle = convertBundle(info.Entity.Charms)
 		// TODO (stickupkid): Get the Bundle.Series and set it to the
 		// InfoResponse at a high level.
 	case "charm":
@@ -200,8 +200,15 @@ func formatRelationPart(rels map[string]charm.Relation) (map[string]string, bool
 	return relations, true
 }
 
-func convertBundle() *params.CharmHubBundle {
-	// TODO (hml) 2020-07-06
-	// Implemented once how to get charms in a bundle is defined by the api.
-	return nil
+func convertBundle(charms []transport.Charm) *params.CharmHubBundle {
+	bundle := &params.CharmHubBundle{
+		Charms: make([]params.BundleCharm, len(charms)),
+	}
+	for i, v := range charms {
+		bundle.Charms[i] = params.BundleCharm{
+			Name:      v.Name,
+			PackageID: v.PackageID,
+		}
+	}
+	return bundle
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -11976,14 +11976,14 @@
                         "name": {
                             "type": "string"
                         },
-                        "revision": {
-                            "type": "integer"
+                        "package-id": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
                         "name",
-                        "revision"
+                        "package-id"
                     ]
                 },
                 "Channel": {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -74,8 +74,8 @@ type CharmHubBundle struct {
 }
 
 type BundleCharm struct {
-	Name     string `json:"name"`
-	Revision int    `json:"revision"`
+	Name      string `json:"name"`
+	PackageID string `json:"package-id"`
 }
 
 type ErrorResponse struct {

--- a/charmhub/filter.go
+++ b/charmhub/filter.go
@@ -15,8 +15,6 @@ func appendFilterList(value string, filters []string) []string {
 	return retVals
 }
 
-// always present are: type, id, and name
-
 var defaultChannelFilter = []string{
 	"channel.name",
 	"channel.platform.architecture",
@@ -31,6 +29,9 @@ var defaultResultFilter = []string{
 	"result.bugs-url",
 	"result.categories.featured",
 	"result.categories.name",
+	"result.contains-charms.name",
+	"result.contains-charms.package-id",
+	"result.contains-charms.store-url",
 	"result.description",
 	"result.license",
 	"result.media.height",

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -43,6 +43,7 @@ type Download struct {
 
 type Entity struct {
 	Categories  []Category        `json:"categories"`
+	Charms      []Charm           `json:"contains-charms"`
 	Description string            `json:"description"`
 	License     string            `json:"license"`
 	Media       []Media           `json:"media"`
@@ -62,4 +63,10 @@ type Media struct {
 	URL    string `json:"url"`
 	Width  int    `json:"width,omitempty"`
 	Height int    `json:"height,omitempty"`
+}
+
+type Charm struct {
+	Name      string `json:"name"`
+	PackageID string `json:"package-id"`
+	StoreURL  string `json:"store-url"`
 }

--- a/cmd/juju/charmhub/data.go
+++ b/cmd/juju/charmhub/data.go
@@ -68,7 +68,7 @@ func convertBundle(in interface{}) (*Bundle, error) {
 		Charms: make([]BundleCharm, len(inB.Charms)),
 	}
 	for i, c := range inB.Charms {
-		out.Charms[i] = BundleCharm(c)
+		out.Charms[i] = BundleCharm{Name: c.Name}
 	}
 	return &out, nil
 }
@@ -166,6 +166,5 @@ type Bundle struct {
 }
 
 type BundleCharm struct {
-	Name     string `json:"name" yaml:"name"`
-	Revision int    `json:"revision" yaml:"revision"`
+	Name string `json:"name" yaml:"name"`
 }


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

Add the bundle specific data to charmhub InfoResponse.  Weave thru for use in juju info.  The package-id is not needed for display.  It maybe useful for deploy later, though juju code might not be ready for it yet.

## QA steps

No current info should change.  There isn't a bundle in staging to test against today.
