### PR TITLE
Fix more deprecation warnings in GHAs

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,7 @@ jobs:
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-        echo "##[add-path]/snap/bin"
+        echo "/snap/bin" >> $GITHUB_PATH
         lxc network set lxdbr0 ipv6.address none
 
     - name: Checkout
@@ -59,7 +59,7 @@ jobs:
         OUT=$(snap info juju | grep -E "${{ matrix.snap_version }}:[[:space:]]+\^" || echo "NOT FOUND")
         set -e
         if [ "$OUT" = "NOT FOUND" ]; then
-          echo "::set-env name=RUN_TEST::RUN"
+          echo "RUN_TEST=RUN" >> $GITHUB_ENV
         fi
 
     - name: Install Dependencies
@@ -73,7 +73,7 @@ jobs:
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-        echo "##[add-path]/snap/bin"
+        echo "/snap/bin" >> $GITHUB_PATH
 
     - name: Bootstrap Juju latest/stable
       if: env.RUN_TEST == 'RUN'

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -18,7 +18,7 @@ jobs:
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-        echo "##[add-path]/snap/bin"
+        echo "/snap/bin" >> $GITHUB_PATH
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,8 +16,8 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
         GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
         GO111MODULE=off go get -u github.com/tsenart/deadcode


### PR DESCRIPTION
See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## QA steps

Wait for actions to pass.

## Documentation changes

N/A

## Bug reference

N/A
