### PR TITLE
Implemente migrate method in ModelClient;

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -5,10 +5,6 @@ from __future__ import print_function
 
 import argparse
 from contextlib import contextmanager
-from distutils.version import (
-    LooseVersion,
-    StrictVersion
-    )
 import logging
 import os
 from subprocess import CalledProcessError
@@ -20,9 +16,6 @@ from assess_user_grant_revoke import User
 from deploy_stack import (
     BootstrapManager,
     get_random_string
-    )
-from jujupy.client import (
-    get_stripped_version_number,
 )
 from jujupy.wait_condition import (
     ModelCheckFailed,
@@ -32,7 +25,7 @@ from jujupy.workloads import (
     assert_deployed_charm_is_responding,
     deploy_dummy_source_to_new_model,
     deploy_simple_server_to_new_model,
-    )
+)
 from remote import remote_from_address
 from utility import (
     JujuAssertionError,
@@ -41,7 +34,7 @@ from utility import (
     qualified_model_name,
     temp_dir,
     until_timeout,
-    )
+)
 
 
 __metaclass__ = type
@@ -348,7 +341,7 @@ def migrate_model_to_controller(
             'Attempting show-model for affected models.')
         try:
             source_client.juju('show-model', (model_name), include_e=False)
-        except:
+        except:  # noqa
             log.info('Ignoring failed output.')
             pass
 
@@ -358,7 +351,7 @@ def migrate_model_to_controller(
                 get_full_model_name(
                     migration_target_client, include_user_name),
                 include_e=False)
-        except:
+        except:  # noqa
             log.info('Ignoring failed output.')
             pass
         raise e

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1402,7 +1402,7 @@ class ModelClient:
         # we're deploying a complex set of machines/containers.
         return retvar, CommandComplete(WaitAgentsStarted(wait_timeout), ct)
 
-    def migrate(self, full_model_name, model_name, dest_client, include_e=False):
+    def migrate(self, full_model_name, model_name, dest_client, include_e=True):
         self.juju(
             'migrate',
             (full_model_name, dest_client.env.controller.name),


### PR DESCRIPTION
*Implemente migrate method in ModelClient to track the migrated model in target client and untrack it in source client;*

We made a change for the `models` to be destroyed when we exit the `runtime_context` context https://github.com/juju/juju/commit/1d047afd7806d167b719ef3174534c3ac9d4d604.
And the existing model migration CI tests run `migrate` directly using `juju` which does `NOT` `untrack` the migrated model from the source client. So we get not found error when the test runs `juju status` on the already migrated model which does not exist anymore on the source controller.

```log
2020-10-21 08:02:24 INFO juju --show-log show-status -m nw-model-migration-amd64-lxd-b:example-model-resource --format yaml
08:02:24 INFO  juju.cmd supercommand.go:54 running juju [2.8.6 302 78e7a5a60ef88bd281835a3dfb3522277474257f gc go1.14.10]
08:02:24 INFO  juju.juju api.go:67 connecting to API addresses: [10.104.238.124:17070]
08:02:24 INFO  juju.api apiclient.go:637 connection established to "wss://10.104.238.124:17070/api"
08:02:24 INFO  juju.juju api.go:67 connecting to API addresses: [10.104.238.124:17070]
08:02:24 INFO  juju.api apiclient.go:637 connection established to "wss://10.104.238.124:17070/api"
08:02:25 INFO  juju.juju api.go:67 connecting to API addresses: [10.104.238.124:17070]
08:02:25 INFO  juju.api apiclient.go:637 connection established to "wss://10.104.238.124:17070/api"
08:02:25 INFO  juju.juju api.go:67 connecting to API addresses: [10.104.238.124:17070]
08:02:25 INFO  juju.api apiclient.go:637 connection established to "wss://10.104.238.124:17070/api"
{}
ERROR model nw-model-migration-amd64-lxd-b:admin/example-model-resource not found


2020-10-21 08:03:14 ERROR Command '('juju', '--show-log', 'show-status', '-m', 'nw-model-migration-amd64-lxd-b:example-model-resource', '--format', 'yaml')' returned non-zero exit status 1
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/utility.py", line 426, in logged_exception
    yield
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/deploy_stack.py", line 1040, in runtime_context
    yield
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/deploy_stack.py", line 1173, in new_bootstrap
    yield machines
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/deploy_stack.py", line 1152, in booted_context
    yield machines
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests//assess_model_migration.py", line 70, in assess_model_migration
    ensure_api_login_redirects(source_client, dest_client)
  File "/usr/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/deploy_stack.py", line 1187, in existing_booted_context
    yield machines
  File "/usr/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/deploy_stack.py", line 1057, in runtime_context
    m_client.show_status()
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/jujupy/client.py", line 1163, in show_status
    self.juju(self._show_status, ('--format', 'yaml'))
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/jujupy/client.py", line 1324, in juju
    model, check, timeout, extra_env, suppress_err=suppress_err)
  File "/var/lib/jenkins/workspace/nw-model-migration-amd64-lxd/acceptancetests/jujupy/backend.py", line 226, in juju
    rval = call_func(args, stderr=stderr)
  File "/usr/lib/python2.7/subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '('juju', '--show-log', 'show-status', '-m', 'nw-model-migration-amd64-lxd-b:example-model-resource', '--format', 'yaml')' returned non-zero exit status 1

```

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run `nw-model-migration-amd64-*`

## Documentation changes

No

## Bug reference

No
