### PR TITLE
 Fix intermittent failure in TestAvailabilityZoneMachinesStartMachinesAZFailures

### DIFF
--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -50,7 +50,7 @@ func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachin
 	task.machinesMutex.RLock()
 	defer task.machinesMutex.RUnlock()
 	// sort to make comparisons in the tests easier.
-	sort.Sort(azMachineFilterSort(task.availabilityZoneMachines))
+	sort.Sort(azMachineSort(task.availabilityZoneMachines))
 	retvalues := make([]AvailabilityZoneMachine, len(task.availabilityZoneMachines))
 	for i := range task.availabilityZoneMachines {
 		retvalues[i] = *task.availabilityZoneMachines[i]

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -874,9 +874,9 @@ func (task *provisionerTask) machineAvailabilityZoneDistribution(
 	// If the machine has a distribution group, assign based on lowest zone
 	// population of the distribution group machine.
 	var machineZone string
-	zoneMap := azMachineFilterSort(task.availabilityZoneMachines)
+	zoneMap := azMachineSort(task.availabilityZoneMachines)
 	if len(distGroupMachineIds) > 0 {
-		zoneMap = azMachineFilterSort(task.populateDistributionGroupZoneMap(distGroupMachineIds))
+		zoneMap = azMachineSort(task.populateDistributionGroupZoneMap(distGroupMachineIds))
 	}
 
 	sort.Sort(zoneMap)
@@ -913,16 +913,15 @@ func (task *provisionerTask) machineAvailabilityZoneDistribution(
 	return machineZone, nil
 }
 
-// azMachineFilterSort extends a slice of AvailabilityZoneMachine references
-// with a sort implementation by zone population and name,
-// and filtration based on zones expressed in constraints.
-type azMachineFilterSort []*AvailabilityZoneMachine
+// azMachineSort extends a slice of AvailabilityZoneMachine references
+// with a sort implementation by zone population and name.
+type azMachineSort []*AvailabilityZoneMachine
 
-func (a azMachineFilterSort) Len() int {
+func (a azMachineSort) Len() int {
 	return len(a)
 }
 
-func (a azMachineFilterSort) Less(i, j int) bool {
+func (a azMachineSort) Less(i, j int) bool {
 	switch {
 	case a[i].MachineIds.Size() < a[j].MachineIds.Size():
 		return true
@@ -932,7 +931,7 @@ func (a azMachineFilterSort) Less(i, j int) bool {
 	return false
 }
 
-func (a azMachineFilterSort) Swap(i, j int) {
+func (a azMachineSort) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
@@ -1275,8 +1274,7 @@ func (task *provisionerTask) markMachineFailedInAZ(machine apiprovisioner.Machin
 	}
 
 	// Check if there are any zones left to try (that also match constraints).
-	zoneMap := azMachineFilterSort(task.availabilityZoneMachines)
-	for _, zoneMachines := range zoneMap {
+	for _, zoneMachines := range task.availabilityZoneMachines {
 		if zoneMachines.MatchesConstraints(cons) &&
 			!zoneMachines.FailedMachineIds.Contains(machine.Id()) &&
 			!zoneMachines.ExcludedMachineIds.Contains(machine.Id()) {
@@ -1292,18 +1290,6 @@ func (task *provisionerTask) clearMachineAZFailures(machine apiprovisioner.Machi
 	for _, zoneMachines := range task.availabilityZoneMachines {
 		zoneMachines.FailedMachineIds.Remove(machine.Id())
 	}
-}
-
-func (task *provisionerTask) addMachineToAZMap(machine *apiprovisioner.Machine, zoneName string) {
-	task.machinesMutex.Lock()
-	defer task.machinesMutex.Unlock()
-	for _, zoneMachines := range task.availabilityZoneMachines {
-		if zoneName == zoneMachines.ZoneName {
-			zoneMachines.MachineIds.Add(machine.Id())
-			break
-		}
-	}
-	return
 }
 
 // removeMachineFromAZMap removes the specified machine from availabilityZoneMachines.

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1534,12 +1534,13 @@ func assertAvailabilityZoneMachines(c *gc.C,
 }
 
 // assertAvailabilityZoneMachinesDistribution checks to see if the
-// machines have been distributed over the zones.  This check method
-// works where there are no machine errors in the test case.
+// machines have been distributed over the zones (with a maximum delta
+// between the max and min number of machines of maxDelta). This check
+// method works where there are no machine errors in the test case.
 //
 // Which machine it will be in which zone is dependent on the order in
 // which they are provisioned, therefore almost impossible to predict.
-func assertAvailabilityZoneMachinesDistribution(c *gc.C, obtained []provisioner.AvailabilityZoneMachine) {
+func assertAvailabilityZoneMachinesDistribution(c *gc.C, obtained []provisioner.AvailabilityZoneMachine, maxDelta int) {
 	// Are the machines evenly distributed?  No zone should have
 	// 2 machines more than any other zone.
 	min, max := 1, 0
@@ -1552,10 +1553,10 @@ func assertAvailabilityZoneMachinesDistribution(c *gc.C, obtained []provisioner.
 			max = count
 		}
 	}
-	c.Assert(max-min, jc.LessThan, 2)
+	c.Assert(max-min, jc.LessThan, maxDelta+1)
 }
 
-// assertAvailabilityZoneMachinesDistribution checks to see if
+// checkAvailabilityZoneMachinesDistributionGroups checks to see if
 // the distribution groups have been honored.
 func checkAvailabilityZoneMachinesDistributionGroups(c *gc.C, groups map[names.MachineTag][]string, obtained []provisioner.AvailabilityZoneMachine) error {
 	// The set containing the machines in a distribution group and the
@@ -1601,7 +1602,7 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStartMachines(c *gc.C) {
 
 	availabilityZoneMachines := provisioner.GetCopyAvailabilityZoneMachines(task)
 	assertAvailabilityZoneMachines(c, machines, nil, availabilityZoneMachines)
-	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines)
+	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines, 1)
 }
 
 func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStartMachinesAZFailures(c *gc.C) {
@@ -1625,7 +1626,13 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStartMachinesAZFailures(c
 
 	availabilityZoneMachines := provisioner.GetCopyAvailabilityZoneMachines(task)
 	assertAvailabilityZoneMachines(c, machines, nil, availabilityZoneMachines)
-	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines)
+
+	// The reason maxDelta is 2 here is because in certain failure cases this
+	// may start two machines on each of two zones, and none on the other (if
+	// the failing machine is started second or third, and the subsequent
+	// machines are started before markMachineFailedInAZ() is called). See
+	// https://github.com/juju/juju/pull/12267 for more detail.
+	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines, 2)
 }
 
 func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStartMachinesWithDG(c *gc.C) {
@@ -1720,7 +1727,7 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStopMachines(c *gc.C) {
 
 	availabilityZoneMachines := provisioner.GetCopyAvailabilityZoneMachines(task)
 	assertAvailabilityZoneMachines(c, machines, nil, availabilityZoneMachines)
-	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines)
+	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines, 1)
 
 	c.Assert(machines[0].EnsureDead(), gc.IsNil)
 	s.waitForRemovalMark(c, machines[0])
@@ -1750,7 +1757,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailMachine(c *gc.C) {
 
 	availabilityZoneMachines := provisioner.GetCopyAvailabilityZoneMachines(task)
 	assertAvailabilityZoneMachines(c, machines, nil, availabilityZoneMachines)
-	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines)
+	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines, 1)
 }
 
 func (s *ProvisionerSuite) TestAvailabilityZoneMachinesRestartTask(c *gc.C) {
@@ -1764,7 +1771,7 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesRestartTask(c *gc.C) {
 
 	availabilityZoneMachinesBefore := provisioner.GetCopyAvailabilityZoneMachines(task)
 	assertAvailabilityZoneMachines(c, machines, nil, availabilityZoneMachinesBefore)
-	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachinesBefore)
+	assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachinesBefore, 1)
 
 	workertest.CleanKill(c, task)
 	newTask := s.newProvisionerTask(c, config.HarvestDestroyed, s.Environ, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{})


### PR DESCRIPTION
This fixes the intermittent test failure we were seeing in the provisioning worker test `TestAvailabilityZoneMachinesStartMachinesAZFailures`. [Example Jenkins output here.](https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-arm64/17/testReport/junit/github/com_juju_juju_worker_provisioner/TestPackage/)

The fix in the end is simply to make this test more forgiving, as this can happen in real life, but is rare and would be complicated to work around, and the "failure mode" is not bad -- one AZ just has one fewer instances on it than the others. Details below.

## Repro steps

To repro, add a `time.Sleep(100 * time.Millisecond)` inside the `if startInstanceParams.AvailabilityZone != "" {` after line 1129 of `worker/provisioner/provisioner_task.go`. Then run

```
go test github.com/juju/juju/worker/provisioner -test.count=10 -test.v -check.f 'TestAvailabilityZoneMachinesStartMachinesAZFailures$' -check.vv
```

and the failure will occur about 50% of the time. The failure looks like:

```
provisioner_test.go:1628:
    assertAvailabilityZoneMachinesDistribution(c, availabilityZoneMachines)
provisioner_test.go:1555:
    c.Assert(max-min, jc.LessThan, 2)
... obtained int = 2
... expected int = 2
```

and the relevant log lines are:

```
[LOG] 0:00.953 INFO test trying machine 1 StartInstance in availability zone zone1
[LOG] 0:00.963 INFO test trying machine 3 StartInstance in availability zone zone3
[LOG] 0:00.971 INFO test trying machine 2 StartInstance in availability zone zone4
[LOG] 0:00.971 WARNING test machine 2 failed to start in availability zone zone4: zing
[LOG] 0:00.971 INFO test trying machine 4 StartInstance in availability zone zone1
[LOG] 0:00.971 DEBUG test failed to start machine 2 in zone "zone4", retrying in 5ms with new availability zone: zing
[LOG] 0:00.983 DEBUG test machine 2 does not match az zone4: excluded in failed machine ids
[LOG] 0:00.983 INFO test trying machine 2 StartInstance in availability zone zone3
```

## Gory details

The test starts 4 machines (machine IDs 1, 2, 3, 4) in 3 availability zones (zone1, zone3, zone4 -- zone2 is marked not available), with machine 2 returning error from StartInstance on the first call and success subsequently. The test asserts that the machines are spread across the AZs as evenly as possible, in this case meaning 1 machine on each of two zones and 2 machines on the other zone. If there are 2 machines on each of two zones and no machines on the other zone the test fails with the error we're seeing.

The failure happens when the machines are started with machine 2 as the second or third to be started (not the first or last), *and* the subsequent machines are started before the `markMachineFailedInAZ()` function is called for the failed machine 2. This results in one of the AZs being unused. For example, here's a failure example:

```
machine 1 started on zone1
machine 3 started on zone3
machine 2 start attempt on zone4 (will fail on first attempt)
machine 4 started on zone1
markMachineFailedInAZ() called for machine 2 (marking zone 4 unusable by machine 2)
machine 2 started on zone3
test fails - zone1 has machines 1 and 4, zone3 has machines 2 and 3, zone4 has none
```

With these parameters, this would actually happen around 50% of the time if StartInstance took a decent amount of time, but it happens much less frequently than that in testing because of the timing issues -- I believe mostly because of how the test's `mockBroker` locks a mutex in its StartInstance, so those calls essentially happen sequentially and not concurrently, and I guess the Go scheduler normally calls the `markMachineFailedInAZ()` before starting machine 4 (allowing machine 4 to be started on zone4 and then the machine 2 retried on zone1).

I don't see a simple way around this. Obviously we want to start these things in parallel in real life, so we can't lock the the zones data structure for that whole time (seconds or minutes). We could retry on the same AZ once before marking that zone unusable by the failed instance? But that complicates the already-complex provisioning logic.

This will happen sometimes in real life (if you're starting N machines in M zones and N > M, and one or more machines fail to start up, and the failed machines aren't the first or last machines started). However, it's going to be fairly rare, and the "failure case" is not bad anyway -- one zone will just have fewer machines assigned to it.

So I'm inclined to just say "this is okay" and change the test assertion to allow 2 machines on each of two zones and none on the other zone.