### PR TITLE
Strict mode validation

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1364,7 +1364,7 @@ func (c *Config) Mode() ([]string, bool) {
 			// Let's be safe here, even though we have validated the type in
 			// a prior step, via the schema.List(schema.String()) type, I would
 			// rather see defensive code than a panic at runtime.
-			if str, ok := v.(string); !ok {
+			if str, ok := v.(string); ok {
 				s.Add(str)
 			}
 		}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1354,11 +1354,18 @@ func (c *Config) validateCharmHubURL() error {
 // Only three modes exist at the moment (strict or ""). Empty string
 // implies compatible mode.
 func (c *Config) Mode() ([]string, bool) {
-	if modes, ok := c.defined[ModeKey]; ok {
-		if m, ok := modes.([]string); ok {
-			return set.NewStrings(m...).SortedValues(), ok
-		}
+	modes, ok := c.defined[ModeKey]
+	if !ok {
+		return []string{}, false
 	}
+	if m, ok := modes.([]interface{}); ok {
+		s := set.NewStrings()
+		for _, v := range m {
+			s.Add(v.(string))
+		}
+		return s.SortedValues(), ok
+	}
+
 	return []string{}, false
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1351,7 +1351,7 @@ func (c *Config) validateCharmHubURL() error {
 }
 
 // Mode returns the mode type for the configuration.
-// Only three modes exist at the moment (strict or ""). Empty string
+// Only two modes exist at the moment (strict or ""). Empty string
 // implies compatible mode.
 func (c *Config) Mode() ([]string, bool) {
 	modes, ok := c.defined[ModeKey]
@@ -1361,7 +1361,12 @@ func (c *Config) Mode() ([]string, bool) {
 	if m, ok := modes.([]interface{}); ok {
 		s := set.NewStrings()
 		for _, v := range m {
-			s.Add(v.(string))
+			// Let's be safe here, even though we have validated the type in
+			// a prior step, via the schema.List(schema.String()) type, I would
+			// rather see defensive code than a panic at runtime.
+			if str, ok := v.(string); !ok {
+				s.Add(str)
+			}
 		}
 		return s.SortedValues(), ok
 	}

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1200,6 +1200,13 @@ func (s *ConfigSuite) TestMode(c *gc.C) {
 	mode, ok := config.Mode()
 	c.Assert(ok, jc.IsFalse)
 	c.Assert(mode, gc.DeepEquals, []string{})
+
+	config = newTestConfig(c, testing.Attrs{
+		"mode": []interface{}{"strict"},
+	})
+	mode, ok = config.Mode()
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(mode, gc.DeepEquals, []string{"strict"})
 }
 
 func (s *ConfigSuite) TestCharmHubURLSettingValue(c *gc.C) {

--- a/tests/suites/model/config.sh
+++ b/tests/suites/model/config.sh
@@ -6,12 +6,12 @@ run_model_config() {
     file="${TEST_DIR}/test-model-config.log"
     ensure "model-config" "${file}"
 
-    juju model-config mode=strict
+    juju model-config mode="[strict]"
     juju model-config mode | grep "strict"
-    juju model-config mode=""
-    juju model-config mode | wc -m | grep "0"
-    juju model-config mode="boom" || echo "ERROR" | grep "ERROR"
-
+    juju model-config mode="[]"
+    juju model-config mode | grep "\[\]"
+    juju model-config mode="[boom]" || echo "ERROR" | grep "ERROR"
+    juju model-config --reset mode
 
     destroy_model "model-config"
 }


### PR DESCRIPTION
Strict mode integration tests hadn't been updated when changed from CSV
to a schema.List(schema.String()). This fixed this but also spotted
that the validation was a bit wonky.

## QA steps

Ensure that the integration tests actually work!

```sh
cd tests && ./main.sh
```
