### PR TITLE
[gce] Update compute auth setup

### DIFF
--- a/provider/gce/google/auth.go
+++ b/provider/gce/google/auth.go
@@ -5,11 +5,21 @@ package google
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/juju/errors"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	transporthttp "google.golang.org/api/transport/http"
 )
+
+var scopes = []string{
+	"https://www.googleapis.com/auth/compute",
+	"https://www.googleapis.com/auth/devstorage.full_control",
+}
 
 // newComputeService opens a new low-level connection to the GCE API using
 // the input credentials and returns it.
@@ -21,25 +31,46 @@ import (
 // This should also be relocated alongside its wrapper,
 // rather than this "auth.go" file.
 func newComputeService(creds *Credentials) (*compute.Service, error) {
-	jsonKey := creds.JSONKey
-	if jsonKey == nil {
-		built, err := creds.buildJSONKey()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		jsonKey = built
-	}
-
-	cfg, err := google.JWTConfigFromJSON(
-		jsonKey,
-		"https://www.googleapis.com/auth/compute",
-		"https://www.googleapis.com/auth/devstorage.full_control",
-	)
+	cfg, err := newJWTConfig(creds)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	client := cfg.Client(context.TODO())
-	service, err := compute.New(client)
+	ctx := context.Background()
+
+	ts := cfg.TokenSource(ctx)
+	tsOpt := option.WithTokenSource(ts)
+
+	newTransport := http.DefaultTransport.(*http.Transport).Clone()
+	newTransport.TLSHandshakeTimeout = 20 * time.Second
+
+	httpTransport, err := transporthttp.NewTransport(ctx, newTransport, tsOpt)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	httpClient := &http.Client{}
+	httpClient.Transport = httpTransport
+
+	service, err := compute.NewService(ctx,
+		tsOpt,
+		option.WithHTTPClient(httpClient),
+	)
 	return service, errors.Trace(err)
+}
+
+func newJWTConfig(creds *Credentials) (*jwt.Config, error) {
+	jsonKey := creds.JSONKey
+	if jsonKey == nil {
+		var err error
+		jsonKey, err = creds.buildJSONKey()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	return google.JWTConfigFromJSON(
+		jsonKey,
+		scopes...,
+	)
 }

--- a/provider/gce/google/auth_test.go
+++ b/provider/gce/google/auth_test.go
@@ -14,7 +14,19 @@ type authSuite struct {
 
 var _ = gc.Suite(&authSuite{})
 
-func (s *authSuite) TestNewConnection(c *gc.C) {
+func (s *authSuite) TestNewComputeService(c *gc.C) {
 	_, err := newComputeService(s.Credentials)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *authSuite) TestCreateJWTConfig(c *gc.C) {
+	cfg, err := newJWTConfig(s.Credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Scopes, jc.DeepEquals, scopes)
+}
+
+func (s *authSuite) TestCreateJWTConfigWithNoJSONKey(c *gc.C) {
+	cfg, err := newJWTConfig(&Credentials{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Scopes, jc.DeepEquals, scopes)
 }


### PR DESCRIPTION
The previous way of connecting to the compute service was deprecated via
this warning[1] in the documentation. This was spotted when
investigating the TLS handshake timeout[2].

The fix is to update to the lastest compute construction with the new
token and scopes.

 1. https://godoc.org/google.golang.org/api/compute/v1#New
 2. https://bugs.launchpad.net/juju/+bug/1899793

## QA steps

Correctly sort the credentials out for GCE then do the following:

```sh
juju bootstrap google test
juju deploy cs:mysql
```
And wait for a very long time...

## Bug reference

https://bugs.launchpad.net/juju/+bug/1899793
