### PR TITLE
fix juju find with no query specified.

### DIFF
--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -110,16 +110,24 @@ func (c *HTTPRESTClient) Get(ctx context.Context, path path.Path, result interfa
 		return errors.Annotate(err, "can not make new request")
 	}
 
+	// Compose the request headers.
+	headers := make(http.Header)
+	headers.Set("Accept", "application/json")
+	headers.Set("Content-Type", "application/json")
+
+	req.Header = c.composeHeaders(headers)
+
 	if c.logger.IsTraceEnabled() {
 		if data, err := httputil.DumpRequest(req, true); err == nil {
-			c.logger.Tracef("Post request %s", data)
+			c.logger.Tracef("Get request %s", data)
 		} else {
-			c.logger.Tracef("Post request DumpRequest error %s", err.Error())
+			c.logger.Tracef("Get request DumpRequest error %s", err.Error())
 		}
 	}
 
 	resp, err := c.transport.Do(req)
 	if err != nil {
+		c.logger.Tracef("Get Do failed with %+v", err)
 		return errors.Trace(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -171,6 +179,7 @@ func (c *HTTPRESTClient) Post(ctx context.Context, path path.Path, body, result 
 
 	resp, err := c.transport.Do(req)
 	if err != nil {
+		c.logger.Tracef("Post Do failed with %+v", err)
 		return errors.Trace(err)
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/charmhub/path/path.go
+++ b/charmhub/path/path.go
@@ -52,7 +52,9 @@ func (u Path) Query(key string, value string) (Path, error) {
 		return Path{}, errors.Trace(err)
 	}
 
-	baseQuery.Add(key, value)
+	if value != "" {
+		baseQuery.Add(key, value)
+	}
 
 	newURL, err := url.Parse(u.base.String())
 	if err != nil {

--- a/charmhub/path/path_test.go
+++ b/charmhub/path/path_test.go
@@ -49,6 +49,17 @@ func (s *PathSuite) TestQuery(c *gc.C) {
 	c.Assert(newPath.String(), gc.Equals, "http://foobar/v1/path?q=foo")
 }
 
+func (s *PathSuite) TestQueryEmptyValue(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path")
+
+	path := MakePath(rawURL)
+
+	newPath, err := path.Query("q", "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(path.String(), gc.Equals, newPath.String())
+	//c.Assert(newPath.String(), gc.Equals, "http://foobar/v1/path?q=foo")
+}
+
 func (s *PathSuite) TestJoinQuery(c *gc.C) {
 	rawURL := MustParseURL(c, "http://foobar/v1/path")
 


### PR DESCRIPTION

Adding a `q=` to a charmhub find query causes a 403 error to be returned.  Can be caused by `juju find`, which expects a result of all, rather than `juju find ubuntu`.  Ensure we never add a query key for charmhub requests if the value provided is empty.

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost testme
$ juju add-model seven --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju find
...              <- returns values to scroll off the screen, not an error.
$ juju find ubuntu
Name                     Bundle  Version  Supports                                        Publisher              Summary
ubuntu                   -       11       xenial,bionic,artful,cosmic,disco,trusty,focal  charmers               A pristine Ubuntu Server
ubuntu-repository-cache  -       4        xenial,trusty                                   cloud-images           Ubuntu archive caching proxy mirror
ubuntu-devenv            -       11       bionic,xenial,trusty                            kwmonroe               Simple Ubuntu development and test environment
ubuntu-qa                -       3        focal,bionic,xenial                             Canonical Juju QA Bot  juju-qa version of the ubuntu charm.

```

