### PR TITLE
Patch host arch for override priority

### DIFF
--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1540,6 +1540,9 @@ func (s *bootstrapSuite) TestTargetArchOverride(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestTargetSeriesAndArchOverridePriority(c *gc.C) {
+	s.PatchValue(&arch.HostArch, func() string {
+		return arch.AMD64
+	})
 	env := newBootstrapEnvironWithHardwareDetection("foo", "haiku", "riscv", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{


### PR DESCRIPTION
The following ensures that we patch the Host Arch so when it falls back
on a different machine arch that isn't AMD64, it does actually pick up
the AMD64 constant and not the real host arch.

## QA steps

Test on another architecture.
