### PR TITLE
Back-port lxd-remote tests provider from develop

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -46,11 +46,14 @@ bootstrap() {
         "aws")
             provider="aws"
             ;;
+        "localhost")
+            provider="lxd"
+            ;;
         "lxd")
             provider="lxd"
             ;;
-        "localhost")
-            provider="lxd"
+        "lxd-remote")
+            provider="lxd-remote"
             ;;
         "manual")
             manual_name=${1}


### PR DESCRIPTION
Cherry-pick of commit https://github.com/juju/juju/pull/12205/commits/49363e9fd285f6cfadd8fd61894cf9b061953a29 from the develop branch, PR https://github.com/juju/juju/pull/12205

This is so that our LXD integration tests work on the 2.8 branch (the tests use the lxd-remote provider now, even though 2.8 doesn't deploy to focal by default).