### PR TITLE
Filter mongo addresses we try to use to exclude fan, public

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -491,6 +491,18 @@ func (*suite) TestAPIInfoServesStandardAPIPortWhenControllerAPIPortNotSet(c *gc.
 
 func (*suite) TestMongoInfo(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88", "3.4.2.1:1070"}
+	servingInfo := stateServingInfo()
+	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	mongoInfo, ok := conf.MongoInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "3.4.2.1:69"})
+	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
+}
+
+func (*suite) TestMongoInfoNoCloudLocalAvailable(c *gc.C) {
+	attrParams := attributeParams
 	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
@@ -503,7 +515,7 @@ func (*suite) TestMongoInfo(c *gc.C) {
 
 func (*suite) TestPromotedMongoInfo(c *gc.C) {
 	attrParams := attributeParams
-	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88", "3.4.2.1:1070"}
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -518,7 +530,7 @@ func (*suite) TestPromotedMongoInfo(c *gc.C) {
 
 	mongoInfo, ok = conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "foo.example:69", "bar.example:69"})
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "3.4.2.1:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 


### PR DESCRIPTION
When dialling mongo, we pull out all of the possible controller api addresses from agent.conf and attempt to use them. Or more correctly, we pass them to the mgo client to use. This includes fan and public addresses. mgo client will try them all and pick the first one that connects. If that's the fan address, subsequent attempts to use that connection in a mongo session fail. 

We should be filtering on cloud local addresses. This is actually what's done in the peer grouper worker which maintains the mongo replicaset. So this PR simply uses the same logic. ie we configure the controller with the same addresses mongo itself uses to talk to itself in the cluster.

## QA steps

Unable to reproduce the actual failure. But enable-ha was tested on an aws bootstrap which did have fan addresses present.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1903557
