### PR TITLE
Remove juju-updateseries

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -97,8 +97,7 @@ var (
 	jujuRun           = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
 	jujuDumpLogs      = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
 	jujuIntrospect    = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
-	jujuUpdateSeries  = paths.MustSucceed(paths.JujuUpdateSeries(series.MustHostSeries()))
-	jujudSymlinks     = []string{jujuRun, jujuDumpLogs, jujuIntrospect, jujuUpdateSeries}
+	jujudSymlinks     = []string{jujuRun, jujuDumpLogs, jujuIntrospect}
 	caasJujudSymlinks = []string{jujuRun, jujuDumpLogs, jujuIntrospect}
 
 	// The following are defined as variables to allow the tests to

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -25,7 +25,6 @@ const (
 	uniterStateDir
 	jujuDumpLogs
 	jujuIntrospect
-	jujuUpdateSeries
 	instanceCloudInitDir
 	cloudInitCfgDir
 	curtinInstallConfig
@@ -54,7 +53,6 @@ var nixVals = map[osVarType]string{
 	jujuRun:              "/usr/bin/juju-run",
 	jujuDumpLogs:         "/usr/bin/juju-dumplogs",
 	jujuIntrospect:       "/usr/bin/juju-introspect",
-	jujuUpdateSeries:     "/usr/bin/juju-updateseries",
 	certDir:              "/etc/juju/certs.d",
 	metricsSpoolDir:      "/var/lib/juju/metricspool",
 	uniterStateDir:       "/var/lib/juju/uniter/state",
@@ -73,7 +71,6 @@ var winVals = map[osVarType]string{
 	jujuRun:          "C:/Juju/bin/juju-run.exe",
 	jujuDumpLogs:     "C:/Juju/bin/juju-dumplogs.exe",
 	jujuIntrospect:   "C:/Juju/bin/juju-introspect.exe",
-	jujuUpdateSeries: "C:/Juju/bin/juju-updateseries.exe",
 	certDir:          "C:/Juju/certs",
 	metricsSpoolDir:  "C:/Juju/lib/juju/metricspool",
 	uniterStateDir:   "C:/Juju/lib/juju/uniter/state",
@@ -183,12 +180,6 @@ func CurtinInstallConfig(series string) (string, error) {
 // cloud config directory for a particular series.
 func CloudInitCfgDir(series string) (string, error) {
 	return osVal(series, cloudInitCfgDir)
-}
-
-// JujuUpdateSeries returns the absolute path to the juju-updateseries
-// binary for a particular series.
-func JujuUpdateSeries(series string) (string, error) {
-	return osVal(series, jujuUpdateSeries)
 }
 
 func MustSucceed(s string, e error) string {

--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -6,13 +6,12 @@
 package names
 
 const (
-	Juju             = "juju"
-	Jujuc            = "jujuc"
-	Jujud            = "jujud"
-	K8sAgent         = "k8sagent"
-	JujudVersions    = "jujud-versions.yaml"
-	JujuRun          = "juju-run"
-	JujuDumpLogs     = "juju-dumplogs"
-	JujuIntrospect   = "juju-introspect"
-	JujuUpdateSeries = "juju-updateseries"
+	Juju           = "juju"
+	Jujuc          = "jujuc"
+	Jujud          = "jujud"
+	K8sAgent       = "k8sagent"
+	JujudVersions  = "jujud-versions.yaml"
+	JujuRun        = "juju-run"
+	JujuDumpLogs   = "juju-dumplogs"
+	JujuIntrospect = "juju-introspect"
 )

--- a/juju/names/names_windows.go
+++ b/juju/names/names_windows.go
@@ -5,13 +5,12 @@
 package names
 
 const (
-	Juju             = "juju.exe"
-	Jujuc            = "jujuc.exe"
-	Jujud            = "jujud.exe"
-	K8sAgent         = "not-available"
-	JujudVersions    = "jujud-versions.yaml"
-	JujuRun          = "juju-run.exe"
-	JujuDumpLogs     = "juju-dumplogs.exe"
-	JujuIntrospect   = "juju-introspect.exe"
-	JujuUpdateSeries = "juju-updateseries.exe"
+	Juju           = "juju.exe"
+	Jujuc          = "jujuc.exe"
+	Jujud          = "jujud.exe"
+	K8sAgent       = "not-available"
+	JujudVersions  = "jujud-versions.yaml"
+	JujuRun        = "juju-run.exe"
+	JujuDumpLogs   = "juju-dumplogs.exe"
+	JujuIntrospect = "juju-introspect.exe"
 )


### PR DESCRIPTION
The _upgrade_-series work superceded the _update_-series work, and that functionality was removed.

However, we were still creating a symlink to jujud in /usr/bin. This vestigial behaviour is removed here.

## QA steps

Bootstrap, add a machine, SSH to it and check that there is no _juju-updateseries_ in /usr/bin.

## Documentation changes

None.

## Bug reference

N/A
