### PR TITLE
Include controller FQDN host in api address for k8s agents

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -39,6 +39,9 @@ import (
 const (
 	// JujuControllerStackName is the juju CAAS controller stack name.
 	JujuControllerStackName = "controller"
+
+	// ControllerServiceFQDNTemplate is the FQDN of the controller service using the cluster DNS.
+	ControllerServiceFQDNTemplate = "controller-service.controller-%s.svc.cluster.local"
 )
 
 var (


### PR DESCRIPTION
If the IP address of a k8s controller changes because the cluster itself changes, deployed agents have no way of communicating to the controller anymore as they use a single IP address of the controller. 
This PR includes in the set of available address in agent.conf the FQDN of the controller based on the cluster DNS, eg
controller-service.controller-test.svc.cluster.local

## QA steps

I didn't have a means to easily get microk8s a new ip address, but I hacked the api address code to only return the FQDN host and tested deploying a charm and confirmed that the agent.conf contained the host name and agent could talk to the controller.
I also verified that the non-hacked code wrote out both the IP address and FQDN of the controller, eg

```
apiaddresses:
- 10.152.183.204:17070
- controller-service.controller-ian.svc.cluster.local:17070
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1900930