### PR TITLE
Fix race in k8sagent/initialize tests

### DIFF
--- a/cmd/k8sagent/initialize/command.go
+++ b/cmd/k8sagent/initialize/command.go
@@ -133,7 +133,6 @@ func (c *initCommand) Run(ctx *cmd.Context) error {
 			} else if err != nil {
 				return errors.Annotatef(err, "copying %q to %q", src, dst)
 			}
-			ctx.Infof("copied %q to %q", src, dst)
 			return nil
 		})
 	}

--- a/cmd/k8sagent/initialize/command_test.go
+++ b/cmd/k8sagent/initialize/command_test.go
@@ -84,16 +84,18 @@ upgradedToVersion: 2.9-beta1
 apiaddresses:
 - localhost:17070
 apiport: 17070`[1:])
-	expectedBytes := []byte(`bytes bytes lots of bytes`)
+	expectedPebble := []byte(`PEBBLE`)
+	expectedK8sagent := []byte(`K8SAGENT`)
+	expectedJujuc := []byte(`JUJUC`)
 
 	pebbleWritten := bytes.NewBuffer(nil)
 	k8sAgentWritten := bytes.NewBuffer(nil)
 	jujucWritten := bytes.NewBuffer(nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedBytes)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedPebble)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/pebble", os.FileMode(0755)).Return(NopWriteCloser(pebbleWritten), nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/k8sagent").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedBytes)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/k8sagent").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedK8sagent)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/k8sagent", os.FileMode(0755)).Return(NopWriteCloser(k8sAgentWritten), nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedBytes)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedJujuc)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/jujuc", os.FileMode(0755)).Return(NopWriteCloser(jujucWritten), nil)
 
 	gomock.InOrder(
@@ -115,9 +117,9 @@ apiport: 17070`[1:])
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(pebbleWritten.Bytes(), jc.SameContents, expectedBytes)
-	c.Assert(k8sAgentWritten.Bytes(), jc.SameContents, expectedBytes)
-	c.Assert(jujucWritten.Bytes(), jc.SameContents, expectedBytes)
+	c.Assert(pebbleWritten.Bytes(), jc.SameContents, expectedPebble)
+	c.Assert(k8sAgentWritten.Bytes(), jc.SameContents, expectedK8sagent)
+	c.Assert(jujucWritten.Bytes(), jc.SameContents, expectedJujuc)
 }
 
 type nopWriterCloser struct {


### PR DESCRIPTION
The cmdtesting version of Context.Stderr is not concurrency-safe
because it's a plain old bytes.Buffer, so ctx.Infof (at least in
testing) is not concurrency-safe, and this was causing a data race
in bytes.Buffer.Write.

Per discussion, just "fix" by avoiding the log here (we didn't have it
before anyway).

Drive-by is updating the tests to use different byte strings for the
three different files. Initially I thought this may have been causing
it, but it's not. Seems safer/better anyway.
