### PR TITLE
Try to fix intermittent TestAPIServerCanShutdownWithOutstandingNext

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -240,13 +240,15 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 	go func() {
 		// Resetting the dummy environment will call Stop on the
 		// embedded API server.
+		start := time.Now()
 		dummy.Reset(c)
+		c.Logf("dummy.Reset() took %v", time.Since(start))
 		close(srvStopped)
 	}()
 
 	select {
 	case <-srvStopped:
-	case <-time.After(testing.LongWait):
+	case <-time.After(time.Minute):
 		c.Fatal("timed out waiting for server to stop")
 	}
 

--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -248,7 +248,7 @@ func (s *legacySuite) TestAPIServerCanShutdownWithOutstandingNext(c *gc.C) {
 
 	select {
 	case <-srvStopped:
-	case <-time.After(time.Minute):
+	case <-time.After(time.Minute): // LongWait (10s) didn't seem quite long enough, see LP 1900931
 		c.Fatal("timed out waiting for server to stop")
 	}
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -359,6 +359,9 @@ func Reset(c *gc.C) {
 			Delay:    time.Millisecond,
 			Clock:    clock.WallClock,
 			Attempts: 5,
+			NotifyFunc: func(lastError error, attempt int) {
+				logger.Infof("retrying MgoServer.Reset() after attempt %d: %v", attempt, lastError)
+			},
 		})
 		c.Assert(err, jc.ErrorIsNil)
 	}


### PR DESCRIPTION
This test is failing intermittently in -race mode, for example: https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-race-amd64/6/consoleFull

Try increasing the timeout for stopping the server from 10s to 60s, and also add logging so we can see how long it usually takes (and if the MgoServer.Reset() is being retried).

Tracking issue: https://bugs.launchpad.net/juju/+bug/1900931