### PR TITLE
Improve upgrade-model error message with permission error

### DIFF
--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -444,14 +444,20 @@ func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowe
 	}
 
 	controllerModelConfig, err := controllerClient.ModelConfig()
-	if err != nil {
+	if err != nil && !params.IsCodeUnauthorized(err) {
 		return err
 	}
-	isControllerModel := cfg.UUID() == controllerModelConfig[config.UUIDKey]
-	if c.BuildAgent && !isControllerModel {
+	haveControllerModelPermission := err == nil
+	isControllerModel := haveControllerModelPermission && cfg.UUID() == controllerModelConfig[config.UUIDKey]
+	if c.BuildAgent {
 		// For UploadTools, model must be the "controller" model,
 		// that is, modelUUID == controllerUUID
-		return errors.Errorf("--build-agent can only be used with the controller model")
+		if !haveControllerModelPermission {
+			return errors.New("--build-agent can only be used with the controller model but you don't have permission to access that model")
+		}
+		if !isControllerModel {
+			return errors.Errorf("--build-agent can only be used with the controller model")
+		}
 	}
 	controllerCfg, err := controllerClient.ControllerConfig()
 	if err != nil {


### PR DESCRIPTION
When running upgrade-model with --build-agent, a check is done to see if the model being upgraded is the controller model.
But if the user is upgrading a different model they do have access to, but they don't have access to the controller model, the error message "permission denied" is not helpful.


## QA steps

bootstrap and create a user and give that user access to a model (not the controller model)
As that user, run juju upgrade-model --build-agent
Check the error message
ERROR --build-agent can only be used with the controller model but you don't have permission to access that model
