### PR TITLE
[wait-for] Reconnect on agent bouncing

### DIFF
--- a/cmd/plugins/juju-wait-for/application.go
+++ b/cmd/plugins/juju-wait-for/application.go
@@ -90,16 +90,11 @@ func (c *applicationCommand) Init(args []string) (err error) {
 }
 
 func (c *applicationCommand) Run(ctx *cmd.Context) error {
-	client, err := c.newWatchAllAPIFunc()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	strategy := &Strategy{
-		Client:  client,
-		Timeout: c.timeout,
+		ClientFn: c.newWatchAllAPIFunc,
+		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.name, c.query, c.waitFor)
+	err := strategy.Run(c.name, c.query, c.waitFor)
 	return errors.Trace(err)
 }
 

--- a/cmd/plugins/juju-wait-for/machine.go
+++ b/cmd/plugins/juju-wait-for/machine.go
@@ -89,16 +89,11 @@ func (c *machineCommand) Init(args []string) (err error) {
 }
 
 func (c *machineCommand) Run(ctx *cmd.Context) error {
-	client, err := c.newWatchAllAPIFunc()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	strategy := &Strategy{
-		Client:  client,
-		Timeout: c.timeout,
+		ClientFn: c.newWatchAllAPIFunc,
+		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.id, c.query, c.waitFor)
+	err := strategy.Run(c.id, c.query, c.waitFor)
 	return errors.Trace(err)
 }
 

--- a/cmd/plugins/juju-wait-for/model.go
+++ b/cmd/plugins/juju-wait-for/model.go
@@ -93,6 +93,14 @@ func (c *modelCommand) Run(ctx *cmd.Context) error {
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
+	strategy.Subscribe(func(event EventType) {
+		switch event {
+		case WatchAllStarted:
+			// When a watch has started, we should prime all the local caches,
+			// this means we should evict all items in the model and resync them
+			// again.
+		}
+	})
 	err := strategy.Run(c.name, c.query, c.waitFor)
 	return errors.Trace(err)
 }

--- a/cmd/plugins/juju-wait-for/model.go
+++ b/cmd/plugins/juju-wait-for/model.go
@@ -89,16 +89,11 @@ func (c *modelCommand) Init(args []string) (err error) {
 }
 
 func (c *modelCommand) Run(ctx *cmd.Context) error {
-	client, err := c.newWatchAllAPIFunc()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	strategy := &Strategy{
-		Client:  client,
-		Timeout: c.timeout,
+		ClientFn: c.newWatchAllAPIFunc,
+		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.name, c.query, c.waitFor)
+	err := strategy.Run(c.name, c.query, c.waitFor)
 	return errors.Trace(err)
 }
 

--- a/cmd/plugins/juju-wait-for/strategy_test.go
+++ b/cmd/plugins/juju-wait-for/strategy_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cmd/plugins/juju-wait-for/api"
 	"github.com/juju/juju/cmd/plugins/juju-wait-for/api/mocks"
 	"github.com/juju/juju/cmd/plugins/juju-wait-for/query"
 )
@@ -43,7 +44,9 @@ func (s *strategySuite) TestRun(c *gc.C) {
 	var deltas []params.Delta
 
 	strategy := Strategy{
-		Client:  client,
+		ClientFn: func() (api.WatchAllAPI, error) {
+			return client, nil
+		},
 		Timeout: time.Minute,
 	}
 	err := strategy.Run("generic", `life=="active"`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {
@@ -62,7 +65,9 @@ func (s *strategySuite) TestRunWithInvalidQuery(c *gc.C) {
 
 	client := mocks.NewMockWatchAllAPI(ctrl)
 	strategy := Strategy{
-		Client:  client,
+		ClientFn: func() (api.WatchAllAPI, error) {
+			return client, nil
+		},
 		Timeout: time.Minute,
 	}
 	err := strategy.Run("generic", `life=="ac`, func(_ string, d []params.Delta, _ query.Query) (bool, error) {

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -89,16 +89,11 @@ func (c *unitCommand) Init(args []string) (err error) {
 }
 
 func (c *unitCommand) Run(ctx *cmd.Context) error {
-	client, err := c.newWatchAllAPIFunc()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	strategy := &Strategy{
-		Client:  client,
-		Timeout: c.timeout,
+		ClientFn: c.newWatchAllAPIFunc,
+		Timeout:  c.timeout,
 	}
-	err = strategy.Run(c.name, c.query, c.waitFor)
+	err := strategy.Run(c.name, c.query, c.waitFor)
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION
We need to ensure that we handle any issues when the agent bounces that
cause the API server to be pulled down and put back up. This is required
when we do a controller upgrade and that causes the agent to bounce and
then the API server.

If the API server doesn't come back up, then the only option is then to die.

## QA steps

We want to ensure that the query never completes, so we insert false to
force it to retry until the timeout occurs.

In one terminal:

```sh
$ juju bootstrap lxd test
$ juju wait-for model test -m controller --query="false" --debug
```

In another terminal

```sh
$ juju upgrade-controller --build-agent
```

Notice that the command retries to connect.
