### PR TITLE
NetworkInfo IAAS/CAAS Factory

### DIFF
--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -46,6 +46,6 @@ func PatchGetStorageStateError(patcher patcher, err error) {
 	patcher.PatchValue(&getStorageState, func(st *state.State) (storageAccess, error) { return nil, err })
 }
 
-func (n *NetworkInfo) MachineNetworkInfos(spaceIDs ...string) (map[string]machineNetworkInfoResult, error) {
+func (n *NetworkInfoBase) MachineNetworkInfos(spaceIDs ...string) (map[string]machineNetworkInfoResult, error) {
 	return n.machineNetworkInfos(spaceIDs...)
 }

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/retry"
 	k8score "k8s.io/api/core/v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	corenetwork "github.com/juju/juju/core/network"
@@ -69,9 +68,9 @@ func NewNetworkInfo(st *state.State, tag names.UnitTag, retryFactory func() retr
 
 	var netInfo NetworkInfo
 	if unit.ShouldBeAssigned() {
-		netInfo = NetworkInfoIAAS{base}
+		netInfo = &NetworkInfoIAAS{base}
 	} else {
-		netInfo = NetworkInfoIAAS{base}
+		netInfo = &NetworkInfoIAAS{base}
 	}
 
 	err = netInfo.init(unit)
@@ -118,138 +117,6 @@ func (n *NetworkInfoBase) getModelEgressSubnets() ([]string, error) {
 // ProcessAPIRequest handles a request to the uniter API NetworkInfo method.
 // TODO (manadart 2019-10-09): This method verges on impossible to reason about
 // and should be rewritten.
-func (n *NetworkInfoBase) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
-	spaces := set.NewStrings()
-	bindings := make(map[string]string)
-	endpointEgressSubnets := make(map[string][]string)
-
-	result := params.NetworkInfoResults{
-		Results: make(map[string]params.NetworkInfoResult),
-	}
-	// For each of the endpoints in the request, get the bound space and
-	// initialise the endpoint egress map with the model's configured
-	// egress subnets. Keep track of the spaces that we observe.
-	for _, endpoint := range args.Endpoints {
-		binding, ok := n.bindings[endpoint]
-		if ok {
-			spaces.Add(binding)
-			bindings[endpoint] = binding
-		} else {
-			// If default binding is not explicitly defined, use the default space.
-			// This should no longer be the case....
-			if endpoint == "" {
-				bindings[endpoint] = corenetwork.AlphaSpaceId
-			} else {
-				err := errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
-				result.Results[endpoint] = params.NetworkInfoResult{Error: common.ServerError(err)}
-			}
-		}
-		endpointEgressSubnets[endpoint] = n.defaultEgress
-	}
-
-	endpointIngressAddresses := make(map[string]corenetwork.SpaceAddresses)
-
-	// If we are working in a relation context, get the network information for
-	// the relation and set it for the relation's binding.
-	if args.RelationId != nil {
-		endpoint, space, ingress, egress, err := n.getRelationNetworkInfo(*args.RelationId)
-		if err != nil {
-			return params.NetworkInfoResults{}, err
-		}
-
-		spaces.Add(space)
-		if len(egress) > 0 {
-			endpointEgressSubnets[endpoint] = egress
-		}
-		endpointIngressAddresses[endpoint] = ingress
-	}
-
-	var (
-		networkInfos            map[string]machineNetworkInfoResult
-		defaultIngressAddresses []string
-	)
-
-	if n.unit.ShouldBeAssigned() {
-		var err error
-		// TODO (manadart 2019-09-10): This looks like it might be called
-		// twice in some cases - getRelationNetworkInfo (called above)
-		// calls NetworksForRelation, which also calls this method.
-		if networkInfos, err = n.machineNetworkInfos(spaces.Values()...); err != nil {
-			return params.NetworkInfoResults{}, err
-		}
-	} else {
-		// For CAAS units, we build up a minimal result struct
-		// based on the default space and unit public/private addresses,
-		// ie the addresses of the CAAS service.
-		addrs, err := n.unit.AllAddresses()
-		if err != nil {
-			return params.NetworkInfoResults{}, err
-		}
-		corenetwork.SortAddresses(addrs)
-
-		// We record the interface addresses as the machine local ones - these
-		// are used later as the binding addresses.
-		// For CAAS models, we need to default ingress addresses to all available
-		// addresses so record those in the default ingress address slice.
-		var interfaceAddr []network.InterfaceAddress
-		for _, a := range addrs {
-			if a.Scope == corenetwork.ScopeMachineLocal {
-				interfaceAddr = append(interfaceAddr, network.InterfaceAddress{Address: a.Value})
-			} else {
-				defaultIngressAddresses = append(defaultIngressAddresses, a.Value)
-			}
-		}
-		networkInfos = make(map[string]machineNetworkInfoResult)
-		networkInfos[corenetwork.AlphaSpaceId] = machineNetworkInfoResult{
-			NetworkInfos: []network.NetworkInfo{{Addresses: interfaceAddr}},
-		}
-	}
-
-	for endpoint, space := range bindings {
-		// The binding address information based on link layer devices.
-		info := machineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
-
-		// Set egress and ingress address information.
-		info.EgressSubnets = endpointEgressSubnets[endpoint]
-
-		ingressAddrs := make([]string, len(endpointIngressAddresses[endpoint]))
-		for i, addr := range endpointIngressAddresses[endpoint] {
-			ingressAddrs[i] = addr.Value
-		}
-		info.IngressAddresses = ingressAddrs
-
-		// If there is no ingress address explicitly defined for a given
-		// binding, set the ingress addresses to either any defaults set above,
-		// or the binding addresses.
-		if len(info.IngressAddresses) == 0 {
-			info.IngressAddresses = defaultIngressAddresses
-		}
-
-		if len(info.IngressAddresses) == 0 {
-			ingress := spaceAddressesFromNetworkInfo(networkInfos[space].NetworkInfos)
-			corenetwork.SortAddresses(ingress)
-			info.IngressAddresses = make([]string, len(ingress))
-			for i, addr := range ingress {
-				info.IngressAddresses[i] = addr.Value
-			}
-		}
-
-		// If there is no egress subnet explicitly defined for a given binding,
-		// default to the first ingress address. This matches the behaviour when
-		// there's a relation in place.
-		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
-			var err error
-			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
-			if err != nil {
-				return result, errors.Trace(err)
-			}
-		}
-
-		result.Results[endpoint] = info
-	}
-
-	return dedupNetworkInfoResults(result), nil
-}
 
 func dedupNetworkInfoResults(info params.NetworkInfoResults) params.NetworkInfoResults {
 	for epName, res := range info.Results {

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -398,7 +398,9 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 
-	netInfo := s.newNetworkInfo(c, unit.UnitTag(), nil)
+	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
+	netInfo := ni.(uniter.NetworkInfoIAAS)
+
 	res, err := netInfo.MachineNetworkInfos(spaceIDDefault, spaceIDDMZ, "666", network.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 4)
@@ -463,7 +465,9 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 
-	netInfo := s.newNetworkInfo(c, unit.UnitTag(), nil)
+	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
+	netInfo := ni.(uniter.NetworkInfoIAAS)
+
 	res, err := netInfo.MachineNetworkInfos(network.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
@@ -533,7 +537,7 @@ func (s *networkInfoSuite) createNICWithIP(
 
 func (s *networkInfoSuite) newNetworkInfo(
 	c *gc.C, tag names.UnitTag, retryFactory func() retry.CallArgs,
-) *uniter.NetworkInfo {
+) uniter.NetworkInfo {
 	// Allow the caller to supply nil if this is not important.
 	// We fill it with an optimistic default.
 	if retryFactory == nil {

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -399,7 +399,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
-	netInfo := ni.(uniter.NetworkInfoIAAS)
+	netInfo := ni.(*uniter.NetworkInfoIAAS)
 
 	res, err := netInfo.MachineNetworkInfos(spaceIDDefault, spaceIDDMZ, "666", network.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
@@ -466,7 +466,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
-	netInfo := ni.(uniter.NetworkInfoIAAS)
+	netInfo := ni.(*uniter.NetworkInfoIAAS)
 
 	res, err := netInfo.MachineNetworkInfos(network.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -1,0 +1,9 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+// NetworkInfoCAAS is used to provide network info for CAAS units.
+type NetworkInfoCAAS struct {
+	*NetworkInfoBase
+}

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -3,7 +3,142 @@
 
 package uniter
 
+import (
+	"fmt"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/network"
+)
+
 // NetworkInfoCAAS is used to provide network info for CAAS units.
 type NetworkInfoCAAS struct {
 	*NetworkInfoBase
+}
+
+func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
+	spaces := set.NewStrings()
+	bindings := make(map[string]string)
+	endpointEgressSubnets := make(map[string][]string)
+
+	result := params.NetworkInfoResults{
+		Results: make(map[string]params.NetworkInfoResult),
+	}
+	// For each of the endpoints in the request, get the bound space and
+	// initialise the endpoint egress map with the model's configured
+	// egress subnets. Keep track of the spaces that we observe.
+	for _, endpoint := range args.Endpoints {
+		binding, ok := n.bindings[endpoint]
+		if ok {
+			spaces.Add(binding)
+			bindings[endpoint] = binding
+		} else {
+			// If default binding is not explicitly defined, use the default space.
+			// This should no longer be the case....
+			if endpoint == "" {
+				bindings[endpoint] = corenetwork.AlphaSpaceId
+			} else {
+				err := errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
+				result.Results[endpoint] = params.NetworkInfoResult{Error: common.ServerError(err)}
+			}
+		}
+		endpointEgressSubnets[endpoint] = n.defaultEgress
+	}
+
+	endpointIngressAddresses := make(map[string]corenetwork.SpaceAddresses)
+
+	// If we are working in a relation context, get the network information for
+	// the relation and set it for the relation's binding.
+	if args.RelationId != nil {
+		endpoint, space, ingress, egress, err := n.getRelationNetworkInfo(*args.RelationId)
+		if err != nil {
+			return params.NetworkInfoResults{}, err
+		}
+
+		spaces.Add(space)
+		if len(egress) > 0 {
+			endpointEgressSubnets[endpoint] = egress
+		}
+		endpointIngressAddresses[endpoint] = ingress
+	}
+
+	var (
+		defaultIngressAddresses []string
+	)
+
+	// For CAAS units, we build up a minimal result struct
+	// based on the default space and unit public/private addresses,
+	// ie the addresses of the CAAS service.
+	addrs, err := n.unit.AllAddresses()
+	if err != nil {
+		return params.NetworkInfoResults{}, err
+	}
+	corenetwork.SortAddresses(addrs)
+
+	// We record the interface addresses as the machine local ones - these
+	// are used later as the binding addresses.
+	// For CAAS models, we need to default ingress addresses to all available
+	// addresses so record those in the default ingress address slice.
+	var interfaceAddr []network.InterfaceAddress
+	for _, a := range addrs {
+		if a.Scope == corenetwork.ScopeMachineLocal {
+			interfaceAddr = append(interfaceAddr, network.InterfaceAddress{Address: a.Value})
+		} else {
+			defaultIngressAddresses = append(defaultIngressAddresses, a.Value)
+		}
+	}
+
+	networkInfos := make(map[string]machineNetworkInfoResult)
+	networkInfos[corenetwork.AlphaSpaceId] = machineNetworkInfoResult{
+		NetworkInfos: []network.NetworkInfo{{Addresses: interfaceAddr}},
+	}
+
+	for endpoint, space := range bindings {
+		// The binding address information based on link layer devices.
+		info := machineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
+
+		// Set egress and ingress address information.
+		info.EgressSubnets = endpointEgressSubnets[endpoint]
+
+		ingressAddrs := make([]string, len(endpointIngressAddresses[endpoint]))
+		for i, addr := range endpointIngressAddresses[endpoint] {
+			ingressAddrs[i] = addr.Value
+		}
+		info.IngressAddresses = ingressAddrs
+
+		// If there is no ingress address explicitly defined for a given
+		// binding, set the ingress addresses to either any defaults set above,
+		// or the binding addresses.
+		if len(info.IngressAddresses) == 0 {
+			info.IngressAddresses = defaultIngressAddresses
+		}
+
+		if len(info.IngressAddresses) == 0 {
+			ingress := spaceAddressesFromNetworkInfo(networkInfos[space].NetworkInfos)
+			corenetwork.SortAddresses(ingress)
+			info.IngressAddresses = make([]string, len(ingress))
+			for i, addr := range ingress {
+				info.IngressAddresses[i] = addr.Value
+			}
+		}
+
+		// If there is no egress subnet explicitly defined for a given binding,
+		// default to the first ingress address. This matches the behaviour when
+		// there's a relation in place.
+		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
+			var err error
+			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+		}
+
+		result.Results[endpoint] = info
+	}
+
+	return dedupNetworkInfoResults(result), nil
 }

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -152,7 +152,7 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 		return "", "", nil, nil, errors.Trace(err)
 	}
 
-	pollAddr := false
+	var pollAddr bool
 	svcType := cfg.GetString(k8sprovider.ServiceTypeConfigKey, "")
 	switch k8score.ServiceType(svcType) {
 	case k8score.ServiceTypeLoadBalancer, k8score.ServiceTypeExternalName:

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -4,9 +4,14 @@
 package uniter
 
 import (
+	"fmt"
+
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
@@ -14,6 +19,92 @@ import (
 // NetworkInfoIAAS is used to provide network info for IAAS units.
 type NetworkInfoIAAS struct {
 	*NetworkInfoBase
+}
+
+func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
+	spaces := set.NewStrings()
+	bindings := make(map[string]string)
+	endpointEgressSubnets := make(map[string][]string)
+
+	result := params.NetworkInfoResults{
+		Results: make(map[string]params.NetworkInfoResult),
+	}
+	// For each of the endpoints in the request, get the bound space and
+	// initialise the endpoint egress map with the model's configured
+	// egress subnets. Keep track of the spaces that we observe.
+	for _, endpoint := range args.Endpoints {
+		if binding, ok := n.bindings[endpoint]; ok {
+			spaces.Add(binding)
+			bindings[endpoint] = binding
+		} else {
+			err := errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
+			result.Results[endpoint] = params.NetworkInfoResult{Error: common.ServerError(err)}
+		}
+		endpointEgressSubnets[endpoint] = n.defaultEgress
+	}
+
+	endpointIngressAddresses := make(map[string]corenetwork.SpaceAddresses)
+
+	// If we are working in a relation context, get the network information for
+	// the relation and set it for the relation's binding.
+	if args.RelationId != nil {
+		endpoint, space, ingress, egress, err := n.getRelationNetworkInfo(*args.RelationId)
+		if err != nil {
+			return params.NetworkInfoResults{}, err
+		}
+
+		spaces.Add(space)
+		if len(egress) > 0 {
+			endpointEgressSubnets[endpoint] = egress
+		}
+		endpointIngressAddresses[endpoint] = ingress
+	}
+
+	// TODO (manadart 2019-09-10): This looks like it might be called
+	// twice in some cases - getRelationNetworkInfo (called above)
+	// calls NetworksForRelation, which also calls this method.
+	networkInfos, err := n.machineNetworkInfos(spaces.Values()...)
+	if err != nil {
+		return params.NetworkInfoResults{}, err
+	}
+
+	for endpoint, space := range bindings {
+		// The binding address information based on link layer devices.
+		info := machineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
+
+		// Set egress and ingress address information.
+		info.EgressSubnets = endpointEgressSubnets[endpoint]
+
+		ingressAddrs := make([]string, len(endpointIngressAddresses[endpoint]))
+		for i, addr := range endpointIngressAddresses[endpoint] {
+			ingressAddrs[i] = addr.Value
+		}
+		info.IngressAddresses = ingressAddrs
+
+		if len(info.IngressAddresses) == 0 {
+			ingress := spaceAddressesFromNetworkInfo(networkInfos[space].NetworkInfos)
+			corenetwork.SortAddresses(ingress)
+			info.IngressAddresses = make([]string, len(ingress))
+			for i, addr := range ingress {
+				info.IngressAddresses[i] = addr.Value
+			}
+		}
+
+		// If there is no egress subnet explicitly defined for a given binding,
+		// default to the first ingress address. This matches the behaviour when
+		// there's a relation in place.
+		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
+			var err error
+			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+		}
+
+		result.Results[endpoint] = info
+	}
+
+	return dedupNetworkInfoResults(result), nil
 }
 
 // TODO (manadart 2020-08-20): The logic below was moved over from the state

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -1,0 +1,87 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/network"
+	"github.com/juju/juju/state"
+)
+
+// NetworkInfoIAAS is used to provide network info for IAAS units.
+type NetworkInfoIAAS struct {
+	*NetworkInfoBase
+}
+
+// TODO (manadart 2020-08-20): The logic below was moved over from the state
+// package when machine.GetNetworkInfoForSpaces was removed from state and
+// implemented here. It is an unnecessary convolution and should be factored
+// out in favour of a simpler return from machineNetworkInfos.
+
+// MachineNetworkInfoResult contains an error or a list of NetworkInfo
+// structures for a specific space.
+type machineNetworkInfoResult struct {
+	NetworkInfos []network.NetworkInfo
+	Error        error
+}
+
+// Add address to a device in list or create a new device with this address.
+func addAddressToResult(networkInfos []network.NetworkInfo, address *state.Address) ([]network.NetworkInfo, error) {
+	deviceAddr := network.InterfaceAddress{
+		Address: address.Value(),
+		CIDR:    address.SubnetCIDR(),
+	}
+	for i := range networkInfos {
+		networkInfo := &networkInfos[i]
+		if networkInfo.InterfaceName == address.DeviceName() {
+			networkInfo.Addresses = append(networkInfo.Addresses, deviceAddr)
+			return networkInfos, nil
+		}
+	}
+
+	var MAC string
+	device, err := address.Device()
+	if err == nil {
+		MAC = device.MACAddress()
+	} else if !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+
+	networkInfo := network.NetworkInfo{
+		InterfaceName: address.DeviceName(),
+		MACAddress:    MAC,
+		Addresses:     []network.InterfaceAddress{deviceAddr},
+	}
+	return append(networkInfos, networkInfo), nil
+}
+
+func machineNetworkInfoResultToNetworkInfoResult(inResult machineNetworkInfoResult) params.NetworkInfoResult {
+	if inResult.Error != nil {
+		return params.NetworkInfoResult{Error: common.ServerError(inResult.Error)}
+	}
+	infos := make([]params.NetworkInfo, len(inResult.NetworkInfos))
+	for i, info := range inResult.NetworkInfos {
+		infos[i] = networkToParamsNetworkInfo(info)
+	}
+	return params.NetworkInfoResult{
+		Info: infos,
+	}
+}
+
+func networkToParamsNetworkInfo(info network.NetworkInfo) params.NetworkInfo {
+	addresses := make([]params.InterfaceAddress, len(info.Addresses))
+	for i, addr := range info.Addresses {
+		addresses[i] = params.InterfaceAddress{
+			Address: addr.Address,
+			CIDR:    addr.CIDR,
+		}
+	}
+	return params.NetworkInfo{
+		MACAddress:    info.MACAddress,
+		InterfaceName: info.InterfaceName,
+		Addresses:     addresses,
+	}
+}

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -21,6 +21,7 @@ type NetworkInfoIAAS struct {
 	*NetworkInfoBase
 }
 
+// ProcessAPIRequest handles a request to the uniter API NetworkInfo method.
 func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
 	spaces := set.NewStrings()
 	bindings := make(map[string]string)
@@ -105,6 +106,20 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 	}
 
 	return dedupNetworkInfoResults(result), nil
+}
+
+// getRelationNetworkInfo returns the endpoint name, network space
+// and ingress/egress addresses for the input relation ID.
+func (n *NetworkInfoIAAS) getRelationNetworkInfo(
+	relationId int,
+) (string, string, corenetwork.SpaceAddresses, []string, error) {
+	rel, endpoint, err := n.getRelationAndEndpointName(relationId)
+	if err != nil {
+		return "", "", nil, nil, errors.Trace(err)
+	}
+
+	space, ingress, egress, err := n.NetworksForRelation(endpoint, rel, true)
+	return endpoint, space, ingress, egress, errors.Trace(err)
 }
 
 // TODO (manadart 2020-08-20): The logic below was moved over from the state

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3553,6 +3553,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 	// Check model attributes are overridden by setting up a value.
 	err := s.Model.UpdateModelConfig(map[string]interface{}{"egress-subnets": "192.168.0.0/16"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
+
 	egress := state.NewRelationEgressNetworks(s.State)
 	_, err = egress.Save(relTag.Id(), false, []string{"10.0.0.0/16", "10.1.2.0/8"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -3561,6 +3562,7 @@ func (s *uniterSuite) TestRelationEgressSubnets(c *gc.C) {
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: "unit-mysql-0"},
 	}}
+
 	result, err := thisUniter.EnterScope(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{


### PR DESCRIPTION
This patch begins pulling apart `NetworkInfo` into separate implementations for IAAS and CAAS, each returned by a factory based on determining the model type from the subject unit.

`NetworkInfo` is notoriously hard to reason about due to convolutions around repeated logical branching based on relation scope, CMR and model type. This makes it a little easier to negotiate, and importantly, modify without increasing said convolutions.

There is still a lot of duplicated code. Patches will follow that increase reuse and begin to audit/modify for correctness.

## QA steps

No functional change; unit tests remain green.

## Documentation changes

None

## Bug reference

N/A
