### PR TITLE
[dev] Fix minor typos in juju expose/unexpose command help

### DIFF
--- a/cmd/juju/application/expose.go
+++ b/cmd/juju/application/expose.go
@@ -92,7 +92,7 @@ func (c *exposeCommand) Info() *cmd.Info {
 
 func (c *exposeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.StringVar(&c.ExposedEndpointsList, "endpoints", "", "Expose only the ports that charms have opened in this comma-delimited list of endpoints")
+	f.StringVar(&c.ExposedEndpointsList, "endpoints", "", "Expose only the ports that charms have opened for this comma-delimited list of endpoints")
 	f.StringVar(&c.ExposeToSpacesList, "to-spaces", "", "A comma-delimited list of spaces that should be able to access the application ports once exposed")
 	f.StringVar(&c.ExposeToCIDRsList, "to-cidrs", "", "A comma-delimited list of CIDRs that should be able to access the application ports once exposed")
 }

--- a/cmd/juju/application/unexpose.go
+++ b/cmd/juju/application/unexpose.go
@@ -38,7 +38,7 @@ run:
 
 juju unexpose apache2 --endpoints www
 
-Note that when a --endpoints options is provided, the application will still
+Note that when the --endpoints option is provided, the application will still
 remain exposed if any other of its endpoints are still exposed. However, if
 none of its endpoints remain exposed, the application will be instead unexposed. 
 
@@ -68,7 +68,7 @@ func (c *unexposeCommand) Info() *cmd.Info {
 
 func (c *unexposeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.StringVar(&c.ExposedEndpointsList, "endpoints", "", "Unexpose only the ports that charms have opened in this comma-delimited list of endpoints")
+	f.StringVar(&c.ExposedEndpointsList, "endpoints", "", "Unexpose only the ports that charms have opened for this comma-delimited list of endpoints")
 }
 
 func (c *unexposeCommand) Init(args []string) error {


### PR DESCRIPTION
This PR fixes some minor typos in the expose/unexpose command help text.
