### PR TITLE
Retry txn watcher on error instead of exiting

### DIFF
--- a/state/pool.go
+++ b/state/pool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/pubsub"
 	"github.com/juju/worker/v2"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/watcher"
@@ -116,12 +117,14 @@ type StatePool struct {
 
 	// watcherRunner makes sure the TxnWatcher stays running.
 	watcherRunner *worker.Runner
+	// txnWatcherSession is used exclusively for the TxnWatcher.
+	txnWatcherSession *mgo.Session
 }
 
 // OpenStatePool returns a new StatePool instance.
-func OpenStatePool(args OpenParams) (*StatePool, error) {
+func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 	logger.Tracef("opening state pool")
-	if err := args.Validate(); err != nil {
+	if err = args.Validate(); err != nil {
 		return nil, errors.Annotate(err, "validating args")
 	}
 
@@ -174,15 +177,21 @@ func OpenStatePool(args OpenParams) (*StatePool, error) {
 		RestartDelay: time.Second,
 		Clock:        args.Clock,
 	})
-	pool.watcherRunner.StartWorker(txnLogWorker, func() (worker.Worker, error) {
+	pool.txnWatcherSession = args.MongoSession.Copy()
+	if err = pool.watcherRunner.StartWorker(txnLogWorker, func() (worker.Worker, error) {
 		return watcher.NewTxnWatcher(
 			watcher.TxnWatcherConfig{
-				ChangeLog: st.getTxnLogCollection(),
-				Hub:       pool.hub,
-				Clock:     args.Clock,
-				Logger:    loggo.GetLogger("juju.state.pool.txnwatcher"),
+				Session:        pool.txnWatcherSession,
+				JujuDBName:     jujuDB,
+				CollectionName: txnLogC,
+				Hub:            pool.hub,
+				Clock:          args.Clock,
+				Logger:         loggo.GetLogger("juju.state.pool.txnwatcher"),
 			})
-	})
+	}); err != nil {
+		pool.txnWatcherSession.Close()
+		return nil, errors.Trace(err)
+	}
 	return pool, nil
 }
 
@@ -411,7 +420,8 @@ func (p *StatePool) Close() error {
 	}
 	p.mu.Lock()
 	if p.watcherRunner != nil {
-		worker.Stop(p.watcherRunner)
+		_ = worker.Stop(p.watcherRunner)
+		p.txnWatcherSession.Close()
 	}
 	p.mu.Unlock()
 	// As with above and the other watchers. Unlock while releas

--- a/state/state.go
+++ b/state/state.go
@@ -491,15 +491,6 @@ func (st *State) EnsureModelRemoved() error {
 	return nil
 }
 
-// getTxnLogCollection returns the raw mongodb txns collection, which is
-// needed to interact with the state/watcher package.
-func (st *State) getTxnLogCollection() *mgo.Collection {
-	if st.Ping() != nil {
-		st.session.Refresh()
-	}
-	return st.session.DB(jujuDB).C(txnLogC)
-}
-
 // newDB returns a database connection using a new session, along with
 // a closer function for the session. This is useful where you need to work
 // with various collections in a single session, so don't want to call

--- a/state/watcher/export_test.go
+++ b/state/watcher/export_test.go
@@ -4,11 +4,14 @@
 package watcher
 
 const (
-	TxnWatcherStarting   = txnWatcherStarting
-	TxnWatcherSyncErr    = txnWatcherSyncErr
-	TxnWatcherCollection = txnWatcherCollection
-	TxnWatcherShortWait  = txnWatcherShortWait
+	TxnWatcherStarting       = txnWatcherStarting
+	TxnWatcherSyncErr        = txnWatcherSyncErr
+	TxnWatcherCollection     = txnWatcherCollection
+	TxnWatcherShortWait      = txnWatcherShortWait
+	TxnWatcherErrorShortWait = txnWatcherErrorShortWait
 )
+
+var OutOfSyncError = outOfSyncError{}
 
 func NewTestHubWatcher(hub HubSource, clock Clock, modelUUID string, logger Logger) (*HubWatcher, <-chan struct{}) {
 	return newHubWatcher(hub, clock, modelUUID, logger)

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -177,7 +177,13 @@ func (w *HubWatcher) receiveEvent(topic string, data interface{}) {
 	case txnWatcherStarting:
 		// We don't do anything on a start.
 	case txnWatcherSyncErr:
-		w.tomb.Kill(errors.New("txn watcher sync error"))
+		syncErr, ok := data.(error)
+		if ok {
+			syncErr = errors.Annotate(syncErr, "hub txn watcher sync error")
+		} else {
+			syncErr = errors.New("hub txn watcher sync unknown error")
+		}
+		w.tomb.Kill(syncErr)
 	case txnWatcherCollection:
 		change, ok := data.(Change)
 		if !ok {

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub"
 	jc "github.com/juju/testing/checkers"
@@ -86,7 +87,7 @@ func (s *HubWatcherSuite) TestTxnWatcherSyncErrWorker(c *gc.C) {
 	// When the TxnWatcher hits a sync error and restarts, the hub watcher needs
 	// to restart too as there may be missed events, so all the watches this hub
 	// has need to be invalidated. This happens by the worker dying.
-	s.hub.Publish(watcher.TxnWatcherSyncErr, nil)
+	s.hub.Publish(watcher.TxnWatcherSyncErr, errors.New("boom"))
 
 	select {
 	case <-s.w.Dead():
@@ -94,7 +95,7 @@ func (s *HubWatcherSuite) TestTxnWatcherSyncErrWorker(c *gc.C) {
 		c.Fatalf("Dead channel should have fired")
 	}
 
-	c.Assert(s.w.Err(), gc.ErrorMatches, "txn watcher sync error")
+	c.Assert(s.w.Err(), gc.ErrorMatches, "hub txn watcher sync error: boom")
 }
 
 func (s *HubWatcherSuite) TestWatchBeforeKnown(c *gc.C) {

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -78,10 +78,12 @@ func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, 
 	logger := loggo.GetLogger("test")
 	logger.SetLogLevel(loggo.TRACE)
 	w, err := watcher.NewTxnWatcher(watcher.TxnWatcherConfig{
-		ChangeLog: s.log,
-		Hub:       hub,
-		Clock:     s.clock,
-		Logger:    logger,
+		Session:        s.MgoSuite.Session,
+		JujuDBName:     "juju",
+		CollectionName: s.log.Name,
+		Hub:            hub,
+		Clock:          s.clock,
+		Logger:         logger,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// Wait for the main loop to have started.

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -29,7 +30,7 @@ type TxnWatcherSuite struct {
 	runner       *txn.Runner
 	w            *watcher.TxnWatcher
 	ch           chan watcher.Change
-	iteratorFunc func() mongo.Iterator
+	iteratorFunc func(collection *mgo.Collection) mongo.Iterator
 	clock        *testclock.Clock
 }
 
@@ -59,6 +60,7 @@ func (s *TxnWatcherSuite) SetUpTest(c *gc.C) {
 	s.runner = txn.NewRunner(db.C("txn"))
 	s.runner.ChangeLog(s.log)
 	s.clock = testclock.NewClock(time.Now())
+	s.iteratorFunc = nil
 }
 
 func (s *TxnWatcherSuite) TearDownTest(c *gc.C) {
@@ -74,6 +76,10 @@ func (s *TxnWatcherSuite) advanceTime(c *gc.C, d time.Duration, waiters int) {
 }
 
 func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, *fakeHub) {
+	return s.newWatcherWithError(c, expect, nil)
+}
+
+func (s *TxnWatcherSuite) newWatcherWithError(c *gc.C, expect int, watcherError error) (*watcher.TxnWatcher, *fakeHub) {
 	hub := newFakeHub(c, expect)
 	logger := loggo.GetLogger("test")
 	logger.SetLogLevel(loggo.TRACE)
@@ -84,6 +90,7 @@ func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, 
 		Hub:            hub,
 		Clock:          s.clock,
 		Logger:         logger,
+		IteratorFunc:   s.iteratorFunc,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// Wait for the main loop to have started.
@@ -93,7 +100,11 @@ func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, 
 		c.Error("txn worker failed to start")
 	}
 	s.AddCleanup(func(c *gc.C) {
-		c.Assert(w.Stop(), jc.ErrorIsNil)
+		if watcherError == nil {
+			c.Assert(w.Stop(), jc.ErrorIsNil)
+		} else {
+			c.Assert(w.Stop(), gc.Equals, watcherError)
+		}
 	})
 	return w, hub
 }
@@ -300,12 +311,76 @@ func (s *TxnWatcherSuite) TestDoubleUpdate(c *gc.C) {
 	})
 }
 
+func (s *TxnWatcherSuite) TestErrorRetry(c *gc.C) {
+	syncCh := make(chan struct{}, 1)
+	s.PatchValue(&watcher.TxnPollNotifyFunc, func() {
+		syncCh <- struct{}{}
+	})
+
+	fakeIter := &fakeIterator{err: errors.New("boom")}
+	s.iteratorFunc = func(collection *mgo.Collection) mongo.Iterator {
+		fakeIter.iter = s.log.Find(nil).Batch(10).Sort("-$natural").Iter()
+		return fakeIter
+	}
+	_, hub := s.newWatcher(c, 1)
+	revno := s.insert(c, "test", "a")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
+	select {
+	case <-syncCh:
+	case <-time.After(testing.LongWait):
+		c.Error("txn watcher didn't sync")
+	}
+
+	fakeIter.err = nil
+	s.advanceTime(c, watcher.TxnWatcherErrorShortWait, 2)
+	hub.waitForExpected(c)
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno},
+	})
+}
+
+func (s *TxnWatcherSuite) TestOutOfSyncError(c *gc.C) {
+	fakeIter := &fakeIterator{err: watcher.OutOfSyncError}
+	s.iteratorFunc = func(collection *mgo.Collection) mongo.Iterator {
+		fakeIter.iter = s.log.Find(nil).Batch(10).Sort("-$natural").Iter()
+		return fakeIter
+	}
+	_, hub := s.newWatcherWithError(c, 1, watcher.OutOfSyncError)
+	s.insert(c, "test", "a")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
+	hub.waitForError(c)
+}
+
+type fakeIterator struct {
+	iter mongo.Iterator
+	err  error
+}
+
+func (i *fakeIterator) Next(result interface{}) bool {
+	return i.iter.Next(result)
+}
+
+func (i *fakeIterator) Timeout() bool {
+	return i.iter.Timeout()
+}
+
+func (i *fakeIterator) Close() error {
+	err := i.iter.Close()
+	if i.err != nil {
+		err = i.err
+	}
+	return err
+}
+
 type fakeHub struct {
 	c       *gc.C
 	expect  int
 	values  []watcher.Change
 	started chan struct{}
 	done    chan struct{}
+	error   chan struct{}
 }
 
 func newFakeHub(c *gc.C, expected int) *fakeHub {
@@ -314,6 +389,7 @@ func newFakeHub(c *gc.C, expected int) *fakeHub {
 		expect:  expected,
 		started: make(chan struct{}),
 		done:    make(chan struct{}),
+		error:   make(chan struct{}),
 	}
 }
 
@@ -327,6 +403,8 @@ func (hub *fakeHub) Publish(topic string, data interface{}) <-chan struct{} {
 		if len(hub.values) == hub.expect {
 			close(hub.done)
 		}
+	case watcher.TxnWatcherSyncErr:
+		close(hub.error)
 	default:
 		hub.c.Errorf("unknown topic %q", topic)
 	}
@@ -338,5 +416,13 @@ func (hub *fakeHub) waitForExpected(c *gc.C) {
 	case <-hub.done:
 	case <-time.After(testing.LongWait):
 		c.Error("hub didn't get the expected number of changes")
+	}
+}
+
+func (hub *fakeHub) waitForError(c *gc.C) {
+	select {
+	case <-hub.error:
+	case <-time.After(testing.LongWait):
+		c.Error("hub didn't get an error")
 	}
 }


### PR DESCRIPTION
This PR attempts to make the txn watcher more robust. There's a suggestion there could be session contamination so the PR does:
- creates a separate session just for the txn watcher worker
- adds exponential backoff / retry if there's a mgo error; attempt to recover before reporting an error
- logs the actual txn watcher error message if the hub watcher does exit

It seems under high load, the txn watcher session gets disconnected and/or closed by mistake. So the retry will attempt to refresh the session and start the worker loop again. It will eventally report an error to the hubwatcher, which will restart all workers as occurs now on the very first error.

## QA steps

bootstrap
deploy mariadb and mediawiki
ssh to the controller
`echo "sync-error"  > /var/lib/juju/wrench/txnwatcher`
check the controller logs for txn watcher errors but the workers stay running
remove  /var/lib/juju/wrench/txnwatcher
relate the 2 charms
check for normal operations

## Bug reference

https://bugs.launchpad.net/juju/+bug/1890167
