### PR TITLE
Update acceptancetests/requirements.txt

### DIFF
--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -1,9 +1,7 @@
 apache-libcloud>=2.4.0
-azure>=2.0.0rc3
 azure-batch>=0.30.0rc3
 azure-common>=1.1.3
 azure-graphrbac>=0.30.0rc3
-azure-mgmt>=0.30.0rc3
 azure-mgmt-authorization>=0.30.0rc3
 azure-mgmt-batch>=0.30.0rc3
 azure-mgmt-cdn>=0.30.0rc3
@@ -20,7 +18,10 @@ azure-mgmt-web>=0.30.0rc3
 azure-nspkg>=1.0.0
 azure-servicebus>=0.20.1
 azure-servicemanagement-legacy>=0.20.3
-azure-storage>=0.31.0
+azure-storage-blob==12.4.0
+azure-storage-file-datalake==12.1.2
+azure-storage-file-share==12.2.0
+azure-storage-queue==12.1.3
 boto>=2.48
 coverage>=3.7.1
 fixtures>=1.3.1
@@ -41,3 +42,4 @@ pyaml>=17.12.1
 dnspython==1.16.0
 google-api-python-client==1.7.8
 google-cloud-container==0.2.1
+cryptography==3.2.1


### PR DESCRIPTION
*Update acceptancetests/requirements.txt*

```
2020-10-27 03:00:15 ERROR 'cryptography library required for Service Account Authentication.'

Starting with v5.0.0, the 'azure' meta-package is deprecated and cannot be installed anymore.
Starting with v0.37.0, the 'azure-storage' meta-package is deprecated and cannot be installed anymore.
Starting with v5.0.0, the 'azure-mgmt' meta-package is deprecated and cannot be installed anymore.

```

## QA steps

Run CI tests;

## Documentation changes

No

## Bug reference

No
