### PR TITLE
Use older ~juju-qa/network-health rev 10 charm

### DIFF
--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -140,7 +140,9 @@ class AssessNetworkHealth:
             self.existing_series.add(info['series'])
         for series in self.existing_series:
             try:
-                client.deploy('~juju-qa/network-health', series=series,
+                # TODO: The latest network-health charm (11 onwards) is broken;
+                # it doesn't properly install charmhelpers.
+                client.deploy('~juju-qa/network-health-10', series=series,
                               alias='network-health-{}'.format(series))
 
             except subprocess.CalledProcessError:
@@ -384,7 +386,9 @@ class AssessNetworkHealth:
         for app, info in apps.items():
             if 'network-health' not in app:
                 alias = 'network-health-{}'.format(app)
-                client.deploy('~juju-qa/network-health', alias=alias,
+                # The latest network-health charm (11 onwards) is broken;
+                # it doesn't properly install charmhelpers.
+                client.deploy('~juju-qa/network-health-10', alias=alias,
                               series=info['series'])
                 try:
                     client.juju('add-relation', (app, alias))

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -11,8 +11,10 @@ run_network_health() {
 
     # Now the testing charm for each series.
     # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
-    juju deploy '~juju-qa/network-health' network-health-xenial --series xenial
-    juju deploy '~juju-qa/network-health' network-health-bionic --series bionic
+    # TODO: The latest network-health charm (11 onwards) is broken;
+    # it doesn't properly install charmhelpers.
+    juju deploy '~juju-qa/network-health-10' network-health-xenial --series xenial
+    juju deploy '~juju-qa/network-health-10' network-health-bionic --series bionic
 
     juju expose network-health-xenial
     juju expose network-health-bionic


### PR DESCRIPTION
The cs:~juju-qa/network-health charm was updated to rev 11. This update was a major rewrite which included how dependencies like charmhelpers are installed. Unfortunately, charmhelpers (and maybe other) dependencies don't get installed properly, which breaks the charm's ability to run actions.

Until the charm gets fixed, update the CI tests to explictly install rev 10 which does work.

## QA steps

nw-network-health tests

