### PR TITLE
Find again

### DIFF
--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -124,59 +124,11 @@ func assertCharmSameContents(c *gc.C, obtained, expected *params.CharmHubCharm) 
 }
 
 func getCharmHubFindResponses() []transport.FindResponse {
-	_, entity, defaultRelease := getCharmHubResponse()
 	return []transport.FindResponse{{
-		Name:           "wordpress",
-		Type:           "object",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		Entity:         entity,
-		DefaultRelease: defaultRelease,
-	}}
-}
-
-func getCharmHubInfoResponse() transport.InfoResponse {
-	channelMap, entity, defaultRelease := getCharmHubResponse()
-	return transport.InfoResponse{
-		Name:           "wordpress",
-		Type:           "charm",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		Entity:         entity,
-		DefaultRelease: defaultRelease,
-	}
-}
-
-func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.ChannelMap) {
-	return []transport.ChannelMap{{
-			Channel: transport.Channel{
-				Name: "latest/stable",
-				Platform: transport.Platform{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				},
-				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
-				Risk:       "stable",
-				Track:      "latest",
-			},
-			Revision: transport.Revision{
-				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
-				Download: transport.Download{
-					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
-					Size:       12042240,
-					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
-				},
-				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []transport.Platform{{
-					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
-				}},
-				Revision: 16,
-				Version:  "1.0.3",
-			},
-		}}, transport.Entity{
+		Name: "wordpress",
+		Type: "object",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		Entity: transport.Entity{
 			Categories: []transport.Category{{
 				Featured: true,
 				Name:     "blog",
@@ -200,7 +152,8 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				"wordpress-jorge",
 				"wordpress-site",
 			},
-		}, transport.ChannelMap{
+		},
+		DefaultRelease: transport.FindChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -212,7 +165,102 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.FindRevision{
+				CreatedAt: "2019-12-16T19:20:26.673192+00:00",
+				Download: transport.Download{
+					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+					Size:       12042240,
+					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
+				},
+				Platforms: []transport.Platform{{
+					Architecture: "all",
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}, {
+					Architecture: "all",
+					OS:           "ubuntu",
+					Series:       "xenial",
+				}},
+				Revision: 16,
+				Version:  "1.0.3",
+			},
+		},
+	}}
+}
+
+func getCharmHubInfoResponse() transport.InfoResponse {
+	return transport.InfoResponse{
+		Name: "wordpress",
+		Type: "charm",
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap: []transport.InfoChannelMap{{
+			Channel: transport.Channel{
+				Name: "latest/stable",
+				Platform: transport.Platform{
+					Architecture: "all",
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Risk:       "stable",
+				Track:      "latest",
+			},
+			Revision: transport.InfoRevision{
+				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
+				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
+				Download: transport.Download{
+					HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
+					Size:       12042240,
+					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
+				},
+				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
+				Platforms: []transport.Platform{{
+					Architecture: "all",
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}},
+				Revision: 16,
+				Version:  "1.0.3",
+			},
+		}},
+		Entity: transport.Entity{
+			Categories: []transport.Category{{
+				Featured: true,
+				Name:     "blog",
+			}},
+			License:     "Apache-2.0",
+			Description: "This will install and setup Wordpress optimized to run in the cloud.\nBy default it will place Ngnix configured to scale horizontally\nwith Nginx's reverse proxy.",
+
+			Media: []transport.Media{{
+				Height: 256,
+				Type:   "icon",
+				URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/wpcom.png",
+				Width:  256,
+			}},
+			Publisher: map[string]string{
+				"display-name": "Wordress Charmers",
+			},
+			Summary:  "WordPress is a full featured web blogging tool, this charm deploys it.",
+			StoreURL: "https://someurl.com/wordpress",
+			UsedBy: []string{
+				"wordpress-everlast",
+				"wordpress-jorge",
+				"wordpress-site",
+			},
+		},
+		DefaultRelease: transport.InfoChannelMap{
+			Channel: transport.Channel{
+				Name: "latest/stable",
+				Platform: transport.Platform{
+					Architecture: "all",
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
+				Risk:       "stable",
+				Track:      "latest",
+			},
+			Revision: transport.InfoRevision{
 				ConfigYAML: entityConfig,
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
@@ -229,7 +277,8 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.Entity, transport.
 				Revision: 16,
 				Version:  "1.0.3",
 			},
-		}
+		},
+	}
 }
 
 func getParamsInfoResponse() params.InfoResponse {

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -166,9 +166,9 @@ func makeChannel(origin params.CharmOrigin) (corecharm.Channel, error) {
 	return corecharm.MakeChannel(track, origin.Risk, "")
 }
 
-func findChannelMap(rev int, preferredChannel corecharm.Channel, channelMaps []transport.ChannelMap) (transport.ChannelMap, error) {
+func findChannelMap(rev int, preferredChannel corecharm.Channel, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, error) {
 	if len(channelMaps) == 0 {
-		return transport.ChannelMap{}, errors.NotValidf("no channels provided by CharmHub")
+		return transport.InfoChannelMap{}, errors.NotValidf("no channels provided by CharmHub")
 	}
 	switch {
 	case preferredChannel.String() != "" && rev != -1:
@@ -180,7 +180,7 @@ func findChannelMap(rev int, preferredChannel corecharm.Channel, channelMaps []t
 	}
 }
 
-func findByRevision(rev int, channelMaps []transport.ChannelMap) (transport.ChannelMap, error) {
+func findByRevision(rev int, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, error) {
 	for _, cMap := range channelMaps {
 		if cMap.Revision.Revision == rev {
 			// Channel map is in order of most newest/stable channel,
@@ -188,32 +188,32 @@ func findByRevision(rev int, channelMaps []transport.ChannelMap) (transport.Chan
 			return cMap, nil
 		}
 	}
-	return transport.ChannelMap{}, errors.NotFoundf("charm revision %d", rev)
+	return transport.InfoChannelMap{}, errors.NotFoundf("charm revision %d", rev)
 }
 
-func findByChannel(preferredChannel corecharm.Channel, channelMaps []transport.ChannelMap) (transport.ChannelMap, error) {
+func findByChannel(preferredChannel corecharm.Channel, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, error) {
 	for _, cMap := range channelMaps {
 		if matchChannel(preferredChannel, cMap.Channel) {
 			return cMap, nil
 		}
 	}
-	return transport.ChannelMap{}, errors.NotFoundf("channel %q", preferredChannel.String())
+	return transport.InfoChannelMap{}, errors.NotFoundf("channel %q", preferredChannel.String())
 }
 
-func findByRevisionAndChannel(rev int, preferredChannel corecharm.Channel, channelMaps []transport.ChannelMap) (transport.ChannelMap, error) {
+func findByRevisionAndChannel(rev int, preferredChannel corecharm.Channel, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, error) {
 	for _, cMap := range channelMaps {
 		if cMap.Revision.Revision == rev && matchChannel(preferredChannel, cMap.Channel) {
 			return cMap, nil
 		}
 	}
-	return transport.ChannelMap{}, errors.NotFoundf("charm revision %d for channel %q", rev, preferredChannel.String())
+	return transport.InfoChannelMap{}, errors.NotFoundf("charm revision %d for channel %q", rev, preferredChannel.String())
 }
 
 func matchChannel(one corecharm.Channel, two transport.Channel) bool {
 	return one.String() == two.Name
 }
 
-func (c *chRepo) resolveViaChannelMap(curl *charm.URL, origin params.CharmOrigin, channelMap transport.ChannelMap) (*charm.URL, params.CharmOrigin, []string, error) {
+func (c *chRepo) resolveViaChannelMap(curl *charm.URL, origin params.CharmOrigin, channelMap transport.InfoChannelMap) (*charm.URL, params.CharmOrigin, []string, error) {
 	mapChannel := channelMap.Channel
 	mapRevision := channelMap.Revision
 

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -176,8 +176,8 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 	}
 }
 
-func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
-	return []transport.ChannelMap{{
+func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap) {
+	return []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name: "stable",
 				Platform: transport.Platform{
@@ -188,7 +188,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 				Risk:  "stable",
 				Track: "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
 					Architecture: "all",
@@ -209,7 +209,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 				Risk:  "candidate",
 				Track: "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
 					Architecture: "all",
@@ -230,7 +230,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 				Risk:  "edge",
 				Track: "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
 					Architecture: "all",
@@ -251,7 +251,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 				Risk:  "stable",
 				Track: "second",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
 					Architecture: "all",
@@ -261,7 +261,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 				Revision: 13,
 				Version:  "1.0.3",
 			},
-		}}, transport.ChannelMap{
+		}}, transport.InfoChannelMap{
 			Channel: transport.Channel{
 				Name: "stable",
 				Platform: transport.Platform{
@@ -272,7 +272,7 @@ func getCharmHubResponse() ([]transport.ChannelMap, transport.ChannelMap) {
 				Risk:  "stable",
 				Track: "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
 					Architecture: "all",

--- a/charmhub/filter.go
+++ b/charmhub/filter.go
@@ -45,17 +45,6 @@ var defaultResultFilter = []string{
 	"result.website",
 }
 
-var defaultRevisionFilter = []string{
-	"revision.config-yaml",
-	"revision.created-at",
-	"revision.metadata-yaml",
-	"revision.platforms.architecture",
-	"revision.platforms.os",
-	"revision.platforms.series",
-	"revision.revision",
-	"revision.version",
-}
-
 var defaultDownloadFilter = []string{
 	"download.hash-sha-256",
 	"download.size",

--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -57,7 +57,16 @@ func (c *FindClient) Find(ctx context.Context, query string) ([]transport.FindRe
 func defaultFindFilter() string {
 	filter := defaultResultFilter
 	filter = append(filter, appendFilterList("default-release.revision", defaultDownloadFilter)...)
-	filter = append(filter, appendFilterList("default-release", defaultRevisionFilter)...)
+	filter = append(filter, appendFilterList("default-release", findRevisionFilter)...)
 	filter = append(filter, appendFilterList("default-release", defaultChannelFilter)...)
 	return strings.Join(filter, ",")
+}
+
+var findRevisionFilter = []string{
+	"revision.created-at",
+	"revision.platforms.architecture",
+	"revision.platforms.os",
+	"revision.platforms.series",
+	"revision.revision",
+	"revision.version",
 }

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -106,7 +106,7 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					"wordpress-site",
 				},
 			},
-			DefaultRelease: transport.ChannelMap{
+			DefaultRelease: transport.FindChannelMap{
 				Channel: transport.Channel{
 					Name: "latest/stable",
 					Platform: transport.Platform{
@@ -118,15 +118,13 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 					Risk:       "stable",
 					Track:      "latest",
 				},
-				Revision: transport.Revision{
-					ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
-					CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
+				Revision: transport.FindRevision{
+					CreatedAt: "2019-12-16T19:20:26.673192+00:00",
 					Download: transport.Download{
 						HashSHA256: "92a8b825ed1108ab64864a7df05eb84ed3925a8d5e4741169185f77cef9b52517ad4b79396bab43b19e544a908ec83c4",
 						Size:       12042240,
 						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 					},
-					MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
 					Platforms: []transport.Platform{{
 						Architecture: "all",
 						OS:           "ubuntu",

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -59,10 +59,21 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 func defaultInfoFilter() string {
 	filter := defaultResultFilter
 	filter = append(filter, appendFilterList("default-release.revision", defaultDownloadFilter)...)
-	filter = append(filter, appendFilterList("default-release", defaultRevisionFilter)...)
+	filter = append(filter, appendFilterList("default-release", infoRevisionFilter)...)
 	filter = append(filter, appendFilterList("default-release", defaultChannelFilter)...)
 	filter = append(filter, appendFilterList("channel-map.revision", defaultDownloadFilter)...)
-	filter = append(filter, appendFilterList("channel-map", defaultRevisionFilter)...)
+	filter = append(filter, appendFilterList("channel-map", infoRevisionFilter)...)
 	filter = append(filter, appendFilterList("channel-map", defaultChannelFilter)...)
 	return strings.Join(filter, ",")
+}
+
+var infoRevisionFilter = []string{
+	"revision.config-yaml",
+	"revision.created-at",
+	"revision.metadata-yaml",
+	"revision.platforms.architecture",
+	"revision.platforms.os",
+	"revision.platforms.series",
+	"revision.revision",
+	"revision.version",
 }

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -110,7 +110,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 		Name: "wordpress",
 		Type: "object",
 		ID:   "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap: []transport.ChannelMap{{
+		ChannelMap: []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -122,7 +122,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{
@@ -163,7 +163,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				"wordpress-site",
 			},
 		},
-		DefaultRelease: transport.ChannelMap{
+		DefaultRelease: transport.InfoChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
 				Platform: transport.Platform{
@@ -175,7 +175,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 				Risk:       "stable",
 				Track:      "latest",
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				ConfigYAML: "one: 1\ntwo: 2\nitems: [1,2,3,4]\n\"",
 				CreatedAt:  "2019-12-16T19:20:26.673192+00:00",
 				Download: transport.Download{

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -6,11 +6,6 @@ package transport
 // The following contains all the common DTOs for a gathering information from
 // a given store.
 
-type ChannelMap struct {
-	Channel  Channel  `json:"channel,omitempty"`
-	Revision Revision `json:"revision,omitempty"`
-}
-
 type Channel struct {
 	Name       string   `json:"name"`
 	Platform   Platform `json:"platform"`
@@ -23,16 +18,6 @@ type Platform struct {
 	Architecture string `json:"architecture"`
 	OS           string `json:"os"`
 	Series       string `json:"series"`
-}
-
-type Revision struct {
-	ConfigYAML   string     `json:"config-yaml"`
-	CreatedAt    string     `json:"created-at"`
-	Download     Download   `json:"download"`
-	MetadataYAML string     `json:"metadata-yaml"`
-	Platforms    []Platform `json:"platforms"`
-	Revision     int        `json:"revision"`
-	Version      string     `json:"version"`
 }
 
 type Download struct {

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -9,9 +9,24 @@ type FindResponses struct {
 }
 
 type FindResponse struct {
-	Type           string     `json:"type"`
-	ID             string     `json:"id"`
-	Name           string     `json:"name"`
-	Entity         Entity     `json:"result,omitempty"`
-	DefaultRelease ChannelMap `json:"default-release,omitempty"`
+	Type           string         `json:"type"`
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	Entity         Entity         `json:"result,omitempty"`
+	DefaultRelease FindChannelMap `json:"default-release,omitempty"`
+}
+
+type FindChannelMap struct {
+	Channel  Channel      `json:"channel,omitempty"`
+	Revision FindRevision `json:"revision,omitempty"`
+}
+
+// FindRevision is different from InfoRevision.  It is missing
+// ConfigYAML and MetadataYAML
+type FindRevision struct {
+	CreatedAt string     `json:"created-at"`
+	Download  Download   `json:"download"`
+	Platforms []Platform `json:"platforms"`
+	Revision  int        `json:"revision"`
+	Version   string     `json:"version"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -4,11 +4,28 @@
 package transport
 
 type InfoResponse struct {
-	Type           string       `json:"type"`
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Entity         Entity       `json:"result"`
-	ChannelMap     []ChannelMap `json:"channel-map"`
-	DefaultRelease ChannelMap   `json:"default-release,omitempty"`
-	ErrorList      APIErrors    `json:"error-list,omitempty"`
+	Type           string           `json:"type"`
+	ID             string           `json:"id"`
+	Name           string           `json:"name"`
+	Entity         Entity           `json:"result"`
+	ChannelMap     []InfoChannelMap `json:"channel-map"`
+	DefaultRelease InfoChannelMap   `json:"default-release,omitempty"`
+	ErrorList      APIErrors        `json:"error-list,omitempty"`
+}
+
+type InfoChannelMap struct {
+	Channel  Channel      `json:"channel,omitempty"`
+	Revision InfoRevision `json:"revision,omitempty"`
+}
+
+// InfoRevision is different from FindRevision.  It has additional
+// fields of ConfigYAML and MetadataYAML.
+type InfoRevision struct {
+	ConfigYAML   string     `json:"config-yaml"`
+	CreatedAt    string     `json:"created-at"`
+	Download     Download   `json:"download"`
+	MetadataYAML string     `json:"metadata-yaml"`
+	Platforms    []Platform `json:"platforms"`
+	Revision     int        `json:"revision"`
+	Version      string     `json:"version"`
 }

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -212,7 +212,7 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 
 	var (
 		found    bool
-		revision transport.Revision
+		revision transport.InfoRevision
 	)
 	// If there is no series, then attempt to select the best one first.
 	if c.series == "" {
@@ -331,7 +331,7 @@ func (stdoutFileSystem) Create(string) (*os.File, error) {
 	return os.NewFile(uintptr(syscall.Stdout), "/dev/stdout"), nil
 }
 
-func (c *downloadCommand) locateRevisionByChannel(channelMaps []transport.ChannelMap, channel corecharm.Channel) (transport.Revision, bool) {
+func (c *downloadCommand) locateRevisionByChannel(channelMaps []transport.InfoChannelMap, channel corecharm.Channel) (transport.InfoRevision, bool) {
 	// Order the channelMap by the ordered supported controller series. That
 	// way we'll always find the newest one first (hopefully the most
 	// supported).
@@ -347,12 +347,12 @@ func (c *downloadCommand) locateRevisionByChannel(channelMaps []transport.Channe
 			return rev, true
 		}
 	}
-	return transport.Revision{}, false
+	return transport.InfoRevision{}, false
 }
 
-func (c *downloadCommand) locateRevisionByChannelAndSeries(channelMaps []transport.ChannelMap, channel corecharm.Channel, series string) (transport.Revision, bool) {
+func (c *downloadCommand) locateRevisionByChannelAndSeries(channelMaps []transport.InfoChannelMap, channel corecharm.Channel, series string) (transport.InfoRevision, bool) {
 	// Filter out any channels that aren't of a given series.
-	var filtered []transport.ChannelMap
+	var filtered []transport.InfoChannelMap
 	for _, channelMap := range channelMaps {
 		if channelMap.Channel.Platform.Series == series || isSeriesInPlatforms(channelMap.Revision.Platforms, series) {
 			filtered = append(filtered, channelMap)
@@ -361,7 +361,7 @@ func (c *downloadCommand) locateRevisionByChannelAndSeries(channelMaps []transpo
 
 	// If we don't have any filtered series then we don't know what to do here.
 	if len(filtered) == 0 {
-		return transport.Revision{}, false
+		return transport.InfoRevision{}, false
 	}
 
 	for _, channelMap := range filtered {
@@ -369,7 +369,7 @@ func (c *downloadCommand) locateRevisionByChannelAndSeries(channelMaps []transpo
 			return rev, true
 		}
 	}
-	return transport.Revision{}, false
+	return transport.InfoRevision{}, false
 }
 
 func isSeriesInPlatforms(platforms []transport.Platform, series string) bool {
@@ -391,10 +391,10 @@ func constructChannelFromTrackAndRisk(track, risk string) (corecharm.Channel, er
 	return corecharm.ParseChannelNormalize(rawChannel)
 }
 
-func locateRevisionByChannelMap(channelMap transport.ChannelMap, channel corecharm.Channel) (transport.Revision, bool) {
+func locateRevisionByChannelMap(channelMap transport.InfoChannelMap, channel corecharm.Channel) (transport.InfoRevision, bool) {
 	charmChannel, err := constructChannelFromTrackAndRisk(channelMap.Channel.Track, channelMap.Channel.Risk)
 	if err != nil {
-		return transport.Revision{}, false
+		return transport.InfoRevision{}, false
 	}
 
 	// Check that we're an exact match.
@@ -402,11 +402,11 @@ func locateRevisionByChannelMap(channelMap transport.ChannelMap, channel corecha
 		return channelMap.Revision, true
 	}
 
-	return transport.Revision{}, false
+	return transport.InfoRevision{}, false
 }
 
 type channelMapBySeries struct {
-	channelMap []transport.ChannelMap
+	channelMap []transport.InfoChannelMap
 	series     []string
 }
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -158,7 +158,7 @@ func (s *downloadSuite) expectInfo(charmHubURL string) {
 	s.charmHubClient.EXPECT().Info(gomock.Any(), "test").Return(transport.InfoResponse{
 		Type: "charm",
 		Name: "test",
-		ChannelMap: []transport.ChannelMap{{
+		ChannelMap: []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name:  "a",
 				Track: "latest",
@@ -167,7 +167,7 @@ func (s *downloadSuite) expectInfo(charmHubURL string) {
 					Series: "xenial",
 				},
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				Revision: 1,
 				Download: transport.Download{
 					URL: charmHubURL,
@@ -187,7 +187,7 @@ func (s *downloadSuite) TestLocateRevisionByChannel(c *gc.C) {
 	command := &downloadCommand{
 		orderedSeries: []string{"focal", "bionic"},
 	}
-	revision, found := command.locateRevisionByChannel([]transport.ChannelMap{{
+	revision, found := command.locateRevisionByChannel([]transport.InfoChannelMap{{
 		Channel: transport.Channel{
 			Name:  "a",
 			Track: "latest",
@@ -196,7 +196,7 @@ func (s *downloadSuite) TestLocateRevisionByChannel(c *gc.C) {
 				Series: "xenial",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 1,
 		},
 	}, {
@@ -208,7 +208,7 @@ func (s *downloadSuite) TestLocateRevisionByChannel(c *gc.C) {
 				Series: "bionic",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 2,
 		},
 	}, {
@@ -220,7 +220,7 @@ func (s *downloadSuite) TestLocateRevisionByChannel(c *gc.C) {
 				Series: "focal",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 3,
 		},
 	}, {
@@ -232,7 +232,7 @@ func (s *downloadSuite) TestLocateRevisionByChannel(c *gc.C) {
 				Series: "focal",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 4,
 		},
 	}}, corecharm.MustParseChannel("latest/stable"))
@@ -245,7 +245,7 @@ func (s *downloadSuite) TestLocateRevisionByChannelAndSeries(c *gc.C) {
 	command := &downloadCommand{
 		orderedSeries: []string{"focal", "bionic"},
 	}
-	revision, found := command.locateRevisionByChannelAndSeries([]transport.ChannelMap{{
+	revision, found := command.locateRevisionByChannelAndSeries([]transport.InfoChannelMap{{
 		Channel: transport.Channel{
 			Name:  "a",
 			Track: "latest",
@@ -254,7 +254,7 @@ func (s *downloadSuite) TestLocateRevisionByChannelAndSeries(c *gc.C) {
 				Series: "xenial",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 1,
 		},
 	}, {
@@ -266,7 +266,7 @@ func (s *downloadSuite) TestLocateRevisionByChannelAndSeries(c *gc.C) {
 				Series: "bionic",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 2,
 		},
 	}, {
@@ -278,7 +278,7 @@ func (s *downloadSuite) TestLocateRevisionByChannelAndSeries(c *gc.C) {
 				Series: "focal",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 3,
 		},
 	}, {
@@ -290,7 +290,7 @@ func (s *downloadSuite) TestLocateRevisionByChannelAndSeries(c *gc.C) {
 				Series: "focal",
 			},
 		},
-		Revision: transport.Revision{
+		Revision: transport.InfoRevision{
 			Revision: 4,
 		},
 	}}, corecharm.MustParseChannel("latest/stable"), "focal")
@@ -324,12 +324,12 @@ func (s *downloadSuite) TestLocateRevisionByChannelMap(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("test %d", i)
 
-		revision, found := locateRevisionByChannelMap(transport.ChannelMap{
+		revision, found := locateRevisionByChannelMap(transport.InfoChannelMap{
 			Channel: transport.Channel{
 				Track: test.InputTrack,
 				Risk:  test.InputRisk,
 			},
-			Revision: transport.Revision{
+			Revision: transport.InfoRevision{
 				Revision: 1,
 			},
 		}, corecharm.MustParseChannel(test.Channel))
@@ -341,7 +341,7 @@ func (s *downloadSuite) TestLocateRevisionByChannelMap(c *gc.C) {
 
 func (s *downloadSuite) TestChannelMapSort(c *gc.C) {
 	series := channelMapBySeries{
-		channelMap: []transport.ChannelMap{{
+		channelMap: []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name: "a",
 				Platform: transport.Platform{


### PR DESCRIPTION

Break the charmhub transport ChannelMap into 2 versions due to change in Find api fields.  The Revision object is now different between Find and Info.  

This changes leads to updates multiple juju packages and how supported series are determined for `juju find` output.

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost test-me
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju find 
$ juju info ubuntu-qa
$ juju download ubuntu-qa
$ juju deploy ubuntu-qa
```

