### PR TITLE
Ignore i/o timeout error in WaitForAgentInitialisation;

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -115,6 +115,7 @@ func WaitForAgentInitialisation(
 		case errors.Cause(err) == io.EOF,
 			strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
 			strings.HasSuffix(errorMessage, "connection is shut down"),
+			strings.HasSuffix(errorMessage, "i/o timeout"),
 			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):
 			ctx.Verbosef("Still waiting for API to become available")


### PR DESCRIPTION

*In WaitForAgentInitialisation, Juju ignore i/o timeout error and continue to ping controller;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

This was found some of the CI test failure caused by GKE loadbalancer provision too slow;


## Documentation changes

No

## Bug reference

No
