### PR TITLE
Merge 2.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(arm|arm64|ppc64le|ppc64|s390x).*/g
 else
 	TEST_TIMEOUT := 1800s
 endif
+TEST_TIMEOUT:=$(TEST_TIMEOUT)
 
 # Limit concurrency on s390x.
 ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(s390x).*/golang/'), golang)


### PR DESCRIPTION
Merge 2.8 with this PR:

#12191 allow makefile test timeout to be overridden

## QA steps

See PR.