### PR TITLE
Destroy containers

### DIFF
--- a/acceptancetests/assess
+++ b/acceptancetests/assess
@@ -459,14 +459,7 @@ def main():
             args.juju,
         ]
     elif assess == "container_networking":
-        machine_types = {
-            'kvm': 'KVM_MACHINE',
-            'lxc': 'LXC_MACHINE',
-            'lxd': 'LXD_MACHINE',
-        }
-        machine_type = machine_types[args.machine_type]
-        testrun_argv.extend(["--machine-type", machine_type])
-
+        testrun_argv.extend(["--machine-type", args.machine_type])
         if args.space_constraint:
             testrun_argv.extend(["--space-constraint", args.space_constraint])
     elif assess == "constraints":

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -288,6 +288,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeUpgradeInProgress
 	case state.IsHasAttachmentsError(err):
 		code = params.CodeMachineHasAttachedStorage
+	case state.IsHasContainersError(err):
+		code = params.CodeMachineHasContainers
 	case state.IsStorageAttachedError(err):
 		code = params.CodeStorageAttached
 	case isUnknownModelError(err):

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -163,6 +163,7 @@ const (
 	CodeHasPersistentStorage      = "controller/model has persistent storage"
 	CodeModelNotEmpty             = "model not empty"
 	CodeMachineHasAttachedStorage = "machine has attached storage"
+	CodeMachineHasContainers      = "machine is hosting containers"
 	CodeStorageAttached           = "storage is attached"
 	CodeNotProvisioned            = "not provisioned"
 	CodeNoAddressSet              = "no address set"
@@ -290,6 +291,10 @@ func IsCodeModelNotEmpty(err error) bool {
 
 func IsCodeMachineHasAttachedStorage(err error) bool {
 	return ErrCode(err) == CodeMachineHasAttachedStorage
+}
+
+func IsCodeMachineHasContainers(err error) bool {
+	return ErrCode(err) == CodeMachineHasContainers
 }
 
 func IsCodeStorageAttached(err error) bool {

--- a/doc/lifecycles.md
+++ b/doc/lifecycles.md
@@ -6,7 +6,7 @@ are:
 
   * Machines
   * Units
-  * Services
+  * Applications
   * Relations
 
 ...and there are only 3 possible states for the above things:
@@ -40,13 +40,17 @@ Machines
   * If a machine has the JobHostUnits job, principal units can be assigned to it
     while it is Alive.
   * While principal units are assigned to a machine, its lifecycle cannot change
-    and `juju destroy-machine` will fail.
-  * When no principal units are assigned, `juju destroy-machine` will set the
+    and `juju remove-machine` will fail.
+  * When no principal units are assigned, `juju remove-machine` will set the
     machine to Dying. (Future plans: allow a machine to become Dying when it
     has principal units, so long as they are not Alive. For now it's extra
     complexity with little direct benefit.)
+  * When a machine has containers, `juju remove-machine` will fail, unless force
+    is used.  However `juju destroy-controller` or `juju destroy-model` allows a
+    machine to move to dying with containers.  
   * Once a machine has been set to Dying, the corresponding Machine Agent (MA)
-    is responsible for setting it to Dead. (Future plans: when Dying units are
+    is responsible for setting it to Dead. A dying machine cannot transition to 
+    dead if there are containers. (Future plans: when Dying units are
     assigned, wait for them to become Dead and remove them completely before
     making the machine Dead; not an issue now because the machine can't yet
     become Dying with units assigned.)
@@ -71,17 +75,17 @@ Units
   * A unit can become Dying at any time, but may not become Dead while any unit
     subordinate to it exists, or while the unit is in scope for any relation.
   * A principal unit can become Dying in one of two ways:
-      * `juju destroy-unit` (This doesn't work on subordinates; see below.)
-      * `juju destroy-service` (This does work on subordinates, but happens
-        indirectly in either case: the Unit Agents (UAs) for each unit of a
-        service set their corresponding units to Dying when they detect their
-        service Dying; this is because we try to assume 100k-scale and we can't
+      * `juju remove-unit` (This doesn't work on subordinates; see below.)
+      * `juju remove-application` (This does work on subordinates, but happens
+        indirectly in either case: the Unit Agents (UAs) for each unit of an
+        application set their corresponding units to Dying when they detect their
+        application Dying; this is because we try to assume 100k-scale and we can't
         use mgo/txn to do a bulk update of 100k units: that makes for a txn
         with at least 100k operations, and that's just crazy.)
   * A subordinate must also become Dying when either:
-      * its principal becomes Dying, via `juju destroy-unit`; or
-      * the last Alive relation between its service and its principal's service
-        is no longer Alive. This may come about via `juju destroy-relation`.
+      * its principal becomes Dying, via `juju remove-unit`; or
+      * the last Alive relation between its application and its principal's
+        application is no longer Alive. This may come about via `juju remove-relation`.
   * When any unit is Dying, its UA is responsible for removing impediments to
     the unit becoming Dead, and then making it so. To do so, the UA must:
       * Depart from all its relations in an orderly fashion.
@@ -92,30 +96,30 @@ Units
     to its assigned machine agent, and of a machine to the JobManageModel
     machine agent.
 
-Services
+Applications
 --------
 
-  * Services are created with `juju deploy`. Services with duplicate names
+  * Applications are created with `juju deploy`. Applications with duplicate names
     are not allowed (units and machine with duplicate names are not possible:
     their identifiers are assigned by juju).
-  * Unlike units and machines, services have no corresponding agent.
-  * In addition, services become Dead and are removed from the database in a
+  * Unlike units and machines, applications have no corresponding agent.
+  * In addition, applications become Dead and are removed from the database in a
     single atomic operation.
-  * When a service is Alive, units may be added to it, and relations can be
-    added using the service's endpoints.
-  * A service can be destroyed at any time, via `juju destroy-service`. This
-    causes all the units to become Dying, as discussed above, and will also
-    cause all relations in which the service is participating to become Dying
+  * When an application is Alive, units may be added to it, and relations can be
+    added using the application's endpoints.
+  * An applications can be destroyed at any time, via `juju remove-application`.
+    This causes all the units to become Dying, as discussed above, and will also
+    cause all relations in which the application is participating to become Dying
     or be removed.
-  * If a destroyed service has no units, and all its relations are eligible
-    for immediate removal, then the service will also be removed immediately
+  * If a removed application has no units, and all its relations are eligible
+    for immediate removal, then the application will also be removed immediately
     rather than being set to Dying.
-  * If no associated relations exist, the service is removed by the MA which
-    removes the last unit of that service from state.
-  * If no units of the service remain, but its relations still exist, the
-    responsibility for removing the service falls to the last UA to leave scope
+  * If no associated relations exist, the application is removed by the MA which
+    removes the last unit of that application from state.
+  * If no units of the application remain, but its relations still exist, the
+    responsibility for removing the application falls to the last UA to leave scope
     for that relation. (Yes, this is a UA for a unit of a totally different
-    service.)
+    application.)
 
 Relations
 ---------
@@ -129,16 +133,16 @@ Relations
         relation. These restrictions mean that the name can never cause
         actual ambiguity; nonetheless, support should be phased out smoothly
         (see lp:1100076).
-  * A relation, like a service, has no corresponding agent; and becomes Dead
+  * A relation, like an application, has no corresponding agent; and becomes Dead
     and is removed from the database in a single operation.
-  * Similarly to a service, a relation cannot be created while an identical
+  * Similarly to an application, a relation cannot be created while an identical
     relation exists in state (in which identity is determined by equality of
     canonical relation name -- a sequence of endpoint pairs sorted by role).
-  * While a relation is Alive, units of services in that relation can enter its
+  * While a relation is Alive, units of applications in that relation can enter its
     scope; that is, the UAs for those units can signal to the system that they
     are participating in the relation.
-  * A relation can be destroyed with either `juju destroy-relation` or
-    `juju destroy-service`.
+  * A relation can be destroyed with either `juju remove-relation` or
+    `juju remove-application`.
   * When a relation is destroyed with no units in scope, it will immediately
     become Dead and be removed from state, rather than being set to Dying.
   * When a relation becomes Dying, the UAs of units that have entered its scope
@@ -147,8 +151,8 @@ Relations
   * When the last unit leaves the scope of a Dying relation, it must remove the
     relation from state.
   * As noted above, the Dying relation may be the only thing keeping a Dying
-    service (different to that of the acting UA) from removal; so, relation
-    removal may also imply service removal.
+    application (different to that of the acting UA) from removal; so, relation
+    removal may also imply application removal.
 
 References
 ----------
@@ -158,14 +162,14 @@ perhaps not always clear. To consider it from another angle:
 
   * Subordinate units reference principal units.
   * Principal units reference machines.
-  * All units reference their services.
+  * All units reference their applications.
   * All units reference the relations whose scopes they have joined.
-  * All relations reference the services they are part of.
+  * All relations reference the applications they are part of.
 
 In every case above, where X references Y, the life state of an X may be
 sufficient to prevent a change in the life state of a Y; and, conversely, a
 life change in an X may be sufficient to cause a life change in a Y. (In only
-one case does the reverse hold -- that is, setting a service or relation to
+one case does the reverse hold -- that is, setting an application or relation to
 Dying will cause appropriate units' agents to individually set their units to
 Dying -- and this is just an implementation detail.)
 
@@ -178,9 +182,9 @@ The following scrawl may help you to visualize the references in play:
     |      |     +--------------+
     |      |                    |
     |      V                    V
-    |   +----------+       +---------+
-    |   | relation |------>| service |
-    |   +----------+       +---------+
+    |   +----------+       +-------------+
+    |   | relation |------>| application |
+    |   +----------+       +-------------+
     |      A                    A
     |      |                    |
     |      |     +--------------+
@@ -196,7 +200,7 @@ perspective the influences appear to travel in the opposite direction:
   * (destroying a machine "would" destroy its principals but that's disallowed)
   * destroying a principal destroys all its subordinates
   * (destroying a subordinate directly is impossible)
-  * destroying a service destroys all its units and relations
+  * destroying a application destroys all its units and relations
   * destroying a container relation destroys all subordinates in the relation
   * (destroying a global relation destroys nothing else)
 
@@ -209,10 +213,10 @@ Agents
 It may also be instructive to consider the responsibilities of the unit and
 machine agents. The unit agent is responsible for:
 
-  * detecting Alive relations incorporating its service and entering their
+  * detecting Alive relations incorporating its application and entering their
     scopes (if a principal, this may involve creating subordinates).
   * detecting Dying relations whose scope it has entered and leaving their
-    scope (this involves removing any relations or services that thereby
+    scope (this involves removing any relations or applications that thereby
     become unreferenced).
   * detecting undeployed Alive subordinates and deploying them.
   * detecting undeployed non-Alive subordinates and removing them (this raises
@@ -220,7 +224,7 @@ machine agents. The unit agent is responsible for:
     but, without persistent storage, there's no point deploying a Dying unit just
     to wait for its agent to set itself to Dead).
   * detecting deployed Dead subordinates, recalling them, and removing them.
-  * detecting its service's Dying state, and setting its own Dying state.
+  * detecting its application's Dying state, and setting its own Dying state.
   * if a subordinate, detecting that no relations with its principal are Alive,
     and setting its own Dying state.
   * detecting its own Dying state, and:
@@ -234,7 +238,7 @@ responsible for:
 
   * detecting undeployed Alive principals assigned to it and deploying them.
   * detecting undeployed non-Alive principals assigned to it and removing them
-    (recall that unit removal may imply service removal).
+    (recall that unit removal may imply application removal).
   * detecting deployed Dead principals assigned to it, recalling them, and
     removing them.
   * detecting deployed principals not assigned to it, and recalling them.
@@ -260,13 +264,11 @@ when implementing them.
 
 Lifecycle support is not complete: relation lifecycles are, mostly, as are
 large parts of the unit and machine agent; but substantial parts of the
-machine, unit and service entity implementation still lack sophistication.
+machine, unit and application entity implementation still lack sophistication.
 This situation is being actively addressed.
 
 Beyond the plans detailed above, it is important to note that an agent that is
 failing to meet its responsibilities can have a somewhat distressing impact on
-the rest of the system. To counteract this, we intend to implement a --force
-flag to destroy-unit (and destroy-machine?) that forcibly sets an entity to
-Dead while maintaining consistency and sanity across all references. The best
-approach to this problem has yet to be agreed; we're not short of options, but
-none are exceptionally compelling.
+the rest of the system. To counteract this, we have implemented a --force
+flag to remove-unit and remove-machine that forcibly sets an entity to
+Dead while maintaining consistency and sanity across all references. 

--- a/state/cleanup.md
+++ b/state/cleanup.md
@@ -1,0 +1,63 @@
+# Cleanup
+
+Cleanup is called by the cleaner worker.  The cleaner worker watches the
+cleanups collection and acts when something changes in the collection related
+to the current model.  It will also act on a period time frame.
+
+Cleanup will interate over the current docs in the collection and call a
+method to handle the doc based on its kind.  If the method is successful,
+the corresponding doc will be removed from the collection.  Otherwise the
+method will be retried later.
+
+Docs in the cleanups collection are handled in a specific order. E.g. cleaning
+up a machine requires that it's units are gone, so clean up the units first.
+
+## Model
+
+Model cleanup starts with `juju destroy-model`, or `juju destroy-controller`.
+Simplistically model destroyOps, causes the model is marked as dying and up to
+5 docs are inserted into the cleanup collection:
+  * cleanupModelsForDyingController, only for controller models
+  * cleanupApplicationsForDyingModel,  only with non empty models
+  * cleanupMachinesForDyingModel, only with non empty IAAS models
+  * cleanupStorageForDyingModel, only with non empty models with storage
+  * cleanupBranchesForDyingModel, for all models
+
+## Docs in the Cleanup collection
+
+### cleanupModelsForDyingController
+### cleanupApplicationsForDyingModel
+
+First it attempts to remove all remote applications from the model, then
+attempts to remove all applications from the model.
+
+Removing an application inserts a cleanupForceApplication into the cleanups
+collection.
+
+### cleanupMachinesForDyingModel
+
+For all machines in the model, which are not managers, call 
+DestroyWithContainers. If force is used, call ForceDestroy instead. Force is
+not allowed for manual machines.  The first failure causes the method to exit.
+
+DestroyWithContainers advances the machine's lifecycle to Dying, and inserts a
+cleanupDyingMachine job into the cleanups collection.
+
+Once a machine is dying, it's lifecycle takes over.
+
+### cleanupStorageForDyingModel
+### cleanupBranchesForDyingModel
+### cleanupDyingMachine
+
+For the dying machine, call cleanupDyingMachineResources.  After that, if
+force is in use, and the machine hasn't been forcedestroyed yet, schedule
+cleanupForceRemoveMachine by inserting the doc into the cleanups collection.
+
+cleanupDyingMachineResources checks that the machine has no filesystem nor
+volume attachments.  Then calls cleanupDyingEntityStorage, which detaches
+all detachable storge and destroys storage which cannot be detached.
+
+### cleanupForceRemoveMachine
+
+### cleanupForceApplication
+

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -191,12 +191,25 @@ func (s *CleanupSuite) TestCleanupControllerModels(c *gc.C) {
 	s.assertDoesNotNeedCleanup(c)
 }
 
+func (s *CleanupSuite) TestCleanupModelMachinesForce(c *gc.C) {
+	s.testCleanupModelMachines(c, true)
+}
+
 func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
+	s.testCleanupModelMachines(c, false)
+}
+
+func (s *CleanupSuite) testCleanupModelMachines(c *gc.C, force bool) {
 	// Create a controller machine, and manual and non-manual
-	// workload machine.
+	// workload machine, the latter with a container workload machine.
 	stateMachine, err := s.State.AddMachine("quantal", state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	modelMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{state.JobHostUnits},
+	}, modelMachine.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
 	manualMachine, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:     "quantal",
@@ -208,7 +221,7 @@ func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
 
 	// Create a relation with a unit in scope and assigned to the hosted machine.
 	pr := newPeerRelation(c, s.State)
-	err = pr.u0.AssignToMachine(machine)
+	err = pr.u0.AssignToMachine(modelMachine)
 	c.Assert(err, jc.ErrorIsNil)
 	preventPeerUnitsDestroyRemove(c, pr)
 
@@ -219,23 +232,30 @@ func (s *CleanupSuite) TestCleanupModelMachines(c *gc.C) {
 	// Destroy model, check cleanup queued.
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	force := true
 	err = model.Destroy(state.DestroyModelParams{Force: &force})
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertNeedsCleanup(c)
 
 	// Clean up, and check that the unit has been removed...
-	// There are 4 jobs for the destroy and then the model
-	// cleanup task queues another set because force is used.
-	s.assertCleanupCountDirty(c, 4)
-	assertRemoved(c, pr.u0)
+	if force {
+		// There are 4 jobs for the destroy and then the model
+		// cleanup task queues another set because force is used.
+		s.assertCleanupCountDirty(c, 4)
+		assertRemoved(c, pr.u0)
+		// ...and the unit has departed relation scope...
+		assertNotJoined(c, pr.ru0)
+		// ...and the machine has been removed (since model destroy does a
+		// force-destroy on the machine).
+		c.Assert(modelMachine.Refresh(), jc.Satisfies, errors.IsNotFound)
+		c.Assert(container.Refresh(), jc.Satisfies, errors.IsNotFound)
+	} else {
+		// Without force, in this test, the machines are not marked Dead,
+		// as no call is made to EnsureDead here, but from the machiner.
+		s.assertCleanupCountDirty(c, 2)
+		assertLife(c, modelMachine, state.Dying)
+		assertLife(c, container, state.Dying)
+	}
 
-	// ...and the unit has departed relation scope...
-	assertNotJoined(c, pr.ru0)
-
-	// ...and the machine has been removed (since model destroy does a
-	// force-destroy on the machine).
-	c.Assert(machine.Refresh(), jc.Satisfies, errors.IsNotFound)
 	assertLife(c, manualMachine, state.Dying)
 	assertLife(c, stateMachine, state.Alive)
 }
@@ -1379,7 +1399,7 @@ func (s *CleanupSuite) assertCleanupRuns(c *gc.C) {
 func (s *CleanupSuite) assertNeedsCleanup(c *gc.C) {
 	actual, err := s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actual, jc.IsTrue)
+	c.Assert(actual, jc.IsTrue, gc.Commentf("NeedsCleanup returned false, expected true"))
 }
 
 func (s *CleanupSuite) assertDoesNotNeedCleanup(c *gc.C) {

--- a/state/machine.go
+++ b/state/machine.go
@@ -779,19 +779,21 @@ func IsHasAttachmentsError(err error) bool {
 // than the supplied value. If the machine already has that lifecycle
 // value, or a later one, no changes will be made to remote state. If
 // the machine has any responsibilities that preclude a valid change in
-// lifecycle, it will return an error.
+// lifecycle, it will return an error. dyingAllowContainers indicates
+// whether the machine can have containers when moving to the dying state.
+// Not allowed for moving to dead.
 func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers bool, maxWait time.Duration) (err error) {
 	logger.Debugf("%s.advanceLifecycle(%s, %t, %t)", original.Id(), life, force, dyingAllowContainers)
-	containers, err := original.Containers()
-	if err != nil {
-		return err
+
+	if life == Dead && dyingAllowContainers {
+		return errors.BadRequestf("life cannot be Dead if dyingAllowContainers true.")
 	}
-	// A machine can be dying with containers, but cannot have any when
+
+	// A machine can be set to dying with containers, but cannot have any when
 	// advanced to dead.
-	if !dyingAllowContainers && len(containers) > 0 {
-		return &HasContainersError{
-			MachineId:    original.doc.Id,
-			ContainerIds: containers,
+	if !dyingAllowContainers && life == Dying {
+		if err := original.evaulateContainersAdvanceLifecycle(); err != nil {
+			return err
 		}
 	}
 
@@ -818,18 +820,8 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 		}
 	}()
 
-	ops := []txn.Op{
-		{
-			C:      machinesC,
-			Id:     m.doc.DocID,
-			Update: bson.D{{"$set", bson.D{{"life", life}}}},
-		},
-		{
-			C:      machineUpgradeSeriesLocksC,
-			Id:     m.doc.Id,
-			Assert: txn.DocMissing,
-		},
-	}
+	ops := m.advanceLifecyleInitialOps(life)
+
 	// multiple attempts: one with original data, one with refreshed data, and a final
 	// one intended to determine the cause of failure of the preceding attempt.
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -858,8 +850,9 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 			if m.doc.Life != Alive {
 				return nil, jujutxn.ErrNoOperations
 			}
-			// Manager nodes are allowed to go to dying even when they have the vote, as that is used as the signal
-			// that they should lose their vote
+			// Manager nodes are allowed to go to dying even when they have
+			// the vote, as that is used as the signal that they should lose
+			// their vote.
 			asserts = append(asserts, isAliveDoc...)
 		case Dead:
 			if m.doc.Life == Dead {
@@ -874,15 +867,7 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 			asserts = append(asserts, bson.DocElem{
 				Name: "jobs", Value: bson.D{{Name: "$nin", Value: []MachineJob{JobManageModel}}}})
 			asserts = append(asserts, notDeadDoc...)
-			controllerOp := txn.Op{
-				C:  controllersC,
-				Id: modelGlobalKey,
-				Assert: bson.D{
-					{"has-vote", bson.M{"$ne": true}},
-					{"wants-vote", bson.M{"$ne": true}},
-				},
-			}
-			ops = append(ops, controllerOp)
+			ops = append(ops, controllerAdvanceLifecyleVoteOp())
 		default:
 			panic(fmt.Errorf("cannot advance lifecycle to %v", life))
 		}
@@ -900,17 +885,9 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 				ops[0].Update = bson.D{
 					{"$set", bson.D{{"life", life}}},
 				}
-				controllerIds, err := m.st.ControllerIds()
+				controllerOp, err := m.controllerIDsOp()
 				if err != nil {
-					return nil, errors.Annotatef(err, "reading controller info")
-				}
-				if len(controllerIds) <= 1 {
-					return nil, errors.Errorf("controller %s is the only controller", m.Id())
-				}
-				controllerOp := txn.Op{
-					C:      controllersC,
-					Id:     modelGlobalKey,
-					Assert: bson.D{{"controller-ids", controllerIds}},
+					return nil, errors.Trace(err)
 				}
 				ops = append(ops, controllerOp)
 				ops = append(ops, setControllerWantsVoteOp(m.st, m.doc.Id, false))
@@ -919,49 +896,29 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 			var principalUnitNames []string
 			for _, principalUnit := range m.doc.Principals {
 				principalUnitNames = append(principalUnitNames, principalUnit)
-				u, err := m.st.Unit(principalUnit)
+				canDie, err = m.assessCanDieUnit(principalUnit)
 				if err != nil {
-					return nil, errors.Annotatef(err, "reading machine %s principal unit %v", m, m.doc.Principals[0])
+					return nil, errors.Trace(err)
 				}
-				app, err := u.Application()
-				if err != nil {
-					return nil, errors.Annotatef(err, "reading machine %s principal unit application %v", m, u.doc.Application)
-				}
-				if u.Life() == Alive && app.Life() == Alive {
-					canDie = false
+				if !canDie {
 					break
 				}
 			}
 
 			if canDie && !dyingAllowContainers {
-				containers, err := m.Containers()
-				if err != nil {
-					return nil, errors.Annotatef(err, "reading machine %s containers", m)
+				if err := m.evaulateContainersAdvanceLifecycle(); !IsHasContainersError(err) {
+					return nil, err
+				} else if IsHasContainersError(err) {
+					canDie = false
 				}
-				canDie = len(containers) == 0
-				containerCheck := txn.Op{
-					C:  containerRefsC,
-					Id: m.doc.DocID,
-					Assert: bson.D{{"$or", []bson.D{
-						{{"children", bson.D{{"$size", 0}}}},
-						{{"children", bson.D{{"$exists", false}}}},
-					}}},
-				}
-				ops = append(ops, containerCheck)
+				ops = append(ops, m.noContainersOp())
 			}
 
 			cleanupOp := newCleanupOp(cleanupDyingMachine, m.doc.Id, force, maxWait)
 			ops = append(ops, cleanupOp)
 
 			if canDie {
-				checkUnits := bson.DocElem{
-					Name: "$or", Value: []bson.D{
-						{{Name: "principals", Value: principalUnitNames}},
-						{{Name: "principals", Value: bson.D{{"$size", 0}}}},
-						{{Name: "principals", Value: bson.D{{"$exists", false}}}},
-					},
-				}
-				ops[0].Assert = append(asserts, checkUnits)
+				ops[0].Assert = append(asserts, advanceLifecycleUnitAsserts(principalUnitNames))
 				txnLogger.Debugf("txn moving machine %q to %s", m.Id(), life)
 				return ops, nil
 			}
@@ -973,23 +930,15 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 				UnitNames: m.doc.Principals,
 			}
 		}
-		asserts = append(asserts, bson.DocElem{
-			Name: "$or", Value: []bson.D{
-				{{"principals", bson.D{{"$size", 0}}}},
-				{{"principals", bson.D{{"$exists", false}}}},
-			},
-		})
+		asserts = append(asserts, noUnitAsserts())
 
 		if life == Dead {
-			containerCheck := txn.Op{
-				C:  containerRefsC,
-				Id: m.doc.DocID,
-				Assert: bson.D{{"$or", []bson.D{
-					{{"children", bson.D{{"$size", 0}}}},
-					{{"children", bson.D{{"$exists", false}}}},
-				}}},
+			// A machine may not become Dead until it has no
+			// containers.
+			if err := m.evaulateContainersAdvanceLifecycle(); err != nil {
+				return nil, err
 			}
-			ops = append(ops, containerCheck)
+			ops = append(ops, m.noContainersOp())
 			if isController(&m.doc) {
 				return nil, errors.Errorf("machine %s is still responsible for being a controller", m.Id())
 			}
@@ -1011,6 +960,120 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 		err = errors.Annotatef(err, "machine %s cannot advance lifecycle", m)
 	}
 	return err
+}
+
+func (m *Machine) advanceLifecyleInitialOps(life Life) []txn.Op {
+	return []txn.Op{
+		{
+			C:      machinesC,
+			Id:     m.doc.DocID,
+			Update: bson.D{{"$set", bson.D{{"life", life}}}},
+		},
+		{
+			C:      machineUpgradeSeriesLocksC,
+			Id:     m.doc.Id,
+			Assert: txn.DocMissing,
+		},
+	}
+}
+
+func controllerAdvanceLifecyleVoteOp() txn.Op {
+	return txn.Op{
+		C:  controllersC,
+		Id: modelGlobalKey,
+		Assert: bson.D{
+			{"has-vote", bson.M{"$ne": true}},
+			{"wants-vote", bson.M{"$ne": true}},
+		},
+	}
+}
+
+// controllerIDsOp returns an Op to assert that the machine's
+// controllerIDs do not change.
+func (m *Machine) controllerIDsOp() (txn.Op, error) {
+	controllerIds, err := m.st.ControllerIds()
+	if err != nil {
+		return txn.Op{}, errors.Annotatef(err, "reading controller info")
+	}
+	if len(controllerIds) <= 1 {
+		return txn.Op{}, errors.Errorf("controller %s is the only controller", m.Id())
+	}
+	return txn.Op{
+		C:      controllersC,
+		Id:     modelGlobalKey,
+		Assert: bson.D{{"controller-ids", controllerIds}},
+	}, nil
+}
+
+// noContainersOp returns an Op to assert that the machine
+// has no containers.
+func (m *Machine) noContainersOp() txn.Op {
+	return txn.Op{
+		C:  containerRefsC,
+		Id: m.doc.DocID,
+		Assert: bson.D{{"$or", []bson.D{
+			{{"children", bson.D{{"$size", 0}}}},
+			{{"children", bson.D{{"$exists", false}}}},
+		}}},
+	}
+}
+
+// assessCanDieUnit returns true if the machine can die, based on
+// evaluating the provided unit.
+func (m *Machine) assessCanDieUnit(principalUnit string) (bool, error) {
+	canDie := true
+	u, err := m.st.Unit(principalUnit)
+	if err != nil {
+		return false, errors.Annotatef(err, "reading machine %s principal unit %v", m, m.doc.Principals[0])
+	}
+	app, err := u.Application()
+	if err != nil {
+		return false, errors.Annotatef(err, "reading machine %s principal unit application %v", m, u.doc.Application)
+	}
+	if u.Life() == Alive && app.Life() == Alive {
+		canDie = false
+	}
+	return canDie, nil
+}
+
+// noUnitAsserts returns bson DocElem which assert that there are
+// no units for the machine.
+func noUnitAsserts() bson.DocElem {
+	return bson.DocElem{
+		Name: "$or", Value: []bson.D{
+			{{"principals", bson.D{{"$size", 0}}}},
+			{{"principals", bson.D{{"$exists", false}}}},
+		},
+	}
+}
+
+// advanceLifecycleUnitAsserts returns bson DocElem which assert that there are
+// no units for the machine, or that the list of units has not changed.
+func advanceLifecycleUnitAsserts(principalUnitNames []string) bson.DocElem {
+	return bson.DocElem{
+		Name: "$or", Value: []bson.D{
+			{{Name: "principals", Value: principalUnitNames}},
+			{{Name: "principals", Value: bson.D{{"$size", 0}}}},
+			{{Name: "principals", Value: bson.D{{"$exists", false}}}},
+		},
+	}
+}
+
+// evaulateContainersAdvanceLifecycle determines if the machine has
+// containers, if so, returns the appropriate error.
+func (m *Machine) evaulateContainersAdvanceLifecycle() error {
+	containers, err := m.Containers()
+	if err != nil {
+		return errors.Annotatef(err, "reading machine %s containers", m)
+	}
+
+	if len(containers) > 0 {
+		return &HasContainersError{
+			MachineId:    m.doc.Id,
+			ContainerIds: containers,
+		}
+	}
+	return nil
 }
 
 // assertNoPersistentStorage ensures that there are no persistent volumes or

--- a/state/machine.go
+++ b/state/machine.go
@@ -906,7 +906,7 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 			}
 
 			if canDie && !dyingAllowContainers {
-				if err := m.evaulateContainersAdvanceLifecycle(); !IsHasContainersError(err) {
+				if err := m.evaulateContainersAdvanceLifecycle(); err != nil && !IsHasContainersError(err) {
 					return nil, err
 				} else if IsHasContainersError(err) {
 					canDie = false

--- a/state/machine.go
+++ b/state/machine.go
@@ -792,7 +792,7 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 	// A machine can be set to dying with containers, but cannot have any when
 	// advanced to dead.
 	if !dyingAllowContainers && life == Dying {
-		if err := original.evaulateContainersAdvanceLifecycle(); err != nil {
+		if err := original.advanceLifecycleIfNoContainers(); err != nil {
 			return err
 		}
 	}
@@ -906,7 +906,7 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 			}
 
 			if canDie && !dyingAllowContainers {
-				if err := m.evaulateContainersAdvanceLifecycle(); err != nil && !IsHasContainersError(err) {
+				if err := m.advanceLifecycleIfNoContainers(); err != nil && !IsHasContainersError(err) {
 					return nil, err
 				} else if IsHasContainersError(err) {
 					canDie = false
@@ -935,7 +935,7 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 		if life == Dead {
 			// A machine may not become Dead until it has no
 			// containers.
-			if err := m.evaulateContainersAdvanceLifecycle(); err != nil {
+			if err := m.advanceLifecycleIfNoContainers(); err != nil {
 				return nil, err
 			}
 			ops = append(ops, m.noContainersOp())
@@ -1059,9 +1059,9 @@ func advanceLifecycleUnitAsserts(principalUnitNames []string) bson.DocElem {
 	}
 }
 
-// evaulateContainersAdvanceLifecycle determines if the machine has
+// advanceLifecycleIfNoContainers determines if the machine has
 // containers, if so, returns the appropriate error.
-func (m *Machine) evaulateContainersAdvanceLifecycle() error {
+func (m *Machine) advanceLifecycleIfNoContainers() error {
 	containers, err := m.Containers()
 	if err != nil {
 		return errors.Annotatef(err, "reading machine %s containers", m)


### PR DESCRIPTION
When destroying a model, don't fail on a machine having containers.  Allow a machine to advance to Dying even if there are containers.  However the machine cannot advance to dead until the containers have been removed.

In this non force scenario EnsureDead called by the machiner to move the machine to Dead.  If it fails due to MachineHasContainers, then let the worker fail and restart.  The machiner's worker will not notify when the machine's containers have all been removed.  When restarting the machiner in a non alive state, there is no need to set its addresses.

Side lines: Updated the lifecycle.md doc and started a cleanups.md doc to start unraveling the mystery of cleanup.

## QA steps

```sh
#
# the acceptance test should not fail on model tear down.
#  
$ ./assess --machine-type=lxd container_networking

# 
# successfully destroy a model with containers on machines.
# 
$ juju bootstrap localhost testme
$ juju deploy ubuntu --to lxd,lxd -n 4
# wait for deploy to complete
$ juju destroy-controller testme -y --debug --destroy-all-models

# 
# fail to remove a machine with a container on it.  
# 
$ juju bootstrap localhost testme
$ juju deploy ubuntu --to lxd
# wait for deploy to complete
$ juju remove-machine 0
removing machine 0 failed: machine 0 is hosting containers "0/lxd/0"
# 
# remove the machine with a container using force.
# 
$ juju remove-machine 0 --force
removing machine 0
# 
# remove a container by itself
# 
$ juju add-machine lxd
created container 1/lxd/0
# wait for start
$ juju remove-machine 1/lxd/0
$ removing machine 1/lxd/0
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1899785
