### PR TITLE
Fix data races in various unit tests

### DIFF
--- a/apiserver/embeddedcli.go
+++ b/apiserver/embeddedcli.go
@@ -157,8 +157,16 @@ func (h *embeddedCLIHandler) runEmbeddedCommands(
 	}
 
 	var cmdErr error
-	lines := linereader.New(in)
-	lines.Timeout = 10 * time.Millisecond
+
+	// Can't use linereader.New() because it starts the Run() goroutine,
+	// so it's not safe to modify fields after that. Construct manually.
+	lines := &linereader.Reader{
+		Reader:  in,
+		Timeout: 10 * time.Millisecond,
+		Ch:      make(chan string),
+	}
+	go lines.Run()
+
 	cmdDone := false
 	outputDone := false
 done:

--- a/apiserver/embeddedcli.go
+++ b/apiserver/embeddedcli.go
@@ -157,16 +157,8 @@ func (h *embeddedCLIHandler) runEmbeddedCommands(
 	}
 
 	var cmdErr error
-
-	// Can't use linereader.New() because it starts the Run() goroutine,
-	// so it's not safe to modify fields after that. Construct manually.
-	lines := &linereader.Reader{
-		Reader:  in,
-		Timeout: 10 * time.Millisecond,
-		Ch:      make(chan string),
-	}
-	go lines.Run()
-
+	lines := linereader.New(in)
+	lines.Timeout = 10 * time.Millisecond
 	cmdDone := false
 	outputDone := false
 done:

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/juju/go4 v0.0.0-20160222163258-40d72ab9641a // indirect
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
 	github.com/juju/gomaasapi v0.0.0-20190826212825-0ab1eb636aba
-	github.com/juju/http v0.0.0-20200729125253-fb155b41a3e2
+	github.com/juju/http v0.0.0-20201019013536-69ae1d429836
 	github.com/juju/jsonschema v0.0.0-20161102181919-a0ef8b74ebcf
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e

--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,8 @@ github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcM
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http v0.0.0-20200729125253-fb155b41a3e2 h1:OecOfP0ioC73BXLmnjb1lDsKNPrK8GCkE9j4BmJVYhs=
 github.com/juju/http v0.0.0-20200729125253-fb155b41a3e2/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
+github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
+github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v1.0.1 h1:p7XMlMkx0A8gW6sws2+uHcRr38f9BvF8MQOfKfJihq4=

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ github.com/juju/gomaasapi v0.0.0-20190826212825-0ab1eb636aba h1:bnsLBCH2BUzTrl+X
 github.com/juju/gomaasapi v0.0.0-20190826212825-0ab1eb636aba/go.mod h1:ppx9XlnQMX/+h/kH+cU9kfDUT6GimqGtNRWdobUZVRE=
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcMb4iW4LzsVKNvDKSVvPf4A89mY=
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
-github.com/juju/http v0.0.0-20200729125253-fb155b41a3e2 h1:OecOfP0ioC73BXLmnjb1lDsKNPrK8GCkE9j4BmJVYhs=
-github.com/juju/http v0.0.0-20200729125253-fb155b41a3e2/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=


### PR DESCRIPTION
Fix the following data races reported by `go test -race` in CI:

* Concurrent access of fakeContext.deployed set in worker/deployer tests
* Overwriting global http.DefaultClient's Jar field in cmd/jujud/agent tests (fixed in juju/http repo)

This fixes the actual "WARNING: DATA RACE" issues reported by https://jenkins.juju.canonical.com/job/RunUnittests-race-amd64/ ... though I think there are other issues with the unittests-race job that aren't actual data races.

See related fix: https://github.com/juju/juju/pull/12159