### PR TITLE
Add an index to the linklayerdevices collection

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -387,8 +387,12 @@ func allCollections() CollectionSchema {
 				{Key: []string{"model-uuid", "name"}},
 			},
 		},
-		subnetsC:              {},
-		linkLayerDevicesC:     {},
+		subnetsC: {},
+		linkLayerDevicesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machine-id"},
+			}},
+		},
 		linkLayerDevicesRefsC: {},
 		ipAddressesC: {
 			indexes: []mgo.Index{{

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -523,8 +523,12 @@ func (s *linkLayerDevicesStateSuite) TestMachineAllLinkLayerDevicesOnlyReturnsSa
 	results, err := s.machine.AllLinkLayerDevices()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 2)
-	c.Assert(results[0].Name(), gc.Equals, "foo")
-	c.Assert(results[1].Name(), gc.Equals, "foo.42")
+
+	deviceNames := make([]string, 2)
+	for i, res := range results {
+		deviceNames[i] = res.Name()
+	}
+	c.Assert(deviceNames, jc.SameContents, []string{"foo", "foo.42"})
 
 	s.assertNoDevicesOnMachine(c, s.otherStateMachine)
 }


### PR DESCRIPTION
The `linklayerdevices` collection is quite large in legacy Juju deployments - we've seen hundreds of thousands. 

Although this should be trimmed down to extant devices by later Juju versions, adding this index will ameliorate full table scans for the common use case of selection by machine ID (and implicitly model ID).

## QA steps

Tested on dump from production controller based on inferred queries from common access strategies. Execution times (estimated) are in milliseconds.

Without index.
- By model: 298
- By model and machine: 316

With index.
- By model: 751
- By model and machine: 0

```
> db.linklayerdevices.find({"model-uuid": "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"}).explain("executionStats")
{
        "queryPlanner" : {
                "plannerVersion" : 1,
                "namespace" : "juju.linklayerdevices",
                "indexFilterSet" : false,
                "parsedQuery" : {
                        "model-uuid" : {
                                "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                        }
                },
                "winningPlan" : {
                        "stage" : "COLLSCAN",
                        "filter" : {
                                "model-uuid" : {
                                        "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                                }
                        },
                        "direction" : "forward"
                },
                "rejectedPlans" : [ ]
        },
        "executionStats" : {
                "executionSuccess" : true,
                "nReturned" : 795834,
                "executionTimeMillis" : 298,
                "totalKeysExamined" : 0,
                "totalDocsExamined" : 795837,
                "executionStages" : {
                        "stage" : "COLLSCAN",
                        "filter" : {
                                "model-uuid" : {
                                        "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                                }
                        },
                        "nReturned" : 795834,
                        "executionTimeMillisEstimate" : 28,
                        "works" : 795839,
                        "advanced" : 795834,
                        "needTime" : 4,
                        "needYield" : 0,
                        "saveState" : 795,
                        "restoreState" : 795,
                        "isEOF" : 1,
                        "direction" : "forward",
                        "docsExamined" : 795837
                }
        },
        "serverInfo" : {
                "host" : "sandbox",
                "port" : 27017,
                "version" : "4.4.1",
                "gitVersion" : "ad91a93a5a31e175f5cbf8c69561e788bbc55ce1"
        },
        "ok" : 1
}

> db.linklayerdevices.find({
...     "model-uuid": "b8026e23-3e7a-475f-89b6-a9debdc5f7d5",
...     "machine-id": "1"
... }).explain("executionStats")
{
        "queryPlanner" : {
                "plannerVersion" : 1,
                "namespace" : "juju.linklayerdevices",
                "indexFilterSet" : false,
                "parsedQuery" : {
                        "$and" : [
                                {
                                        "machine-id" : {
                                                "$eq" : "1"
                                        }
                                },
                                {
                                        "model-uuid" : {
                                                "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                                        }
                                }
                        ]
                },
                "winningPlan" : {
                        "stage" : "COLLSCAN",
                        "filter" : {
                                "$and" : [
                                        {
                                                "machine-id" : {
                                                        "$eq" : "1"
                                                }
                                        },
                                        {
                                                "model-uuid" : {
                                                        "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                                                }
                                        }
                                ]
                        },
                        "direction" : "forward"
                },
                "rejectedPlans" : [ ]
        },
        "executionStats" : {
                "executionSuccess" : true,
                "nReturned" : 20,
                "executionTimeMillis" : 316,
                "totalKeysExamined" : 0,
                "totalDocsExamined" : 795837,
                "executionStages" : {
                        "stage" : "COLLSCAN",
                        "filter" : {
                                "$and" : [
                                        {
                                                "machine-id" : {
                                                        "$eq" : "1"
                                                }
                                        },
                                        {
                                                "model-uuid" : {
                                                        "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                                                }
                                        }
                                ]
                        },
                        "nReturned" : 20,
                        "executionTimeMillisEstimate" : 23,
                        "works" : 795839,
                        "advanced" : 20,
                        "needTime" : 795818,
                        "needYield" : 0,
                        "saveState" : 795,
                        "restoreState" : 795,
                        "isEOF" : 1,
                        "direction" : "forward",
                        "docsExamined" : 795837
                }
        },
        "serverInfo" : {
                "host" : "sandbox",
                "port" : 27017,
                "version" : "4.4.1",
                "gitVersion" : "ad91a93a5a31e175f5cbf8c69561e788bbc55ce1"
        },
        "ok" : 1
}

> db.linklayerdevices.createIndex({ "model-uuid": 1, "machine-id": 1})
{
        "createdCollectionAutomatically" : false,
        "numIndexesBefore" : 1,
        "numIndexesAfter" : 2,
        "ok" : 1
}

> db.linklayerdevices.find({"model-uuid": "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"}).explain("executionStats")
{
        "queryPlanner" : {
                "plannerVersion" : 1,
                "namespace" : "juju.linklayerdevices",
                "indexFilterSet" : false,
                "parsedQuery" : {
                        "model-uuid" : {
                                "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                        }
                },
                "winningPlan" : {
                        "stage" : "FETCH",
                        "inputStage" : {
                                "stage" : "IXSCAN",
                                "keyPattern" : {
                                        "model-uuid" : 1,
                                        "machine-id" : 1
                                },
                                "indexName" : "model-uuid_1_machine-id_1",
                                "isMultiKey" : false,
                                "multiKeyPaths" : {
                                        "model-uuid" : [ ],
                                        "machine-id" : [ ]
                                },
                                "isUnique" : false,
                                "isSparse" : false,
                                "isPartial" : false,
                                "indexVersion" : 2,
                                "direction" : "forward",
                                "indexBounds" : {
                                        "model-uuid" : [
                                                "[\"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\", \"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\"]"
                                        ],
                                        "machine-id" : [
                                                "[MinKey, MaxKey]"
                                        ]
                                }
                        }
                },
                "rejectedPlans" : [ ]
        },
        "executionStats" : {
                "executionSuccess" : true,
                "nReturned" : 795834,
                "executionTimeMillis" : 751,
                "totalKeysExamined" : 795834,
                "totalDocsExamined" : 795834,
                "executionStages" : {
                        "stage" : "FETCH",
                        "nReturned" : 795834,
                        "executionTimeMillisEstimate" : 67,
                        "works" : 795835,
                        "advanced" : 795834,
                        "needTime" : 0,
                        "needYield" : 0,
                        "saveState" : 795,
                        "restoreState" : 795,
                        "isEOF" : 1,
                        "docsExamined" : 795834,
                        "alreadyHasObj" : 0,
                        "inputStage" : {
                                "stage" : "IXSCAN",
                                "nReturned" : 795834,
                                "executionTimeMillisEstimate" : 32,
                                "works" : 795835,
                                "advanced" : 795834,
                                "needTime" : 0,
                                "needYield" : 0,
                                "saveState" : 795,
                                "restoreState" : 795,
                                "isEOF" : 1,
                                "keyPattern" : {
                                        "model-uuid" : 1,
                                        "machine-id" : 1
                                },
                                "indexName" : "model-uuid_1_machine-id_1",
                                "isMultiKey" : false,
                                "multiKeyPaths" : {
                                        "model-uuid" : [ ],
                                        "machine-id" : [ ]
                                },
                                "isUnique" : false,
                                "isSparse" : false,
                                "isPartial" : false,
                                "indexVersion" : 2,
                                "direction" : "forward",
                                "indexBounds" : {
                                        "model-uuid" : [
                                                "[\"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\", \"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\"]"
                                        ],
                                        "machine-id" : [
                                                "[MinKey, MaxKey]"
                                        ]
                                },
                                "keysExamined" : 795834,
                                "seeks" : 1,
                                "dupsTested" : 0,
                                "dupsDropped" : 0
                        }
                }
        },
        "serverInfo" : {
                "host" : "sandbox",
                "port" : 27017,
                "version" : "4.4.1",
                "gitVersion" : "ad91a93a5a31e175f5cbf8c69561e788bbc55ce1"
        },
        "ok" : 1
}

> db.linklayerdevices.find({
...     "model-uuid": "b8026e23-3e7a-475f-89b6-a9debdc5f7d5",
...     "machine-id": "1"
... }).explain("executionStats")
{
        "queryPlanner" : {
                "plannerVersion" : 1,
                "namespace" : "juju.linklayerdevices",
                "indexFilterSet" : false,
                "parsedQuery" : {
                        "$and" : [
                                {
                                        "machine-id" : {
                                                "$eq" : "1"
                                        }
                                },
                                {
                                        "model-uuid" : {
                                                "$eq" : "b8026e23-3e7a-475f-89b6-a9debdc5f7d5"
                                        }
                                }
                        ]
                },
                "winningPlan" : {
                        "stage" : "FETCH",
                        "inputStage" : {
                                "stage" : "IXSCAN",
                                "keyPattern" : {
                                        "model-uuid" : 1,
                                        "machine-id" : 1
                                },
                                "indexName" : "model-uuid_1_machine-id_1",
                                "isMultiKey" : false,
                                "multiKeyPaths" : {
                                        "model-uuid" : [ ],
                                        "machine-id" : [ ]
                                },
                                "isUnique" : false,
                                "isSparse" : false,
                                "isPartial" : false,
                                "indexVersion" : 2,
                                "direction" : "forward",
                                "indexBounds" : {
                                        "model-uuid" : [
                                                "[\"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\", \"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\"]"
                                        ],
                                        "machine-id" : [
                                                "[\"1\", \"1\"]"
                                        ]
                                }
                        }
                },
                "rejectedPlans" : [ ]
        },
        "executionStats" : {
                "executionSuccess" : true,
                "nReturned" : 20,
                "executionTimeMillis" : 0,
                "totalKeysExamined" : 20,
                "totalDocsExamined" : 20,
                "executionStages" : {
                        "stage" : "FETCH",
                        "nReturned" : 20,
                        "executionTimeMillisEstimate" : 0,
                        "works" : 21,
                        "advanced" : 20,
                        "needTime" : 0,
                        "needYield" : 0,
                        "saveState" : 0,
                        "restoreState" : 0,
                        "isEOF" : 1,
                        "docsExamined" : 20,
                        "alreadyHasObj" : 0,
                        "inputStage" : {
                                "stage" : "IXSCAN",
                                "nReturned" : 20,
                                "executionTimeMillisEstimate" : 0,
                                "works" : 21,
                                "advanced" : 20,
                                "needTime" : 0,
                                "needYield" : 0,
                                "saveState" : 0,
                                "restoreState" : 0,
                                "isEOF" : 1,
                                "keyPattern" : {
                                        "model-uuid" : 1,
                                        "machine-id" : 1
                                },
                                "indexName" : "model-uuid_1_machine-id_1",
                                "isMultiKey" : false,
                                "multiKeyPaths" : {
                                        "model-uuid" : [ ],
                                        "machine-id" : [ ]
                                },
                                "isUnique" : false,
                                "isSparse" : false,
                                "isPartial" : false,
                                "indexVersion" : 2,
                                "direction" : "forward",
                                "indexBounds" : {
                                        "model-uuid" : [
                                                "[\"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\", \"b8026e23-3e7a-475f-89b6-a9debdc5f7d5\"]"
                                        ],
                                        "machine-id" : [
                                                "[\"1\", \"1\"]"
                                        ]
                                },
                                "keysExamined" : 20,
                                "seeks" : 1,
                                "dupsTested" : 0,
                                "dupsDropped" : 0
                        }
                }
        },
        "serverInfo" : {
                "host" : "sandbox",
                "port" : 27017,
                "version" : "4.4.1",
                "gitVersion" : "ad91a93a5a31e175f5cbf8c69561e788bbc55ce1"
        },
        "ok" : 1
}
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1899536
