### PR TITLE
Merge 2.8 into develop

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -511,12 +511,12 @@ def deploy_job():
     if not args.logs:
         args.logs = generate_default_clean_dir(args.temp_env_name)
     if series is None:
-        series = 'precise'
+        series = 'bionic'
     charm_series = series
     # Don't need windows or centos state servers.
     if series.startswith("win") or series.startswith("centos"):
-        logging.info('Setting default series to trusty for win and centos.')
-        series = 'trusty'
+        logging.info('Setting default series to bionic for win and centos.')
+        series = 'bionic'
     return _deploy_job(args, charm_series, series)
 
 

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -43,3 +43,4 @@ dnspython==1.16.0
 google-api-python-client==1.7.8
 google-cloud-container==0.2.1
 cryptography==3.2.1
+six>=1.15.0

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -102,10 +102,6 @@ const (
 	// global clock updates.
 	globalClockUpdaterUpdateInterval = 1 * time.Second
 
-	// globalClockUpdaterBackoffDelay is the amount of time to
-	// delay when a concurrent global clock update is detected.
-	globalClockUpdaterBackoffDelay = 10 * time.Second
-
 	// leaseRequestTopic is the pubsub topic that lease FSM updates
 	// will be published on.
 	leaseRequestTopic = "lease.request"
@@ -553,16 +549,17 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:            loggo.GetLogger("juju.worker.migrationminion"),
 		}),
 
-		// We run clock updaters for every controller machine to
-		// ensure the lease clock is updated monotonically and at a
-		// rate no faster than real time.
+		// We start clock updaters for every controller machine to ensure the
+		// lease clock is updated monotonically and at a rate no faster than
+		// real time.
+		// In practice, dependency on the Raft forwarder means that this worker
+		// will only ever be running on the Raft leader node.
 		leaseClockUpdaterName: globalclockupdater.Manifold(globalclockupdater.ManifoldConfig{
 			Clock:            config.Clock,
 			LeaseManagerName: leaseManagerName,
 			RaftName:         raftForwarderName,
 			NewWorker:        globalclockupdater.NewWorker,
 			UpdateInterval:   globalClockUpdaterUpdateInterval,
-			BackoffDelay:     globalClockUpdaterBackoffDelay,
 			Logger:           loggo.GetLogger("juju.worker.globalclockupdater.raft"),
 		}),
 

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -139,10 +139,15 @@ func (a *Application) setDetails(details ApplicationChange) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	a.setRemovalMessage(RemoveApplication{
-		ModelUUID: details.ModelUUID,
-		Name:      details.Name,
-	})
+	// If this is the first receipt of details, set the removal message.
+	if a.removalMessage == nil {
+		a.removalMessage = RemoveApplication{
+			ModelUUID: details.ModelUUID,
+			Name:      details.Name,
+		}
+	}
+
+	a.setStale(false)
 
 	if a.details.CharmURL != details.CharmURL {
 		a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -81,10 +81,15 @@ func (b *Branch) CompletedBy() string {
 }
 
 func (b *Branch) setDetails(details BranchChange) {
-	b.setRemovalMessage(RemoveBranch{
-		ModelUUID: details.ModelUUID,
-		Id:        details.Id,
-	})
+	// If this is the first receipt of details, set the removal message.
+	if b.removalMessage == nil {
+		b.removalMessage = RemoveBranch{
+			ModelUUID: details.ModelUUID,
+			Id:        details.Id,
+		}
+	}
+
+	b.setStale(false)
 
 	b.details = details
 	b.hub.Publish(branchChange, b.copy())

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -42,11 +42,15 @@ func (c *Charm) DefaultConfig() map[string]interface{} {
 }
 
 func (c *Charm) setDetails(details CharmChange) {
-	c.setRemovalMessage(RemoveCharm{
-		ModelUUID: details.ModelUUID,
-		CharmURL:  details.CharmURL,
-	})
+	// If this is the first receipt of details, set the removal message.
+	if c.removalMessage == nil {
+		c.removalMessage = RemoveCharm{
+			ModelUUID: details.ModelUUID,
+			CharmURL:  details.CharmURL,
+		}
+	}
 
+	c.setStale(false)
 	c.details = details
 }
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -160,10 +160,15 @@ func (m *Machine) containerRegexp() (*regexp.Regexp, error) {
 }
 
 func (m *Machine) setDetails(details MachineChange) {
-	m.setRemovalMessage(RemoveMachine{
-		ModelUUID: details.ModelUUID,
-		Id:        details.Id,
-	})
+	// If this is the first receipt of details, set the removal message.
+	if m.removalMessage == nil {
+		m.removalMessage = RemoveMachine{
+			ModelUUID: details.ModelUUID,
+			Id:        details.Id,
+		}
+	}
+
+	m.setStale(false)
 
 	provisioned := details.InstanceId != m.details.InstanceId
 	m.details = details

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -560,9 +560,14 @@ func (m *Model) removeBranch(ch RemoveBranch) error {
 func (m *Model) setDetails(details ModelChange) {
 	m.mu.Lock()
 
-	m.setRemovalMessage(RemoveModel{
-		ModelUUID: details.ModelUUID,
-	})
+	// If this is the first receipt of details, set the removal message.
+	if m.removalMessage == nil {
+		m.removalMessage = RemoveModel{
+			ModelUUID: details.ModelUUID,
+		}
+	}
+
+	m.setStale(false)
 	m.details = details
 
 	hashCache, configHash := newHashCache(details.Config, m.metrics.ModelHashCacheHit, m.metrics.ModelHashCacheMiss)

--- a/core/cache/relation.go
+++ b/core/cache/relation.go
@@ -35,10 +35,15 @@ func (r *Relation) Endpoints() []Endpoint {
 }
 
 func (r *Relation) setDetails(details RelationChange) {
-	r.setRemovalMessage(RemoveRelation{
-		ModelUUID: details.ModelUUID,
-		Key:       details.Key,
-	})
+	// If this is the first receipt of details, set the removal message.
+	if r.removalMessage == nil {
+		r.removalMessage = RemoveRelation{
+			ModelUUID: details.ModelUUID,
+			Key:       details.Key,
+		}
+	}
+
+	r.setStale(false)
 }
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -153,16 +153,15 @@ func (m *residentManager) evictions() ([]uint64, map[uint64]interface{}) {
 	var removalIds []uint64
 	removalMessages := make(map[uint64]interface{})
 	for id, r := range m.residents {
-		r.mu.Lock()
-		if r.stale {
+		if r.isStale() {
 			if r.removalMessage == nil {
 				logger.Warningf("cache resident %d has no removal message; skipping eviction", id)
-			} else {
-				removalIds = append(removalIds, id)
-				removalMessages[id] = r.removalMessage
+				continue
 			}
+
+			removalIds = append(removalIds, id)
+			removalMessages[id] = r.removalMessage
 		}
-		r.mu.Unlock()
 	}
 	sort.Sort(uint64Reverse(removalIds))
 
@@ -277,23 +276,16 @@ func (r *Resident) deregisterWorker(id uint64) {
 	r.mu.Unlock()
 }
 
+func (r *Resident) isStale() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stale
+}
+
 func (r *Resident) setStale(stale bool) {
 	r.mu.Lock()
 	r.stale = stale
 	r.mu.Unlock()
-}
-
-func (r *Resident) setRemovalMessage(msg interface{}) bool {
-	// If this is the first receipt of details, set the removal message.
-	r.mu.Lock()
-	wasNil := false
-	if r.removalMessage == nil {
-		r.removalMessage = msg
-		wasNil = true
-	}
-	r.stale = false
-	r.mu.Unlock()
-	return wasNil
 }
 
 // unint64Reverse facilitates sorting of a slice in *descending* order.

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -184,14 +184,17 @@ func (u *Unit) WatchConfigSettings() (*CharmConfigWatcher, error) {
 func (u *Unit) setDetails(details UnitChange) {
 	var newSubordinate bool
 
-	if u.setRemovalMessage(RemoveUnit{
-		ModelUUID: details.ModelUUID,
-		Name:      details.Name,
-	}) {
-		// First receipt of the details so we
-		// may have a new subordinate also.
+	// If this is the first receipt of details, set the removal message.
+	if u.removalMessage == nil {
+		u.removalMessage = RemoveUnit{
+			ModelUUID: details.ModelUUID,
+			Name:      details.Name,
+		}
+
 		newSubordinate = details.Subordinate
 	}
+
+	u.setStale(false)
 
 	landingOnMachine := u.details.MachineId != details.MachineId
 	u.details = details

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -200,7 +200,7 @@ func (f *FSM) unpin(key lease.Key, entity string) *response {
 
 func (f *FSM) setTime(oldTime, newTime time.Time) *response {
 	if f.globalTime != oldTime {
-		return &response{err: globalclock.ErrConcurrentUpdate}
+		return &response{err: globalclock.ErrOutOfSyncUpdate}
 	}
 	f.globalTime = newTime
 	return &response{expired: f.removeExpired(newTime)}

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -223,7 +223,7 @@ func (s *fsmSuite) TestSetTime(c *gc.C) {
 		Operation: raftlease.OperationSetTime,
 		OldTime:   zero,
 		NewTime:   zero.Add(time.Second),
-	}).Error(), jc.Satisfies, globalclock.IsConcurrentUpdate)
+	}).Error(), jc.Satisfies, globalclock.IsOutOfSyncUpdate)
 }
 
 func (s *fsmSuite) TestSetTimeExpiresLeases(c *gc.C) {

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -193,6 +193,7 @@ func (s *Store) pinOp(operation string, key lease.Key, entity string, stop <-cha
 func (s *Store) Advance(duration time.Duration, stop <-chan struct{}) error {
 	s.prevTimeMu.Lock()
 	defer s.prevTimeMu.Unlock()
+
 	newTime := s.prevTime.Add(duration)
 	err := s.runOnLeader(&Command{
 		Version:   CommandVersion,
@@ -200,17 +201,23 @@ func (s *Store) Advance(duration time.Duration, stop <-chan struct{}) error {
 		OldTime:   s.prevTime,
 		NewTime:   newTime,
 	}, stop)
-	if globalclock.IsConcurrentUpdate(err) {
-		// Someone else updated before us - get the new time.
-		s.prevTime = s.fsm.GlobalTime()
-	} else if lease.IsTimeout(err) {
-		// Convert this to a globalclock timeout to match the Updater
-		// interface.
-		err = globalclock.ErrTimeout
-	} else if err == nil {
-		s.prevTime = newTime
+
+	if err != nil {
+		// If we timed out, convert the error to match the Updater interface.
+		if lease.IsTimeout(err) {
+			return globalclock.ErrTimeout
+		}
+
+		// If we had an incorrect notion of global time, resync with the FSM.
+		if globalclock.IsOutOfSyncUpdate(err) {
+			s.prevTime = s.fsm.GlobalTime()
+		}
+
+		return errors.Trace(err)
 	}
-	return errors.Trace(err)
+
+	s.prevTime = newTime
+	return nil
 }
 
 func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
@@ -221,16 +228,16 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 	requestID := atomic.AddUint64(&s.requestID, 1)
 	responseTopic := s.config.ResponseTopic(requestID)
 
-	responseChan := make(chan ForwardResponse, 1)
+	responseChan := make(chan ForwardResponse)
 	errChan := make(chan error)
 	unsubscribe, err := s.hub.Subscribe(
 		responseTopic,
 		func(_ string, resp ForwardResponse, err error) {
 			if err != nil {
 				errChan <- err
-				return
+			} else {
+				responseChan <- resp
 			}
-			responseChan <- resp
 		},
 	)
 	if err != nil {
@@ -243,7 +250,8 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 		elapsed := time.Now().Sub(start)
 		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
-	_, err = s.hub.Publish(s.config.RequestTopic, ForwardRequest{
+
+	delivered, err := s.hub.Publish(s.config.RequestTopic, ForwardRequest{
 		Command:       string(bytes),
 		ResponseTopic: responseTopic,
 	})
@@ -252,30 +260,46 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 		return errors.Annotatef(err, "publishing %s", command)
 	}
 
+	// First block until subscribers are notified.
+	// In practice, this will be the Raft forwarder running on the leader node.
+	// This is an explicit step so that we can more accurately diagnose issues
+	// in-theatre.
 	select {
+	case <-delivered:
 	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		// TODO (thumper) 2019-12-20, bug 1857072
-		// Scale testing hit this a *lot*,
-		// perhaps we need to consider batching messages to run on the leader?
-		logger.Errorf("timeout waiting for %s to be processed", command)
-		s.record(command.Operation, "timeout", start)
+		logger.Warningf("delivery timeout waiting for %s to be processed", command)
+		s.record(command.Operation, "delivery timeout", start)
 		return lease.ErrTimeout
-	case err := <-errChan:
-		logger.Errorf("processing %s: %v", command, err)
-		s.record(command.Operation, "error", start)
-		return errors.Trace(err)
+	}
+
+	// Now wait for the response.
+	// The timeout starts again here, which is deliberate.
+	// It is the same timeout that is used by the Raft forwarder
+	// when `Apply` is called on the FSM.
+	select {
 	case response := <-responseChan:
 		err := RecoverError(response.Error)
 		logger.Tracef("got response, err %v", err)
 		result := "success"
 		if err != nil {
-			logger.Errorf("command %s: %v", command, err)
+			logger.Warningf("command %s: %v", command, err)
 			result = "failure"
 		}
 		s.record(command.Operation, result, start)
 		return err
+	case err := <-errChan:
+		logger.Warningf("processing %s: %v", command, err)
+		s.record(command.Operation, "error", start)
+		return errors.Trace(err)
 	case <-stop:
 		return aborted(command)
+	case <-s.config.Clock.After(s.config.ForwardTimeout):
+		// TODO (thumper) 2019-12-20, bug 1857072
+		// Scale testing hit this a *lot*,
+		// perhaps we need to consider batching messages to run on the leader?
+		logger.Warningf("response timeout waiting for %s to be processed", command)
+		s.record(command.Operation, "response timeout", start)
+		return lease.ErrTimeout
 	}
 }
 
@@ -317,8 +341,8 @@ func AsResponseError(err error) *ResponseError {
 	switch errors.Cause(err) {
 	case lease.ErrInvalid:
 		code = "invalid"
-	case globalclock.ErrConcurrentUpdate:
-		code = "concurrent-update"
+	case globalclock.ErrOutOfSyncUpdate:
+		code = "out-of-sync"
 	case lease.ErrHeld:
 		code = "already-held"
 	default:
@@ -340,8 +364,8 @@ func RecoverError(resp *ResponseError) error {
 	switch resp.Code {
 	case "invalid":
 		return lease.ErrInvalid
-	case "concurrent-update":
-		return globalclock.ErrConcurrentUpdate
+	case "out-of-sync":
+		return globalclock.ErrOutOfSyncUpdate
 	case "already-held":
 		return lease.ErrHeld
 	default:

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -138,7 +138,7 @@ func (s *storeSuite) TestClaimTimeout(c *gc.C) {
 			}()
 			// Jump time forward further than the 1-second forward
 			// timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -280,7 +280,7 @@ func (s *storeSuite) TestExtendLeaseTimeout(c *gc.C) {
 
 			// Jump time forward further than the 1-second forward
 			// timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -386,7 +386,7 @@ func (s *storeSuite) TestRevokeLeaseTimeout(c *gc.C) {
 
 			// Jump time forward further than the 1-second forward
 			// timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -570,7 +570,7 @@ func (s *storeSuite) TestPinTimeout(c *gc.C) {
 				)
 			}()
 			// Move time forward so the request is timed out
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -672,7 +672,7 @@ func (s *storeSuite) TestUnpinTimeout(c *gc.C) {
 				)
 			}()
 			// Move time forward so the request is timed out
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -786,7 +786,7 @@ func (s *storeSuite) TestAdvanceConcurrentUpdate(c *gc.C) {
 	s.handleHubRequest(c,
 		func() {
 			err := s.store.Advance(10*time.Second, nil)
-			c.Assert(err, jc.Satisfies, globalclock.IsConcurrentUpdate)
+			c.Assert(err, jc.Satisfies, globalclock.IsOutOfSyncUpdate)
 		},
 		raftlease.Command{
 			Version:   1,
@@ -799,7 +799,7 @@ func (s *storeSuite) TestAdvanceConcurrentUpdate(c *gc.C) {
 				req.ResponseTopic,
 				raftlease.ForwardResponse{
 					Error: &raftlease.ResponseError{
-						Code: "concurrent-update",
+						Code: "out-of-sync",
 					},
 				},
 			)
@@ -841,7 +841,7 @@ func (s *storeSuite) TestAdvanceTimeout(c *gc.C) {
 			}()
 
 			// Move time forward to trigger the timeout.
-			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 1), jc.ErrorIsNil)
+			c.Assert(s.clock.WaitAdvance(2*time.Second, coretesting.LongWait, 2), jc.ErrorIsNil)
 
 			select {
 			case err := <-errChan:
@@ -903,11 +903,11 @@ func (s *storeSuite) TestAsResponseError(c *gc.C) {
 		},
 	)
 	c.Assert(
-		raftlease.AsResponseError(globalclock.ErrConcurrentUpdate),
+		raftlease.AsResponseError(globalclock.ErrOutOfSyncUpdate),
 		gc.DeepEquals,
 		&raftlease.ResponseError{
-			Message: "clock was updated concurrently, retry",
-			Code:    "concurrent-update",
+			Message: "clock update attempt by out-of-sync caller, retry",
+			Code:    "out-of-sync",
 		},
 	)
 	c.Assert(
@@ -937,7 +937,7 @@ func (s *storeSuite) TestRecoverError(c *gc.C) {
 		})
 	}
 	c.Assert(re("", "invalid"), jc.Satisfies, lease.IsInvalid)
-	c.Assert(re("", "concurrent-update"), jc.Satisfies, globalclock.IsConcurrentUpdate)
+	c.Assert(re("", "out-of-sync"), jc.Satisfies, globalclock.IsOutOfSyncUpdate)
 	c.Assert(re("something", "else"), gc.ErrorMatches, "something")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012
 
 replace gopkg.in/natefinch/lumberjack.v2 => github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible
 
-replace gopkg.in/mgo.v2 => github.com/juju/mgo v2.0.0-20190418114320-e9d4866cb7fc+incompatible
+replace gopkg.in/mgo.v2 => github.com/juju/mgo v2.0.0-20201106044211-d9585b0b0d28+incompatible
 
 replace github.com/hashicorp/raft => github.com/juju/raft v2.0.0-20200420012049-88ad3b3f0a54+incompatible
 

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,8 @@ github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7L
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible/go.mod h1:YQBneJkXlAAye6yHFYH8CabVID+0Oq2by8DDKGj5OIU=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f h1:a3Vd00a20dTKLpyS2hdUafNG5zxQdTw5KhDMK5C0a8U=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f/go.mod h1:+7K7MqWi5xWI+s1LyB2g0Di71jZo27y+XOlmhNtV1Y0=
-github.com/juju/mgo v2.0.0-20190418114320-e9d4866cb7fc+incompatible h1:QRdXk1MzzBiLHL8GHNJVnrsh8y3AW8h6CQkTr9qtKXI=
-github.com/juju/mgo v2.0.0-20190418114320-e9d4866cb7fc+incompatible/go.mod h1:7a/cakyF0q2iwjcD35dn0dgVCdKnLW5j/5iCCAFu7vg=
+github.com/juju/mgo v2.0.0-20201106044211-d9585b0b0d28+incompatible h1:EZ8JH/I7PZ5OdZPPAPN24eQhrGYLVKjTvvzv86o2F4Q=
+github.com/juju/mgo v2.0.0-20201106044211-d9585b0b0d28+incompatible/go.mod h1:7a/cakyF0q2iwjcD35dn0dgVCdKnLW5j/5iCCAFu7vg=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31 h1:v6GpXmpXOD6KwPbApRlwDGQxf1FpS6gfLdfVbE4ZLzk=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31/go.mod h1:m6E+J+I+cE+6rcaVxSI4HwGLIEOCSOBMYedt3Sewh+U=
 github.com/juju/mgotest v1.0.1 h1:XvuZ2whmkHZ5G+Y/wQaSe28p2FyTwcBaqTzStn+QaLc=

--- a/state/globalclock/updater.go
+++ b/state/globalclock/updater.go
@@ -41,6 +41,9 @@ func NewUpdater(config UpdaterConfig) (*Updater, error) {
 // Updater provides a means of updating the global clock time.
 //
 // Updater is not goroutine-safe.
+// TODO (manadart 2020-11-03): This implementation is no longer used,
+// except by upgrade steps.
+// Remove it and the steps for Juju 3.0.
 type Updater struct {
 	config UpdaterConfig
 	time   time.Time
@@ -49,12 +52,12 @@ type Updater struct {
 // Advance adds the given duration to the global clock, ensuring
 // that the clock has not been updated concurrently.
 //
-// Advance will return ErrConcurrentUpdate if another updater
+// Advance will return ErrOutOfSyncUpdate if another updater
 // updates the clock concurrently. In this case, the updater
 // will refresh its view of the clock, and the caller can
 // attempt Advance later.
 //
-// If Advance returns any error other than ErrConcurrentUpdate,
+// If Advance returns any error other than ErrOutOfSyncUpdate,
 // the Updater should be considered invalid, and the caller
 // should obtain a new Updater. Failing to do so could lead
 // to non-monotonic time, since there is no way of knowing in
@@ -79,7 +82,7 @@ func (u *Updater) Advance(d time.Duration, _ <-chan struct{}) error {
 				return errors.Annotate(err, "refreshing time after write conflict")
 			}
 			u.time = t
-			return globalclock.ErrConcurrentUpdate
+			return globalclock.ErrOutOfSyncUpdate
 		}
 		return errors.Annotatef(err,
 			"adding %s to current time %s", d, u.time,

--- a/state/globalclock/updater_test.go
+++ b/state/globalclock/updater_test.go
@@ -92,11 +92,11 @@ func (s *UpdaterSuite) TestUpdaterConcurrentAdvance(c *gc.C) {
 	c.Assert(s.readTime(c), gc.Equals, globalEpoch.Add(time.Second))
 
 	err = u1.Advance(time.Second, nil)
-	c.Assert(err, gc.Equals, coreglobalclock.ErrConcurrentUpdate)
+	c.Assert(err, gc.Equals, coreglobalclock.ErrOutOfSyncUpdate)
 	c.Assert(s.readTime(c), gc.Equals, globalEpoch.Add(time.Second)) // no change
 
 	// u1's view of the clock should have been updated when
-	// ErrConcurrentUpdate was returned, so Advance should
+	// ErrOutOfSyncUpdate was returned, so Advance should
 	// now succeed.
 	err = u1.Advance(time.Second, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/mgo/logger.go
+++ b/state/mgo/logger.go
@@ -9,17 +9,21 @@ import (
 
 	"github.com/juju/loggo"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/txn"
 )
 
 const (
-	mgoLoggerName = "juju.mgo"
+	mgoLoggerName    = "juju.mgo"
+	mgoTxnLoggerName = "juju.mgo.txn"
 )
+
+var mgoLogger = loggo.GetLogger(mgoLoggerName)
+var mgoTxnLogger = loggo.GetLogger(mgoTxnLoggerName)
 
 // ConfigureMgoLogging sets up juju/mgo package logging according
 // to the logging config value for "juju.mgo".
 func ConfigureMgoLogging() {
-	logger := loggo.GetLogger(mgoLoggerName)
-	logLevel := logger.EffectiveLogLevel()
+	logLevel := mgoLogger.EffectiveLogLevel()
 	// mgo logging is quite verbose.
 	// mgo "debug" is similar to juju "trace".
 	mgo.SetDebug(logLevel == loggo.TRACE)
@@ -28,23 +32,51 @@ func ConfigureMgoLogging() {
 		mgo.SetLogger(nil)
 		return
 	}
-	mgo.SetLogger(&mgoLogger{
-		logger: logger,
+	mgo.SetLogger(&mgoLogWriter{
+		logger: mgoLogger,
+	})
+
+	logLevel = mgoTxnLogger.EffectiveLogLevel()
+	txn.SetDebug(logLevel == loggo.DEBUG)
+	// Only output mgo txn logging for juju "info" or greater.
+	if logLevel == loggo.UNSPECIFIED || logLevel >= loggo.WARNING {
+		mgo.SetLogger(nil)
+		return
+	}
+	txn.SetLogger(&mgoTxnLogWriter{
+		logger: mgoLogger,
 	})
 }
 
-type mgoLogger struct {
+type mgoLogWriter struct {
 	logger loggo.Logger
 }
 
 // Output implements the mgo log_Logger interface.
-func (s *mgoLogger) Output(calldepth int, message string) error {
+func (s *mgoLogWriter) Output(calldepth int, message string) error {
 	// If the output results from a debug function,
 	// log at trace level.
 	caller := callerFunc(calldepth - 1)
 	level := loggo.DEBUG
 	if strings.HasPrefix(caller, "debug") {
 		level = loggo.TRACE
+	}
+	s.logger.LogCallf(calldepth, level, message)
+	return nil
+}
+
+type mgoTxnLogWriter struct {
+	logger loggo.Logger
+}
+
+// Output implements the mgo log_Logger interface.
+func (s *mgoTxnLogWriter) Output(calldepth int, message string) error {
+	// If the output results from a debug function,
+	// log at debug level.
+	caller := callerFunc(calldepth - 1)
+	level := loggo.INFO
+	if strings.HasPrefix(caller, "debug") {
+		level = loggo.DEBUG
 	}
 	s.logger.LogCallf(calldepth, level, message)
 	return nil

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -54,13 +54,10 @@ ensure() {
 bootstrap() {
     local provider name output model bootstrapped_name
     case "${BOOTSTRAP_PROVIDER:-}" in
-        "aws")
+        "aws" | "ec2")
             provider="aws"
             ;;
-        "localhost")
-            provider="lxd"
-            ;;
-        "lxd")
+        "localhost" | "lxd")
             provider="lxd"
             ;;
         "lxd-remote")

--- a/tests/suites/deploy/charms/centos-dummy-sink/README
+++ b/tests/suites/deploy/charms/centos-dummy-sink/README
@@ -1,0 +1,1 @@
+CentOS version of basic dummy-sink testing charm.

--- a/tests/suites/deploy/charms/centos-dummy-sink/config.yaml
+++ b/tests/suites/deploy/charms/centos-dummy-sink/config.yaml
@@ -1,0 +1,5 @@
+options:
+  token:
+    type: string
+    default: ''
+    description: Token used to prove that the relation is working

--- a/tests/suites/deploy/charms/centos-dummy-sink/copyright
+++ b/tests/suites/deploy/charms/centos-dummy-sink/copyright
@@ -1,0 +1,1 @@
+Copyright 2014 Canonical Ltd.

--- a/tests/suites/deploy/charms/centos-dummy-sink/hooks/source-relation-changed
+++ b/tests/suites/deploy/charms/centos-dummy-sink/hooks/source-relation-changed
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /var/run/dummy-sink
+relation-get token > /var/run/dummy-sink/token

--- a/tests/suites/deploy/charms/centos-dummy-sink/metadata.yaml
+++ b/tests/suites/deploy/charms/centos-dummy-sink/metadata.yaml
@@ -1,0 +1,13 @@
+name: dummy-sink
+maintainer: Martin Packman <martin.packman@canonical.com>
+summary: Dummy charm that accepts data
+description: |
+  This dummy charm is used to verify that a relationship is created correctly
+provides:
+  source:
+    interface: dummy-token
+categories:
+  - misc
+series:
+  - centos7
+  - centos8

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -160,11 +160,7 @@ test_deploy_bundles() {
         run "run_deploy_trusted_bundle"
 
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "lxd")
-                run "run_deploy_lxd_profile_bundle_openstack"
-                run "run_deploy_lxd_profile_bundle"
-                ;;
-            "localhost")
+            "lxd" | "localhost")
                 run "run_deploy_lxd_profile_bundle_openstack"
                 run "run_deploy_lxd_profile_bundle"
                 ;;

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -234,17 +234,14 @@ test_deploy_charms() {
         run "run_deploy_lxd_profile_charm_container"
 
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "lxd")
-                run "run_deploy_lxd_to_machine"
-                run "run_deploy_lxd_profile_charm"
-                run "run_deploy_local_lxd_profile_charm"
-                ;;
-            "localhost")
+            "lxd" | "localhost")
                 run "run_deploy_lxd_to_machine"
                 run "run_deploy_lxd_profile_charm"
                 run "run_deploy_local_lxd_profile_charm"
                 ;;
             *)
+                echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"
+                echo "==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only"
                 echo "==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only"
                 ;;
         esac

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -1,0 +1,56 @@
+
+test_deploy_os() {
+    if [ "$(skip 'test_deploy_os')" ]; then
+        echo "==> TEST SKIPPED: deploy to os"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+
+
+        case "${BOOTSTRAP_PROVIDER:-}" in
+            "ec2" | "aws")
+                run "run_deploy_centos"
+                ;;
+            *)
+                echo "==> TEST SKIPPED: deploy_centos - tests for AWS only"
+                ;;
+        esac
+    )
+}
+
+run_deploy_centos() {
+    echo
+
+    name="test-deploy-centos"
+    file="${TEST_DIR}/${name}.log"
+
+    ensure "${name}" "${file}"
+
+    #
+    # Images have been setup and and subscribed for juju-qa aws
+    # in us-west-2.  Take care editing the details.
+    #
+    juju add-model test-deploy-centos-west2 aws/us-west-2
+
+    juju metadata add-image --series centos7 ami-0bc06212a56393ee1
+
+    #
+    # There is a specific list of instance types which can be used with
+    # this image.  Sometimes juju chooses the wrong one e.g. t3a.medium.
+    # Ensure we use one that is allowed.
+    #
+    juju deploy ./tests/suites/deploy/charms/centos-dummy-sink --series centos7 --constraints instance-type=t3.medium
+
+    series=$(juju status --format=json | jq '.applications."dummy-sink".series')
+    echo "$series" | check "centos7"
+
+    wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
+
+    destroy_model "${name}"
+    destroy_model "test-deploy-centos-west2"
+}

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -16,6 +16,7 @@ test_deploy() {
     test_deploy_charms
     test_deploy_bundles
     test_cmr_bundles_export_overlay
+    test_deploy_os
 
     destroy_controller "test-deploy-ctl"
 }

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -10,20 +10,16 @@ test_deploy_manual() {
         cd .. || exit
 
         case "${BOOTSTRAP_PROVIDER:-}" in
-            "lxd")
+            "lxd" | "localhost")
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_lxd"
                 ;;
-            "localhost")
-                export BOOTSTRAP_PROVIDER="manual"
-                run "run_deploy_manual_lxd"
-                ;;
-            "aws")
+            "aws" | "ec2")
                 export BOOTSTRAP_PROVIDER="manual"
                 run "run_deploy_manual_aws"
                 ;;
             *)
-                echo "==> TEST SKIPPED: deploy manual - tests for LXD and AWS"
+                echo "==> TEST SKIPPED: deploy manual - tests for LXD and AWS only"
                 ;;
         esac
     )

--- a/worker/globalclockupdater/manifold.go
+++ b/worker/globalclockupdater/manifold.go
@@ -23,7 +23,6 @@ type ManifoldConfig struct {
 
 	NewWorker      func(Config) (worker.Worker, error)
 	UpdateInterval time.Duration
-	BackoffDelay   time.Duration
 	Logger         Logger
 }
 
@@ -42,9 +41,6 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.UpdateInterval <= 0 {
 		return errors.NotValidf("non-positive UpdateInterval")
-	}
-	if config.BackoffDelay <= 0 {
-		return errors.NotValidf("non-positive BackoffDelay")
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -68,8 +64,10 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	// We don't need anything from raft directly, but ensure it's
-	// running before continuing.
+	// This enforces a dependency on the Raft forwarder,
+	// effectively ensuring this worker is only active on the Raft leader.
+	// By extension, this also ensures that Raft is running on the node
+	// before we begin updating its FSM clock.
 	if err := context.Get(config.RaftName, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -79,18 +77,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	worker, err := config.NewWorker(Config{
+	w, err := config.NewWorker(Config{
 		NewUpdater: func() (globalclock.Updater, error) {
 			return updater, nil
 		},
 		LocalClock:     config.Clock,
 		UpdateInterval: config.UpdateInterval,
-		BackoffDelay:   config.BackoffDelay,
 		Logger:         config.Logger,
 	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return worker, nil
+	return w, errors.Trace(err)
 }

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -41,7 +41,6 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		RaftName:         "raft",
 		NewWorker:        s.newWorker,
 		UpdateInterval:   time.Second,
-		BackoffDelay:     time.Second,
 		Logger:           s.logger,
 	}
 	s.worker = worker.NewRunner(worker.RunnerParams{})
@@ -80,11 +79,6 @@ func (s *ManifoldSuite) TestStartValidateRaftName(c *gc.C) {
 func (s *ManifoldSuite) TestStartValidateUpdateInterval(c *gc.C) {
 	s.config.UpdateInterval = 0
 	s.testStartValidateConfig(c, "non-positive UpdateInterval not valid")
-}
-
-func (s *ManifoldSuite) TestStartValidateBackoffDelay(c *gc.C) {
-	s.config.BackoffDelay = -1
-	s.testStartValidateConfig(c, "non-positive BackoffDelay not valid")
 }
 
 func (s *ManifoldSuite) testStartValidateConfig(c *gc.C, expect string) {
@@ -145,7 +139,6 @@ func (s *ManifoldSuite) TestStartNewWorkerSuccessWithLeaseManager(c *gc.C) {
 	c.Assert(config, jc.DeepEquals, globalclockupdater.Config{
 		LocalClock:     fakeClock{},
 		UpdateInterval: s.config.UpdateInterval,
-		BackoffDelay:   s.config.BackoffDelay,
 		Logger:         s.logger,
 	})
 }

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -50,7 +50,7 @@ func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachin
 	task.machinesMutex.RLock()
 	defer task.machinesMutex.RUnlock()
 	// sort to make comparisons in the tests easier.
-	sort.Sort(azMachineFilterSort(task.availabilityZoneMachines))
+	sort.Sort(azMachineSort(task.availabilityZoneMachines))
 	retvalues := make([]AvailabilityZoneMachine, len(task.availabilityZoneMachines))
 	for i := range task.availabilityZoneMachines {
 		retvalues[i] = *task.availabilityZoneMachines[i]


### PR DESCRIPTION
Merge from 2.8 to bring forward:
- #12248 from manadart/2.8-raft-clock-updates
- #12261 from manadart/2.8-raft-explicit-delivery-check
- #12267 from benhoyt/fix-machine-az-test
- #12269 from wallyworld/revert-cache-race-fix
- #12268 from wallyworld/mgo-logging-part2
- #12255 from hmlanigan/deploy-windows-centos
- #12264 from hmlanigan/six-requirement
- #12260 from achilleasa/2.8-fix-race-in-start-hook-after-reboot-test
- #12259 from wallyworld/update-mgo-upstream

2 trivial conflicts resolved in test files.
