### PR TITLE
[2.8] Request a NIC per unique space for MAAS instances

### DIFF
--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -9,11 +9,9 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/context"
 )
 
@@ -133,172 +131,46 @@ func parseDelimitedValues(rawValues []string) (positives, negatives []string) {
 	return positives, negatives
 }
 
-// interfaceBinding defines a requirement that a node interface must satisfy in
-// order for that node to get selected and started, based on deploy-time
-// bindings of a service.
-//
-// TODO(dimitern): Once the services have bindings defined in state, a version
-// of this should go to the network package (needs to be non-MAAS-specifc
-// first). Also, we need to transform Juju space names from constraints into
-// MAAS space provider IDs.
-type interfaceBinding struct {
-	Name            string
-	SpaceProviderId string
-
-	// add more as needed.
-}
-
-// numericLabelLimit is a sentinel value used in addInterfaces to limit the
-// number of disambiguation inner loop iterations in case named labels clash
-// with numeric labels for spaces coming from constraints. It's defined here to
-// facilitate testing this behavior.
-var numericLabelLimit uint = 0xffff
-
-// addInterfaces converts a slice of interface bindings, positiveSpaces and
-// negativeSpaces coming from constraints to the format MAAS expects for the
-// "interfaces" and "not_networks" arguments to acquire node. Returns an error
-// satisfying errors.IsNotValid() if the bindings contains duplicates, empty
-// Name/ProviderSpaceID, or if negative spaces clash with specified bindings.
-// Duplicates between specified bindings and positiveSpaces are silently
-// skipped.
-func addInterfaces(
-	params url.Values,
-	bindings []interfaceBinding,
-	positiveSpaces, negativeSpaces []network.SpaceInfo,
-) error {
-	combinedBindings, negatives, err := getBindings(bindings, positiveSpaces, negativeSpaces)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(combinedBindings) > 0 {
-		combinedBindingsString := make([]string, len(combinedBindings))
-		for i, binding := range combinedBindings {
-			combinedBindingsString[i] = fmt.Sprintf("%s:space=%s", binding.Name, binding.SpaceProviderId)
+// addInterfaces converts a slice of positiveSpaces and negativeSpaces coming
+// from application bindings and provided constraints to the format MAAS
+// expects for the "interfaces" and "not_networks" arguments to acquire node.
+func addInterfaces(params url.Values, positiveSpaceIDs, negativeSpaceIDs set.Strings) {
+	if len(positiveSpaceIDs) > 0 {
+		var ifList []string
+		for _, providerSpaceID := range positiveSpaceIDs.SortedValues() {
+			ifList = append(ifList, fmt.Sprintf("space=%s", providerSpaceID))
 		}
-		params.Add("interfaces", strings.Join(combinedBindingsString, ";"))
+		params.Add("interfaces", strings.Join(ifList, ";"))
 	}
-	if len(negatives) > 0 {
-		for _, binding := range negatives {
-			notNetwork := fmt.Sprintf("space:%s", binding.SpaceProviderId)
+
+	if len(negativeSpaceIDs) > 0 {
+		for _, providerSpaceID := range negativeSpaceIDs.SortedValues() {
+			notNetwork := fmt.Sprintf("space:%s", providerSpaceID)
 			params.Add("not_networks", notNetwork)
 		}
 	}
-	return nil
 }
 
-func getBindings(
-	bindings []interfaceBinding,
-	positiveSpaces, negativeSpaces []network.SpaceInfo,
-) ([]interfaceBinding, []interfaceBinding, error) {
-	var (
-		index            uint
-		combinedBindings []interfaceBinding
-	)
-	namesSet := set.NewStrings()
-	spacesSet := set.NewStrings()
-	createLabel := func(index uint, namesSet set.Strings) (string, uint, error) {
-		var label string
-		for {
-			label = fmt.Sprintf("%v", index)
-			if !namesSet.Contains(label) {
-				break
-			}
-			if index > numericLabelLimit { // ...just to make sure we won't loop forever.
-				return "", index, errors.Errorf("too many conflicting numeric labels, giving up.")
-			}
-			index++
+func addInterfaces2(params *gomaasapi.AllocateMachineArgs, positiveSpaceIDs, negativeSpaceIDs set.Strings) {
+	if len(positiveSpaceIDs) > 0 {
+		for _, providerSpaceID := range positiveSpaceIDs.SortedValues() {
+			// NOTE(achilleasa): use the provider ID as the label for the
+			// iface. Using the space name might seem to be more
+			// user-friendly but space names can change after the machine
+			// gets provisioned so they should not be used for labeling things.
+			params.Interfaces = append(
+				params.Interfaces,
+				gomaasapi.InterfaceSpec{
+					Label: providerSpaceID,
+					Space: providerSpaceID,
+				},
+			)
 		}
-		namesSet.Add(label)
-		return label, index, nil
-	}
-	for _, binding := range bindings {
-		switch {
-		case binding.SpaceProviderId == "":
-			return nil, nil, errors.NewNotValid(nil, fmt.Sprintf(
-				"invalid interface binding %q: space provider ID is required",
-				binding.Name,
-			))
-		case binding.Name == "":
-			var label string
-			var err error
-			label, index, err = createLabel(index, namesSet)
-			if err != nil {
-				return nil, nil, errors.Trace(err)
-			}
-			binding.Name = label
-		case namesSet.Contains(binding.Name):
-			return nil, nil, errors.NewNotValid(nil, fmt.Sprintf(
-				"duplicated interface binding %q",
-				binding.Name,
-			))
-		}
-		namesSet.Add(binding.Name)
-		spacesSet.Add(binding.SpaceProviderId)
-
-		combinedBindings = append(combinedBindings, binding)
 	}
 
-	for _, space := range positiveSpaces {
-		if spacesSet.Contains(string(space.ProviderId)) {
-			// Skip duplicates in positiveSpaces.
-			continue
-		}
-		spacesSet.Add(string(space.ProviderId))
-
-		var label string
-		var err error
-		label, index, err = createLabel(index, namesSet)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-		// Make sure we pick a label that doesn't clash with possible bindings.
-		combinedBindings = append(combinedBindings, interfaceBinding{label, string(space.ProviderId)})
+	if len(negativeSpaceIDs) != 0 {
+		params.NotSpace = negativeSpaceIDs.SortedValues()
 	}
-
-	var negatives []interfaceBinding
-	for _, space := range negativeSpaces {
-		if spacesSet.Contains(string(space.ProviderId)) {
-			return nil, nil, errors.NewNotValid(nil, fmt.Sprintf(
-				"negative space %q from constraints clashes with interface bindings",
-				space.Name,
-			))
-		}
-		var label string
-		var err error
-		label, index, err = createLabel(index, namesSet)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-		negatives = append(negatives, interfaceBinding{label, string(space.ProviderId)})
-	}
-	return combinedBindings, negatives, nil
-}
-
-func addInterfaces2(
-	params *gomaasapi.AllocateMachineArgs,
-	bindings []interfaceBinding,
-	positiveSpaces, negativeSpaces []network.SpaceInfo,
-) error {
-	combinedBindings, negatives, err := getBindings(bindings, positiveSpaces, negativeSpaces)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if len(combinedBindings) > 0 {
-		interfaceSpecs := make([]gomaasapi.InterfaceSpec, len(combinedBindings))
-		for i, space := range combinedBindings {
-			interfaceSpecs[i] = gomaasapi.InterfaceSpec{Label: space.Name, Space: space.SpaceProviderId}
-		}
-		params.Interfaces = interfaceSpecs
-	}
-	if len(negatives) > 0 {
-		negativeStrings := make([]string, len(negatives))
-		for i, space := range negatives {
-			negativeStrings[i] = space.SpaceProviderId
-		}
-		params.NotSpace = negativeStrings
-	}
-	return nil
 }
 
 // addStorage converts volume information into url.Values object suitable to

--- a/provider/maas/constraints_test.go
+++ b/provider/maas/constraints_test.go
@@ -483,14 +483,14 @@ func (suite *environSuite) TestAcquireNodeInterfaces(c *gc.C) {
 	}, {
 		descr: "bindings (to the same provider space ID) and space constraints",
 		endpointBindings: map[string]network.Id{
-			"":         "bogus", // the default space is ignored; it has already been applied to any non-explicitly specified endpoints
+			"":         "52", // we should get a NIC in this space even if none of the endpoints are bound to it
 			"name-1":   "1",
 			"name-2":   "1",
 			"name-3":   "2",
 			"name-4":   "3",
 			"to-alpha": network.AlphaSpaceName, // alpha space is not present on maas and is skipped
 		},
-		expectedPositives: "space=1;space=2;space=3;space=5",
+		expectedPositives: "space=1;space=2;space=3;space=5;space=52",
 		expectedNegatives: "space:6",
 	}} {
 		suite.testMAASObject.TestServer.Clear()

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -775,26 +775,89 @@ func (env *maasEnviron) spaceNamesToSpaceInfo(
 	return positiveSpaceIds, negativeSpaceIds, nil
 }
 
+// networkSpaceRequirements combines the space requirements for the application
+// bindings and the specified constraints and returns back a set of provider
+// space IDs for which a NIC needs to be provisioned in the instance we are
+// about to launch and a second (negative) set of space IDs that must not be
+// present in the launched instance NICs.
+func (env *maasEnviron) networkSpaceRequirements(ctx context.ProviderCallContext, endpointToProviderSpaceID map[string]corenetwork.Id, cons constraints.Value) (set.Strings, set.Strings, error) {
+	positiveSpaceIds := set.NewStrings()
+	negativeSpaceIds := set.NewStrings()
+
+	// Iterate the application bindings and add each bound space ID to the
+	// positive space set.
+	for epName, providerSpaceID := range endpointToProviderSpaceID {
+		// The default space is applied at deploy time to all endpoints
+		// that are not explicitly bound but should be ignored when
+		// collecting the spaces we need. Consider this edge case:
+		// an explicit space binding is provided for all endpoints as
+		// well as a default one that is *different* from all others.
+		// In this case, we shouldn't request for a NIC in the default
+		// space as it is not actually going to be used.
+		if epName == "" {
+			continue
+		}
+
+		// The alpha space is not part of the MAAS space list. When the
+		// code that maps between space IDs and provider space IDs
+		// encounters a space that it cannot map, it passes the space
+		// name through.
+		if providerSpaceID == corenetwork.AlphaSpaceName {
+			continue
+		}
+
+		positiveSpaceIds.Add(string(providerSpaceID))
+	}
+
+	// Convert space constraints into a list of space IDs to include and
+	// a list of space IDs to omit.
+	positiveSpaceNames, negativeSpaceNames := convertSpacesFromConstraints(cons.Spaces)
+	positiveSpaceInfo, negativeSpaceInfo, err := env.spaceNamesToSpaceInfo(ctx, positiveSpaceNames, negativeSpaceNames)
+	if err != nil {
+		// Spaces are not supported by this MAAS instance.
+		if errors.IsNotSupported(err) {
+			return nil, nil, nil
+		}
+
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return nil, nil, errors.Trace(err)
+	}
+
+	// Append required space IDs from constraints.
+	for _, si := range positiveSpaceInfo {
+		if si.ProviderId == "" {
+			continue
+		}
+		positiveSpaceIds.Add(string(si.ProviderId))
+	}
+
+	// Calculate negative space ID set and check for clashes with the positive set.
+	for _, si := range negativeSpaceInfo {
+		if si.ProviderId == "" {
+			continue
+		}
+
+		if positiveSpaceIds.Contains(string(si.ProviderId)) {
+			return nil, nil, errors.NewNotValid(nil, fmt.Sprintf("negative space %q from constraints clashes with required spaces for instance NICs", si.Name))
+		}
+
+		negativeSpaceIds.Add(string(si.ProviderId))
+	}
+
+	return positiveSpaceIds, negativeSpaceIds, nil
+}
+
 // acquireNode2 allocates a machine from MAAS2.
 func (env *maasEnviron) acquireNode2(
 	ctx context.ProviderCallContext,
 	nodeName, zoneName, systemId string,
 	cons constraints.Value,
-	interfaces []interfaceBinding,
+	positiveSpaceIDs set.Strings,
+	negativeSpaceIDs set.Strings,
 	volumes []volumeInfo,
 ) (maasInstance, error) {
 	acquireParams := convertConstraints2(cons)
-	positiveSpaceNames, negativeSpaceNames := convertSpacesFromConstraints(cons.Spaces)
-	positiveSpaces, negativeSpaces, err := env.spaceNamesToSpaceInfo(ctx, positiveSpaceNames, negativeSpaceNames)
-	// If spaces aren't supported the constraints should be empty anyway.
-	if err != nil && !errors.IsNotSupported(err) {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
-		return nil, errors.Trace(err)
-	}
-	err = addInterfaces2(&acquireParams, interfaces, positiveSpaces, negativeSpaces)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	addInterfaces2(&acquireParams, positiveSpaceIDs, negativeSpaceIDs)
 	addStorage2(&acquireParams, volumes)
 	acquireParams.AgentName = env.uuid
 	if zoneName != "" {
@@ -824,7 +887,8 @@ func (env *maasEnviron) acquireNode(
 	ctx context.ProviderCallContext,
 	nodeName, zoneName, systemId string,
 	cons constraints.Value,
-	interfaces []interfaceBinding,
+	positiveSpaceIDs set.Strings,
+	negativeSpaceIDs set.Strings,
 	volumes []volumeInfo,
 ) (gomaasapi.MAASObject, error) {
 
@@ -838,16 +902,7 @@ func (env *maasEnviron) acquireNode(
 	// demand (which may fail) if not handled properly.
 
 	acquireParams := convertConstraints(cons)
-	positiveSpaceNames, negativeSpaceNames := convertSpacesFromConstraints(cons.Spaces)
-	positiveSpaces, negativeSpaces, err := env.spaceNamesToSpaceInfo(ctx, positiveSpaceNames, negativeSpaceNames)
-	// If spaces aren't supported the constraints should be empty anyway.
-	if err != nil && !errors.IsNotSupported(err) {
-		return gomaasapi.MAASObject{}, errors.Trace(err)
-	}
-	err = addInterfaces(acquireParams, interfaces, positiveSpaces, negativeSpaces)
-	if err != nil {
-		return gomaasapi.MAASObject{}, errors.Trace(err)
-	}
+	addInterfaces(acquireParams, positiveSpaceIDs, negativeSpaceIDs)
 	addStorage(acquireParams, volumes)
 	acquireParams.Add("agent_name", env.uuid)
 	if zoneName != "" {
@@ -860,13 +915,15 @@ func (env *maasEnviron) acquireNode(
 		acquireParams.Add("system_id", systemId)
 	}
 
-	var result gomaasapi.JSONObject
+	var (
+		result gomaasapi.JSONObject
+		err    error
+	)
 	for a := shortAttempt.Start(); a.Next(); {
 		client := env.getMAASClient().GetSubObject("nodes/")
 		logger.Tracef("calling acquire with params: %+v", acquireParams)
-		result, err = client.CallPost("acquire", acquireParams)
-		if err == nil {
-			break
+		if result, err = client.CallPost("acquire", acquireParams); err == nil {
+			break // Got a result back.
 		}
 	}
 	if err != nil {
@@ -969,20 +1026,12 @@ func (env *maasEnviron) StartInstance(
 		return nil, common.ZoneIndependentError(errors.Annotate(err, "invalid volume parameters"))
 	}
 
-	var interfaceBindings []interfaceBinding
-	if len(args.EndpointBindings) != 0 {
-		for endpoint, spaceProviderID := range args.EndpointBindings {
-			// Ignore alpha space bindings, which we assume will be the result
-			// defaults. It doesn't have a provider ID, and so will be passed
-			// by name.
-			if spaceProviderID != corenetwork.AlphaSpaceName {
-				interfaceBindings = append(interfaceBindings, interfaceBinding{
-					Name:            endpoint,
-					SpaceProviderId: string(spaceProviderID),
-				})
-			}
-		}
+	// Calculate network space requirements.
+	positiveSpaceIDs, negativeSpaceIDs, err := env.networkSpaceRequirements(ctx, args.EndpointBindings, args.Constraints)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+
 	selectNode := env.selectNode2
 	if !env.usingMAAS2() {
 		selectNode = env.selectNode
@@ -993,7 +1042,8 @@ func (env *maasEnviron) StartInstance(
 			AvailabilityZone: availabilityZone,
 			NodeName:         nodeName,
 			SystemId:         systemId,
-			Interfaces:       interfaceBindings,
+			PositiveSpaceIDs: positiveSpaceIDs,
+			NegativeSpaceIDs: negativeSpaceIDs,
 			Volumes:          volumes,
 		})
 	if selectNodeErr != nil {
@@ -1292,7 +1342,8 @@ type selectNodeArgs struct {
 	NodeName         string
 	SystemId         string
 	Constraints      constraints.Value
-	Interfaces       []interfaceBinding
+	PositiveSpaceIDs set.Strings
+	NegativeSpaceIDs set.Strings
 	Volumes          []volumeInfo
 }
 
@@ -1308,7 +1359,8 @@ func (env *maasEnviron) selectNode(ctx context.ProviderCallContext, args selectN
 		args.AvailabilityZone,
 		args.SystemId,
 		args.Constraints,
-		args.Interfaces,
+		args.PositiveSpaceIDs,
+		args.NegativeSpaceIDs,
 		args.Volumes,
 	)
 	if err != nil {
@@ -1337,7 +1389,8 @@ func (env *maasEnviron) selectNode2(ctx context.ProviderCallContext, args select
 		args.AvailabilityZone,
 		args.SystemId,
 		args.Constraints,
-		args.Interfaces,
+		args.PositiveSpaceIDs,
+		args.NegativeSpaceIDs,
 		args.Volumes,
 	)
 	if err != nil {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -786,18 +786,7 @@ func (env *maasEnviron) networkSpaceRequirements(ctx context.ProviderCallContext
 
 	// Iterate the application bindings and add each bound space ID to the
 	// positive space set.
-	for epName, providerSpaceID := range endpointToProviderSpaceID {
-		// The default space is applied at deploy time to all endpoints
-		// that are not explicitly bound but should be ignored when
-		// collecting the spaces we need. Consider this edge case:
-		// an explicit space binding is provided for all endpoints as
-		// well as a default one that is *different* from all others.
-		// In this case, we shouldn't request for a NIC in the default
-		// space as it is not actually going to be used.
-		if epName == "" {
-			continue
-		}
-
+	for _, providerSpaceID := range endpointToProviderSpaceID {
 		// The alpha space is not part of the MAAS space list. When the
 		// code that maps between space IDs and provider space IDs
 		// encounters a space that it cannot map, it passes the space

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -612,7 +612,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 	}, {
 		descr: "bindings (to the same provider space ID) and space constraints",
 		endpointBindings: map[string]corenetwork.Id{
-			"":         "bogus", // the default space is ignored; it has already been applied to any non-explicitly specified endpoints
+			"":         "999", // we should get a NIC in this space even if none of the endpoints are bound to it
 			"name-1":   "1",
 			"name-2":   "1",
 			"name-3":   "2",
@@ -623,6 +623,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 			{Label: "1", Space: "1"},
 			{Label: "2", Space: "2"},
 			{Label: "42", Space: "42"},
+			{Label: "999", Space: "999"},
 		},
 		expectedNegatives: []string{"3"},
 	}} {

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -445,7 +445,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodePassedAgentName(c *gc.C) {
 	suite.setupFakeTools(c)
 	env = suite.makeEnviron(c, nil)
 
-	_, err := env.acquireNode2(suite.callCtx, "", "", "", constraints.Value{}, nil, nil)
+	_, err := env.acquireNode2(suite.callCtx, "", "", "", constraints.Value{}, nil, nil, nil)
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -460,7 +460,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodePassesPositiveAndNegativeTags(c *
 	_, err := env.acquireNode2(suite.callCtx,
 		"", "", "",
 		constraints.Value{Tags: stringslicep("tag1", "^tag2", "tag3", "^tag4")},
-		nil, nil,
+		nil, nil, nil,
 	)
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -494,32 +494,23 @@ func (suite *maas2EnvironSuite) TestAcquireNodePassesPositiveAndNegativeSpaces(c
 	expected := gomaasapi.AllocateMachineArgs{
 		NotSpace: []string{"6", "8"},
 		Interfaces: []gomaasapi.InterfaceSpec{
-			{Label: "0", Space: "5"},
-			{Label: "1", Space: "7"},
+			{Label: "5", Space: "5"},
+			{Label: "7", Space: "7"},
 		},
 	}
 	env, _ := suite.injectControllerWithSpacesAndCheck(c, getFourSpaces(), expected)
 
-	_, err := env.acquireNode2(suite.callCtx,
-		"", "", "",
-		constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")},
-		nil, nil,
-	)
+	cons := constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")}
+	positiveSpaceIDs, negativeSpaceIDs, err := env.networkSpaceRequirements(suite.callCtx, nil, cons)
 	c.Check(err, jc.ErrorIsNil)
-}
 
-func (suite *maas2EnvironSuite) TestAcquireNodeDisambiguatesNamedLabelsFromIndexedUpToALimit(c *gc.C) {
-	env, _ := suite.injectControllerWithSpacesAndCheck(c, getFourSpaces(), gomaasapi.AllocateMachineArgs{})
-	var shortLimit uint = 0
-	suite.PatchValue(&numericLabelLimit, shortLimit)
-
-	_, err := env.acquireNode2(suite.callCtx,
+	_, err = env.acquireNode2(suite.callCtx,
 		"", "", "",
-		constraints.Value{Spaces: stringslicep("space-1", "^space-2", "space-3", "^space-4")},
-		[]interfaceBinding{{"0", "first-clash"}, {"1", "final-clash"}},
+		cons,
+		positiveSpaceIDs, negativeSpaceIDs,
 		nil,
 	)
-	c.Assert(err, gc.ErrorMatches, `too many conflicting numeric labels, giving up.`)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (suite *maas2EnvironSuite) TestAcquireNodeStorage(c *gc.C) {
@@ -568,7 +559,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeStorage(c *gc.C) {
 			return test.expected
 		}
 		env = suite.makeEnviron(c, nil)
-		_, err := env.acquireNode2(suite.callCtx, "", "", "", constraints.Value{}, nil, test.volumes)
+		_, err := env.acquireNode2(suite.callCtx, "", "", "", constraints.Value{}, nil, nil, test.volumes)
 		c.Check(err, jc.ErrorIsNil)
 	}
 }
@@ -592,6 +583,7 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		spaces: getTwoSpaces(),
 	})
 	suite.setupFakeTools(c)
+
 	// Add some constraints, including spaces to verify specified bindings
 	// always override any spaces constraints.
 	cons := constraints.Value{
@@ -599,79 +591,43 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 	}
 	// In the tests below Space 2 means foo, Space 3 means bar.
 	for i, test := range []struct {
-		interfaces        []interfaceBinding
+		descr             string
+		endpointBindings  map[string]corenetwork.Id
 		expectedPositives []gomaasapi.InterfaceSpec
 		expectedNegatives []string
 		expectedError     string
-	}{{ // without specified bindings, spaces constraints are used instead.
-		interfaces:        nil,
-		expectedPositives: []gomaasapi.InterfaceSpec{{"0", "2"}},
+	}{{
+		descr:             "no bindings and space constraints",
+		expectedPositives: []gomaasapi.InterfaceSpec{{Label: "2", Space: "2"}},
 		expectedNegatives: []string{"3"},
 		expectedError:     "",
 	}, {
-		interfaces:        []interfaceBinding{{"name-1", "space-1"}},
-		expectedPositives: []gomaasapi.InterfaceSpec{{"name-1", "space-1"}, {"0", "2"}},
+		descr:            "bindings and no space constraints",
+		endpointBindings: map[string]corenetwork.Id{"name-1": "space-1"},
+		expectedPositives: []gomaasapi.InterfaceSpec{
+			{Label: "2", Space: "2"},
+			{Label: "space-1", Space: "space-1"},
+		},
 		expectedNegatives: []string{"3"},
 	}, {
-		interfaces: []interfaceBinding{
-			{"name-1", "7"},
-			{"name-2", "8"},
-			{"name-3", "9"},
+		descr: "bindings (to the same provider space ID) and space constraints",
+		endpointBindings: map[string]corenetwork.Id{
+			"":         "bogus", // the default space is ignored; it has already been applied to any non-explicitly specified endpoints
+			"name-1":   "1",
+			"name-2":   "1",
+			"name-3":   "2",
+			"name-4":   "42",
+			"to-alpha": corenetwork.AlphaSpaceName, // alpha space is not present on maas and is skipped
 		},
-		expectedPositives: []gomaasapi.InterfaceSpec{{"name-1", "7"}, {"name-2", "8"}, {"name-3", "9"}, {"0", "2"}},
+		expectedPositives: []gomaasapi.InterfaceSpec{
+			{Label: "1", Space: "1"},
+			{Label: "2", Space: "2"},
+			{Label: "42", Space: "42"},
+		},
 		expectedNegatives: []string{"3"},
-	}, {
-		interfaces:        []interfaceBinding{{"", "anything"}},
-		expectedPositives: []gomaasapi.InterfaceSpec{{"0", "anything"}, {"1", "2"}},
-		expectedNegatives: []string{"3"},
-	}, {
-		interfaces:    []interfaceBinding{{"shared-db", "3"}},
-		expectedError: `negative space "bar" from constraints clashes with interface bindings`,
-	}, {
-		interfaces: []interfaceBinding{
-			{"shared-db", "1"},
-			{"db", "1"},
-		},
-		expectedPositives: []gomaasapi.InterfaceSpec{{"shared-db", "1"}, {"db", "1"}, {"0", "2"}},
-		expectedNegatives: []string{"3"},
-	}, {
-		interfaces:    []interfaceBinding{{"", ""}},
-		expectedError: `invalid interface binding "": space provider ID is required`,
-	}, {
-		interfaces: []interfaceBinding{
-			{"valid", "ok"},
-			{"", "valid-but-ignored-space"},
-			{"valid-name-empty-space", ""},
-			{"", ""},
-		},
-		expectedError: `invalid interface binding "valid-name-empty-space": space provider ID is required`,
-	}, {
-		interfaces:    []interfaceBinding{{"foo", ""}},
-		expectedError: `invalid interface binding "foo": space provider ID is required`,
-	}, {
-		interfaces: []interfaceBinding{
-			{"bar", ""},
-			{"valid", "ok"},
-			{"", "valid-but-ignored-space"},
-			{"", ""},
-		},
-		expectedError: `invalid interface binding "bar": space provider ID is required`,
-	}, {
-		interfaces: []interfaceBinding{
-			{"dup-name", "1"},
-			{"dup-name", "2"},
-		},
-		expectedError: `duplicated interface binding "dup-name"`,
-	}, {
-		interfaces: []interfaceBinding{
-			{"valid-1", "0"},
-			{"dup-name", "1"},
-			{"dup-name", "2"},
-			{"valid-2", "3"},
-		},
-		expectedError: `duplicated interface binding "dup-name"`,
 	}} {
-		c.Logf("test #%d: interfaces=%v", i, test.interfaces)
+		c.Logf("test #%d: %s", i, test.descr)
+
 		env = suite.makeEnviron(c, nil)
 		getNegatives = func() []string {
 			return test.expectedNegatives
@@ -679,7 +635,11 @@ func (suite *maas2EnvironSuite) TestAcquireNodeInterfaces(c *gc.C) {
 		getPositives = func() []gomaasapi.InterfaceSpec {
 			return test.expectedPositives
 		}
-		_, err := env.acquireNode2(suite.callCtx, "", "", "", cons, test.interfaces, nil)
+
+		positiveSpaceIDs, negativeSpaceIDs, err := env.networkSpaceRequirements(suite.callCtx, test.endpointBindings, cons)
+		c.Check(err, jc.ErrorIsNil)
+
+		_, err = env.acquireNode2(suite.callCtx, "", "", "", cons, positiveSpaceIDs, negativeSpaceIDs, nil)
 		if test.expectedError != "" {
 			c.Check(err, gc.ErrorMatches, test.expectedError)
 			c.Check(err, jc.Satisfies, errors.IsNotValid)
@@ -702,42 +662,6 @@ func getTwoSpaces() []gomaasapi.Space {
 			id:      3,
 		},
 	}
-}
-
-func (suite *maas2EnvironSuite) TestAcquireNodeConvertsSpaceNames(c *gc.C) {
-	expected := gomaasapi.AllocateMachineArgs{
-		NotSpace:   []string{"3"},
-		Interfaces: []gomaasapi.InterfaceSpec{{Label: "0", Space: "2"}},
-	}
-	env, _ := suite.injectControllerWithSpacesAndCheck(c, getTwoSpaces(), expected)
-	cons := constraints.Value{
-		Spaces: stringslicep("foo", "^bar"),
-	}
-	_, err := env.acquireNode2(suite.callCtx, "", "", "", cons, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (suite *maas2EnvironSuite) TestAcquireNodeTranslatesSpaceNames(c *gc.C) {
-	expected := gomaasapi.AllocateMachineArgs{
-		NotSpace:   []string{"3"},
-		Interfaces: []gomaasapi.InterfaceSpec{{Label: "0", Space: "2"}},
-	}
-	env, _ := suite.injectControllerWithSpacesAndCheck(c, getTwoSpaces(), expected)
-	cons := constraints.Value{
-		Spaces: stringslicep("foo-1", "^bar-3"),
-	}
-	_, err := env.acquireNode2(suite.callCtx, "", "", "", cons, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (suite *maas2EnvironSuite) TestAcquireNodeUnrecognisedSpace(c *gc.C) {
-	suite.injectController(&fakeController{})
-	env := suite.makeEnviron(c, nil)
-	cons := constraints.Value{
-		Spaces: stringslicep("baz"),
-	}
-	_, err := env.acquireNode2(suite.callCtx, "", "", "", cons, nil, nil)
-	c.Assert(err, gc.ErrorMatches, `unrecognised space in constraint "baz"`)
 }
 
 func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {


### PR DESCRIPTION
Prior to this change, the constraints mapping code in the MAAS provider
would iterate the list of endpoint bindings and request an interface for
each individual endpoint even thought they might all be bound to the
same space.

As a result, when MAAS was asked to synthesize a KVM node with those
constraints it would generate multiple NICs labeled after each endpoint
thus triggering LP1902878.

Instead of having two separate code paths (v1 and v2) that intersected
(getBindings) and then diverged again, the fix introduced by this commit
extracts the space requirement calculation logic into a separate method
that is invoked by StartInstance and whose results are passed into
acquireNode/acquireNode2. This new method calculates the unique set of
endpoints from the application bindings (if provided) and appends any
positive space constraints. Then it calculates the negative space set
and checks for clashes with the positive set.

After this change, various bits of logic have been made redundant and
therefore removed. In addition, new tests have been added for the
introduced space requirement calculation logic and the existing
AcquireNode tests have been cleaned up as the validation logic is
applied before they are invoked.

## QA steps

Setup you virtual maas instance with a KVM instance and create 3 spaces: space1, space2, space3.
Assign each space to a different subnet and ensure that **none** of your already composed KVM pods
have a NIC in spaces 1 and 2 (the goal is to have MAAS synthesize a pod for us based on the constraints)

```sh
$ juju model-config logging-config='<root>=INFO;juju.provider.maas=TRACE'
$ juju deploy apache2 --bind space1 --constraints spaces=space2,^space3
```

Then check the provisioned KVM pod in MAAS web UI and verify that you have two NICs, one on space1 and one on space2.
If you check the model logs, you should be able to spot the constraints being passed to maas (IDs will probably be different in your case): "interfaces=space=1;space=2;not_subnets=space=3"

Try the same steps with juju from snap and you should see a NIC per endpoint name.

For consistency, we should try the same with a V1 MAAS.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1902878