### PR TITLE
Use unit private address(pod address) for relation egress address for…

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -402,8 +402,10 @@ func (n *NetworkInfo) NetworksForRelation(
 		var addr corenetwork.SpaceAddress
 		// If no egress subnets defined, We default to the ingress address for IaaS
 		// and pod address for CaaS.
-		if n.unit.ShouldBeAssigned() && len(ingress) > 0 {
-			addr = ingress[0]
+		if n.unit.ShouldBeAssigned() {
+			if len(ingress) > 0 {
+				addr = ingress[0]
+			}
 		} else {
 			addr, err = n.unit.PrivateAddress()
 			if err != nil && !network.IsNoAddressError(err) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -5275,7 +5275,7 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 				},
 			},
 		},
-		EgressSubnets:    []string{"54.32.1.2/32"},
+		EgressSubnets:    []string{"192.168.1.2/32"},
 		IngressAddresses: []string{"54.32.1.2", "192.168.1.2"},
 	}
 


### PR DESCRIPTION
*Use unit private address(pod address) for relation egress address for CAAS;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ 
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
