### PR TITLE
Wait for summary

### DIFF
--- a/cmd/plugins/juju-wait-for/application.go
+++ b/cmd/plugins/juju-wait-for/application.go
@@ -138,22 +138,23 @@ func (c *applicationCommand) waitFor(ctx ScopeContext) func(string, []params.Del
 
 			switch entityInfo := delta.Entity.(type) {
 			case *params.ApplicationInfo:
-				if entityInfo.Name == name {
-					if delta.Removed {
-						return false, errors.Errorf("application %v removed", name)
-					}
-
-					c.appInfo = *entityInfo
-
-					scope := MakeApplicationScope(ctx, entityInfo)
-					if done, err := runQuery(q, scope); err != nil {
-						return false, errors.Trace(err)
-					} else if done {
-						return true, nil
-					}
-
-					c.found = entityInfo.Life != life.Dead
+				if entityInfo.Name != name {
+					break
 				}
+				if delta.Removed {
+					return false, errors.Errorf("application %v removed", name)
+				}
+
+				c.appInfo = *entityInfo
+
+				scope := MakeApplicationScope(ctx, entityInfo)
+				if done, err := runQuery(q, scope); err != nil {
+					return false, errors.Trace(err)
+				} else if done {
+					return true, nil
+				}
+
+				c.found = entityInfo.Life != life.Dead
 
 			case *params.UnitInfo:
 				if delta.Removed {

--- a/cmd/plugins/juju-wait-for/application.go
+++ b/cmd/plugins/juju-wait-for/application.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/cmd"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
@@ -51,9 +52,11 @@ type applicationCommand struct {
 	name    string
 	query   string
 	timeout time.Duration
+	summary bool
 
 	found   bool
 	appInfo params.ApplicationInfo
+	units   map[string]*params.UnitInfo
 }
 
 // Info implements Command.Info.
@@ -71,6 +74,7 @@ func (c *applicationCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.waitForCommandBase.SetFlags(f)
 	f.StringVar(&c.query, "query", `life=="alive" && status=="active"`, "query the goal state")
 	f.DurationVar(&c.timeout, "timeout", time.Minute*10, "how long to wait, before timing out")
+	f.BoolVar(&c.summary, "summary", true, "output a summary of the application query if successful")
 }
 
 // Init implements Command.Init.
@@ -90,85 +94,132 @@ func (c *applicationCommand) Init(args []string) (err error) {
 }
 
 func (c *applicationCommand) Run(ctx *cmd.Context) error {
+	scopedContext := ScopeContext{
+		idents: set.NewStrings(),
+	}
+
 	strategy := &Strategy{
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err := strategy.Run(c.name, c.query, c.waitFor)
-	return errors.Trace(err)
+	strategy.Subscribe(func(event EventType) {
+		switch event {
+		case WatchAllStarted:
+			c.primeCache()
+		}
+	})
+	err := strategy.Run(c.name, c.query, c.waitFor(scopedContext))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if c.summary {
+		switch c.appInfo.Life {
+		case life.Dead:
+			ctx.Infof("%s has been removed", c.name)
+		case life.Dying:
+			ctx.Infof("%s is being removed", c.name)
+		default:
+			ctx.Infof("%s is running", c.name)
+
+			idents := scopedContext.RecordedIdents()
+			for _, ident := range idents {
+				// We have to special case status here because of the issue that
+				// unset propagates through and we have to read it via the unit
+				// information.
+				if ident == "status" {
+					currentStatus := c.appInfo.Status.Current
+					currentStatus = deriveApplicationStatus(currentStatus, c.units)
+					ctx.Infof("  - %s: %v", ident, currentStatus)
+					continue
+				}
+
+				scope := MakeApplicationScope(scopedContext, &c.appInfo)
+				box, err := scope.GetIdentValue(ident)
+				if err != nil {
+					continue
+				}
+				ctx.Infof("  - %s: %v", ident, box.Value())
+			}
+		}
+	}
+	return nil
 }
 
-func (c *applicationCommand) waitFor(name string, deltas []params.Delta, q query.Query) (bool, error) {
-	for _, delta := range deltas {
-		logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+func (c *applicationCommand) primeCache() {
+	c.units = make(map[string]*params.UnitInfo)
+}
 
-		switch entityInfo := delta.Entity.(type) {
-		case *params.ApplicationInfo:
-			if entityInfo.Name == name {
+func (c *applicationCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
+		for _, delta := range deltas {
+			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+
+			switch entityInfo := delta.Entity.(type) {
+			case *params.ApplicationInfo:
+				if entityInfo.Name == name {
+					if delta.Removed {
+						return false, errors.Errorf("application %v removed", name)
+					}
+
+					c.appInfo = *entityInfo
+
+					scope := MakeApplicationScope(ctx, entityInfo)
+					if done, err := runQuery(q, scope); err != nil {
+						return false, errors.Trace(err)
+					} else if done {
+						return true, nil
+					}
+
+					c.found = entityInfo.Life != life.Dead
+				}
+
+			case *params.UnitInfo:
 				if delta.Removed {
-					return false, errors.Errorf("application %v removed", name)
+					delete(c.units, entityInfo.Name)
+					break
 				}
-
-				scope := MakeApplicationScope(entityInfo)
-				if done, err := runQuery(q, scope); err != nil {
-					return false, errors.Trace(err)
-				} else if done {
-					return true, nil
+				if entityInfo.Application == name {
+					c.units[entityInfo.Name] = entityInfo
 				}
-
-				c.found = entityInfo.Life != life.Dead
-				c.appInfo = *entityInfo
 			}
 		}
-	}
 
-	if !c.found {
-		logger.Infof("application %q not found, waiting...", name)
+		if !c.found {
+			logger.Infof("application %q not found, waiting...", name)
+			return false, nil
+		}
+
+		currentStatus := c.appInfo.Status.Current
+		logOutput := currentStatus.String() != "unset" && len(c.units) > 0
+
+		appInfo := c.appInfo
+		appInfo.Status.Current = deriveApplicationStatus(currentStatus, c.units)
+
+		scope := MakeApplicationScope(ctx, &appInfo)
+		if done, err := runQuery(q, scope); err != nil {
+			return false, errors.Trace(err)
+		} else if done {
+			return true, nil
+		}
+
+		if logOutput {
+			logger.Infof("application %q found with %q, waiting for goal state", name, currentStatus)
+		}
+
 		return false, nil
 	}
-
-	currentStatus := c.appInfo.Status.Current
-
-	units := make(map[string]*params.UnitInfo)
-	for _, delta := range deltas {
-		switch entityInfo := delta.Entity.(type) {
-		case *params.UnitInfo:
-			if delta.Removed {
-				delete(units, entityInfo.Name)
-			}
-			if entityInfo.Application == name {
-				units[entityInfo.Name] = entityInfo
-			}
-		}
-	}
-
-	logOutput := currentStatus.String() != "unset" && len(units) > 0
-
-	appInfo := c.appInfo
-	appInfo.Status.Current = deriveApplicationStatus(currentStatus, units)
-
-	scope := MakeApplicationScope(&appInfo)
-	if done, err := runQuery(q, scope); err != nil {
-		return false, errors.Trace(err)
-	} else if done {
-		return true, nil
-	}
-
-	if logOutput {
-		logger.Infof("application %q found with %q, waiting for goal state", name, currentStatus)
-	}
-
-	return false, nil
 }
 
 // ApplicationScope allows the query to introspect a application entity.
 type ApplicationScope struct {
+	ctx             ScopeContext
 	ApplicationInfo *params.ApplicationInfo
 }
 
 // MakeApplicationScope creates an ApplicationScope from an ApplicationInfo
-func MakeApplicationScope(info *params.ApplicationInfo) ApplicationScope {
+func MakeApplicationScope(ctx ScopeContext, info *params.ApplicationInfo) ApplicationScope {
 	return ApplicationScope{
+		ctx:             ctx,
 		ApplicationInfo: info,
 	}
 }
@@ -180,6 +231,8 @@ func (m ApplicationScope) GetIdents() []string {
 
 // GetIdentValue returns the value of the identifier in a given scope.
 func (m ApplicationScope) GetIdentValue(name string) (query.Box, error) {
+	m.ctx.RecordIdent(name)
+
 	switch name {
 	case "name":
 		return query.NewString(m.ApplicationInfo.Name), nil

--- a/cmd/plugins/juju-wait-for/application_test.go
+++ b/cmd/plugins/juju-wait-for/application_test.go
@@ -54,6 +54,7 @@ func (s *applicationScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := ApplicationScope{
+			ctx:             MakeScopeContext(),
 			ApplicationInfo: test.ApplicationInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -64,6 +65,7 @@ func (s *applicationScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *applicationScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := ApplicationScope{
+		ctx:             MakeScopeContext(),
 		ApplicationInfo: &params.ApplicationInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/cmd/plugins/juju-wait-for/machine.go
+++ b/cmd/plugins/juju-wait-for/machine.go
@@ -128,22 +128,23 @@ func (c *machineCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, 
 
 			switch entityInfo := delta.Entity.(type) {
 			case *params.MachineInfo:
-				if entityInfo.Id == id {
-					if delta.Removed {
-						return false, errors.Errorf("machine %v removed", id)
-					}
-
-					c.machineInfo = *entityInfo
-
-					scope := MakeMachineScope(ctx, entityInfo)
-					if done, err := runQuery(q, scope); err != nil {
-						return false, errors.Trace(err)
-					} else if done {
-						return true, nil
-					}
-					c.found = entityInfo.Life != life.Dead
+				if entityInfo.Id != id {
+					break
 				}
-				break
+
+				if delta.Removed {
+					return false, errors.Errorf("machine %v removed", id)
+				}
+
+				c.machineInfo = *entityInfo
+
+				scope := MakeMachineScope(ctx, entityInfo)
+				if done, err := runQuery(q, scope); err != nil {
+					return false, errors.Trace(err)
+				} else if done {
+					return true, nil
+				}
+				c.found = entityInfo.Life != life.Dead
 			}
 		}
 

--- a/cmd/plugins/juju-wait-for/machine.go
+++ b/cmd/plugins/juju-wait-for/machine.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"io"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
@@ -53,6 +55,9 @@ type machineCommand struct {
 	query   string
 	timeout time.Duration
 	found   bool
+	summary bool
+
+	machineInfo params.MachineInfo
 }
 
 // Info implements Command.Info.
@@ -70,6 +75,7 @@ func (c *machineCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.waitForCommandBase.SetFlags(f)
 	f.StringVar(&c.query, "query", `life=="alive" && status=="started"`, "query the goal state")
 	f.DurationVar(&c.timeout, "timeout", time.Minute*10, "how long to wait, before timing out")
+	f.BoolVar(&c.summary, "summary", true, "output a summary of the application query on exit")
 }
 
 // Init implements Command.Init.
@@ -89,54 +95,78 @@ func (c *machineCommand) Init(args []string) (err error) {
 }
 
 func (c *machineCommand) Run(ctx *cmd.Context) error {
+	scopedContext := MakeScopeContext()
+
+	defer func() {
+		if !c.summary {
+			return
+		}
+
+		switch c.machineInfo.Life {
+		case life.Dead:
+			ctx.Infof("Machine %q has been removed", c.id)
+		case life.Dying:
+			ctx.Infof("Machine %q is being removed", c.id)
+		default:
+			ctx.Infof("Machine %q is running", c.id)
+			outputMachineSummary(ctx.Stdout, scopedContext, &c.machineInfo)
+		}
+	}()
+
 	strategy := &Strategy{
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err := strategy.Run(c.id, c.query, c.waitFor)
+	err := strategy.Run(c.id, c.query, c.waitFor(scopedContext))
 	return errors.Trace(err)
 }
 
-func (c *machineCommand) waitFor(id string, deltas []params.Delta, q query.Query) (bool, error) {
-	for _, delta := range deltas {
-		logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+func (c *machineCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+	return func(id string, deltas []params.Delta, q query.Query) (bool, error) {
+		for _, delta := range deltas {
+			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
 
-		switch entityInfo := delta.Entity.(type) {
-		case *params.MachineInfo:
-			if entityInfo.Id == id {
-				if delta.Removed {
-					return false, errors.Errorf("machine %v removed", id)
-				}
+			switch entityInfo := delta.Entity.(type) {
+			case *params.MachineInfo:
+				if entityInfo.Id == id {
+					if delta.Removed {
+						return false, errors.Errorf("machine %v removed", id)
+					}
 
-				scope := MakeMachineScope(entityInfo)
-				if done, err := runQuery(q, scope); err != nil {
-					return false, errors.Trace(err)
-				} else if done {
-					return true, nil
+					c.machineInfo = *entityInfo
+
+					scope := MakeMachineScope(ctx, entityInfo)
+					if done, err := runQuery(q, scope); err != nil {
+						return false, errors.Trace(err)
+					} else if done {
+						return true, nil
+					}
+					c.found = entityInfo.Life != life.Dead
 				}
-				c.found = entityInfo.Life != life.Dead
+				break
 			}
-			break
 		}
-	}
 
-	if !c.found {
-		logger.Infof("machine %q not found, waiting...", id)
+		if !c.found {
+			logger.Infof("machine %q not found, waiting...", id)
+			return false, nil
+		}
+
+		logger.Infof("machine %q found, waiting...", id)
 		return false, nil
 	}
-
-	logger.Infof("machine %q found, waiting...", id)
-	return false, nil
 }
 
 // MachineScope allows the query to introspect a model entity.
 type MachineScope struct {
+	ctx         ScopeContext
 	MachineInfo *params.MachineInfo
 }
 
 // MakeMachineScope creates an MachineScope from an MachineInfo
-func MakeMachineScope(info *params.MachineInfo) MachineScope {
+func MakeMachineScope(ctx ScopeContext, info *params.MachineInfo) MachineScope {
 	return MachineScope{
+		ctx:         ctx,
 		MachineInfo: info,
 	}
 }
@@ -148,6 +178,8 @@ func (m MachineScope) GetIdents() []string {
 
 // GetIdentValue returns the value of the identifier in a given scope.
 func (m MachineScope) GetIdentValue(name string) (query.Box, error) {
+	m.ctx.RecordIdent(name)
+
 	switch name {
 	case "id":
 		return query.NewString(m.MachineInfo.Id), nil
@@ -171,4 +203,24 @@ func (m MachineScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewSliceString(containerTypes), nil
 	}
 	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on MachineInfo", name)
+}
+
+func outputMachineSummary(writer io.Writer, scopedContext ScopeContext, machineInfo *params.MachineInfo) {
+	result := struct {
+		Elements map[string]interface{} `yaml:"properties"`
+	}{
+		Elements: make(map[string]interface{}),
+	}
+
+	idents := scopedContext.RecordedIdents()
+	for _, ident := range idents {
+		scope := MakeMachineScope(scopedContext, machineInfo)
+		box, err := scope.GetIdentValue(ident)
+		if err != nil {
+			continue
+		}
+		result.Elements[ident] = box.Value()
+	}
+
+	_ = yaml.NewEncoder(writer).Encode(result)
 }

--- a/cmd/plugins/juju-wait-for/machine_test.go
+++ b/cmd/plugins/juju-wait-for/machine_test.go
@@ -57,6 +57,7 @@ func (s *machineScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := MachineScope{
+			ctx:         MakeScopeContext(),
 			MachineInfo: test.MachineInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -67,6 +68,7 @@ func (s *machineScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *machineScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := MachineScope{
+		ctx:         MakeScopeContext(),
 		MachineInfo: &params.MachineInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/cmd/plugins/juju-wait-for/model.go
+++ b/cmd/plugins/juju-wait-for/model.go
@@ -167,13 +167,15 @@ func (c *modelCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, qu
 				c.units[entityInfo.Name] = entityInfo
 
 			case *params.ModelUpdate:
-				if entityInfo.Name == name {
-					if delta.Removed {
-						return false, errors.Errorf("model %v removed", name)
-					}
-					c.model = entityInfo
-					c.found = entityInfo.Life != life.Dead
+				if entityInfo.Name != name {
+					break
 				}
+
+				if delta.Removed {
+					return false, errors.Errorf("model %v removed", name)
+				}
+				c.model = entityInfo
+				c.found = entityInfo.Life != life.Dead
 			}
 		}
 
@@ -203,7 +205,7 @@ type ModelScope struct {
 	Model     *modelCommand
 }
 
-// MakeModelScope creates an ModelScope from an ModelUpdate
+// MakeModelScope creates a ModelScope from a ModelUpdate
 func MakeModelScope(ctx ScopeContext, model *modelCommand) ModelScope {
 	return ModelScope{
 		ctx:       ctx,
@@ -251,19 +253,19 @@ func (m ModelScope) GetIdentValue(name string) (query.Box, error) {
 			appInfo := app
 			appInfo.Status.Current = newStatus
 
-			scopes[k] = MakeApplicationScope(m.ctx.SubScope(name, app.Name), appInfo)
+			scopes[k] = MakeApplicationScope(m.ctx.Child(name, app.Name), appInfo)
 		}
 		return NewScopedBox(scopes), nil
 	case "machines":
 		scopes := make(map[string]query.Scope)
 		for k, machine := range m.Model.machines {
-			scopes[k] = MakeMachineScope(m.ctx.SubScope(name, machine.Id), machine)
+			scopes[k] = MakeMachineScope(m.ctx.Child(name, machine.Id), machine)
 		}
 		return NewScopedBox(scopes), nil
 	case "units":
 		scopes := make(map[string]query.Scope)
 		for k, unit := range m.Model.units {
-			scopes[k] = MakeUnitScope(m.ctx.SubScope(name, unit.Name), unit)
+			scopes[k] = MakeUnitScope(m.ctx.Child(name, unit.Name), unit)
 		}
 		return NewScopedBox(scopes), nil
 	}

--- a/cmd/plugins/juju-wait-for/model_test.go
+++ b/cmd/plugins/juju-wait-for/model_test.go
@@ -47,6 +47,7 @@ func (s *modelScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := ModelScope{
+			ctx:       MakeScopeContext(),
 			ModelInfo: test.ModelInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -57,6 +58,7 @@ func (s *modelScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *modelScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := ModelScope{
+		ctx:       MakeScopeContext(),
 		ModelInfo: &params.ModelUpdate{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/cmd/plugins/juju-wait-for/strategy.go
+++ b/cmd/plugins/juju-wait-for/strategy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
 
@@ -194,4 +195,19 @@ func (m *GenericScope) Clone() query.Scope {
 	return &GenericScope{
 		scopes: scopes,
 	}
+}
+
+// ScopeContext defines a context for a given scope.
+type ScopeContext struct {
+	idents set.Strings
+}
+
+// RecordIdent records the witnessing of a ident.
+func (c ScopeContext) RecordIdent(ident string) {
+	c.idents.Add(ident)
+}
+
+// RecordedIdents returns the witnessed idents via a scoped context.
+func (c ScopeContext) RecordedIdents() []string {
+	return c.idents.SortedValues()
 }

--- a/cmd/plugins/juju-wait-for/strategy.go
+++ b/cmd/plugins/juju-wait-for/strategy.go
@@ -224,16 +224,12 @@ func (c ScopeContext) RecordedIdents() []string {
 	return c.idents.SortedValues()
 }
 
-// SubScope creates a subscope of all idents for a given context.
-func (c ScopeContext) SubScope(entityName, name string) ScopeContext {
+// Child creates a child context of all idents for a given context.
+func (c ScopeContext) Child(entityName, name string) ScopeContext {
 	if child, ok := c.children[entityName][name]; ok {
 		return child
 	}
 	ctx := MakeScopeContext()
 	c.children[entityName][name] = ctx
 	return ctx
-}
-
-type LogContext interface {
-	Infof(string, ...interface{})
 }

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -128,23 +128,24 @@ func (c *unitCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, que
 
 			switch entityInfo := delta.Entity.(type) {
 			case *params.UnitInfo:
-				if entityInfo.Name == name {
-					if delta.Removed {
-						return false, errors.Errorf("unit %v removed", name)
-					}
-
-					c.unitInfo = *entityInfo
-
-					scope := MakeUnitScope(ctx, entityInfo)
-					if done, err := runQuery(q, scope); err != nil {
-						return false, errors.Trace(err)
-					} else if done {
-						return true, nil
-					}
-
-					c.found = entityInfo.Life != life.Dead
+				if entityInfo.Name != name {
+					break
 				}
-				break
+
+				if delta.Removed {
+					return false, errors.Errorf("unit %v removed", name)
+				}
+
+				c.unitInfo = *entityInfo
+
+				scope := MakeUnitScope(ctx, entityInfo)
+				if done, err := runQuery(q, scope); err != nil {
+					return false, errors.Trace(err)
+				} else if done {
+					return true, nil
+				}
+
+				c.found = entityInfo.Life != life.Dead
 			}
 		}
 

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -4,12 +4,14 @@
 package main
 
 import (
+	"io"
 	"time"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
@@ -53,6 +55,9 @@ type unitCommand struct {
 	query   string
 	timeout time.Duration
 	found   bool
+	summary bool
+
+	unitInfo params.UnitInfo
 }
 
 // Info implements Command.Info.
@@ -70,6 +75,7 @@ func (c *unitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.waitForCommandBase.SetFlags(f)
 	f.StringVar(&c.query, "query", `life=="alive" && workload-status=="active"`, "query the goal state")
 	f.DurationVar(&c.timeout, "timeout", time.Minute*10, "how long to wait, before timing out")
+	f.BoolVar(&c.summary, "summary", true, "output a summary of the application query on exit")
 }
 
 // Init implements Command.Init.
@@ -89,55 +95,79 @@ func (c *unitCommand) Init(args []string) (err error) {
 }
 
 func (c *unitCommand) Run(ctx *cmd.Context) error {
+	scopedContext := MakeScopeContext()
+
+	defer func() {
+		if !c.summary {
+			return
+		}
+
+		switch c.unitInfo.Life {
+		case life.Dead:
+			ctx.Infof("Unit %q has been removed", c.name)
+		case life.Dying:
+			ctx.Infof("Unit %q is being removed", c.name)
+		default:
+			ctx.Infof("Unit %q is running", c.name)
+			outputUnitSummary(ctx.Stdout, scopedContext, &c.unitInfo)
+		}
+	}()
+
 	strategy := &Strategy{
 		ClientFn: c.newWatchAllAPIFunc,
 		Timeout:  c.timeout,
 	}
-	err := strategy.Run(c.name, c.query, c.waitFor)
+	err := strategy.Run(c.name, c.query, c.waitFor(scopedContext))
 	return errors.Trace(err)
 }
 
-func (c *unitCommand) waitFor(name string, deltas []params.Delta, q query.Query) (bool, error) {
-	for _, delta := range deltas {
-		logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
+func (c *unitCommand) waitFor(ctx ScopeContext) func(string, []params.Delta, query.Query) (bool, error) {
+	return func(name string, deltas []params.Delta, q query.Query) (bool, error) {
+		for _, delta := range deltas {
+			logger.Tracef("delta %T: %v", delta.Entity, delta.Entity)
 
-		switch entityInfo := delta.Entity.(type) {
-		case *params.UnitInfo:
-			if entityInfo.Name == name {
-				if delta.Removed {
-					return false, errors.Errorf("unit %v removed", name)
+			switch entityInfo := delta.Entity.(type) {
+			case *params.UnitInfo:
+				if entityInfo.Name == name {
+					if delta.Removed {
+						return false, errors.Errorf("unit %v removed", name)
+					}
+
+					c.unitInfo = *entityInfo
+
+					scope := MakeUnitScope(ctx, entityInfo)
+					if done, err := runQuery(q, scope); err != nil {
+						return false, errors.Trace(err)
+					} else if done {
+						return true, nil
+					}
+
+					c.found = entityInfo.Life != life.Dead
 				}
-
-				scope := MakeUnitScope(entityInfo)
-				if done, err := runQuery(q, scope); err != nil {
-					return false, errors.Trace(err)
-				} else if done {
-					return true, nil
-				}
-
-				c.found = entityInfo.Life != life.Dead
+				break
 			}
-			break
 		}
-	}
 
-	if !c.found {
-		logger.Infof("unit %q not found, waiting...", name)
+		if !c.found {
+			logger.Infof("unit %q not found, waiting...", name)
+			return false, nil
+		}
+
+		logger.Infof("unit %q found, waiting...", name)
 		return false, nil
 	}
-
-	logger.Infof("unit %q found, waiting...", name)
-	return false, nil
 }
 
 // UnitScope allows the query to introspect a unit entity.
 type UnitScope struct {
+	ctx      ScopeContext
 	UnitInfo *params.UnitInfo
 }
 
 // MakeUnitScope creates an UnitScope from an UnitInfo
-func MakeUnitScope(info *params.UnitInfo) UnitScope {
+func MakeUnitScope(ctx ScopeContext, info *params.UnitInfo) UnitScope {
 	return UnitScope{
+		ctx:      ctx,
 		UnitInfo: info,
 	}
 }
@@ -149,6 +179,8 @@ func (m UnitScope) GetIdents() []string {
 
 // GetIdentValue returns the value of the identifier in a given scope.
 func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
+	m.ctx.RecordIdent(name)
+
 	switch name {
 	case "name":
 		return query.NewString(m.UnitInfo.Name), nil
@@ -176,4 +208,24 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}
 	return nil, errors.Annotatef(query.ErrInvalidIdentifier(name), "Runtime Error: identifier %q not found on UnitInfo", name)
+}
+
+func outputUnitSummary(writer io.Writer, scopedContext ScopeContext, unitInfo *params.UnitInfo) {
+	result := struct {
+		Elements map[string]interface{} `yaml:"properties"`
+	}{
+		Elements: make(map[string]interface{}),
+	}
+
+	idents := scopedContext.RecordedIdents()
+	for _, ident := range idents {
+		scope := MakeUnitScope(scopedContext, unitInfo)
+		box, err := scope.GetIdentValue(ident)
+		if err != nil {
+			continue
+		}
+		result.Elements[ident] = box.Value()
+	}
+
+	_ = yaml.NewEncoder(writer).Encode(result)
 }

--- a/cmd/plugins/juju-wait-for/unit_test.go
+++ b/cmd/plugins/juju-wait-for/unit_test.go
@@ -81,6 +81,7 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := UnitScope{
+			ctx:      MakeScopeContext(),
 			UnitInfo: test.UnitInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -91,6 +92,7 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *unitScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := UnitScope{
+		ctx:      MakeScopeContext(),
 		UnitInfo: &params.UnitInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")


### PR DESCRIPTION
Depending on the query it is good to know what the outcome of that query
was. You can suppress this information via a flag, but it really helps
with debugging as well.


## QA steps

```sh
$ juju deploy mysql
$ juju wait-for application mysql --query='name=="mysql" && (status=="active" || status=="idle")'
mysql is running
  - name: mysql
  - status: active
```
