### PR TITLE
Ensure Azure mirrors used for agent metadata

### DIFF
--- a/acceptancetests/jujupy/tests/test_status.py
+++ b/acceptancetests/jujupy/tests/test_status.py
@@ -627,7 +627,7 @@ class TestStatus(FakeHomeTestCase):
         self.assertEqual(e.state, failure)
 
     def test_check_agents_started_read_juju_status_error(self):
-        failures = ['no "centos7" images in us-east-1 with arches [amd64]',
+        failures = ['no metadata for "centos7" images in us-east-1 with arches [amd64]',
                     'sending new instance request: GCE operation ' +
                     '"operation-143" failed', '']
         for failure in failures:

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -209,21 +209,6 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithRegionOverride(c 
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)
 }
 
-func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithNoHasRegion(c *gc.C) {
-	ctx, err := runImageMetadata(c, s.store,
-		"-d", s.dir, "-c", "azure-controller", "-r", "region", "-u", "endpoint", "-i", "1234",
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	out := cmdtesting.Stdout(ctx)
-	expected := expectedMetadata{
-		series:   "raring",
-		arch:     "amd64",
-		region:   "region",
-		endpoint: "endpoint",
-	}
-	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)
-}
-
 type errTestParams struct {
 	args []string
 }
@@ -240,10 +225,6 @@ var errTests = []errTestParams{
 	{
 		// Missing endpoint
 		args: []string{"-i", "1234", "-u", "endpoint", "-a", "arch", "-s", "precise"},
-	},
-	{
-		// Missing endpoint/region for model with no HasRegion interface
-		args: []string{"-i", "1234", "-c", "azure-controller"},
 	},
 }
 

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/amz.v3/aws"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
@@ -75,7 +74,7 @@ func (s *ValidateImageMetadataSuite) TestUnsupportedProviderError(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `maas provider does not support image metadata validation`)
 }
 
-func (s *ValidateImageMetadataSuite) makeLocalMetadata(c *gc.C, id, region, series, endpoint, stream string) error {
+func (s *ValidateImageMetadataSuite) makeLocalMetadata(id, region, series, endpoint, stream string) error {
 	im := &imagemetadata.ImageMetadata{
 		Id:     id,
 		Arch:   "amd64",
@@ -141,55 +140,6 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclient.MemStore) {
 		CloudRegion:         "us-east-1",
 		CloudEndpoint:       "https://ec2.us-east-1.amazonaws.com",
 	}
-
-	azureUUID := utils.MustNewUUID().String()
-	azureConfig, err := config.New(config.UseDefaults, map[string]interface{}{
-		"name":                "azure",
-		"type":                "azure",
-		"controller-uuid":     coretesting.ControllerTag.Id(),
-		"uuid":                azureUUID,
-		"default-series":      "raring",
-		"resource-group-name": "rg",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	store.Controllers["azure-controller"] = jujuclient.ControllerDetails{
-		ControllerUUID: coretesting.ControllerTag.Id(),
-		CACert:         coretesting.CACert,
-	}
-	store.Models["azure-controller"] = &jujuclient.ControllerModels{
-		Models: map[string]jujuclient.ModelDetails{
-			"admin/azure": {
-				ModelType: model.IAAS,
-			},
-		},
-		CurrentModel: "admin/controller",
-	}
-	store.Accounts["azure-controller"] = jujuclient.AccountDetails{
-		User: "admin",
-	}
-	store.BootstrapConfig["azure-controller"] = jujuclient.BootstrapConfig{
-		ControllerConfig:     coretesting.FakeControllerConfig(),
-		ControllerModelUUID:  azureUUID,
-		Config:               azureConfig.AllAttrs(),
-		Cloud:                "azure",
-		CloudType:            "azure",
-		CloudRegion:          "West US",
-		CloudEndpoint:        "https://management.azure.com",
-		CloudStorageEndpoint: "https://core.windows.net",
-		Credential:           "default",
-	}
-	store.Credentials["azure"] = cloud.CloudCredential{
-		AuthCredentials: map[string]cloud.Credential{
-			"default": cloud.NewCredential(
-				"service-principal-secret",
-				map[string]string{
-					"application-id":       "application-id",
-					"subscription-id":      "subscription-id",
-					"application-password": "application-password",
-				},
-			),
-		},
-	}
 }
 
 func (s *ValidateImageMetadataSuite) SetUpTest(c *gc.C) {
@@ -214,7 +164,8 @@ func (s *ValidateImageMetadataSuite) setupEc2LocalMetadata(c *gc.C, region, stre
 		c.Fatalf("unknown ec2 region %q", region)
 	}
 	endpoint := ec2Region.EC2Endpoint
-	s.makeLocalMetadata(c, "1234", region, "precise", endpoint, stream)
+	err := s.makeLocalMetadata("1234", region, "precise", endpoint, stream)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ValidateImageMetadataSuite) assertEc2LocalMetadataUsingEnvironment(c *gc.C, stream string) {
@@ -275,7 +226,8 @@ func (s *ValidateImageMetadataSuite) TestEc2LocalMetadataNoMatch(c *gc.C) {
 }
 
 func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataWithManualParams(c *gc.C) {
-	s.makeLocalMetadata(c, "1234", "region-2", "raring", "some-auth-url", "")
+	err := s.makeLocalMetadata("1234", "region-2", "raring", "some-auth-url", "")
+	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := runValidateImageMetadata(c, s.store,
 		"-p", "openstack", "-s", "raring", "-r", "region-2",
 		"-u", "some-auth-url", "-d", s.metadataDir,
@@ -289,8 +241,9 @@ func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataWithManualParams(
 }
 
 func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataNoMatch(c *gc.C) {
-	s.makeLocalMetadata(c, "1234", "region-2", "raring", "some-auth-url", "")
-	_, err := runValidateImageMetadata(c, s.store,
+	err := s.makeLocalMetadata("1234", "region-2", "raring", "some-auth-url", "")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = runValidateImageMetadata(c, s.store,
 		"-p", "openstack", "-s", "precise", "-r", "region-2",
 		"-u", "some-auth-url", "-d", s.metadataDir,
 	)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -904,9 +904,6 @@ func bootstrapImageMetadata(
 	}
 
 	logger.Debugf("found %d image metadata from all image data sources", len(publicImageMetadata))
-	if len(publicImageMetadata) == 0 {
-		return nil, errors.New("no image metadata found")
-	}
 	return publicImageMetadata, nil
 }
 

--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/arch"
 
@@ -63,7 +64,7 @@ type InstanceSpec struct {
 func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanceTypes []InstanceType) (*InstanceSpec, error) {
 	logger.Debugf("instance constraints %+v", ic)
 	if len(possibleImages) == 0 {
-		return nil, fmt.Errorf("no %q images in %s with arches %s",
+		return nil, errors.Errorf("no metadata for %q images in %s with arches %s",
 			ic.Series, ic.Region, ic.Arches)
 	}
 

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -329,7 +329,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 	{
 		desc:   "no image exists in metadata",
 		region: "invalid-region",
-		err:    `no "precise" images in invalid-region with arches \[amd64 armhf\]`,
+		err:    `no metadata for "precise" images in invalid-region with arches \[amd64 armhf\]`,
 	},
 	{
 		desc:          "no valid instance types",

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -63,20 +63,6 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 	return toolsConstraint, nil
 }
 
-// HasAgentMirror is an optional interface that an Environ may
-// implement to support agent/tools mirror lookup.
-//
-// TODO(axw) 2016-04-11 #1568715
-// This exists only because we currently lack
-// image simplestreams usable by the new Azure
-// Resource Manager provider. When we have that,
-// we can use "HasRegion" everywhere.
-type HasAgentMirror interface {
-	// AgentMirror returns the CloudSpec to use for looking up agent
-	// binaries.
-	AgentMirror() (simplestreams.CloudSpec, error)
-}
-
 // FindTools returns a List containing all tools in the given stream, with a given
 // major.minor version number available in the cloud instance, filtered by filter.
 // If minorVersion = -1, then only majorVersion is considered.
@@ -87,10 +73,6 @@ func FindTools(env environs.BootstrapEnviron, majorVersion, minorVersion int, st
 	switch env := env.(type) {
 	case simplestreams.HasRegion:
 		if cloudSpec, err = env.Region(); err != nil {
-			return nil, err
-		}
-	case HasAgentMirror:
-		if cloudSpec, err = env.AgentMirror(); err != nil {
 			return nil, err
 		}
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -2046,16 +2046,10 @@ func (env *azureEnviron) getStorageAccountKeyLocked(accountName string, refresh 
 	return key, nil
 }
 
-// AgentMirror is specified in the tools.HasAgentMirror interface.
-//
-// TODO(axw) 2016-04-11 #1568715
-// When we have image simplestreams, we should rename this to "Region",
-// to implement simplestreams.HasRegion.
-func (env *azureEnviron) AgentMirror() (simplestreams.CloudSpec, error) {
+// Region is specified in the HasRegion interface.
+func (e *azureEnviron) Region() (simplestreams.CloudSpec, error) {
 	return simplestreams.CloudSpec{
-		Region: env.location,
-		// The endpoints published in simplestreams
-		// data are the storage endpoints.
-		Endpoint: fmt.Sprintf("https://%s/", env.storageEndpoint),
+		Region:   e.cloud.Region,
+		Endpoint: e.cloud.Endpoint,
 	}, nil
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/environs/tags"
 	envtesting "github.com/juju/juju/environs/testing"
-	envtools "github.com/juju/juju/environs/tools"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
@@ -1750,14 +1749,14 @@ func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {
 	return validator
 }
 
-func (s *environSuite) TestAgentMirror(c *gc.C) {
+func (s *environSuite) TestHasRegion(c *gc.C) {
 	env := s.openEnviron(c)
-	c.Assert(env, gc.Implements, new(envtools.HasAgentMirror))
-	cloudSpec, err := env.(envtools.HasAgentMirror).AgentMirror()
+	c.Assert(env, gc.Implements, new(simplestreams.HasRegion))
+	cloudSpec, err := env.(simplestreams.HasRegion).Region()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, gc.Equals, simplestreams.CloudSpec{
 		Region:   "westus",
-		Endpoint: "https://storage.azurestack.local/",
+		Endpoint: "https://api.azurestack.local",
 	})
 }
 

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -284,7 +284,7 @@ var findInstanceSpecErrorTests = []struct {
 	{
 		series: series.DefaultSupportedLTS(),
 		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, series.DefaultSupportedLTS()),
+		err:    fmt.Sprintf(`no metadata for "%s" images in test with arches \[arm\]`, series.DefaultSupportedLTS()),
 	}, {
 		series: "raring",
 		arches: []string{"amd64", "i386"},

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -371,7 +371,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	env := s.Prepare(c)
 	// An error occurs if no suitable image is found.
 	_, err := joyent.FindInstanceSpec(env, "saucy", "amd64", "mem=4G", nil)
-	c.Assert(err, gc.ErrorMatches, `no "saucy" images in some-region with arches \[amd64\]`)
+	c.Assert(err, gc.ErrorMatches, `no metadata for "saucy" images in some-region with arches \[amd64\]`)
 }
 
 func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1449,7 +1449,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 
 	// An error occurs if no suitable image is found.
 	_, err := openstack.FindInstanceSpec(env, "saucy", "amd64", "mem=1G", nil)
-	c.Assert(err, gc.ErrorMatches, `no "saucy" images in some-region with arches \[amd64\]`)
+	c.Assert(err, gc.ErrorMatches, `no metadata for "saucy" images in some-region with arches \[amd64\]`)
 }
 
 func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {


### PR DESCRIPTION
When bootstrapping on Azure, ensure the local mirrors are used for agent metadata and binaries.

The Azure cpc mirror metadata now uses the proper cloud endpoint instead of the now obsolete storage endpoint, however, out of date cloud images Azure metadata is still published to [cloud-images.canonical.com](https://cloud-images.ubuntu.com/releases/streams/v1). This meant that in this PR, updating the Azure set up to use the correct endpoint to look up agents breaks image metadata lookup.

So the PR also includes a fix so that not having public cloud metadata is not fatal to bootstrap at that point - the error is still raised, but at a slightly later stage and also now with more context instead of a generic message. ie instead of 
`no image metadata found`
it says
`no metadata for "focal" images in ap-southeast-2 with arches [amd64]`

## QA steps

juju bootstrap azure --show-log

Look for a line like below, which shows agent binary comes from the blobstore mirror.
```
11:18:24 INFO  juju.cloudconfig userdatacfg_unix.go:573 Fetching agent: curl -sSfw 'agent binaries from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s ' --retry 10 -o $bin/tools.tar.gz <[https://jujuagents.blob.core.windows.net/juju-agents/agents/agent/2.9-rc1/juju-2.9-rc1-ubuntu-amd64.tgz]>
```
