### PR TITLE
Plug mgo logging into juju's log stream

### DIFF
--- a/cmd/jujud/agent/agent.go
+++ b/cmd/jujud/agent/agent.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/state/mgo"
 )
 
 // EngineErrorDelay is the amount of time the dependency engine waits
@@ -143,6 +144,7 @@ func setupAgentLogging(config agent.Config) {
 		if err != nil {
 			logger.Errorf("problem setting logging config %v", err)
 		}
+		mgo.ConfigureMgoLogging()
 	}
 
 	if flags := featureflag.String(); flags != "" {

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -106,7 +106,7 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 
 		// The logging config updater is a leaf worker that indirectly
 		// controls the messages sent via the log sender or rsyslog,
-		// according to changes in environment config. We should only need
+		// according to changes in model config. We should only need
 		// one of these in a consolidated agent.
 		loggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
 			AgentName:       agentName,

--- a/state/mgo/logger.go
+++ b/state/mgo/logger.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mgo
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/juju/loggo"
+	"gopkg.in/mgo.v2"
+)
+
+const (
+	mgoLoggerName = "juju.mgo"
+)
+
+// ConfigureMgoLogging sets up juju/mgo package logging according
+// to the logging config value for "juju.mgo".
+func ConfigureMgoLogging() {
+	logger := loggo.GetLogger(mgoLoggerName)
+	logLevel := logger.EffectiveLogLevel()
+	// mgo logging is quite verbose.
+	// mgo "debug" is similar to juju "trace".
+	mgo.SetDebug(logLevel == loggo.TRACE)
+	// Only output mgo logging for juju "debug" or greater.
+	if logLevel == loggo.UNSPECIFIED || logLevel >= loggo.INFO {
+		mgo.SetLogger(nil)
+		return
+	}
+	mgo.SetLogger(&mgoLogger{
+		logger: logger,
+	})
+}
+
+type mgoLogger struct {
+	logger loggo.Logger
+}
+
+// Output implements the mgo log_Logger interface.
+func (s *mgoLogger) Output(calldepth int, message string) error {
+	// If the output results from a debug function,
+	// log at trace level.
+	caller := callerFunc(calldepth - 1)
+	level := loggo.DEBUG
+	if strings.HasPrefix(caller, "debug") {
+		level = loggo.TRACE
+	}
+	s.logger.LogCallf(calldepth, level, message)
+	return nil
+}
+
+// callerFunc returns the name of the function
+// at the specified call depth.
+func callerFunc(calldepth int) string {
+	var pcs [100]uintptr
+	n := runtime.Callers(calldepth+2, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+	frame, _ := frames.Next()
+	if frame.Func == nil {
+		return ""
+	}
+	parts := strings.Split(frame.Func.Name(), ".")
+	return parts[len(parts)-1]
+}

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/state/mgo"
 )
 
 // LoggerAPI represents the API calls the logger makes.
@@ -100,6 +101,7 @@ func (l *loggerWorker) setLogging() {
 			context.ConfigureLoggers(l.lastConfig)
 			return
 		}
+		mgo.ConfigureMgoLogging()
 		l.lastConfig = loggingConfig
 		// Save the logging config in the agent.conf file.
 		if callback := l.config.Callback; callback != nil {


### PR DESCRIPTION
The mgo transaction library has logging, but you need to plug in a logger to receive the output.
Here's we plum the mgo logs into a "juju.mgo" logger. The mgo logging is really all debug, so the behaviour is to show mgo info logs when "juju.mgo=DEBUG" and mgo debug logs when "juju.mgo=TRACE".

## QA steps

bootstrap
on the controller model:

juju model-config logging-config="juju.mgo=DEBUG"
see some mgo logs in juju debug-log

juju model-config logging-config="juju.mgo=TRACE"
see a lot of low level mgo logs in juju debug-log

