### PR TITLE
Patch arch in TestTargetSeriesAndArchOverridePriority test

### DIFF
--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1517,6 +1517,9 @@ func (s *bootstrapSuite) TestTargetArchOverride(c *gc.C) {
 }
 
 func (s *bootstrapSuite) TestTargetSeriesAndArchOverridePriority(c *gc.C) {
+	s.PatchValue(&arch.HostArch, func() string {
+		return arch.AMD64
+	})
 	env := newBootstrapEnvironWithHardwareDetection("foo", "haiku", "riscv", useDefaultKeys, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
 		s.callContext, bootstrap.BootstrapParams{


### PR DESCRIPTION
PR #12219 targetted develop branch. We want the fix for TestTargetSeriesAndArchOverridePriority on 2.8 as well. This PR simply copies the few lines across.

## QA steps

Run the unit test on a non amd64 arch.

