### PR TITLE
Update os series

### DIFF
--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -35,10 +35,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.ControllerSeries()
-	c.Assert(ctrlSeries, jc.SameContents, []string{"focal", "bionic", "trusty", "xenial"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.WorkloadSeries()
-	c.Assert(wrkSeries, jc.SameContents, []string{"bionic", "centos7", "centos8", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -51,10 +51,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.ControllerSeries()
-	c.Assert(ctrlSeries, jc.SameContents, []string{"bionic", "focal", "trusty", "xenial"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.WorkloadSeries()
-	c.Assert(wrkSeries, jc.SameContents, []string{"bionic", "centos7", "centos8", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -67,10 +67,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.ControllerSeries()
-	c.Assert(ctrlSeries, jc.SameContents, []string{"bionic", "focal", "trusty", "xenial"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.WorkloadSeries()
-	c.Assert(wrkSeries, jc.SameContents, []string{"bionic", "centos7", "centos8", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -83,10 +83,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.ControllerSeries()
-	c.Assert(ctrlSeries, jc.SameContents, []string{"bionic", "focal", "trusty", "xenial"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.WorkloadSeries()
-	c.Assert(wrkSeries, jc.SameContents, []string{"bionic", "centos7", "centos8", "focal", "genericlinux", "kubernetes", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func makeTempFile(c *gc.C, content string) (*os.File, func()) {

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20201009104722-9ea36b308caa
+	github.com/juju/os v0.0.0-20201029152849-68703c0e39a2
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,6 @@ github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
-github.com/juju/os v0.0.0-20201009104722-9ea36b308caa h1:2EaAdGJlb83txyv3wwJnSbsUyEEDkgO/4xlcRrTRa7A=
-github.com/juju/os v0.0.0-20201009104722-9ea36b308caa/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/os v0.0.0-20201029152849-68703c0e39a2 h1:bIQ+0f4YGosp1CU8YoOUARfX96s4ateTf3k2vcTB5Os=
 github.com/juju/os v0.0.0-20201029152849-68703c0e39a2/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=

--- a/go.sum
+++ b/go.sum
@@ -487,6 +487,8 @@ github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsy
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/os v0.0.0-20201009104722-9ea36b308caa h1:2EaAdGJlb83txyv3wwJnSbsUyEEDkgO/4xlcRrTRa7A=
 github.com/juju/os v0.0.0-20201009104722-9ea36b308caa/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
+github.com/juju/os v0.0.0-20201029152849-68703c0e39a2 h1:bIQ+0f4YGosp1CU8YoOUARfX96s4ateTf3k2vcTB5Os=
+github.com/juju/os v0.0.0-20201029152849-68703c0e39a2/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=


### PR DESCRIPTION
The following commit updates the default series to include groovy, it
drops support for all other series that are no longer supported (eoan)
and additionally brings the supported code inline with the juju/os
package.

## QA steps

The tests pass, we're interested in ensuring that we correctly handle the
series correctly when bootstrapping with in the tests.
