### PR TITLE
Cleanup error messages when shutting down units

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -269,8 +269,13 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	defer func() {
 		// If this is a CAAS unit, then dead errors are fairly normal ways to exit
 		// the uniter main loop, but the parent operator agent needs to keep running.
+		errorString := "<unknown>"
+		if err != nil {
+			errorString = err.Error()
+		}
 		if errors.Cause(err) == ErrCAASUnitDead {
 			err = nil
+			errorString = "caas unit dead"
 		}
 		if u.runListener != nil {
 			u.runListener.UnregisterRunner(unitTag.Id())
@@ -278,7 +283,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		if u.localRunListener != nil {
 			u.localRunListener.UnregisterRunner(unitTag.Id())
 		}
-		u.logger.Infof("unit %q shutting down: %s", unitTag.Id(), err)
+		u.logger.Infof("unit %q shutting down: %s", unitTag.Id(), errorString)
 	}()
 
 	if err := u.init(unitTag); err != nil {


### PR DESCRIPTION
When a K8s unit is stopped, we end up with a log line that looks like:
```
2020-11-10 10:06:36 INFO juju.worker.uniter uniter.go:289 unit "discourse/0" shutting down: %!s(<nil>)
```

The intent is that it isn't an error for a K8s unit to be stopped, and we shouldn't treat it as an error. I'm happy to bike shed what message we want to be giving, but we certainly don't want to be giving `%!s(<nil>)`.


## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

I have not done my own QA, so I would appreciate someone doing explicit QA and confirming these steps (and update this message).

```sh
$ juju bootstrap microk8s
$ juju deploy cs:~juju/mariadb-k8s-3
$ juju config mariadb-k8s query-cache-type=ON
$ juju debug-log
# see that the log message indicates why we are stopping mariadb-k8s/0
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1903726