### PR TITLE
Increased idle time for model cache.

### DIFF
--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -105,6 +105,10 @@ type agentStatusSetter interface {
 	SetAgentStatus(agent string, status corepresence.Status)
 }
 
+type idleModelWatcherRequirer interface {
+	requireModelWatchersIdle() bool
+}
+
 type context struct {
 	st            *state.State
 	pool          *state.StatePool
@@ -116,7 +120,7 @@ type context struct {
 	skipTest      bool
 }
 
-func (ctx *context) run(c *gc.C, steps []stepper) {
+func (ctx *context) run(c *gc.C, steps []stepper, waitForWatchersFn func(*gc.C, string)) {
 	for i, s := range steps {
 		if ctx.skipTest {
 			c.Logf("skipping test %d", i)
@@ -124,6 +128,9 @@ func (ctx *context) run(c *gc.C, steps []stepper) {
 		}
 		c.Logf("step %d", i)
 		c.Logf("%#v", s)
+		if req, ok := s.(idleModelWatcherRequirer); ok && req.requireModelWatchersIdle() {
+			waitForWatchersFn(c, ctx.st.ModelUUID())
+		}
 		s.step(c, ctx)
 	}
 }
@@ -4604,6 +4611,13 @@ func (e expect) step(c *gc.C, ctx *context) {
 	scopedExpect{e.what, nil, e.output, e.stderr}.step(c, ctx)
 }
 
+// Ensure that we model watchers to become idle before running step(). This
+// avoids time-related races when updating the cached status that can in turn
+// make status tests behave inconsistently.
+func (e expect) requireModelWatchersIdle() bool {
+	return true
+}
+
 type setToolsUpgradeAvailable struct{}
 
 func (ua setToolsUpgradeAvailable) step(c *gc.C, ctx *context) {
@@ -4620,7 +4634,7 @@ func (s *StatusSuite) TestStatusAllFormats(c *gc.C) {
 			// Prepare context and run all steps to setup.
 			ctx := s.newContext(c)
 			defer s.resetContext(c, ctx)
-			ctx.run(c, t.steps)
+			ctx.run(c, t.steps, s.WaitForModelWatchersIdle)
 		}(t)
 	}
 }
@@ -4874,7 +4888,7 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 		setAgentStatus{"logging/1", status.Error, "somehow lost in all those logs", nil},
 	}
 
-	ctx.run(c, steps)
+	ctx.run(c, steps, s.WaitForModelWatchersIdle)
 
 	const expected = `
 - mysql/0: 10.0.2.1 (agent:idle, workload:active)
@@ -5385,7 +5399,7 @@ func (s *StatusSuite) FilteringTestSetup(c *gc.C) *context {
 		setUnitStatus{"logging/1", status.Active, "", nil},
 	}
 
-	ctx.run(c, steps)
+	ctx.run(c, steps, s.WaitForModelWatchersIdle)
 	return ctx
 }
 
@@ -5822,7 +5836,7 @@ func (s *StatusSuite) TestIsoTimeFormat(c *gc.C) {
 		ctx := s.newContext(c)
 		ctx.expectIsoTime = true
 		defer s.resetContext(c, ctx)
-		ctx.run(c, t.steps)
+		ctx.run(c, t.steps, s.WaitForModelWatchersIdle)
 	}(statusTimeTest)
 }
 

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -32,13 +32,16 @@ const (
 )
 
 var (
+	// Idle* vars below are used for testing. Last changed by tlm on 05/11/20
+	// Changed IdleTime to a larger value to allow high churn tests to catch up
+
 	// IdleFunc allows tests to be able to get callbacks when the controller
 	// hasn't been given any changes for a specified time.
 	IdleFunc func()
 
 	// IdleTime relates to how long the controller needs to wait with no changes
 	// to be considered idle.
-	IdleTime = 50 * time.Millisecond
+	IdleTime = 200 * time.Millisecond
 )
 
 // Clock defines the clockish methods used by the controller.


### PR DESCRIPTION
## Description

Increase the idle timeout for the model cache. This is important when
tests are synching on the cache. We have done this to address test
failures in Jenkins when a high rate of churn is seen.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
cd cmd/juju/status
go test -check.f=StatusSuite.TestIsoTimeFormat .
```
