### PR TITLE
deploy_centos integration test

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -511,12 +511,12 @@ def deploy_job():
     if not args.logs:
         args.logs = generate_default_clean_dir(args.temp_env_name)
     if series is None:
-        series = 'precise'
+        series = 'bionic'
     charm_series = series
     # Don't need windows or centos state servers.
     if series.startswith("win") or series.startswith("centos"):
-        logging.info('Setting default series to trusty for win and centos.')
-        series = 'trusty'
+        logging.info('Setting default series to bionic for win and centos.')
+        series = 'bionic'
     return _deploy_job(args, charm_series, series)
 
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -46,6 +46,9 @@ bootstrap() {
         "aws")
             provider="aws"
             ;;
+        "ec2")
+            provider="aws"
+            ;;
         "localhost")
             provider="lxd"
             ;;

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -43,14 +43,10 @@ ensure() {
 bootstrap() {
     local provider name output model bootstrapped_name
     case "${BOOTSTRAP_PROVIDER:-}" in
-        "aws")
-            ;&
-        "ec2")
+        "aws" | "ec2")
             provider="aws"
             ;;
-        "localhost")
-            ;&
-        "lxd")
+        "localhost" | "lxd")
             provider="lxd"
             ;;
         "lxd-remote")

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -44,14 +44,12 @@ bootstrap() {
     local provider name output model bootstrapped_name
     case "${BOOTSTRAP_PROVIDER:-}" in
         "aws")
-            provider="aws"
-            ;;
+            ;&
         "ec2")
             provider="aws"
             ;;
         "localhost")
-            provider="lxd"
-            ;;
+            ;&
         "lxd")
             provider="lxd"
             ;;

--- a/tests/suites/deploy/charms/centos-dummy-sink/README
+++ b/tests/suites/deploy/charms/centos-dummy-sink/README
@@ -1,0 +1,1 @@
+CentOS version of basic dummy-sink testing charm.

--- a/tests/suites/deploy/charms/centos-dummy-sink/config.yaml
+++ b/tests/suites/deploy/charms/centos-dummy-sink/config.yaml
@@ -1,0 +1,5 @@
+options:
+  token:
+    type: string
+    default: ''
+    description: Token used to prove that the relation is working

--- a/tests/suites/deploy/charms/centos-dummy-sink/copyright
+++ b/tests/suites/deploy/charms/centos-dummy-sink/copyright
@@ -1,0 +1,1 @@
+Copyright 2014 Canonical Ltd.

--- a/tests/suites/deploy/charms/centos-dummy-sink/hooks/source-relation-changed
+++ b/tests/suites/deploy/charms/centos-dummy-sink/hooks/source-relation-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /var/run/dummy-sink
+relation-get token > /var/run/dummy-sink/token

--- a/tests/suites/deploy/charms/centos-dummy-sink/metadata.yaml
+++ b/tests/suites/deploy/charms/centos-dummy-sink/metadata.yaml
@@ -1,0 +1,13 @@
+name: dummy-sink
+maintainer: Martin Packman <martin.packman@canonical.com>
+summary: Dummy charm that accepts data
+description: |
+  This dummy charm is used to verify that a relationship is created correctly
+provides:
+  source:
+    interface: dummy-token
+categories:
+  - misc
+series:
+  - centos7
+  - centos8

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -161,9 +161,7 @@ test_deploy_bundles() {
 
         case "${BOOTSTRAP_PROVIDER:-}" in
             "lxd")
-                run "run_deploy_lxd_profile_bundle_openstack"
-                run "run_deploy_lxd_profile_bundle"
-                ;;
+                ;&
             "localhost")
                 run "run_deploy_lxd_profile_bundle_openstack"
                 run "run_deploy_lxd_profile_bundle"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -160,9 +160,7 @@ test_deploy_bundles() {
         run "run_deploy_trusted_bundle"
 
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "lxd")
-                ;&
-            "localhost")
+            "lxd" | "localhost")
                 run "run_deploy_lxd_profile_bundle_openstack"
                 run "run_deploy_lxd_profile_bundle"
                 ;;

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -218,9 +218,7 @@ test_deploy_charms() {
         run "run_deploy_lxd_profile_charm_container"
 
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "lxd")
-                ;&
-            "localhost")
+            "lxd" | "localhost")
                 run "run_deploy_lxd_to_machine"
                 run "run_deploy_lxd_profile_charm"
                 run "run_deploy_local_lxd_profile_charm"

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -219,16 +219,15 @@ test_deploy_charms() {
 
         case "${BOOTSTRAP_PROVIDER:-}" in
             "lxd")
-                run "run_deploy_lxd_to_machine"
-                run "run_deploy_lxd_profile_charm"
-                run "run_deploy_local_lxd_profile_charm"
-                ;;
+                ;&
             "localhost")
                 run "run_deploy_lxd_to_machine"
                 run "run_deploy_lxd_profile_charm"
                 run "run_deploy_local_lxd_profile_charm"
                 ;;
             *)
+                echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"
+                echo "==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only"
                 echo "==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only"
                 ;;
         esac

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -41,7 +41,12 @@ run_deploy_centos() {
 
     juju metadata add-image --series centos7 ami-0bc06212a56393ee1
 
-    juju deploy ./tests/suites/deploy/charms/centos-dummy-sink --series centos7
+    #
+    # There is a specific list of instance types which can be used with
+    # this image.  Sometimes juju chooses the wrong one e.g. t3a.medium.
+    # Ensure we use one that is allowed.
+    #
+    juju deploy ./tests/suites/deploy/charms/centos-dummy-sink --series centos7 --constraints instance-type=t3.medium
 
     series=$(juju status --format=json | jq '.applications."dummy-sink".series')
     echo "$series" | check "centos7"

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -14,10 +14,12 @@ test_deploy_os() {
 
         case "${BOOTSTRAP_PROVIDER:-}" in
             "ec2")
+                ;&
+            "aws")
                 run "run_deploy_centos"
                 ;;
             *)
-                echo "==> TEST SKIPPED: deploy_centos - tests for LXD only"
+                echo "==> TEST SKIPPED: deploy_centos - tests for AWS only"
                 ;;
         esac
     )
@@ -27,12 +29,15 @@ run_deploy_centos() {
     echo
 
     name="test-deploy-centos"
+    file="${TEST_DIR}/${name}.log"
+
+    ensure "${name}" "${file}"
 
     #
     # Images have been setup and and subscribed for juju-qa aws
     # in us-west-2.  Take care editing the details.
     #
-    juju add-model "${name}" aws/us-west-2
+    juju add-model test-deploy-centos-west2 aws/us-west-2
 
     juju metadata add-image --series centos7 ami-0bc06212a56393ee1
 
@@ -44,4 +49,5 @@ run_deploy_centos() {
     wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
     destroy_model "${name}"
+    destroy_model "test-deploy-centos-west2"
 }

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -13,9 +13,7 @@ test_deploy_os() {
 
 
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "ec2")
-                ;&
-            "aws")
+            "ec2" | "aws")
                 run "run_deploy_centos"
                 ;;
             *)

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -1,0 +1,47 @@
+
+test_deploy_os() {
+    if [ "$(skip 'test_deploy_os')" ]; then
+        echo "==> TEST SKIPPED: deploy to os"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+
+
+        case "${BOOTSTRAP_PROVIDER:-}" in
+            "ec2")
+                run "run_deploy_centos"
+                ;;
+            *)
+                echo "==> TEST SKIPPED: deploy_centos - tests for LXD only"
+                ;;
+        esac
+    )
+}
+
+run_deploy_centos() {
+    echo
+
+    name="test-deploy-centos"
+
+    #
+    # Images have been setup and and subscribed for juju-qa aws
+    # in us-west-2.  Take care editing the details.
+    #
+    juju add-model "${name}" aws/us-west-2
+
+    juju metadata add-image --series centos7 ami-0bc06212a56393ee1
+
+    juju deploy ./tests/suites/deploy/charms/centos-dummy-sink --series centos7
+
+    series=$(juju status --format=json | jq '.applications."dummy-sink".series')
+    echo "$series" | check "centos7"
+
+    wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
+
+    destroy_model "${name}"
+}

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -16,6 +16,7 @@ test_deploy() {
     test_deploy_charms
     test_deploy_bundles
     test_cmr_bundles_export_overlay
+    test_deploy_os
 
     destroy_controller "test-deploy-ctl"
 }

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -12,15 +12,11 @@ test_deploy_manual() {
         # TODO (stickupkid): We currently only support LXD in this test
         # currently, future tests should run on aws.
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "lxd")
-                ;&
-            "localhost")
+            "lxd" | "localhost")
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_lxd"
                 ;;
-            "aws")
-                ;&
-            "ec2")
+            "aws" | "ec2")
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_aws"
                 ;;

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -13,19 +13,19 @@ test_deploy_manual() {
         # currently, future tests should run on aws.
         case "${BOOTSTRAP_PROVIDER:-}" in
             "lxd")
-                export BOOTSTRAP_PROVIDER="manual"
-                run "run_deploy_manual_lxd"
-                ;;
+                ;&
             "localhost")
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_lxd"
                 ;;
             "aws")
+                ;&
+            "ec2")
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_aws"
                 ;;
             *)
-                echo "==> TEST SKIPPED: deploy manual - tests for LXD only"
+                echo "==> TEST SKIPPED: deploy manual - tests for LXD and AWS only"
                 ;;
         esac
     )


### PR DESCRIPTION
nw-deploy-centos7-amd64-aws both bootstraps with a centos client and deploys a centos charm.  Breaking into 2 pieces to better provide centos images to the model for deployment.  A separate pr will address using the centos client to bootstrap.

The new test, test_deploy_os for centos is snowflake test.  It has a specific AMI in a specific region and will only take some of the instance types that juju might choose to use.  It will require tweaking as things change.

I tried to update to use the centos8 image.  However centos.org does not list one in the aws marketplace today. I was not able to use the aws centos8 image to create an juju machine.  More investigation is needed.  There are other centos8 images, but do not want to trust ones from unknown places.

Add 'ec2' to list of provider names to be aws for integration tests when using an already bootstrapped controller.

Update the default and bootstrap series for bootstrap to when deploying on win or centos in the acceptance tests to bionic instead of trusty.

## QA steps

```console
$ juju bootstrap aws --credentials <juju qa creds> deploy-centos-test
$ (cd tests ; ./main.sh -l centos-deploy -v deploy test_deploy_os)

# should not run
$ (cd tests ; ./main.sh -p lxd -v deploy test_deploy_os)

==> Checking for dependencies
==> TEST BEGIN: test_deploy (tmp.MMu)
==> TEST SKIPPED: deploy_centos - tests for AWS only
==> TEST DONE: test_deploy (0s)
==> Cleaning up
====> Completed cleaning up jujus

==> Test result: success
==> Tests Removed: /home/heather/work/src/github.com/juju/juju/tests/tmp.MMu
==> TEST COMPLETE
```
