### PR TITLE
Fix k8s charm v2 cleanup and upgrade.

### DIFF
--- a/api/caasfirewaller/client.go
+++ b/api/caasfirewaller/client.go
@@ -6,10 +6,10 @@ package caasfirewaller
 import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
-	"github.com/juju/juju/api/common"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
 	charmscommon "github.com/juju/juju/api/common/charms"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -176,15 +176,16 @@ func (m *mockModel) Containers(providerIds ...string) ([]state.CloudContainer, e
 type mockApplication struct {
 	testing.Stub
 	state.Authenticator
-	life               state.Life
-	tag                names.Tag
-	password           string
-	series             string
-	charm              caasapplicationprovisioner.Charm
-	units              []*mockUnit
-	constraints        constraints.Value
-	storageConstraints map[string]state.StorageConstraints
-	deviceConstraints  map[string]state.DeviceConstraints
+	life                 state.Life
+	tag                  names.Tag
+	password             string
+	series               string
+	charm                caasapplicationprovisioner.Charm
+	units                []*mockUnit
+	constraints          constraints.Value
+	storageConstraints   map[string]state.StorageConstraints
+	deviceConstraints    map[string]state.DeviceConstraints
+	charmModifiedVersion int
 }
 
 func (a *mockApplication) Tag() names.Tag {
@@ -273,6 +274,16 @@ func (a *mockApplication) SetOperatorStatus(statusInfo status.StatusInfo) error 
 func (a *mockApplication) SetStatus(statusInfo status.StatusInfo) error {
 	a.MethodCall(a, "SetStatus", statusInfo)
 	return a.NextErr()
+}
+
+func (a *mockApplication) CharmModifiedVersion() int {
+	a.MethodCall(a, "CharmModifiedVersion")
+	return a.charmModifiedVersion
+}
+
+func (a *mockApplication) CharmURL() (curl *charm.URL, force bool) {
+	a.MethodCall(a, "CharmURL")
+	return a.charm.URL(), false
 }
 
 type mockCharm struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -48,6 +48,7 @@ var logger = loggo.GetLogger("juju.apiserver.caasapplicationprovisioner")
 type APIGroup struct {
 	*common.PasswordChanger
 	*common.LifeGetter
+	*common.AgentEntityWatcher
 	*charmscommon.CharmsAPI
 	*common.ApplicationWatcherFacade
 	*API
@@ -109,6 +110,7 @@ func NewStateCAASApplicationProvisionerAPI(ctx facade.Context) (*APIGroup, error
 	apiGroup := &APIGroup{
 		PasswordChanger:          common.NewPasswordChanger(st, common.AuthFuncForTagKind(names.ApplicationTagKind)),
 		LifeGetter:               common.NewLifeGetter(st, common.AuthFuncForTagKind(names.ApplicationTagKind)),
+		AgentEntityWatcher:       common.NewAgentEntityWatcher(st, resources, common.AuthFuncForTagKind(names.ApplicationTagKind)),
 		CharmsAPI:                commonCharmsAPI,
 		ApplicationWatcherFacade: common.NewApplicationWatcherFacadeFromState(st, resources, common.ApplicationFilterCAASEmbedded),
 		API:                      api,
@@ -229,18 +231,20 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		}
 	}
 	caCert, _ := cfg.CACert()
-
+	charmURL, _ := app.CharmURL()
 	return &params.CAASApplicationProvisioningInfo{
-		ImagePath:    imagePath,
-		Version:      vers,
-		APIAddresses: addrs,
-		CACert:       caCert,
-		Tags:         resourceTags,
-		Filesystems:  filesystemParams,
-		Devices:      devices,
-		Constraints:  mergedCons,
-		Series:       app.Series(),
-		ImageRepo:    cfg.CAASImageRepo(),
+		ImagePath:            imagePath,
+		Version:              vers,
+		APIAddresses:         addrs,
+		CACert:               caCert,
+		Tags:                 resourceTags,
+		Filesystems:          filesystemParams,
+		Devices:              devices,
+		Constraints:          mergedCons,
+		Series:               app.Series(),
+		ImageRepo:            cfg.CAASImageRepo(),
+		CharmModifiedVersion: app.CharmModifiedVersion(),
+		CharmURL:             charmURL.String(),
 	}, nil
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -83,8 +83,16 @@ func (s *CAASApplicationProvisionerSuite) TestPermission(c *gc.C) {
 
 func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	s.st.app = &mockApplication{
-		life:  state.Alive,
-		charm: &mockCharm{meta: &charm.Meta{}},
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
+		},
+		charmModifiedVersion: 10,
 	}
 	result, err := s.api.ProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -100,14 +108,23 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
 				"juju-controller-uuid": coretesting.ControllerTag.Id(),
 			},
+			CharmURL:             "cs:gitlab",
+			CharmModifiedVersion: 10,
 		}},
 	})
 }
 
 func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 	s.st.app = &mockApplication{
-		life:  state.Alive,
-		charm: &mockCharm{meta: &charm.Meta{}},
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
+		},
 	}
 	result, err := s.api.SetOperatorStatus(params.SetStatus{
 		Entities: []params.EntityStatusArgs{{
@@ -124,8 +141,15 @@ func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 
 func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 	s.st.app = &mockApplication{
-		life:  state.Alive,
-		charm: &mockCharm{meta: &charm.Meta{}},
+		life: state.Alive,
+		charm: &mockCharm{
+			meta: &charm.Meta{},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
+		},
 		units: []*mockUnit{
 			{tag: names.NewUnitTag("gitlab/0")},
 			{tag: names.NewUnitTag("gitlab/1")},
@@ -166,6 +190,11 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectStateful(c *gc.C) {
 						},
 					},
 				},
+			},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
 			},
 		},
 		units: []*mockUnit{
@@ -235,6 +264,11 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectDeployment(c *gc.C) 
 					},
 				},
 			},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
 		},
 		units: []*mockUnit{
 			{
@@ -302,6 +336,11 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectDaemon(c *gc.C) {
 						},
 					},
 				},
+			},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
 			},
 		},
 		units: []*mockUnit{
@@ -372,6 +411,11 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectForced(c *gc.C) {
 						},
 					},
 				},
+			},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
 			},
 		},
 		units: []*mockUnit{
@@ -512,6 +556,11 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithStorage
 						},
 					},
 				},
+			},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
 			},
 		},
 		units: []*mockUnit{
@@ -690,6 +739,11 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStor
 						},
 					},
 				},
+			},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
 			},
 		},
 		units: []*mockUnit{

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -56,6 +56,8 @@ type Application interface {
 	Life() state.Life
 	Series() string
 	SetStatus(statusInfo status.StatusInfo) error
+	CharmModifiedVersion() int
+	CharmURL() (curl *charm.URL, force bool)
 }
 
 type Charm interface {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6688,6 +6688,18 @@
                     },
                     "description": "UpdateApplicationsUnits updates the Juju data model to reflect the given\nunits of the specified application."
                 },
+                "Watch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    },
+                    "description": "Watch starts an NotifyWatcher for each given entity."
+                },
                 "WatchApplications": {
                     "type": "object",
                     "properties": {
@@ -6868,6 +6880,12 @@
                             }
                         },
                         "ca-cert": {
+                            "type": "string"
+                        },
+                        "charm-modified-version": {
+                            "type": "integer"
+                        },
+                        "charm-url": {
                             "type": "string"
                         },
                         "constraints": {
@@ -7958,6 +7976,36 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
                             }
                         }
                     },

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -34,18 +34,20 @@ type CAASApplicationProvisioningInfoResults struct {
 
 // CAASApplicationProvisioningInfo holds info needed to provision a caas application.
 type CAASApplicationProvisioningInfo struct {
-	ImagePath    string                       `json:"image-path"`
-	Version      version.Number               `json:"version"`
-	APIAddresses []string                     `json:"api-addresses"`
-	CACert       string                       `json:"ca-cert"`
-	Constraints  constraints.Value            `json:"constraints"`
-	Tags         map[string]string            `json:"tags,omitempty"`
-	Filesystems  []KubernetesFilesystemParams `json:"filesystems,omitempty"`
-	Volumes      []KubernetesVolumeParams     `json:"volumes,omitempty"`
-	Devices      []KubernetesDeviceParams     `json:"devices,omitempty"`
-	Series       string                       `json:"series,omitempty"`
-	ImageRepo    string                       `json:"image-repo,omitempty"`
-	Error        *Error                       `json:"error,omitempty"`
+	ImagePath            string                       `json:"image-path"`
+	Version              version.Number               `json:"version"`
+	APIAddresses         []string                     `json:"api-addresses"`
+	CACert               string                       `json:"ca-cert"`
+	Constraints          constraints.Value            `json:"constraints"`
+	Tags                 map[string]string            `json:"tags,omitempty"`
+	Filesystems          []KubernetesFilesystemParams `json:"filesystems,omitempty"`
+	Volumes              []KubernetesVolumeParams     `json:"volumes,omitempty"`
+	Devices              []KubernetesDeviceParams     `json:"devices,omitempty"`
+	Series               string                       `json:"series,omitempty"`
+	ImageRepo            string                       `json:"image-repo,omitempty"`
+	CharmModifiedVersion int                          `json:"charm-modified-version,omitempty"`
+	CharmURL             string                       `json:"charm-url,omitempty"`
+	Error                *Error                       `json:"error,omitempty"`
 }
 
 // CAASApplicationGarbageCollectArg holds info needed to cleanup units that have

--- a/caas/application.go
+++ b/caas/application.go
@@ -63,6 +63,12 @@ type ApplicationConfig struct {
 	// AgentImagePath is the docker registry URL for the image.
 	AgentImagePath string
 
+	// CharmModifiedVersion is a monotonically incrementing version number
+	// that represents the version of the charm and resources with regards to
+	// this application. The CAAS provider will pass this to the uniter worker
+	// to ensure the container infrastructure matches the charm.
+	CharmModifiedVersion int
+
 	// CharmBaseImage is the docker image used by the charm.
 	CharmBaseImage resources.DockerImageDetails
 

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/juju/clock"
@@ -876,7 +877,7 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		Image:           config.CharmBaseImage.RegistryPath,
 		WorkingDir:      jujuDataDir,
 		Command:         []string{"/usr/bin/k8sagent"},
-		Args:            []string{"unit", "--data-dir", jujuDataDir},
+		Args:            []string{"unit", "--data-dir", jujuDataDir, "--charm-modified-version", strconv.Itoa(config.CharmModifiedVersion)},
 		Env: []corev1.EnvVar{
 			{
 				Name:  "JUJU_CONTAINER_NAMES",

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -152,6 +152,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, deploymentType caas.DeploymentT
 			CharmBaseImage: coreresources.DockerImageDetails{
 				RegistryPath: "ubuntu:20.04",
 			},
+			CharmModifiedVersion: 9001,
 			Filesystems: []storage.KubernetesFilesystemParams{
 				{
 					StorageName: "database",
@@ -269,7 +270,7 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 			Image:           "ubuntu:20.04",
 			WorkingDir:      jujuDataDir,
 			Command:         []string{"/usr/bin/k8sagent"},
-			Args:            []string{"unit", "--data-dir", jujuDataDir},
+			Args:            []string{"unit", "--data-dir", jujuDataDir, "--charm-modified-version", "9001"},
 			Env: []corev1.EnvVar{
 				{
 					Name:  "JUJU_CONTAINER_NAMES",

--- a/cmd/k8sagent/unit/agent.go
+++ b/cmd/k8sagent/unit/agent.go
@@ -46,6 +46,7 @@ var logger = loggo.GetLogger("juju.cmd.k8sagent.unit")
 type k8sUnitAgent struct {
 	cmd.CommandBase
 	agentconf.AgentConf
+
 	configChangedVal *voyeur.Value
 	clk              clock.Clock
 	runner           *worker.Runner
@@ -59,6 +60,8 @@ type k8sUnitAgent struct {
 	prometheusRegistry *prometheus.Registry
 
 	fileReaderWriter utils.FileReaderWriter
+
+	charmModifiedVersion int
 }
 
 // New creates k8sagent unit command.
@@ -90,6 +93,11 @@ func (c *k8sUnitAgent) Info() *cmd.Info {
 // SetFlags implements Command.
 func (c *k8sUnitAgent) SetFlags(f *gnuflag.FlagSet) {
 	c.AgentConf.AddFlags(f)
+	f.IntVar(&c.charmModifiedVersion, "charm-modified-version", -1, "charm modified version to validate downloaded charm is for the provided infrastructure")
+}
+
+func (c *k8sUnitAgent) CharmModifiedVersion() int {
+	return c.charmModifiedVersion
 }
 
 func (c *k8sUnitAgent) ensureAgentConf(dataDir string) error {
@@ -231,6 +239,7 @@ func (c *k8sUnitAgent) workers() (worker.Worker, error) {
 		ProbePort:            probePort,
 		MachineLock:          c.machineLock,
 		Clock:                c.clk,
+		CharmModifiedVersion: c.CharmModifiedVersion(),
 	}
 	manifolds := Manifolds(cfg)
 

--- a/cmd/k8sagent/unit/agent_test.go
+++ b/cmd/k8sagent/unit/agent_test.go
@@ -104,6 +104,7 @@ func (s *k8sUnitAgentSuite) TestParseSuccess(c *gc.C) {
 
 	err := cmdtesting.InitCommand(s.cmd, []string{
 		"--data-dir", s.dataDir,
+		"--charm-modified-version", "10",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -111,7 +112,7 @@ func (s *k8sUnitAgentSuite) TestParseSuccess(c *gc.C) {
 	c.Assert(s.cmd.Tag().String(), jc.DeepEquals, `unit-wordpress-0`)
 	c.Assert(s.cmd.CurrentConfig().Controller().String(), jc.DeepEquals, `controller-deadbeef-1bad-500d-9000-4b1d0d06f00d`)
 	c.Assert(s.cmd.CurrentConfig().Model().String(), jc.DeepEquals, `model-deadbeef-0bad-400d-8000-4b1d0d06f00d`)
-
+	c.Assert(s.cmd.CharmModifiedVersion(), gc.Equals, 10)
 }
 
 func (s *k8sUnitAgentSuite) TestParseUnknown(c *gc.C) {

--- a/cmd/k8sagent/unit/export_test.go
+++ b/cmd/k8sagent/unit/export_test.go
@@ -28,6 +28,7 @@ type K8sUnitAgentTest interface {
 	ChangeConfig(change agent.ConfigMutator) error
 	CurrentConfig() agent.Config
 	Tag() names.UnitTag
+	CharmModifiedVersion() int
 }
 
 func NewForTest(

--- a/cmd/k8sagent/unit/manifolds.go
+++ b/cmd/k8sagent/unit/manifolds.go
@@ -82,6 +82,10 @@ type manifoldsConfig struct {
 
 	// Clock contains the clock that will be made available to manifolds.
 	Clock clock.Clock
+
+	// CharmModifiedVersion to validate downloaded charm is for the provided
+	// infrastructure.
+	CharmModifiedVersion int
 }
 
 // Manifolds returns a set of co-configured manifolds covering the various
@@ -236,17 +240,18 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 		// coming weeks, and to need one per unit in a consolidated agent
 		// (and probably one for each component broken out).
 		uniterName: ifNotMigrating(uniter.Manifold(uniter.ManifoldConfig{
-			AgentName:             agentName,
-			ModelType:             model.CAAS,
-			APICallerName:         apiCallerName,
-			MachineLock:           config.MachineLock,
-			Clock:                 config.Clock,
-			LeadershipTrackerName: leadershipTrackerName,
-			CharmDirName:          charmDirName,
-			HookRetryStrategyName: hookRetryStrategyName,
-			TranslateResolverErr:  uniter.TranslateFortressErrors,
-			Logger:                loggo.GetLogger("juju.worker.uniter"),
-			Embedded:              true,
+			AgentName:                    agentName,
+			ModelType:                    model.CAAS,
+			APICallerName:                apiCallerName,
+			MachineLock:                  config.MachineLock,
+			Clock:                        config.Clock,
+			LeadershipTrackerName:        leadershipTrackerName,
+			CharmDirName:                 charmDirName,
+			HookRetryStrategyName:        hookRetryStrategyName,
+			TranslateResolverErr:         uniter.TranslateFortressErrors,
+			Logger:                       loggo.GetLogger("juju.worker.uniter"),
+			Embedded:                     true,
+			EnforcedCharmModifiedVersion: config.CharmModifiedVersion,
 		})),
 	}
 }

--- a/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -188,6 +188,21 @@ func (mr *MockCAASProvisionerFacadeMockRecorder) UpdateUnits(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnits", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).UpdateUnits), arg0)
 }
 
+// WatchApplication mocks base method
+func (m *MockCAASProvisionerFacade) WatchApplication(arg0 string) (watcher.NotifyWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchApplication", arg0)
+	ret0, _ := ret[0].(watcher.NotifyWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchApplication indicates an expected call of WatchApplication
+func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplication(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplication), arg0)
+}
+
 // WatchApplications mocks base method
 func (m *MockCAASProvisionerFacade) WatchApplications() (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -40,6 +40,7 @@ type CAASProvisionerFacade interface {
 	GarbageCollect(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error
 	ApplicationOCIResources(appName string) (map[string]resources.DockerImageDetails, error)
 	UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error)
+	WatchApplication(appName string) (watcher.NotifyWatcher, error)
 }
 
 // CAASBroker exposes CAAS broker functionality to a worker.

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -40,17 +40,18 @@ type Logger interface {
 // ManifoldConfig defines the names of the manifolds on which a
 // Manifold will depend.
 type ManifoldConfig struct {
-	AgentName             string
-	ModelType             model.ModelType
-	APICallerName         string
-	MachineLock           machinelock.Lock
-	Clock                 clock.Clock
-	LeadershipTrackerName string
-	CharmDirName          string
-	HookRetryStrategyName string
-	TranslateResolverErr  func(error) error
-	Logger                Logger
-	Embedded              bool
+	AgentName                    string
+	ModelType                    model.ModelType
+	APICallerName                string
+	MachineLock                  machinelock.Lock
+	Clock                        clock.Clock
+	LeadershipTrackerName        string
+	CharmDirName                 string
+	HookRetryStrategyName        string
+	TranslateResolverErr         func(error) error
+	Logger                       Logger
+	Embedded                     bool
+	EnforcedCharmModifiedVersion int
 }
 
 // Validate ensures all the required values for the config are set.
@@ -126,24 +127,25 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			uniterFacade := uniter.NewState(apiConn, unitTag)
 			uniter, err := NewUniter(&UniterParams{
-				UniterFacade:          uniterFacade,
-				UnitTag:               unitTag,
-				ModelType:             config.ModelType,
-				LeadershipTrackerFunc: leadershipTrackerFunc,
-				DataDir:               agentConfig.DataDir(),
-				Downloader:            downloader,
-				MachineLock:           manifoldConfig.MachineLock,
-				CharmDirGuard:         charmDirGuard,
-				UpdateStatusSignal:    NewUpdateStatusTimer(),
-				HookRetryStrategy:     hookRetryStrategy,
-				NewOperationExecutor:  operation.NewExecutor,
-				NewDeployer:           charm.NewDeployer,
-				NewProcessRunner:      runner.NewRunner,
-				TranslateResolverErr:  config.TranslateResolverErr,
-				Clock:                 manifoldConfig.Clock,
-				RebootQuerier:         reboot.NewMonitor(agentConfig.TransientDataDir()),
-				Logger:                config.Logger,
-				Embedded:              config.Embedded,
+				UniterFacade:                 uniterFacade,
+				UnitTag:                      unitTag,
+				ModelType:                    config.ModelType,
+				LeadershipTrackerFunc:        leadershipTrackerFunc,
+				DataDir:                      agentConfig.DataDir(),
+				Downloader:                   downloader,
+				MachineLock:                  manifoldConfig.MachineLock,
+				CharmDirGuard:                charmDirGuard,
+				UpdateStatusSignal:           NewUpdateStatusTimer(),
+				HookRetryStrategy:            hookRetryStrategy,
+				NewOperationExecutor:         operation.NewExecutor,
+				NewDeployer:                  charm.NewDeployer,
+				NewProcessRunner:             runner.NewRunner,
+				TranslateResolverErr:         config.TranslateResolverErr,
+				Clock:                        manifoldConfig.Clock,
+				RebootQuerier:                reboot.NewMonitor(agentConfig.TransientDataDir()),
+				Logger:                       config.Logger,
+				Embedded:                     config.Embedded,
+				EnforcedCharmModifiedVersion: config.EnforcedCharmModifiedVersion,
 			})
 			if err != nil {
 				return nil, errors.Trace(err)


### PR DESCRIPTION
- Fixes charm upgrade on charm v2 k8s applications.
- Fixes application removal and caasapplicationprovisioner application worker teardown.

## QA steps

Deploy a charm, upgrade the charm (no changes), upgrade the charm (use a different oci-image resource), remove-application.

## Documentation changes

N/A

## Bug reference

N/A