### PR TITLE
Prevent fetching of oci timing out snap install

### DIFF
--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -13,7 +13,7 @@ if ! which timeout; then
     exit 0
 fi
 
-timeout 2m sh <<EOT || echo true
+timeout 2m sh <<EOT || echo "Timed out waiting to install microk8s image."
 container_cmd=microk8s.ctr
 image_arg="--namespace k8s.io images"
 if ! which $container_cmd; then

--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -13,7 +13,6 @@ if ! which timeout; then
     exit 0
 fi
 
-timeout 2m sh <<EOT || echo "Timed out waiting to install microk8s image."
 container_cmd=microk8s.ctr
 image_arg="--namespace k8s.io images"
 if ! which $container_cmd; then
@@ -39,6 +38,7 @@ mongo_image="docker.io/jujusolutions/juju-db:4.0"
 echo "Going to cache images: $oci_image and $mongo_image."
 
 # It's not an install/refresh blocker if we can't get the images.
+timeout 2m sh <<EOT || echo "Timed out waiting to install microk8s image."
 echo "Pulling: $oci_image."
 $container_cmd $image_arg list | grep $oci_image || $container_cmd $image_arg pull $oci_image || true
 

--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -8,6 +8,12 @@ if ! which microk8s.kubectl; then
     exit 0
 fi
 
+if ! which timeout; then
+    echo "timeout is not installed."
+    exit 0
+fi
+
+timeout 2m sh <<EOT || echo true
 container_cmd=microk8s.ctr
 image_arg="--namespace k8s.io images"
 if ! which $container_cmd; then
@@ -38,3 +44,4 @@ $container_cmd $image_arg list | grep $oci_image || $container_cmd $image_arg pu
 
 echo "Pulling: $mongo_image."
 $container_cmd $image_arg list | grep $mongo_image || $container_cmd $image_arg pull $mongo_image || true
+EOT


### PR DESCRIPTION
The following wraps the installing of the oci image in a timeout. As we
don't actually require the image to be installed when we bootstrap we
can be a bit fast and loose about it. If you don't have timeout
installed (BSD and macosx) then we exit and install the image using
manual intervention/bootstrap.

The code ensures that if it takes longer than we expect we just cancel
it, but importantly ignore the timeout error and return true. That way
we can still install the snap.

I've used 2 minutes because it can take a long time to install a snap on
slower systems, so we don't want to gobble that time up installing an
image that might not install anyway.

## QA steps

Ensure you have microk8s installed.
If you've built the snap before then it's wise to do `lxc delete snapcraft-juju --force`

```sh
snap install snapcraft --classic
snapcraft --use-lxd
sudo snap install *.snap --dangerous --classic
sudo snap logs juju
```

Ensure that we did in fact attempt to pull the images down.
