### PR TITLE
Retain Azure custom resource group contents

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -829,7 +829,7 @@ func NewBootstrapInstanceConfig(
 ) (*InstanceConfig, error) {
 	// For a bootstrap instance, the caller must provide the state.Info
 	// and the api.Info. The machine id must *always* be "0".
-	icfg, err := NewInstanceConfig(names.NewControllerTag(config.ControllerUUID()), "0", agent.BootstrapNonce, "", series, nil)
+	icfg, err := NewInstanceConfig(names.NewControllerTag(config.ControllerUUID()), agent.BootstrapControllerId, agent.BootstrapNonce, "", series, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -21,6 +21,7 @@ import (
 	azurestorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -30,17 +31,17 @@ import (
 	"github.com/juju/utils/arch"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/tags"
-
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	internalazurestorage "github.com/juju/juju/provider/azure/internal/azurestorage"
 	"github.com/juju/juju/provider/azure/internal/errorutils"
@@ -253,6 +254,26 @@ func (env *azureEnviron) Bootstrap(
 	result, err := common.Bootstrap(ctx, env, callCtx, args)
 	if err != nil {
 		logger.Errorf("bootstrap failed, destroying model: %v", err)
+
+		// First cancel the in-progress deployment.
+		var wg sync.WaitGroup
+		var cancelResult error
+		logger.Debugf("canceling deployment for bootstrap instance")
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			sdkCtx := stdcontext.Background()
+			cancelResult = errors.Annotatef(
+				env.cancelDeployment(callCtx, sdkCtx, id),
+				"canceling deployment %q", id,
+			)
+		}(names.NewMachineTag(agent.BootstrapControllerId).String())
+		wg.Wait()
+		if cancelResult != nil && !errors.IsNotFound(cancelResult) {
+			return nil, errors.Annotate(cancelResult, "aborting failed bootstrap")
+		}
+
+		// The cleanup the resource group.
 		if err := env.Destroy(callCtx); err != nil {
 			logger.Errorf("failed to destroy model: %v", err)
 		}
@@ -1677,7 +1698,7 @@ func (env *azureEnviron) DestroyController(ctx context.ProviderCallContext, cont
 
 func (env *azureEnviron) deleteControllerManagedResourceGroups(ctx context.ProviderCallContext, controllerUUID string) error {
 	filter := fmt.Sprintf(
-		"tagname eq '%s' and tagvalue eq '%s'",
+		"tagName eq '%s' and tagValue eq '%s'",
 		tags.JujuController, controllerUUID,
 	)
 	client := resources.GroupsClient{env.resources}
@@ -1765,39 +1786,140 @@ func (env *azureEnviron) deleteResourceGroup(ctx context.ProviderCallContext, sd
 	return nil
 }
 
-func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext, sdkCtx stdcontext.Context, resourceGroup string) error {
+func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext, sdkCtx stdcontext.Context, resourceGroup string) (err error) {
 	logger.Debugf("deleting all resources in %s", resourceGroup)
 
-	// We purge the contents of a resource group by deploying an empty deployment.
-	client := resources.DeploymentsClient{env.resources}
-	template := armtemplates.Template{
-		Resources: []armtemplates.Resource{},
-	}
-	templateMap, err := template.Map()
+	defer func() {
+		err = errorutils.HandleCredentialError(err, ctx)
+	}()
+
+	// Find all the resources tagged as belonging to this model.
+	resourcesClient := resources.Client{env.resources}
+	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", tags.JujuModel, env.config.UUID())
+	result, err := resourcesClient.ListByResourceGroupComplete(sdkCtx, resourceGroup, filter, "", nil)
 	if err != nil {
-		return errors.Trace(err)
-	}
-	deployment := resources.Deployment{
-		Properties: &resources.DeploymentProperties{
-			Mode:     resources.Complete,
-			Template: &templateMap,
-		},
-	}
-	future, err := client.CreateOrUpdate(
-		sdkCtx,
-		resourceGroup,
-		"purge-resource-group",
-		deployment,
-	)
-	if err != nil {
-		return errorutils.HandleCredentialError(errors.Annotatef(err, "purging resource group %q", resourceGroup), ctx)
+		return errors.Annotate(err, "listing resources to delete")
 	}
 
-	err = future.WaitForCompletionRef(sdkCtx, client.Client)
+	var resourceItems []resources.GenericResourceExpanded
+	for result.NotDone() {
+		resourceItems = append(resourceItems, result.Value())
+		err = result.NextWithContext(sdkCtx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Older APIs can ignore the filter above, so query the hard way just in case.
+	if len(resourceItems) == 0 {
+		result, err = resourcesClient.ListByResourceGroupComplete(sdkCtx, resourceGroup, "", "", nil)
+		if err != nil {
+			return errors.Annotate(err, "listing resources to delete")
+		}
+		for result.NotDone() {
+			res := result.Value()
+			fullRes, err := resourcesClient.GetByID(sdkCtx, to.String(res.ID), computeAPIVersion)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if env.config.UUID() != to.String(fullRes.Tags[tags.JujuModel]) {
+				continue
+			}
+			resourceItems = append(resourceItems, res)
+			err = result.NextWithContext(sdkCtx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+
+	// These will be deleted as part of stopping the instance below.
+	machineResourceTypes := set.NewStrings(
+		"Microsoft.Compute/virtualMachines",
+		"Microsoft.Compute/disks",
+		"Microsoft.Network/publicIPAddresses",
+		"Microsoft.Network/networkInterfaces",
+	)
+
+	var ids []instance.Id
+	var otherResources []resources.GenericResourceExpanded
+	for _, r := range resourceItems {
+		rType := to.String(r.Type)
+		logger.Debugf("resource to delete: %v (%v)", to.String(r.Name), rType)
+		if !machineResourceTypes.Contains(rType) {
+			otherResources = append(otherResources, r)
+			continue
+		}
+		if rType == "Microsoft.Compute/virtualMachines" {
+			ids = append(ids, instance.Id(to.String(r.Name)))
+		}
+	}
+
+	// Stopping instances will also remove most of their dependent resources.
+	err = env.StopInstances(ctx, ids...)
 	if err != nil {
-		return errors.Annotatef(err, "purging resource group %q", resourceGroup)
+		return errors.Annotatef(err, "deleting machine instances %q", ids)
+	}
+
+	// Loop until all remaining resources are deleted.
+	remainingResources := otherResources
+	for len(remainingResources) > 0 {
+		remainingResources, err = env.deleteResources(sdkCtx, remainingResources)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
+}
+
+// deleteResources deletes the specified resources, returning any that
+// cannot be deleted because they are in use.
+func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []resources.GenericResourceExpanded) ([]resources.GenericResourceExpanded, error) {
+	logger.Debugf("deleting %d resources", len(toDelete))
+
+	resourcesClient := resources.Client{env.resources}
+	resourcesClient.ResponseInspector = errorutils.CheckForDetailedError
+
+	var remainingResources []resources.GenericResourceExpanded
+	var wg sync.WaitGroup
+	deleteResults := make([]error, len(toDelete))
+	for i, res := range toDelete {
+		id := to.String(res.ID)
+		logger.Debugf("- deleting resource %q", id)
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			result, err := resourcesClient.DeleteByID(sdkCtx, id, computeAPIVersion)
+			if err != nil {
+				// If the resource is in use, don't error, just queue it up for another pass.
+				if se, ok := errorutils.ServiceError(err); ok && strings.HasPrefix(se.Code, "InUse") {
+					remainingResources = append(remainingResources, toDelete[i])
+				} else {
+					deleteResults[i] = errors.Annotatef(err, "deleting resource %q: %v", id, err)
+				}
+				return
+			}
+			if err = result.WaitForCompletionRef(sdkCtx, resourcesClient.Client); err != nil {
+				resp := result.Response()
+				if !isNotFoundResponse(resp) {
+					deleteResults[i] = errors.Annotatef(err, "deleting resource %q: %v", id, err)
+				}
+			}
+		}(i, id)
+	}
+	wg.Wait()
+
+	var errStrings []string
+	for i, err := range deleteResults {
+		if err != nil && !errors.IsNotFound(err) {
+			msg := fmt.Sprintf("error deleting resource %q: %#v", to.String(toDelete[i].ID), err)
+			errStrings = append(errStrings, msg)
+		}
+	}
+	if len(errStrings) > 0 {
+		return nil, errors.Annotate(errors.New(strings.Join(errStrings, "\n")), "deleting resources")
+	}
+	return remainingResources, nil
 }
 
 // Provider is specified in the Environ interface.

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-07-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
+	autorestazure "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/clock/testclock"
@@ -1774,14 +1775,48 @@ func (s *environSuite) TestDestroyHostedModel(c *gc.C) {
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 	env := s.openEnviron(c,
 		testing.Attrs{"controller-uuid": utils.MustNewUUID().String(), "resource-group-name": "foo"})
+	res := []resources.GenericResourceExpanded{{
+		ID:   to.StringPtr("id-0"),
+		Name: to.StringPtr("machine-0"),
+		Type: to.StringPtr("Microsoft.Compute/virtualMachines"),
+	}, {
+		ID:   to.StringPtr("id-0"),
+		Name: to.StringPtr("machine-0-disk"),
+		Type: to.StringPtr("Microsoft.Compute/disks"),
+	}, {
+		ID:   to.StringPtr("networkSecurityGroups/nsg-0"),
+		Name: to.StringPtr("nsg-0"),
+		Type: to.StringPtr("Microsoft.Network/networkSecurityGroups"),
+	}}
+	resourceListResult := resources.ListResult{Value: &res}
+
+	nic0IPConfiguration := makeIPConfiguration("192.168.0.4")
+	nic0IPConfiguration.PublicIPAddress = &network.PublicIPAddress{}
+	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPConfiguration)
+
+	machine0Blob := azuretesting.MockStorageBlob{Name_: "machine-0"}
+	s.osvhdsContainer.Blobs_ = []azurestorage.Blob{&machine0Blob}
+
 	s.sender = azuretesting.Senders{
-		makeSender("/deployments/purge-resource-group", nil), // PUT
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET
+		makeSender(".*/deployments/machine-0/cancel", nil),                  // POST
+		s.storageAccountSender(),
+		s.storageAccountKeysSender(),
+		s.networkInterfacesSender(nic0),
+		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "machine-0", "1.2.3.4")),
+		makeSender(".*/virtualMachines/machine-0", nil), // DELETE
+		s.makeErrorSender(c, "/networkSecurityGroups/nsg-0", autorest.DetailedError{Original: autorestazure.ServiceError{Code: "InUse"}}, 1), // DELETE
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 1)
-	c.Assert(s.requests[0].Method, gc.Equals, "PUT")
-	c.Assert(s.requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222/resourcegroups/foo/providers/Microsoft.Resources/deployments/purge-resource-group")
+	c.Assert(s.requests, gc.HasLen, 9)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
+		testing.ModelTag.Id(),
+	))
+	c.Assert(s.requests[7].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[8].Method, gc.Equals, "DELETE")
 }
 
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *gc.C) {
@@ -1815,7 +1850,7 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	c.Assert(s.requests, gc.HasLen, 3)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
-		"tagname eq 'juju-controller-uuid' and tagvalue eq '%s'",
+		"tagName eq 'juju-controller-uuid' and tagValue eq '%s'",
 		testing.ControllerTag.Id(),
 	))
 	c.Assert(s.requests[1].Method, gc.Equals, "DELETE")
@@ -1841,7 +1876,7 @@ func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *gc.C) {
 	c.Assert(s.requests, gc.HasLen, 1)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
-		"tagname eq 'juju-controller-uuid' and tagvalue eq '%s'",
+		"tagName eq 'juju-controller-uuid' and tagValue eq '%s'",
 		testing.ControllerTag.Id(),
 	))
 }

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -7,7 +7,6 @@ import (
 	stdcontext "context"
 	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
@@ -18,19 +17,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/azure/internal/errorutils"
 )
-
-const (
-	retryDelay       = 5 * time.Second
-	maxRetryDelay    = 1 * time.Minute
-	maxRetryDuration = 5 * time.Minute
-)
-
-func toTags(tags *map[string]*string) map[string]string {
-	if tags == nil {
-		return nil
-	}
-	return to.StringMap(*tags)
-}
 
 // randomAdminPassword returns a random administrator password for
 // Windows machines.


### PR DESCRIPTION
When bootstrapping on Azure using a BYO resource group, and the bootstrap fails, Juju would purge the entire resource group. This would also happen if a model using a BYO resource group were destroyed.

To fix the issue, 2 key changes are implemented:
- on a failed bootstrap, cancel the existing ARM deployment; this will remove only juju resources that were provisioned udring bootstrap
- when destroying a model, first remove only Juju machines; this would also delete any machine resources like NICs etc; then loop over the remaining Juju resources and delete, catching any errors due to the resource being in use and try again

Any non-Juju tagged resources are left alone.

## QA steps

Ensure a bootstrap on Azure will fail (eg see bug)
juju bootstrap to an existing resource group (see bug)
Ensure bootstrap operation terminate and only the juju bootstrap machine and nic and public ip etc are removed
(any existing vnet etc in the resource group are retained)

bootstrap successfully and add a model using an existing resource group
destroy the model
again, check that any non-juju content is retained

## Bug reference

https://bugs.launchpad.net/juju/+bug/1904020
