### PR TITLE
Add ResourcesClient for charmhub

### DIFF
--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -114,12 +114,13 @@ func (c Config) BasePath() (charmhubpath.Path, error) {
 
 // Client represents the client side of a charm store.
 type Client struct {
-	url            string
-	infoClient     *InfoClient
-	findClient     *FindClient
-	downloadClient *DownloadClient
-	refreshClient  *RefreshClient
-	logger         Logger
+	url             string
+	infoClient      *InfoClient
+	findClient      *FindClient
+	downloadClient  *DownloadClient
+	refreshClient   *RefreshClient
+	resourcesClient *ResourcesClient
+	logger          Logger
 }
 
 // NewClient creates a new charmHub client from the supplied configuration.
@@ -151,6 +152,11 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 		return nil, errors.Annotate(err, "constructing refresh path")
 	}
 
+	resourcesPath, err := base.Join("resources")
+	if err != nil {
+		return nil, errors.Annotate(err, "constructing resources path")
+	}
+
 	config.Logger.Tracef("NewClient to %q", config.URL)
 
 	httpClient := DefaultHTTPTransport()
@@ -165,8 +171,9 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 		// download client doesn't require a path here, as the download could
 		// be from any server in theory. That information is found from the
 		// refresh response.
-		downloadClient: NewDownloadClient(httpClient, fileSystem, config.Logger),
-		logger:         config.Logger,
+		downloadClient:  NewDownloadClient(httpClient, fileSystem, config.Logger),
+		resourcesClient: NewResourcesClient(resourcesPath, restClient, config.Logger),
+		logger:          config.Logger,
 	}, nil
 }
 

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/kr/pretty"
+
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
+)
+
+// ResourcesClient defines a client for resources requests.
+type ResourcesClient struct {
+	path   path.Path
+	client RESTClient
+	logger Logger
+}
+
+// NewResourcesClient creates a ResourcesClient for requesting
+func NewResourcesClient(path path.Path, client RESTClient, logger Logger) *ResourcesClient {
+	return &ResourcesClient{
+		path:   path,
+		client: client,
+		logger: logger,
+	}
+}
+
+func (c *ResourcesClient) ListResourceRevisions(ctx context.Context, charm, resource string) (transport.ResourcesResponse, error) {
+	c.logger.Tracef("ListResourceRevisions(%s, %s)", charm, resource)
+	var resp transport.ResourcesResponse
+	path, err := c.path.Join(charm, resource, "revisions")
+	if err != nil {
+		return resp, errors.Trace(err)
+	}
+	if err := c.client.Get(ctx, path, &resp); err != nil {
+		return resp, errors.Trace(err)
+	}
+
+	c.logger.Tracef("ListResourceRevisions(%s, %s) unmarshalled: %s", charm, resource, pretty.Sprint(resp))
+	return resp, nil
+}

--- a/charmhub/resources_test.go
+++ b/charmhub/resources_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+	"encoding/json"
+	http "net/http"
+	"net/http/httptest"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
+)
+
+type ResourcesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ResourcesSuite{})
+
+func (s *ResourcesSuite) TestListResourceRevisions(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	name := "meshuggah"
+	resource := "image"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, path, name, resource)
+
+	client := NewResourcesClient(path, restClient, &FakeLogger{})
+	response, err := client.ListResourceRevisions(context.TODO(), name, resource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response.Revisions, gc.HasLen, 3)
+}
+
+func (s *ResourcesSuite) TestListResourceRevisionsFailure(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	name := "meshuggah"
+	resource := "image"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGetFailure(restClient)
+
+	client := NewResourcesClient(path, restClient, &FakeLogger{})
+	_, err := client.ListResourceRevisions(context.TODO(), name, resource)
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
+}
+
+func (s *ResourcesSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, charm, resource string) {
+	namedPath, err := p.Join(charm, resource, "revisions")
+	c.Assert(err, jc.ErrorIsNil)
+
+	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, response *transport.ResourcesResponse) {
+		response.Revisions = make([]transport.ResourceRevision, 3)
+	}).Return(nil)
+}
+
+func (s *ResourcesSuite) expectGetFailure(client *MockRESTClient) {
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("boom"))
+}
+
+func (s *ResourcesSuite) TestListResourceRevisionsRequestPayload(c *gc.C) {
+	resourcesResponse := transport.ResourcesResponse{Revisions: []transport.ResourceRevision{
+		{Name: "image", Revision: 3, Type: "image"},
+		{Name: "image", Revision: 2, Type: "image"},
+		{Name: "image", Revision: 1, Type: "image"},
+	}}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		err := json.NewEncoder(w).Encode(resourcesResponse)
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := Config{
+		URL: server.URL,
+	}
+	basePath, err := config.BasePath()
+	c.Assert(err, jc.ErrorIsNil)
+
+	resourcesPath, err := basePath.Join("resources")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRequester := NewAPIRequester(DefaultHTTPTransport())
+	restClient := NewHTTPRESTClient(apiRequester, nil, &FakeLogger{})
+
+	client := NewResourcesClient(resourcesPath, restClient, &FakeLogger{})
+	response, err := client.ListResourceRevisions(context.TODO(), "wordpress", "image")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response, gc.DeepEquals, resourcesResponse)
+}

--- a/charmhub/transport/resources.go
+++ b/charmhub/transport/resources.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transport
+
+type ResourcesResponse struct {
+	Revisions []ResourceRevision `json:"revisions"`
+}
+
+type ResourceRevision struct {
+	Download ResourceDownload `json:"download"`
+	Name     string           `json:"name"`
+	Revision int              `json:"revision"`
+	Type     string           `json:"type"`
+}
+
+type ResourceDownload struct {
+	// As of 12-Nov-2020, the json for HashSHA256 is different
+	// between the resource version of the download object and
+	// the info etc versions.  This object also has more hash types.
+	HashSHA256 string `json:"hash-sha256"`
+	Size       int    `json:"size"`
+	URL        string `json:"url"`
+}


### PR DESCRIPTION
Includes the new client, response structures and ListResourceRevisons.
A new api endpoint for charmhub from: http://api.snapcraft.io/docs/charms.html#list_resource_revisions

There may be changes up coming to have the same property names, avoid hash-sha256 vs hash-sha256.

## QA steps

No change to current charmhub client behavior.  
