### PR TITLE
Log vs throw for host-name resolution when deriving egress subnets from ingress addresses

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -723,7 +723,7 @@ func addRemoteRU(c *gc.C, rel *state.Relation, unitName string) *state.RelationU
 var testingRetryFactory = func() retry.CallArgs {
 	return retry.CallArgs{
 		Clock:       clock.WallClock,
-		Delay:       3 * time.Second,
-		MaxDuration: 30 * time.Second,
+		Delay:       1 * time.Millisecond,
+		MaxDuration: 3 * time.Millisecond,
 	}
 }

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -6,7 +6,10 @@ package uniter_test
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"time"
+
+	"github.com/juju/errors"
 
 	"github.com/juju/charm/v7"
 	"github.com/juju/clock"
@@ -17,8 +20,9 @@ import (
 
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/network"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -55,8 +59,8 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal),
+		corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -64,9 +68,52 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal)})
+	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
+}
+
+func (s *networkInfoSuite) TestNetworksForRelationEgressHostnameRetry(c *gc.C) {
+	prr := s.newProReqRelation(c, charm.ScopeGlobal)
+	err := prr.pu0.AssignToNewMachine()
+	c.Assert(err, jc.ErrorIsNil)
+	id, err := prr.pu0.AssignedMachineId()
+	c.Assert(err, jc.ErrorIsNil)
+	machine, err := s.State.Machine(id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addr := corenetwork.NewSpaceAddress("host.badname.somewhere")
+	err = machine.SetProviderAddresses(addr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// First time failure for the hostname.
+	s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
+		return nil, errors.Errorf("Nope")
+	})
+
+	retryFactory := func() retry.CallArgs {
+		return retry.CallArgs{
+			Clock:       clock.WallClock,
+			Delay:       1 * time.Millisecond,
+			MaxDuration: coretesting.LongWait,
+			NotifyFunc: func(lastError error, attempt int) {
+				// Then set it up to return an IP address.
+				if attempt == 1 {
+					s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
+						return &net.IPAddr{IP: net.ParseIP("10.2.3.4")}, nil
+					})
+				}
+			},
+		}
+	}
+
+	netInfo := s.newNetworkInfo(c, prr.pu0.UnitTag(), retryFactory)
+	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(ingress, gc.DeepEquals, corenetwork.SpaceAddresses{addr})
 	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
@@ -75,7 +122,7 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 		name := fmt.Sprintf("e%x", rand.Int31())
 		deviceArgs := state.LinkLayerDeviceArgs{
 			Name: name,
-			Type: network.EthernetDevice,
+			Type: corenetwork.EthernetDevice,
 		}
 		err := machine.SetLinkLayerDevices(deviceArgs)
 		c.Assert(err, jc.ErrorIsNil)
@@ -84,7 +131,7 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 
 		addressesArg := state.LinkLayerDeviceAddress{
 			DeviceName:   name,
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: corenetwork.StaticAddress,
 			CIDRAddress:  address,
 		}
 		err = machine.SetDevicesAddresses(addressesArg)
@@ -98,21 +145,21 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 func (s *networkInfoSuite) TestNetworksForBinding(c *gc.C) {
 	// Add subnets for the addresses that the machine will have.
 	// We are testing a space-less deployment here.
-	_, err := s.State.AddSubnet(network.SubnetInfo{
+	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{
 		CIDR:    "10.2.0.0/16",
-		SpaceID: network.AlphaSpaceId,
+		SpaceID: corenetwork.AlphaSpaceId,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddSubnet(network.SubnetInfo{
+	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
 		CIDR:    "100.2.3.0/24",
-		SpaceID: network.AlphaSpaceId,
+		SpaceID: corenetwork.AlphaSpaceId,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	bindings := map[string]string{
-		"":             network.AlphaSpaceName,
-		"server-admin": network.AlphaSpaceName,
+		"":             corenetwork.AlphaSpaceName,
+		"server-admin": corenetwork.AlphaSpaceName,
 	}
 	app := s.AddTestingApplicationWithBindings(c, "mysql", s.AddTestingCharm(c, "mysql"), bindings)
 
@@ -128,8 +175,8 @@ func (s *networkInfoSuite) TestNetworksForBinding(c *gc.C) {
 	// We need at least one address on the machine itself, because these are
 	// retrieved up-front to use as a fallback when we fail to locate addresses
 	// on link-layer devices.
-	addresses := []network.SpaceAddress{
-		network.NewSpaceAddress("10.2.3.4/16"),
+	addresses := []corenetwork.SpaceAddress{
+		corenetwork.NewSpaceAddress("10.2.3.4/16"),
 	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -178,11 +225,11 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	machine, err := s.State.Machine(id)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addresses := []network.SpaceAddress{
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("2.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+	addresses := []corenetwork.SpaceAddress{
+		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
+		corenetwork.NewScopedSpaceAddress("2.2.3.4", corenetwork.ScopeCloudLocal),
+		corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal),
+		corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic),
 	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -195,7 +242,7 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, spaceID3)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
@@ -209,8 +256,8 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
+		corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -218,9 +265,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -234,7 +281,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -242,9 +289,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -265,7 +312,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic))
+					err := machine.SetProviderAddresses(corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic))
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -276,9 +323,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -313,7 +360,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the private address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal))
+					err := machine.SetProviderAddresses(corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopeCloudLocal))
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -324,9 +371,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -343,19 +390,19 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	prr := newProReqRelationForApps(c, st, mysql, gitlab)
 
 	// We need to instantiate this with the new CAAS model state.
-	netInfo, err := uniter.NewNetworkInfo(st, prr.pu0.UnitTag(), nil)
+	netInfo, err := uniter.NewNetworkInfo(st, prr.pu0.UnitTag(), testingRetryFactory)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// First no address.
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.HasLen, 0)
 	c.Assert(egress, gc.HasLen, 0)
 
 	// Add a application address.
-	err = mysql.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+	err = mysql.UpdateCloudService("", corenetwork.SpaceAddresses{
+		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
@@ -363,9 +410,9 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	boundSpace, ingress, egress, err = netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -389,19 +436,19 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createNICAndBridgeWithIP(c, machine, "eth0", "br-eth0", "10.0.0.20/24")
-	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
-	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
+	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth1", "10.10.0.20/24")
+	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("10.0.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.30", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(corenetwork.NewScopedSpaceAddress("10.0.0.20", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.10.0.20", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.10.0.30", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.20.0.20", corenetwork.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
 	netInfo := ni.(*uniter.NetworkInfoIAAS)
 
-	res, err := netInfo.MachineNetworkInfos(spaceIDDefault, spaceIDDMZ, "666", network.AlphaSpaceId)
+	res, err := netInfo.MachineNetworkInfos(spaceIDDefault, spaceIDDMZ, "666", corenetwork.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 4)
 
@@ -423,7 +470,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	c.Check(resDMZ.NetworkInfos[0].Addresses[0].Address, gc.Equals, "10.10.0.20")
 	c.Check(resDMZ.NetworkInfos[0].Addresses[0].CIDR, gc.Equals, "10.10.0.0/24")
 
-	resEmpty, ok := res[network.AlphaSpaceId]
+	resEmpty, ok := res[corenetwork.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
 	c.Check(resEmpty.Error, jc.ErrorIsNil)
 	c.Assert(resEmpty.NetworkInfos, gc.HasLen, 1)
@@ -456,23 +503,23 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createNICAndBridgeWithIP(c, machine, "eth0", "br-eth0", "10.0.0.20/24")
-	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
-	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
+	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth1", "10.10.0.20/24")
+	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("10.0.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.30", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(corenetwork.NewScopedSpaceAddress("10.0.0.20", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.10.0.20", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.10.0.30", corenetwork.ScopePublic),
+		corenetwork.NewScopedSpaceAddress("10.20.0.20", corenetwork.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
 	netInfo := ni.(*uniter.NetworkInfoIAAS)
 
-	res, err := netInfo.MachineNetworkInfos(network.AlphaSpaceId)
+	res, err := netInfo.MachineNetworkInfos(corenetwork.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 
-	resEmpty, ok := res[network.AlphaSpaceId]
+	resEmpty, ok := res[corenetwork.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
 	c.Check(resEmpty.Error, jc.ErrorIsNil)
 	c.Assert(resEmpty.NetworkInfos, gc.HasLen, 1)
@@ -483,10 +530,10 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 }
 
 func (s *networkInfoSuite) setupSpace(c *gc.C, spaceName, cidr string, public bool) string {
-	space, err := s.State.AddSpace(spaceName, network.Id(spaceName), nil, true)
+	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddSubnet(network.SubnetInfo{
+	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
 		CIDR:    cidr,
 		SpaceID: space.Id(),
 	})
@@ -500,12 +547,12 @@ func (s *networkInfoSuite) setupSpace(c *gc.C, spaceName, cidr string, public bo
 func (s *networkInfoSuite) createNICAndBridgeWithIP(
 	c *gc.C, machine *state.Machine, deviceName, bridgeName, cidrAddress string,
 ) {
-	s.createNICWithIP(c, machine, network.BridgeDevice, bridgeName, cidrAddress)
+	s.createNICWithIP(c, machine, corenetwork.BridgeDevice, bridgeName, cidrAddress)
 
 	err := machine.SetLinkLayerDevices(
 		state.LinkLayerDeviceArgs{
 			Name:       deviceName,
-			Type:       network.EthernetDevice,
+			Type:       corenetwork.EthernetDevice,
 			ParentName: bridgeName,
 			IsUp:       true,
 		},
@@ -514,7 +561,7 @@ func (s *networkInfoSuite) createNICAndBridgeWithIP(
 }
 
 func (s *networkInfoSuite) createNICWithIP(
-	c *gc.C, machine *state.Machine, deviceType network.LinkLayerDeviceType, deviceName, cidrAddress string,
+	c *gc.C, machine *state.Machine, deviceType corenetwork.LinkLayerDeviceType, deviceName, cidrAddress string,
 ) {
 	err := machine.SetLinkLayerDevices(
 		state.LinkLayerDeviceArgs{
@@ -529,7 +576,7 @@ func (s *networkInfoSuite) createNICWithIP(
 		state.LinkLayerDeviceAddress{
 			DeviceName:   deviceName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: corenetwork.StaticAddress,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -671,4 +718,12 @@ func addRemoteRU(c *gc.C, rel *state.Relation, unitName string) *state.RelationU
 	ru, err := rel.RemoteUnit(unitName)
 	c.Assert(err, jc.ErrorIsNil)
 	return ru
+}
+
+var testingRetryFactory = func() retry.CallArgs {
+	return retry.CallArgs{
+		Clock:       clock.WallClock,
+		Delay:       3 * time.Second,
+		MaxDuration: 30 * time.Second,
+	}
 }

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -170,12 +170,9 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 func (n *NetworkInfoBase) NetworksForRelation(
 	_ string, rel *state.Relation, pollAddr bool,
 ) (string, corenetwork.SpaceAddresses, []string, error) {
-	egress, err := n.getRelationEgressSubnets(rel)
-	if err != nil {
-		return "", nil, nil, errors.Trace(err)
-	}
-
 	var ingress corenetwork.SpaceAddresses
+	var err error
+
 	if pollAddr {
 		if ingress, err = n.maybeGetUnitAddress(rel); err != nil {
 			return "", nil, nil, errors.Trace(err)
@@ -197,12 +194,10 @@ func (n *NetworkInfoBase) NetworksForRelation(
 
 	corenetwork.SortAddresses(ingress)
 
-	// If no egress subnets defined, We default to the ingress address.
-	if len(egress) == 0 && len(ingress) > 0 {
-		egress, err = network.FormatAsCIDR([]string{ingress[0].Value})
-		if err != nil {
-			return "", nil, nil, errors.Trace(err)
-		}
+	egress, err := n.getEgressForRelation(rel, ingress)
+	if err != nil {
+		return "", nil, nil, errors.Trace(err)
 	}
+
 	return corenetwork.AlphaSpaceId, ingress, egress, nil
 }

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -159,18 +159,11 @@ func (n *NetworkInfoIAAS) NetworksForRelation(
 
 	corenetwork.SortAddresses(ingress)
 
-	egress, err := n.getRelationEgressSubnets(rel)
+	egress, err := n.getEgressForRelation(rel, ingress)
 	if err != nil {
 		return "", nil, nil, errors.Trace(err)
 	}
 
-	// If no egress subnets defined, We default to the ingress address.
-	if len(egress) == 0 && len(ingress) > 0 {
-		egress, err = network.FormatAsCIDR([]string{ingress[0].Value})
-		if err != nil {
-			return "", nil, nil, errors.Trace(err)
-		}
-	}
 	return boundSpace, ingress, egress, nil
 }
 

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -74,31 +74,17 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		// The binding address information based on link layer devices.
 		info := machineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
 
-		// Set egress and ingress address information.
 		info.EgressSubnets = endpointEgressSubnets[endpoint]
-
-		ingressAddrs := make([]string, len(endpointIngressAddresses[endpoint]))
-		for i, addr := range endpointIngressAddresses[endpoint] {
-			ingressAddrs[i] = addr.Value
-		}
-		info.IngressAddresses = ingressAddrs
+		info.IngressAddresses = endpointIngressAddresses[endpoint].Values()
 
 		if len(info.IngressAddresses) == 0 {
 			ingress := spaceAddressesFromNetworkInfo(networkInfos[space].NetworkInfos)
 			corenetwork.SortAddresses(ingress)
-			info.IngressAddresses = make([]string, len(ingress))
-			for i, addr := range ingress {
-				info.IngressAddresses[i] = addr.Value
-			}
+			info.IngressAddresses = ingress.Values()
 		}
 
-		// If there is no egress subnet explicitly defined for a given binding,
-		// default to the first ingress address. This matches the behaviour when
-		// there's a relation in place.
-		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
-			var err error
-			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
-			if err != nil {
+		if len(info.EgressSubnets) == 0 {
+			if info.EgressSubnets, err = n.getEgressFromIngress(info.IngressAddresses); err != nil {
 				return result, errors.Trace(err)
 			}
 		}

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -539,6 +539,20 @@ func NewSpaceAddresses(inAddresses ...string) (outAddresses SpaceAddresses) {
 	return outAddresses
 }
 
+// Values returns a slice of strings containing the IP/host-name of each of
+// the receiver addresses.
+func (sas SpaceAddresses) Values() []string {
+	if sas == nil {
+		return nil
+	}
+
+	values := make([]string, len(sas))
+	for i, a := range sas {
+		values[i] = a.Value
+	}
+	return values
+}
+
 // ToProviderAddresses transforms the SpaceAddresses to ProviderAddresses by using
 // the input lookup for conversion of space ID to space info.
 func (sas SpaceAddresses) ToProviderAddresses(lookup SpaceLookup) (ProviderAddresses, error) {

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -850,6 +850,12 @@ func (s *AddressSuite) TestSpaceAddressesToProviderAddresses(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *AddressSuite) TestSpaceAddressesValues(c *gc.C) {
+	values := []string{"1.2.3.4", "2.3.4.5", "3.4.5.6"}
+	addrs := network.NewSpaceAddresses(values...)
+	c.Check(addrs.Values(), gc.DeepEquals, values)
+}
+
 func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 	type test struct {
 		IP   string

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -30,6 +30,8 @@ type NetworkGetCommand struct {
 	egressSubnets  bool
 	keys           []string
 
+	resolveIngressAddresses bool
+
 	// deprecated
 	primaryAddress bool
 
@@ -64,6 +66,8 @@ If more than one flag is specified, a map of values is returned.
                     as the address that should be advertised to its peers.
     --ingress-address: the address the local unit should advertise as being used for incoming connections.
     --egress-subnets: subnets (in CIDR notation) from which traffic on this relation will originate.
+If --resolve-ingress-addresses is set to false, then any ingress addresses which are FQDN are included
+without attempting to resolve them to an IP address.
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "network-get",
@@ -80,6 +84,7 @@ func (c *NetworkGetCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.bindAddress, "bind-address", false, "get the address for the binding on which the unit should listen")
 	f.BoolVar(&c.ingressAddress, "ingress-address", false, "get the ingress address for the binding")
 	f.BoolVar(&c.egressSubnets, "egress-subnets", false, "get the egress subnets for the binding")
+	f.BoolVar(&c.resolveIngressAddresses, "resolve-ingress-addresses", true, "resolve any ingress FQDN hostnames to an IP address")
 	f.Var(c.relationIdProxy, "r", "specify a relation by id")
 	f.Var(c.relationIdProxy, "relation", "")
 }
@@ -126,7 +131,7 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
-	ni = resolveNetworkInfoAddresses(ni, LookupHost)
+	ni = resolveNetworkInfoAddresses(ni, LookupHost, c.resolveIngressAddresses)
 
 	// If no specific attributes were asked for, write everything we know.
 	if !c.primaryAddress && len(c.keys) == 0 {
@@ -177,7 +182,7 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 // but rather the IP, that is, it might be better to do the resolution on input
 // rather than output (network-get) as we do here.
 func resolveNetworkInfoAddresses(
-	netInfoResult params.NetworkInfoResult, lookupHost resolver,
+	netInfoResult params.NetworkInfoResult, lookupHost resolver, resolveIngressAddresses bool,
 ) params.NetworkInfoResult {
 	// Maintain a cache of host-name -> address resolutions.
 	resolved := make(map[string]string)
@@ -200,6 +205,10 @@ func resolveNetworkInfoAddresses(
 				netInfoResult.Info[i].Addresses[j] = addr
 			}
 		}
+	}
+
+	if !resolveIngressAddresses {
+		return netInfoResult
 	}
 
 	// Resolve addresses in IngressAddresses.

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -306,6 +306,19 @@ bind-addresses:
     cidr: 10.33.1.8/24`[1:])
 }
 
+func (s *NetworkGetSuite) TestNetworkGetDoNotResolve(c *gc.C) {
+	s.testScenario(c, []string{"resolvable-hostname", "--resolve-ingress-addresses=false"}, 0, `
+bind-addresses:
+- macaddress: "00:11:22:33:44:33"
+  interfacename: eth3
+  addresses:
+  - hostname: resolvable-hostname
+    address: 10.3.3.3
+    cidr: 10.33.1.8/24
+ingress-addresses:
+- resolvable-hostname`[1:])
+}
+
 func (s *NetworkGetSuite) testScenario(c *gc.C, args []string, code int, out string) {
 	ctx := cmdtesting.Context(c)
 


### PR DESCRIPTION
The linked bug describes a scenario where:
- We have acquired a FQDN as a load-balancer address for a CAAS service.
- This is returned as the public address of the service in a call to `network-get`.
- There are no explicit egress subnets declared for the model or the relation context of the `network-get` call.
- The service pod/container is not yet available.
- Therefore, when we invoke our fall-back position attempt to resolve the FQDN as an IP and in turn as an egress subnet, we return an error.
- The workload goes into an error state.

This patch unifies the egress subnet resolution and instead of throwing out all errors, logs a warning when we detect `net.DNSError`, returning a nil slice for egress subnets.

There are additional modularisations following on from #12309 that continue to make `NetworkInfo` more cogent.

## QA steps

Regression:

- Bootstrap to AWS.
- `juju add-space space-1 172.31.80.0/20`.
- `juju deploy percona-cluster --bind "space-1"`.
- Once quiesced, `juju run --unit percona-cluster/0 'network-get cluster'`.
- Execution will succeed and return something akin to:
```
bind-addresses:
- macaddress: 12:08:86:e8:3c:8d
  interfacename: ens5
  addresses:
  - hostname: ""
    address: 172.31.81.88
    cidr: 172.31.80.0/20
- macaddress: 02:d4:9d:5c:e2:ed
  interfacename: fan-252
  addresses:
  - hostname: ""
    address: 252.81.88.1
    cidr: 252.80.0.0/12
egress-subnets:
- 172.31.81.88/32
ingress-addresses:
- 172.31.81.88
- 252.81.88.1
```
This Feature:

- Bootstrap to AWS.
- Save [this](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/aws-overlay.yaml) as aws-integrator.yaml
- `juju deploy charmed-kubernetes --overlay aws-integrator.yaml --trust`.
- `juju scp kubernetes-master/0:/home/ubuntu/config ~/.kube/config`.
- Add the k8s as a cloud to the same controller: `juju juju add-k8s k8s`.
- `juju add-model qa k8s/us-east-1 --config logging-config="<root>=DEBUG"`.
- `juju deploy cs:ambassador`.
- `juju config ambassador juju-external-hostname=<app service address>`.
- `juju run --unit ambassador/0 "network-get ambassador"`

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1901749
