### PR TITLE
Fix data race in model cache

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -139,15 +139,10 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// If this is the first receipt of details, set the removal message.
-	if a.removalMessage == nil {
-		a.removalMessage = RemoveApplication{
-			ModelUUID: details.ModelUUID,
-			Name:      details.Name,
-		}
-	}
-
-	a.setStale(false)
+	a.setRemovalMessage(RemoveApplication{
+		ModelUUID: details.ModelUUID,
+		Name:      details.Name,
+	})
 
 	if a.details.CharmURL != details.CharmURL {
 		a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -81,15 +81,10 @@ func (b *Branch) CompletedBy() string {
 }
 
 func (b *Branch) setDetails(details BranchChange) {
-	// If this is the first receipt of details, set the removal message.
-	if b.removalMessage == nil {
-		b.removalMessage = RemoveBranch{
-			ModelUUID: details.ModelUUID,
-			Id:        details.Id,
-		}
-	}
-
-	b.setStale(false)
+	b.setRemovalMessage(RemoveBranch{
+		ModelUUID: details.ModelUUID,
+		Id:        details.Id,
+	})
 
 	b.details = details
 	b.hub.Publish(branchChange, b.copy())

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -42,15 +42,11 @@ func (c *Charm) DefaultConfig() map[string]interface{} {
 }
 
 func (c *Charm) setDetails(details CharmChange) {
-	// If this is the first receipt of details, set the removal message.
-	if c.removalMessage == nil {
-		c.removalMessage = RemoveCharm{
-			ModelUUID: details.ModelUUID,
-			CharmURL:  details.CharmURL,
-		}
-	}
+	c.setRemovalMessage(RemoveCharm{
+		ModelUUID: details.ModelUUID,
+		CharmURL:  details.CharmURL,
+	})
 
-	c.setStale(false)
 	c.details = details
 }
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -160,15 +160,10 @@ func (m *Machine) containerRegexp() (*regexp.Regexp, error) {
 }
 
 func (m *Machine) setDetails(details MachineChange) {
-	// If this is the first receipt of details, set the removal message.
-	if m.removalMessage == nil {
-		m.removalMessage = RemoveMachine{
-			ModelUUID: details.ModelUUID,
-			Id:        details.Id,
-		}
-	}
-
-	m.setStale(false)
+	m.setRemovalMessage(RemoveMachine{
+		ModelUUID: details.ModelUUID,
+		Id:        details.Id,
+	})
 
 	provisioned := details.InstanceId != m.details.InstanceId
 	m.details = details

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -560,14 +560,9 @@ func (m *Model) removeBranch(ch RemoveBranch) error {
 func (m *Model) setDetails(details ModelChange) {
 	m.mu.Lock()
 
-	// If this is the first receipt of details, set the removal message.
-	if m.removalMessage == nil {
-		m.removalMessage = RemoveModel{
-			ModelUUID: details.ModelUUID,
-		}
-	}
-
-	m.setStale(false)
+	m.setRemovalMessage(RemoveModel{
+		ModelUUID: details.ModelUUID,
+	})
 	m.details = details
 
 	hashCache, configHash := newHashCache(details.Config, m.metrics.ModelHashCacheHit, m.metrics.ModelHashCacheMiss)

--- a/core/cache/relation.go
+++ b/core/cache/relation.go
@@ -35,15 +35,10 @@ func (r *Relation) Endpoints() []Endpoint {
 }
 
 func (r *Relation) setDetails(details RelationChange) {
-	// If this is the first receipt of details, set the removal message.
-	if r.removalMessage == nil {
-		r.removalMessage = RemoveRelation{
-			ModelUUID: details.ModelUUID,
-			Key:       details.Key,
-		}
-	}
-
-	r.setStale(false)
+	r.setRemovalMessage(RemoveRelation{
+		ModelUUID: details.ModelUUID,
+		Key:       details.Key,
+	})
 }
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -183,17 +183,14 @@ func (u *Unit) WatchConfigSettings() (*CharmConfigWatcher, error) {
 func (u *Unit) setDetails(details UnitChange) {
 	var newSubordinate bool
 
-	// If this is the first receipt of details, set the removal message.
-	if u.removalMessage == nil {
-		u.removalMessage = RemoveUnit{
-			ModelUUID: details.ModelUUID,
-			Name:      details.Name,
-		}
-
+	if u.setRemovalMessage(RemoveUnit{
+		ModelUUID: details.ModelUUID,
+		Name:      details.Name,
+	}) {
+		// First receipt of the details so we
+		// may have a new subordinate also.
 		newSubordinate = details.Subordinate
 	}
-
-	u.setStale(false)
 
 	landingOnMachine := u.details.MachineId != details.MachineId
 	u.details = details


### PR DESCRIPTION
As seen here

https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-race-arm64/7/testReport/junit/github/com_juju_juju_core_cache/TestPackage/

There's concurrent access to the removal message when recording changes and doing a sweep operation.
Refactor access to the removal message and stale attribute to avoid the race.

## QA steps

go test --race

