### PR TITLE
Generate uniter params via copying rather than referencing from templ…

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -576,7 +576,7 @@ func (op *caasOperator) loop() (err error) {
 				if err := op.makeAgentSymlinks(unitTag); err != nil {
 					return errors.Trace(err)
 				}
-				params := op.config.UniterParams
+				params := *op.config.UniterParams
 				params.ModelType = model.CAAS
 				params.UnitTag = unitTag
 				params.Downloader = op.config.Downloader // TODO(caas): write a cache downloader
@@ -603,7 +603,7 @@ func (op *caasOperator) loop() (err error) {
 					}
 					params.NewRemoteRunnerExecutor = getNewRunnerExecutor(logger, execClient)
 				}
-				if err := op.config.StartUniterFunc(op.runner, params); err != nil {
+				if err := op.config.StartUniterFunc(op.runner, &params); err != nil {
 					return errors.Trace(err)
 				}
 			}

--- a/worker/uniter/operation/executor.go
+++ b/worker/uniter/operation/executor.go
@@ -85,7 +85,7 @@ func (x *executor) Run(op Operation, remoteStateChange <-chan remotestate.Snapsh
 	if op.NeedsGlobalMachineLock() {
 		releaser, err := x.acquireMachineLock(op.String())
 		if err != nil {
-			return errors.Annotate(err, "could not acquire lock")
+			return errors.Annotatef(err, "could not acquire lock for %q", op)
 		}
 		defer x.logger.Debugf("lock released")
 		defer releaser()

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -209,7 +209,7 @@ func NewUniter(uniterParams *UniterParams) (*Uniter, error) {
 // StartUniter creates a new Uniter and starts it using the specified runner.
 func StartUniter(runner *worker.Runner, params *UniterParams) error {
 	startFunc := newUniter(params)
-	params.Logger.Debugf("starting uniter for  %q", params.UnitTag.Id())
+	params.Logger.Debugf("starting uniter for %q", params.UnitTag.Id())
 	err := runner.StartWorker(params.UnitTag.Id(), startFunc)
 	return errors.Annotate(err, "error starting uniter worker")
 }
@@ -273,12 +273,12 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			err = nil
 		}
 		if u.runListener != nil {
-			u.runListener.UnregisterRunner(u.unit.Name())
+			u.runListener.UnregisterRunner(unitTag.Id())
 		}
 		if u.localRunListener != nil {
-			u.localRunListener.UnregisterRunner(u.unit.Name())
+			u.localRunListener.UnregisterRunner(unitTag.Id())
 		}
-		u.logger.Infof("unit %q shutting down: %s", u.unit, err)
+		u.logger.Infof("unit %q shutting down: %s", unitTag.Id(), err)
 	}()
 
 	if err := u.init(unitTag); err != nil {


### PR DESCRIPTION
*Generate the CAAS uniter params via copying rather than referencing from the template params to fix below issues*

```text
# unit tag mismatching;
application-mariadb-k8s: 11:55:22 ERROR juju.worker.caasoperator exited "mariadb-k8s/31": executing operation "install local:kubernetes/mariadb-k8s-0": cannot install charm: cannot extract "lib/netaddr/ip/ipv4-address-space.xml": open /var/lib/juju/agents/unit-mariadb-k8s-29/charm/lib/netaddr/ip/ipv4-address-space.xml: file exists
```

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made


## QA steps

deploy CAAS workload and scale the app to a large number of pods, then watch the debug log to see if there are any errors.

```console
$ juju deploy /tmp/charm-builds/mariadb-k8s --resource mysql_image=ycliuhw/mariadb

$ juju scale-application mariadb-k8s -m t1 50

$ juju debug-log -m k1:t1 --color --replay --level WARNING
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1898792
