### PR TITLE
Allow podspec to specify pod labels

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1546,7 +1546,7 @@ func (k *kubernetesClient) configureDaemonSet(
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
-					Labels:       k.getDaemonSetLabels(appName),
+					Labels:       AppendLabels(k.getDaemonSetLabels(appName), workloadSpec.Pod.Labels),
 					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 				Spec: workloadSpec.Pod.PodSpec,
@@ -1645,7 +1645,7 @@ func (k *kubernetesClient) configureDeployment(
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
-					Labels:       LabelsForApp(appName),
+					Labels:       AppendLabels(LabelsForApp(appName), workloadSpec.Pod.Labels),
 					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 				Spec: workloadSpec.Pod.PodSpec,
@@ -2484,6 +2484,7 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 			spec.ValidatingWebhookConfigurations = k8sResources.ValidatingWebhookConfigurations
 			spec.IngressResources = k8sResources.IngressResources
 			if k8sResources.Pod != nil {
+				spec.Pod.Labels = AppendLabels(nil, k8sResources.Pod.Labels)
 				spec.Pod.Annotations = k8sResources.Pod.Annotations.Copy()
 				spec.Pod.RestartPolicy = k8sResources.Pod.RestartPolicy
 				spec.Pod.ActiveDeadlineSeconds = k8sResources.Pod.ActiveDeadlineSeconds

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -188,6 +188,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		Labels:      map[string]string{},
 		Annotations: annotations.Annotation{},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
@@ -391,6 +392,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		Labels:      map[string]string{},
 		Annotations: annotations.Annotation{},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
@@ -577,6 +579,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 	podSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
 			Pod: &k8sspecs.PodSpec{
+				Labels:                        map[string]string{"foo": "bax"},
 				Annotations:                   map[string]string{"foo": "baz"},
 				RestartPolicy:                 core.RestartPolicyOnFailure,
 				ActiveDeadlineSeconds:         int64Ptr(10),
@@ -606,6 +609,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		Labels:      map[string]string{"foo": "bax"},
 		Annotations: map[string]string{"foo": "baz"},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
@@ -5030,7 +5034,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	basicPodSpec := getBasicPodspec()
 	basicPodSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
-			Pod: &k8sspecs.PodSpec{Annotations: map[string]string{"foo": "baz"}},
+			Pod: &k8sspecs.PodSpec{
+				Labels:      map[string]string{"foo": "bax"},
+				Annotations: map[string]string{"foo": "baz"},
+			},
 		},
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
@@ -5054,6 +5061,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	})
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	statefulSetArg.Spec.Template.Annotations["foo"] = "baz"
+	statefulSetArg.Spec.Template.Labels["foo"] = "bax"
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get("juju-operator-app-name", v1.GetOptions{}).
@@ -5616,7 +5624,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 	basicPodSpec := getBasicPodspec()
 	basicPodSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
-			Pod: &k8sspecs.PodSpec{Annotations: map[string]string{"foo": "baz"}},
+			Pod: &k8sspecs.PodSpec{
+				Labels:      map[string]string{"foo": "bax"},
+				Annotations: map[string]string{"foo": "baz"},
+			},
 		},
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
@@ -5704,7 +5715,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
-					Labels:       map[string]string{"juju-app": "app-name"},
+					Labels:       map[string]string{"juju-app": "app-name", "foo": "bax"},
 					Annotations: map[string]string{
 						"foo": "baz",
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -145,6 +145,12 @@ func (p podSpecLegacy) ToLatest() *specs.PodSpec {
 		ReadinessGates:                p.k8sPodSpecLegacy.ReadinessGates,
 		DNSPolicy:                     p.k8sPodSpecLegacy.DNSPolicy,
 	}
+	if len(p.k8sPodSpecLegacy.Labels) > 0 {
+		iPodSpec.Labels = make(map[string]string)
+		for k, v := range p.k8sPodSpecLegacy.Labels {
+			iPodSpec.Labels[k] = v
+		}
+	}
 	if !iPodSpec.IsEmpty() || p.k8sPodSpecLegacy.CustomResourceDefinitions != nil {
 		pSpec.ProviderPod = &K8sPodSpec{
 			KubernetesResources: &KubernetesResources{

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -27,6 +27,8 @@ func (s *legacySpecsSuite) TestParse(c *gc.C) {
 omitServiceFrontend: true
 annotations:
   foo: baz
+labels:
+  foo: bax
 activeDeadlineSeconds: 10
 restartPolicy: OnFailure
 terminationGracePeriodSeconds: 20
@@ -292,6 +294,7 @@ echo "do some stuff here for gitlab-init container"
 		pSpecs.ProviderPod = &k8sspecs.K8sPodSpec{
 			KubernetesResources: &k8sspecs.KubernetesResources{
 				Pod: &k8sspecs.PodSpec{
+					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					RestartPolicy:                 core.RestartPolicyOnFailure,
 					ActiveDeadlineSeconds:         int64Ptr(10),

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -81,8 +81,9 @@ func (*K8sContainerSpec) Validate() error {
 	return nil
 }
 
-// PodSpecWithAnnotations wraps a k8s podspec to add annotations.
+// PodSpecWithAnnotations wraps a k8s podspec to add annotations and labels.
 type PodSpecWithAnnotations struct {
+	Labels      map[string]string
 	Annotations annotations.Annotation
 	core.PodSpec
 }
@@ -90,6 +91,7 @@ type PodSpecWithAnnotations struct {
 // PodSpec is a subset of v1.PodSpec which defines
 // attributes we expose for charms to set.
 type PodSpec struct {
+	Labels                        map[string]string        `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations                   annotations.Annotation   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	RestartPolicy                 core.RestartPolicy       `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
 	ActiveDeadlineSeconds         *int64                   `json:"activeDeadlineSeconds,omitempty" yaml:"activeDeadlineSeconds,omitempty"`
@@ -110,6 +112,8 @@ func (ps PodSpec) IsEmpty() bool {
 		ps.TerminationGracePeriodSeconds == nil &&
 		ps.SecurityContext == nil &&
 		len(ps.ReadinessGates) == 0 &&
+		len(ps.Labels) == 0 &&
+		len(ps.Annotations) == 0 &&
 		ps.DNSPolicy == ""
 }
 
@@ -144,14 +148,6 @@ func validateLabels(labels map[string]string) error {
 
 type k8sContainersInterface interface {
 	Validate() error
-}
-
-func parseContainers(in string, containerSpec k8sContainersInterface) error {
-	decoder := newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
-	if err := decoder.Decode(containerSpec); err != nil {
-		return errors.Trace(err)
-	}
-	return errors.Trace(containerSpec.Validate())
 }
 
 // ParseRawK8sSpec parses a k8s format of YAML file which defines how to

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -270,11 +270,6 @@ func (krs *KubernetesResourcesV2) Validate() error {
 		}
 	}
 
-	for k, crs := range krs.CustomResources {
-		if len(crs) == 0 {
-			return errors.NotValidf("empty custom resources %q", k)
-		}
-	}
 	for k, webhooks := range krs.MutatingWebhookConfigurations {
 		if len(webhooks) == 0 {
 			return errors.NotValidf("empty webhooks %q", k)

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -169,6 +169,8 @@ kubernetesResources:
   pod:
     annotations:
       foo: baz
+    labels:
+      foo: bax
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
     terminationGracePeriodSeconds: 20
@@ -619,6 +621,7 @@ echo "do some stuff here for gitlab-init container"
 			KubernetesResources: &k8sspecs.KubernetesResources{
 				K8sRBACResources: rbacResources,
 				Pod: &k8sspecs.PodSpec{
+					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -324,11 +324,6 @@ func (krs *KubernetesResources) Validate() error {
 			return errors.Trace(err)
 		}
 	}
-	for k, crs := range krs.CustomResources {
-		if len(crs) == 0 {
-			return errors.NotValidf("empty custom resources %q", k)
-		}
-	}
 
 	for _, webhook := range krs.MutatingWebhookConfigurations {
 		if err := webhook.Validate(); err != nil {

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -231,6 +231,8 @@ kubernetesResources:
   pod:
     annotations:
       foo: baz
+    labels:
+      foo: bax
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
     terminationGracePeriodSeconds: 20
@@ -803,6 +805,7 @@ echo "do some stuff here for gitlab-init container"
 				},
 				K8sRBACResources: rbacResources,
 				Pod: &k8sspecs.PodSpec{
+					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -78,7 +78,7 @@ func (k *kubernetesClient) configureStatefulSet(
 			RevisionHistoryLimit: int32Ptr(statefulSetRevisionHistoryLimit),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels:      k.getStatefulSetLabels(appName),
+					Labels:      AppendLabels(k.getStatefulSetLabels(appName), workloadSpec.Pod.Labels),
 					Annotations: podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 			},


### PR DESCRIPTION
Add pod labels support to k8s pod spec.
We already support pod annotations. Now also labels.
Also, add a driveby fix to allow empty custom resource lists".

## QA steps

deploy a k8s charm with some pod labels in the pod spec
use kubectl to check that the labels have been applied

## Bug reference
https://bugs.launchpad.net/juju/+bug/1903074
https://bugs.launchpad.net/bugs/1900475