### PR TITLE
Move ModelUUID method away from APIAddresser

### DIFF
--- a/api/common/apiaddresser.go
+++ b/api/common/apiaddresser.go
@@ -39,21 +39,6 @@ func (a *APIAddresser) APIAddresses() ([]string, error) {
 	return result.Result, nil
 }
 
-// ModelUUID returns the model UUID to connect to the model
-// that the current connection is for.
-//
-// TODO(axw) this has bugger all to do with addresses, and
-// so should not be on this type. Get it from somewhere else,
-// e.g. by passing it into the model-specific workers.
-func (a *APIAddresser) ModelUUID() (string, error) {
-	var result params.StringResult
-	err := a.facade.FacadeCall("ModelUUID", nil, &result)
-	if err != nil {
-		return "", err
-	}
-	return result.Result, nil
-}
-
 // APIHostPorts returns the host/port addresses of the API servers.
 func (a *APIAddresser) APIHostPorts() ([]network.ProviderHostPorts, error) {
 	var result params.APIHostPortsResult

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/juju/tools"
 )
 
-// State provides access to the Machiner API facade.
+// State provides access to the Provisioner API facade.
 type State struct {
 	*common.ModelWatcher
 	*common.APIAddresser
@@ -399,4 +399,15 @@ func (st *State) GetContainerProfileInfo(containerTag names.MachineTag) ([]*LXDP
 		})
 	}
 	return res, nil
+}
+
+// ModelUUID returns the model UUID to connect to the model
+// that the current connection is for.
+func (a *State) ModelUUID() (string, error) {
+	var result params.StringResult
+	err := a.facade.FacadeCall("ModelUUID", nil, &result)
+	if err != nil {
+		return "", err
+	}
+	return result.Result, nil
 }

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -15,7 +15,6 @@ import (
 // and the CA public certificate.
 type AddressAndCertGetter interface {
 	Addresses() ([]string, error)
-	ModelUUID() string
 	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
 }
@@ -93,12 +92,6 @@ func apiAddresses(getter APIHostPortsForAgentsGetter) ([]string, error) {
 		}
 	}
 	return addrs, nil
-}
-
-// ModelUUID returns the model UUID to connect to the model
-// that the current connection is for.
-func (a *APIAddresser) ModelUUID() params.StringResult {
-	return params.StringResult{Result: a.getter.ModelUUID()}
 }
 
 // StateAddresser implements a common set of methods for getting state

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
-// AddressAndCertGetter can be used to find out controller addresses
-// and the CA public certificate.
-type AddressAndCertGetter interface {
+// APIAddressAccessor describes methods that allow agents to maintain
+// up-to-date information on how to connect to the Juju API server.
+type APIAddressAccessor interface {
 	Addresses() ([]string, error)
 	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
@@ -25,12 +25,12 @@ type AddressAndCertGetter interface {
 // It is not suitable for callers requiring *all* available API addresses.
 type APIAddresser struct {
 	resources facade.Resources
-	getter    AddressAndCertGetter
+	getter    APIAddressAccessor
 }
 
 // NewAPIAddresser returns a new APIAddresser that uses the given getter to
 // fetch its addresses.
-func NewAPIAddresser(getter AddressAndCertGetter, resources facade.Resources) *APIAddresser {
+func NewAPIAddresser(getter APIAddressAccessor, resources facade.Resources) *APIAddresser {
 	return &APIAddresser{
 		getter:    getter,
 		resources: resources,
@@ -97,12 +97,12 @@ func apiAddresses(getter APIHostPortsForAgentsGetter) ([]string, error) {
 // StateAddresser implements a common set of methods for getting state
 // server addresses, and the CA certificate used to authenticate them.
 type StateAddresser struct {
-	getter AddressAndCertGetter
+	getter APIAddressAccessor
 }
 
 // NewStateAddresser returns a new StateAddresser that uses the given
 // st value to fetch its addresses.
-func NewStateAddresser(getter AddressAndCertGetter) *StateAddresser {
+func NewStateAddresser(getter APIAddressAccessor) *StateAddresser {
 	return &StateAddresser{getter}
 }
 

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -92,11 +92,6 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 	})
 }
 
-func (s *apiAddresserSuite) TestModelUUID(c *gc.C) {
-	result := s.addresser.ModelUUID()
-	c.Assert(result.Result, gc.Equals, "the model uuid")
-}
-
 var _ common.AddressAndCertGetter = fakeAddresses{}
 
 type fakeAddresses struct {
@@ -109,10 +104,6 @@ func (fakeAddresses) Addresses() ([]string, error) {
 
 func (fakeAddresses) ControllerConfig() (controller.Config, error) {
 	return coretesting.FakeControllerConfig(), nil
-}
-
-func (fakeAddresses) ModelUUID() string {
-	return "the model uuid"
 }
 
 func (f fakeAddresses) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -35,8 +35,8 @@ func (s *stateAddresserSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-// Verify that AddressAndCertGetter is satisfied by *state.State.
-var _ common.AddressAndCertGetter = (*state.State)(nil)
+// Verify that APIAddressAccessor is satisfied by *state.State.
+var _ common.APIAddressAccessor = (*state.State)(nil)
 
 func (s *stateAddresserSuite) TestStateAddresses(c *gc.C) {
 	result, err := s.addresser.StateAddresses()
@@ -92,7 +92,7 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 	})
 }
 
-var _ common.AddressAndCertGetter = fakeAddresses{}
+var _ common.APIAddressAccessor = fakeAddresses{}
 
 type fakeAddresses struct {
 	hostPorts []network.SpaceHostPorts

--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -25,7 +25,7 @@ import (
 
 type mockState struct {
 	testing.Stub
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	app              mockApplication
 	model            mockModel
 	units            map[string]*mockUnit

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -71,6 +71,11 @@ func (st *mockState) WatchAPIHostPortsForAgents() state.NotifyWatcher {
 	return apiservertesting.NewFakeNotifyWatcher()
 }
 
+func (st *mockState) ModelUUID() string {
+	st.MethodCall(st, "ModelUUID")
+	return coretesting.ModelTag.Id()
+}
+
 func (st *mockState) Application(id string) (caasoperator.Application, error) {
 	st.MethodCall(st, "Application", id)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -28,7 +28,7 @@ import (
 
 type mockState struct {
 	testing.Stub
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	entities map[string]state.Entity
 	app      mockApplication
 	unit     mockUnit

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -22,6 +22,10 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
+// TODO (manadart 2020-10-21): Remove the ModelUUID method
+// from the next version of this facade.
+
+// Facade is the CAAS operator API facade.
 type Facade struct {
 	auth      facade.Authorizer
 	resources facade.Resources
@@ -283,4 +287,12 @@ func (f *Facade) watchContainerStart(tagString string, containerName string) (st
 		return f.resources.Register(uw), changes, nil
 	}
 	return "", nil, watcher.EnsureErr(uw)
+}
+
+// ModelUUID returns the model UUID that this facade is used to operate.
+// It is implemented here directly as a result of removing it from
+// embedded APIAddresser *without* bumping the facade version.
+// It should be blanked when this facade version is next incremented.
+func (f *Facade) ModelUUID() params.StringResult {
+	return params.StringResult{Result: f.model.UUID()}
 }

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -16,6 +16,9 @@ import (
 	"github.com/juju/juju/state"
 )
 
+// TODO (manadart 2020-10-21): Remove the ModelUUID method
+// from the next version of this facade.
+
 // DeployerAPI provides access to the Deployer API facade.
 type DeployerAPI struct {
 	*common.Remover
@@ -94,6 +97,14 @@ func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, 
 // SetStatus sets the status of the specified entities.
 func (d *DeployerAPI) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
 	return d.StatusSetter.SetStatus(args)
+}
+
+// ModelUUID returns the model UUID that this facade is deploying into.
+// It is implemented here directly as a result of removing it from
+// embedded APIAddresser *without* bumping the facade version.
+// It should be blanked when this facade version is next incremented.
+func (d *DeployerAPI) ModelUUID() params.StringResult {
+	return params.StringResult{Result: d.st.ModelUUID()}
 }
 
 // getAllUnits returns a list of all principal and subordinate units

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -21,6 +21,9 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.machine")
 
+// TODO (manadart 2020-10-21): Remove the ModelUUID method
+// from the next version of this facade.
+
 // MachinerAPI implements the API used by the machiner worker.
 type MachinerAPI struct {
 	*common.LifeGetter
@@ -164,6 +167,14 @@ func (api *MachinerAPI) RecordAgentStartTime(args params.Entities) (params.Error
 		}
 	}
 	return results, nil
+}
+
+// ModelUUID returns the model UUID that this machine resides in.
+// It is implemented here directly as a result of removing it from
+// embedded APIAddresser *without* bumping the facade version.
+// It should be blanked when this facade version is next incremented.
+func (api *MachinerAPI) ModelUUID() params.StringResult {
+	return params.StringResult{Result: api.st.ModelUUID()}
 }
 
 // MachinerAPIV1 implements the V1 API used by the machiner worker.

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1522,6 +1522,11 @@ func (api *ProvisionerAPI) setOneMachineCharmProfiles(machineTag string, profile
 	return machine.SetCharmProfiles(profiles)
 }
 
+// ModelUUID returns the model UUID that the current connection is for.
+func (api *ProvisionerAPI) ModelUUID() params.StringResult {
+	return params.StringResult{Result: api.st.ModelUUID()}
+}
+
 // SetUpgradeCharmProfileComplete recorded that the result of updating
 // the machine's charm profile(s)
 //

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -40,6 +40,9 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.uniter")
 
+// TODO (manadart 2020-10-21): Remove the ModelUUID method
+// from the next version of this facade.
+
 // UniterAPI implements the latest version (v17) of the Uniter API, which
 // augments the payload of the CommitHookChanges API call and introduces
 // the OpenedMachinePortRanges call as a replacement for AllMachinePorts.
@@ -82,7 +85,7 @@ type UniterAPI struct {
 }
 
 // UniterAPIV16 implements version (v16) of the Uniter API, which adds
-// LXDPorfileAPIV2.
+// LXDProfileAPIV2.
 type UniterAPIV16 struct {
 	UniterAPI
 }
@@ -1165,6 +1168,14 @@ func (u *UniterAPI) ClosePorts(args params.EntitiesPortRanges) (params.ErrorResu
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
+}
+
+// ModelUUID returns the model UUID that this unit resides in.
+// It is implemented here directly as a result of removing it from
+// embedded APIAddresser *without* bumping the facade version.
+// It should be blanked when this facade version is next incremented.
+func (u *UniterAPI) ModelUUID() params.StringResult {
+	return params.StringResult{Result: u.m.UUID()}
 }
 
 // WatchConfigSettings returns a NotifyWatcher for observing changes

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -296,7 +296,7 @@ type offerAccess struct {
 
 type mockState struct {
 	crossmodel.Backend
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	modelUUID         string
 	model             *mockModel
 	AdminTag          names.UserTag
@@ -311,7 +311,7 @@ type mockState struct {
 	relationNetworks  state.RelationNetworks
 }
 
-func (m *mockState) GetAddressAndCertGetter() common.AddressAndCertGetter {
+func (m *mockState) GetAddressAndCertGetter() common.APIAddressAccessor {
 	return m
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -36,7 +36,7 @@ import (
 type mockState struct {
 	testing.Stub
 
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	model              *mockModel
 	applicationWatcher *mockStringsWatcher
 	app                *mockApplication

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -86,6 +86,11 @@ func (st *mockState) Model() (caasapplicationprovisioner.Model, error) {
 	return st.model, nil
 }
 
+func (st *mockState) ModelUUID() string {
+	st.MethodCall(st, "ModelUUID")
+	return coretesting.ModelTag.Id()
+}
+
 func (st *mockState) ResolveConstraints(cons constraints.Value) (constraints.Value, error) {
 	st.MethodCall(st, "ResolveConstraints", cons)
 	if err := st.NextErr(); err != nil {

--- a/apiserver/facades/controller/caasmodeloperator/mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/mock_test.go
@@ -39,6 +39,10 @@ func (st *mockState) APIHostPortsForAgents() ([]network.SpaceHostPorts, error) {
 	}, nil
 }
 
+func (st *mockState) ModelUUID() string {
+	return st.model.UUID()
+}
+
 func (st *mockState) ControllerConfig() (controller.Config, error) {
 	cfg := coretesting.FakeControllerConfig()
 	cfg[controller.CAASImageRepo] = st.operatorRepo

--- a/apiserver/facades/controller/caasmodeloperator/mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/mock_test.go
@@ -22,7 +22,7 @@ type mockModel struct {
 }
 
 type mockState struct {
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	operatorRepo string
 	model        *mockModel
 }

--- a/apiserver/facades/controller/caasmodeloperator/mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/mock_test.go
@@ -56,10 +56,6 @@ func (st *mockState) Model() (caasmodeloperator.Model, error) {
 	return st.model, nil
 }
 
-func (st *mockState) ModelUUID() string {
-	return st.model.UUID()
-}
-
 func (m *mockModel) Tag() names.Tag {
 	return m.tag
 }

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -17,7 +17,10 @@ import (
 	"github.com/juju/juju/version"
 )
 
-// API represents the controller model operator facade
+// TODO (manadart 2020-10-21): Remove the ModelUUID method
+// from the next version of this facade.
+
+// API represents the controller model operator facade.
 type API struct {
 	*common.APIAddresser
 	*common.PasswordChanger
@@ -28,7 +31,7 @@ type API struct {
 }
 
 // NewAPIFromContent creates a new controller model facade from the supplied
-// context
+// context.
 func NewAPIFromContext(ctx facade.Context) (*API, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
@@ -37,7 +40,7 @@ func NewAPIFromContext(ctx facade.Context) (*API, error) {
 		stateShim{ctx.State()})
 }
 
-// NewAPI is alternative means of constructing a controller model facade
+// NewAPI is alternative means of constructing a controller model facade.
 func NewAPI(
 	authorizer facade.Authorizer,
 	resources facade.Resources,
@@ -97,4 +100,12 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 		Version: vers,
 	}
 	return result, nil
+}
+
+// ModelUUID returns the model UUID that this facade is used to operate.
+// It is implemented here directly as a result of removing it from
+// embedded APIAddresser *without* bumping the facade version.
+// It should be blanked when this facade version is next incremented.
+func (a *API) ModelUUID() params.StringResult {
+	return params.StringResult{Result: a.state.ModelUUID()}
 }

--- a/apiserver/facades/controller/caasmodeloperator/state.go
+++ b/apiserver/facades/controller/caasmodeloperator/state.go
@@ -6,8 +6,8 @@ package caasmodeloperator
 import (
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -22,10 +22,7 @@ type CAASModelOperatorState interface {
 // CAASModelOperatorState provides the subset of controller state required by the
 // model operator provisioner.
 type CAASControllerState interface {
-	Addresses() ([]string, error)
-	ModelUUID() string
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
-	WatchAPIHostPortsForAgents() state.NotifyWatcher
+	common.AddressAndCertGetter
 	ControllerConfig() (controller.Config, error)
 }
 

--- a/apiserver/facades/controller/caasmodeloperator/state.go
+++ b/apiserver/facades/controller/caasmodeloperator/state.go
@@ -17,6 +17,7 @@ import (
 type CAASModelOperatorState interface {
 	FindEntity(tag names.Tag) (state.Entity, error)
 	Model() (Model, error)
+	ModelUUID() string
 }
 
 // CAASModelOperatorState provides the subset of controller state required by the

--- a/apiserver/facades/controller/caasmodeloperator/state.go
+++ b/apiserver/facades/controller/caasmodeloperator/state.go
@@ -22,7 +22,7 @@ type CAASModelOperatorState interface {
 // CAASModelOperatorState provides the subset of controller state required by the
 // model operator provisioner.
 type CAASControllerState interface {
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	ControllerConfig() (controller.Config, error)
 }
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -24,7 +24,7 @@ import (
 
 type mockState struct {
 	testing.Stub
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	model              *mockModel
 	applicationWatcher *mockStringsWatcher
 	app                *mockApplication

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -35,6 +35,10 @@ type APIGroup struct {
 	*API
 }
 
+// TODO (manadart 2020-10-21): Remove the ModelUUID method
+// from the next version of this facade.
+
+// API is CAAS operator provisioner API facade.
 type API struct {
 	*common.PasswordChanger
 	*common.LifeGetter
@@ -252,6 +256,18 @@ func (a *API) IssueOperatorCertificate(args params.Entities) (params.IssueOperat
 	}
 
 	return res, nil
+}
+
+// ModelUUID returns the model UUID that this facade is used to operate.
+// It is implemented here directly as a result of removing it from
+// embedded APIAddresser *without* bumping the facade version.
+// It should be blanked when this facade version is next incremented.
+func (a *API) ModelUUID() params.StringResult {
+	m, err := a.state.Model()
+	if err != nil {
+		return params.StringResult{Error: apiservererrors.ServerError(err)}
+	}
+	return params.StringResult{Result: m.UUID()}
 }
 
 // CharmStorageParams returns filesystem parameters needed

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -25,7 +25,7 @@ type CAASOperatorProvisionerState interface {
 // CAASControllerState provides the subset of controller state
 // required by the CAAS operator provisioner facade.
 type CAASControllerState interface {
-	common.AddressAndCertGetter
+	common.APIAddressAccessor
 	ControllerConfig() (controller.Config, error)
 	StateServingInfo() (controller.StateServingInfo, error)
 }

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -7,8 +7,8 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -22,13 +22,10 @@ type CAASOperatorProvisionerState interface {
 	Application(string) (Application, error)
 }
 
-// CAASOperatorProvisionerState provides the subset of controller state
+// CAASControllerState provides the subset of controller state
 // required by the CAAS operator provisioner facade.
 type CAASControllerState interface {
-	Addresses() ([]string, error)
-	ModelUUID() string
-	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
-	WatchAPIHostPortsForAgents() state.NotifyWatcher
+	common.AddressAndCertGetter
 	ControllerConfig() (controller.Config, error)
 	StateServingInfo() (controller.StateServingInfo, error)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9380,7 +9380,7 @@
     },
     {
         "Name": "CAASModelOperator",
-        "Description": "API represents the controller model operator facade",
+        "Description": "API represents the controller model operator facade.",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent"
@@ -9422,7 +9422,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that this facade is used to operate.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
                 },
                 "SetPasswords": {
                     "type": "object",
@@ -9706,7 +9706,7 @@
     },
     {
         "Name": "CAASOperator",
-        "Description": "",
+        "Description": "Facade is the CAAS operator API facade.",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent",
@@ -9775,7 +9775,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that this facade is used to operate.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
                 },
                 "Remove": {
                     "type": "object",
@@ -10510,7 +10510,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that this facade is used to operate.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
                 },
                 "OperatorProvisioningInfo": {
                     "type": "object",
@@ -19532,7 +19532,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that this facade is deploying into.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
                 },
                 "Remove": {
                     "type": "object",
@@ -26393,7 +26393,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that this machine resides in.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
                 },
                 "RecordAgentStartTime": {
                     "type": "object",
@@ -32111,7 +32111,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that the current connection is for."
                 },
                 "PrepareContainerInterfaceInfo": {
                     "type": "object",
@@ -42017,7 +42017,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                    "description": "ModelUUID returns the model UUID that this unit resides in.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
                 },
                 "NetworkInfo": {
                     "type": "object",


### PR DESCRIPTION
This fixes a subtle bug introduced by https://github.com/juju/juju/pull/12154.

The `APIAddresser` used in various facades was changed so that it is always instantiated with a controller state. However, this type supplied a `ModelUUID` method, the return of which changed to the controller model for facades embedding it.

The only API using this method is the provisioner API which in turn is used by `NewAPIAuthenticator`. The downstream effect was that machine agents got the controller model UUID written to their agent configs, and when they attempted to access API resources got an unauthorised error, causing permanent shut-down.

This patch removes the `ModelUUID` method from `APIAddresser` and its indirections, and implements it directly on all the facades that previously got the method by virtue of embedding. This had to be done to preserve compatibility with released facade versions. Note that aside from comments, the facade schema remains unchanged.

Other miscellaneous clean-ups and comments accompany.

## QA steps

Any IAAS provider should work for this, but I used Oracle as I consistently replicated the error there.

- Bootstrap and deploy a machine in a workload model.
- The machine should transition to the `started` state.

## Documentation changes

None.

## Bug reference

N/A
