### PR TITLE
Mount the primary service account to workload pod if it was defined;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2464,6 +2464,9 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 			return nil, errors.Annotatef(err, "converting prime service account for app %q", appName)
 		}
 		spec.ServiceAccounts = append(spec.ServiceAccounts, primeSA)
+
+		spec.Pod.ServiceAccountName = podSpec.ServiceAccount.GetName()
+		spec.Pod.AutomountServiceAccountToken = podSpec.ServiceAccount.AutomountServiceAccountToken
 	}
 	if podSpec.ProviderPod != nil {
 		pSpec, ok := podSpec.ProviderPod.(*k8sspecs.K8sPodSpec)
@@ -2494,10 +2497,6 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 				spec.Pod.Priority = k8sResources.Pod.Priority
 			}
 			spec.ServiceAccounts = append(spec.ServiceAccounts, &k8sResources.K8sRBACResources)
-		}
-		if podSpec.ServiceAccount != nil {
-			spec.Pod.ServiceAccountName = podSpec.ServiceAccount.GetName()
-			spec.Pod.AutomountServiceAccountToken = podSpec.ServiceAccount.AutomountServiceAccountToken
 		}
 	}
 	return &spec, nil

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -643,6 +643,43 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 	})
 }
 
+func (s *K8sSuite) TestPrepareWorkloadSpecPrimarySA(c *gc.C) {
+	podSpec := specs.PodSpec{ServiceAccount: primeServiceAccount}
+	podSpec.Containers = []specs.ContainerSpec{
+		{
+			Name:            "test",
+			Ports:           []specs.ContainerPort{{ContainerPort: 80, Protocol: "TCP"}},
+			Image:           "juju/image",
+			ImagePullPolicy: "Always",
+		},
+	}
+
+	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		PodSpec: core.PodSpec{
+			ServiceAccountName:           "app-name",
+			AutomountServiceAccountToken: boolPtr(true),
+			InitContainers:               initContainers(),
+			Containers: []core.Container{
+				{
+					Name:            "test",
+					Image:           "juju/image",
+					Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
+					ImagePullPolicy: core.PullAlways,
+					SecurityContext: &core.SecurityContext{
+						RunAsNonRoot:             boolPtr(false),
+						ReadOnlyRootFilesystem:   boolPtr(false),
+						AllowPrivilegeEscalation: boolPtr(true),
+					},
+					VolumeMounts: dataVolumeMounts(),
+				},
+			},
+			Volumes: dataVolumes(),
+		},
+	})
+}
+
 func getBasicPodspec() *specs.PodSpec {
 	pSpecs := &specs.PodSpec{}
 	pSpecs.Containers = []specs.ContainerSpec{{


### PR DESCRIPTION

*Mount the primary service account to workload pod if it was defined;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
$ juju deploy cs:~charmed-osm/mongodb-k8s --config enable-sidecar=true

$ mkubectl get pod/mongodb-k8s-0 -n t2 -o json | jq '.spec.serviceAccountName,.spec.serviceAccount'
"mongodb-k8s"
"mongodb-k8s"
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1899987
