### PR TITLE
Upgrade step to remove unused link-layer device provider IDs

### DIFF
--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -85,6 +85,7 @@ type StateBackend interface {
 	AddBakeryConfig() error
 	ReplaceNeverSetWithUnset() error
 	ResetDefaultRelationLimitInCharmMetadata() error
+	RemoveUnusedLinkLayerDeviceProviderIDs() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -352,4 +353,8 @@ func (s stateBackend) ReplaceNeverSetWithUnset() error {
 
 func (s stateBackend) ResetDefaultRelationLimitInCharmMetadata() error {
 	return state.ResetDefaultRelationLimitInCharmMetadata(s.pool)
+}
+
+func (s stateBackend) RemoveUnusedLinkLayerDeviceProviderIDs() error {
+	return state.RemoveUnusedLinkLayerDeviceProviderIDs(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -43,6 +43,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.0"), stateStepsFor28()},
 		upgradeToVersion{version.MustParse("2.8.1"), stateStepsFor281()},
 		upgradeToVersion{version.MustParse("2.8.2"), stateStepsFor282()},
+		upgradeToVersion{version.MustParse("2.8.6"), stateStepsFor286()},
 	}
 	return steps
 }

--- a/upgrades/steps_286.go
+++ b/upgrades/steps_286.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor286 returns database upgrade steps for Juju 2.8.6.
+func stateStepsFor286() []Step {
+	return []Step{
+		// Prior versions of Juju could end up in a state with link-layer
+		// device provider IDs in the global collection that were not assigned
+		// to a device.
+		// This prevents the newer corrected logic for assigning these IDs,
+		// because Juju thinks they are already in use.
+		&upgradeStep{
+			description: "remove unused link-layer device provider IDs",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveUnusedLinkLayerDeviceProviderIDs()
+			},
+		},
+	}
+}

--- a/upgrades/steps_286_test.go
+++ b/upgrades/steps_286_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v286 = version.MustParse("2.8.6")
+
+type steps286Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps286Suite{})
+
+func (s *steps286Suite) TestRemoveUnusedLinkLayerDeviceProviderIDs(c *gc.C) {
+	step := findStateStep(c, v286, "remove unused link-layer device provider IDs")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -633,6 +633,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.0",
 		"2.8.1",
 		"2.8.2",
+		"2.8.6",
 	})
 }
 


### PR DESCRIPTION
It has been observed in older models the the `providerIDs` collection could end up with IDs registered for link-layer devices that were not actually against devices in the `linklayerdevices` collection.

If the instance-poller attempts to set those IDs against devices, we get log messages saying that we cannot assign those IDs because they are already in use.

This patch adds an upgrade step to remove unused link-layer device IDs from the global collection so that they can be used again, and the log output no longer occurs.

## QA steps

- Bootstrap to MAAS with 2.8 and add a machine.
- Connect to Mongo and add a global ID:
```javascript
db.linklayerdevices.insertOne({
    "_id" : "cd5b11f3-6534-4623-8127-53dc0ca0108d:linklayerdevice:GOOOOONE",
    "model-uuid" : "cd5b11f3-6534-4623-8127-53dc0ca0108d"
})
```
- Run the upgrade.
- Check the collection and ensure that the inserted ID is gone and all others remain.

## Documentation changes

None.

## Bug reference

Potentially https://bugs.launchpad.net/bugs/1898195
