### PR TITLE
Fix lp:1891227 - openstack networks with no AZ

### DIFF
--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -122,46 +122,11 @@ func newNetworking(e *Environ) Networking {
 }
 
 // AllocatePublicIP is part of the Networking interface.
-func (n *NeutronNetworking) AllocatePublicIP(instId instance.Id) (*string, error) {
-	extNetworkIds := make([]string, 0)
-	neutronClient := n.env.neutron()
-	externalNetwork := n.env.ecfg().externalNetwork()
-	if externalNetwork != "" {
-		// the config specified an external network, try it first.
-		netId, err := resolveNeutronNetwork(neutronClient, externalNetwork, true)
-		if err != nil {
-			logger.Debugf("external network %s not found, search for one", externalNetwork)
-		} else {
-			logger.Debugf("using external network %q", externalNetwork)
-			extNetworkIds = []string{netId}
-		}
-	}
-
-	if len(extNetworkIds) == 0 {
-		// Create slice of network.Ids for external networks in the same AZ as
-		// the instance's network, to find an existing floating ip in, or allocate
-		// a new floating ip from.
-		net := n.env.ecfg().network()
-		netId, err := resolveNeutronNetwork(neutronClient, net, false)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		netDetails, err := neutronClient.GetNetworkV2(netId)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		for _, az := range netDetails.AvailabilityZones {
-			extNetIds, _ := getExternalNeutronNetworksByAZ(n.env, az)
-			if len(extNetIds) > 0 {
-				extNetworkIds = append(extNetworkIds, extNetIds...)
-			}
-		}
-
-		if len(extNetworkIds) == 0 {
-			return nil, errors.NotFoundf(
-				"could not find an external network in availability zone %s", netDetails.AvailabilityZones)
-		}
+func (n *NeutronNetworking) AllocatePublicIP(_ instance.Id) (*string, error) {
+	// Look for an external network to use for the FIP.
+	extNetworkIds, err := n.getExternalNetworkIDs()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	// Look for FIPs in same project as the credentials.
@@ -191,7 +156,7 @@ func (n *NeutronNetworking) AllocatePublicIP(instId instance.Id) (*string, error
 	var lastErr error
 	for _, extNetId := range extNetworkIds {
 		var newfip *neutron.FloatingIPV2
-		newfip, lastErr = neutronClient.AllocateFloatingIPV2(extNetId)
+		newfip, lastErr = n.env.neutron().AllocateFloatingIPV2(extNetId)
 		if lastErr == nil {
 			logger.Debugf("allocated new public IP: %s", newfip.IP)
 			return &newfip.IP, nil
@@ -202,12 +167,68 @@ func (n *NeutronNetworking) AllocatePublicIP(instId instance.Id) (*string, error
 	return nil, lastErr
 }
 
+// getExternalNetworkIDs returns a slice of external network IDs.
+// If specified, the configured external network is returned.
+// Otherwise search for an external network in the same
+// availability zone as the private network.
+func (n *NeutronNetworking) getExternalNetworkIDs() ([]string, error) {
+	extNetworkIds := make([]string, 0)
+	neutronClient := n.env.neutron()
+	externalNetwork := n.env.ecfg().externalNetwork()
+	if externalNetwork != "" {
+		// the config specified an external network, try it first.
+		netId, err := resolveNeutronNetwork(neutronClient, externalNetwork, true)
+		if err != nil {
+			logger.Debugf("external network %s not found, search for one", externalNetwork)
+		} else {
+			logger.Debugf("using external network %q", externalNetwork)
+			extNetworkIds = []string{netId}
+		}
+	}
+
+	if len(extNetworkIds) == 0 {
+		// Create slice of network.Ids for external networks in the same AZ as
+		// the instance's network, to find an existing floating ip in, or allocate
+		// a new floating ip from.
+		configNetwork := n.env.ecfg().network()
+		netId, err := resolveNeutronNetwork(neutronClient, configNetwork, false)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		netDetails, err := neutronClient.GetNetworkV2(netId)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		availabilityZones := netDetails.AvailabilityZones
+		if len(availabilityZones) == 0 {
+			// No availability zones is valid, check for empty string
+			// to ensure we still find the external network with no
+			// AZ specified.  lp: 1891227
+			availabilityZones = []string{""}
+		}
+		for _, az := range availabilityZones {
+			extNetIds, _ := getExternalNeutronNetworksByAZ(n.env, az)
+			if len(extNetIds) > 0 {
+				extNetworkIds = append(extNetworkIds, extNetIds...)
+			}
+		}
+
+		if len(extNetworkIds) == 0 {
+			return nil, errors.NotFoundf(
+				"could not find an external network in availability zone %s", netDetails.AvailabilityZones)
+		}
+	}
+	return extNetworkIds, nil
+}
+
 // getExternalNeutronNetworksByAZ returns all external networks within the
-// given availability zone. If azName is empty, return all external networks.
+// given availability zone. If azName is empty, return all external networks
+// with no AZ.
 func getExternalNeutronNetworksByAZ(e *Environ, azName string) ([]string, error) {
-	neutron := e.neutron()
+	neutronClient := e.neutron()
 	// Find all external networks in availability zone
-	networks, err := neutron.ListNetworksV2(externalNetworkFilter())
+	networks, err := neutronClient.ListNetworksV2(externalNetworkFilter())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -218,6 +239,9 @@ func getExternalNeutronNetworksByAZ(e *Environ, azName string) ([]string, error)
 				netIds = append(netIds, network.Id)
 				break
 			}
+		}
+		if azName == "" && len(network.AvailabilityZones) == 0 {
+			netIds = append(netIds, network.Id)
 		}
 	}
 	if len(netIds) == 0 {


### PR DESCRIPTION

Some openstack configurations do no specify availability zones for networks.  When looking for an external network to create a FIP, if the private network has no AZ, look for the same with the external network.

Did a little refactoring on AllocatePublicIP to shorten the method and make it easier to understand.

## QA steps

We do not have an exact environment within the team to test this.  The unit test added, does produce the same result if the provider change is not met.  

Test for not change to Openstack bootstrap where AZ for networks are available.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1891227
