### PR TITLE
Remove unused ModelConfigValues method

### DIFF
--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -62,7 +62,6 @@ type Backend interface {
 	Machine(string) (*state.Machine, error)
 	Model() (*state.Model, error)
 	ModelConfig() (*config.Config, error)
-	ModelConfigValues() (config.ConfigValues, error)
 	ModelConstraints() (constraints.Value, error)
 	ModelTag() names.ModelTag
 	ModelUUID() string
@@ -115,10 +114,6 @@ type stateShim struct {
 
 func (s stateShim) UpdateModelConfig(u map[string]interface{}, r []string, a ...state.ValidateConfigFunc) error {
 	return s.model.UpdateModelConfig(u, r, a...)
-}
-
-func (s stateShim) ModelConfigValues() (config.ConfigValues, error) {
-	return s.model.ModelConfigValues()
 }
 
 func (s *stateShim) Annotations(entity state.GlobalEntity) (map[string]string, error) {

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -1570,7 +1570,7 @@ func (s *clientSuite) TestProvisioningScriptDisablePackageCommands(c *gc.C) {
 	c.Check(script, gc.Not(jc.Contains), "apt-get update")
 	c.Check(script, gc.Not(jc.Contains), "apt-get upgrade")
 
-	// Test that in the abasence of a client-specified
+	// Test that in the absence of a client-specified
 	// DisablePackageCommands we use what's set in environment config.
 	provParams.DisablePackageCommands = false
 	setUpdateBehavior(false, false)


### PR DESCRIPTION
Trims down the large state indirection used in the client API facade by removing the unused `ModelConfigValues` method.

No functional change - build and unit tests remain green.