### PR TITLE
Raft trace log detail

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -379,19 +379,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:              prworker.NewWorker,
 		}),
 
-		/* TODO(menn0) - this is currently unused, pending further
-		 * refactoring in the state package.
-
-			// The controller manifold creates a *state.Controller and
-			// makes it available to other manifolds. It pings the MongoDB
-			// session regularly and will die if pings fail.
-			controllerName: workercontroller.Manifold(workercontroller.ManifoldConfig{
-				AgentName:              agentName,
-				StateConfigWatcherName: stateConfigWatcherName,
-				OpenController:         config.OpenController,
-			}),
-		*/
-
 		// The state manifold creates a *state.State and makes it
 		// available to other manifolds. It pings the mongodb session
 		// regularly and will die if pings fail.

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -437,7 +437,7 @@ func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
 
 // Restore is part of raft.FSM.
 func (f *FSM) Restore(reader io.ReadCloser) error {
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	var snapshot Snapshot
 	decoder := yaml.NewDecoder(reader)
@@ -691,8 +691,8 @@ func (c *Command) String() string {
 	switch c.Operation {
 	case OperationSetTime:
 		return fmt.Sprintf(
-			"Command(ver: %d, op: %s, new time: %v)",
-			c.Version, c.Operation, c.NewTime,
+			"Command(ver: %d, op: %s, old time: %v, new time: %v)",
+			c.Version, c.Operation, c.OldTime, c.NewTime,
 		)
 	case OperationPin, OperationUnpin:
 		return fmt.Sprintf(

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -246,7 +246,7 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 	start := time.Now()
 	defer func() {
 		elapsed := time.Now().Sub(start)
-		logger.Tracef("runOnLeader elapsed from publish: %v", elapsed.Round(time.Millisecond))
+		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
 	_, err = s.hub.Publish(s.config.RequestTopic, ForwardRequest{
 		Command:       string(bytes),


### PR DESCRIPTION
Adds some detail to the trace log output, in order to enhance Raft diagnostics.

## QA steps

- `juju bootstrap lxd test-lease --debug --config logging-config="<root>=DEBUG;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE"`
- See the output with `juju debug-log -m controller --include-module juju.core.raftlease --include-module juju.worker.lease.raft`

## Documentation changes

None.

## Bug reference

Relevant to https://bugs.launchpad.net/juju/+bug/1900724, though not a fix.
