### PR TITLE
Smoke tests: Do not tee the output

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -165,7 +165,7 @@ jobs:
 
         VERSION=$(juju version | cut -d "-" -f 1,2 | xargs -I% echo "%.1")
         while true; do
-            juju upgrade-model --agent-version="$VERSION" 2>&1 | tee -a output.log || true
+            juju upgrade-model --agent-version="$VERSION" 2>&1 | tee output.log || true
             RES=$(cat output.log | grep "upgrade in progress" || echo "NOT-UPGRADING")
             if [ "$RES" = "NOT-UPGRADING" ]; then
                 break


### PR DESCRIPTION
Do not append when tee'ing to the output.log. Otherwise the following
grep will always match and so will never die!


## QA steps

Smoke tests pass.