### PR TITLE
[2.8] Update azure regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -265,7 +265,7 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net
-      switzerlandeast:
+      switzerlandnorth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -272,7 +272,7 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net
-      switzerlandeast:
+      switzerlandnorth:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net


### PR DESCRIPTION
This PR updates the fallback cloud metadata entries for azure to rename `switzerlandeast` to `switzerlandnorth`

Interestingly, running the following command also yields the `brazilsoutheast` region but we cannot bootstrap to it at this point in time so it was omitted.

```console
diff \
<(az account list-locations | grep 'name.' | cut -d '"' -f4 | sort) \
<(cat cloud/fallback-public-cloud.yaml| sed -n '/azure:/,/azure-china:/p' | grep -E '^      [[:alnum:]]' | tr -d ' ' | tr -d ':' | sort)
```

The [list](https://streams.canonical.com/juju/public-clouds.syaml) of public clouds has already been updated/signed.
## QA steps

```console
$ juju update-public-clouds
This operation can be applied to both a copy on this client and to the one on a controller.
No current controller was detected but there are other controllers registered: use -c or --controller to specify a controller if needed.
Do you ONLY want to update public clouds on this client? (Y/n): Y

Fetching latest public cloud list...
Updated list of public clouds on this client, 1 cloud region added as well as 1 cloud region deleted:

    added cloud region:
        - azure/switzerlandnorth
    deleted cloud region:
        - azure/switzerlandeast

$ juju bootstrap --credential azure --no-gui azure/switzerlandnorth azure-test
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1900638