### PR TITLE
Fix 1902319 using Application.SetConfig on Application v12.

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -378,7 +378,7 @@ func (c *configCommand) setConfig(client applicationAPI, ctx *cmd.Context) error
 			break
 		}
 		err = client.Set(c.applicationName, settings)
-	case ver < 12:
+	case ver < 13:
 		if settingsYAML != "" {
 			err = c.callUpdate(client, settingsYAML)
 			break


### PR DESCRIPTION
Incorrect API version selection for Application v12.

## QA steps

Use 2.9 client on a 2.8 controller with juju config command.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1902319
