### PR TITLE
Fix add-machine error return

### DIFF
--- a/api/machinemanager/machinemanager.go
+++ b/api/machinemanager/machinemanager.go
@@ -41,11 +41,17 @@ func (client *Client) AddMachines(machineParams []params.AddMachineParams) ([]pa
 		MachineParams: machineParams,
 	}
 	results := new(params.AddMachinesResults)
+
 	err := client.facade.FacadeCall("AddMachines", args, results)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	if len(results.Machines) != len(machineParams) {
 		return nil, errors.Errorf("expected %d result, got %d", len(machineParams), len(results.Machines))
 	}
-	return results.Machines, err
+
+	return results.Machines, nil
 }
 
 // DestroyMachines removes a given set of machines.

--- a/api/machinemanager/machinemanager_test.go
+++ b/api/machinemanager/machinemanager_test.go
@@ -75,7 +75,7 @@ func (s *MachinemanagerSuite) TestAddMachinesClientError(c *gc.C) {
 	st := newClient(func(objType string, version int, id, request string, arg, result interface{}) error {
 		return errors.New("blargh")
 	})
-	_, err := st.AddMachines(nil)
+	_, err := st.AddMachines([]params.AddMachineParams{{Series: "focal"}})
 	c.Check(err, gc.ErrorMatches, "blargh")
 }
 


### PR DESCRIPTION
The return from `juju add-machine` was verifying the result count before checking the error return meaning that a user without model write access got `ERROR expected 1 result, got 0` instead of an indicative message.

This patch addresses that

## QA steps

- Bootstrap to LXD.
- `juju add-user joe`
- `juju grant joe read default`
- Set the admin password, logout, register with the token, then login as "joe".
- `juju add-machine` should return `ERROR permission denied (unauthorized access)`

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1896089
