### PR TITLE
Check for python3 not python

### DIFF
--- a/tests/suites/bootstrap/task.sh
+++ b/tests/suites/bootstrap/task.sh
@@ -7,7 +7,8 @@ test_bootstrap() {
     set_verbosity
 
     echo "==> Checking for dependencies"
-    check_dependencies juju jujud juju-metadata python
+    check_dependencies juju jujud python3
+    check_juju_dependencies metadata
 
     test_bootstrap_simplestream
 }


### PR DESCRIPTION
The bootstrap command originally checked for python and not python3
which is what we actually wanted to use.

This is an issue where local doesn't replicate what's in the CI setup.

## QA steps

```sh
(cd tests && ./main.sh bootstrap)
```
