### PR TITLE
Use netlink to retrieve observed machine addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/rogpeppe/fastuuid v1.2.0 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/vishvananda/netlink v1.1.0
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9

--- a/go.sum
+++ b/go.sum
@@ -747,6 +747,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45 h1:zpQBW+l4uPQTfTOxedN5GEcSONhabbCf3X+5+P/H4Jk=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
@@ -903,6 +907,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This patch addres a new dependency, [netlink](https://github.com/vishvananda/netlink), and uses it to discover on-machine IP addresses.

Unlike the standard library `net` package, `netlink` surfaces address flags, allowing us to detect when an IP is a secondary address via the `IFA_F_SECONDARY` flag. This detection and reporting will come in a subsequent patch.

To test:
- Bootstrap to LXD
- Connect to Mongo and check that we still get addresses:
```
juju:PRIMARY> db.ip.addresses.find().pretty()
{
        "_id" : "ffff009d-f244-4a8b-8de4-5107bc8d6bb4:m#0#d#lo#ip#127.0.0.1",
        "model-uuid" : "ffff009d-f244-4a8b-8de4-5107bc8d6bb4",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "127.0.0.0/8",
        "config-method" : "loopback",
        "value" : "127.0.0.1",
        "origin" : "machine",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f96bcc52f987a1dcf1de8fe_19a8f071"
        ]
}
{
        "_id" : "ffff009d-f244-4a8b-8de4-5107bc8d6bb4:m#0#d#lo#ip#::1",
        "model-uuid" : "ffff009d-f244-4a8b-8de4-5107bc8d6bb4",
        "device-name" : "lo",
        "machine-id" : "0",
        "subnet-cidr" : "::1/128",
        "config-method" : "loopback",
        "value" : "::1",
        "origin" : "machine",
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "5f96bcc52f987a1dcf1de8fe_19a8f071"
        ]
}
{
        "_id" : "ffff009d-f244-4a8b-8de4-5107bc8d6bb4:m#0#d#eth0#ip#10.161.87.173",
        "model-uuid" : "ffff009d-f244-4a8b-8de4-5107bc8d6bb4",
        "device-name" : "eth0",
        "machine-id" : "0",
        "subnet-cidr" : "10.161.87.0/24",
        "config-method" : "static",
        "value" : "10.161.87.173",
        "gateway-address" : "10.161.87.1",
        "is-default-gateway" : true,
        "origin" : "machine",
        "txn-revno" : NumberLong(3),
        "txn-queue" : [
                "5f96bcd02f987a1dcf1deac4_0f8685ed"
        ],
        "provider-network-id" : "net-lxdbr0",
        "provider-subnet-id" : "subnet-lxdbr0-10.161.87.0/24"
}
```
