### PR TITLE
Fix a race in the worker/introspection tests TestUnitStatusTimeout

### DIFF
--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -355,7 +355,7 @@ two: stopped`[1:])
 
 func (s *introspectionSuite) TestUnitStatusTimeout(c *gc.C) {
 	unsub := s.hub.Subscribe(agent.UnitStatusTopic, func(string, interface{}) {
-		s.clock.Advance(10 * time.Second)
+		s.clock.WaitAdvance(10 * time.Second, time.Second, 1)
 	})
 	defer unsub()
 
@@ -556,6 +556,7 @@ func newPrometheusGatherer() prometheus.Gatherer {
 func unixSocketHTTPClient(socketPath string) *http.Client {
 	return &http.Client{
 		Transport: unixSocketHTTPTransport(socketPath),
+		Timeout: 15 * time.Second,
 	}
 }
 

--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -355,7 +355,7 @@ two: stopped`[1:])
 
 func (s *introspectionSuite) TestUnitStatusTimeout(c *gc.C) {
 	unsub := s.hub.Subscribe(agent.UnitStatusTopic, func(string, interface{}) {
-		s.clock.WaitAdvance(10 * time.Second, time.Second, 1)
+		s.clock.WaitAdvance(10*time.Second, time.Second, 1)
 	})
 	defer unsub()
 
@@ -556,7 +556,7 @@ func newPrometheusGatherer() prometheus.Gatherer {
 func unixSocketHTTPClient(socketPath string) *http.Client {
 	return &http.Client{
 		Transport: unixSocketHTTPTransport(socketPath),
-		Timeout: 15 * time.Second,
+		Timeout:   15 * time.Second,
 	}
 }
 


### PR DESCRIPTION
What was happening is that sometimes (specifically in `-race` mode), the `Advance()` call in the test was happening before the select on `time.After()` in the worker code, and the `time.After()` never triggered. Fixed by using `WaitAdvance()` -- see https://github.com/juju/juju/wiki/Intermittent-failures

Additionally, there was no timeout on the testing `http.Client`, so the `Get()` never returned and the test didn't stop till the 40 minute overall timeout kicked in. Once I added an http.Client timeout the actual issue above was a lot more clear.
