### PR TITLE
[2.8] Backup task name fix

### DIFF
--- a/tests/suites/backup/task.sh
+++ b/tests/suites/backup/task.sh
@@ -7,13 +7,13 @@ test_backup() {
     set_verbosity
 
     echo "==> Checking for dependencies"
-    check_dependencies juju
+    check_dependencies juju jq
 
     file="${TEST_DIR}/test-backup-restore.log"
 
-    bootstrap "test-cli" "${file}"
+    bootstrap "test-backup" "${file}"
 
     test_basic_backup
 
-    destroy_controller "test-cli"
+    destroy_controller "test-backup"
 }


### PR DESCRIPTION
The name of the backup test was incorrectly named, this fixes that and additionally
fixes the missing jq dependency.

## QA steps

```sh
(cd tests && ./main.sh backup)
```
