### PR TITLE
Add integration test for deploy --series

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -23,7 +23,7 @@ run_deploy_specific_series() {
 
     destroy_model "test-deploy-specific-series"
 
-    echo $series | check "bionic"
+    echo "$series" | check "bionic"
 }
 
 run_deploy_lxd_profile_charm() {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -19,9 +19,11 @@ run_deploy_specific_series() {
     ensure "test-deploy-specific-series" "${file}"
 
     juju deploy postgresql --series bionic
-    juju status --format=json | jq .applications.postgresql.series | check "bionic"
+    series=$(juju status --format=json | jq ".applications.postgresql.series")
 
     destroy_model "test-deploy-specific-series"
+
+    echo $series | check "bionic"
 }
 
 run_deploy_lxd_profile_charm() {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -11,6 +11,19 @@ run_deploy_charm() {
     destroy_model "test-deploy-charm"
 }
 
+run_deploy_specific_series() {
+    echo
+
+    file="${TEST_DIR}/test-deploy-specific-series.log"
+
+    ensure "test-deploy-specific-series" "${file}"
+
+    juju deploy postgresql --series bionic
+    juju status --format=json | jq .applications.postgresql.series | check "bionic"
+
+    destroy_model "test-deploy-specific-series"
+}
+
 run_deploy_lxd_profile_charm() {
     echo
 
@@ -209,6 +222,7 @@ test_deploy_charms() {
         cd .. || exit
 
         run "run_deploy_charm"
+        run "run_deploy_specific_series"
         run "run_deploy_lxd_to_container"
         run "run_deploy_lxd_profile_charm_container"
 


### PR DESCRIPTION
Added CI integration test for the `deploy --series` fix. Actual fix in https://github.com/juju/juju/pull/12121.

I've verified that this fails without the `--series` fix, and succeeds as expected with the fix.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
cd tests
./main.sh deploy test_deploy_charms
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1899496
