### PR TITLE
show-cloud command includes user access

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -90,6 +90,7 @@ See also:
 
 type ListCloudsAPI interface {
 	Clouds() (map[names.CloudTag]jujucloud.Cloud, error)
+	CloudInfo(tags []names.CloudTag) ([]cloudapi.CloudInfo, error)
 	Close() error
 }
 
@@ -164,8 +165,18 @@ func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) 
 			if err != nil {
 				return errors.Trace(err)
 			}
+			tags := make([]names.CloudTag, len(controllerClouds))
+			i := 0
 			for _, cloud := range controllerClouds {
-				cloudDetails := makeCloudDetails(c.Store, cloud)
+				tags[i] = names.NewCloudTag(cloud.Name)
+				i++
+			}
+			cloudInfos, err := api.CloudInfo(tags)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			for _, cloud := range cloudInfos {
+				cloudDetails := makeCloudDetailsForUser(c.Store, cloud)
 				details.remote[cloud.Name] = cloudDetails
 			}
 			return nil


### PR DESCRIPTION
The show and list cloud CLI output did not include the users who had access to the clouds (like we do for show-model).
We actually have the backend APIs already implemented, but the CLI was not using them.

## QA steps

bootstrap and add a user and grant that user add-model access to a cloud on the controller
As that user, 

```
$ juju show-cloud localhost --controller test
Cloud "localhost" from controller "test":

defined: public
type: lxd
auth-types: [certificate]
endpoint: https://10.115.246.1:8443
regions:
  localhost: {}
users:
  bob:
    access: add-model
```

As admin,

```
$ juju show-cloud localhost  --controller test
Cloud "localhost" from controller "test":

defined: public
type: lxd
auth-types: [certificate]
endpoint: https://10.115.246.1:8443
credential-count: 1
regions:
  localhost: {}
users:
  admin:
    display-name: admin
    access: admin
  bob:
    access: add-model
```

Repeat with `list-clouds --format yaml`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892233
