### PR TITLE
Remove double validation

### DIFF
--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -610,9 +610,6 @@ func (w *modelCommandWrapper) Init(args []string) error {
 		if err := w.validateCommandForModelType(false); err != nil {
 			return errors.Trace(err)
 		}
-		if err := w.validateCommandForModelType(false); err != nil {
-			return errors.Trace(err)
-		}
 	}
 
 	if err := w.ModelCommand.Init(args); err != nil {


### PR DESCRIPTION
Seems like a simple copy and paste error when adding documentation.

Simply removing the offending code to clean that up, prevents the double
calling of the validation method.