### PR TITLE
update network integration test for focal and 2.9

### DIFF
--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -7,25 +7,28 @@ run_network_health() {
 
     # Deploy some applications for different series.
     juju deploy mongodb --series xenial
-    juju deploy ubuntu -n 2 --series bionic
+    juju deploy ubuntu ubuntu-bionic --series bionic
+    juju deploy ubuntu ubuntu-focal --series focal
 
     # Now the testing charm for each series.
-    # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
-    juju deploy '~juju-qa/network-health' network-health-xenial --series xenial
-    juju deploy '~juju-qa/network-health' network-health-bionic --series bionic
+    juju deploy 'cs:~juju-qa/network-health' network-health-xenial --series xenial
+    juju deploy 'cs:~juju-qa/network-health' network-health-bionic --series bionic
+    juju deploy 'cs:~juju-qa/network-health' network-health-focal --series focal
 
     juju expose network-health-xenial
     juju expose network-health-bionic
+    juju expose network-health-focal
 
     juju add-relation network-health-xenial mongodb
-    juju add-relation network-health-bionic ubuntu
+    juju add-relation network-health-bionic ubuntu-bionic
+    juju add-relation network-health-focal ubuntu-focal
 
     wait_for "mongodb" "$(idle_condition "mongodb")"
-    wait_for "ubuntu" "$(idle_condition "ubuntu" 3 0)"
-    wait_for "ubuntu" "$(idle_condition "ubuntu" 3 1)"
+    wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 4)"
+    wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 5)"
     wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "mongodb")"
-    wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu" 0)"
-    wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu" 1)"
+    wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu-bionic")"
+    wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "ubuntu-focal")"
 
     check_default_routes
     check_accessibility
@@ -48,13 +51,13 @@ check_default_routes() {
 check_accessibility() {
     echo "[+] checking neighbour connectivity and external access"
 
-    for net_health_unit in "network-health-xenial/0" "network-health-bionic/0"  "network-health-bionic/1"; do
+    for net_health_unit in "network-health-xenial/0" "network-health-bionic/0"  "network-health-focal/0"; do
         ip="$(juju show-unit $net_health_unit --format json | jq -r ".[\"$net_health_unit\"] | .[\"public-address\"]")"
 
         curl_cmd="curl 2>/dev/null ${ip}:8039"
 
         # Check that each of the principles can access the subordinate.
-        for principle_unit in "mongodb/0" "ubuntu/0" "ubuntu/1"; do
+        for principle_unit in "mongodb/0" "ubuntu-bionic/0" "ubuntu-focal/0"; do
             check_contains "$(juju run --unit $principle_unit "$curl_cmd")" "pass"
         done
 


### PR DESCRIPTION
Update test to use focal and cs: prefix now required by juju 2.9.

## QA steps

```sh
(cd tests ; ./main.sh network)
```

