### PR TITLE
Plugin mgo txn logging to juju logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012
 
 replace gopkg.in/natefinch/lumberjack.v2 => github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible
 
-replace gopkg.in/mgo.v2 => github.com/juju/mgo v2.0.0-20201105041946-086e3ddaf23c+incompatible
+replace gopkg.in/mgo.v2 => github.com/juju/mgo v2.0.0-20201106044211-d9585b0b0d28+incompatible
 
 replace github.com/hashicorp/raft => github.com/juju/raft v2.0.0-20200420012049-88ad3b3f0a54+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7L
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible/go.mod h1:YQBneJkXlAAye6yHFYH8CabVID+0Oq2by8DDKGj5OIU=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f h1:a3Vd00a20dTKLpyS2hdUafNG5zxQdTw5KhDMK5C0a8U=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f/go.mod h1:+7K7MqWi5xWI+s1LyB2g0Di71jZo27y+XOlmhNtV1Y0=
-github.com/juju/mgo v2.0.0-20201105041946-086e3ddaf23c+incompatible h1:4R9otumcue1OMv/MimLav3Ikyx2t2YYlpLIzE3EFJFs=
-github.com/juju/mgo v2.0.0-20201105041946-086e3ddaf23c+incompatible/go.mod h1:7a/cakyF0q2iwjcD35dn0dgVCdKnLW5j/5iCCAFu7vg=
+github.com/juju/mgo v2.0.0-20201106044211-d9585b0b0d28+incompatible h1:EZ8JH/I7PZ5OdZPPAPN24eQhrGYLVKjTvvzv86o2F4Q=
+github.com/juju/mgo v2.0.0-20201106044211-d9585b0b0d28+incompatible/go.mod h1:7a/cakyF0q2iwjcD35dn0dgVCdKnLW5j/5iCCAFu7vg=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31 h1:v6GpXmpXOD6KwPbApRlwDGQxf1FpS6gfLdfVbE4ZLzk=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31/go.mod h1:m6E+J+I+cE+6rcaVxSI4HwGLIEOCSOBMYedt3Sewh+U=
 github.com/juju/mgotest v1.0.1 h1:XvuZ2whmkHZ5G+Y/wQaSe28p2FyTwcBaqTzStn+QaLc=

--- a/state/mgo/logger.go
+++ b/state/mgo/logger.go
@@ -9,17 +9,21 @@ import (
 
 	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
 )
 
 const (
-	mgoLoggerName = "juju.mgo"
+	mgoLoggerName    = "juju.mgo"
+	mgoTxnLoggerName = "juju.mgo.txn"
 )
+
+var mgoLogger = loggo.GetLogger(mgoLoggerName)
+var mgoTxnLogger = loggo.GetLogger(mgoTxnLoggerName)
 
 // ConfigureMgoLogging sets up juju/mgo package logging according
 // to the logging config value for "juju.mgo".
 func ConfigureMgoLogging() {
-	logger := loggo.GetLogger(mgoLoggerName)
-	logLevel := logger.EffectiveLogLevel()
+	logLevel := mgoLogger.EffectiveLogLevel()
 	// mgo logging is quite verbose.
 	// mgo "debug" is similar to juju "trace".
 	mgo.SetDebug(logLevel == loggo.TRACE)
@@ -28,23 +32,51 @@ func ConfigureMgoLogging() {
 		mgo.SetLogger(nil)
 		return
 	}
-	mgo.SetLogger(&mgoLogger{
-		logger: logger,
+	mgo.SetLogger(&mgoLogWriter{
+		logger: mgoLogger,
+	})
+
+	logLevel = mgoTxnLogger.EffectiveLogLevel()
+	txn.SetDebug(logLevel == loggo.DEBUG)
+	// Only output mgo txn logging for juju "info" or greater.
+	if logLevel == loggo.UNSPECIFIED || logLevel >= loggo.WARNING {
+		mgo.SetLogger(nil)
+		return
+	}
+	txn.SetLogger(&mgoTxnLogWriter{
+		logger: mgoLogger,
 	})
 }
 
-type mgoLogger struct {
+type mgoLogWriter struct {
 	logger loggo.Logger
 }
 
 // Output implements the mgo log_Logger interface.
-func (s *mgoLogger) Output(calldepth int, message string) error {
+func (s *mgoLogWriter) Output(calldepth int, message string) error {
 	// If the output results from a debug function,
 	// log at trace level.
 	caller := callerFunc(calldepth - 1)
 	level := loggo.DEBUG
 	if strings.HasPrefix(caller, "debug") {
 		level = loggo.TRACE
+	}
+	s.logger.LogCallf(calldepth, level, message)
+	return nil
+}
+
+type mgoTxnLogWriter struct {
+	logger loggo.Logger
+}
+
+// Output implements the mgo log_Logger interface.
+func (s *mgoTxnLogWriter) Output(calldepth int, message string) error {
+	// If the output results from a debug function,
+	// log at debug level.
+	caller := callerFunc(calldepth - 1)
+	level := loggo.INFO
+	if strings.HasPrefix(caller, "debug") {
+		level = loggo.DEBUG
 	}
 	s.logger.LogCallf(calldepth, level, message)
 	return nil


### PR DESCRIPTION
A recent PR #12256 added integration for juju/mgo logging into Juju.
This PR also adds mgo/txn logging.
The dep update is for the above, as well as a change to make avoiding races more efficient.

## QA steps

bootstrap
switch to controller model
juju model-config logging-config="<root>=INFO;juju.mgo=DEBUG;juju.mgo.txn=DEBUG;"

check logs