### PR TITLE
Add unit status and storage status updating for new k8s.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,9 @@ else
 	@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/."
 endif
 	make build-pebble
+ifneq (${BIN_DIR},${JUJUD_BIN_DIR})
+	@cp ${BIN_DIR}/juju-fake-init ${JUJUD_BIN_DIR}/juju-fake-init
+endif
 
 build-pebble:
 	@mkdir -p ${BIN_DIR}

--- a/api/caasapplicationprovisioner/client.go
+++ b/api/caasapplicationprovisioner/client.go
@@ -315,3 +315,22 @@ func (c *Client) ApplicationOCIResources(appName string) (map[string]resources.D
 	}
 	return images, nil
 }
+
+// UpdateUnits updates the state model to reflect the state of the units
+// as reported by the cloud.
+func (c *Client) UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error) {
+	var result params.UpdateApplicationUnitResults
+	args := params.UpdateApplicationUnitArgs{Args: []params.UpdateApplicationUnits{arg}}
+	err := c.facade.FacadeCall("UpdateApplicationsUnits", args, &result)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(result.Results) != len(args.Args) {
+		return nil, errors.Errorf("expected %d result(s), got %d", len(args.Args), len(result.Results))
+	}
+	firstResult := result.Results[0]
+	if firstResult.Error == nil {
+		return firstResult.Info, nil
+	}
+	return firstResult.Info, maybeNotFound(firstResult.Error)
+}

--- a/api/caasapplicationprovisioner/client_test.go
+++ b/api/caasapplicationprovisioner/client_test.go
@@ -307,3 +307,70 @@ func (s *provisionerSuite) TestApplicationCharmURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, jc.DeepEquals, &charm.URL{Schema: "cs", Name: "charm", Revision: -1})
 }
+
+func (s *provisionerSuite) TestUpdateUnits(c *gc.C) {
+	var called bool
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		called = true
+		c.Check(objType, gc.Equals, "CAASApplicationProvisioner")
+		c.Check(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "UpdateApplicationsUnits")
+		c.Assert(a, jc.DeepEquals, params.UpdateApplicationUnitArgs{
+			Args: []params.UpdateApplicationUnits{
+				{
+					ApplicationTag: "application-app",
+					Units: []params.ApplicationUnitParams{
+						{ProviderId: "uuid", UnitTag: "unit-gitlab-0", Address: "address", Ports: []string{"port"},
+							Status: "active", Info: "message"},
+					},
+				},
+			},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.UpdateApplicationUnitResults{})
+		*(result.(*params.UpdateApplicationUnitResults)) = params.UpdateApplicationUnitResults{
+			Results: []params.UpdateApplicationUnitResult{{
+				Info: &params.UpdateApplicationUnitsInfo{
+					Units: []params.ApplicationUnitInfo{
+						{ProviderId: "uuid", UnitTag: "unit-gitlab-0"},
+					},
+				},
+			}},
+		}
+		return nil
+	})
+	info, err := client.UpdateUnits(params.UpdateApplicationUnits{
+		ApplicationTag: names.NewApplicationTag("app").String(),
+		Units: []params.ApplicationUnitParams{
+			{ProviderId: "uuid", UnitTag: "unit-gitlab-0", Address: "address", Ports: []string{"port"},
+				Status: "active", Info: "message"},
+		},
+	})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(called, jc.IsTrue)
+	c.Check(info, jc.DeepEquals, &params.UpdateApplicationUnitsInfo{
+		Units: []params.ApplicationUnitInfo{
+			{ProviderId: "uuid", UnitTag: "unit-gitlab-0"},
+		},
+	})
+}
+
+func (s *provisionerSuite) TestUpdateUnitsCount(c *gc.C) {
+	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
+		c.Assert(result, gc.FitsTypeOf, &params.UpdateApplicationUnitResults{})
+		*(result.(*params.UpdateApplicationUnitResults)) = params.UpdateApplicationUnitResults{
+			Results: []params.UpdateApplicationUnitResult{
+				{Error: &params.Error{Message: "FAIL"}},
+				{Error: &params.Error{Message: "FAIL"}},
+			},
+		}
+		return nil
+	})
+	info, err := client.UpdateUnits(params.UpdateApplicationUnits{
+		ApplicationTag: names.NewApplicationTag("app").String(),
+		Units: []params.ApplicationUnitParams{
+			{ProviderId: "uuid", Address: "address"},
+		},
+	})
+	c.Check(err, gc.ErrorMatches, `expected 1 result\(s\), got 2`)
+	c.Assert(info, gc.IsNil)
+}

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -4,8 +4,12 @@
 package caasapplicationprovisioner_test
 
 import (
+	"time"
+
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
+	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/systems"
@@ -29,11 +33,13 @@ var _ = gc.Suite(&CAASApplicationProvisionerSuite{})
 
 type CAASApplicationProvisionerSuite struct {
 	coretesting.BaseSuite
+	clock clock.Clock
 
 	resources          *common.Resources
 	authorizer         *apiservertesting.FakeAuthorizer
 	api                *caasapplicationprovisioner.API
 	st                 *mockState
+	storage            *mockStorage
 	storagePoolManager *mockStoragePoolManager
 	registry           *mockStorageRegistry
 }
@@ -50,10 +56,17 @@ func (s *CAASApplicationProvisionerSuite) SetUpTest(c *gc.C) {
 		Controller: true,
 	}
 
+	s.clock = testclock.NewClock(time.Now())
 	s.st = newMockState()
+	s.storage = &mockStorage{
+		storageFilesystems: make(map[names.StorageTag]names.FilesystemTag),
+		storageVolumes:     make(map[names.StorageTag]names.VolumeTag),
+		storageAttachments: make(map[names.UnitTag]names.StorageTag),
+		backingVolume:      names.NewVolumeTag("66"),
+	}
 	s.storagePoolManager = &mockStoragePoolManager{}
 	s.registry = &mockStorageRegistry{}
-	api, err := caasapplicationprovisioner.NewCAASApplicationProvisionerAPI(s.st, s.resources, s.authorizer, s.storagePoolManager, s.registry)
+	api, err := caasapplicationprovisioner.NewCAASApplicationProvisionerAPI(s.st, s.resources, s.authorizer, s.storage, s.storagePoolManager, s.registry, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -62,7 +75,7 @@ func (s *CAASApplicationProvisionerSuite) TestPermission(c *gc.C) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: names.NewMachineTag("0"),
 	}
-	_, err := caasapplicationprovisioner.NewCAASApplicationProvisionerAPI(s.st, s.resources, s.authorizer, s.storagePoolManager, s.registry)
+	_, err := caasapplicationprovisioner.NewCAASApplicationProvisionerAPI(s.st, s.resources, s.authorizer, s.storage, s.storagePoolManager, s.registry, s.clock)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
@@ -194,7 +207,7 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectStateful(c *gc.C) {
 	s.st.model.CheckCallNames(c, "Containers")
 	c.Assert(s.st.app.Calls()[1].Args[0].(*state.UpdateUnitsOperation).Deletes, gc.HasLen, 1)
 	c.Assert(s.st.app.Calls()[1].Args[0].(*state.UpdateUnitsOperation).Deletes[0], gc.Equals, destroyOp)
-	s.st.app.units[1].CheckCallNames(c, "EnsureDead", "DestroyOperation")
+	s.st.app.units[1].CheckCallNames(c, "UpdateOperation", "DestroyOperation")
 }
 
 func (s *CAASApplicationProvisionerSuite) TestGarbageCollectDeployment(c *gc.C) {
@@ -475,4 +488,282 @@ func (s *CAASApplicationProvisionerSuite) TestApplicationOCIResources(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithStorage(c *gc.C) {
+	s.st.app = &mockApplication{
+		tag:  names.NewApplicationTag("gitlab"),
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{
+				Deployment: &charm.Deployment{
+					DeploymentType: charm.DeploymentStateful,
+				},
+				// charm.FormatV2.
+				Systems: []systems.System{
+					{
+						OS: "ubuntu",
+						Channel: channel.Channel{
+							Name:  "20.04/stable",
+							Risk:  "stable",
+							Track: "20.04",
+						},
+					},
+				},
+			},
+		},
+		units: []*mockUnit{
+			{
+				tag: names.NewUnitTag("gitlab/0"),
+				containerInfo: &mockCloudContainer{
+					unit:       "gitlab/0",
+					providerId: "gitlab-0",
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/1"),
+				containerInfo: &mockCloudContainer{
+					unit:       "gitlab/1",
+					providerId: "gitlab-1",
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/2"),
+				containerInfo: &mockCloudContainer{
+					unit:       "gitlab/2",
+					providerId: "gitlab-2",
+				},
+			},
+		},
+	}
+	s.storage.storageFilesystems[names.NewStorageTag("data/0")] = names.NewFilesystemTag("gitlab/0/0")
+	s.storage.storageFilesystems[names.NewStorageTag("data/1")] = names.NewFilesystemTag("gitlab/1/0")
+	s.storage.storageFilesystems[names.NewStorageTag("data/2")] = names.NewFilesystemTag("gitlab/2/0")
+	s.storage.storageVolumes[names.NewStorageTag("data/0")] = names.NewVolumeTag("0")
+	s.storage.storageVolumes[names.NewStorageTag("data/1")] = names.NewVolumeTag("1")
+	s.storage.storageAttachments[names.NewUnitTag("gitlab/0")] = names.NewStorageTag("data/0")
+	s.storage.storageAttachments[names.NewUnitTag("gitlab/1")] = names.NewStorageTag("data/1")
+	s.storage.storageAttachments[names.NewUnitTag("gitlab/2")] = names.NewStorageTag("data/2")
+
+	units := []params.ApplicationUnitParams{
+		{ProviderId: "gitlab-0", Address: "address", Ports: []string{"port"},
+			Status: "running", Info: "message", Stateful: true,
+			FilesystemInfo: []params.KubernetesFilesystemInfo{
+				{StorageName: "data", FilesystemId: "fs-id", Size: 100, MountPoint: "/path/to/here", ReadOnly: true,
+					Status: "pending", Info: "not ready",
+					Volume: params.KubernetesVolumeInfo{
+						VolumeId: "vol-id", Size: 100, Persistent: true,
+						Status: "pending", Info: "vol not ready",
+					}},
+			},
+		},
+		{ProviderId: "gitlab-1", Address: "another-address", Ports: []string{"another-port"},
+			Status: "running", Info: "another message", Stateful: true,
+			FilesystemInfo: []params.KubernetesFilesystemInfo{
+				{StorageName: "data", FilesystemId: "fs-id2", Size: 200, MountPoint: "/path/to/there", ReadOnly: true,
+					Status: "attached", Info: "ready",
+					Volume: params.KubernetesVolumeInfo{
+						VolumeId: "vol-id2", Size: 200, Persistent: true,
+						Status: "attached", Info: "vol ready",
+					}},
+			},
+		},
+	}
+
+	args := params.UpdateApplicationUnitArgs{
+		Args: []params.UpdateApplicationUnits{
+			{ApplicationTag: "application-gitlab", Units: units},
+		},
+	}
+	results, err := s.api.UpdateApplicationsUnits(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0], gc.DeepEquals, params.UpdateApplicationUnitResult{
+		Info: &params.UpdateApplicationUnitsInfo{
+			Units: []params.ApplicationUnitInfo{
+				{ProviderId: "gitlab-0", UnitTag: "unit-gitlab-0"},
+				{ProviderId: "gitlab-1", UnitTag: "unit-gitlab-1"},
+			},
+		},
+	})
+	s.st.app.CheckCallNames(c, "Life", "AllUnits", "UpdateUnits", "Name")
+	s.st.app.units[0].CheckCallNames(c, "UpdateOperation")
+	s.st.app.units[0].CheckCall(c, 0, "UpdateOperation", state.UnitUpdateProperties{
+		ProviderId: strPtr("gitlab-0"),
+		Address:    strPtr("address"), Ports: &[]string{"port"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
+	})
+	s.st.app.units[1].CheckCallNames(c, "UpdateOperation")
+	s.st.app.units[1].CheckCall(c, 0, "UpdateOperation", state.UnitUpdateProperties{
+		ProviderId: strPtr("gitlab-1"),
+		Address:    strPtr("another-address"), Ports: &[]string{"another-port"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "another message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
+	})
+	// Missing units are handled by the GarbageCollect call.
+	s.st.app.units[2].CheckCallNames(c)
+
+	s.storage.CheckCallNames(c,
+		"UnitStorageAttachments", "StorageInstance", "UnitStorageAttachments", "StorageInstance",
+		"AllFilesystems", "Volume", "SetVolumeInfo", "SetVolumeAttachmentInfo", "Volume", "SetStatus",
+		"Volume", "SetStatus", "Filesystem", "SetFilesystemInfo", "SetFilesystemAttachmentInfo",
+		"Filesystem", "SetStatus", "Filesystem", "SetStatus")
+	s.storage.CheckCall(c, 0, "UnitStorageAttachments", names.NewUnitTag("gitlab/0"))
+	s.storage.CheckCall(c, 1, "StorageInstance", names.NewStorageTag("data/0"))
+	s.storage.CheckCall(c, 2, "UnitStorageAttachments", names.NewUnitTag("gitlab/1"))
+	s.storage.CheckCall(c, 3, "StorageInstance", names.NewStorageTag("data/1"))
+
+	now := s.clock.Now()
+	s.storage.CheckCall(c, 6, "SetVolumeInfo",
+		names.NewVolumeTag("1"),
+		state.VolumeInfo{
+			Size:       200,
+			VolumeId:   "vol-id2",
+			Persistent: true,
+		})
+	s.storage.CheckCall(c, 7, "SetVolumeAttachmentInfo",
+		names.NewUnitTag("gitlab/1"), names.NewVolumeTag("1"),
+		state.VolumeAttachmentInfo{
+			ReadOnly: true,
+		})
+	s.storage.CheckCall(c, 9, "SetStatus",
+		status.StatusInfo{
+			Status:  status.Pending,
+			Message: "vol not ready",
+			Since:   &now,
+		})
+	s.storage.CheckCall(c, 11, "SetStatus",
+		status.StatusInfo{
+			Status:  status.Attached,
+			Message: "vol ready",
+			Since:   &now,
+		})
+
+	s.storage.CheckCall(c, 13, "SetFilesystemInfo",
+		names.NewFilesystemTag("gitlab/1/0"),
+		state.FilesystemInfo{
+			Size:         200,
+			FilesystemId: "fs-id2",
+		})
+	s.storage.CheckCall(c, 14, "SetFilesystemAttachmentInfo",
+		names.NewUnitTag("gitlab/1"), names.NewFilesystemTag("gitlab/1/0"),
+		state.FilesystemAttachmentInfo{
+			MountPoint: "/path/to/there",
+			ReadOnly:   true,
+		})
+	s.storage.CheckCall(c, 16, "SetStatus",
+		status.StatusInfo{
+			Status:  status.Pending,
+			Message: "not ready",
+			Since:   &now,
+		})
+	s.storage.CheckCall(c, 18, "SetStatus",
+		status.StatusInfo{
+			Status:  status.Attached,
+			Message: "ready",
+			Since:   &now,
+		})
+
+	s.st.model.CheckCallNames(c, "Containers")
+	s.st.model.CheckCall(c, 0, "Containers", []string{"gitlab-0", "gitlab-1"})
+}
+
+func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStorage(c *gc.C) {
+	s.st.app = &mockApplication{
+		tag:  names.NewApplicationTag("gitlab"),
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{
+				Deployment: &charm.Deployment{
+					DeploymentType: charm.DeploymentStateful,
+				},
+				// charm.FormatV2.
+				Systems: []systems.System{
+					{
+						OS: "ubuntu",
+						Channel: channel.Channel{
+							Name:  "20.04/stable",
+							Risk:  "stable",
+							Track: "20.04",
+						},
+					},
+				},
+			},
+		},
+		units: []*mockUnit{
+			{
+				tag: names.NewUnitTag("gitlab/0"),
+				containerInfo: &mockCloudContainer{
+					unit:       "gitlab/0",
+					providerId: "gitlab-0",
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/1"),
+				containerInfo: &mockCloudContainer{
+					unit:       "gitlab/1",
+					providerId: "gitlab-1",
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/2"),
+				containerInfo: &mockCloudContainer{
+					unit:       "gitlab/2",
+					providerId: "gitlab-2",
+				},
+			},
+		},
+	}
+
+	units := []params.ApplicationUnitParams{
+		{
+			ProviderId: "gitlab-0", Address: "address", Ports: []string{"port"},
+			Status: "running", Info: "message", Stateful: true,
+		},
+		{
+			ProviderId: "gitlab-1", Address: "another-address", Ports: []string{"another-port"},
+			Status: "running", Info: "another message", Stateful: true,
+		},
+	}
+
+	args := params.UpdateApplicationUnitArgs{
+		Args: []params.UpdateApplicationUnits{
+			{ApplicationTag: "application-gitlab", Units: units},
+		},
+	}
+	results, err := s.api.UpdateApplicationsUnits(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results[0], gc.DeepEquals, params.UpdateApplicationUnitResult{
+		Info: &params.UpdateApplicationUnitsInfo{
+			Units: []params.ApplicationUnitInfo{
+				{ProviderId: "gitlab-0", UnitTag: "unit-gitlab-0"},
+				{ProviderId: "gitlab-1", UnitTag: "unit-gitlab-1"},
+			},
+		},
+	})
+	s.st.app.CheckCallNames(c, "Life", "AllUnits", "UpdateUnits", "Name")
+	s.st.app.units[0].CheckCallNames(c, "UpdateOperation")
+	s.st.app.units[0].CheckCall(c, 0, "UpdateOperation", state.UnitUpdateProperties{
+		ProviderId: strPtr("gitlab-0"),
+		Address:    strPtr("address"), Ports: &[]string{"port"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
+	})
+	s.st.app.units[1].CheckCallNames(c, "UpdateOperation")
+	s.st.app.units[1].CheckCall(c, 0, "UpdateOperation", state.UnitUpdateProperties{
+		ProviderId: strPtr("gitlab-1"),
+		Address:    strPtr("another-address"), Ports: &[]string{"another-port"},
+		CloudContainerStatus: &status.StatusInfo{Status: status.Running, Message: "another message"},
+		AgentStatus:          &status.StatusInfo{Status: status.Idle},
+	})
+	// Missing units are handled by the GarbageCollect call.
+	s.st.app.units[2].CheckCallNames(c)
+
+	s.storage.CheckCallNames(c, "AllFilesystems")
+	s.st.model.CheckCallNames(c, "Containers")
+	s.st.model.CheckCall(c, 0, "Containers", []string{"gitlab-0", "gitlab-1"})
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -408,20 +408,6 @@ func (m *mockStorage) SetFilesystemAttachmentInfo(host names.Tag, fsTag names.Fi
 	return nil
 }
 
-type mockDeviceBackend struct {
-	testing.Stub
-	devices            map[names.StorageTag]names.FilesystemTag
-	storageAttachments map[names.UnitTag]names.StorageTag
-}
-
-func (d *mockDeviceBackend) DeviceConstraints(id string) (map[string]state.DeviceConstraints, error) {
-	d.MethodCall(d, "DeviceConstraints", id)
-	return map[string]state.DeviceConstraints{
-		"bitcoinminer": {Type: "nvidia.com/gpu",
-			Count:      3,
-			Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
-		}}, nil
-}
 func (m *mockStorage) Volume(volTag names.VolumeTag) (state.Volume, error) {
 	m.MethodCall(m, "Volume", volTag)
 	return &mockVolume{Stub: &m.Stub, tag: volTag}, nil
@@ -439,6 +425,21 @@ func (m *mockStorage) SetVolumeInfo(volTag names.VolumeTag, volInfo state.Volume
 func (m *mockStorage) SetVolumeAttachmentInfo(host names.Tag, volTag names.VolumeTag, info state.VolumeAttachmentInfo) error {
 	m.MethodCall(m, "SetVolumeAttachmentInfo", host, volTag, info)
 	return nil
+}
+
+type mockDeviceBackend struct {
+	testing.Stub
+	devices            map[names.StorageTag]names.FilesystemTag
+	storageAttachments map[names.UnitTag]names.StorageTag
+}
+
+func (d *mockDeviceBackend) DeviceConstraints(id string) (map[string]state.DeviceConstraints, error) {
+	d.MethodCall(d, "DeviceConstraints", id)
+	return map[string]state.DeviceConstraints{
+		"bitcoinminer": {Type: "nvidia.com/gpu",
+			Count:      3,
+			Attributes: map[string]string{"gpu": "nvidia-tesla-p100"},
+		}}, nil
 }
 
 type mockStorageInstance struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6676,6 +6676,18 @@
                     },
                     "description": "Units returns all the units for each application specified."
                 },
+                "UpdateApplicationsUnits": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateApplicationUnitArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UpdateApplicationUnitResults"
+                        }
+                    },
+                    "description": "UpdateApplicationsUnits updates the Juju data model to reflect the given\nunits of the specified application."
+                },
                 "WatchApplications": {
                     "type": "object",
                     "properties": {
@@ -6687,6 +6699,75 @@
                 }
             },
             "definitions": {
+                "ApplicationUnitInfo": {
+                    "type": "object",
+                    "properties": {
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "provider-id",
+                        "unit-tag"
+                    ]
+                },
+                "ApplicationUnitParams": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "filesystem-info": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/KubernetesFilesystemInfo"
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "stateful": {
+                            "type": "boolean"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "provider-id",
+                        "unit-tag",
+                        "address",
+                        "ports",
+                        "status",
+                        "info"
+                    ]
+                },
                 "CAASApplicationGarbageCollectArg": {
                     "type": "object",
                     "properties": {
@@ -7517,6 +7598,36 @@
                         "changes"
                     ]
                 },
+                "EntityStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "since"
+                    ]
+                },
                 "EntityStatusArgs": {
                     "type": "object",
                     "properties": {
@@ -7639,6 +7750,57 @@
                         "provider"
                     ]
                 },
+                "KubernetesFilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "filesystem-id": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "storagename": {
+                            "type": "string"
+                        },
+                        "volume": {
+                            "$ref": "#/definitions/KubernetesVolumeInfo"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storagename",
+                        "pool",
+                        "size",
+                        "filesystem-id",
+                        "status",
+                        "info",
+                        "volume"
+                    ]
+                },
                 "KubernetesFilesystemParams": {
                     "type": "object",
                     "properties": {
@@ -7692,6 +7854,46 @@
                     "additionalProperties": false,
                     "required": [
                         "provider"
+                    ]
+                },
+                "KubernetesVolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-id",
+                        "size",
+                        "persistent",
+                        "status",
+                        "info"
                     ]
                 },
                 "KubernetesVolumeParams": {
@@ -7856,6 +8058,91 @@
                     "additionalProperties": false,
                     "required": [
                         "watcher-id"
+                    ]
+                },
+                "UpdateApplicationUnitArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateApplicationUnits"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "UpdateApplicationUnitResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/UpdateApplicationUnitsInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UpdateApplicationUnitResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateApplicationUnitResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UpdateApplicationUnits": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "generation": {
+                            "type": "integer"
+                        },
+                        "scale": {
+                            "type": "integer"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationUnitParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "units"
+                    ]
+                },
+                "UpdateApplicationUnitsInfo": {
+                    "type": "object",
+                    "properties": {
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationUnitInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "units"
                     ]
                 },
                 "Value": {

--- a/caas/application.go
+++ b/caas/application.go
@@ -23,6 +23,7 @@ type Application interface {
 	Watch() (watcher.NotifyWatcher, error)
 	WatchReplicas() (watcher.NotifyWatcher, error)
 	State() (ApplicationState, error)
+	Units() ([]Unit, error)
 
 	ServiceInterface
 }

--- a/caas/kubernetes/provider/resources/events.go
+++ b/caas/kubernetes/provider/resources/events.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+)
+
+const maxEventsToPage = 100
+
+// ListEventsForObject returns all the events for the specified object.
+func ListEventsForObject(ctx context.Context, client kubernetes.Interface,
+	namespace string, name string, kind string) ([]corev1.Event, error) {
+	selector := fields.AndSelectors(
+		fields.OneTermEqualSelector("involvedObject.name", name),
+		fields.OneTermEqualSelector("involvedObject.kind", kind),
+	).String()
+	opts := metav1.ListOptions{
+		FieldSelector: selector,
+	}
+	api := client.CoreV1().Events(namespace)
+	var items []corev1.Event
+	for len(items) < maxEventsToPage {
+		res, err := api.List(ctx, opts)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, v := range res.Items {
+			items = append(items, v)
+		}
+		if res.RemainingItemCount == nil || *res.RemainingItemCount == 0 {
+			break
+		}
+		opts.Continue = res.Continue
+	}
+	return items, nil
+}

--- a/caas/kubernetes/provider/resources/events_test.go
+++ b/caas/kubernetes/provider/resources/events_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources_test
+
+import (
+	"context"
+	"strconv"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
+)
+
+type eventsSuite struct {
+	resourceSuite
+}
+
+var _ = gc.Suite(&eventsSuite{})
+
+func (s *eventsSuite) TestList(c *gc.C) {
+	template := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ev",
+			Namespace: "test",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Name: "test",
+			Kind: "Pod",
+		},
+	}
+	res := []corev1.Event{}
+	for i := 0; i < 1000; i++ {
+		ev := template
+		ev.ObjectMeta.Name += strconv.Itoa(i)
+		_, err := s.client.CoreV1().Events("test").Create(context.TODO(), &ev, metav1.CreateOptions{})
+		c.Assert(err, jc.ErrorIsNil)
+		res = append(res, ev)
+	}
+	events, err := resources.ListEventsForObject(context.TODO(), s.client, "test", "test", "Pod")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(events, jc.DeepEquals, res)
+}

--- a/caas/kubernetes/provider/resources/interface.go
+++ b/caas/kubernetes/provider/resources/interface.go
@@ -5,8 +5,12 @@ package resources
 
 import (
 	"context"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/juju/juju/core/status"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/resources_mock.go github.com/juju/juju/caas/kubernetes/provider/resources Resource,Applier
@@ -28,6 +32,10 @@ type Resource interface {
 	Delete(ctx context.Context, client kubernetes.Interface) error
 	// String returns a string format containing the name and type of the resource.
 	String() string
+	// ComputeStatus returns a juju status for the resource.
+	ComputeStatus(ctx context.Context, client kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error)
+	// Events emitted by the object.
+	Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error)
 }
 
 // Applier defines methods for processing a slice of resource operations.

--- a/caas/kubernetes/provider/resources/mocks/resources_mock.go
+++ b/caas/kubernetes/provider/resources/mocks/resources_mock.go
@@ -6,11 +6,13 @@ package mocks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	resources "github.com/juju/juju/caas/kubernetes/provider/resources"
+	status "github.com/juju/juju/core/status"
+	v1 "k8s.io/api/core/v1"
 	kubernetes "k8s.io/client-go/kubernetes"
+	reflect "reflect"
+	time "time"
 )
 
 // MockResource is a mock of Resource interface
@@ -64,6 +66,23 @@ func (mr *MockResourceMockRecorder) Clone() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockResource)(nil).Clone))
 }
 
+// ComputeStatus mocks base method
+func (m *MockResource) ComputeStatus(arg0 context.Context, arg1 kubernetes.Interface, arg2 time.Time) (string, status.Status, time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ComputeStatus", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(status.Status)
+	ret2, _ := ret[2].(time.Time)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// ComputeStatus indicates an expected call of ComputeStatus
+func (mr *MockResourceMockRecorder) ComputeStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeStatus", reflect.TypeOf((*MockResource)(nil).ComputeStatus), arg0, arg1, arg2)
+}
+
 // Delete mocks base method
 func (m *MockResource) Delete(arg0 context.Context, arg1 kubernetes.Interface) error {
 	m.ctrl.T.Helper()
@@ -76,6 +95,21 @@ func (m *MockResource) Delete(arg0 context.Context, arg1 kubernetes.Interface) e
 func (mr *MockResourceMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResource)(nil).Delete), arg0, arg1)
+}
+
+// Events mocks base method
+func (m *MockResource) Events(arg0 context.Context, arg1 kubernetes.Interface) ([]v1.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Events", arg0, arg1)
+	ret0, _ := ret[0].([]v1.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Events indicates an expected call of Events
+func (mr *MockResourceMockRecorder) Events(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockResource)(nil).Events), arg0, arg1)
 }
 
 // Get mocks base method

--- a/caas/kubernetes/provider/resources/pod.go
+++ b/caas/kubernetes/provider/resources/pod.go
@@ -1,0 +1,157 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
+)
+
+// Pod extends the k8s service.
+type Pod struct {
+	corev1.Pod
+}
+
+// NewPod creates a new service resource.
+func NewPod(name string, namespace string, in *corev1.Pod) *Pod {
+	if in == nil {
+		in = &corev1.Pod{}
+	}
+	in.SetName(name)
+	in.SetNamespace(namespace)
+	return &Pod{*in}
+}
+
+// ListPods returns a list of storage classes.
+func ListPods(ctx context.Context, client kubernetes.Interface, namespace string, opts metav1.ListOptions) ([]Pod, error) {
+	api := client.CoreV1().Pods(namespace)
+	var items []Pod
+	for {
+		res, err := api.List(ctx, opts)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, v := range res.Items {
+			items = append(items, Pod{Pod: v})
+		}
+		if res.RemainingItemCount == nil || *res.RemainingItemCount == 0 {
+			break
+		}
+		opts.Continue = res.Continue
+	}
+	return items, nil
+}
+
+// Clone returns a copy of the resource.
+func (p *Pod) Clone() Resource {
+	clone := *p
+	return &clone
+}
+
+// Apply patches the resource change.
+func (p *Pod) Apply(ctx context.Context, client kubernetes.Interface) error {
+	api := client.CoreV1().Pods(p.Namespace)
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &p.Pod)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	res, err := api.Patch(ctx, p.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+		FieldManager: JujuFieldManager,
+	})
+	if k8serrors.IsNotFound(err) {
+		res, err = api.Create(ctx, &p.Pod, metav1.CreateOptions{
+			FieldManager: JujuFieldManager,
+		})
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	p.Pod = *res
+	return nil
+}
+
+// Get refreshes the resource.
+func (p *Pod) Get(ctx context.Context, client kubernetes.Interface) error {
+	api := client.CoreV1().Pods(p.Namespace)
+	res, err := api.Get(ctx, p.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NewNotFound(err, "k8s")
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	p.Pod = *res
+	return nil
+}
+
+// Delete removes the resource.
+func (p *Pod) Delete(ctx context.Context, client kubernetes.Interface) error {
+	api := client.CoreV1().Pods(p.Namespace)
+	err := api.Delete(ctx, p.Name, metav1.DeleteOptions{
+		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// Events emitted by the resource.
+func (p *Pod) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, client, p.Namespace, p.Name, "Pod")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (p *Pod) ComputeStatus(ctx context.Context, client kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if p.DeletionTimestamp != nil {
+		return "", status.Terminated, p.DeletionTimestamp.Time, nil
+	}
+	jujuStatus := status.Unknown
+	switch p.Status.Phase {
+	case corev1.PodRunning:
+		jujuStatus = status.Running
+	case corev1.PodFailed:
+		jujuStatus = status.Error
+	case corev1.PodPending:
+		jujuStatus = status.Allocating
+	}
+	statusMessage := p.Status.Message
+	since := now
+	if statusMessage == "" {
+		for _, cond := range p.Status.Conditions {
+			statusMessage = cond.Message
+			since = cond.LastProbeTime.Time
+			if cond.Type == corev1.PodScheduled && cond.Reason == corev1.PodReasonUnschedulable {
+				jujuStatus = status.Blocked
+				break
+			}
+		}
+	}
+	if statusMessage == "" {
+		// If there are any events for this pod we can use the
+		// most recent to set the status.
+		eventList, err := p.Events(ctx, client)
+		if err != nil {
+			return "", "", time.Time{}, errors.Trace(err)
+		}
+		// Take the most recent event.
+		if count := len(eventList); count > 0 {
+			statusMessage = eventList[count-1].Message
+		}
+	}
+	return statusMessage, jujuStatus, since, nil
+}

--- a/caas/kubernetes/provider/resources/pod_test.go
+++ b/caas/kubernetes/provider/resources/pod_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources_test
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
+)
+
+type podSuite struct {
+	resourceSuite
+}
+
+var _ = gc.Suite(&podSuite{})
+
+func (s *podSuite) TestApply(c *gc.C) {
+	ds := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds1",
+			Namespace: "test",
+		},
+	}
+	// Create.
+	dsResource := resources.NewPod("ds1", "test", ds)
+	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
+
+	// Update.
+	ds.SetAnnotations(map[string]string{"a": "b"})
+	dsResource = resources.NewPod("ds1", "test", ds)
+	c.Assert(dsResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+
+	result, err = s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `ds1`)
+	c.Assert(result.GetNamespace(), gc.Equals, `test`)
+	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *podSuite) TestGet(c *gc.C) {
+	template := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds1",
+			Namespace: "test",
+		},
+	}
+	ds1 := template
+	ds1.SetAnnotations(map[string]string{"a": "b"})
+	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(), &ds1, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	dsResource := resources.NewPod("ds1", "test", &template)
+	c.Assert(len(dsResource.GetAnnotations()), gc.Equals, 0)
+	err = dsResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(dsResource.GetName(), gc.Equals, `ds1`)
+	c.Assert(dsResource.GetNamespace(), gc.Equals, `test`)
+	c.Assert(dsResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *podSuite) TestDelete(c *gc.C) {
+	ds := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds1",
+			Namespace: "test",
+		},
+	}
+	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(), &ds, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `ds1`)
+
+	dsResource := resources.NewPod("ds1", "test", &ds)
+	err = dsResource.Delete(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = dsResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = s.client.CoreV1().Pods("test").Get(context.TODO(), "ds1", metav1.GetOptions{})
+	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
+}

--- a/caas/kubernetes/provider/resources/secret.go
+++ b/caas/kubernetes/provider/resources/secret.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
 )
 
 // Secret extends the k8s secret.
@@ -86,4 +88,17 @@ func (s *Secret) Delete(ctx context.Context, client kubernetes.Interface) error 
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// Events emitted by the resource.
+func (s *Secret) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, client, s.Namespace, s.Name, "Secret")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (s *Secret) ComputeStatus(ctx context.Context, client kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if s.DeletionTimestamp != nil {
+		return "", status.Terminated, s.DeletionTimestamp.Time, nil
+	}
+	return "", status.Active, s.CreationTimestamp.Time, nil
 }

--- a/caas/kubernetes/provider/resources/service.go
+++ b/caas/kubernetes/provider/resources/service.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
 )
 
 // Service extends the k8s service.
@@ -86,4 +88,17 @@ func (s *Service) Delete(ctx context.Context, client kubernetes.Interface) error
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// Events emitted by the resource.
+func (s *Service) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, client, s.Namespace, s.Name, "Service")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (s *Service) ComputeStatus(ctx context.Context, client kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if s.DeletionTimestamp != nil {
+		return "", status.Terminated, s.DeletionTimestamp.Time, nil
+	}
+	return "", status.Active, s.CreationTimestamp.Time, nil
 }

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -92,6 +92,21 @@ func (mr *MockApplicationMockRecorder) State() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockApplication)(nil).State))
 }
 
+// Units mocks base method
+func (m *MockApplication) Units() ([]caas.Unit, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Units")
+	ret0, _ := ret[0].([]caas.Unit)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Units indicates an expected call of Units
+func (mr *MockApplicationMockRecorder) Units() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockApplication)(nil).Units))
+}
+
 // UpdatePorts mocks base method
 func (m *MockApplication) UpdatePorts(arg0 []caas.ServicePort, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/worker/caasapplicationprovisioner/manifold.go
+++ b/worker/caasapplicationprovisioner/manifold.go
@@ -19,6 +19,7 @@ type Logger interface {
 	Debugf(string, ...interface{})
 	Infof(string, ...interface{})
 	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
 }
 
 // ManifoldConfig defines a CAAS operator provisioner's dependencies.

--- a/worker/caasapplicationprovisioner/mocks/broker_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/broker_mock.go
@@ -5,10 +5,10 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	caas "github.com/juju/juju/caas"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockCAASBroker is a mock of CAASBroker interface
@@ -32,6 +32,20 @@ func NewMockCAASBroker(ctrl *gomock.Controller) *MockCAASBroker {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 	return m.recorder
+}
+
+// AnnotateUnit mocks base method
+func (m *MockCAASBroker) AnnotateUnit(arg0 string, arg1 caas.DeploymentMode, arg2 string, arg3 names.UnitTag) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AnnotateUnit indicates an expected call of AnnotateUnit
+func (mr *MockCAASBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockCAASBroker)(nil).AnnotateUnit), arg0, arg1, arg2, arg3)
 }
 
 // Application mocks base method

--- a/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -5,17 +5,17 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	caasapplicationprovisioner "github.com/juju/juju/api/caasapplicationprovisioner"
 	charms "github.com/juju/juju/api/common/charms"
+	params "github.com/juju/juju/apiserver/params"
 	life "github.com/juju/juju/core/life"
 	resources "github.com/juju/juju/core/resources"
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
 // MockCAASProvisionerFacade is a mock of CAASProvisionerFacade interface
@@ -171,6 +171,21 @@ func (m *MockCAASProvisionerFacade) Units(arg0 string) ([]names.Tag, error) {
 func (mr *MockCAASProvisionerFacadeMockRecorder) Units(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).Units), arg0)
+}
+
+// UpdateUnits mocks base method
+func (m *MockCAASProvisionerFacade) UpdateUnits(arg0 params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUnits", arg0)
+	ret0, _ := ret[0].(*params.UpdateApplicationUnitsInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUnits indicates an expected call of UpdateUnits
+func (mr *MockCAASProvisionerFacadeMockRecorder) UpdateUnits(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnits", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).UpdateUnits), arg0)
 }
 
 // WatchApplications mocks base method

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -15,6 +15,7 @@ import (
 
 	api "github.com/juju/juju/api/caasapplicationprovisioner"
 	charmscommon "github.com/juju/juju/api/common/charms"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/resources"
@@ -38,11 +39,13 @@ type CAASProvisionerFacade interface {
 	Units(appName string) ([]names.Tag, error)
 	GarbageCollect(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error
 	ApplicationOCIResources(appName string) (map[string]resources.DockerImageDetails, error)
+	UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error)
 }
 
 // CAASBroker exposes CAAS broker functionality to a worker.
 type CAASBroker interface {
 	Application(string, caas.DeploymentType) caas.Application
+	AnnotateUnit(appName string, mode caas.DeploymentMode, podName string, unit names.UnitTag) error
 }
 
 // Config defines the operation of a Worker.


### PR DESCRIPTION
## Description

Propagates pod status to storage and unit status in Juju model.

## QA steps

Deploy v2 charm with storage. Storage should appear correctly in status.
Pod IP should also be present in unit status.

Test scaling of statefulset. Storage should appear detached in juju status when scaling down.

## Documentation changes

N/A

## Bug reference

N/A