### PR TITLE
Basic backup and juju-restore bash tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,8 @@ Tests are structured into test suites. Each suite contains a root task (akin
 to a package test) that will setup and run each individual test.
 
 To help break tests down, each test can have a number of subtests. Subtests
-are meant for indivdual units of work, without having to bootstrap a controller
-for every test. Each subtest will just `ensure` that it does have one, failure
+are meant for individual units of work, without having to bootstrap a controller
+for every test. Each subtest will just `ensure` that it does have one; failing
 to find a suitable controller, it will create one for you.
 
 ### Example of a test suite
@@ -33,7 +33,7 @@ test_deploy_bundles() {            # Test
 ## Exit codes / Success
 
 All tests will run through until the end of a test/subtest, unless it encounters
-a none zero exit code. In otherwards if you want to assert something passes,
+a non-zero exit code. In other words, if you want to assert something passes,
 ensure that the command returns `exit 0`. Failure can then be detected of the
 inverse.
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -30,10 +30,11 @@ import_subdir_files() {
 
 import_subdir_files includes
 
-# If adding a test suite, then ensure to add it here to be picked up!
-TEST_NAMES="static_analysis \
-            agents \
+# If adding a test suite, then ensure to add it here to be picked up! (Please
+# keep these in alphabetic order.)
+TEST_NAMES="agents \
             appdata \
+            backup_restore \
             branches \
             caasadmission \
             cli \
@@ -48,7 +49,8 @@ TEST_NAMES="static_analysis \
             network \
             relations \
             smoke \
-            spaces_ec2"
+            spaces_ec2 \
+            static_analysis"
 
 # Show test suites, can be used to test if a test suite is available or not.
 show_test_suites() {

--- a/tests/suites/backup_restore/backup_restore.sh
+++ b/tests/suites/backup_restore/backup_restore.sh
@@ -1,6 +1,10 @@
 run_basic_backup_create() {
     echo
 
+    file="${TEST_DIR}/test-basic-backup-create.log"
+
+    ensure "test-basic-backup-create" "${file}"
+
     juju switch controller
     juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz"
 
@@ -12,6 +16,8 @@ run_basic_backup_create() {
     test -s "${TEST_DIR}/juju-backup/root.tar"
     echo "checking oplog.bson is present"
     test -s "${TEST_DIR}/juju-backup/dump/oplog.bson"
+
+    destroy_model "test-basic-backup-create"
 }
 
 run_basic_backup_restore() {

--- a/tests/suites/backup_restore/backup_restore.sh
+++ b/tests/suites/backup_restore/backup_restore.sh
@@ -1,0 +1,71 @@
+run_basic_backup_create() {
+    set -e  # TODO benhoyt: remove once "set +e" issue is fixed
+    echo
+
+    juju switch controller
+    juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz"
+
+    # Do some basic sanity checks on what's inside the backup
+    tar xf "${TEST_DIR}/basic_backup.tar.gz" -C "${TEST_DIR}"
+    echo "checking metadata.json is present"
+    test -s "${TEST_DIR}/juju-backup/metadata.json"
+    echo "checking root.tar is present"
+    test -s "${TEST_DIR}/juju-backup/root.tar"
+    echo "checking oplog.bson is present"
+    test -s "${TEST_DIR}/juju-backup/dump/oplog.bson"
+}
+
+run_basic_backup_restore() {
+    set -e  # TODO benhoyt: remove once "set +e" issue is fixed
+    echo
+
+    wget -O "${TEST_DIR}/juju-restore" https://github.com/juju/juju-restore/releases/latest/download/juju-restore
+    chmod +x "${TEST_DIR}/juju-restore"
+
+    file="${TEST_DIR}/test-basic-backup-restore.log"
+
+    ensure "test-basic-backup-restore" "${file}"
+
+    echo "Deploy a workload (1 machine)"
+    juju deploy cs:~jameinel/ubuntu-lite-7
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+    juju status --format json | jq '.machines | length' | check 1
+
+    echo "Create a backup"
+    juju switch controller
+    juju create-backup --filename "${TEST_DIR}/basic_backup.tar.gz"
+
+    echo "Add another machine (after the backup)"
+    juju switch test-basic-backup-restore
+    juju add-unit ubuntu-lite
+    juju status --format json | jq '.machines | length' | check 2
+
+    echo "Restore the backup"
+    juju switch controller
+    juju scp "${TEST_DIR}/juju-restore" 0:
+    juju scp "${TEST_DIR}/basic_backup.tar.gz" 0:
+    juju ssh 0 ./juju-restore --yes basic_backup.tar.gz
+
+    echo "Ensure there's only one machine (state before the backup)"
+    juju switch test-basic-backup-restore
+    wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
+    juju status --format json | jq '.machines | length' | check 1
+
+    destroy_model "test-basic-backup-restore"
+}
+
+test_basic_backup() {
+    if [ "$(skip 'test_basic_backup')" ]; then
+        echo "==> TEST SKIPPED: basic backup"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_basic_backup_create"
+        run "run_basic_backup_restore"
+    )
+}

--- a/tests/suites/backup_restore/task.sh
+++ b/tests/suites/backup_restore/task.sh
@@ -1,0 +1,19 @@
+test_backup_restore() {
+    if [ "$(skip 'test_backup_restore')" ]; then
+        echo "==> TEST SKIPPED: Backup and Restore tests"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-backup-restore.log"
+
+    bootstrap "test-cli" "${file}"
+
+    test_basic_backup
+
+    destroy_controller "test-cli"
+}


### PR DESCRIPTION
We don't have any CI tests for the new stand-alone [`juju-restore`](https://github.com/juju/juju-restore) tool, and our current backup/restore tests are Python acceptance tests. This PR adds a basic "sanity check" test for `juju create-backup`, as well as a basic end-to-end test of `juju-restore`.
