### PR TITLE
Fix network health tests charm deploy.

### DIFF
--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -142,7 +142,7 @@ class AssessNetworkHealth:
             try:
                 # TODO: The latest network-health charm (11 onwards) is broken;
                 # it doesn't properly install charmhelpers.
-                client.deploy('~juju-qa/network-health-10', series=series,
+                client.deploy('cs:~juju-qa/network-health-10', series=series,
                               alias='network-health-{}'.format(series))
 
             except subprocess.CalledProcessError:
@@ -388,7 +388,7 @@ class AssessNetworkHealth:
                 alias = 'network-health-{}'.format(app)
                 # The latest network-health charm (11 onwards) is broken;
                 # it doesn't properly install charmhelpers.
-                client.deploy('~juju-qa/network-health-10', alias=alias,
+                client.deploy('cs:~juju-qa/network-health-10', alias=alias,
                               series=info['series'])
                 try:
                     client.juju('add-relation', (app, alias))

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -14,8 +14,8 @@ run_network_health() {
     # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
     # TODO: The latest network-health charm (11 onwards) is broken;
     # it doesn't properly install charmhelpers.
-    juju deploy '~juju-qa/network-health-10' network-health-xenial --series xenial
-    juju deploy '~juju-qa/network-health-10' network-health-bionic --series bionic
+    juju deploy 'cs:~juju-qa/network-health-10' network-health-xenial --series xenial
+    juju deploy 'cs:~juju-qa/network-health-10' network-health-bionic --series bionic
 
     juju expose network-health-xenial
     juju expose network-health-bionic


### PR DESCRIPTION
Fix the deployment of the network-health charm from charm store.

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A