### PR TITLE
Fix test_mongo_memory_profile on focal (Mongo is installed via snap)

### DIFF
--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -1,6 +1,12 @@
 cat_mongo_service() {
-    # shellcheck disable=SC2046
-    echo $(juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service' | grep "^ExecStart")
+    if juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service'; then
+        # shellcheck disable=SC2046
+        echo $(juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service' | grep "^ExecStart")
+    else
+        # On focal and beyond we install Mongo via a snap
+        # shellcheck disable=SC2046
+        echo $(juju run -m controller --machine 0 'sudo cat /var/snap/juju-db/common/juju-db.config' | grep "wiredTigerCacheSizeGB")
+    fi
 }
 
 run_mongo_memory_profile() {


### PR DESCRIPTION
The test previously looked for the Mongo config change in the service file `/etc/systemd/system/juju-db.service`, but that doesn't exist on focal (where Mongo is installed via snap). Update to see if that file exists first (bionic), and if not try the snap config file (focal+).

This fixes the [`test-controller-lxd` tests on 2.9](https://jenkins.juju.canonical.com/job/test-controller-lxd/659/console) -- this error:

```
05:08:00 ==> RUN OUTPUT: test_controller
05:08:00     | 
05:08:00     | ====> Reusing bootstrapped juju (2.9:lxd-remote)
05:08:00     | 
05:08:00     | | Added 'mongo-memory-profile' model on lxd-remote/default with credential 'admin' for user 'admin'
05:08:00     | 
05:08:00     | ====> Bootstrapped juju (12s)
05:08:00     | cat: /etc/systemd/system/juju-db.service: No such file or directory
05:08:00     | Success: "wiredTigerCacheSizeGB" not found
05:08:00     | cat: /etc/systemd/system/juju-db.service: No such file or directory
05:08:00     | [+] (attempt 0) polling mongo service
05:08:00     | cat: /etc/systemd/system/juju-db.service: No such file or directory
```

Side note: IMO this test isn't great, because it just tests that the config file is updated, not that Mongo actually reloaded it and picked up the change. Ideally we'd query Mongo to determine whether the change had gone through. But leave that as is for now.
