### PR TITLE
Prevent inheritance of bundle channels

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -318,18 +318,24 @@ type DeployCommand struct {
 	unknownModel bool
 }
 
+// TODO (stickupkid): Update/re-write the following doc for charmhub related
+// charm urls.
 const deployDoc = `
-A charm can be referred to by its simple name and a series can optionally be
-specified:
+A charm or bundle can be referred to by its simple name and a series or channel
+can optionally be specified:
 
-  juju deploy postgresql
-  juju deploy bionic/postgresql
   juju deploy cs:postgresql
   juju deploy cs:bionic/postgresql
-  juju deploy postgresql --series bionic
+  juju deploy cs:postgresql --series bionic
+  juju deploy cs:postgresql --channel edge
 
 All the above deployments use remote charms found in the Charm Store (denoted
-by 'cs') and therefore also make use of "charm URLs".
+by 'cs' prefix) and therefore also make use of "charm URLs".
+
+Specifying a channel source will use that as the source to look for the charm or
+bundle from the Charm Store. Using a channel with a bundle will refer to
+the bundle only, to override a charm source in a bundle requires setting
+channel per each required charm.
 
 A versioned charm URL will be expanded as expected. For example, 'mysql-56'
 becomes 'cs:bionic/mysql-56'.

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -332,10 +332,11 @@ can optionally be specified:
 All the above deployments use remote charms found in the Charm Store (denoted
 by 'cs' prefix) and therefore also make use of "charm URLs".
 
-Specifying a channel source will use that as the source to look for the charm or
-bundle from the Charm Store. Using a channel with a bundle will refer to
-the bundle only, to override a charm source in a bundle requires setting
-channel per each required charm.
+If a channel is specified, it will be used as the source for looking up the
+charm or bundle from the Charm Store. When used in a bundle deployment context,
+the specified channel is only used for retrieving the bundle and is ignored when
+looking up the charms referenced by the bundle. However, each charm within a
+bundle is allowed to explicitly specify the channel used to look it up.
 
 A versioned charm URL will be expanded as expected. For example, 'mysql-56'
 becomes 'cs:bionic/mysql-56'.

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -215,7 +215,11 @@ type charmstoreBundle struct {
 
 // String returns a string description of the deployer.
 func (d *charmstoreBundle) String() string {
-	return fmt.Sprintf("deploy charm store bundle: %s", d.bundleURL.String())
+	str := fmt.Sprintf("deploy charm store bundle: %s", d.bundleURL.String())
+	if d.origin == (commoncharm.Origin{}) {
+		return str
+	}
+	return fmt.Sprintf("%s with origin: %s", str, d.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -202,10 +202,10 @@ type localBundle struct {
 // String returns a string description of the deployer.
 func (d *localBundle) String() string {
 	str := fmt.Sprintf("deploy local bundle from: %s", d.bundleDir)
-	if d.origin == (commoncharm.Origin{}) {
+	if isEmptyOrigin(d.origin, commoncharm.OriginLocal) {
 		return str
 	}
-	return fmt.Sprintf("%s with origin: %s", str, d.origin.CoreChannel().String())
+	return fmt.Sprintf("%s from channel %s", str, d.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.
@@ -220,10 +220,10 @@ type charmstoreBundle struct {
 // String returns a string description of the deployer.
 func (d *charmstoreBundle) String() string {
 	str := fmt.Sprintf("deploy charm store bundle: %s", d.bundleURL.String())
-	if d.origin == (commoncharm.Origin{}) {
+	if isEmptyOrigin(d.origin, commoncharm.OriginCharmStore) {
 		return str
 	}
-	return fmt.Sprintf("%s with origin: %s", str, d.origin.CoreChannel().String())
+	return fmt.Sprintf("%s from channel %s", str, d.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -201,7 +201,11 @@ type localBundle struct {
 
 // String returns a string description of the deployer.
 func (d *localBundle) String() string {
-	return fmt.Sprintf("deploy local bundle from: %s", d.bundleDir)
+	str := fmt.Sprintf("deploy local bundle from: %s", d.bundleDir)
+	if d.origin == (commoncharm.Origin{}) {
+		return str
+	}
+	return fmt.Sprintf("%s with origin: %s", str, d.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -335,7 +335,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		var fromChannel string
 		var channel corecharm.Channel
 		if spec.Channel != "" {
-			fromChannel = fmt.Sprintf(" from channel: %s", spec.Channel)
+			fromChannel = fmt.Sprintf(" from channel %s", spec.Channel)
 			channel, err = corecharm.ParseChannelNormalize(spec.Channel)
 			if err != nil {
 				return errors.Trace(err)

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -273,7 +273,11 @@ type predeployedLocalCharm struct {
 
 // String returns a string description of the deployer.
 func (d *predeployedLocalCharm) String() string {
-	return fmt.Sprintf("deploy predeployed local charm: %s", d.userCharmURL.String())
+	str := fmt.Sprintf("deploy predeployed local charm: %s", d.userCharmURL.String())
+	if d.origin == (commoncharm.Origin{}) {
+		return str
+	}
+	return fmt.Sprintf("%s with origin: %s", str, d.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy finishes preparing to deploy a predeployed local charm,
@@ -330,8 +334,8 @@ type localCharm struct {
 }
 
 // String returns a string description of the deployer.
-func (d *localCharm) String() string {
-	return fmt.Sprintf("deploy local charm: %s", d.curl.String())
+func (l *localCharm) String() string {
+	return fmt.Sprintf("deploy local charm: %s", l.curl.String())
 }
 
 // PrepareAndDeploy finishes preparing to deploy a local charm,
@@ -371,8 +375,12 @@ type charmStoreCharm struct {
 }
 
 // String returns a string description of the deployer.
-func (d *charmStoreCharm) String() string {
-	return fmt.Sprintf("deploy charm store charm: %s", d.userRequestedURL.String())
+func (c *charmStoreCharm) String() string {
+	str := fmt.Sprintf("deploy charm store charm: %s", c.userRequestedURL.String())
+	if c.origin == (commoncharm.Origin{Source: commoncharm.OriginCharmStore}) {
+		return str
+	}
+	return fmt.Sprintf("%s with origin: %s", str, c.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy finishes preparing to deploy a charm store charm,

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -253,6 +253,7 @@ func (d *deployCharm) deploy(
 }
 
 var (
+	// BundleOnlyFlags represents what flags are used for bundles only.
 	// TODO(thumper): support dry-run for apps as well as bundles.
 	BundleOnlyFlags = []string{
 		"overlay", "dry-run", "map-machines",
@@ -274,10 +275,10 @@ type predeployedLocalCharm struct {
 // String returns a string description of the deployer.
 func (d *predeployedLocalCharm) String() string {
 	str := fmt.Sprintf("deploy predeployed local charm: %s", d.userCharmURL.String())
-	if d.origin == (commoncharm.Origin{}) {
+	if isEmptyOrigin(d.origin, commoncharm.OriginLocal) {
 		return str
 	}
-	return fmt.Sprintf("%s with origin: %s", str, d.origin.CoreChannel().String())
+	return fmt.Sprintf("%s from channel %s", str, d.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy finishes preparing to deploy a predeployed local charm,
@@ -377,10 +378,10 @@ type charmStoreCharm struct {
 // String returns a string description of the deployer.
 func (c *charmStoreCharm) String() string {
 	str := fmt.Sprintf("deploy charm store charm: %s", c.userRequestedURL.String())
-	if c.origin == (commoncharm.Origin{Source: commoncharm.OriginCharmStore}) {
+	if isEmptyOrigin(c.origin, commoncharm.OriginCharmStore) {
 		return str
 	}
-	return fmt.Sprintf("%s with origin: %s", str, c.origin.CoreChannel().String())
+	return fmt.Sprintf("%s from channel %s", str, c.origin.CoreChannel().String())
 }
 
 // PrepareAndDeploy finishes preparing to deploy a charm store charm,
@@ -491,4 +492,16 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	c.csMac = csMac
 	c.origin = csOrigin
 	return c.deploy(ctx, deployAPI)
+}
+
+func isEmptyOrigin(origin commoncharm.Origin, source commoncharm.OriginSource) bool {
+	other := commoncharm.Origin{}
+	if origin == other {
+		return true
+	}
+	other.Source = source
+	if origin == other {
+		return true
+	}
+	return false
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -372,8 +372,14 @@ func (d *factory) maybeReadCharmstoreBundle(resolver Resolver) (Deployer, error)
 		return nil, errors.Trace(err)
 	}
 
-	// validate this is a charmstore bundle
-	bundleURL, origin, err := resolver.ResolveBundleURL(curl, origin)
+	// Resolve the bundle URL using the channel supplied via the channel
+	// supplied. All charms with in this bundle unless pinned via a channel are
+	// NOT expected to be in the same channel as the bundle channel.
+	// The pinning of a bundle does not flow down to charms as well. Each charm
+	// has it's own channel supplied via a bundle, if no is supplied then the
+	// channel is worked out via the resolving what is available.
+	// See: LP:1677404 and LP:1832873
+	bundleURL, _, err := resolver.ResolveBundleURL(curl, origin)
 	if charm.IsUnsupportedSeriesError(errors.Cause(err)) {
 		return nil, errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	}
@@ -406,7 +412,6 @@ func (d *factory) maybeReadCharmstoreBundle(resolver Resolver) (Deployer, error)
 
 	db := d.newDeployBundle(store.NewResolvedBundle(bundle))
 	db.bundleURL = bundleURL
-	db.origin = origin
 	db.bundleOverlayFile = d.bundleOverlayFile
 	return &charmstoreBundle{deployBundle: db}, nil
 }

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -367,7 +367,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	} else if newURL.Scheme != "" && newURL.Scheme != "local" {
 		// If not upgrading from a local path, display the channel we
 		// are pulling the charm from.
-		channel := fmt.Sprintf(" (channel: %s)", c.Channel)
+		channel := fmt.Sprintf(" from channel %s", c.Channel)
 		ctx.Infof("Looking up metadata for charm %v%s", newRef, channel)
 	}
 

--- a/testcharms/charm-repo/bundle/basic/bundle.yaml
+++ b/testcharms/charm-repo/bundle/basic/bundle.yaml
@@ -1,0 +1,4 @@
+services:
+    ubuntu-lite:
+        charm: cs:~jameinel/ubuntu-lite-7
+        num_units: 1


### PR DESCRIPTION
Bundles can have their own channels that are separate from the
application charm channels. This feature was implemented in PR#10480[1].
When moving the deployer code out from the application package into a
more testable setup we ended up causing a regression.

If a user wants to specify their own channels for each charm then they
should pin each charm correctly inside that bundle and not inherit that
channel from the bundle.

The fix is really simple, we just don't pass the origin through and
expect each charm to correctly resolve itself.

 1. https://github.com/juju/juju/pull/10480

## QA steps

Setup microk8s

```sh
sudo snap install microk8s --classic 
sudo usermod -a -G microk8s $USER
su - $USER

microk8s status --wait-ready
microk8s.enable dns storage

make microk8s-operator-update
juju bootstrap microk8s micro
```

The following would previously fail without this patch, running this will
make this work now.

```sh
juju deploy cs:kubeflow-lite
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1902945
