### PR TITLE
[dev] Remove transitive dependency to apiserver in state package

### DIFF
--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -17,7 +17,6 @@ import (
 	"gopkg.in/macaroon.v2"
 	"gopkg.in/mgo.v2"
 
-	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/testcharms"
@@ -299,7 +298,7 @@ func (s *CharmSuite) TestAddCharmWithAuth(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ms, err := dummy.Macaroon()
 	c.Assert(err, jc.ErrorIsNil)
-	apitesting.MacaroonEquals(c, ms[0], info.Macaroon[0])
+	assertMacaroonEquals(c, ms[0], info.Macaroon[0])
 }
 
 func (s *CharmSuite) TestAddCharmUpdatesPlaceholder(c *gc.C) {
@@ -491,7 +490,7 @@ func (s *CharmSuite) TestUpdateUploadedCharm(c *gc.C) {
 	c.Assert(sch.BundleSha256(), gc.Equals, "missing")
 	ms, err := sch.Macaroon()
 	c.Assert(err, jc.ErrorIsNil)
-	apitesting.MacaroonEquals(c, ms[0], info.Macaroon[0])
+	assertMacaroonEquals(c, ms[0], info.Macaroon[0])
 }
 
 func (s *CharmSuite) TestUpdateUploadedCharmEscapesSpecialCharsInConfig(c *gc.C) {

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -11,11 +11,11 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
+	dummystorage "github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
@@ -39,7 +39,7 @@ func (s *ConnSuite) SetUpTest(c *gc.C) {
 	s.policy = statetesting.MockPolicy{
 		GetStorageProviderRegistry: func() (storage.ProviderRegistry, error) {
 			return storage.ChainedProviderRegistry{
-				dummy.StorageProviders(),
+				dummystorage.StorageProviders(),
 				provider.CommonStorageProviders(),
 			}, nil
 		},

--- a/state/conn_wallclock_test.go
+++ b/state/conn_wallclock_test.go
@@ -10,11 +10,11 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
+	dummystorage "github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/testing"
 )
 
@@ -40,7 +40,7 @@ func (cs *ConnWithWallClockSuite) SetUpTest(c *gc.C) {
 	cs.policy = statetesting.MockPolicy{
 		GetStorageProviderRegistry: func() (storage.ProviderRegistry, error) {
 			return storage.ChainedProviderRegistry{
-				dummy.StorageProviders(),
+				dummystorage.StorageProviders(),
 				provider.CommonStorageProviders(),
 			}, nil
 		},

--- a/state/macaroon_helpers_test.go
+++ b/state/macaroon_helpers_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon.v2"
+)
+
+func newMacaroon(id string) (*macaroon.Macaroon, error) {
+	return macaroon.New(nil, []byte(id), "", macaroon.LatestVersion)
+}
+
+func assertMacaroonsEqual(c *gc.C, ms1, ms2 []macaroon.Slice) error {
+	if len(ms1) != len(ms2) {
+		return errors.Errorf("length mismatch, %d vs %d", len(ms1), len(ms2))
+	}
+
+	for i := 0; i < len(ms1); i++ {
+		m1 := ms1[i]
+		m2 := ms2[i]
+		if len(m1) != len(m2) {
+			return errors.Errorf("length mismatch, %d vs %d", len(m1), len(m2))
+		}
+		for i := 0; i < len(m1); i++ {
+			assertMacaroonEquals(c, m1[i], m2[i])
+		}
+	}
+	return nil
+}
+
+func assertMacaroonEquals(c *gc.C, m1, m2 *macaroon.Macaroon) {
+	c.Assert(m1.Id(), jc.DeepEquals, m2.Id())
+	c.Assert(m1.Signature(), jc.DeepEquals, m2.Signature())
+	c.Assert(m1.Location(), jc.DeepEquals, m2.Location())
+}

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
 	"github.com/juju/juju/network"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
+	dummystorage "github.com/juju/juju/storage/provider/dummy"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
@@ -951,7 +951,7 @@ func (s *MachineSuite) addVolume(c *gc.C, params state.VolumeParams, machineId s
 
 func (s *MachineSuite) TestMachineSetInstanceInfoSuccess(c *gc.C) {
 	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
-		dummy.StorageProviders(),
+		dummystorage.StorageProviders(),
 		provider.CommonStorageProviders(),
 	})
 	_, err := pm.Create("loop-pool", provider.LoopProviderType, map[string]interface{}{})

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/payload"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/state"
@@ -45,6 +44,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
+	dummystorage "github.com/juju/juju/storage/provider/dummy"
 	"github.com/juju/juju/testing/factory"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -121,7 +121,7 @@ func (s *MigrationBaseSuite) makeUnitWithStorage(c *gc.C) (*state.Application, *
 	kind := "block"
 	// Create a default pool for block devices.
 	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
-		dummy.StorageProviders(),
+		dummystorage.StorageProviders(),
 		provider.CommonStorageProviders(),
 	})
 	_, err := pm.Create(pool, provider.LoopProviderType, map[string]interface{}{})

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -24,7 +24,6 @@ import (
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/macaroon.v2"
 
-	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
@@ -2259,7 +2258,7 @@ func (s *MigrationExportSuite) newResource(c *gc.C, appName, name string, revisi
 }
 
 func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
-	mac, err := apitesting.NewMacaroon("apimac")
+	mac, err := newMacaroon("apimac")
 	c.Assert(err, gc.IsNil)
 	dbApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "gravy-rainbow",
@@ -2472,7 +2471,7 @@ func (s *MigrationExportSuite) TestRelationWithNoStatus(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestRemoteRelationSettingsForLocalUnitInCMR(c *gc.C) {
-	mac, err := apitesting.NewMacaroon("apimac")
+	mac, err := newMacaroon("apimac")
 	c.Assert(err, gc.IsNil)
 
 	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
-	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/state"
@@ -82,7 +81,7 @@ func (s *MigrationSuite) TestCreate(c *gc.C) {
 	// (as they can't be compared using DeepEquals due to 'UnmarshaledAs')
 	infoMacs := info.Macaroons
 	info.Macaroons = nil
-	apitesting.MacaroonsEqual(c, infoMacs, s.stdSpec.TargetInfo.Macaroons)
+	assertMacaroonsEqual(c, infoMacs, s.stdSpec.TargetInfo.Macaroons)
 	s.stdSpec.TargetInfo.Macaroons = nil
 	c.Check(*info, jc.DeepEquals, s.stdSpec.TargetInfo)
 	c.Check(info.ControllerAlias, gc.Equals, s.stdSpec.TargetInfo.ControllerAlias)

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -12,7 +12,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -93,7 +92,7 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 		"db-admin": "private",
 		"logging":  "public",
 	}
-	mac, err := apitesting.NewMacaroon("test")
+	mac, err := newMacaroon("test")
 	c.Assert(err, jc.ErrorIsNil)
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "mysql",
@@ -328,11 +327,11 @@ func (s *remoteApplicationSuite) TestMysqlEndpoints(c *gc.C) {
 }
 
 func (s *remoteApplicationSuite) TestMacaroon(c *gc.C) {
-	mac, err := apitesting.NewMacaroon("test")
+	mac, err := newMacaroon("test")
 	c.Assert(err, jc.ErrorIsNil)
 	appMac, err := s.application.Macaroon()
 	c.Assert(err, jc.ErrorIsNil)
-	apitesting.MacaroonEquals(c, appMac, mac)
+	assertMacaroonEquals(c, appMac, mac)
 }
 
 func (s *remoteApplicationSuite) TestApplicationRefresh(c *gc.C) {

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -9,8 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	gc "gopkg.in/check.v1"
-
-	apitesting "github.com/juju/juju/api/testing"
 )
 
 type RemoteEntitiesSuite struct {
@@ -74,7 +72,7 @@ func (s *RemoteEntitiesSuite) TestMacaroon(c *gc.C) {
 	s.assertExportLocalEntity(c, entity)
 
 	re := s.State.RemoteEntities()
-	mac, err := apitesting.NewMacaroon("id")
+	mac, err := newMacaroon("id")
 	c.Assert(err, jc.ErrorIsNil)
 	err = re.SaveMacaroon(entity, mac)
 	c.Assert(err, jc.ErrorIsNil)
@@ -82,7 +80,7 @@ func (s *RemoteEntitiesSuite) TestMacaroon(c *gc.C) {
 	re = s.State.RemoteEntities()
 	expected, err := re.GetMacaroon(entity)
 	c.Assert(err, jc.ErrorIsNil)
-	apitesting.MacaroonEquals(c, mac, expected)
+	assertMacaroonEquals(c, mac, expected)
 }
 
 func (s *RemoteEntitiesSuite) TestRemoveRemoteEntity(c *gc.C) {

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/testing"
@@ -56,7 +55,7 @@ func (s *StorageStateSuiteBase) SetUpTest(c *gc.C) {
 		s.st = s.State
 		s.series = "quantal"
 		registry = storage.ChainedProviderRegistry{
-			dummy.StorageProviders(),
+			dummystorage.StorageProviders(),
 			provider.CommonStorageProviders(),
 		}
 	}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
 	"github.com/juju/juju/storage/provider"
+	dummystorage "github.com/juju/juju/storage/provider/dummy"
 )
 
 type VolumeStateSuite struct {
@@ -115,7 +115,7 @@ func (s *VolumeStateSuite) TestAddApplicationNoUserDefaultPool(c *gc.C) {
 func (s *VolumeStateSuite) TestAddApplicationDefaultPool(c *gc.C) {
 	// Register a default pool.
 	pm := poolmanager.New(state.NewStateSettings(s.State), storage.ChainedProviderRegistry{
-		dummy.StorageProviders(),
+		dummystorage.StorageProviders(),
 		provider.CommonStorageProviders(),
 	})
 	_, err := pm.Create("default-block", provider.LoopProviderType, map[string]interface{}{})


### PR DESCRIPTION
This is a maintenance PR that removes a transitive dependency between the `state` package and the `apiserver` package. As a result of the transitive dep, running the tests within the `state` package would trigger a recompile of a large part of the code-base. 

The issue was caused by the import of the `api/testing` package which some of the tests used for creating/comparing macaroons. The relevant code has been copied into state and the transitive dependency has been eliminated.

In addition, redundant imports of `provider/dummy` in the test suite code have been removed and replaced with a direct import to `storage/provider/dummy`.

## QA steps

Add this block in one of the files in the apiserver package (e.g. rest.go)

```go
func init(){
  panic("state imports apiserver")
}
```

Run the tests in the state package and verify that the test suites begin to execute without hitting the injected panic

```console
cd state
go test -check.v
```