### PR TITLE
Fix bash tests part deux

### DIFF
--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -22,7 +22,7 @@ run() {
   # Do not remove or none of the tests will report correctly!
   set +e
 
-  cmd_output=$("${CMD}" "$@" 2>&1)
+  cmd_output=$(run_error_early "${CMD}" "$@" 2>&1)
   cmd_status=$?
 
   set_verbosity
@@ -42,12 +42,58 @@ run() {
   fi
 }
 
+run_error_early() {
+  set -e
+  shift
+
+  "${1}" "$@"
+}
+
 # run_linter will run until the end of a pipeline even if there is a failure.
 # This is different from `run` as we require the output of a linter.
 run_linter() {
+  CMD="${1}"
+
+  if [ -n "${RUN_SUBTEST}" ]; then
+    # shellcheck disable=SC2143
+    if [ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]; then
+        echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
+        exit 0
+    fi
+  fi
+
+  DESC=$(echo "${1}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
+
+  echo -n "===> [   ] Running: ${DESC}"
+
+  START_TIME=$(date +%s)
+
+  # Prevent the sub-shell from killing our script if that sub-shell fails on an
+  # error. We need this so that we can capture the full output and collect the
+  # exit code when it does fail.
+  # Do not remove or none of the tests will report correctly!
+  set +e
   set -o pipefail
-  run "$@"
+
+  cmd_output=$("${CMD}" "$@" 2>&1)
+  cmd_status=$?
+
+  set_verbosity
   set +o pipefail
+
+  # Only output if it's not empty.
+  if [ -n "${cmd_output}" ]; then
+    echo -e "${cmd_output}" | OUTPUT "${TEST_DIR}/${TEST_CURRENT}.log"
+  fi
+
+  END_TIME=$(date +%s)
+
+  if [ "${cmd_status}" -eq 0 ]; then
+    echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME-START_TIME))s)"
+  else
+    echo -e "\r===> [ $(red "x") ] Fail: ${DESC} ($((END_TIME-START_TIME))s)"
+    exit 1
+  fi
 }
 
 skip() {

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -294,14 +294,14 @@ if [ "$#" -gt 0 ]; then
         exit
     fi
 
-    run_test "test_${1}" "" "$@"
+    run_test "test_${1}" "" "$@" ""
     TEST_RESULT=success
     exit
 fi
 
 for test in ${TEST_NAMES}; do
     name=$(echo "${test}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
-    run_test "test_${test}" "${name}"
+    run_test "test_${test}" "${name}" "" ""
 done
 
 TEST_RESULT=success

--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -3,7 +3,6 @@ run_deploy_local_charm_revision() {
   echo
 
   file="${TEST_DIR}/local-charm-deploy-git.log"
-
   ensure "local-charm-deploy" "${file}"
 
   TMP=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -34,7 +33,6 @@ run_deploy_local_charm_revision_no_vcs() {
   echo
 
   file="${TEST_DIR}/local-charm-deploy-no-vcs.log"
-
   ensure "local-charm-deploy-no-vcs" "${file}"
 
   TMP=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -49,6 +47,8 @@ run_deploy_local_charm_revision_no_vcs() {
   OUTPUT=$(juju deploy --debug . 2>&1)
 
   check_contains "${OUTPUT}" "charm is not versioned"
+
+  destroy_model "local-charm-deploy-no-vcs"
 }
 
 # Checks the cwd has no vcs but a version file.
@@ -56,7 +56,6 @@ run_deploy_local_charm_revision_no_vcs_but_version_file() {
   echo
 
   file="${TEST_DIR}/local-charm-deploy-version-file.log"
-
   ensure "local-charm-deploy-version-file" "${file}"
 
   TMP=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -84,6 +83,8 @@ run_deploy_local_charm_revision_no_vcs_but_version_file() {
 
   # we expect the debug output to be absolute and not relative.
   check_contains "${OUTPUT}" "${CURRENT_DIRECTORY}"
+
+  destroy_model "local-charm-deploy-version-file"
 }
 
 # Checks whether the cwd is used for the juju local deploy.

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -1,13 +1,21 @@
 run_model_config_isomorphic() {
   echo
 
+  file="${TEST_DIR}/model-config-isomorphic.log"
+  ensure "model-config-isomorphic" "${file}"
+
   FILE=$(mktemp)
 
   juju model-config --format=yaml | juju model-config --ignore-agent-version -
+
+  destroy_model "model-config-isomorphic"
 }
 
 run_model_config_cloudinit_userdata() {
   echo
+
+  file="${TEST_DIR}/model-config-cloudinit-userdata.log"
+  ensure "model-config-cloudinit-userdata" "${file}"
 
   FILE=$(mktemp)
 
@@ -26,6 +34,8 @@ EOF
 
   # cloudinit-userdata is hidden in the normal output
   juju model-config | grep -q "<value set, see juju model-config cloudinit-userdata>"
+
+  destroy_model "model-config-cloudinit-userdata"
 }
 
 test_model_config() {

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -52,7 +52,7 @@ run_deploy_exported_bundle() {
     juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
     diff ${bundle} "${TEST_DIR}/exported-bundle.yaml"
 
-    destroy_model test-export-bundles-deploy
+    destroy_model "test-export-bundles-deploy"
 }
 
 run_deploy_trusted_bundle() {
@@ -70,7 +70,7 @@ run_deploy_trusted_bundle() {
 
     wait_for "trust-checker" "$(idle_condition "trust-checker")"
 
-    destroy_model test-trusted-bundles-deploy
+    destroy_model "test-trusted-bundles-deploy"
 }
 
 # run_deploy_lxd_profile_bundle_openstack is to test a more

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -140,6 +140,8 @@ run_deploy_lxd_to_machine() {
         fi
         sleep 5
     done
+
+    destroy_model "${model_name}"
 }
 
 run_deploy_lxd_to_container() {
@@ -195,6 +197,8 @@ run_deploy_lxd_to_container() {
         fi
         sleep 5
     done
+
+    destroy_model "${model_name}"
 }
 
 test_deploy_charms() {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -101,7 +101,7 @@ run_deploy_lxd_to_machine() {
     wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 
     lxc profile show "juju-test-deploy-lxd-machine-lxd-profile-alt-0" | \
-        grep "linux.kernel_modules: ip_tables,ip6_tables"
+        grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
     juju upgrade-charm "lxd-profile-alt" --path "${charm}"
 
@@ -112,10 +112,11 @@ run_deploy_lxd_to_machine() {
 
     attempt=0
     while true; do
-        OUT=$(lxc profile show "juju-test-deploy-lxd-machine-lxd-profile-alt-1" | grep "linux.kernel_modules: ip_tables,ip6_tables" || echo 'NOT FOUND')
+        OUT=$(lxc profile show "juju-test-deploy-lxd-machine-lxd-profile-alt-1" | grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?" || echo 'NOT FOUND')
         if [ "${OUT}" != "NOT FOUND" ]; then
             break
         fi
+        lxc profile show "juju-test-deploy-lxd-machine-lxd-profile-alt-1"
         attempt=$((attempt+1))
         if [ $attempt -eq 10 ]; then
              # shellcheck disable=SC2046
@@ -135,7 +136,7 @@ run_deploy_lxd_to_machine() {
         attempt=$((attempt+1))
         if [ $attempt -eq 10 ]; then
              # shellcheck disable=SC2046
-             echo $(red "timeout: waiting for lxc profile to show 50sec")
+             echo $(red "timeout: waiting for removal of lxc profile 50sec")
              exit 5
         fi
         sleep 5
@@ -158,7 +159,7 @@ run_deploy_lxd_to_container() {
     wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 
     OUT=$(juju run --machine 0 -- sh -c "sudo lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-0\"")
-    echo "${OUT}" | grep "linux.kernel_modules: ip_tables,ip6_tables"
+    echo "${OUT}" | grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
     juju upgrade-charm "lxd-profile-alt" --path "${charm}"
 
@@ -170,7 +171,7 @@ run_deploy_lxd_to_container() {
     attempt=0
     while true; do
         OUT=$(juju run --machine 0 -- sh -c "sudo lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-1\"" || echo 'NOT FOUND')
-        if echo "${OUT}" | grep -q "linux.kernel_modules: ip_tables,ip6_tables"; then
+        if echo "${OUT}" | grep -E -q "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"; then
             break
         fi
         attempt=$((attempt+1))


### PR DESCRIPTION
Turns out the tension between run and run_linter was too great. This
instead makes it more evident that the two should never be merged
together as they require different things from the set modes.

Some time should be used to potentially merge the run functions together
with maybe a MODE envar, but for now, we'll have duplicate functions
so we can make any tweaks without breaking the abstractions.

## QA steps

This takes some time, but is worth testing...

```sh
make go-install
juju bootstrap lxd test --no-gui
cd tests && ./main.sh -l test deploy
```

```sh
make static-analysis
```
