### PR TITLE
Fix provider/common tests if repo not checked out at */juju/juju

### DIFF
--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -29,9 +29,9 @@ func (*ErrorsSuite) TestWrapZoneIndependentError(c *gc.C) {
 
 	stack := errors.ErrorStack(wrapped)
 	c.Assert(stack, gc.Matches, `
-.*/juju/juju/provider/common/errors_test.go:.*: foo
-.*/juju/juju/provider/common/errors_test.go:.*: bar
-.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/provider/common/errors_test.go:.*: foo
+.*/provider/common/errors_test.go:.*: bar
+.*/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
@@ -46,9 +46,9 @@ func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
 
 	stack := errors.ErrorStack(err)
 	c.Assert(stack, gc.Matches, `
-.*/juju/juju/provider/common/errors_test.go:.*: foo
-.*/juju/juju/provider/common/errors_test.go:.*: bar
-.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/provider/common/errors_test.go:.*: foo
+.*/provider/common/errors_test.go:.*: bar
+.*/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialNew(c *gc.C) {


### PR DESCRIPTION
Simple fix for test failures I was seeing locally with `provider/common` package. I home the juju repo checked out at `~/w/juju`, but it seems the tests expect it at `*/juju/juju` (probably most people have it at `~/go/src/github.com/juju/juju`?). Was probably happening only to me (and I guess I've never run the entire unit tests suite locally! I usually run by subdirectory or package).

Either way, the tests shouldn't depend on the checkout directory, so loosen up this regex a bit.
