### PR TITLE
Fix services list on Windows

### DIFF
--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -81,6 +81,7 @@ func (w *windowsConfigure) ConfigureBasic() error {
 		// This is necessary for setACLs to work
 		`$adminsGroup = (New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")).Translate([System.Security.Principal.NTAccount])`,
 		fmt.Sprintf(`icacls "%s" /inheritance:r /grant "${adminsGroup}:(OI)(CI)(F)" /t`, renderer.FromSlash(baseDir)),
+		fmt.Sprintf(`icacls "%s" /inheritance:e /grant "SYSTEM:(OI)(CI)(F)" /t`, renderer.FromSlash(baseDir)),
 	)
 
 	// TODO(bogdanteleaga): This, together with the call above, should be using setACLs, once it starts working across all windows versions properly.

--- a/cloudconfig/windows_userdata_test.go
+++ b/cloudconfig/windows_userdata_test.go
@@ -699,6 +699,7 @@ mkdir "C:\Juju\lib\juju\locks"
 setx /m PATH "$env:PATH;C:\Juju\bin\"
 $adminsGroup = (New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")).Translate([System.Security.Principal.NTAccount])
 icacls "C:\Juju" /inheritance:r /grant "${adminsGroup}:(OI)(CI)(F)" /t
+icacls "C:\Juju" /inheritance:e /grant "SYSTEM:(OI)(CI)(F)" /t
 icacls "C:\Juju" /inheritance:r /grant "jujud:(OI)(CI)(F)" /t
 Set-Content "C:\Juju\lib\juju\nonce.txt" "'FAKE_NONCE'"
 $binDir="C:\Juju\lib\juju\tools\1.2.3-win8-amd64"
@@ -763,11 +764,7 @@ mongoversion: "0.0"
 
 "@
 cmd.exe /C mklink /D C:\Juju\lib\juju\tools\machine-10 1.2.3-win8-amd64
-if ($jujuCreds) {
-  New-Service -Credential $jujuCreds -Name 'jujud-machine-10' -DependsOn Winmgmt -DisplayName 'juju agent for machine-10' '"C:\Juju\lib\juju\tools\machine-10\jujud.exe" machine --data-dir "C:\Juju\lib\juju" --machine-id 10 --debug'
-} else {
-  New-Service -Name 'jujud-machine-10' -DependsOn Winmgmt -DisplayName 'juju agent for machine-10' '"C:\Juju\lib\juju\tools\machine-10\jujud.exe" machine --data-dir "C:\Juju\lib\juju" --machine-id 10 --debug'
-}
+New-Service -Name 'jujud-machine-10' -DependsOn Winmgmt -DisplayName 'juju agent for machine-10' '"C:\Juju\lib\juju\tools\machine-10\jujud.exe" machine --data-dir "C:\Juju\lib\juju" --machine-id 10 --debug'
 sc.exe failure 'jujud-machine-10' reset=5 actions=restart/1000
-sc.exe failureflag 'jujud-machine-10' 1
+sc.exe failureflag 'juju agent for machine-10' 1%!(EXTRA string='"C:\Juju\lib\juju\tools\machine-10\jujud.exe" machine --data-dir "C:\Juju\lib\juju" --machine-id 10 --debug', string='jujud-machine-10', string='jujud-machine-10')
 Start-Service 'jujud-machine-10'`

--- a/service/windows/service.go
+++ b/service/windows/service.go
@@ -249,10 +249,6 @@ func (s *Service) StartCommands() ([]string, error) {
 }
 
 const serviceCreateCommandTemplate = `
-if ($jujuCreds) {
-  New-Service -Credential $jujuCreds -Name %s -DependsOn Winmgmt -DisplayName %s %s
-} else {
-  New-Service -Name %s -DependsOn Winmgmt -DisplayName %s %s
-}
+New-Service -Name %s -DependsOn Winmgmt -DisplayName %s %s
 sc.exe failure %s reset=5 actions=restart/1000
 sc.exe failureflag %s 1`


### PR DESCRIPTION
  * Run machine agent under LocalSystem on Windows. There is no need to
run it under a regular user.
  * Remove ListServices() code from juju and use the upstream
implementation. It seems 6 years later, the ability to list services has
been added. No need to keep using the one in juju.
  * Only attempt to reset password on services that belong to juju unit
agents. This fixes https://bugs.launchpad.net/juju/+bug/1900002

## QA steps

```sh
juju add-machine --series win2016
```
RDP into the windows machine

```sh
juju deploy cs:~cloudbaseit/active-directory --to 1
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1900002