### PR TITLE
add aws regions eu-south-1 and af-south-1

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -25,6 +25,10 @@ clouds:
         endpoint: https://ec2.eu-central-1.amazonaws.com
       eu-north-1:
         endpoint: https://ec2.eu-north-1.amazonaws.com
+      eu-south-1:
+        endpoint: https://ec2.eu-south-1.amazonaws.com
+      af-south-1:
+        endpoint: https://ec2.af-south-1.amazonaws.com
       ap-east-1:
         endpoint: https://ec2.ap-east-1.amazonaws.com
       ap-south-1:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -32,6 +32,10 @@ clouds:
         endpoint: https://ec2.eu-central-1.amazonaws.com
       eu-north-1:
         endpoint: https://ec2.eu-north-1.amazonaws.com
+      eu-south-1:
+        endpoint: https://ec2.eu-south-1.amazonaws.com
+      af-south-1:
+        endpoint: https://ec2.af-south-1.amazonaws.com
       ap-east-1:
         endpoint: https://ec2.ap-east-1.amazonaws.com
       ap-south-1:

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2032,6 +2032,8 @@ eu-west-2
 eu-west-3
 eu-central-1
 eu-north-1
+eu-south-1
+af-south-1
 ap-east-1
 ap-south-1
 ap-southeast-1
@@ -2048,7 +2050,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
 	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-west-1, eu-west-2, eu-west-3, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-south-1, eu-west-1, eu-west-2, eu-west-3, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 }
 


### PR DESCRIPTION
Add new regions for AWS: af-south-1 and eu-south-1.  

## QA steps

Bootstrapping either of these 2 regions requires enabling it in your aws account.

```console
$ juju region aws

Client Cloud Regions
...
eu-north-1
eu-south-1
af-south-1
ap-east-1
...
# 
# enabling the eu-south-1 region is taking a while, however the api endpoint works and we can attempt to start
# an instance, seeing that there are 3 AZ for the region.
# 
$ juju bootstrap aws/eu-south-1
Creating Juju controller "aws-eu-south-1" on aws/eu-south-1
Looking for packaged Juju agent version 2.8.6 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on aws/eu-south-1...
Cloud credential "credentials" is not accepted by cloud provider:
Your account is pending verification by Amazon.: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to aws-verification@amazon.com for further assistance. (PendingVerification)
Cloud credential "credentials" is not accepted by cloud provider:
Your account is pending verification by Amazon.: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to aws-verification@amazon.com for further assistance. (PendingVerification)
Cloud credential "credentials" is not accepted by cloud provider:
Your account is pending verification by Amazon.: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to aws-verification@amazon.com for further assistance. (PendingVerification)
ERROR failed to bootstrap model: cannot start bootstrap instance in any availability zone (eu-south-1a, eu-south-1b, eu-south-1c)
```

