### PR TITLE
Handle user charmstore urls

### DIFF
--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -469,7 +469,8 @@ func resolveCharmURL(path string) (*charm.URL, error) {
 
 	// If we find a scheme that is empty, force it to become a charmstore scheme
 	// so every other subsequent parse url call knows the correct type.
-	if u.Scheme == "" {
+	// Ensure we don't prefix a absolute path with a cs: prefix.
+	if u.Scheme == "" && !strings.HasPrefix(u.Path, "/") {
 		return charm.ParseURL(fmt.Sprintf("cs:%s", u.Path))
 	}
 

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -225,6 +225,9 @@ func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
 		path: "cs:~user/series/name",
 		url:  &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
 	}, {
+		path: "~user/series/name",
+		url:  &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
+	}, {
 		path: "ch:~user/series/name",
 		err:  errors.Errorf(`unexpected charm schema: cannot parse URL "ch:~user/series/name": schema "ch" not valid`),
 	}}


### PR DESCRIPTION
The following ensures that we correctly handle when there is no prefix
for a charmstore url. The way the url path is handled in the library
means we need to do a bit more work upfront if we want to maintain
strict compatibility. This was not the original goal of the library as
the feature flag was intended to be lifted by now, but that's how it is.

## QA steps

Ensure you don't have the feature flag enabled for charmhub.

```sh
juju bootstrap lxd test
juju deploy ~juju-qa/network-health-10
```