### PR TITLE
Allow tests provider of "lxd-remote"

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -57,11 +57,14 @@ bootstrap() {
         "aws")
             provider="aws"
             ;;
+        "localhost")
+            provider="lxd"
+            ;;
         "lxd")
             provider="lxd"
             ;;
-        "localhost")
-            provider="lxd"
+        "lxd-remote")
+            provider="lxd-remote"
             ;;
         "manual")
             manual_name=${1}


### PR DESCRIPTION
This is for an upcoming change to the juju-qa-jenkins repo to use an lxd-remote "cloud" for creating the LXD containers on the host in order to avoid nested containers (they don't work on focal).
