### PR TITLE
Charmhub download integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,131 @@
-[![Juju logo](doc/juju-logo.png?raw=true)](https://jujucharms.com/)
+[![Juju logo](doc/juju-logo.png?raw=true)](https://juju.is/)
 
-Simple, secure and stable devops tooling. 
-Juju keeps complexity low and productivity high. 
-Built to manage today’s complex application architectures wherever they are run.
- 
-Built for
-- SRE and operations teams
-- Developers
-- Data engineers
+[Juju is a model-driven **Operator Lifecycle Manager**
+(OLM)](https://juju.is/overview). Juju greatly improves the experience of
+running Kubernetes operators, especially in projects that integrate many
+operators from different publishers.
 
-Excels at
-- Making your deployment understandable 
-- Simplifying post-install operations, such as upgrades, updates and configuration management
-- Managing hybrid-cloud services, whether on Kubernetes, VMs, bare metal or any combination
+## Why Juju
 
-## Why Juju?
+A Kubernetes operator is [a container that drives the config and operation
+of a workload](https://charmhub.io/about). By encapsulating ops code as a
+reusable container, the operator pattern moves [beyond traditional config
+management](https://juju.is/beyond-configuration-management) to allow much
+more agile operations for complex cloud workloads.
 
-Juju increases your productivity and decreases your costs.
+Shared, open source operators **take infra as code to the next level** with
+community-driven ops and integration code. Reuse of ops code [improves
+quality](https://juju.is/ops-code-quality) and encourages wider community
+engagement and contribution. Operators also improve security through
+consistent automation. Juju operators are a [community-driven
+devsecops](https://juju.is/devsecops) approach to open source operations.
 
-- **Increase confidence**  
- If you have ever put off upgrading something in production because something might break, then consider Juju.
- Juju allows applications to automatically negotiate their configuration, creating optimal settings dynamically.
+Juju implements the Kubernetes operator pattern, but is also a **universal
+OLM** that extends the operator pattern to traditional applications (without
+Kubernetes) on Linux and Windows. Such machine operators can work on bare
+metal, virtual machines or cloud instances, enabling [multi cloud and hybrid
+cloud operations](https://juju.is/multi-cloud-operations). Juju allows you
+to embrace the operator pattern on [both container and legacy
+estate](https://juju.is/universal-operators). An operator for machine-based
+environments can share 95% of its code with a Kubernetes operator for the
+same app.
 
+**Juju excels at application integration**. Instead of simply focusing on
+lifecycle management, the Juju OLM provides a [rich application graph
+model](https://juju.is/model-driven-operations) that tells operators how to
+integrate with one another. This dramatically simplifies the operations of
+large deployments.
 
-- **Reduce complexity**  
- Microservices have made applications simpler, but operations more complex.
- Regain your understanding of the whole stack.
+A key focus for Juju is to **simplify operator design, development and
+usage**.  Instead of making very complex operators for specific scenarios,
+Juju encourages devops to make composable operators, each of which drives a
+single Docker image, and which can be reused in different settings.
+[Composable operators](https://juju.is/integration) enable very rich
+scenarios to be constructed out of simpler **operators that do one thing and
+do it well**.
 
+The OLM provides a central mechanism for operator instantiation,
+configuration, upgrades, integration and administration. The OLM provides a
+range of [operator lifecycle services](https://juju.is/operator-services)
+including leader election and persistent state. Instead of manually
+deploying and configuring operators, the OLM manages all the operators in a
+model at the direction of the administrator.
 
-- **Strengthen operations knowledge**  
- Everyone has their in-house expert.
- Encapsulating their know-how in charms distributes that knowledge throughout the business.
+## Open Operator Collection
 
+A world's [largest collection of operators](https://charmhub.io/) all use
+Juju as their OLM. The Charmhub community emphasizes quality, collaboration
+and consistency. Publish your own operator and share integration code for
+other operators to connect to your application.
 
-- **Simplify day two and beyond**  
- Upgrades, provisioning new capacity, applying configuration changes can be subtle and difficult.
- Juju takes responsibility for them, as well as deployment.
+The [Open Operator Manifesto](https://charmhub.io/manifesto) outlines the
+values of the community and describe the ideal behaviour of operators, to
+shape contributions and discussions.
 
+## Multi cloud and hybrid operations across ARM and x86 infrastructure
 
- - **Maintain portability and repeatability**  
- Retain control over your deployment and eliminate the need for vendor-specific offerings.
- Your devops tooling should be cloud-agnostic and Kubernetes-aware.
+The Juju OLM supports AWS, Azure, Google, Oracle, OpenStack, VMware and bare
+metal machines, as well as any conformant Kubernetes cluster. Integrate
+operators across clouds, and across machines and containers, just as easily.
+A single scenario can include applications on Kubernetes, as well as
+applications on a range of clouds and bare metal instances, all integrated
+automatically.
 
+Juju operators support multiple CPU architectures. Connect applications on
+ARM with applications on x86 and take advantage of silicon-specific
+optimisations. It is good practice for operators to adapt to their
+environment and accelerate workloads accordingly.
+
+## Pure Python operators
+
+The [Python Operator Framework](https://pythonoperatorframework.io/) makes
+it easy to write an operator. The framework handles all the details of
+communication between integrated operators, so you can focus on your own
+[application lifecycle
+management](https://juju.is/operator-lifecycle-manager).
+
+Code sharing between operator publishers is simplified making it much faster
+to collaborate on distributed systems involving components from many
+different publishers and upstreams. Your operator is a Python event handler.
+Lifecycle management, configuration and integration are all events delivered
+to your charm by the framework.
+
+## Architecture
+
+The Juju [client, server and agent](https://juju.is/architecture) are all
+written in Golang. The standard Juju packaging includes an embedded database
+for centralised logging and persistence, but there is no need to manage that
+database separately.
+
+Operators can be written in any language but we do encourage new authors to
+use the Python Operator Framework for ease of contribution, support and
+community participation.
+
+## Production grade
+
+The Juju server has built-in support for [high
+availability](https://juju.is/high-availability-enterprise-olm) when scaled
+out to three instances. It can monitor itself and grow additional instances
+in the event of failure, within predetermined limits. Juju supports backup,
+restore, and rolling upgrade operations appropriate for large-scale
+centralised enterprise grade management and operations systems.
 
 ## Get started
 
-[Install Juju][] and [get started][] with your first project.
+Our community hangs out at the [Charmhub
+discourse](https://discourse.juju.is/) which serves as a combination mailing
+list and web forum. Keep up with the news and get a feel for operator
+engineering and usage there. Get  the Juju CLI on Windows, macOS or Linux
+with the [install instructions](https://juju.is/docs/installing) and [try
+the tutorials](https://juju.is/docs/tutorials). All you need is a small K8s
+cluster, or an Ubuntu machine or VM to run MicroK8s.
 
-Read the [project’s documentation](https://jaas.ai/docs).
+Read the [documentation](https://juju.is/docs) for a comprehensive reference
+of commands and usage.
 
-Explore questions and conversations on our [Discourse forum](https://discourse.jujucharms.com/).
+## Contributing
 
-Developers are welcome to read through our [contributing guidelines](CONTRIBUTING.md) to learn how to make code changes.
-
-File bugs at our project [Launchpad](https://bugs.launchpad.net/juju/+filebug) site
-
-Find out more, get help or ask questions on our [Freenode IRC channel](https://webchat.freenode.net/#juju).
-
-  [Install Juju]: https://jaas.ai/docs/install
-  [get started]: https://jaas.ai/docs/getting-started
+Follow our [code and contribution guidelines](CONTRIBUTING.md) to learn how
+to make code changes. File bugs in
+[Launchpad](https://bugs.launchpad.net/juju/+filebug) or ask questions on
+our [Freenode IRC channel](https://webchat.freenode.net/#juju).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ model at the direction of the administrator.
 
 ## Open Operator Collection
 
-A world's [largest collection of operators](https://charmhub.io/) all use
+The world's [largest collection of operators](https://charmhub.io/) all use
 Juju as their OLM. The Charmhub community emphasizes quality, collaboration
 and consistency. Publish your own operator and share integration code for
 other operators to connect to your application.

--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -1,0 +1,55 @@
+run_charmhub_download() {
+    echo
+    name="charmhub-download"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    output=$(juju download mysql - 2>&1 > "${TEST_DIR}/mysql.charm" || true)
+    check_contains "${output}" "Fetching charm \"mysql\""
+
+    juju deploy "${TEST_DIR}/mysql.charm" mysql
+    juju wait-for application mysql
+}
+
+run_charmstore_download() {
+    echo
+    name="charmstore-download"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    output=$(juju download cs:meshuggah 2>&1 || echo "not found")
+    check_contains "${output}" "\"cs:meshuggah\" is not a Charm Hub charm"
+}
+
+run_unknown_download() {
+    echo
+    name="unknown-download"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    output=$(juju download meshuggah 2>&1 || echo "not found")
+    check_contains "${output}" "No charm or bundle with name"
+}
+
+test_charmhub_download() {
+      if [ "$(skip 'test_charmhub_download')" ]; then
+        echo "==> TEST SKIPPED: Charm Hub download"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_charmhub_download"
+        run "run_charmstore_download"
+        run "run_unknown_download"
+    )
+}

--- a/tests/suites/charmhub/task.sh
+++ b/tests/suites/charmhub/task.sh
@@ -15,6 +15,7 @@ test_charmhub() {
 
     bootstrap "test-charmhub" "${file}"
 
+    test_charmhub_download
     test_charmhub_find
 
     destroy_controller "test-charmhub"


### PR DESCRIPTION
The following adds an integration test for downloading a charm and then
deploying. The test fails because there is an error in the underlying
charmhub.

## Please provide the following details to expedite review (and delete this heading)

*Replace with a description about why this change is needed, along with a description of what changed.*

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
