### PR TITLE
Adds OCI support for AllocatePublicIP constraint.

### DIFF
--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -470,20 +470,31 @@ func shortenMachineId(machineId *string, nRunesShown int) string {
 }
 
 // StartInstance implements environs.InstanceBroker.
-func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (e *Environ) StartInstance(
+	ctx envcontext.ProviderCallContext, args environs.StartInstanceParams,
+) (*environs.StartInstanceResult, error) {
+	result, err := e.startInstance(ctx, args)
+	if err != nil {
+		providerCommon.HandleCredentialError(err, ctx)
+		return nil, errors.Trace(err)
+	}
+	return result, nil
+}
+
+func (e *Environ) startInstance(
+	ctx envcontext.ProviderCallContext, args environs.StartInstanceParams,
+) (*environs.StartInstanceResult, error) {
 	if args.ControllerUUID == "" {
 		return nil, errors.NotFoundf("Controller UUID")
 	}
 
 	networks, err := e.ensureNetworksAndSubnets(ctx, args.ControllerUUID, e.Config().UUID())
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
 	zones, err := e.AvailabilityZones(ctx)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -494,7 +505,6 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 	// from cache
 	imgCache, err := refreshImageCache(e.Compute, e.ecfg().compartmentID())
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	logger.Tracef("Image cache contains: %# v", pretty.Formatter(imgCache))
@@ -523,31 +533,23 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 		},
 	)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
 	tools, err := args.Tools.Match(tools.Filter{Arch: spec.Image.Arch})
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	logger.Tracef("agent binaries: %v", tools)
 	if err = args.InstanceConfig.SetTools(tools); err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
-	if err = instancecfg.FinishInstanceConfig(
-		args.InstanceConfig,
-		e.Config(),
-	); err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
+	if err = instancecfg.FinishInstanceConfig(args.InstanceConfig, e.Config()); err != nil {
 		return nil, errors.Trace(err)
 	}
 	hostname, err := e.namespace.Hostname(args.InstanceConfig.MachineId)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	tags := args.InstanceConfig.Tags
@@ -571,7 +573,6 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 
 	cloudcfg, err := e.getCloudInitConfig(series, apiPort, statePort)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Annotate(err, "cannot create cloudinit template")
 	}
 
@@ -583,7 +584,6 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 		OCIRenderer{},
 	)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Annotate(err, "cannot make user data")
 	}
 
@@ -637,31 +637,25 @@ func (e *Environ) StartInstance(ctx envcontext.ProviderCallContext, args environ
 
 	response, err := e.Compute.LaunchInstance(context.Background(), request)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
 	instance, err := newInstance(response.Instance, e)
 	if err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 
 	machineId := response.Instance.Id
 	timeout := 10 * time.Minute
 	if err := instance.waitForMachineStatus(desiredStatus, timeout); err != nil {
-		providerCommon.HandleCredentialError(err, ctx)
 		return nil, errors.Trace(err)
 	}
 	logger.Infof("started instance %q", *machineId)
 	displayName := shortenMachineId(machineId, 6)
 
-	if desiredStatus == ociCore.InstanceLifecycleStateRunning {
-		if allocatePublicIP {
-			if err := instance.waitForPublicIP(ctx); err != nil {
-				providerCommon.HandleCredentialError(err, ctx)
-				return nil, errors.Trace(err)
-			}
+	if desiredStatus == ociCore.InstanceLifecycleStateRunning && allocatePublicIP {
+		if err := instance.waitForPublicIP(ctx); err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
 


### PR DESCRIPTION
Adds support to the Oracle (OCI) provider for constraint `allocate-public-ip`.

## QA steps

- Bootstrap to OCI.
- `juju add-machine` and check that the machine is assigned a public IP.
- `juju add-machine --constraints allocate-public-ip=false` and check that the machine is not assigned a public IP.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1898708
