### PR TITLE
Annotate error return from AllLinkLayerDevices

### DIFF
--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -364,7 +364,7 @@ func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
 	var sDocs []linkLayerDeviceDoc
 	err = devicesCollection.Find(nil).All(&sDocs)
 	if err != nil {
-		return nil, errors.Errorf("cannot get all link layer devices")
+		return nil, errors.Annotate(err, "retrieving link-layer devices")
 	}
 	for _, d := range sDocs {
 		devices = append(devices, newLinkLayerDevice(st, d))


### PR DESCRIPTION
This exact error was surfaced in-theatre, but of course the cause was hidden by using Errorf.

Annotating the error instead will surface the root cause.