### PR TITLE
Fix deployment of IAAS charms

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1247,7 +1247,7 @@ func (s *DeploySuite) TestInvalidSeriesForModel(c *gc.C) {
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	err := s.runDeployForState(c, charmDir.Path, "portlandia", "--series", "kubernetes")
-	c.Assert(err, gc.ErrorMatches, `series "kubernetes" in a non container model not valid`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "portlandia": series "kubernetes" in a non container model not valid`)
 }
 
 func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -55,7 +55,7 @@ type deployCharm struct {
 	storage         map[string]storage.Constraints
 	trust           bool
 
-	validateCharmSeriesWithName           func(series, name string, imageStream string, meta *charm.Meta) error
+	validateCharmSeriesWithName           func(series, name string, imageStream string) error
 	validateResourcesNeededForLocalDeploy func(charmMeta *charm.Meta) error
 }
 
@@ -287,6 +287,11 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		return errors.Trace(err)
 	}
 
+	// Avoid deploying charm if it's not valid for the model.
+	if err := d.validateCharmSeriesWithName(userCharmURL.Series, userCharmURL.Name, modelCfg.ImageStream()); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err := d.validateCharmFlags(); err != nil {
 		return errors.Trace(err)
 	}
@@ -297,11 +302,6 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		return errors.Trace(err)
 	}
 	ctx.Infof("Located charm %q.", formattedCharmURL)
-
-	// Avoid deploying charm if it's not valid for the model.
-	if err := d.validateCharmSeriesWithName(userCharmURL.Series, userCharmURL.Name, modelCfg.ImageStream(), charmInfo.Meta); err != nil {
-		return errors.Trace(err)
-	}
 
 	if err := d.validateResourcesNeededForLocalDeploy(charmInfo.Meta); err != nil {
 		return errors.Trace(err)
@@ -425,18 +425,13 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		fromBundle:          false,
 	}
 
-	charmInfo, err := deployAPI.CharmInfo(storeCharmOrBundleURL.String())
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	// Get the series to use.
 	series, err := selector.charmSeries()
 
 	// Avoid deploying charm if it's not valid for the model.
 	// We check this first before possibly suggesting --force.
 	if err == nil {
-		if err2 := c.validateCharmSeriesWithName(series, storeCharmOrBundleURL.Name, imageStream, charmInfo.Meta); err2 != nil {
+		if err2 := c.validateCharmSeriesWithName(series, storeCharmOrBundleURL.Name, imageStream); err2 != nil {
 			return errors.Trace(err2)
 		}
 	}
@@ -474,7 +469,7 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	// what we deploy, we should converge the two so that both report identical
 	// values.
 	if curl != nil && series == "" {
-		if err := c.validateCharmSeriesWithName(curl.Series, storeCharmOrBundleURL.Name, imageStream, charmInfo.Meta); err != nil {
+		if err := c.validateCharmSeriesWithName(curl.Series, storeCharmOrBundleURL.Name, imageStream); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -347,7 +347,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	}
 
 	// Avoid deploying charm if it's not valid for the model.
-	if err := d.validateCharmSeriesWithName(seriesName, curl.Name, imageStream, ch.Meta()); err != nil {
+	if err := d.validateCharmSeriesWithName(seriesName, curl.Name, imageStream); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := d.validateResourcesNeededForLocalDeploy(ch.Meta()); err != nil {
@@ -499,7 +499,7 @@ var getModelConfig = func(api ModelConfigGetter) (*config.Config, error) {
 	return config.New(config.NoDefaults, attrs)
 }
 
-func (d *factory) validateCharmSeries(seriesName string, imageStream string, charmMeta *charm.Meta) error {
+func (d *factory) validateCharmSeries(seriesName string, imageStream string) error {
 	// TODO(embedded): handle systems
 
 	// attempt to locate the charm series from the list of known juju series
@@ -519,19 +519,14 @@ func (d *factory) validateCharmSeries(seriesName string, imageStream string, cha
 	if !found && !d.force {
 		return errors.NotSupportedf("series: %s", seriesName)
 	}
-
-	modelType, err := d.model.ModelType()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return model.ValidateSeries(modelType, seriesName, charmMeta.Format())
+	return nil
 }
 
 // validateCharmSeriesWithName calls the validateCharmSeries, but handles the
 // error return value to check for NotSupported error and returns a custom error
 // message if that's found.
-func (d *factory) validateCharmSeriesWithName(series, name string, imageStream string, charmMeta *charm.Meta) error {
-	err := d.validateCharmSeries(series, imageStream, charmMeta)
+func (d *factory) validateCharmSeriesWithName(series, name string, imageStream string) error {
+	err := d.validateCharmSeries(series, imageStream)
 	return charmValidationError(series, name, errors.Trace(err))
 }
 


### PR DESCRIPTION
This PR reverts a charm validation check introduced when the k8s spike was merged.
An extra check of charm series was done based on the metadata version. The point at which the check was done was before the charm was available. However, the exact same check is done in state/AddCharm() so it is not possible to write a bad charm to state. So there's no real need to do this particular check client side.
The changes here are to essentially revert some of the recent changes, which were not really specifically unit tested, so there's no test fallout. The validateCharmSeriesWithName() method has the metadata format argument removed.

## QA steps

Deploy any IAAS charm... eg
juju deploy mysql

