### PR TITLE
Remove lease store Refresh method

### DIFF
--- a/core/lease/store.go
+++ b/core/lease/store.go
@@ -43,9 +43,6 @@ type Store interface {
 	// are many models.
 	LeaseGroup(namespace, modelUUID string) map[Key]Info
 
-	// Refresh reads all lease state from the database.
-	Refresh() error
-
 	// Pin ensures that the current holder of the lease for the input key will
 	// not lose the lease to expiry.
 	// If there is no current holder of the lease, the next claimant will be

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -163,11 +163,6 @@ func (s *Store) addTrapdoors(leaseMap map[lease.Key]lease.Info) {
 	}
 }
 
-// Refresh is part of lease.Store.
-func (s *Store) Refresh() error {
-	return nil
-}
-
 // PinLease is part of lease.Store.
 func (s *Store) PinLease(key lease.Key, entity string, stop <-chan struct{}) error {
 	return errors.Trace(s.pinOp(OperationPin, key, entity, stop))

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -143,11 +143,6 @@ func (s *leaseStore) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease
 	return results
 }
 
-// Refresh is part of lease.Store.
-func (s *leaseStore) Refresh() error {
-	return nil
-}
-
 // PinLease is part of lease.Store.
 func (s *leaseStore) PinLease(key lease.Key, entity string, _ <-chan struct{}) error {
 	return errors.NotImplementedf("lease pinning")

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -135,9 +135,6 @@ func (s *CrossSuite) testChecks(c *gc.C, lease1, lease2 corelease.Key) {
 				Trapdoor: corelease.LockedTrapdoor,
 			},
 		},
-		expectCalls: []call{{
-			method: "Refresh",
-		}},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		checker1, err := manager.Checker(lease1.Namespace, lease1.ModelUUID)

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -148,25 +148,22 @@ func (s *ValidationSuite) TestToken_HolderName(c *gc.C) {
 	})
 }
 
-func (s *ValidationSuite) TestToken_OutPtr(c *gc.C) {
+func (s *ValidationSuite) TestTokenOutPtr(c *gc.C) {
 	expectKey := "bad"
 	expectErr := errors.New("bad")
 
 	fix := &Fixture{
-		expectCalls: []call{{
-			method: "Refresh",
-			callback: func(leases map[corelease.Key]corelease.Info) {
-				leases[key("redis")] = corelease.Info{
-					Holder: "redis/0",
-					Expiry: offset(time.Second),
-					Trapdoor: func(attempt int, gotKey interface{}) error {
-						c.Check(attempt, gc.Equals, 27)
-						c.Check(gotKey, gc.Equals, &expectKey)
-						return expectErr
-					},
-				}
+		leases: map[corelease.Key]corelease.Info{
+			key("redis"): {
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+				Trapdoor: func(attempt int, gotKey interface{}) error {
+					c.Check(attempt, gc.Equals, 27)
+					c.Check(gotKey, gc.Equals, &expectKey)
+					return expectErr
+				},
 			},
-		}},
+		},
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")

--- a/worker/lease/util_test.go
+++ b/worker/lease/util_test.go
@@ -214,11 +214,6 @@ func (store *Store) RevokeLease(lease lease.Key, holder string, stop <-chan stru
 	return store.call("RevokeLease", []interface{}{lease, holder})
 }
 
-// Refresh is part of the lease.Store interface.
-func (store *Store) Refresh() error {
-	return store.call("Refresh", nil)
-}
-
 // PinLease is part of the corelease.Store interface.
 func (store *Store) PinLease(key lease.Key, entity string, stop <-chan struct{}) error {
 	return store.call("PinLease", []interface{}{key, entity})


### PR DESCRIPTION
The lease store indirection had a `Refresh` method, which was a no-op for the Raft implementation.

The lease manager called this method when a check was made for a lease not held by the caller, then retried the check subsequently.

Now that we no longer have the legacy lease implementation, we can remove the `Refresh` method and the double invocation of check logic.

Test scenarios are removed where they relied on a call to `Refresh` without an associated change in lease store data. Where lease store change simulating synchronisation is required, this is just done directly.

## QA steps

There is no functional change here. 

Regression can be tested for by:
- Deploying some workload charms.
- Enabling HA.
- Checking that each application has single leader unit.

## Documentation changes

None.

## Bug reference

N/A
