### PR TITLE
No discharge interactor for embedded commands

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -317,6 +317,7 @@ func (c *CommandBase) NewAPIConnectionParams(
 	return newAPIConnectionParams(
 		store, controllerName, modelName,
 		accountDetails,
+		c.Embedded,
 		bakeryClient,
 		c.apiOpen,
 		getPassword,
@@ -452,6 +453,7 @@ func (c *CommandBase) getAPIContext(store jujuclient.CookieStore, controllerName
 	if controllerName == "" {
 		return nil, errors.New("cannot get API context from empty controller name")
 	}
+	c.authOpts.Embedded = c.Embedded
 	ctx, err := newAPIContext(c.cmdContext, &c.authOpts, store, controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -534,6 +536,7 @@ func newAPIConnectionParams(
 	controllerName,
 	modelName string,
 	accountDetails *jujuclient.AccountDetails,
+	embedded bool,
 	bakery *httpbakery.Client,
 	apiOpen api.OpenFunc,
 	getPassword func(string) (string, error),
@@ -553,7 +556,7 @@ func newAPIConnectionParams(
 	dialOpts.BakeryClient = bakery
 
 	// Embedded clients with macaroons cannot discharge.
-	if accountDetails != nil && len(accountDetails.Macaroons) == 0 {
+	if accountDetails != nil && !embedded {
 		bakery.InteractionMethods = []httpbakery.Interactor{
 			authentication.NewInteractor(accountDetails.User, getPassword),
 			httpbakery.WebBrowserInteractor{},

--- a/cmd/modelcmd/export_test.go
+++ b/cmd/modelcmd/export_test.go
@@ -5,11 +5,16 @@ package modelcmd
 
 import (
 	"github.com/juju/cmd"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/juju/juju/jujuclient"
 )
 
 var NewAPIContext = newAPIContext
+
+func Interactor(ctx *apiContext) httpbakery.Interactor {
+	return ctx.interactor
+}
 
 func SetRunStarted(b interface {
 	setRunStarted()


### PR DESCRIPTION
When running embedded commands, ensure the macaroon discharge interactor on the http bakery client is nil.
We don't support prompting for passwords etc for embedded commands. GUI testing with bad macaroons resulted in juju controller logging the discharge errors and trying to wait for web based auth which never could occur.

## QA steps

bootstrap controller
add-user
as that user, ensure juju cli works as before, including logout, login

Using test cli tool
https://gist.github.com/wallyworld/4e8de75d5a439bd511e27d9bf5046c31

as the user above, logout and attempt to run juju status

ERROR cannot get discharge from "https://localhost:17070/auth": invalid macaroon for "bob"

