### PR TITLE
Fix bundle diff

### DIFF
--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -6,7 +6,7 @@ package application
 import (
 	"fmt"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/bundlechanges/v3"
@@ -253,7 +253,7 @@ func (c *bundleDiffCommand) bundleDataSource(ctx *cmd.Context) (charm.BundleData
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	bundlePath := path.Join(dir, bundleURL.Name)
+	bundlePath := filepath.Join(dir, bundleURL.Name)
 	bundle, err := charmAdaptor.GetBundle(bundleURL, bundlePath)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
Whilst looking at the work required to implement charmhub charms in the
bundle-diff export I noticed it doesn't work, at all!

This fixes it to just work whilst we work on other things before
coming back around to add charmhub support.

## QA steps


```sh
$ juju bootstrap lxd test
```

#### Local bundles

```sh
$ juju diff-bundle "./testcharms/charm-repo/bundle/basic"
applications:
  ubuntu-lite:
    missing: model 
```

#### Charmstore bundles

```sh
$ juju diff-bundle cs:bundle/wiki-simple
applications:
  mysql:
    missing: model
  wiki:
    missing: model
relations:
  bundle-additions:
  - - mysql:db
    - wiki:db
```
