### PR TITLE
Python3 changes in the acceptance tests

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -591,6 +591,8 @@ def get_stripped_version_number(version_string):
 
 def get_version_string_parts(version_string):
     # strip the series and arch from the built version.
+    if isinstance(version_string, bytes):
+        version_string = version_string.decode()
     version_parts = version_string.split('-')
     if len(version_parts) == 4:
         # Version contains "-<patchname>", reconstruct it after the split.

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -187,7 +187,7 @@ def agent_tgz_from_juju_binary(
 
     try:
         version_output = subprocess.check_output(
-            [jujud_path, 'version']).rstrip('\n')
+            [jujud_path, 'version']).rstrip(b'\n')
         version, bin_series, arch = get_version_string_parts(version_output)
         bin_agent_series = _series_lookup(bin_series)
     except subprocess.CalledProcessError as e:
@@ -267,7 +267,7 @@ def _get_series_details(series):
 
 def _get_tgz_file_details(agent_tgz_path):
     file_details = dict(size=os.path.getsize(agent_tgz_path))
-    with open(agent_tgz_path) as f:
+    with open(agent_tgz_path, "rb") as f:
         content = f.read()
     for hashtype in 'md5', 'sha256':
         hash_obj = hashlib.new(hashtype)


### PR DESCRIPTION
The following changes are required to get python3.6 or greater to work
with assess_upgrade.py.

This is a bit clumsy as I don't really know why we're getting an array of
bytes and not a string and probably should be ensuring that we
encode/decode into utf-8 in the correct places.
