### PR TITLE
Fix missing defer on mutex lock for BufferedLogger in logdb pkg.

### DIFF
--- a/state/logdb/buf.go
+++ b/state/logdb/buf.go
@@ -79,7 +79,7 @@ func (b *BufferedLogger) Log(in []state.LogRecord) error {
 // Flush flushes any buffered log records to the underlying Logger.
 func (b *BufferedLogger) Flush() error {
 	b.mu.Lock()
-	b.mu.Unlock()
+	defer b.mu.Unlock()
 	return b.flush()
 }
 


### PR DESCRIPTION
## Fix logdb race

Fixes bad mutex Unlock due to missing defer on mutex scope for state/logdb.BufferedLogger

## QA steps

Run race tests

## Documentation changes

N/A

## Bug reference

N/A
