### PR TITLE
Provisioner state address

### DIFF
--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -137,16 +137,6 @@ func (st *State) WatchMachineErrorRetry() (watcher.NotifyWatcher, error) {
 	return w, nil
 }
 
-// StateAddresses returns the list of addresses used to connect to the state.
-func (st *State) StateAddresses() ([]string, error) {
-	var result params.StringsResult
-	err := st.facade.FacadeCall("StateAddresses", nil, &result)
-	if err != nil {
-		return nil, err
-	}
-	return result.Result, nil
-}
-
 // ContainerManagerConfig returns information from the model config that is
 // needed for configuring the container manager.
 func (st *State) ContainerManagerConfig(args params.ContainerManagerConfigParams) (result params.ContainerManagerConfig, err error) {

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -672,18 +672,6 @@ func (s *provisionerSuite) TestWatchModelMachines(c *gc.C) {
 	wc.AssertNoChange()
 }
 
-func (s *provisionerSuite) TestStateAddresses(c *gc.C) {
-	err := s.machine.SetProviderAddresses(corenetwork.NewSpaceAddress("0.1.2.3"))
-	c.Assert(err, jc.ErrorIsNil)
-
-	stateAddresses, err := s.State.Addresses()
-	c.Assert(err, jc.ErrorIsNil)
-
-	addresses, err := s.provisioner.StateAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addresses, gc.DeepEquals, stateAddresses)
-}
-
 func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType) map[string]string {
 	args := params.ContainerManagerConfigParams{Type: typ}
 	result, err := s.provisioner.ContainerManagerConfig(args)

--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -93,26 +93,3 @@ func apiAddresses(getter APIHostPortsForAgentsGetter) ([]string, error) {
 	}
 	return addrs, nil
 }
-
-// StateAddresser implements a common set of methods for getting state
-// server addresses, and the CA certificate used to authenticate them.
-type StateAddresser struct {
-	getter APIAddressAccessor
-}
-
-// NewStateAddresser returns a new StateAddresser that uses the given
-// st value to fetch its addresses.
-func NewStateAddresser(getter APIAddressAccessor) *StateAddresser {
-	return &StateAddresser{getter}
-}
-
-// StateAddresses returns the list of addresses used to connect to the state.
-func (a *StateAddresser) StateAddresses() (params.StringsResult, error) {
-	addrs, err := a.getter.Addresses()
-	if err != nil {
-		return params.StringsResult{}, err
-	}
-	return params.StringsResult{
-		Result: addrs,
-	}, nil
-}

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -14,35 +14,15 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-type stateAddresserSuite struct {
-	addresser *common.StateAddresser
-}
-
 type apiAddresserSuite struct {
 	addresser *common.APIAddresser
 	fake      *fakeAddresses
 }
 
-var _ = gc.Suite(&stateAddresserSuite{})
 var _ = gc.Suite(&apiAddresserSuite{})
-
-func (s *stateAddresserSuite) SetUpTest(c *gc.C) {
-	s.addresser = common.NewStateAddresser(fakeAddresses{
-		hostPorts: []network.SpaceHostPorts{
-			network.NewSpaceHostPorts(1, "apiaddresses"),
-			network.NewSpaceHostPorts(2, "apiaddresses"),
-		},
-	})
-}
 
 // Verify that APIAddressAccessor is satisfied by *state.State.
 var _ common.APIAddressAccessor = (*state.State)(nil)
-
-func (s *stateAddresserSuite) TestStateAddresses(c *gc.C) {
-	result, err := s.addresser.StateAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Result, gc.DeepEquals, []string{"addresses:1", "addresses:2"})
-}
 
 func (s *apiAddresserSuite) SetUpTest(c *gc.C) {
 	s.fake = &fakeAddresses{

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/state"
+	"github.com/juju/juju/core/container"
 )
 
 // AuthFunc returns whether the given entity is available to some operation.
@@ -112,7 +112,7 @@ func AuthFuncForMachineAgent(authorizer Authorizer) GetAuthFunc {
 
 			switch tag := tag.(type) {
 			case names.MachineTag:
-				parentId := state.ParentId(tag.Id())
+				parentId := container.ParentId(tag.Id())
 				if parentId == "" {
 					// All top-level machines are accessible by the controller.
 					return isModelManager

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -46,7 +46,6 @@ type ProvisionerAPI struct {
 	*common.DeadEnsurer
 	*common.PasswordChanger
 	*common.LifeGetter
-	*common.StateAddresser
 	*common.APIAddresser
 	*common.ModelWatcher
 	*common.ModelMachinesWatcher
@@ -144,7 +143,6 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		DeadEnsurer:             common.NewDeadEnsurer(st, nil, getAuthFunc),
 		PasswordChanger:         common.NewPasswordChanger(st, getAuthFunc),
 		LifeGetter:              common.NewLifeGetter(st, getAuthFunc),
-		StateAddresser:          common.NewStateAddresser(st),
 		APIAddresser:            common.NewAPIAddresser(ctx.StatePool().SystemState(), resources),
 		ModelWatcher:            common.NewModelWatcher(model, resources, authorizer),
 		ModelMachinesWatcher:    common.NewModelMachinesWatcher(st, resources, authorizer),

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/core/constraints"
+	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
@@ -87,7 +88,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 			}
 			switch tag := tag.(type) {
 			case names.MachineTag:
-				parentId := state.ParentId(tag.Id())
+				parentId := corecontainer.ParentId(tag.Id())
 				if parentId == "" {
 					// All top-level machines are accessible by the controller.
 					return isModelManager

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1860,17 +1860,6 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 	})
 }
 
-func (s *withControllerSuite) TestStateAddresses(c *gc.C) {
-	addresses, err := s.State.Addresses()
-	c.Assert(err, jc.ErrorIsNil)
-
-	result, err := s.provisioner.StateAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.StringsResult{
-		Result: addresses,
-	})
-}
-
 func (s *withControllerSuite) TestCACert(c *gc.C) {
 	result, err := s.provisioner.CACert()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
@@ -73,7 +74,7 @@ func NewStorageProvisionerAPIv3(
 			// scoped to their own machine.
 			return true
 		}
-		parentId := state.ParentId(tag.Id())
+		parentId := container.ParentId(tag.Id())
 		if parentId == "" {
 			return allowController && authorizer.AuthController()
 		}

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -98,7 +98,7 @@ func InstanceConfig(ctrlSt *state.State, st *state.State, machineId, nonce, data
 		ModelTag: model.ModelTag(),
 	}
 
-	_, apiInfo, err = authentication.SetupAuthentication(machine, nil, apiInfo)
+	apiInfo, err = authentication.SetupAuthentication(machine, apiInfo)
 	if err != nil {
 		return nil, errors.Annotate(err, "setting up machine authentication")
 	}

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
@@ -582,7 +583,7 @@ func (context *statusContext) fetchMachines(st Backend) error {
 			// Only top level host machines go directly into the machine map.
 			context.machines[m.Id()] = []*state.Machine{m}
 		} else {
-			topParentId := state.TopParentId(m.Id())
+			topParentId := container.TopParentId(m.Id())
 			machines := context.machines[topParentId]
 			context.machines[topParentId] = append(machines, m)
 		}
@@ -932,7 +933,7 @@ func (c *statusContext) processMachines() map[string]params.MachineStatus {
 		aCache[id] = hostStatus
 
 		for _, machine := range machines[1:] {
-			parent, ok := aCache[state.ParentId(machine.Id())]
+			parent, ok := aCache[container.ParentId(machine.Id())]
 			if !ok {
 				logger.Errorf("programmer error, please file a bug, reference this whole log line: %q, %q", id, machine.Id())
 				continue

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -32322,15 +32322,6 @@
                     },
                     "description": "SetSupportedContainers updates the list of containers supported by the machines passed in args."
                 },
-                "StateAddresses": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/StringsResult"
-                        }
-                    },
-                    "description": "StateAddresses returns the list of addresses used to connect to the state."
-                },
                 "Status": {
                     "type": "object",
                     "properties": {

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -74,9 +73,6 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 		Password: "password",
 		CACert:   testing.CACert,
 		ModelTag: testing.ModelTag,
-	}
-	pcfg.Controller.MongoInfo = &mongo.MongoInfo{
-		Password: "password", Info: mongo.Info{CACert: testing.CACert},
 	}
 	pcfg.Bootstrap.ControllerModelConfig = s.cfg
 	pcfg.Bootstrap.BootstrapMachineInstanceId = "instance-id"

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
-	"github.com/juju/juju/mongo"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 )
@@ -69,9 +68,6 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 			Password: "password",
 			CACert:   coretesting.CACert,
 			ModelTag: coretesting.ModelTag,
-		}
-		icfg.Controller.MongoInfo = &mongo.MongoInfo{
-			Password: "password", Info: mongo.Info{CACert: coretesting.CACert},
 		}
 		icfg.Bootstrap.ControllerModelConfig = modelConfig
 		icfg.Bootstrap.BootstrapMachineInstanceId = "instance-id"

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/provider/openstack"
 	"github.com/juju/juju/testing"
@@ -197,16 +196,6 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 				Cert:         testing.ServerCert,
 				PrivateKey:   testing.ServerKey,
 				CAPrivateKey: testing.CAKey,
-			},
-		}
-		cfg.Controller = &instancecfg.ControllerConfig{
-			MongoInfo: &mongo.MongoInfo{
-				Info: mongo.Info{
-					Addrs:  []string{"127.0.0.1:1234"},
-					CACert: "CA CERT\n" + testing.CACert,
-				},
-				Password: "pw1",
-				Tag:      names.NewMachineTag("10"),
 			},
 		}
 	}

--- a/controller/authentication/authentication.go
+++ b/controller/authentication/authentication.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/api"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
-	"github.com/juju/juju/mongo"
 )
 
 // TaggedPasswordChanger defines an interface for a entity with a
@@ -25,7 +24,7 @@ type TaggedPasswordChanger interface {
 // AuthenticationProvider defines the single method that the provisioner
 // task needs to set up authentication for a machine.
 type AuthenticationProvider interface {
-	SetupAuthentication(machine TaggedPasswordChanger) (*mongo.MongoInfo, *api.Info, error)
+	SetupAuthentication(machine TaggedPasswordChanger) (*api.Info, error)
 }
 
 // NewAPIAuthenticator gets the state and api info once from the
@@ -43,24 +42,12 @@ func NewAPIAuthenticator(st *apiprovisioner.State) (AuthenticationProvider, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	var stateInfo *mongo.MongoInfo
-	stateAddresses, err := st.StateAddresses()
-	// We may not have stateAddresses (we don't on K8s), but the common case is that we don't need them
-	//  (we only need them for controller machines).
-	if err == nil {
-		stateInfo = &mongo.MongoInfo{
-			Info: mongo.Info{
-				Addrs:  stateAddresses,
-				CACert: caCert,
-			},
-		}
-	}
 	apiInfo := &api.Info{
 		Addrs:    apiAddresses,
 		CACert:   caCert,
 		ModelTag: names.NewModelTag(modelUUID),
 	}
-	return &simpleAuth{stateInfo, apiInfo}, nil
+	return &simpleAuth{apiInfo}, nil
 }
 
 // SetupAuthentication generates a random password for the given machine,
@@ -68,32 +55,24 @@ func NewAPIAuthenticator(st *apiprovisioner.State) (AuthenticationProvider, erro
 // info arguments with the tag and password.
 func SetupAuthentication(
 	machine TaggedPasswordChanger,
-	stateInfo *mongo.MongoInfo,
 	apiInfo *api.Info,
-) (*mongo.MongoInfo, *api.Info, error) {
-	auth := simpleAuth{stateInfo, apiInfo}
+) (*api.Info, error) {
+	auth := simpleAuth{apiInfo}
 	return auth.SetupAuthentication(machine)
 }
 
 type simpleAuth struct {
-	stateInfo *mongo.MongoInfo
-	apiInfo   *api.Info
+	apiInfo *api.Info
 }
 
-func (auth *simpleAuth) SetupAuthentication(machine TaggedPasswordChanger) (*mongo.MongoInfo, *api.Info, error) {
+// SetupAuthentication implements AuthenticationProvider.
+func (auth *simpleAuth) SetupAuthentication(machine TaggedPasswordChanger) (*api.Info, error) {
 	password, err := utils.RandomPassword()
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot make password for machine %v: %v", machine, err)
+		return nil, fmt.Errorf("cannot make password for machine %v: %v", machine, err)
 	}
 	if err := machine.SetPassword(password); err != nil {
-		return nil, nil, fmt.Errorf("cannot set API password for machine %v: %v", machine, err)
-	}
-	var stateInfo *mongo.MongoInfo
-	if auth.stateInfo != nil {
-		stateInfoCopy := *auth.stateInfo
-		stateInfo = &stateInfoCopy
-		stateInfo.Tag = machine.Tag()
-		stateInfo.Password = password
+		return nil, fmt.Errorf("cannot set API password for machine %v: %v", machine, err)
 	}
 	var apiInfo *api.Info
 	if auth.apiInfo != nil {
@@ -102,5 +81,5 @@ func (auth *simpleAuth) SetupAuthentication(machine TaggedPasswordChanger) (*mon
 		apiInfo.Tag = machine.Tag()
 		apiInfo.Password = password
 	}
-	return stateInfo, apiInfo, nil
+	return apiInfo, nil
 }

--- a/core/container/container.go
+++ b/core/container/container.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package container
+
+import (
+	"strings"
+
+	"github.com/juju/juju/core/instance"
+)
+
+// ParentId returns the id of the host machine if machineId a container id, or ""
+// if machineId is not for a container.
+func ParentId(machineId string) string {
+	idParts := strings.Split(machineId, "/")
+	if len(idParts) < 3 {
+		return ""
+	}
+	return strings.Join(idParts[:len(idParts)-2], "/")
+}
+
+// ContainerTypeFromId returns the container type if machineId is a container id, or ""
+// if machineId is not for a container.
+func ContainerTypeFromId(machineId string) instance.ContainerType {
+	idParts := strings.Split(machineId, "/")
+	if len(idParts) < 3 {
+		return instance.ContainerType("")
+	}
+	return instance.ContainerType(idParts[len(idParts)-2])
+}
+
+// NestingLevel returns how many levels of nesting exist for a machine id.
+func NestingLevel(machineId string) int {
+	idParts := strings.Split(machineId, "/")
+	return (len(idParts) - 1) / 2
+}
+
+// TopParentId returns the id of the top level host machine for a container id.
+func TopParentId(machineId string) string {
+	idParts := strings.Split(machineId, "/")
+	return idParts[0]
+}

--- a/core/container/container_test.go
+++ b/core/container/container_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package container_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/container"
+	"github.com/juju/juju/core/instance"
+)
+
+type ContainerSuite struct{}
+
+var _ = gc.Suite(&ContainerSuite{})
+
+func (s *ContainerSuite) TestNestingLevel(c *gc.C) {
+	c.Assert(container.NestingLevel("0"), gc.Equals, 0)
+	c.Assert(container.NestingLevel("0/lxd/1"), gc.Equals, 1)
+	c.Assert(container.NestingLevel("0/lxd/1/kvm/0"), gc.Equals, 2)
+}
+
+func (s *ContainerSuite) TestTopParentId(c *gc.C) {
+	c.Assert(container.TopParentId("0"), gc.Equals, "0")
+	c.Assert(container.TopParentId("0/lxd/1"), gc.Equals, "0")
+	c.Assert(container.TopParentId("0/lxd/1/kvm/2"), gc.Equals, "0")
+}
+
+func (s *ContainerSuite) TestParentId(c *gc.C) {
+	c.Assert(container.ParentId("0"), gc.Equals, "")
+	c.Assert(container.ParentId("0/lxd/1"), gc.Equals, "0")
+	c.Assert(container.ParentId("0/lxd/1/kvm/0"), gc.Equals, "0/lxd/1")
+}
+
+func (s *ContainerSuite) TestContainerTypeFromId(c *gc.C) {
+	c.Assert(container.ContainerTypeFromId("0"), gc.Equals, instance.ContainerType(""))
+	c.Assert(container.ContainerTypeFromId("0/lxd/1"), gc.Equals, instance.LXD)
+	c.Assert(container.ContainerTypeFromId("0/lxd/1/kvm/0"), gc.Equals, instance.KVM)
+}

--- a/core/container/package_test.go
+++ b/core/container/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package container_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -38,7 +38,6 @@ import (
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/pki"
 	corestorage "github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
@@ -657,8 +656,8 @@ func finalizeInstanceBootstrapConfig(
 	environVersion int,
 	customImageMetadata []*imagemetadata.ImageMetadata,
 ) error {
-	if icfg.APIInfo != nil || icfg.Controller.MongoInfo != nil {
-		return errors.New("machine configuration already has api/state info")
+	if icfg.APIInfo != nil {
+		return errors.New("machine configuration already has api info")
 	}
 	controllerCfg := icfg.Controller.Config
 	caCert, hasCACert := controllerCfg.CACert()
@@ -669,10 +668,6 @@ func finalizeInstanceBootstrapConfig(
 		Password: args.AdminSecret,
 		CACert:   caCert,
 		ModelTag: names.NewModelTag(cfg.UUID()),
-	}
-	icfg.Controller.MongoInfo = &mongo.MongoInfo{
-		Password: args.AdminSecret,
-		Info:     mongo.Info{CACert: caCert},
 	}
 
 	authority, err := pki.NewDefaultAuthorityPemCAKey(
@@ -733,8 +728,8 @@ func finalizePodBootstrapConfig(
 	args BootstrapParams,
 	cfg *config.Config,
 ) error {
-	if pcfg.APIInfo != nil || pcfg.Controller.MongoInfo != nil {
-		return errors.New("machine configuration already has api/state info")
+	if pcfg.APIInfo != nil {
+		return errors.New("machine configuration already has api info")
 	}
 
 	controllerCfg := pcfg.Controller.Config
@@ -746,10 +741,6 @@ func finalizePodBootstrapConfig(
 		Password: args.AdminSecret,
 		CACert:   caCert,
 		ModelTag: names.NewModelTag(cfg.UUID()),
-	}
-	pcfg.Controller.MongoInfo = &mongo.MongoInfo{
-		Password: args.AdminSecret,
-		Info:     mongo.Info{CACert: caCert},
 	}
 
 	authority, err := pki.NewDefaultAuthorityPemCAKey(

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -45,7 +45,6 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/keys"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/dummy"
 	corestorage "github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
@@ -1330,9 +1329,6 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 		Password: password,
 		CACert:   coretesting.CACert,
 		ModelTag: coretesting.ModelTag,
-	})
-	c.Check(icfg.Controller.MongoInfo, jc.DeepEquals, &mongo.MongoInfo{
-		Password: password, Info: mongo.Info{CACert: coretesting.CACert},
 	})
 	c.Check(icfg.Bootstrap.ControllerInheritedConfig, gc.DeepEquals, map[string]interface{}{"ftp-proxy": "http://proxy"})
 	c.Check(icfg.Bootstrap.RegionInheritedConfig, jc.DeepEquals, cloud.RegionConfig{

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/tools"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
 )
@@ -203,14 +202,6 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 	if isController {
 		instanceConfig.Controller = &instancecfg.ControllerConfig{
 			Config: testing.FakeControllerConfig(),
-			MongoInfo: &mongo.MongoInfo{
-				Info: mongo.Info{
-					Addrs:  []string{"localhost:1234"},
-					CACert: "CA CERT\n" + testing.CACert,
-				},
-				Password: "mongosecret",
-				Tag:      names.NewMachineTag(machineId),
-			},
 		}
 		instanceConfig.Jobs = []model.MachineJob{model.JobHostUnits, model.JobManageModel}
 	}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -59,6 +59,7 @@ import (
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
@@ -1216,7 +1217,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	var hc *instance.HardwareCharacteristics
 	// To match current system capability, only provide hardware characteristics for
 	// environ machines, not containers.
-	if state.ParentId(machineId) == "" {
+	if container.ParentId(machineId) == "" {
 		// Assume that the provided Availability Zone won't fail,
 		// though one is required.
 		var zone string

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage/poolmanager"
@@ -337,8 +338,8 @@ func (s *AssignSuite) assertAssignUnitToNewMachineContainerConstraint(c *gc.C) {
 	err = unit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	machineId := s.assertAssignedUnit(c, unit)
-	c.Assert(state.ParentId(machineId), gc.Not(gc.Equals), "")
-	c.Assert(state.ContainerTypeFromId(machineId), gc.Equals, instance.LXD)
+	c.Assert(container.ParentId(machineId), gc.Not(gc.Equals), "")
+	c.Assert(container.ContainerTypeFromId(machineId), gc.Equals, instance.LXD)
 }
 
 func (s *AssignSuite) TestAssignUnitToNewMachineContainerConstraint(c *gc.C) {
@@ -572,7 +573,7 @@ func (s *AssignSuite) assertAssignUnitNewPolicyNoContainer(c *gc.C) {
 	assertMachineCount(c, s.State, 2)
 	id, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(state.ParentId(id), gc.Equals, "")
+	c.Assert(container.ParentId(id), gc.Equals, "")
 }
 
 func (s *AssignSuite) TestAssignUnitNewPolicy(c *gc.C) {

--- a/state/container.go
+++ b/state/container.go
@@ -4,12 +4,10 @@
 package state
 
 import (
-	"strings"
-
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/container"
 )
 
 // machineContainers holds the machine ids of all the containers belonging to a parent machine.
@@ -52,7 +50,7 @@ func removeContainerRefOps(mb modelBackend, machineId string) []txn.Op {
 		Remove: true,
 	}
 	// If the machine is a container, figure out its parent host.
-	parentId := ParentId(machineId)
+	parentId := container.ParentId(machineId)
 	if parentId == "" {
 		return []txn.Op{removeRefOp}
 	}
@@ -63,36 +61,4 @@ func removeContainerRefOps(mb modelBackend, machineId string) []txn.Op {
 		Update: bson.D{{"$pull", bson.D{{"children", machineId}}}},
 	}
 	return []txn.Op{removeRefOp, removeParentRefOp}
-}
-
-// ParentId returns the id of the host machine if machineId a container id, or ""
-// if machineId is not for a container.
-func ParentId(machineId string) string {
-	idParts := strings.Split(machineId, "/")
-	if len(idParts) < 3 {
-		return ""
-	}
-	return strings.Join(idParts[:len(idParts)-2], "/")
-}
-
-// ContainerTypeFromId returns the container type if machineId is a container id, or ""
-// if machineId is not for a container.
-func ContainerTypeFromId(machineId string) instance.ContainerType {
-	idParts := strings.Split(machineId, "/")
-	if len(idParts) < 3 {
-		return instance.ContainerType("")
-	}
-	return instance.ContainerType(idParts[len(idParts)-2])
-}
-
-// NestingLevel returns how many levels of nesting exist for a machine id.
-func NestingLevel(machineId string) int {
-	idParts := strings.Split(machineId, "/")
-	return (len(idParts) - 1) / 2
-}
-
-// TopParentId returns the id of the top level host machine for a container id.
-func TopParentId(machineId string) string {
-	idParts := strings.Split(machineId, "/")
-	return idParts[0]
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/constraints"
+	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
@@ -723,7 +724,7 @@ func (m *Machine) Containers() ([]string, error) {
 
 // ParentId returns the Id of the host machine if this machine is a container.
 func (m *Machine) ParentId() (string, bool) {
-	parentId := ParentId(m.Id())
+	parentId := corecontainer.ParentId(m.Id())
 	return parentId, parentId != ""
 }
 
@@ -2033,7 +2034,7 @@ func (m *Machine) markInvalidContainers() error {
 		return err
 	}
 	for _, containerId := range currentContainers {
-		if !isSupportedContainer(ContainerTypeFromId(containerId), m.doc.SupportedContainers) {
+		if !isSupportedContainer(corecontainer.ContainerTypeFromId(containerId), m.doc.SupportedContainers) {
 			container, err := m.st.Machine(containerId)
 			if err != nil {
 				logger.Errorf("loading container %v to mark as invalid: %v", containerId, err)
@@ -2047,7 +2048,7 @@ func (m *Machine) markInvalidContainers() error {
 				continue
 			}
 			if statusInfo.Status == status.Pending {
-				containerType := ContainerTypeFromId(containerId)
+				containerType := corecontainer.ContainerTypeFromId(containerId)
 				now := m.st.clock().Now()
 				s := status.StatusInfo{
 					Status:  status.Error,

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/constraints"
+	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -2517,7 +2518,7 @@ func (s *MachineSuite) TestSupportsNoContainersSetsAllToError(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(statusInfo.Status, gc.Equals, status.Error)
 		c.Assert(statusInfo.Message, gc.Equals, "unsupported container")
-		containerType := state.ContainerTypeFromId(container.Id())
+		containerType := corecontainer.ContainerTypeFromId(container.Id())
 		c.Assert(statusInfo.Data, gc.DeepEquals, map[string]interface{}{"type": string(containerType)})
 	}
 }

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
@@ -385,7 +386,7 @@ func (e *exporter) machines() error {
 		e.logger.Debugf("export machine %s", machine.Id())
 
 		var exParent description.Machine
-		if parentId := ParentId(machine.Id()); parentId != "" {
+		if parentId := container.ParentId(machine.Id()); parentId != "" {
 			var found bool
 			exParent, found = machineMap[parentId]
 			if !found {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/controller"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
@@ -452,7 +453,7 @@ func (i *importer) machine(m description.Machine) error {
 	// 3. create op for adding in instance data
 	prereqOps = append(prereqOps, i.machineInstanceOp(mdoc, instance))
 
-	if parentId := ParentId(mdoc.Id); parentId != "" {
+	if parentId := container.ParentId(mdoc.Id); parentId != "" {
 		prereqOps = append(prereqOps,
 			// Update containers record for host machine.
 			addChildToContainerRefOp(i.st, parentId, mdoc.Id),

--- a/state/reboot.go
+++ b/state/reboot.go
@@ -11,6 +11,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+
+	"github.com/juju/juju/core/container"
 )
 
 var _ RebootFlagSetter = (*Machine)(nil)
@@ -127,7 +129,7 @@ func (m *Machine) machinesToCareAboutRebootsFor() []string {
 	var possibleIds []string
 	for currentId := m.Id(); currentId != ""; {
 		possibleIds = append(possibleIds, currentId)
-		currentId = ParentId(currentId)
+		currentId = container.ParentId(currentId)
 	}
 	return possibleIds
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3703,30 +3703,6 @@ func (s *StateSuite) TestWatchRemoteRelationsDiesOnStateClose(c *gc.C) {
 	})
 }
 
-func (s *StateSuite) TestNestingLevel(c *gc.C) {
-	c.Assert(state.NestingLevel("0"), gc.Equals, 0)
-	c.Assert(state.NestingLevel("0/lxd/1"), gc.Equals, 1)
-	c.Assert(state.NestingLevel("0/lxd/1/kvm/0"), gc.Equals, 2)
-}
-
-func (s *StateSuite) TestTopParentId(c *gc.C) {
-	c.Assert(state.TopParentId("0"), gc.Equals, "0")
-	c.Assert(state.TopParentId("0/lxd/1"), gc.Equals, "0")
-	c.Assert(state.TopParentId("0/lxd/1/kvm/2"), gc.Equals, "0")
-}
-
-func (s *StateSuite) TestParentId(c *gc.C) {
-	c.Assert(state.ParentId("0"), gc.Equals, "")
-	c.Assert(state.ParentId("0/lxd/1"), gc.Equals, "0")
-	c.Assert(state.ParentId("0/lxd/1/kvm/0"), gc.Equals, "0/lxd/1")
-}
-
-func (s *StateSuite) TestContainerTypeFromId(c *gc.C) {
-	c.Assert(state.ContainerTypeFromId("0"), gc.Equals, instance.ContainerType(""))
-	c.Assert(state.ContainerTypeFromId("0/lxd/1"), gc.Equals, instance.LXD)
-	c.Assert(state.ContainerTypeFromId("0/lxd/1/kvm/0"), gc.Equals, instance.KVM)
-}
-
 func (s *StateSuite) TestIsUpgradeInProgressError(c *gc.C) {
 	c.Assert(stateerrors.IsUpgradeInProgressError(errors.New("foo")), jc.IsFalse)
 	c.Assert(stateerrors.IsUpgradeInProgressError(stateerrors.ErrUpgradeInProgress), jc.IsTrue)

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -19,12 +19,12 @@ import (
 	"github.com/juju/juju/container/broker"
 	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/container/lxd"
+	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/state"
 	workercommon "github.com/juju/juju/worker/common"
 )
 
@@ -108,7 +108,7 @@ func (cs *ContainerSetup) Handle(abort <-chan struct{}, containerIds []string) (
 
 	cs.logger.Infof("initial container setup with ids: %v", containerIds)
 	for _, id := range containerIds {
-		containerType := state.ContainerTypeFromId(id)
+		containerType := corecontainer.ContainerTypeFromId(id)
 		// If this container type has been dealt with, do nothing.
 		if atomic.LoadInt32(cs.setupDone[containerType]) != 0 {
 			continue

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -559,7 +559,7 @@ func (task *provisionerTask) constructInstanceConfig(
 	pInfo *params.ProvisioningInfoV10,
 ) (*instancecfg.InstanceConfig, error) {
 
-	stateInfo, apiInfo, err := auth.SetupAuthentication(machine)
+	apiInfo, err := auth.SetupAuthentication(machine)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to setup authentication")
 	}
@@ -595,13 +595,8 @@ func (task *provisionerTask) constructInstanceConfig(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		if stateInfo == nil {
-			return nil, errors.Errorf("Job needs state, but stateInfo is nil: jobs %v for %v",
-				instanceConfig.Jobs, machine.Tag().String())
-		}
 		instanceConfig.Controller = &instancecfg.ControllerConfig{
 			PublicImageSigningKey: publicKey,
-			MongoInfo:             stateInfo,
 		}
 		instanceConfig.Controller.Config = make(map[string]interface{})
 		for k, v := range pInfo.ControllerConfig {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/provider/common/mocks"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -872,9 +871,9 @@ type testAuthenticationProvider struct {
 
 func (m *testAuthenticationProvider) SetupAuthentication(
 	machine authentication.TaggedPasswordChanger,
-) (*mongo.MongoInfo, *api.Info, error) {
+) (*api.Info, error) {
 	m.AddCall("SetupAuthentication", machine)
-	return nil, nil, nil
+	return nil, nil
 }
 
 // startInstanceParamsMatcher is a GoMock matcher that applies a collection of


### PR DESCRIPTION
The provisioner worker was calling a StateAddresses() API but it doesn't need that info. Remove the API and fix the associated fallout.

The second commit is a drive by to move some trivial container helper methods from state to core. This removes one of the cases where the worker package imports state. Sadly it's one of many, so there's more to do.


## QA steps

bootstrap k8s and deploy a charm
juju show-controller and check the api address is correct

bootstrap lxd and deploy a charm
juju show-controller and check the api address is correct
juju enable-ha
juju show-controller and check the api addresses are correct
remove a controller machine
enable-ha again
check that a replacement controller comes up and show-controller is happy

## Bug reference

https://bugs.launchpad.net/juju/+bug/1866643
