### PR TITLE
Confirm mutating lease operation delivery before waiting on result

### DIFF
--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -243,7 +243,8 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 		elapsed := time.Now().Sub(start)
 		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
-	_, err = s.hub.Publish(s.config.RequestTopic, ForwardRequest{
+
+	delivered, err := s.hub.Publish(s.config.RequestTopic, ForwardRequest{
 		Command:       string(bytes),
 		ResponseTopic: responseTopic,
 	})
@@ -252,18 +253,23 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 		return errors.Annotatef(err, "publishing %s", command)
 	}
 
+	// First block until subscribers are notified.
+	// In practice, this will be the Raft forwarder running on the leader node.
+	// This is an explicit step so that we can more accurately diagnose issues
+	// in-theatre.
 	select {
+	case <-delivered:
 	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		// TODO (thumper) 2019-12-20, bug 1857072
-		// Scale testing hit this a *lot*,
-		// perhaps we need to consider batching messages to run on the leader?
-		logger.Errorf("timeout waiting for %s to be processed", command)
-		s.record(command.Operation, "timeout", start)
+		logger.Errorf("delivery timeout waiting for %s to be processed", command)
+		s.record(command.Operation, "delivery timeout", start)
 		return lease.ErrTimeout
-	case err := <-errChan:
-		logger.Errorf("processing %s: %v", command, err)
-		s.record(command.Operation, "error", start)
-		return errors.Trace(err)
+	}
+
+	// Now wait for the response.
+	// The timeout starts again here, which is deliberate.
+	// It is the same timeout that is used by the Raft forwarder
+	// when `Apply` is called on the FSM.
+	select {
 	case response := <-responseChan:
 		err := RecoverError(response.Error)
 		logger.Tracef("got response, err %v", err)
@@ -274,8 +280,19 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 		}
 		s.record(command.Operation, result, start)
 		return err
+	case err := <-errChan:
+		logger.Errorf("processing %s: %v", command, err)
+		s.record(command.Operation, "error", start)
+		return errors.Trace(err)
 	case <-stop:
 		return aborted(command)
+	case <-s.config.Clock.After(s.config.ForwardTimeout):
+		// TODO (thumper) 2019-12-20, bug 1857072
+		// Scale testing hit this a *lot*,
+		// perhaps we need to consider batching messages to run on the leader?
+		logger.Errorf("response timeout waiting for %s to be processed", command)
+		s.record(command.Operation, "response timeout", start)
+		return lease.ErrTimeout
 	}
 }
 

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -138,7 +138,7 @@ func (s *storeSuite) TestClaimTimeout(c *gc.C) {
 			}()
 			// Jump time forward further than the 1-second forward
 			// timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -280,7 +280,7 @@ func (s *storeSuite) TestExtendLeaseTimeout(c *gc.C) {
 
 			// Jump time forward further than the 1-second forward
 			// timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -386,7 +386,7 @@ func (s *storeSuite) TestRevokeLeaseTimeout(c *gc.C) {
 
 			// Jump time forward further than the 1-second forward
 			// timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -570,7 +570,7 @@ func (s *storeSuite) TestPinTimeout(c *gc.C) {
 				)
 			}()
 			// Move time forward so the request is timed out
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -672,7 +672,7 @@ func (s *storeSuite) TestUnpinTimeout(c *gc.C) {
 				)
 			}()
 			// Move time forward so the request is timed out
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -841,7 +841,7 @@ func (s *storeSuite) TestAdvanceTimeout(c *gc.C) {
 			}()
 
 			// Move time forward to trigger the timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:


### PR DESCRIPTION
This patch adds a step to read the delivery confirmation channel returned by `hub.Publish` when we forward mutating lease operations to the Raft leader.

Timeout errors now indicate whether they were related to delivery or result receipt, which will help diagnose issues in production.

## QA steps

No functional changes; test for regression:
- Bootstrap this patch with `--config logging-config="<root>=DEBUG;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE"`.
- Deploy some workloads.
- Check for errors with after quiescence with `juju debug-log -m controller --include-module juju.core.raftlease --include-module juju.worker.lease.raft --include-module juju.worker.lease.raft`.

## Documentation changes

None.

## Bug reference

N/A
