### PR TITLE
Pull in latest juju/os to support macOS Big Sur

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	"github.com/juju/replicaset"
 	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -1271,7 +1270,7 @@ func (s *clientSuite) TestClientAddMachinesDefaultSeries(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, series.DefaultSupportedLTS(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, jujuversion.DefaultSupportedLTS(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1287,7 +1286,7 @@ func (s *clientSuite) assertAddMachines(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, series.DefaultSupportedLTS(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, jujuversion.DefaultSupportedLTS(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1363,7 +1362,7 @@ func (s *clientSuite) TestClientAddMachinesWithConstraints(c *gc.C) {
 	c.Assert(len(machines), gc.Equals, 3)
 	for i, machineResult := range machines {
 		c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-		s.checkMachine(c, machineResult.Machine, series.DefaultSupportedLTS(), apiParams[i].Constraints.String())
+		s.checkMachine(c, machineResult.Machine, jujuversion.DefaultSupportedLTS(), apiParams[i].Constraints.String())
 	}
 }
 
@@ -1453,7 +1452,7 @@ func (s *clientSuite) TestClientAddMachinesWithInstanceIdSomeErrors(c *gc.C) {
 			c.Assert(machineResult.Error, gc.ErrorMatches, "cannot add a new machine: cannot add a machine with an instance id and no nonce")
 		} else {
 			c.Assert(machineResult.Machine, gc.DeepEquals, strconv.Itoa(i))
-			s.checkMachine(c, machineResult.Machine, series.DefaultSupportedLTS(), apiParams[i].Constraints.String())
+			s.checkMachine(c, machineResult.Machine, jujuversion.DefaultSupportedLTS(), apiParams[i].Constraints.String())
 			instanceId := fmt.Sprintf("1234-%d", i)
 			s.checkInstance(c, machineResult.Machine, instanceId, "foo", hc, network.NewSpaceAddresses("1.2.3.4"))
 		}

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/description/v2"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -33,6 +32,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type modelInfoSuite struct {
@@ -226,7 +226,7 @@ func (s *modelInfoSuite) expectedModelInfo(c *gc.C, credentialValidity *bool) pa
 		CloudTag:           "cloud-some-cloud",
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
-		DefaultSeries:      series.DefaultSupportedLTS(),
+		DefaultSeries:      version.DefaultSupportedLTS(),
 		Life:               life.Dying,
 		Status: params.EntityStatus{
 			Status: status.Destroying,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // defaultSupportedJujuSeries is used to return canned information about what
@@ -354,7 +355,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeries(c *gc.C) {
 
 func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c *gc.C) {
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "dummy")
-	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", series.DefaultSupportedLTS()))
+	curl := charm.MustParseURL(fmt.Sprintf("local:%s/dummy-1", jujuversion.DefaultSupportedLTS()))
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
@@ -1131,7 +1132,7 @@ func (s *DeploySuite) TestDeployStorageFailContainer(c *gc.C) {
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
-	machine, err := s.State.AddMachine(series.DefaultSupportedLTS(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(jujuversion.DefaultSupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	container := "lxd:" + machine.Id()
 	err = s.runDeploy(c, charmDir.Path, "--to", container, "--storage", "data=machinescoped,1G")
@@ -1144,7 +1145,7 @@ func (s *DeploySuite) TestPlacement(c *gc.C) {
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 	// Add a machine that will be ignored due to placement directive.
-	machine, err := s.State.AddMachine(series.DefaultSupportedLTS(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(jujuversion.DefaultSupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.runDeployForState(c, charmDir.Path, "-n", "1", "--to", "valid", "--series", "bionic")
@@ -1223,9 +1224,9 @@ func (s *DeploySuite) TestForceMachine(c *gc.C) {
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
-	machine, err := s.State.AddMachine(series.DefaultSupportedLTS(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(jujuversion.DefaultSupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.runDeployForState(c, "--to", machine.Id(), charmDir.Path, "portlandia", "--series", series.DefaultSupportedLTS())
+	err = s.runDeployForState(c, "--to", machine.Id(), charmDir.Path, "portlandia", "--series", jujuversion.DefaultSupportedLTS())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, machine.Id())
 }
@@ -1247,12 +1248,12 @@ func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	template := state.MachineTemplate{
-		Series: series.DefaultSupportedLTS(),
+		Series: jujuversion.DefaultSupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideNewMachine(template, template, instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.runDeployForState(c, "--to", container.Id(), charmDir.Path, "portlandia", "--series", series.DefaultSupportedLTS())
+	err = s.runDeployForState(c, "--to", container.Id(), charmDir.Path, "portlandia", "--series", jujuversion.DefaultSupportedLTS())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertForceMachine(c, container.Id())
 	machines, err := s.State.AllMachines()
@@ -1264,10 +1265,10 @@ func (s *DeploySuite) TestForceMachineNewContainer(c *gc.C) {
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "dummy")
 	curl := charm.MustParseURL("local:bionic/dummy-1")
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
-	ltsseries := series.DefaultSupportedLTS()
+	ltsseries := jujuversion.DefaultSupportedLTS()
 	withCharmDeployable(s.fakeAPI, curl, ltsseries, charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
-	machine, err := s.State.AddMachine(series.DefaultSupportedLTS(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(jujuversion.DefaultSupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.runDeployForState(c, "--to", "lxd:"+machine.Id(), charmDir.Path, "portlandia", "--series", ltsseries)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1299,7 +1300,7 @@ func (s *DeploySuite) TestForceMachineNotFound(c *gc.C) {
 }
 
 func (s *DeploySuite) TestForceMachineSubordinate(c *gc.C) {
-	machine, err := s.State.AddMachine(series.DefaultSupportedLTS(), state.JobHostUnits)
+	machine, err := s.State.AddMachine(jujuversion.DefaultSupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "logging")
 	curl := charm.MustParseURL("local:bionic/logging-1")

--- a/cmd/juju/application/series_selector.go
+++ b/cmd/juju/application/series_selector.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
+	"github.com/juju/juju/version"
 )
 
 const (
@@ -107,7 +107,7 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 		return "", err
 	}
 
-	latestLTS := series.DefaultSupportedLTS()
+	latestLTS := version.DefaultSupportedLTS()
 	logger.Infof(msgLatestLTSSeries, latestLTS)
 	return latestLTS, nil
 }

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -464,7 +464,7 @@ func (s *UpgradeBaseSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgr
 
 		for _, uploaded := range test.expectUploaded {
 			// Substitute latest LTS for placeholder in expected series for uploaded tools
-			uploaded = strings.Replace(uploaded, "%LTS%", series.DefaultSupportedLTS(), 1)
+			uploaded = strings.Replace(uploaded, "%LTS%", jujuversion.DefaultSupportedLTS(), 1)
 			vers := version.MustParseBinary(uploaded)
 			s.checkToolsUploaded(c, vers, agentVersion)
 		}

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
-	"github.com/juju/os/series"
 	"github.com/juju/utils/arch"
 
 	"github.com/juju/juju/caas"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/storage"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/version"
 )
 
 func prepare(context *cmd.Context, controllerName string, store jujuclient.ClientStore) (environs.Environ, error) {
@@ -157,7 +157,7 @@ func (c *imageMetadataCommand) setParams(context *cmd.Context) error {
 		logger.Infof("no model found, creating image metadata using user supplied data")
 	}
 	if c.Series == "" {
-		c.Series = series.DefaultSupportedLTS()
+		c.Series = version.DefaultSupportedLTS()
 	}
 	if c.ImageId == "" {
 		return errors.Errorf("image id must be specified")

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 type ImageMetadataSuite struct {
@@ -171,7 +171,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesLatestLTS(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
-		series: series.DefaultSupportedLTS(),
+		series: version.DefaultSupportedLTS(),
 		arch:   "arch",
 	}
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -61,7 +61,7 @@ var (
 	// Ensure that we add the default supported series so that tests that
 	// use the default supported lts internally will always work in the
 	// future.
-	supportedJujuSeries = set.NewStrings("precise", "trusty", "quantal", "bionic", series.DefaultSupportedLTS())
+	supportedJujuSeries = set.NewStrings("precise", "trusty", "quantal", "bionic", jujuversion.DefaultSupportedLTS())
 )
 
 type bootstrapSuite struct {
@@ -221,7 +221,7 @@ func (s *bootstrapSuite) TestBootstrapFallbackBootstrapSeries(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	cfg, err := env.Config().Apply(map[string]interface{}{
-		"default-series": series.DefaultSupportedLTS(),
+		"default-series": jujuversion.DefaultSupportedLTS(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
@@ -235,7 +235,7 @@ func (s *bootstrapSuite) TestBootstrapFallbackBootstrapSeries(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(env.bootstrapCount, gc.Equals, 1)
-	c.Check(env.args.AvailableTools.AllSeries(), jc.SameContents, []string{series.DefaultSupportedLTS()})
+	c.Check(env.args.AvailableTools.AllSeries(), jc.SameContents, []string{jujuversion.DefaultSupportedLTS()})
 }
 
 func (s *bootstrapSuite) TestBootstrapForcedBootstrapSeries(c *gc.C) {
@@ -1365,7 +1365,7 @@ func (s *bootstrapSuite) setupBootstrapSpecificVersion(c *gc.C, clientMajor, cli
 	})
 	defer envtools.UnregisterToolsDataSourceFunc("local storage")
 
-	supportedSeries := series.DefaultSupportedLTS()
+	supportedSeries := jujuversion.DefaultSupportedLTS()
 	toolsBinaries := []version.Binary{
 		version.MustParseBinary(fmt.Sprintf("10.11.12-%s-amd64", supportedSeries)),
 		version.MustParseBinary(fmt.Sprintf("10.11.13-%s-amd64", supportedSeries)),
@@ -1608,7 +1608,7 @@ func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx cont
 		e.instanceConfig = icfg
 		return nil
 	}
-	series := series.DefaultSupportedLTS()
+	series := jujuversion.DefaultSupportedLTS()
 	if args.BootstrapSeries != "" {
 		series = args.BootstrapSeries
 	}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	"github.com/juju/proxy"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
@@ -335,7 +334,7 @@ type HasDefaultSeries interface {
 // The fact that PreferredSeries doesn't take an argument for a default series
 // as a fallback. We then have to expose this so we can exercise the branching
 // code for other scenarios makes me sad.
-var GetDefaultSupportedLTS = series.DefaultSupportedLTS
+var GetDefaultSupportedLTS = jujuversion.DefaultSupportedLTS
 
 // PreferredSeries returns the preferred series to use when a charm does not
 // explicitly specify a series.

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/logfwd/syslog"
 	"github.com/juju/juju/network"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.environs.config")
@@ -451,7 +452,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":              series.DefaultSupportedLTS(),
+	"default-series":              jujuversion.DefaultSupportedLTS(),
 	ProvisionerHarvestModeKey:     HarvestDestroyed.String(),
 	ResourceTagsKey:               "",
 	"logging-config":              "",

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/juju/loggo"
-	"github.com/juju/os/series"
 	"github.com/juju/proxy"
 	"github.com/juju/schema"
 	gitjujutesting "github.com/juju/testing"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 func Test(t *stdtesting.T) {
@@ -53,7 +53,7 @@ var sampleConfig = testing.Attrs{
 	"unknown":                    "my-unknown",
 	"ssl-hostname-verification":  true,
 	"development":                false,
-	"default-series":             series.DefaultSupportedLTS(),
+	"default-series":             jujuversion.DefaultSupportedLTS(),
 	"disable-network-management": false,
 	"ignore-machine-addresses":   false,
 	"automatically-retry-hooks":  true,
@@ -644,7 +644,7 @@ func (test configTest) check(c *gc.C, home *gitjujutesting.FakeHome) {
 	if seriesAttr != "" {
 		c.Assert(defaultSeries, gc.Equals, seriesAttr)
 	} else {
-		c.Assert(defaultSeries, gc.Equals, series.DefaultSupportedLTS())
+		c.Assert(defaultSeries, gc.Equals, jujuversion.DefaultSupportedLTS())
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
@@ -794,7 +794,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"firewall-mode":              config.FwInstance,
 		"unknown":                    "my-unknown",
 		"ssl-hostname-verification":  true,
-		"default-series":             series.DefaultSupportedLTS(),
+		"default-series":             jujuversion.DefaultSupportedLTS(),
 		"disable-network-management": false,
 		"ignore-machine-addresses":   false,
 		"automatically-retry-hooks":  true,

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -217,7 +217,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	// we could connect to (actual live tests, rather than local-only)
 	cons := constraints.MustParse("mem=2G")
 	if t.CanOpenState {
-		_, err := sync.Upload(t.toolsStorage, "released", nil, series.DefaultSupportedLTS())
+		_, err := sync.Upload(t.toolsStorage, "released", nil, jujuversion.DefaultSupportedLTS())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	args := t.bootstrapParams()
@@ -673,7 +673,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	expectedVersion := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.DefaultSupportedLTS(),
+		Series: jujuversion.DefaultSupportedLTS(),
 	}
 
 	mtools0 := waitAgentTools(c, mw0, expectedVersion)

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/shell"
 	"github.com/juju/version"
@@ -25,6 +24,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type provisionerSuite struct {
@@ -46,7 +46,7 @@ func (s *provisionerSuite) getArgs(c *gc.C) manual.ProvisionMachineArgs {
 }
 
 func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
-	var series = series.DefaultSupportedLTS()
+	var series = jujuversion.DefaultSupportedLTS()
 	const arch = "amd64"
 
 	args := s.getArgs(c)
@@ -128,7 +128,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
-	var series = series.DefaultSupportedLTS()
+	var series = jujuversion.DefaultSupportedLTS()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,
@@ -150,7 +150,7 @@ func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestProvisioningScript(c *gc.C) {
-	var series = series.DefaultSupportedLTS()
+	var series = jujuversion.DefaultSupportedLTS()
 	const arch = "amd64"
 	defer fakeSSH{
 		Series:         series,

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -315,7 +315,7 @@ func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
-	defaultSeries := series.DefaultSupportedLTS()
+	defaultSeries := jujuversion.DefaultSupportedLTS()
 	if series.MustHostSeries() != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200424054733-9a8294627524
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438
+	github.com/juju/os v0.0.0-20201115220950-10720519c304
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,6 @@ github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdG
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
-github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
-github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/os v0.0.0-20201115220950-10720519c304 h1:VtqPkMkHPHK2vtw1lVHUawAnulOpjiF3ltXMQuqcuz4=
 github.com/juju/os v0.0.0-20201115220950-10720519c304/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
+github.com/juju/os v0.0.0-20201115220950-10720519c304 h1:VtqPkMkHPHK2vtw1lVHUawAnulOpjiF3ltXMQuqcuz4=
+github.com/juju/os v0.0.0-20201115220950-10720519c304/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/juju/charm/v7"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
+	"github.com/juju/juju/version"
 )
 
 type RepoSuite struct {
@@ -24,7 +24,7 @@ type RepoSuite struct {
 func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	// Change the environ's config to ensure we're using the one in state.
-	updateAttrs := map[string]interface{}{"default-series": series.DefaultSupportedLTS()}
+	updateAttrs := map[string]interface{}{"default-series": version.DefaultSupportedLTS()}
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -79,7 +79,7 @@ func newStorage(suite cleaner, c *gc.C) storage.Storage {
 }
 
 func minimalConfig(c *gc.C) *config.Config {
-	return minimalConfigWithSeries(c, series.DefaultSupportedLTS())
+	return minimalConfigWithSeries(c, jujuversion.DefaultSupportedLTS())
 }
 
 func minimalConfigWithSeries(c *gc.C, series string) *config.Config {
@@ -169,7 +169,7 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 		config:        fakeMinimalConfig(c),
 	}
 	ctx := envtesting.BootstrapContext(c)
-	bootstrapSeries := series.DefaultSupportedLTS()
+	bootstrapSeries := jujuversion.DefaultSupportedLTS()
 	availableTools := fakeAvailableTools()
 	availableTools[0].Version.Series = bootstrapSeries
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
@@ -221,7 +221,7 @@ func (s *BootstrapSuite) TestBootstrapFallbackSeries(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Arch, gc.Equals, "ppc64el") // based on hardware characteristics
-	c.Check(result.Series, gc.Equals, series.DefaultSupportedLTS())
+	c.Check(result.Series, gc.Equals, jujuversion.DefaultSupportedLTS())
 }
 
 func (s *BootstrapSuite) TestBootstrapSeriesWithForce(c *gc.C) {
@@ -642,7 +642,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 		},
 	}
 	ctx := envtesting.BootstrapContext(c)
-	bootstrapSeries := series.DefaultSupportedLTS()
+	bootstrapSeries := jujuversion.DefaultSupportedLTS()
 	availableTools := fakeAvailableTools()
 	availableTools[0].Version.Series = bootstrapSeries
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
@@ -928,7 +928,7 @@ func fakeAvailableTools() tools.List {
 			Version: version.Binary{
 				Number: jujuversion.Current,
 				Arch:   arch.HostArch(),
-				Series: series.DefaultSupportedLTS(),
+				Series: jujuversion.DefaultSupportedLTS(),
 			},
 		},
 	}

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -29,9 +29,9 @@ func (*ErrorsSuite) TestWrapZoneIndependentError(c *gc.C) {
 
 	stack := errors.ErrorStack(wrapped)
 	c.Assert(stack, gc.Matches, `
-.*/juju/juju/provider/common/errors_test.go:.*: foo
-.*/juju/juju/provider/common/errors_test.go:.*: bar
-.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/provider/common/errors_test.go:.*: foo
+.*/provider/common/errors_test.go:.*: bar
+.*/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
@@ -46,9 +46,9 @@ func (s *ErrorsSuite) TestInvalidCredentialWrapped(c *gc.C) {
 
 	stack := errors.ErrorStack(err)
 	c.Assert(stack, gc.Matches, `
-.*/juju/juju/provider/common/errors_test.go:.*: foo
-.*/juju/juju/provider/common/errors_test.go:.*: bar
-.*/juju/juju/provider/common/errors_test.go:.*: bar: foo`[1:])
+.*/provider/common/errors_test.go:.*: foo
+.*/provider/common/errors_test.go:.*: bar
+.*/provider/common/errors_test.go:.*: bar: foo`[1:])
 }
 
 func (s *ErrorsSuite) TestInvalidCredentialNew(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	"github.com/juju/pubsub"
 	"github.com/juju/retry"
 	"github.com/juju/schema"
@@ -82,6 +81,7 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/lease"
 	"github.com/juju/juju/worker/modelcache"
@@ -122,7 +122,7 @@ func SampleConfig() testing.Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            series.DefaultSupportedLTS(),
+		"default-series":            jujuversion.DefaultSupportedLTS(),
 		"default-space":             "",
 		"secret":                    "pork",
 		"controller":                true,

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -285,7 +285,7 @@ var findInstanceSpecErrorTests = []struct {
 	{
 		series: version.DefaultSupportedLTS(),
 		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, version.DefaultSupportedLTS()),
+		err:    fmt.Sprintf(`no metadata for "%s" images in test with arches \[arm\]`, version.DefaultSupportedLTS()),
 	}, {
 		series: "raring",
 		arches: []string{"amd64", "i386"},

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&specSuite{})
@@ -259,7 +260,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.C) {
 	instanceConstraint := &instances.InstanceConstraint{
 		Region:      "test",
-		Series:      series.DefaultSupportedLTS(),
+		Series:      version.DefaultSupportedLTS(),
 		Constraints: constraints.MustParse("instance-type=t2.medium"),
 	}
 
@@ -282,16 +283,16 @@ var findInstanceSpecErrorTests = []struct {
 	err    string
 }{
 	{
-		series: series.DefaultSupportedLTS(),
+		series: version.DefaultSupportedLTS(),
 		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no metadata for "%s" images in test with arches \[arm\]`, series.DefaultSupportedLTS()),
+		err:    fmt.Sprintf(`no "%s" images in test with arches \[arm\]`, version.DefaultSupportedLTS()),
 	}, {
 		series: "raring",
 		arches: []string{"amd64", "i386"},
 		cons:   "mem=4G",
 		err:    `no "raring" images in test matching instance types \[.*\]`,
 	}, {
-		series: series.DefaultSupportedLTS(),
+		series: version.DefaultSupportedLTS(),
 		arches: []string{"amd64"},
 		cons:   "instance-type=m1.small mem=4G",
 		err:    `no instance types in test matching constraints "instance-type=m1.small mem=4096M"`,

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -85,7 +85,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.LiveTests.SetUpSuite(c)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.DefaultSupportedLTS() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.DefaultSupportedLTS() })
 	// Use the real ec2 session if we are running with real creds.
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	if accessKey == "" {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -239,7 +239,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return series.DefaultSupportedLTS() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.DefaultSupportedLTS() })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2iface.EC2API {
 		c.Assert(region, gc.Equals, "test")
@@ -1452,7 +1452,7 @@ func (t *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.small root-disk=1G")
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:      series.DefaultSupportedLTS(),
+		Series:      jujuversion.DefaultSupportedLTS(),
 		Constraints: cons,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1462,7 +1462,7 @@ func (t *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=m1.invalid")
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:      series.DefaultSupportedLTS(),
+		Series:      jujuversion.DefaultSupportedLTS(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "m1.invalid" specified`)
@@ -1472,7 +1472,7 @@ func (t *localServerSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	env := t.Prepare(c)
 	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=i386")
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:      series.DefaultSupportedLTS(),
+		Series:      jujuversion.DefaultSupportedLTS(),
 		Constraints: cons,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "i386" specified`)
@@ -1482,7 +1482,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-available"
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: placement,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1492,7 +1492,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unavailable"
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is "unavailable"`)
@@ -1502,7 +1502,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	env := t.Prepare(c)
 	placement := "zone=test-unknown"
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: placement,
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid availability zone "test-unknown"`)
@@ -1526,7 +1526,7 @@ func (t *localServerSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placemen
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1549,7 +1549,7 @@ func (t *localServerSuite) TestPrecheckInstanceAvailZoneVolumeConflict(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: "zone=test-available",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			AttachmentParams: storage.AttachmentParams{
@@ -1570,7 +1570,7 @@ func (t *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	env := t.Prepare(c)
 	params, err := env.(simplestreams.MetadataValidator).MetadataLookupParams("test")
 	c.Assert(err, jc.ErrorIsNil)
-	params.Series = series.DefaultSupportedLTS()
+	params.Series = jujuversion.DefaultSupportedLTS()
 	params.Endpoint = region.EC2Endpoint
 	params.Sources, err = environs.ImageMetadataSources(env)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -5,7 +5,6 @@ package gce_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/juju/juju/provider/gce"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/storage"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type environPolSuite struct {
@@ -23,7 +23,7 @@ type environPolSuite struct {
 var _ = gc.Suite(&environPolSuite{})
 
 func (s *environPolSuite) TestPrecheckInstanceDefaults(c *gc.C) {
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS()})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 0)
@@ -36,7 +36,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=amd64 root-disk=1G")
 	placement := "zone=home-zone"
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons, Placement: placement})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons, Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
@@ -46,14 +46,14 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 
 func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1")
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1.invalid")
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, gc.ErrorMatches, `.*invalid GCE instance type.*`)
 }
@@ -61,14 +61,14 @@ func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 root-disk=1G")
 	placement := ""
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons, Placement: placement})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons, Placement: placement})
 
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	cons := constraints.MustParse("instance-type=n1-standard-1 arch=i386")
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -79,7 +79,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -90,7 +90,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `.*availability zone "a-zone" is DOWN`)
 }
@@ -101,7 +101,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	}
 
 	placement := "zone=a-zone"
-	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 
 	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
@@ -120,7 +120,7 @@ func (s *environPolSuite) testPrecheckInstanceVolumeAvailZone(c *gc.C, placement
 	}
 
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			VolumeId: "away-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",
@@ -135,7 +135,7 @@ func (s *environPolSuite) TestPrecheckInstanceAvailZoneConflictsVolume(c *gc.C) 
 	}
 
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{
-		Series:    series.DefaultSupportedLTS(),
+		Series:    jujuversion.DefaultSupportedLTS(),
 		Placement: "zone=away-zone",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{
 			VolumeId: "home-zone--c930380d-8337-4bf5-b07a-9dbb5ae771e4",

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/lxc/lxd/shared/api"
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type environPolicySuite struct {
@@ -38,7 +38,7 @@ func (s *environPolicySuite) TestPrecheckInstanceDefaults(c *gc.C) {
 	svr := lxd.NewMockServer(ctrl)
 
 	env := s.NewEnviron(c, svr, nil)
-	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS()})
+	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS()})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -50,7 +50,7 @@ func (s *environPolicySuite) TestPrecheckInstanceHasInstanceType(c *gc.C) {
 	env := s.NewEnviron(c, svr, nil)
 
 	cons := constraints.MustParse("instance-type=some-instance-type")
-	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -63,7 +63,7 @@ func (s *environPolicySuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 	env := s.NewEnviron(c, svr, nil)
 
 	cons := constraints.MustParse("root-disk=1G")
-	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -76,7 +76,7 @@ func (s *environPolicySuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	cons := constraints.MustParse("arch=i386")
 
 	env := s.NewEnviron(c, svr, nil)
-	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
 }
@@ -106,7 +106,7 @@ func (s *environPolicySuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	)
 
 	placement := "zone=a-zone"
-	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 
 	c.Check(err, gc.ErrorMatches, `availability zone "a-zone" not valid`)
 }

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -8,10 +8,10 @@ import (
 	"path"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 
 	"github.com/juju/juju/cloud"
 	jujupaths "github.com/juju/juju/core/paths"
+	"github.com/juju/juju/version"
 )
 
 // ReadLegacyCloudCredentials reads cloud credentials off disk for an old
@@ -22,7 +22,7 @@ import (
 // satisfying errors.IsNotFound will be returned.
 func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
 	var (
-		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(series.DefaultSupportedLTS()))
+		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(version.DefaultSupportedLTS()))
 		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
 		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
 		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	"github.com/juju/utils/arch"
@@ -40,6 +39,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // ensure we conform to the right interfaces
@@ -691,32 +691,32 @@ func (suite *environSuite) TestSubnetsMissingSubnet(c *gc.C) {
 func (s *environSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: "zone=zone1"})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: "zone=zone1"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	s.testMAASObject.TestServer.AddZone("zone1", "the grass is greener in zone1")
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: "zone=zone2"})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: "zone=zone2"})
 	c.Assert(err, gc.ErrorMatches, `availability zone "zone2" not valid`)
 }
 
 func (s *environSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: "zone=test-unknown"})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: "zone=test-unknown"})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
 func (s *environSuite) TestPrecheckInvalidPlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: "notzone=anything"})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: "notzone=anything"})
 	c.Assert(err, gc.ErrorMatches, "unknown placement directive: notzone=anything")
 }
 
 func (s *environSuite) TestPrecheckNodePlacement(c *gc.C) {
 	env := s.makeEnviron()
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: "assumed_node_name"})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: "assumed_node_name"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -80,7 +80,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.MustHostSeries, func() string { return series.DefaultSupportedLTS() })
+	s.PatchValue(&series.MustHostSeries, func() string { return jujuversion.DefaultSupportedLTS() })
 	s.callCtx = &context.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/series"
 	"github.com/juju/utils"
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/paths"
+	"github.com/juju/juju/version"
 )
 
 // extractSystemId extracts the 'system_id' part from an InstanceId.
@@ -48,7 +48,7 @@ type machineInfo struct {
 	Hostname string `yaml:",omitempty"`
 }
 
-var maasDataDir = paths.MustSucceed(paths.DataDir(series.DefaultSupportedLTS()))
+var maasDataDir = paths.MustSucceed(paths.DataDir(version.DefaultSupportedLTS()))
 var _MAASInstanceFilename = path.Join(maasDataDir, "MAASmachine.txt")
 
 // cloudinitRunCmd returns the shell command that, when run, will create the

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1643,7 +1643,7 @@ func (s *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
 	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
-	c.Assert(err, gc.ErrorMatches, `zone "test-unavailable" is unavailable`)
+	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1539,7 +1539,7 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.DefaultSupportedLTS(), "amd64", "instance-type=m1.tiny",
+		env, jujuversion.DefaultSupportedLTS(), "amd64", "instance-type=m1.tiny",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1556,7 +1556,7 @@ func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.DefaultSupportedLTS(), "amd64", "virt-type="+testVirtType,
+		env, jujuversion.DefaultSupportedLTS(), "amd64", "virt-type="+testVirtType,
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1575,7 +1575,7 @@ func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.DefaultSupportedLTS(), "amd64", "",
+		env, jujuversion.DefaultSupportedLTS(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1592,7 +1592,7 @@ func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
 	}}
 
 	spec, err := openstack.FindInstanceSpec(
-		env, series.DefaultSupportedLTS(), "amd64", "",
+		env, jujuversion.DefaultSupportedLTS(), "amd64", "",
 		imageMetadata,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1607,7 +1607,7 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 		Arch: "amd64",
 	}}
 	_, err := openstack.FindInstanceSpec(
-		env, series.DefaultSupportedLTS(), "amd64", "instance-type=m1.large",
+		env, jujuversion.DefaultSupportedLTS(), "amd64", "instance-type=m1.large",
 		imageMetadata,
 	)
 	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
@@ -1616,46 +1616,46 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small")
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.large")
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskConstraint(c *gc.C) {
 	env := s.Open(c, s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small root-disk=10G")
-	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Constraints: cons})
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless constraint root-disk-source=volume`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
-	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZoneUnavailable(c *gc.C) {
 	placement := "zone=test-unavailable"
-	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
-	c.Assert(err, gc.ErrorMatches, `availability zone "test-unavailable" is unavailable`)
+	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
+	c.Assert(err, gc.ErrorMatches, `zone "test-unavailable" is unavailable`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZoneUnknown(c *gc.C) {
 	placement := "zone=test-unknown"
-	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 	c.Assert(err, gc.ErrorMatches, `availability zone "test-unknown" not valid`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZonesUnsupported(c *gc.C) {
 	s.srv.Nova.SetAvailabilityZones() // no availability zone support
 	placement := "zone=test-unknown"
-	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: series.DefaultSupportedLTS(), Placement: placement})
+	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Placement: placement})
 	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }
 
@@ -1689,7 +1689,7 @@ func (s *localServerSuite) testPrecheckInstanceVolumeAvailZones(c *gc.C, placeme
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{
-		Series:            series.DefaultSupportedLTS(),
+		Series:            jujuversion.DefaultSupportedLTS(),
 		Placement:         placement,
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})
@@ -1724,7 +1724,7 @@ func (s *localServerSuite) TestPrecheckInstanceAvailZonesConflictsVolume(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{
-		Series:            series.DefaultSupportedLTS(),
+		Series:            jujuversion.DefaultSupportedLTS(),
 		Placement:         "zone=az2",
 		VolumeAttachments: []storage.VolumeAttachmentParams{{VolumeId: "foo"}},
 	})

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // FakeAuthKeys holds the authorized key used for testing
@@ -33,7 +33,7 @@ func init() {
 var (
 	// FakeSupportedJujuSeries is used to provide a series of canned results
 	// of series to test bootstrap code against.
-	FakeSupportedJujuSeries = set.NewStrings("precise", "trusty", "quantal", "bionic", series.DefaultSupportedLTS())
+	FakeSupportedJujuSeries = set.NewStrings("precise", "trusty", "quantal", "bionic", jujuversion.DefaultSupportedLTS())
 )
 
 // FakeVersionNumber is a valid version number that can be used in testing.
@@ -45,7 +45,7 @@ var ModelTag = names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 // ControllerTag is a defined known valid UUID that can be used in testing.
 var ControllerTag = names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 
-// FakeControllerConfig() returns an environment configuration
+// FakeControllerConfig returns an environment configuration
 // that is expected to be found in state for a fake controller.
 func FakeControllerConfig() controller.Config {
 	return controller.Config{
@@ -65,7 +65,7 @@ func FakeControllerConfig() controller.Config {
 	}
 }
 
-// FakeConfig() returns an environment configuration for a
+// FakeConfig returns an environment configuration for a
 // fake provider with all required attributes set.
 func FakeConfig() Attrs {
 	return Attrs{
@@ -76,7 +76,7 @@ func FakeConfig() Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            series.DefaultSupportedLTS(),
+		"default-series":            jujuversion.DefaultSupportedLTS(),
 	}
 }
 

--- a/version/series.go
+++ b/version/series.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+// DefaultSupportedLTS returns the latest LTS that Juju supports and is
+// compatible with.
+func DefaultSupportedLTS() string {
+	return "bionic"
+}

--- a/version/series_test.go
+++ b/version/series_test.go
@@ -1,0 +1,20 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package version
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type seriesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&seriesSuite{})
+
+func (s *seriesSuite) TestDefaultSupportedLTS(c *gc.C) {
+	name := DefaultSupportedLTS()
+	c.Assert(name, gc.Equals, "bionic")
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -7,15 +7,14 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	semversion "github.com/juju/version"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/testing"
 )
 
 type suite struct {
-	testing.BaseSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&suite{})

--- a/worker/provisioner/containerprovisioner_test.go
+++ b/worker/provisioner/containerprovisioner_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/arch"
 	"github.com/juju/worker/v2/workertest"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/provisioner"
 )
 
@@ -125,7 +125,7 @@ func (s *kvmProvisionerSuite) TestDoesNotStartEnvironMachines(c *gc.C) {
 	defer workertest.CleanKill(c, p)
 
 	// Check that an instance is not provisioned when the machine is created.
-	_, err := s.State.AddMachine(series.DefaultSupportedLTS(), state.JobHostUnits)
+	_, err := s.State.AddMachine(jujuversion.DefaultSupportedLTS(), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.expectNoEvents(c)
@@ -142,7 +142,7 @@ func (s *kvmProvisionerSuite) TestDoesNotHaveRetryWatcher(c *gc.C) {
 
 func (s *kvmProvisionerSuite) addContainer(c *gc.C) *state.Machine {
 	template := state.MachineTemplate{
-		Series: series.DefaultSupportedLTS(),
+		Series: jujuversion.DefaultSupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, "0", instance.KVM)

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/series"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version"
@@ -40,6 +39,7 @@ import (
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/common/mocks"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/provisioner"
 )
 
@@ -864,7 +864,7 @@ func (m *testMachine) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
 	return &params.ProvisioningInfoV10{
 		ProvisioningInfoBase: params.ProvisioningInfoBase{
 			ControllerConfig: coretesting.FakeControllerConfig(),
-			Series:           series.DefaultSupportedLTS(),
+			Series:           jujuversion.DefaultSupportedLTS(),
 			Constraints:      constraints.MustParse(m.constraints),
 		},
 		ProvisioningNetworkTopology: m.topology,

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -486,7 +486,7 @@ func (s *CommonProvisionerSuite) addMachine() (*state.Machine, error) {
 
 func (s *CommonProvisionerSuite) addMachineWithConstraints(cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series.DefaultSupportedLTS(),
+		Series:      jujuversion.DefaultSupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 	})
@@ -496,7 +496,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 	templates := make([]state.MachineTemplate, number)
 	for i := range templates {
 		templates[i] = state.MachineTemplate{
-			Series:      series.DefaultSupportedLTS(),
+			Series:      jujuversion.DefaultSupportedLTS(),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
 			Constraints: s.defaultConstraints,
 		}
@@ -505,7 +505,7 @@ func (s *CommonProvisionerSuite) addMachines(number int) ([]*state.Machine, erro
 }
 
 func (s *CommonProvisionerSuite) enableHA(c *gc.C, n int) []*state.Machine {
-	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, series.DefaultSupportedLTS(), nil)
+	changes, err := s.BackingState.EnableHA(n, s.defaultConstraints, jujuversion.DefaultSupportedLTS(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	added := make([]*state.Machine, len(changes.Added))
 	for i, mid := range changes.Added {
@@ -814,7 +814,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForLXD(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: series.DefaultSupportedLTS(),
+		Series: jujuversion.DefaultSupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.LXD)
@@ -842,7 +842,7 @@ func (s *ProvisionerSuite) TestProvisioningDoesNotOccurForKVM(c *gc.C) {
 
 	// make a container on the machine we just created
 	template := state.MachineTemplate{
-		Series: series.DefaultSupportedLTS(),
+		Series: jujuversion.DefaultSupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	container, err := s.State.AddMachineInsideMachine(template, m.Id(), instance.KVM)
@@ -1126,7 +1126,7 @@ func (s *ProvisionerSuite) TestProvisioningMachinesFailsWithEmptySpaces(c *gc.C)
 
 func (s *CommonProvisionerSuite) addMachineWithRequestedVolumes(volumes []state.HostVolumeParams, cons constraints.Value) (*state.Machine, error) {
 	return s.BackingState.AddOneMachine(state.MachineTemplate{
-		Series:      series.DefaultSupportedLTS(),
+		Series:      jujuversion.DefaultSupportedLTS(),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 		Volumes:     volumes,

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/clock"
-	"github.com/juju/os/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/reboot"
 )
@@ -41,7 +41,7 @@ var _ = gc.Suite(&rebootSuite{})
 func (s *rebootSuite) SetUpTest(c *gc.C) {
 	var err error
 	template := state.MachineTemplate{
-		Series: series.DefaultSupportedLTS(),
+		Series: version.DefaultSupportedLTS(),
 		Jobs:   []state.MachineJob{state.JobHostUnits},
 	}
 	s.JujuConnSuite.SetUpTest(c)


### PR DESCRIPTION
Unfortunately the [juju/os](https://github.com/juju/os) repo's master branch had a breaking change applied to it, specifically the removal of `version.DefaultSupportedLTS()` (it moved into `juju/juju`). So updating required the same refactoring as we'd done on develop to use the `DefaultSupportedLTS` function in `juju/juju/version`.

We're pulling in these changes from `juju/os`, so the reviewer should also look here: https://github.com/juju/os/compare/8e6dd7a2b438d448578b32d0115ca0daaabb6d1f...10720519c304290ca6b6e7586a60ce0015323cfe -- I don't *think* the other changes should be a problem, as we're not changing the default series.

These changes were from https://github.com/juju/juju/pull/12103/files and https://github.com/juju/juju/pull/12108/files cherry-picked, with some manual fix-ups and a few conflict resolutions due to 2.8/develop differences.

## QA steps

Run `juju status` on macOS Big Sur and see if it works. I can't test as I don't have access to macOS Big Sur, but we'll ask the bug reporter to check. The relevant fix itself is a straight-forward one-liner in https://github.com/juju/os/commit/10720519c304290ca6b6e7586a60ce0015323cfe.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1904252