### PR TITLE
Fix lp:1901752, add detail to error message.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -721,7 +721,7 @@ func (p *CloudFileReader) ReadCloudFromFile(cloudFile string, ctxt *cmd.Context)
 		return nil, errors.Trace(err)
 	}
 	if len(specifiedClouds) == 0 {
-		return nil, errors.New("no personal clouds are defined")
+		return nil, errors.New("no clouds found in parsed yaml, please validate yaml keys")
 	}
 
 	var newCloud jujucloud.Cloud


### PR DESCRIPTION
Add detail to juju add-cloud error message to help user understanding of the problem.

## QA steps

```console
# 
# Create a foo.yaml for adding a cloud, see help.  Instead of "clouds:" on the first line, put "louds:"
$ juju add-cloud foo foo.yaml
ERROR "no clouds found in parsed yaml, please validate yaml keys
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1901743
