### PR TITLE
ensure_text is in six 1.12.0+, ensure we have a better version.

### DIFF
--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -43,3 +43,4 @@ dnspython==1.16.0
 google-api-python-client==1.7.8
 google-cloud-container==0.2.1
 cryptography==3.2.1
+six>=1.15.0


### PR DESCRIPTION
Sometimes we use the wrong version of six, ensure we have the correct one.  Older versions, pre 1.12.0 do not include 'ensure_text' which leads to:

AttributeError: 'module' object has no attribute 'ensure_text'

in CI tests.