### PR TITLE
Juju plugin check

### DIFF
--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -15,6 +15,23 @@ check_dependencies() {
     fi
 }
 
+check_juju_dependencies() {
+    local dep missing
+    missing=""
+
+    for dep in "$@"; do
+        if ! juju "$dep" >/dev/null 2>&1; then
+            [ "$missing" ] && missing="$missing $dep" || missing="$dep"
+        fi
+    done
+
+    if [ "$missing" ]; then
+        echo "Missing dependencies: $missing" >&2
+        echo ""
+        exit 1
+    fi
+}
+
 check_not_contains() {
     local input value chk
 

--- a/tests/suites/upgrade/task.sh
+++ b/tests/suites/upgrade/task.sh
@@ -7,7 +7,8 @@ test_upgrade() {
     set_verbosity
 
     echo "==> Checking for dependencies"
-    check_dependencies juju jujud juju-metadata python
+    check_dependencies juju jujud python3
+    check_juju_dependencies metadata
 
     test_upgrade_simplestream
 }


### PR DESCRIPTION
If using snaps then juju-metadata won't exist, instead it will have sort
of forwarding from juju to juju metadata and so the which check won't
work.

Interestingly I'm surprised this even works with plugins as it expects
things to be on a given path.

## QA steps

```sh
(cd tests && ./main.sh upgrade)
```

## Bug reference

Additional work, but doesn't fix https://bugs.launchpad.net/juju/+bug/1899786