### PR TITLE
Fix pebble building and remove k8sagent image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,10 +222,6 @@ OPERATOR_IMAGE_BUILD_SRC   ?= true
 BUILD_OPERATOR_IMAGE=sh -c '. "${PROJECT_DIR}/make_functions.sh"; build_operator_image "$$@"' build_operator_image
 OPERATOR_IMAGE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; operator_image_path "$$@"' operator_image_path
 OPERATOR_IMAGE_RELEASE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; operator_image_release_path "$$@"' operator_image_release_path
-# For the new k8s agent.
-BUILD_K8SAGENT_IMAGE=sh -c '. "${PROJECT_DIR}/make_functions.sh"; build_k8sagent_image "$$@"' build_k8sagent_image
-K8SAGENT_IMAGE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; k8sagent_image_path "$$@"' k8sagent_image_path
-K8SAGENT_IMAGE_RELEASE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; k8sagent_image_release_path "$$@"' k8sagent_image_release_path
 
 image-check-build:
 ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
@@ -233,43 +229,27 @@ ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
 else
 	@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/."
 endif
-	make build-pebble
-ifneq (${BIN_DIR},${JUJUD_BIN_DIR})
-	@cp ${BIN_DIR}/juju-fake-init ${JUJUD_BIN_DIR}/juju-fake-init
-endif
-
-build-pebble:
-	@mkdir -p ${BIN_DIR}
-	@echo 'go build -mod=$(JUJU_GOMOD_MODE) -o ${BIN_DIR} $(COMPILE_FLAGS) $(LINK_FLAGS) -v github.com/hpidcock/juju-fake-init'
-	@go build -mod=$(JUJU_GOMOD_MODE) -o ${BIN_DIR} $(COMPILE_FLAGS) $(LINK_FLAGS) -v github.com/hpidcock/juju-fake-init
 
 operator-image: image-check-build
 ## operator-image: Build operator image via docker
 	$(BUILD_OPERATOR_IMAGE)
-	
-k8sagent-image: image-check-build
-## k8sagent-image: Build k8sagent image via docker
-	$(BUILD_K8SAGENT_IMAGE)
 
-push-operator-image: operator-image k8sagent-image
+push-operator-image: operator-image
 ## push-operator-image: Push up the newly built operator image via docker
 	@:$(if $(value JUJU_BUILD_NUMBER),, $(error Undefined JUJU_BUILD_NUMBER))
 	docker push "$(shell ${OPERATOR_IMAGE_PATH})"
-	docker push "$(shell ${K8SAGENT_IMAGE_PATH})"
 
-push-release-operator-image: operator-image k8sagent-image
+push-release-operator-image: operator-image
 ## push-release-operator-image: Push up the newly built release operator image via docker
 	docker push "$(shell ${OPERATOR_IMAGE_RELEASE_PATH})"
-	docker push "$(shell ${K8SAGENT_IMAGE_RELEASE_PATH})"
 
 host-install:
 ## install juju for host os/architecture
 	GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) make install
 
-microk8s-operator-update: host-install operator-image k8sagent-image
+microk8s-operator-update: host-install operator-image
 ## microk8s-operator-update: Push up the newly built operator image for use with microk8s
 	docker save "$(shell ${OPERATOR_IMAGE_PATH})" | microk8s.ctr --namespace k8s.io image import -
-	docker save "$(shell ${K8SAGENT_IMAGE_PATH})" | microk8s.ctr --namespace k8s.io image import -
 
 check-k8s-model:
 ## check-k8s-model: Check if k8s model is present in show-model

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -209,7 +209,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	imagePath := podcfg.GetJujuK8sOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
+	imagePath := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
 
 	apiHostPorts, err := a.state.APIHostPortsForAgents()
 	if err != nil {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -91,7 +91,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	mc.AddExpr(`_.Results[0].CACert`, jc.Ignore)
 	c.Assert(result, mc, params.CAASApplicationProvisioningInfoResults{
 		Results: []params.CAASApplicationProvisioningInfo{{
-			ImagePath:    "jujusolutions/k8sagent:2.6-beta3.666",
+			ImagePath:    "jujusolutions/jujud-operator:2.6-beta3.666",
 			Version:      version.MustParse("2.6-beta3"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{

--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -1,4 +1,20 @@
 ARG BASE_IMAGE
+ARG BASE_GOLANG_IMAGE
+
+# Build pebble.
+FROM $BASE_GOLANG_IMAGE AS pebblebuild
+
+ARG GOOS
+ENV GOOS=${GOOS}
+ARG GOARCH
+ENV GOARCH=${GOARCH}
+
+WORKDIR /tmp/pebble
+ADD go.mod .
+ADD go.sum .
+RUN go build -o /usr/local/bin/pebble -ldflags "-s -w -extldflags '-static'" -v github.com/hpidcock/juju-fake-init
+
+# Build operator image.
 FROM $BASE_IMAGE
 
 # Add the syslog user for audit logging.
@@ -31,12 +47,9 @@ COPY requirements.txt /tmp/wheelhouse/requirements.txt
 RUN pip3 install -r /tmp/wheelhouse/requirements.txt
 
 WORKDIR /var/lib/juju
-# copy Juju executables.
-# in-pod agent binary will be "k8sagent".
+COPY jujud /opt/
 COPY jujuc /opt/
-COPY juju-fake-init /opt/pebble
-
-ARG AGENT_BINARY_NAME=jujud
-COPY $AGENT_BINARY_NAME /opt/
+COPY k8sagent /opt/
+COPY --from=pebblebuild /usr/local/bin/pebble /opt/pebble
 
 ENTRYPOINT ["sh", "-c"]

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -55,17 +55,6 @@ func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number, bu
 	return imageRepoToPath(controllerCfg.CAASImageRepo(), ver)
 }
 
-// GetJujuK8sOCIImagePath returns the k8s agent oci image path.
-func GetJujuK8sOCIImagePath(controllerCfg controller.Config, ver version.Number, build int) string {
-	ver.Build = build
-	imageRepo := controllerCfg.CAASImageRepo()
-	if imageRepo == "" {
-		imageRepo = JujudOCINamespace
-	}
-	path := fmt.Sprintf("%s/%s", imageRepo, JujuK8sAgentName)
-	return tagImagePath(path, ver)
-}
-
 // RebuildOldOperatorImagePath returns a updated image path for the specified juju version.
 func RebuildOldOperatorImagePath(imagePath string, ver version.Number) string {
 	if imagePath == "" {

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -15,6 +15,8 @@ DOCKER_USERNAME=${DOCKER_USERNAME:-jujusolutions}
 DOCKER_STAGING_DIR="${BUILD_DIR}/docker-staging"
 DOCKER_BIN=${DOCKER_BIN:-$(which docker)}
 
+BASE_GOLANG_IMAGE="golang:1.14"
+
 _base_image() {
     IMG_linux_amd64="amd64/ubuntu:20.04" \
     IMG_linux_arm64="arm64v8/ubuntu:20.04" \
@@ -44,55 +46,29 @@ operator_image_path() {
     fi
 }
 
-k8sagent_image_release_path() {
-    echo "${DOCKER_USERNAME}/k8sagent:$(_image_version)"
-}
-k8sagent_image_path() {
-    if [ -z "${JUJU_BUILD_NUMBER}" ]; then
-        k8sagent_image_release_path
-    else
-        echo "${DOCKER_USERNAME}/k8sagent:$(_image_version).${JUJU_BUILD_NUMBER}"
-    fi
-}
-
 build_operator_image() {
     WORKDIR="${DOCKER_STAGING_DIR}/jujud-operator"
     rm -rf "${WORKDIR}"
     mkdir -p "${WORKDIR}"
 
     # Populate docker build context
-    cp "${JUJUD_BIN_DIR}/jujuc" "${WORKDIR}/" || true
-    cp "${JUJUD_BIN_DIR}/juju-fake-init" "${WORKDIR}/"
     cp "${JUJUD_BIN_DIR}/jujud" "${WORKDIR}/"
-    cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"
-    cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
-
-    # Build image. We tar up the build context to support docker snap confinement.
-    tar cf - -C "${WORKDIR}" . | "${DOCKER_BIN}" build --build-arg BASE_IMAGE=$(_base_image) -t "$(operator_image_path)" - 
-    if [ "$(operator_image_path)" != "$(operator_image_release_path)" ]; then
-        "${DOCKER_BIN}" tag "$(operator_image_path)" "$(operator_image_release_path)"
-    fi
-
-    # Cleanup
-    rm -rf "${WORKDIR}"
-}
-
-build_k8sagent_image() {
-    WORKDIR="${DOCKER_STAGING_DIR}/k8sagent"
-    rm -rf "${WORKDIR}"
-    mkdir -p "${WORKDIR}"
-
-    # Populate docker build context
     cp "${JUJUD_BIN_DIR}/jujuc" "${WORKDIR}/" || true
-    cp "${JUJUD_BIN_DIR}/juju-fake-init" "${WORKDIR}/"
     cp "${JUJUD_BIN_DIR}/k8sagent" "${WORKDIR}/"
     cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"
     cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
+    cp "${PROJECT_DIR}/go.mod" "${WORKDIR}/"
+    cp "${PROJECT_DIR}/go.sum" "${WORKDIR}/"
 
     # Build image. We tar up the build context to support docker snap confinement.
-    tar cf - -C "${WORKDIR}" . | "${DOCKER_BIN}" build --build-arg AGENT_BINARY_NAME=k8sagent --build-arg BASE_IMAGE=$(_base_image) -t "$(k8sagent_image_path)" - 
-    if [ "$(k8sagent_image_path)" != "$(k8sagent_image_release_path)" ]; then
-        "${DOCKER_BIN}" tag "$(k8sagent_image_path)" "$(k8sagent_image_release_path)"
+    tar cf - -C "${WORKDIR}" . | "${DOCKER_BIN}" build \
+        --build-arg BASE_IMAGE=$(_base_image) \
+        --build-arg BASE_GOLANG_IMAGE=${BASE_GOLANG_IMAGE} \
+        --build-arg GOOS=$(go env GOOS) \
+        --build-arg GOARCH=$(go env GOARCH) \
+        -t "$(operator_image_path)" - 
+    if [ "$(operator_image_path)" != "$(operator_image_release_path)" ]; then
+        "${DOCKER_BIN}" tag "$(operator_image_path)" "$(operator_image_release_path)"
     fi
 
     # Cleanup


### PR DESCRIPTION
Build the pebble inside the dockerfile for simplified CI.
Drop building the k8sagent image and instead use the operator image for now.

## QA steps

`make microk8s-operator-update`

Then bootstrap k8s and deploy a v2 charm.

## Documentation changes

N/A

## Bug reference

N/A