### PR TITLE
Refresh polish

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -168,17 +168,19 @@ func stateDeviceConstraints(cons map[string]devices.Constraints) map[string]stat
 func stateCharmOrigin(origin corecharm.Origin) *state.CharmOrigin {
 	var ch *state.Channel
 	if c := origin.Channel; c != nil {
+		normalizedC := c.Normalize()
 		ch = &state.Channel{
-			Track:  c.Track,
-			Risk:   string(c.Risk),
-			Branch: c.Branch,
+			Track:  normalizedC.Track,
+			Risk:   string(normalizedC.Risk),
+			Branch: normalizedC.Branch,
 		}
 	}
-	return &state.CharmOrigin{
+	stateOrigin := &state.CharmOrigin{
 		Source:   string(origin.Source),
 		ID:       origin.ID,
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
 		Channel:  ch,
 	}
+	return stateOrigin
 }

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -163,10 +163,6 @@ func makeChannel(origin params.CharmOrigin) (corecharm.Channel, error) {
 	if track == "" && origin.Risk == "" {
 		return corecharm.Channel{}, nil
 	}
-	if track == "" {
-		// If Risk only, assume "latest"
-		track = "latest"
-	}
 	return corecharm.MakeChannel(track, origin.Risk, "")
 }
 

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -80,14 +80,14 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 	s.expectInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress")
-	track := "latest"
-	origin := params.CharmOrigin{Source: "charm-hub", Risk: "edge", Track: &track}
+	track := "second"
+	origin := params.CharmOrigin{Source: "charm-hub", Risk: "stable", Track: &track}
 
 	resolver := &chRepo{client: s.client}
 	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl.Revision = 19
+	curl.Revision = 13
 	origin.Revision = &curl.Revision
 	c.Assert(obtainedCurl, jc.DeepEquals, curl)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
@@ -179,7 +179,7 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 	return []transport.ChannelMap{{
 			Channel: transport.Channel{
-				Name: "latest/stable",
+				Name: "stable",
 				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
@@ -200,7 +200,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 			},
 		}, {
 			Channel: transport.Channel{
-				Name: "latest/candidate",
+				Name: "candidate",
 				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
@@ -221,7 +221,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 			},
 		}, {
 			Channel: transport.Channel{
-				Name: "latest/edge",
+				Name: "edge",
 				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",
@@ -263,7 +263,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 			},
 		}}, transport.ChannelMap{
 			Channel: transport.Channel{
-				Name: "latest/stable",
+				Name: "stable",
 				Platform: transport.Platform{
 					Architecture: "all",
 					OS:           "ubuntu",

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -117,7 +117,7 @@ func (c *bundleDiffCommand) Init(args []string) error {
 	}
 	c.bundleMachines = mapping
 	if c.channelStr != "" {
-		c.channel, err = corecharm.ParseChannel(c.channelStr)
+		c.channel, err = corecharm.ParseChannelNormalize(c.channelStr)
 		if err != nil {
 			return errors.Annotate(err, "error in --channel")
 		}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -645,7 +645,7 @@ func (c *DeployCommand) Init(args []string) error {
 		c.unknownModel = true
 	}
 	if c.channelStr != "" {
-		c.Channel, err = corecharm.ParseChannel(c.channelStr)
+		c.Channel, err = corecharm.ParseChannelNormalize(c.channelStr)
 		if err != nil {
 			return errors.Annotate(err, "error in --channel")
 		}

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -336,7 +336,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		var channel corecharm.Channel
 		if spec.Channel != "" {
 			fromChannel = fmt.Sprintf(" from channel: %s", spec.Channel)
-			channel, err = corecharm.ParseChannel(spec.Channel)
+			channel, err = corecharm.ParseChannelNormalize(spec.Channel)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -538,7 +538,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 	// A channel is needed whether the risk is valid or not.
-	channel, _ := corecharm.ParseChannel(chParams.Channel)
+	channel, _ := corecharm.ParseChannelNormalize(chParams.Channel)
 	origin, err := utils.DeduceOrigin(ch, channel)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -349,6 +349,9 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	// Only parse the channel here.  If the channel is normalized, the refresher
+	// cannot determine the difference between the "latest" track and the current
+	// track if only risk is specified.
 	if c.channelStr == "" {
 		c.Channel, _ = corecharm.ParseChannel(applicationInfo.Channel)
 	} else {
@@ -377,6 +380,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		DeployedSeries:  applicationInfo.Series,
 		Force:           c.Force,
 		ForceSeries:     c.ForceSeries,
+		Logger:          ctx,
 	}
 	factory, err := c.getRefresherFactory(apiRoot)
 	if err != nil {

--- a/cmd/juju/application/refresher/interface.go
+++ b/cmd/juju/application/refresher/interface.go
@@ -56,3 +56,11 @@ type CharmRepository interface {
 	// define any.
 	NewCharmAtPathForceSeries(path, series string, force bool) (charm.Charm, *charm.URL, error)
 }
+
+// CommandLogger represents a logger which follows the logging
+// precepts of a cmd.Context.
+type CommandLogger interface {
+	Infof(format string, params ...interface{})
+	Warningf(format string, params ...interface{})
+	Verbosef(format string, params ...interface{})
+}

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -205,7 +205,7 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	if c.channel == "" {
 		c.channel = DefaultReleaseChannel
 	}
-	charmChannel, err := corecharm.ParseChannel(c.channel)
+	charmChannel, err := corecharm.ParseChannelNormalize(c.channel)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -388,7 +388,7 @@ func constructChannelFromTrackAndRisk(track, risk string) (corecharm.Channel, er
 	} else if strings.HasSuffix(rawChannel, "/") {
 		rawChannel = rawChannel[:len(rawChannel)-1]
 	}
-	return corecharm.ParseChannel(rawChannel)
+	return corecharm.ParseChannelNormalize(rawChannel)
 }
 
 func locateRevisionByChannelMap(channelMap transport.ChannelMap, channel corecharm.Channel) (transport.Revision, bool) {

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -72,7 +72,7 @@ func MakeChannel(track, risk, branch string) (Channel, error) {
 
 // MustParseChannel parses a given string or returns a panic.
 func MustParseChannel(s string) Channel {
-	c, err := ParseChannel(s)
+	c, err := ParseChannelNormalize(s)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +80,6 @@ func MustParseChannel(s string) Channel {
 }
 
 // ParseChannel parses a string representing a store channel.
-// The returned channel's track, risk and name are normalized.
 func ParseChannel(s string) (Channel, error) {
 	if s == "" {
 		return Channel{}, errors.Errorf("channel cannot be empty")
@@ -130,7 +129,16 @@ func ParseChannel(s string) (Channel, error) {
 		}
 		ch.Branch = *branch
 	}
+	return ch, nil
+}
 
+// ParseChannelNormalize parses a string representing a store channel.
+// The returned channel's track, risk and name are normalized.
+func ParseChannelNormalize(s string) (Channel, error) {
+	ch, err := ParseChannel(s)
+	if err != nil {
+		return Channel{}, err
+	}
 	return ch.Normalize(), nil
 }
 

--- a/core/charm/channel_test.go
+++ b/core/charm/channel_test.go
@@ -76,7 +76,7 @@ func (s channelSuite) TestParseChannel(c *gc.C) {
 	}}
 	for k, test := range tests {
 		c.Logf("test %q at %d", test.Name, k)
-		ch, err := charm.ParseChannel(test.Value)
+		ch, err := charm.ParseChannelNormalize(test.Value)
 		if test.ExpectedErr != "" {
 			c.Assert(err, gc.ErrorMatches, test.ExpectedErr)
 		} else {
@@ -114,7 +114,7 @@ func (s channelSuite) TestString(c *gc.C) {
 	}}
 	for k, test := range tests {
 		c.Logf("test %q at %d", test.Name, k)
-		ch, err := charm.ParseChannel(test.Value)
+		ch, err := charm.ParseChannelNormalize(test.Value)
 		c.Assert(err, gc.IsNil)
 		c.Assert(ch.String(), gc.DeepEquals, test.Expected)
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1293,7 +1293,7 @@ func makeCharmOrigin(a description.Application, curl *charm.URL) (*CharmOrigin, 
 
 	var channel *Channel
 	if serialized := co.Channel(); serialized != "" {
-		c, err := corecharm.ParseChannel(serialized)
+		c, err := corecharm.ParseChannelNormalize(serialized)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION

Fix detail of refresh.  They should mimic how snap refresh works:

- `juju refresh <charm>` upgrades to the latest revision of the charm in the channel which was deployed. 
- `juju refresh <charm> --channel <risk>` upgrades to the latest revision of the charm in the track which was deployed, with the risk given. 
- `juju refresh <charm> --channel <track>/<risk>` upgrades to the latest revision of the charm in the channel provided.

Part of the fix is to ensure that the channel has been normalized where we need.  It should be normalized in the db.  However the input channel cannot be normalized before the determination is made on which channel to refresh too.

Side effort was to add verbose messaging into the fresher for debug purposes.

## QA steps

We can test moving around to the different channels easily.  Testing a refresh in the current channel requires uploading a new revision to a specific channel.

Note for testing, there is a bug with the info api, where we get channels which have been closed.  This may lead to some odd results if you try to refresh to a channel which is closed.

```console 
#
# Setup for deploy/refresh
# 
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost test
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io" 
# 
# Get charm craft status on the charm, to know the expected results of refresh 
# 
$ charmcraft status --name ubuntu-qa
Track    Channel    Version    Revision
latest   stable     3          3
         candidate  1.1        4
         beta       ↑          ↑
         edge       ↑          ↑
1.0      stable     -          -
         candidate  1          1
         beta       ↑          ↑
         edge       2          2
2.0      stable     -          -
         candidate  -          -
         beta       -          -
         edge       3          3
# 
# Deploy, starting with the latest/candidate channel, refresh to the stable channel.  In this case the latest/stable has revision of 3.
# 
$ juju deploy ubuntu-qa --channel candidate
Located charm "ubuntu-qa-4".
Deploying charm "ubuntu-qa-4".
$ juju refresh ubuntu-qa --channel stable
Added charm "ubuntu-qa-3" to the model.
# 
# Deploy, starting with the 1.0/edge channel, refresh to the candidate channel.  In this case the 1.0/candidate has revision of 1.
# 
$ juju deploy ubuntu-qa --channel 1.0/edge
Located charm "ubuntu-qa-2".
Deploying charm "ubuntu-qa-2".
$ juju refresh ubuntu-qa --channel candidate
Added charm "ubuntu-qa-1" to the model.
$ juju refresh ubuntu-qa --channel latest/stable
Added charm "ubuntu-qa-3" to the model.
```

