### PR TITLE
Ingore only less important errors for destroy-model --force;

### DIFF
--- a/state/model.go
+++ b/state/model.go
@@ -1152,6 +1152,11 @@ func IsHasHostedModelsError(err error) bool {
 	return ok
 }
 
+// NewHasPersistentStorageError returns hasPersistentStorageError.
+func NewHasPersistentStorageError() error {
+	return hasPersistentStorageError{}
+}
+
 type hasPersistentStorageError struct{}
 
 func (hasPersistentStorageError) Error() string {


### PR DESCRIPTION
*Only ingore less important errors for destroy-model --force;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# deploy charm with storage
$ juju add-model t1 microk8s && juju deploy cs:~juju/mariadb-k8s-3 && juju deploy cs:~juju/mediawiki-k8s-4 --config kubernetes-service-type=LoadBalancer && juju relate mediawiki-k8s:db mariadb-k8s:server


# now destroy-model raise an error and tell to use "--destroy-storage"
$ juju destroy-model t1 -y  --force
Destroying modelERROR cannot destroy model "t1"

The model has persistent storage remaining:
	1 volume and 1 filesystem

To destroy the storage, run the destroy-model
command again with the "--destroy-storage" option.

To release the storage from Juju's management
without destroying it, use the "--release-storage"
option instead. The storage can then be imported
into another Juju model.

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1901439
