### PR TITLE
Strict mode model config

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1289,8 +1289,9 @@ func (c *bootstrapCommand) bootstrapConfigs(
 	}
 	// The provider may define some custom attributes specific
 	// to the provider. These will be added to the model config.
-	providerAttrs := make(map[string]interface{})
+	var providerAttrs map[string]interface{}
 	if ps, ok := provider.(config.ConfigSchemaSource); ok {
+		providerAttrs = make(map[string]interface{})
 		for attr := range ps.ConfigSchema() {
 			// Start with the model defaults, and if also specified
 			// in the user config attrs, they override the model default.
@@ -1302,12 +1303,12 @@ func (c *bootstrapCommand) bootstrapConfigs(
 			}
 		}
 		fields := schema.FieldMap(ps.ConfigSchema(), ps.ConfigDefaults())
-		if coercedAttrs, err := fields.Coerce(providerAttrs, nil); err != nil {
+		coercedAttrs, err := fields.Coerce(providerAttrs, nil)
+		if err != nil {
 			return bootstrapConfigs{},
 				errors.Annotatef(err, "invalid attribute value(s) for %v cloud", cloud.Type)
-		} else {
-			providerAttrs = coercedAttrs.(map[string]interface{})
 		}
+		providerAttrs = coercedAttrs.(map[string]interface{})
 	}
 
 	storagePoolAttrs, err := c.storagePool.ReadAttrs(ctx)

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -487,7 +487,7 @@ var defaultConfigValues = map[string]interface{}{
 	"enable-os-upgrade":           true,
 	"development":                 false,
 	TestModeKey:                   false,
-	ModeKey:                       []string{},
+	ModeKey:                       []interface{}{},
 	TransmitVendorMetricsKey:      true,
 	UpdateStatusHookInterval:      DefaultUpdateStatusHookInterval,
 	EgressSubnets:                 "",

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1738,12 +1738,12 @@ func (c *Config) ValidateUnknownAttrs(extrafields schema.Fields, defaults schema
 			case []interface{}:
 				for _, val := range t {
 					if _, ok := val.(string); !ok {
-						return nil, fmt.Errorf("%s: unknown type (%q)", name, value)
+						return nil, errors.Errorf("%s: unknown type (%v)", name, value)
 					}
 				}
 				continue
 			default:
-				return nil, fmt.Errorf("%s: unknown type (%q)", name, value)
+				return nil, errors.Errorf("%s: unknown type (%q)", name, value)
 			}
 		}
 	}

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -612,11 +612,11 @@ type testFile struct {
 
 func (s *ConfigSuite) TestConfig(c *gc.C) {
 	files := []gitjujutesting.TestFile{
-		{".ssh/id_dsa.pub", "dsa"},
-		{".ssh/id_rsa.pub", "rsa\n"},
-		{".ssh/identity.pub", "identity"},
-		{".ssh/authorized_keys", "auth0\n# first\nauth1\n\n"},
-		{".ssh/authorized_keys2", "auth2\nauth3\n"},
+		{Name: ".ssh/id_dsa.pub", Data: "dsa"},
+		{Name: ".ssh/id_rsa.pub", Data: "rsa\n"},
+		{Name: ".ssh/identity.pub", Data: "identity"},
+		{Name: ".ssh/authorized_keys", Data: "auth0\n# first\nauth1\n\n"},
+		{Name: ".ssh/authorized_keys2", Data: "auth2\nauth3\n"},
 	}
 	s.FakeHomeSuite.Home.AddFiles(c, files...)
 	for i, test := range configTests {
@@ -711,9 +711,9 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	}
 
 	if v, ok := test.attrs["provisioner-harvest-mode"]; ok {
-		hvstMeth, err := config.ParseHarvestMode(v.(string))
+		harvestMeth, err := config.ParseHarvestMode(v.(string))
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, hvstMeth)
+		c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, harvestMeth)
 	} else {
 		c.Assert(cfg.ProvisionerHarvestMode(), gc.Equals, config.HarvestDestroyed)
 	}
@@ -900,7 +900,7 @@ var validationTests = []validationTest{{
 
 func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 	files := []gitjujutesting.TestFile{
-		{".ssh/identity.pub", "identity"},
+		{Name: ".ssh/identity.pub", Data: "identity"},
 	}
 	s.FakeHomeSuite.Home.AddFiles(c, files...)
 
@@ -952,11 +952,11 @@ var configValidateCloudInitUserDataTests = []configValidateCloudInitUserDataTest
 
 func (s *ConfigSuite) TestValidateCloudInitUserData(c *gc.C) {
 	files := []gitjujutesting.TestFile{
-		{".ssh/id_dsa.pub", "dsa"},
-		{".ssh/id_rsa.pub", "rsa\n"},
-		{".ssh/identity.pub", "identity"},
-		{".ssh/authorized_keys", "auth0\n# first\nauth1\n\n"},
-		{".ssh/authorized_keys2", "auth2\nauth3\n"},
+		{Name: ".ssh/id_dsa.pub", Data: "dsa"},
+		{Name: ".ssh/id_rsa.pub", Data: "rsa\n"},
+		{Name: ".ssh/identity.pub", Data: "identity"},
+		{Name: ".ssh/authorized_keys", Data: "auth0\n# first\nauth1\n\n"},
+		{Name: ".ssh/authorized_keys2", Data: "auth2\nauth3\n"},
 	}
 	s.FakeHomeSuite.Home.AddFiles(c, files...)
 	for i, test := range configValidateCloudInitUserDataTests {
@@ -982,7 +982,7 @@ func (test configValidateCloudInitUserDataTest) checkNew(c *gc.C) {
 
 func (s *ConfigSuite) addJujuFiles(c *gc.C) {
 	s.FakeHomeSuite.Home.AddFiles(c, []gitjujutesting.TestFile{
-		{".ssh/id_rsa.pub", "rsa\n"},
+		{Name: ".ssh/id_rsa.pub", Data: "rsa\n"},
 	}...)
 }
 

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -414,6 +414,12 @@ var configTests = []configTest{
 			"test-mode": true,
 		}),
 	}, {
+		about:       "Mode flag specified",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"mode": "strict",
+		}),
+	}, {
 		about:       "valid uuid",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
@@ -1169,6 +1175,13 @@ func (s *ConfigSuite) TestCharmHubURL(c *gc.C) {
 	chURL, ok := config.CharmHubURL()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(chURL, gc.Equals, charmhub.CharmHubServerURL)
+}
+
+func (s *ConfigSuite) TestMode(c *gc.C) {
+	config := newTestConfig(c, testing.Attrs{})
+	mode, ok := config.Mode()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(mode, gc.Equals, "")
 }
 
 func (s *ConfigSuite) TestCharmHubURLSettingValue(c *gc.C) {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -417,7 +417,7 @@ var configTests = []configTest{
 		about:       "Mode flag specified",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"mode": "strict",
+			"mode": []interface{}{"strict"},
 		}),
 	}, {
 		about:       "valid uuid",
@@ -1180,8 +1180,8 @@ func (s *ConfigSuite) TestCharmHubURL(c *gc.C) {
 func (s *ConfigSuite) TestMode(c *gc.C) {
 	config := newTestConfig(c, testing.Attrs{})
 	mode, ok := config.Mode()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(mode, gc.Equals, "")
+	c.Assert(ok, jc.IsFalse)
+	c.Assert(mode, gc.DeepEquals, []string{})
 }
 
 func (s *ConfigSuite) TestCharmHubURLSettingValue(c *gc.C) {

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.10.1
 	gopkg.in/juju/blobstore.v2 v2.0.0-20160125023703-51fa6e26128d
-	gopkg.in/juju/environschema.v1 v1.0.0
+	gopkg.in/juju/environschema.v1 v1.0.1-0.20201027142642-c89a4490670a
 	gopkg.in/juju/idmclient.v1 v1.0.0-20180320161856-203d20774ce8
 	gopkg.in/juju/names.v3 v3.0.0-20200331100531-2c9a102df211 // indirect
 	gopkg.in/juju/worker.v1 v1.0.0-20191018043616-19a698a7150f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1094,6 +1094,8 @@ gopkg.in/juju/charmstore.v5 v5.7.1 h1:rBe/X8cPNzegeiTjT8PMf8Ul/E5jsQYzfncpEMqHFl
 gopkg.in/juju/charmstore.v5 v5.7.1/go.mod h1:wJ7iRLP4tEbR8Fv2t4Jueuj3TQmZgrqnG/Bb8cbCt7c=
 gopkg.in/juju/environschema.v1 v1.0.0 h1:51vT1bzbP9fntQ0I9ECSlku2p19Szj/N2beZFeIH2kM=
 gopkg.in/juju/environschema.v1 v1.0.0/go.mod h1:WTgU3KXKCVoO9bMmG/4KHzoaRvLeoxfjArpgd1MGWFA=
+gopkg.in/juju/environschema.v1 v1.0.1-0.20201027142642-c89a4490670a h1:tOwxh73E6us6t6MJHVe/erls2255hEwFKY8TJ40wcWY=
+gopkg.in/juju/environschema.v1 v1.0.1-0.20201027142642-c89a4490670a/go.mod h1:WTgU3KXKCVoO9bMmG/4KHzoaRvLeoxfjArpgd1MGWFA=
 gopkg.in/juju/idmclient.v1 v1.0.0-20180320161856-203d20774ce8 h1:gW6CxMJ4C4R7VQ0PUk2mtNl5WSqdruCkd+JUepUovoE=
 gopkg.in/juju/idmclient.v1 v1.0.0-20180320161856-203d20774ce8/go.mod h1:yZ1Jx1AYkBmv6lrKV6jWBKHZAeF9SgPj6QiqAiJo3ew=
 gopkg.in/juju/jujusvg.v3 v3.0.0-20180629065738-1ebf5c5481e8 h1:Xq1uwjNDSbxdZtkVgBD49tcYA7ZAzKLE3Vzz7VNyXv0=

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"reflect"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/version"
@@ -138,7 +140,18 @@ func (model *Model) modelConfigValues(modelCfg attrValues) (config.ConfigValues,
 		source := config.JujuModelConfigSource
 		n := len(sourceAttrs)
 		for i := range sourceAttrs {
-			if sourceAttrs[n-i-1][attr] == val {
+			// With the introduction of a slice for mode it makes it not
+			// possible to use equality check for slice types. We should fall
+			// back to the reflect.Deep equality to ensure we don't panic at
+			// runtime.
+			var equal bool
+			switch val.(type) {
+			case []interface{}:
+				equal = reflect.DeepEqual(sourceAttrs[n-i-1][attr], val)
+			default:
+				equal = sourceAttrs[n-i-1][attr] == val
+			}
+			if equal {
 				source = sourceNames[n-i-1]
 				break
 			}

--- a/tests/suites/model/config.sh
+++ b/tests/suites/model/config.sh
@@ -1,0 +1,32 @@
+run_model_config() {
+    # Echo out to ensure nice output to the test suite.
+    echo
+
+    # The following ensures that a bootstrap juju exists.
+    file="${TEST_DIR}/test-model-config.log"
+    ensure "model-config" "${file}"
+
+    juju model-config mode=strict
+    juju model-config mode | grep "strict"
+    juju model-config mode=""
+    juju model-config mode | wc -m | grep "0"
+    juju model-config mode="boom" || echo "ERROR" | grep "ERROR"
+
+
+    destroy_model "model-config"
+}
+
+test_model_config() {
+    if [ -n "$(skip 'test_model_config')" ]; then
+        echo "==> SKIP: Asked to skip model config tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_model_config"
+    )
+}

--- a/tests/suites/model/model_migration.sh
+++ b/tests/suites/model/model_migration.sh
@@ -223,7 +223,7 @@ run_model_migration_saas_consumer() {
 
 test_model_migration() {
     if [ -n "$(skip 'test_model_migration')" ]; then
-        echo "==> SKIP: Asked to skip model tests"
+        echo "==> SKIP: Asked to skip model migration tests"
         return
     fi
 

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -14,6 +14,7 @@ test_model() {
     bootstrap "test-models" "${file}"
 
     # Tests that need to be run are added here.
+    test_model_config
     test_model_migration
 
     destroy_controller "test-models"


### PR DESCRIPTION
Define a `mode` that can be used to tell what mode juju should be running in. With
the idea being, setting `strict` mode will force certain code paths (to come later) to not
fallback and error out early.

Eventually, the idea will be to remove test-mode from the model config and move
that to `mode` as well. So you can then run both `[strict,test]` mode. I can see this being
really useful when doing test setups.

## QA steps

```sh
$ juju bootstrap lxd test --config mode="[strict]"
$ juju model-config mode
strict
$ juju model-confg mode="[]"

$ juju add-model other --config mode="[strict]"
$ juju model-config mode
strict
```

<h4 id="backwards-compat">Backwards compatibility</h4>

The sticky part, how we handle backwards compatibility with 2.8 clients.

```sh
$ git checkout <#12183>
$ make go-install
$ juju bootstrap lxd test --build-agent
$ juju model-config mode="[strict]"
```

##### Prior Juju Failures

So using 2.8 and prior versions of Juju will fail. That's ok it's a known issue
on the model-config. As we ensure that mode won't have a default value we
can say that if you set a mode on a model-config then you have the latest
client and should use the latest client. If you do want to use an older client
then reverting the model config value will unlock the user to perform the
actions they desire.

```sh
$ git checkout 2.8
$ make go-install
$ juju destroy-controller test
ERROR getting controller environ: getting environ using bootstrap config from client store: invalid config: mode: unknown type ([strict])
```

To remedy this, you need to do this:

```sh
$ git checkout <#12183>
$ make go-install
$ juju model-config --reset mode
```

Note you have to use `--reset` and not `mode="[]"` as that leads to the same error.

##### Bootstrap config

In addition to model-config, you also have to perform:

```sh
$ juju model-config -m controller --reset mode
$ grep "mode" ./local/share/juju/bootstrap-config.yaml # if found, delete mode from yaml file
```
