### PR TITLE
Expose juju wait-for in a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
       - github.com/juju/juju/cmd/jujuc
       - github.com/juju/juju/cmd/jujud
       - github.com/juju/juju/cmd/plugins/juju-metadata
+      - github.com/juju/juju/cmd/plugins/juju-wait-for
     # go-external-strings is not supported by the standard go plugin.
     # these strings are filled in by CI.
     go-external-strings:


### PR DESCRIPTION
Now that we're going to use juju wait-for for tests we should expose it
via a snap.

## QA steps

Run this from the root of juju and ensure you don't have an existing one 
in the path, if so remove it...

```sh
$ snapcraft --use-lxd
$ sudo snap install *.snap --dangerous --classic
```

In one terminal do the following:

```sh
$ juju bootstrap lxd test
$ juju wait-for model test
```

In another terminal and ensure it's running from a snap...

```sh
$ ps aux | grep "juju wait-for"
... /snap/juju/x1/bin/juju wait-for model test
```
