### PR TITLE
Charmhub not found errors

### DIFF
--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -46,6 +46,7 @@ var (
 
 const defaultMinMultipartUploadSize = 5 * 1024 * 1024
 
+// Logger is a in place interface to represent a logger for consuming.
 type Logger interface {
 	IsTraceEnabled() bool
 
@@ -154,8 +155,8 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 	config.Logger.Tracef("NewClient to %q", config.URL)
 
 	httpClient := DefaultHTTPTransport()
-	apiRequester := NewAPIRequester(httpClient)
-	restClient := NewHTTPRESTClient(apiRequester, config.Headers, config.Logger)
+	apiRequester := NewAPIRequester(httpClient, config.Logger)
+	restClient := NewHTTPRESTClient(apiRequester, config.Headers)
 
 	return &Client{
 		url:           base.String(),

--- a/charmhub/client_mock_test.go
+++ b/charmhub/client_mock_test.go
@@ -74,27 +74,13 @@ func (m *MockRESTClient) EXPECT() *MockRESTClientMockRecorder {
 	return m.recorder
 }
 
-// Do mocks base method
-func (m *MockRESTClient) Do(arg0 *http.Request) (*http.Response, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Do", arg0)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Do indicates an expected call of Do
-func (mr *MockRESTClientMockRecorder) Do(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockRESTClient)(nil).Do), arg0)
-}
-
 // Get mocks base method
-func (m *MockRESTClient) Get(arg0 context.Context, arg1 path.Path, arg2 interface{}) error {
+func (m *MockRESTClient) Get(arg0 context.Context, arg1 path.Path, arg2 interface{}) (RESTResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(RESTResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Get indicates an expected call of Get
@@ -104,11 +90,12 @@ func (mr *MockRESTClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.
 }
 
 // Post mocks base method
-func (m *MockRESTClient) Post(arg0 context.Context, arg1 path.Path, arg2, arg3 interface{}) error {
+func (m *MockRESTClient) Post(arg0 context.Context, arg1 path.Path, arg2, arg3 interface{}) (RESTResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Post", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(RESTResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Post indicates an expected call of Post

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -157,8 +157,8 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewFindClient(findPath, restClient, &FakeLogger{})
 	responses, err := client.Find(context.TODO(), "wordpress")
@@ -194,8 +194,8 @@ func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
 	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewFindClient(findPath, restClient, &FakeLogger{})
 	_, err = client.Find(context.TODO(), "wordpress")

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -70,11 +70,11 @@ func (s *FindSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name
 		responses.Results = []transport.FindResponse{{
 			Name: name,
 		}}
-	}).Return(nil)
+	}).Return(RESTResponse{StatusCode: http.StatusOK}, nil)
 }
 
 func (s *FindSuite) expectGetFailure(client *MockRESTClient) {
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(RESTResponse{StatusCode: http.StatusInternalServerError}, errors.Errorf("boom"))
 }
 
 func (s *FindSuite) TestFindRequestPayload(c *gc.C) {

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -202,7 +202,7 @@ func (c *HTTPRESTClient) Post(ctx context.Context, path path.Path, body, result 
 
 	// Parse the response.
 	if err := httprequest.UnmarshalJSONResponse(resp, result); err != nil {
-		return RESTResponse{}, errors.Annotate(err, "charm hub client get")
+		return RESTResponse{}, errors.Annotate(err, "charm hub client post")
 	}
 	return RESTResponse{
 		StatusCode: resp.StatusCode,

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -101,7 +101,7 @@ func (s *RESTSuite) TestGet(c *gc.C) {
 	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
 
 	var result interface{}
-	err := client.Get(context.TODO(), base, &result)
+	_, err := client.Get(context.TODO(), base, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(recievedURL, gc.Equals, "http://api.foo.bar")
 }
@@ -116,7 +116,7 @@ func (s *RESTSuite) TestGetWithInvalidContext(c *gc.C) {
 	base := MustMakePath(c, "http://api.foo.bar")
 
 	var result interface{}
-	err := client.Get(nil, base, &result)
+	_, err := client.Get(nil, base, &result)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
@@ -132,7 +132,7 @@ func (s *RESTSuite) TestGetWithFailure(c *gc.C) {
 	base := MustMakePath(c, "http://api.foo.bar")
 
 	var result interface{}
-	err := client.Get(context.TODO(), base, &result)
+	_, err := client.Get(context.TODO(), base, &result)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
@@ -148,7 +148,7 @@ func (s *RESTSuite) TestGetWithUnmarshalFailure(c *gc.C) {
 	base := MustMakePath(c, "http://api.foo.bar")
 
 	var result interface{}
-	err := client.Get(context.TODO(), base, &result)
+	_, err := client.Get(context.TODO(), base, &result)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -30,7 +30,7 @@ func (s *APIRequesterSuite) TestDo(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(req).Return(emptyResponse(), nil)
 
-	requester := NewAPIRequester(mockTransport)
+	requester := NewAPIRequester(mockTransport, &FakeLogger{})
 	resp, err := requester.Do(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
@@ -45,7 +45,7 @@ func (s *APIRequesterSuite) TestDoWithFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(req).Return(emptyResponse(), errors.Errorf("boom"))
 
-	requester := NewAPIRequester(mockTransport)
+	requester := NewAPIRequester(mockTransport, &FakeLogger{})
 	_, err := requester.Do(req)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -59,7 +59,7 @@ func (s *APIRequesterSuite) TestDoWithInvalidContentType(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(req).Return(invalidContentTypeResponse(), nil)
 
-	requester := NewAPIRequester(mockTransport)
+	requester := NewAPIRequester(mockTransport, &FakeLogger{})
 	_, err := requester.Do(req)
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
@@ -73,7 +73,7 @@ func (s *APIRequesterSuite) TestDoWithNotFoundResponse(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(req).Return(notFoundResponse(), nil)
 
-	requester := NewAPIRequester(mockTransport)
+	requester := NewAPIRequester(mockTransport, &FakeLogger{})
 	resp, err := requester.Do(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusNotFound)
@@ -98,7 +98,7 @@ func (s *RESTSuite) TestGet(c *gc.C) {
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
-	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil)
 
 	var result interface{}
 	_, err := client.Get(context.TODO(), base, &result)
@@ -111,7 +111,7 @@ func (s *RESTSuite) TestGetWithInvalidContext(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockTransport := NewMockTransport(ctrl)
-	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil)
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
@@ -127,7 +127,7 @@ func (s *RESTSuite) TestGetWithFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(gomock.Any()).Return(emptyResponse(), errors.Errorf("boom"))
 
-	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil)
 
 	base := MustMakePath(c, "http://api.foo.bar")
 
@@ -143,7 +143,7 @@ func (s *RESTSuite) TestGetWithUnmarshalFailure(c *gc.C) {
 	mockTransport := NewMockTransport(ctrl)
 	mockTransport.EXPECT().Do(gomock.Any()).Return(invalidResponse(), nil)
 
-	client := NewHTTPRESTClient(mockTransport, nil, &FakeLogger{})
+	client := NewHTTPRESTClient(mockTransport, nil)
 
 	base := MustMakePath(c, "http://api.foo.bar")
 

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -85,11 +85,11 @@ func (s *InfoSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, name
 
 	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, response *transport.InfoResponse) {
 		response.Name = name
-	}).Return(nil)
+	}).Return(RESTResponse{}, nil)
 }
 
 func (s *InfoSuite) expectGetFailure(client *MockRESTClient) {
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(RESTResponse{StatusCode: http.StatusInternalServerError}, errors.Errorf("boom"))
 }
 
 func (s *InfoSuite) expectGetError(c *gc.C, client *MockRESTClient, p path.Path, name string) {
@@ -102,7 +102,7 @@ func (s *InfoSuite) expectGetError(c *gc.C, client *MockRESTClient, p path.Path,
 		response.ErrorList = []transport.APIError{{
 			Message: "not found",
 		}}
-	}).Return(nil)
+	}).Return(RESTResponse{StatusCode: http.StatusNotFound}, nil)
 }
 
 func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -215,8 +215,8 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 	infoPath, err := basePath.Join("info")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport())
-	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewInfoClient(infoPath, restClient, &FakeLogger{})
 	response, err := client.Info(context.TODO(), "wordpress")

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -5,6 +5,7 @@ package charmhub
 
 import (
 	"context"
+	"net/http"
 
 	gomock "github.com/golang/mock/gomock"
 	"github.com/juju/errors"
@@ -92,11 +93,11 @@ func (s *RefreshSuite) expectPost(c *gc.C, client *MockRESTClient, p path.Path, 
 			InstanceKey: "foo-bar",
 			Name:        name,
 		}}
-	}).Return(nil)
+	}).Return(RESTResponse{StatusCode: http.StatusOK}, nil)
 }
 
 func (s *RefreshSuite) expectPostFailure(c *gc.C, client *MockRESTClient) {
-	client.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
+	client.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(RESTResponse{StatusCode: http.StatusInternalServerError}, errors.Errorf("boom"))
 }
 
 func DefineInstanceKey(c *gc.C, config RefreshConfig, key string) RefreshConfig {

--- a/cmd/juju/charmhub/find.go
+++ b/cmd/juju/charmhub/find.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/api/charmhub"
+	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 )
@@ -92,8 +93,10 @@ func (c *findCommand) Run(ctx *cmd.Context) error {
 	defer func() { _ = client.Close() }()
 
 	results, err := client.Find(c.query)
-	if err != nil {
-		return err
+	if params.IsCodeNotFound(err) {
+		return errors.Wrap(err, errors.Errorf("Nothing found for query %q.", c.query))
+	} else if err != nil {
+		return errors.Trace(err)
 	}
 
 	// This is a side effect of the formatting code not wanting to error out

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -120,7 +120,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 	}
 	info, err := charmHubClient.Info(c.charmOrBundle)
 	if params.IsCodeNotFound(err) {
-		return errors.Wrap(err, errors.Errorf("No charm or bundle info found for %q.", c.charmOrBundle))
+		return errors.Wrap(err, errors.Errorf("No information found for charm or bundle with the name %q", c.charmOrBundle))
 	} else if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/charmhub"
 	"github.com/juju/juju/api/modelconfig"
+	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs/config"
@@ -118,7 +119,9 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	info, err := charmHubClient.Info(c.charmOrBundle)
-	if err != nil {
+	if params.IsCodeNotFound(err) {
+		return errors.Wrap(err, errors.Errorf("No charm or bundle info found for %q.", c.charmOrBundle))
+	} else if err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
The following exposes the "not found" errors for a given request. There
are other errors we could be exposing (403, 500 for example) and showing
to the user.

This is the first pass that we do that and in a subsequent PR we can
handle that by exposing an error message to the user if required
explaining that the charm/bundle could not be found.

The code is simple, we return a `RESTResponse` that has a status code 
`int` that we can check against the `http.StatusCode` before returning a
different error based on the Error from the api response. It's a bit
convoluted because the status code is in the header and the message is
in a json blob.

## QA steps

```sh
juju bootstrap lxd test
juju deploy meshuggah
```
