### PR TITLE
Set charmStoreCharm.series correctly from CLI --series argument

### DIFF
--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -216,6 +216,7 @@ func (d *factory) newDeployCharm() deployCharm {
 		placement:       d.placement,
 		placementSpec:   d.placementSpec,
 		resources:       d.resources,
+		series:          d.series,
 		steps:           d.steps,
 		storage:         d.storage,
 		trust:           d.trust,
@@ -276,7 +277,7 @@ func (d *factory) newDeployBundle(ds charm.BundleDataSource) deployBundle {
 
 func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error) {
 	// NOTE: Here we select the series using the algorithm defined by
-	// `seriesSelector.CharmSeries`. This serves to override the algorithm found in
+	// `seriesSelector.charmSeries`. This serves to override the algorithm found in
 	// `charmrepo.NewCharmAtPath` which is outdated (but must still be
 	// called since the code is coupled with path interpretation logic which
 	// cannot easily be factored out).


### PR DESCRIPTION
Fixes issue with `juju deploy` no longer honouring `--series`: https://bugs.launchpad.net/juju/+bug/1899496

This was introduced with the refactoring in https://github.com/juju/juju/pull/11901 -- deploy with `--series bionic` produces a bionic series before that commit, focal after.

NOTE: tests to come later (or in subsequent PR).

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
juju deploy postgresql --series bionic
```

And then `juju status` to see that the machine is actually running bionic.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1899496