### PR TITLE
Add extra logging to uniter operations

### DIFF
--- a/worker/uniter/operation/executor.go
+++ b/worker/uniter/operation/executor.go
@@ -16,8 +16,8 @@ type executorStep struct {
 	run  func(op Operation, state State) (*State, error)
 }
 
-func (step executorStep) message(op Operation) string {
-	return fmt.Sprintf("%s operation %q", step.verb, op)
+func (step executorStep) message(op Operation, unitName string) string {
+	return fmt.Sprintf("%s operation %q for %s", step.verb, op, unitName)
 }
 
 var (
@@ -27,6 +27,7 @@ var (
 )
 
 type executor struct {
+	unitName           string
 	stateOps           *StateOps
 	state              *State
 	acquireMachineLock func(string) (func(), error)
@@ -54,7 +55,7 @@ func (e ExecutorConfig) validate() error {
 // NewExecutor returns an Executor which takes its starting state from
 // the controller, and records state changes there. If no saved state
 // exists, the executor's starting state will be the supplied InitialState.
-func NewExecutor(cfg ExecutorConfig) (Executor, error) {
+func NewExecutor(unitName string, cfg ExecutorConfig) (Executor, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
@@ -66,6 +67,7 @@ func NewExecutor(cfg ExecutorConfig) (Executor, error) {
 		return nil, err
 	}
 	return &executor{
+		unitName:           unitName,
 		stateOps:           stateOps,
 		state:              state,
 		acquireMachineLock: cfg.AcquireLock,
@@ -80,14 +82,14 @@ func (x *executor) State() State {
 
 // Run is part of the Executor interface.
 func (x *executor) Run(op Operation, remoteStateChange <-chan remotestate.Snapshot) error {
-	x.logger.Debugf("running operation %v", op)
+	x.logger.Debugf("running operation %v for %s", op, x.unitName)
 
 	if op.NeedsGlobalMachineLock() {
 		releaser, err := x.acquireMachineLock(op.String())
 		if err != nil {
-			return errors.Annotatef(err, "could not acquire lock for %q", op)
+			return errors.Annotatef(err, "could not acquire %q lock for %s", op, x.unitName)
 		}
-		defer x.logger.Debugf("lock released")
+		defer x.logger.Debugf("lock released for %s", x.unitName)
 		defer releaser()
 	}
 
@@ -121,12 +123,12 @@ func (x *executor) Run(op Operation, remoteStateChange <-chan remotestate.Snapsh
 
 // Skip is part of the Executor interface.
 func (x *executor) Skip(op Operation) error {
-	x.logger.Debugf("skipping operation %v", op)
+	x.logger.Debugf("skipping operation %v for %s", op, x.unitName)
 	return x.do(op, stepCommit)
 }
 
 func (x *executor) do(op Operation, step executorStep) (err error) {
-	message := step.message(op)
+	message := step.message(op, x.unitName)
 	x.logger.Debugf(message)
 	newState, firstErr := step.run(op, *x.state)
 	if newState != nil {
@@ -134,7 +136,7 @@ func (x *executor) do(op Operation, step executorStep) (err error) {
 		if firstErr == nil {
 			firstErr = writeErr
 		} else if writeErr != nil {
-			x.logger.Errorf("after %s: %v", message, writeErr)
+			x.logger.Errorf("after %s for %s: %v", message, x.unitName, writeErr)
 		}
 	}
 	return errors.Annotatef(firstErr, message)

--- a/worker/uniter/operation/executor_test.go
+++ b/worker/uniter/operation/executor_test.go
@@ -69,7 +69,7 @@ func (s *NewExecutorSuite) TestNewExecutorInvalidStateRead(c *gc.C) {
 		AcquireLock:     failAcquireLock,
 		Logger:          loggo.GetLogger("test"),
 	}
-	executor, err := operation.NewExecutor(cfg)
+	executor, err := operation.NewExecutor("test", cfg)
 	c.Assert(executor, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `validation of uniter state: invalid operation state: .*`)
 }
@@ -84,7 +84,7 @@ func (s *NewExecutorSuite) TestNewExecutorNoInitialState(c *gc.C) {
 		AcquireLock:     failAcquireLock,
 		Logger:          loggo.GetLogger("test"),
 	}
-	executor, err := operation.NewExecutor(cfg)
+	executor, err := operation.NewExecutor("test", cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(executor.State(), gc.DeepEquals, initialState)
 }
@@ -102,7 +102,7 @@ func (s *NewExecutorSuite) TestNewExecutorValidFile(c *gc.C) {
 		AcquireLock:     failAcquireLock,
 		Logger:          loggo.GetLogger("test"),
 	}
-	executor, err := operation.NewExecutor(cfg)
+	executor, err := operation.NewExecutor("test", cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(executor.State(), gc.DeepEquals, operation.State{
 		Kind:    operation.Continue,
@@ -193,7 +193,7 @@ func (s *ExecutorSuite) newExecutor(c *gc.C, st *operation.State) operation.Exec
 		AcquireLock:     failAcquireLock,
 		Logger:          loggo.GetLogger("test"),
 	}
-	executor, err := operation.NewExecutor(cfg)
+	executor, err := operation.NewExecutor("test", cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	return executor
 }
@@ -333,7 +333,7 @@ func (s *ExecutorSuite) TestValidateStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": invalid operation state: missing hook info with Kind RunHook`)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation" for test: invalid operation state: missing hook info with Kind RunHook`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "missing hook info with Kind RunHook")
 	c.Assert(executor.State(), gc.DeepEquals, initialState)
 }
@@ -350,7 +350,7 @@ func (s *ExecutorSuite) TestFailPrepareNoStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": pow`)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation" for test: pow`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "pow")
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -370,7 +370,7 @@ func (s *ExecutorSuite) TestFailPrepareWithStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation": blam`)
+	c.Assert(err, gc.ErrorMatches, `preparing operation "mock operation" for test: blam`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "blam")
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -391,7 +391,7 @@ func (s *ExecutorSuite) TestFailExecuteNoStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation": splat`)
+	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation" for test: splat`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "splat")
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -413,7 +413,7 @@ func (s *ExecutorSuite) TestFailExecuteWithStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation": kerblooie`)
+	c.Assert(err, gc.ErrorMatches, `executing operation "mock operation" for test: kerblooie`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "kerblooie")
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -436,7 +436,7 @@ func (s *ExecutorSuite) TestFailCommitNoStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation": whack`)
+	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation" for test: whack`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "whack")
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -460,7 +460,7 @@ func (s *ExecutorSuite) TestFailCommitWithStateChange(c *gc.C) {
 	}
 
 	err := executor.Run(op, nil)
-	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation": take that you bandit`)
+	c.Assert(err, gc.ErrorMatches, `committing operation "mock operation" for test: take that you bandit`)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "take that you bandit")
 
 	c.Assert(prepare.gotState, gc.DeepEquals, initialState)
@@ -477,7 +477,7 @@ func (s *ExecutorSuite) initLockTest(c *gc.C, lockFunc func(string) (func(), err
 		AcquireLock:     lockFunc,
 		Logger:          loggo.GetLogger("test"),
 	}
-	executor, err := operation.NewExecutor(cfg)
+	executor, err := operation.NewExecutor("test", cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return executor

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -458,7 +458,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			return w.catacomb.ErrDying()
 
 		case _, ok := <-unitw.Changes():
-			w.logger.Debugf("got unit change")
+			w.logger.Debugf("got unit change for %s", w.unit.Tag().Id())
 			if !ok {
 				return errors.New("unit watcher closed")
 			}
@@ -468,7 +468,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenUnitChange)
 
 		case _, ok := <-w.applicationChannel:
-			w.logger.Debugf("got application change")
+			w.logger.Debugf("got application change for %s", w.unit.Tag().Id())
 			if !ok {
 				return errors.New("application watcher closed")
 			}
@@ -478,7 +478,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenApplicationChange)
 
 		case _, ok := <-instanceDataChannel:
-			w.logger.Debugf("got instance data change")
+			w.logger.Debugf("got instance data change for %s", w.unit.Tag().Id())
 			if !ok {
 				return errors.New("instance data watcher closed")
 			}
@@ -488,7 +488,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenInstanceDataChange)
 
 		case _, ok := <-w.containerRunningStatusChannel:
-			w.logger.Debugf("got running status change")
+			w.logger.Debugf("got running status change for %s", w.unit.Tag().Id())
 			if !ok {
 				return errors.New("running status watcher closed")
 			}
@@ -498,7 +498,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 				}
 				if w.current.ProviderID == "" {
 					// This shouldn't happen.
-					w.logger.Warningf("we should already be assigned a provider id but got an empty id")
+					w.logger.Warningf("we should already be assigned a provider id for %s but got an empty id", w.unit.Tag().Id())
 					return nil
 				}
 			}
@@ -509,7 +509,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			w.containerRunningStatus(*runningStatus)
 
 		case hashes, ok := <-charmConfigw.Changes():
-			w.logger.Debugf("got config change: ok=%t, hashes=%v", ok, hashes)
+			w.logger.Debugf("got config change for %s: ok=%t, hashes=%v", w.unit.Tag().Id(), ok, hashes)
 			if !ok {
 				return errors.New("config watcher closed")
 			}
@@ -520,7 +520,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenConfigChange)
 
 		case hashes, ok := <-trustConfigw.Changes():
-			w.logger.Debugf("got trust config change: ok=%t, hashes=%v", ok, hashes)
+			w.logger.Debugf("got trust config change for %s: ok=%t, hashes=%v", w.unit.Tag().Id(), ok, hashes)
 			if !ok {
 				return errors.New("trust config watcher closed")
 			}
@@ -541,7 +541,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenUpgradeSeriesChange)
 
 		case hashes, ok := <-addressesChanges:
-			w.logger.Debugf("got address change: ok=%t, hashes=%v", ok, hashes)
+			w.logger.Debugf("got address change for %s: ok=%t, hashes=%v", w.unit.Tag().Id(), ok, hashes)
 			if !ok {
 				return errors.New("addresses watcher closed")
 			}
@@ -552,7 +552,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenAddressesChange)
 
 		case _, ok := <-leaderSettingsw.Changes():
-			w.logger.Debugf("got leader settings change: ok=%t", ok)
+			w.logger.Debugf("got leader settings change for %s: ok=%t", w.unit.Tag().Id(), ok)
 			if !ok {
 				return errors.New("leader settings watcher closed")
 			}
@@ -562,7 +562,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenLeaderSettingsChange)
 
 		case actions, ok := <-actionsw.Changes():
-			w.logger.Debugf("got action change: %v ok=%t", actions, ok)
+			w.logger.Debugf("got action change for %s: %v ok=%t", w.unit.Tag().Id(), actions, ok)
 			if !ok {
 				return errors.New("actions watcher closed")
 			}
@@ -570,7 +570,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenActionsChange)
 
 		case keys, ok := <-relationsw.Changes():
-			w.logger.Debugf("got relations change: ok=%t", ok)
+			w.logger.Debugf("got relations change for %s: ok=%t", w.unit.Tag().Id(), ok)
 			if !ok {
 				return errors.New("relations watcher closed")
 			}
@@ -580,7 +580,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenRelationsChange)
 
 		case keys, ok := <-storagew.Changes():
-			w.logger.Debugf("got storage change: %v ok=%t", keys, ok)
+			w.logger.Debugf("got storage change for %s: %v ok=%t", w.unit.Tag().Id(), keys, ok)
 			if !ok {
 				return errors.New("storage watcher closed")
 			}
@@ -590,7 +590,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			observedEvent(&seenStorageChange)
 
 		case _, ok := <-updateStatusIntervalw.Changes():
-			w.logger.Debugf("got update status interval change: ok=%t", ok)
+			w.logger.Debugf("got update status interval change for %s: ok=%t", w.unit.Tag().Id(), ok)
 			if !ok {
 				return errors.New("update status interval watcher closed")
 			}
@@ -623,17 +623,17 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			waitMinion = w.leadershipTracker.WaitMinion().Ready()
 
 		case change := <-w.storageAttachmentChanges:
-			w.logger.Debugf("storage attachment change %v", change)
+			w.logger.Debugf("storage attachment change for %s: %v", w.unit.Tag().Id(), change)
 			w.storageAttachmentChanged(change)
 
 		case change := <-w.relationUnitsChanges:
-			w.logger.Debugf("got a relation units change: %v", change)
+			w.logger.Debugf("got a relation units change for %s : %v", w.unit.Tag().Id(), change)
 			if err := w.relationUnitsChanged(change); err != nil {
 				return errors.Trace(err)
 			}
 
 		case <-updateStatusTimer:
-			w.logger.Debugf("update status timer triggered")
+			w.logger.Debugf("update status timer triggered for %s", w.unit.Tag().Id())
 			w.updateStatusChanged()
 			resetUpdateStatusTimer()
 
@@ -641,14 +641,14 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			if !ok {
 				return errors.New("commandChannel closed")
 			}
-			w.logger.Debugf("command enqueued: %v", id)
+			w.logger.Debugf("command enqueued for %s: %v", w.unit.Tag().Id(), id)
 			w.commandsChanged(id)
 
 		case _, ok := <-w.retryHookChannel:
 			if !ok {
 				return errors.New("retryHookChannel closed")
 			}
-			w.logger.Debugf("retry hook timer triggered")
+			w.logger.Debugf("retry hook timer triggered for %s", w.unit.Tag().Id())
 			w.retryHookTimerTriggered()
 		}
 
@@ -842,7 +842,7 @@ func (w *RemoteStateWatcher) ensureRelationUnits(rel Relation) error {
 				if err != nil {
 					// This was always silently ignored, so it can't be
 					// particularly useful, but avoid suppressing errors entirely.
-					w.logger.Debugf("error stopping relation watcher: %v", err)
+					w.logger.Debugf("error stopping relation watcher for %s: %v", w.unit.Tag().Id(), err)
 				}
 				delete(w.relations, relationTag)
 			}
@@ -1013,8 +1013,8 @@ func (w *RemoteStateWatcher) storageChanged(keys []string) error {
 			delete(w.current.Storage, tag)
 		} else {
 			return errors.Annotatef(
-				result.Error, "getting life of %s attachment",
-				names.ReadableString(tag),
+				result.Error, "getting life of %s attachment for %s",
+				names.ReadableString(tag), w.unit.Tag().Id(),
 			)
 		}
 	}
@@ -1035,7 +1035,7 @@ func (w *RemoteStateWatcher) watchStorageAttachment(
 		return w.catacomb.ErrDying()
 	case _, ok := <-saw.Changes():
 		if !ok {
-			return errors.New("storage attachment watcher closed")
+			return errors.Errorf("storage attachment watcher closed for %s", w.unit.Tag().Id())
 		}
 		var err error
 		storageSnapshot, err = getStorageSnapshot(w.st, tag, w.unit.Tag())
@@ -1046,7 +1046,7 @@ func (w *RemoteStateWatcher) watchStorageAttachment(
 			// pending storage attachments to be provisioned.
 			storageSnapshot = StorageSnapshot{Life: life}
 		} else if err != nil {
-			return errors.Annotatef(err, "processing initial storage attachment change")
+			return errors.Annotatef(err, "processing initial storage attachment change for %s", w.unit.Tag().Id())
 		}
 	}
 	innerSAW, err := newStorageAttachmentWatcher(

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -208,7 +208,7 @@ func (j *Jujuc) Main(req Request, resp *exec.ExecResponse) error {
 	// Beware, reducing the log level of the following line will lead
 	// to passwords leaking if passed as args.
 	logger.Tracef("running hook tool %q %q", req.CommandName, req.Args)
-	logger.Debugf("running hook tool %q", req.CommandName)
+	logger.Debugf("running hook tool %q for %s", req.CommandName, req.ContextId)
 	logger.Tracef("hook context id %q; dir %q", req.ContextId, req.Dir)
 	wrapper := &cmdWrapper{c, nil}
 	resp.Code = cmd.Main(wrapper, ctx, req.Args)

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -185,7 +185,7 @@ type UniterParams struct {
 }
 
 // NewOperationExecutorFunc is a func which returns an operations.Executor.
-type NewOperationExecutorFunc func(operation.ExecutorConfig) (operation.Executor, error)
+type NewOperationExecutorFunc func(string, operation.ExecutorConfig) (operation.Executor, error)
 
 // ProviderIDGetter defines the API to get provider ID.
 type ProviderIDGetter interface {
@@ -780,7 +780,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		CharmURL: charmURL,
 	}
 
-	operationExecutor, err := u.newOperationExecutor(operation.ExecutorConfig{
+	operationExecutor, err := u.newOperationExecutor(u.unit.Name(), operation.ExecutorConfig{
 		StateReadWriter: u.unit,
 		InitialState:    initialState,
 		AcquireLock:     u.acquireExecutionLock,
@@ -854,7 +854,7 @@ func (u *Uniter) acquireExecutionLock(action string) (func(), error) {
 	// Uniter's catacomb into account.
 	spec := machinelock.Spec{
 		Cancel:  u.catacomb.Dying(),
-		Worker:  "uniter",
+		Worker:  fmt.Sprintf("%s uniter", u.unit.Name()),
 		Comment: action,
 	}
 	releaser, err := u.hookLock.Acquire(spec)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -169,13 +169,13 @@ func (s *UniterSuite) TestUniterBootstrap(c *gc.C) {
 			serveCharm{},
 			writeFile{"charm", 0644},
 			createUniter{},
-			waitUniterDead{err: `executing operation "install cs:quantal/wordpress-0": .*` + errNotDir},
+			waitUniterDead{err: `executing operation "install cs:quantal/wordpress-0" for u/0: .*` + errNotDir},
 		), ut(
 			"charm cannot be downloaded",
 			createCharm{},
 			// don't serve charm
 			createUniter{},
-			waitUniterDead{err: `preparing operation "install cs:quantal/wordpress-0": failed to download charm .* not found`},
+			waitUniterDead{err: `preparing operation "install cs:quantal/wordpress-0" for u/0: failed to download charm .* not found`},
 		),
 	})
 }
@@ -1439,8 +1439,8 @@ func (s *UniterSuite) TestTranslateResolverError(c *gc.C) {
 }
 
 func executorFunc(c *gc.C) uniter.NewOperationExecutorFunc {
-	return func(cfg operation.ExecutorConfig) (operation.Executor, error) {
-		e, err := operation.NewExecutor(cfg)
+	return func(unitName string, cfg operation.ExecutorConfig) (operation.Executor, error) {
+		e, err := operation.NewExecutor(unitName, cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		return &mockExecutor{e}, nil
 	}


### PR DESCRIPTION
Add the unit name to various uniter log lines to make debugged k8s operations easier.

## QA steps

deploy a k8s charm with debug logging and check logs

