### PR TITLE
Fix/destroy caas controller hangs

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -555,7 +555,7 @@ func (u *backingUnit) updated(ctx *allWatcherContext) error {
 		info.CharmURL = u.CharmURL.String()
 	}
 
-	// Construct a unit for the purpose of retieving other fields as necessary.
+	// Construct a unit for the purpose of retrieving other fields as necessary.
 	modelType, err := ctx.modelType()
 	if err != nil {
 		return errors.Annotatef(err, "get model type for %q", ctx.modelUUID)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -706,7 +706,6 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 	units, closer := st.db().GetCollection(unitsC)
 	defer closer()
 
-	unit := Unit{st: st}
 	sel := bson.D{{"application", applicationname}}
 	// If we're forcing then include dying and dead units, since we
 	// still want the opportunity to schedule fallback cleanups if the
@@ -716,7 +715,14 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 	}
 	iter := units.Find(sel).Iter()
 	defer closeIter(iter, &err, "reading unit document")
-	for iter.Next(&unit.doc) {
+
+	m, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	var unitDoc unitDoc
+	for iter.Next(&unitDoc) {
+		unit := newUnit(st, m.Type(), &unitDoc)
 		op := unit.DestroyOperation()
 		op.DestroyStorage = destroyStorage
 		op.Force = force

--- a/state/unit.go
+++ b/state/unit.go
@@ -129,7 +129,7 @@ func (u *Unit) ContainerInfo() (CloudContainer, error) {
 // ShouldBeAssigned returns whether the unit should be assigned to a machine.
 // IAAS models require units to be assigned.
 func (u *Unit) ShouldBeAssigned() bool {
-	return u.modelType != ModelTypeCAAS
+	return u.modelType == ModelTypeIAAS
 }
 
 // Application returns the application.

--- a/state/unit.go
+++ b/state/unit.go
@@ -129,7 +129,7 @@ func (u *Unit) ContainerInfo() (CloudContainer, error) {
 // ShouldBeAssigned returns whether the unit should be assigned to a machine.
 // IAAS models require units to be assigned.
 func (u *Unit) ShouldBeAssigned() bool {
-	return u.modelType == ModelTypeIAAS
+	return u.modelType != ModelTypeCAAS
 }
 
 // Application returns the application.


### PR DESCRIPTION
*Fix destroying caas controller/models hang issue by constructing Unit  properly in cleanupUnitsForDyingApplication;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju add-model t1 microk8s
$ juju deploy cs:~juju/mariadb-k8s-3
$ juju deploy cs:~juju/mediawiki-k8s-4 --config kubernetes-service-type=LoadBalancer
$ juju relate mediawiki-k8s:db mariadb-k8s:server
$ juju destroy-controller k1 --destroy-all-models --destroy-storage  --debug -y
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1900937
