### PR TITLE
Metadata dependency

### DIFF
--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -15,6 +15,23 @@ check_dependencies() {
     fi
 }
 
+check_juju_dependencies() {
+    local dep missing
+    missing=""
+
+    for dep in "$@"; do
+        if ! juju "$dep" >/dev/null 2>&1; then
+            [ "$missing" ] && missing="$missing $dep" || missing="$dep"
+        fi
+    done
+
+    if [ "$missing" ]; then
+        echo "Missing dependencies: $missing" >&2
+        echo ""
+        exit 1
+    fi
+}
+
 check_not_contains() {
     local input value chk
 

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -26,6 +26,9 @@ test_deploy_os() {
 run_deploy_centos() {
     echo
 
+    echo "==> Checking for dependencies"
+    check_juju_dependencies metadata
+
     name="test-deploy-centos"
     file="${TEST_DIR}/${name}.log"
 


### PR DESCRIPTION
Backport integration test plugin dependency check from develop, #12243.  Use in run_deploy_centos.

## QA steps

```console
$ juju bootstrap aws --credentials <juju qa creds> deploy-centos-test
$ (cd tests ; ./main.sh -l centos-deploy -v deploy test_deploy_os)

# should not run
$ (cd tests ; ./main.sh -p lxd -v deploy test_deploy_os)

==> Checking for dependencies
==> TEST BEGIN: test_deploy (tmp.MMu)
==> TEST SKIPPED: deploy_centos - tests for AWS only
==> TEST DONE: test_deploy (0s)
==> Cleaning up
====> Completed cleaning up jujus

==> Test result: success
==> Tests Removed: /home/heather/work/src/github.com/juju/juju/tests/tmp.MMu
==> TEST COMPLETE
```
