### PR TITLE
Avoid use of ##[add-path] in GitHub Actions

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,11 +1,13 @@
 name: "Snapcraft"
 on: [push, pull_request]
 jobs:
+
   snap:
     name: linux-amd64
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+
     - name: Install Dependencies
       shell: bash
       run: |
@@ -16,19 +18,23 @@ jobs:
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-        echo "##[add-path]/snap/bin"
+        echo "/snap/bin" >> $GITHUB_PATH
+
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Build snap
       shell: bash
       run: |
         set -euxo pipefail
         snapcraft --use-lxd
+
     - name: Install snap
       shell: bash
       run: |
         set -euxo pipefail
         sudo snap install *.snap --dangerous --classic
+
     - name: Test bootstrap
       shell: bash
       run: |


### PR DESCRIPTION
This is already done in the develop branch. Whitespace changes are to match the version of this file in develop too.

This causes the following failure due to a GitHub Actions change:

https://github.com/juju/juju/pull/12324/checks?check_run_id=1408765804:

```
Error: Unable to process command '+ echo '##[add-path]/snap/bin'' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '##[add-path]/snap/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

GitHub blog post about this: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/