### PR TITLE
Merge 2.8

### DIFF
--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -854,8 +854,8 @@ def maas_account_from_boot_config(env):
     manager = MAASAccount(*args)
     try:
         manager.login()
-    except subprocess.CalledProcessError:
-        log.info("Could not login with MAAS 2.0 API, trying 1.0")
+    except subprocess.CalledProcessError as e:
+        log.info("Could not login with MAAS 2.0 API, trying 1.0! err -> %s", e)
         manager = MAAS1Account(*args)
         manager.login()
     yield manager

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -491,6 +491,18 @@ func (*suite) TestAPIInfoServesStandardAPIPortWhenControllerAPIPortNotSet(c *gc.
 
 func (*suite) TestMongoInfo(c *gc.C) {
 	attrParams := attributeParams
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88", "3.4.2.1:1070"}
+	servingInfo := stateServingInfo()
+	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	mongoInfo, ok := conf.MongoInfo()
+	c.Assert(ok, jc.IsTrue)
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "3.4.2.1:69"})
+	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
+}
+
+func (*suite) TestMongoInfoNoCloudLocalAvailable(c *gc.C) {
+	attrParams := attributeParams
 	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
 	servingInfo := stateServingInfo()
 	conf, err := agent.NewStateMachineConfig(attrParams, servingInfo)
@@ -503,7 +515,7 @@ func (*suite) TestMongoInfo(c *gc.C) {
 
 func (*suite) TestPromotedMongoInfo(c *gc.C) {
 	attrParams := attributeParams
-	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88"}
+	attrParams.APIAddresses = []string{"foo.example:1235", "bar.example:1236", "localhost:88", "3.4.2.1:1070"}
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -518,7 +530,7 @@ func (*suite) TestPromotedMongoInfo(c *gc.C) {
 
 	mongoInfo, ok = conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "foo.example:69", "bar.example:69"})
+	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "3.4.2.1:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)
 }
 

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -42,6 +42,9 @@ import (
 const (
 	// JujuControllerStackName is the juju CAAS controller stack name.
 	JujuControllerStackName = "controller"
+
+	// ControllerServiceFQDNTemplate is the FQDN of the controller service using the cluster DNS.
+	ControllerServiceFQDNTemplate = "controller-service.controller-%s.svc.cluster.local"
 )
 
 var (

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1494,7 +1494,7 @@ func (k *kubernetesClient) configureDaemonSet(
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
-					Labels:       selectorLabels,
+					Labels:       utils.LabelsMerge(workloadSpec.Pod.Labels, selectorLabels),
 					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 				Spec: workloadSpec.Pod.PodSpec,
@@ -1595,7 +1595,7 @@ func (k *kubernetesClient) configureDeployment(
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
-					Labels:       selectorLabels,
+					Labels:       utils.LabelsMerge(workloadSpec.Pod.Labels, selectorLabels),
 					Annotations:  podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 				Spec: workloadSpec.Pod.PodSpec,
@@ -2392,6 +2392,7 @@ func prepareWorkloadSpec(appName, deploymentName string, podSpec *specs.PodSpec,
 			spec.ValidatingWebhookConfigurations = k8sResources.ValidatingWebhookConfigurations
 			spec.IngressResources = k8sResources.IngressResources
 			if k8sResources.Pod != nil {
+				spec.Pod.Labels = utils.LabelsMerge(nil, k8sResources.Pod.Labels)
 				spec.Pod.Annotations = k8sResources.Pod.Annotations.Copy()
 				spec.Pod.RestartPolicy = k8sResources.Pod.RestartPolicy
 				spec.Pod.ActiveDeadlineSeconds = k8sResources.Pod.ActiveDeadlineSeconds

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -135,6 +135,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		Labels:      map[string]string{},
 		Annotations: annotations.Annotation{},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
@@ -338,6 +339,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		Labels:      map[string]string{},
 		Annotations: annotations.Annotation{},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
@@ -524,6 +526,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 	podSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
 			Pod: &k8sspecs.PodSpec{
+				Labels:                        map[string]string{"foo": "bax"},
 				Annotations:                   map[string]string{"foo": "baz"},
 				RestartPolicy:                 core.RestartPolicyOnFailure,
 				ActiveDeadlineSeconds:         int64Ptr(10),
@@ -553,6 +556,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
+		Labels:      map[string]string{"foo": "bax"},
 		Annotations: map[string]string{"foo": "baz"},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
@@ -4956,7 +4960,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	basicPodSpec := getBasicPodspec()
 	basicPodSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
-			Pod: &k8sspecs.PodSpec{Annotations: map[string]string{"foo": "baz"}},
+			Pod: &k8sspecs.PodSpec{
+				Labels:      map[string]string{"foo": "bax"},
+				Annotations: map[string]string{"foo": "baz"},
+			},
 		},
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
@@ -4980,6 +4987,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	})
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	statefulSetArg.Spec.Template.Annotations["foo"] = "baz"
+	statefulSetArg.Spec.Template.Labels["foo"] = "bax"
 	ociImageSecret := s.getOCIImageSecret(c, nil)
 	gomock.InOrder(
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
@@ -5544,7 +5552,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 	basicPodSpec := getBasicPodspec()
 	basicPodSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
-			Pod: &k8sspecs.PodSpec{Annotations: map[string]string{"foo": "baz"}},
+			Pod: &k8sspecs.PodSpec{
+				Labels:      map[string]string{"foo": "bax"},
+				Annotations: map[string]string{"foo": "baz"},
+			},
 		},
 	}
 	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
@@ -5633,7 +5644,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
-					Labels:       map[string]string{"app.kubernetes.io/name": "app-name"},
+					Labels:       map[string]string{"app.kubernetes.io/name": "app-name", "foo": "bax"},
 					Annotations: map[string]string{
 						"foo": "baz",
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",

--- a/caas/kubernetes/provider/specs/legacy.go
+++ b/caas/kubernetes/provider/specs/legacy.go
@@ -145,6 +145,12 @@ func (p podSpecLegacy) ToLatest() *specs.PodSpec {
 		ReadinessGates:                p.k8sPodSpecLegacy.ReadinessGates,
 		DNSPolicy:                     p.k8sPodSpecLegacy.DNSPolicy,
 	}
+	if len(p.k8sPodSpecLegacy.Labels) > 0 {
+		iPodSpec.Labels = make(map[string]string)
+		for k, v := range p.k8sPodSpecLegacy.Labels {
+			iPodSpec.Labels[k] = v
+		}
+	}
 	if !iPodSpec.IsEmpty() || p.k8sPodSpecLegacy.CustomResourceDefinitions != nil {
 		pSpec.ProviderPod = &K8sPodSpec{
 			KubernetesResources: &KubernetesResources{

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -27,6 +27,8 @@ func (s *legacySpecsSuite) TestParse(c *gc.C) {
 omitServiceFrontend: true
 annotations:
   foo: baz
+labels:
+  foo: bax
 activeDeadlineSeconds: 10
 restartPolicy: OnFailure
 terminationGracePeriodSeconds: 20
@@ -292,6 +294,7 @@ echo "do some stuff here for gitlab-init container"
 		pSpecs.ProviderPod = &k8sspecs.K8sPodSpec{
 			KubernetesResources: &k8sspecs.KubernetesResources{
 				Pod: &k8sspecs.PodSpec{
+					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					RestartPolicy:                 core.RestartPolicyOnFailure,
 					ActiveDeadlineSeconds:         int64Ptr(10),

--- a/caas/kubernetes/provider/specs/types.go
+++ b/caas/kubernetes/provider/specs/types.go
@@ -81,8 +81,9 @@ func (*K8sContainerSpec) Validate() error {
 	return nil
 }
 
-// PodSpecWithAnnotations wraps a k8s podspec to add annotations.
+// PodSpecWithAnnotations wraps a k8s podspec to add annotations and labels.
 type PodSpecWithAnnotations struct {
+	Labels      map[string]string
 	Annotations annotations.Annotation
 	core.PodSpec
 }
@@ -90,6 +91,7 @@ type PodSpecWithAnnotations struct {
 // PodSpec is a subset of v1.PodSpec which defines
 // attributes we expose for charms to set.
 type PodSpec struct {
+	Labels                        map[string]string        `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations                   annotations.Annotation   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	RestartPolicy                 core.RestartPolicy       `json:"restartPolicy,omitempty" yaml:"restartPolicy,omitempty"`
 	ActiveDeadlineSeconds         *int64                   `json:"activeDeadlineSeconds,omitempty" yaml:"activeDeadlineSeconds,omitempty"`
@@ -110,6 +112,8 @@ func (ps PodSpec) IsEmpty() bool {
 		ps.TerminationGracePeriodSeconds == nil &&
 		ps.SecurityContext == nil &&
 		len(ps.ReadinessGates) == 0 &&
+		len(ps.Labels) == 0 &&
+		len(ps.Annotations) == 0 &&
 		ps.DNSPolicy == ""
 }
 
@@ -144,14 +148,6 @@ func validateLabels(labels map[string]string) error {
 
 type k8sContainersInterface interface {
 	Validate() error
-}
-
-func parseContainers(in string, containerSpec k8sContainersInterface) error {
-	decoder := newStrictYAMLOrJSONDecoder(strings.NewReader(in), len(in))
-	if err := decoder.Decode(containerSpec); err != nil {
-		return errors.Trace(err)
-	}
-	return errors.Trace(containerSpec.Validate())
 }
 
 // ParseRawK8sSpec parses a k8s format of YAML file which defines how to

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -270,11 +270,6 @@ func (krs *KubernetesResourcesV2) Validate() error {
 		}
 	}
 
-	for k, crs := range krs.CustomResources {
-		if len(crs) == 0 {
-			return errors.NotValidf("empty custom resources %q", k)
-		}
-	}
 	for k, webhooks := range krs.MutatingWebhookConfigurations {
 		if len(webhooks) == 0 {
 			return errors.NotValidf("empty webhooks %q", k)

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -169,6 +169,8 @@ kubernetesResources:
   pod:
     annotations:
       foo: baz
+    labels:
+      foo: bax
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
     terminationGracePeriodSeconds: 20
@@ -619,6 +621,7 @@ echo "do some stuff here for gitlab-init container"
 			KubernetesResources: &k8sspecs.KubernetesResources{
 				K8sRBACResources: rbacResources,
 				Pod: &k8sspecs.PodSpec{
+					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -324,11 +324,6 @@ func (krs *KubernetesResources) Validate() error {
 			return errors.Trace(err)
 		}
 	}
-	for k, crs := range krs.CustomResources {
-		if len(crs) == 0 {
-			return errors.NotValidf("empty custom resources %q", k)
-		}
-	}
 
 	for _, webhook := range krs.MutatingWebhookConfigurations {
 		if err := webhook.Validate(); err != nil {

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -231,6 +231,8 @@ kubernetesResources:
   pod:
     annotations:
       foo: baz
+    labels:
+      foo: bax
     restartPolicy: OnFailure
     activeDeadlineSeconds: 10
     terminationGracePeriodSeconds: 20
@@ -803,6 +805,7 @@ echo "do some stuff here for gitlab-init container"
 				},
 				K8sRBACResources: rbacResources,
 				Pod: &k8sspecs.PodSpec{
+					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					ActiveDeadlineSeconds:         int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -78,7 +78,7 @@ func (k *kubernetesClient) configureStatefulSet(
 			RevisionHistoryLimit: int32Ptr(statefulSetRevisionHistoryLimit),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels:      selectorLabels,
+					Labels:      utils.LabelsMerge(workloadSpec.Pod.Labels, selectorLabels),
 					Annotations: podAnnotations(k8sannotations.New(workloadSpec.Pod.Annotations).Merge(annotations).Copy()).ToMap(),
 				},
 			},

--- a/provider/gce/google/auth.go
+++ b/provider/gce/google/auth.go
@@ -5,11 +5,21 @@ package google
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/juju/errors"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	transporthttp "google.golang.org/api/transport/http"
 )
+
+var scopes = []string{
+	"https://www.googleapis.com/auth/compute",
+	"https://www.googleapis.com/auth/devstorage.full_control",
+}
 
 // newComputeService opens a new low-level connection to the GCE API using
 // the input credentials and returns it.
@@ -21,25 +31,46 @@ import (
 // This should also be relocated alongside its wrapper,
 // rather than this "auth.go" file.
 func newComputeService(creds *Credentials) (*compute.Service, error) {
-	jsonKey := creds.JSONKey
-	if jsonKey == nil {
-		built, err := creds.buildJSONKey()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		jsonKey = built
-	}
-
-	cfg, err := google.JWTConfigFromJSON(
-		jsonKey,
-		"https://www.googleapis.com/auth/compute",
-		"https://www.googleapis.com/auth/devstorage.full_control",
-	)
+	cfg, err := newJWTConfig(creds)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	client := cfg.Client(context.TODO())
-	service, err := compute.New(client)
+	ctx := context.Background()
+
+	ts := cfg.TokenSource(ctx)
+	tsOpt := option.WithTokenSource(ts)
+
+	newTransport := http.DefaultTransport.(*http.Transport).Clone()
+	newTransport.TLSHandshakeTimeout = 20 * time.Second
+
+	httpTransport, err := transporthttp.NewTransport(ctx, newTransport, tsOpt)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	httpClient := &http.Client{}
+	httpClient.Transport = httpTransport
+
+	service, err := compute.NewService(ctx,
+		tsOpt,
+		option.WithHTTPClient(httpClient),
+	)
 	return service, errors.Trace(err)
+}
+
+func newJWTConfig(creds *Credentials) (*jwt.Config, error) {
+	jsonKey := creds.JSONKey
+	if jsonKey == nil {
+		var err error
+		jsonKey, err = creds.buildJSONKey()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	return google.JWTConfigFromJSON(
+		jsonKey,
+		scopes...,
+	)
 }

--- a/provider/gce/google/auth_test.go
+++ b/provider/gce/google/auth_test.go
@@ -14,7 +14,19 @@ type authSuite struct {
 
 var _ = gc.Suite(&authSuite{})
 
-func (s *authSuite) TestNewConnection(c *gc.C) {
+func (s *authSuite) TestNewComputeService(c *gc.C) {
 	_, err := newComputeService(s.Credentials)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *authSuite) TestCreateJWTConfig(c *gc.C) {
+	cfg, err := newJWTConfig(s.Credentials)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Scopes, jc.DeepEquals, scopes)
+}
+
+func (s *authSuite) TestCreateJWTConfigWithNoJSONKey(c *gc.C) {
+	cfg, err := newJWTConfig(&Credentials{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Scopes, jc.DeepEquals, scopes)
 }

--- a/state/address.go
+++ b/state/address.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/mongo"
 )
@@ -306,23 +307,36 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 		return addrsToHostPorts(publicAddrs...), nil
 	}
 
+	var hostAddresses network.SpaceAddresses
+	// Add in the FQDN of the controller service for agents to use as an option.
+	controllerName := controllerConfig.ControllerName()
+	if controllerName != "" {
+		hostAddresses = append(
+			hostAddresses, network.NewScopedSpaceAddress(
+				fmt.Sprintf(k8sprovider.ControllerServiceFQDNTemplate, controllerName),
+				network.ScopeCloudLocal,
+			))
+	}
+
 	// TODO(wallyworld) - for now, return all addresses for agents to try, public last.
 
 	// If we are after local-cloud addresses and those were all that public
 	// matching turned up, just return those.
 	if len(publicAddrs) > 0 && publicAddrs[0].Scope == network.ScopeCloudLocal {
-		return addrsToHostPorts(publicAddrs...), nil
+		return addrsToHostPorts(append(hostAddresses, publicAddrs...)...), nil
 	}
 
 	localAddrs := addrs.AllMatchingScope(network.ScopeMatchCloudLocal)
 
 	// If there were no local-cloud addresses, return the public ones.
 	if len(localAddrs) == 0 || localAddrs[0].Scope == network.ScopePublic {
-		return addrsToHostPorts(publicAddrs...), nil
+		return addrsToHostPorts(append(hostAddresses, publicAddrs...)...), nil
 	}
 
 	// Otherwise return everything, local-cloud first.
-	return addrsToHostPorts(append(localAddrs, publicAddrs...)...), nil
+	hostAddresses = append(hostAddresses, localAddrs...)
+	hostAddresses = append(hostAddresses, publicAddrs...)
+	return addrsToHostPorts(hostAddresses...), nil
 }
 
 // apiHostPortsForKey returns API addresses extracted from the document

--- a/state/machine_ports_test.go
+++ b/state/machine_ports_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"
@@ -13,6 +15,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -419,6 +422,12 @@ func (s *MachinePortsDocSuite) TestWatchMachinePorts(c *gc.C) {
 	// No port ranges open initially, no changes.
 	w := s.State.WatchOpenedPorts()
 	c.Assert(w, gc.NotNil)
+	select {
+	case <-s.StatePool.TxnWatcherStarted():
+		// Started successfully
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for ports watcher to start")
+	}
 
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)

--- a/state/watcher/export_test.go
+++ b/state/watcher/export_test.go
@@ -4,9 +4,6 @@
 package watcher
 
 const (
-	TxnWatcherStarting       = txnWatcherStarting
-	TxnWatcherSyncErr        = txnWatcherSyncErr
-	TxnWatcherCollection     = txnWatcherCollection
 	TxnWatcherShortWait      = txnWatcherShortWait
 	TxnWatcherErrorShortWait = txnWatcherErrorShortWait
 )

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -174,9 +174,9 @@ func newHubWatcher(hub HubSource, clock Clock, modelUUID string, logger Logger) 
 
 func (w *HubWatcher) receiveEvent(topic string, data interface{}) {
 	switch topic {
-	case txnWatcherStarting:
+	case TxnWatcherStarting:
 		// We don't do anything on a start.
-	case txnWatcherSyncErr:
+	case TxnWatcherSyncErr:
 		syncErr, ok := data.(error)
 		if ok {
 			syncErr = errors.Annotate(syncErr, "hub txn watcher sync error")
@@ -184,7 +184,7 @@ func (w *HubWatcher) receiveEvent(topic string, data interface{}) {
 			syncErr = errors.New("hub txn watcher sync unknown error")
 		}
 		w.tomb.Kill(syncErr)
-	case txnWatcherCollection:
+	case TxnWatcherCollection:
 		change, ok := data.(Change)
 		if !ok {
 			w.logger.Warningf("incoming event not a Change")

--- a/tests/suites/backup/task.sh
+++ b/tests/suites/backup/task.sh
@@ -7,13 +7,13 @@ test_backup() {
     set_verbosity
 
     echo "==> Checking for dependencies"
-    check_dependencies juju
+    check_dependencies juju jq
 
     file="${TEST_DIR}/test-backup-restore.log"
 
-    bootstrap "test-cli" "${file}"
+    bootstrap "test-backup" "${file}"
 
     test_basic_backup
 
-    destroy_controller "test-cli"
+    destroy_controller "test-backup"
 }

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -26,6 +26,9 @@ test_deploy_os() {
 run_deploy_centos() {
     echo
 
+    echo "==> Checking for dependencies"
+    check_juju_dependencies metadata
+
     name="test-deploy-centos"
     file="${TEST_DIR}/${name}.log"
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -277,8 +277,13 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	defer func() {
 		// If this is a CAAS unit, then dead errors are fairly normal ways to exit
 		// the uniter main loop, but the parent operator agent needs to keep running.
+		errorString := "<unknown>"
+		if err != nil {
+			errorString = err.Error()
+		}
 		if errors.Cause(err) == ErrCAASUnitDead {
 			err = nil
+			errorString = "caas unit dead"
 		}
 		if u.runListener != nil {
 			u.runListener.UnregisterRunner(unitTag.Id())
@@ -286,7 +291,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 		if u.localRunListener != nil {
 			u.localRunListener.UnregisterRunner(unitTag.Id())
 		}
-		u.logger.Infof("unit %q shutting down: %s", unitTag.Id(), err)
+		u.logger.Infof("unit %q shutting down: %s", unitTag.Id(), errorString)
 	}()
 
 	if err := u.init(unitTag); err != nil {


### PR DESCRIPTION
Merge 2.8 into develop with these PRs

#12286  Fix test timeouts by updating juju/testing.
#12279 [gce] Update compute auth setup
#12273 Metadata dependency
#12287 Backup task name fix
#12289 Cleanup error messages when shutting down units
#12293 Filter mongo addresses we try to use to exclude fan, public
#12294 Allow podspec to specify pod labels
#12296 Log the MAAS 2 login error;
#12292 Fix intermittent fail in TestWatchPorts with clock.Advance timing issue
#12297 Include controller FQDN host in api address for k8s agents

```
# Conflicts:
#       caas/kubernetes/provider/k8s.go
#       caas/kubernetes/provider/k8s_test.go
#       caas/kubernetes/provider/statefulsets.go
#       go.sum
#       state/address_test.go
#       state/pool.go
#       state/ports_test.go
#       state/watcher/export_test.go
#       state/watcher/hubwatcher.go
#       state/watcher/txnwatcher.go
```

## QA steps

See PRs

