### PR TITLE
Remove the tracked model from _backend cache;

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1402,7 +1402,7 @@ class ModelClient:
         # we're deploying a complex set of machines/containers.
         return retvar, CommandComplete(WaitAgentsStarted(wait_timeout), ct)
 
-    def migrate(self, full_model_name, model_name, dest_client, include_e=True):
+    def migrate(self, full_model_name, model_name, src_model_client, dest_client, include_e=True):
         self.juju(
             'migrate',
             (full_model_name, dest_client.env.controller.name),
@@ -1410,8 +1410,7 @@ class ModelClient:
         )
         # the specified source model has been migrated to the dest client,
         # so remove it from self._backend._added_models,
-        src_model = self.clone(self.env.clone(model_name))
-        self._backend.untrack_model(src_model)
+        self._backend.untrack_model(src_model_client)
 
         migration_target_client = dest_client.clone(
             dest_client.env.clone(model_name),


### PR DESCRIPTION

*Remove the tracked model from _backend cache after the model has been migrated to another controller;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


Run `nw-model-migration-amd64-*`

## Documentation changes

No

## Bug reference

No
