### PR TITLE
Add ResourceRevision for use in charmhub info and refresh.

### DIFF
--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -71,6 +71,8 @@ func defaultInfoFilter() string {
 	filter = append(filter, appendFilterList("channel-map.revision", defaultDownloadFilter)...)
 	filter = append(filter, appendFilterList("channel-map", infoRevisionFilter)...)
 	filter = append(filter, appendFilterList("channel-map", defaultChannelFilter)...)
+	filter = append(filter, appendFilterList("default-release.resources", resourceFilter)...)
+	filter = append(filter, appendFilterList("channel-map.resources", resourceFilter)...)
 	return strings.Join(filter, ",")
 }
 

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+var resourceFilter = []string{
+	"download.hash-sha256",
+	"download.hash-sha3-384",
+	"download.hash-sha384",
+	"download.hash-sha512",
+	"download.size",
+	"download.url",
+	"name",
+	"revision",
+	"type",
+}

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -14,8 +14,9 @@ type InfoResponse struct {
 }
 
 type InfoChannelMap struct {
-	Channel  Channel      `json:"channel,omitempty"`
-	Revision InfoRevision `json:"revision,omitempty"`
+	Channel   Channel            `json:"channel,omitempty"`
+	Resources []ResourceRevision `json:"resources,omitempty"`
+	Revision  InfoRevision       `json:"revision,omitempty"`
 }
 
 // InfoRevision is different from FindRevision.  It has additional

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -44,7 +44,6 @@ type RefreshResponses struct {
 }
 
 type RefreshResponse struct {
-	// TODO (stickupkid): Swap this over to the new name if it ever happens.
 	Entity           RefreshEntity `json:"charm"`
 	EffectiveChannel string        `json:"effective-channel"`
 	Error            *APIError     `json:"error,omitempty"`
@@ -59,12 +58,13 @@ type RefreshResponse struct {
 }
 
 type RefreshEntity struct {
-	CreatedAt string            `json:"created-at"`
-	Download  Download          `json:"download"`
-	ID        string            `json:"id"`
-	License   string            `json:"license"`
-	Name      string            `json:"name"`
-	Publisher map[string]string `json:"publisher,omitempty"`
-	Summary   string            `json:"summary"`
-	Version   string            `json:"version"`
+	CreatedAt string             `json:"created-at"`
+	Download  Download           `json:"download"`
+	ID        string             `json:"id"`
+	License   string             `json:"license"`
+	Name      string             `json:"name"`
+	Publisher map[string]string  `json:"publisher,omitempty"`
+	Resources []ResourceRevision `json:"resources"`
+	Summary   string             `json:"summary"`
+	Version   string             `json:"version"`
 }

--- a/charmhub/transport/resources.go
+++ b/charmhub/transport/resources.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package transport
+
+type ResourceRevision struct {
+	Download ResourceDownload `json:"download"`
+	Name     string           `json:"name"`
+	Revision int              `json:"revision"`
+	Type     string           `json:"type"`
+}
+
+type ResourceDownload struct {
+	HashSHA256  string `json:"hash-sha256"`
+	HashSHA3384 string `json:"hash-sha3-384"`
+	HashSHA384  string `json:"hash-sha384"`
+	HashSHA512  string `json:"hash-sha512"`
+	Size        int    `json:"size"`
+	URL         string `json:"url"`
+}


### PR DESCRIPTION
Add ResourceRevision for use in charmhub info and refresh.

A recent addition to the charmhub api for resources.  Including fields
to include the data with the info response.

Verify the names against: http://api.snapcraft.io/docs/charms.html, there is no live data to verify against.

## QA steps

```console
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy ubuntu-devenv
Located charm "ubuntu-devenv-6".
Deploying charm "ubuntu-devenv-6".
```

