### PR TITLE
Charmhub download integration tests

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,7 +6,7 @@ run_charmhub_download() {
 
     ensure "test-${name}" "${file}"
 
-    output=$(juju download mysql - 2>&1 > "${TEST_DIR}/mysql.charm" || true)
+    output=$(juju download mysql --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
     check_contains "${output}" "Fetching charm \"mysql\""
 
     juju deploy "${TEST_DIR}/mysql.charm" mysql

--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -1,0 +1,55 @@
+run_charmhub_download() {
+    echo
+    name="charmhub-download"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    output=$(juju download mysql - 2>&1 > "${TEST_DIR}/mysql.charm" || true)
+    check_contains "${output}" "Fetching charm \"mysql\""
+
+    juju deploy "${TEST_DIR}/mysql.charm" mysql
+    juju wait-for application mysql
+}
+
+run_charmstore_download() {
+    echo
+    name="charmstore-download"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    output=$(juju download cs:meshuggah 2>&1 || echo "not found")
+    check_contains "${output}" "\"cs:meshuggah\" is not a Charm Hub charm"
+}
+
+run_unknown_download() {
+    echo
+    name="unknown-download"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    output=$(juju download meshuggah 2>&1 || echo "not found")
+    check_contains "${output}" "No charm or bundle with name"
+}
+
+test_charmhub_download() {
+      if [ "$(skip 'test_charmhub_download')" ]; then
+        echo "==> TEST SKIPPED: Charm Hub download"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_charmhub_download"
+        run "run_charmstore_download"
+        run "run_unknown_download"
+    )
+}

--- a/tests/suites/charmhub/find.sh
+++ b/tests/suites/charmhub/find.sh
@@ -24,14 +24,7 @@ run_charmhub_find_all() {
 
     output=$(juju find 2>&1 || true)
 
-    # This list is subject to change and could cause failures
-    # in the future as we do not have controller over the data.
-    # Series appear to be in alphabetical order, using example
-    # with LTS only.
     check_contains "${output}" "No search term specified. Here are some interesting charms"
-    check_contains "${output}" "bionic,focal,trusty,xenial"
-    check_contains "${output}" "kubernetes"
-    check_contains "${output}" "openstack-charmers"
 
     destroy_model "test-${name}"
 }

--- a/tests/suites/charmhub/task.sh
+++ b/tests/suites/charmhub/task.sh
@@ -15,6 +15,7 @@ test_charmhub() {
 
     bootstrap "test-charmhub" "${file}"
 
+    test_charmhub_download
     test_charmhub_find
     test_charmhub_info
 


### PR DESCRIPTION
The following adds an integration test for downloading a charm and then
deploying. The test fails because there is an error in the underlying
charmhub.

## QA steps

Until they fix the API we're using staging and so we need to bootstrap our
own controller and ensure that we use the staging url.

```sh
$ (cd tests && ./main.sh charmhub)
```
