### PR TITLE
Allow makefile unit test timeout to be overriden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(arm|arm64|ppc64le|ppc64|s390x).*/g
 else
 	TEST_TIMEOUT := 1800s
 endif
+TEST_TIMEOUT:=$(TEST_TIMEOUT)
 
 # Limit concurrency on s390x.
 ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(s390x).*/golang/'), golang)


### PR DESCRIPTION
Allow the Makefile unit test timeout to be overridden when running `make test`

## QA steps

make test
go test -mod=mod -tags ""  -test.timeout=1800s $TEST_PACKAGES -check.

make test TEST_TIMEOUT=100s
go test -mod=mod -tags ""  -test.timeout=100s $TEST_PACKAGES -check.

