### PR TITLE
Fix bundle diff 2.8

### DIFF
--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -230,6 +230,9 @@ func (c *bundleDiffCommand) bundleDataSource(ctx *cmd.Context) (charm.BundleData
 		return nil, errors.Errorf("couldn't interpret %q as a local or charmstore bundle", c.bundle)
 	}
 
+	// GetBundle creates the directory so we actually want to create a temp
+	// directory then add a namespace (bundle name) so that charmstore get
+	// bundle can create it.
 	dir, err := ioutil.TempDir("", "bundle-diff-")
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/application/bundlediff.go
+++ b/cmd/juju/application/bundlediff.go
@@ -6,6 +6,7 @@ package application
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/bundlechanges"
@@ -229,11 +230,12 @@ func (c *bundleDiffCommand) bundleDataSource(ctx *cmd.Context) (charm.BundleData
 		return nil, errors.Errorf("couldn't interpret %q as a local or charmstore bundle", c.bundle)
 	}
 
-	dir, err := ioutil.TempDir("", bundleURL.Name)
+	dir, err := ioutil.TempDir("", "bundle-diff-")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	bundle, err := charmStore.GetBundle(bundleURL, dir)
+	bundlePath := filepath.Join(dir, bundleURL.Name)
+	bundle, err := charmStore.GetBundle(bundleURL, bundlePath)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Whilst looking at the work required to implement charmhub charms in the
bundle-diff export I noticed it doesn't work, at all!

This fixes it to just work whilst we work on other things before
coming back around to add charmhub support.

## QA steps


```sh
$ juju bootstrap lxd test
```

#### Local bundles

```sh
$ juju diff-bundle "./testcharms/charm-repo/bundle/basic"
applications:
  ubuntu-lite:
    missing: model 
```

#### Charmstore bundles

```sh
$ juju diff-bundle cs:bundle/wiki-simple
applications:
  mysql:
    missing: model
  wiki:
    missing: model
relations:
  bundle-additions:
  - - mysql:db
    - wiki:db
```
