### PR TITLE
Fix deprecation warning with GHA

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,8 +16,8 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
         GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
         GO111MODULE=off go get -u github.com/tsenart/deadcode


### PR DESCRIPTION
See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## QA steps

Wait for actions to pass.

## Documentation changes

N/A

## Bug reference

N/A
