### PR TITLE
Make the juju-fake-init/pebble binary like juju.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ define MAIN_PACKAGES
   github.com/juju/juju/cmd/plugins/juju-wait-for
 endef
 
+ifeq ($(GOOS),linux)
+	MAIN_PACKAGES += github.com/hpidcock/juju-fake-init
+endif
+
 # Allow the tests to take longer on restricted platforms.
 ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(arm|arm64|ppc64le|ppc64|s390x).*/golang/'), golang)
 	TEST_TIMEOUT := 5400s

--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -1,20 +1,4 @@
 ARG BASE_IMAGE
-ARG BASE_GOLANG_IMAGE
-
-# Build pebble.
-FROM $BASE_GOLANG_IMAGE AS pebblebuild
-
-ARG GOOS
-ENV GOOS=${GOOS}
-ARG GOARCH
-ENV GOARCH=${GOARCH}
-
-WORKDIR /tmp/pebble
-ADD go.mod .
-ADD go.sum .
-RUN go build -o /usr/local/bin/pebble -ldflags "-s -w -extldflags '-static'" -v github.com/hpidcock/juju-fake-init
-
-# Build operator image.
 FROM $BASE_IMAGE
 
 # Add the syslog user for audit logging.
@@ -50,6 +34,6 @@ WORKDIR /var/lib/juju
 COPY jujud /opt/
 COPY jujuc /opt/
 COPY k8sagent /opt/
-COPY --from=pebblebuild /usr/local/bin/pebble /opt/pebble
+COPY pebble /opt/
 
 ENTRYPOINT ["sh", "-c"]

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -15,8 +15,6 @@ DOCKER_USERNAME=${DOCKER_USERNAME:-jujusolutions}
 DOCKER_STAGING_DIR="${BUILD_DIR}/docker-staging"
 DOCKER_BIN=${DOCKER_BIN:-$(which docker)}
 
-BASE_GOLANG_IMAGE="golang:1.14"
-
 _base_image() {
     IMG_linux_amd64="amd64/ubuntu:20.04" \
     IMG_linux_arm64="arm64v8/ubuntu:20.04" \
@@ -53,19 +51,15 @@ build_operator_image() {
 
     # Populate docker build context
     cp "${JUJUD_BIN_DIR}/jujud" "${WORKDIR}/"
-    cp "${JUJUD_BIN_DIR}/jujuc" "${WORKDIR}/" || true
+    cp "${JUJUD_BIN_DIR}/jujuc" "${WORKDIR}/"
     cp "${JUJUD_BIN_DIR}/k8sagent" "${WORKDIR}/"
+    cp "${JUJUD_BIN_DIR}/juju-fake-init" "${WORKDIR}/pebble"
     cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"
     cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
-    cp "${PROJECT_DIR}/go.mod" "${WORKDIR}/"
-    cp "${PROJECT_DIR}/go.sum" "${WORKDIR}/"
 
     # Build image. We tar up the build context to support docker snap confinement.
     tar cf - -C "${WORKDIR}" . | "${DOCKER_BIN}" build \
         --build-arg BASE_IMAGE=$(_base_image) \
-        --build-arg BASE_GOLANG_IMAGE=${BASE_GOLANG_IMAGE} \
-        --build-arg GOOS=$(go env GOOS) \
-        --build-arg GOARCH=$(go env GOARCH) \
         -t "$(operator_image_path)" - 
     if [ "$(operator_image_path)" != "$(operator_image_release_path)" ]; then
         "${DOCKER_BIN}" tag "$(operator_image_path)" "$(operator_image_release_path)"


### PR DESCRIPTION
## Description

This is to include the juju-fake-init/pebble binary in the juju k8s operator image. Eventually this will be replaced with the real binary, so this commit is only temporary for 2.9-beta1+

## QA steps

Build juju

## Documentation changes

N/A

## Bug reference

N/A
