### PR TITLE
Fix charm disk storage on LXD

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -134,6 +134,7 @@ func (c *Container) AddDisk(name, path, source, pool string, readOnly bool) erro
 	c.Devices[name] = map[string]string{
 		"path":   path,
 		"source": source,
+		"type":   "disk",
 	}
 	if pool != "" {
 		c.Devices[name]["pool"] = pool

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -64,6 +64,7 @@ func (s *containerSuite) TestContainerAddDiskNoDevices(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := map[string]string{
+		"type":     "disk",
 		"path":     "/",
 		"source":   "source",
 		"pool":     "default",

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -97,7 +97,7 @@ type lxdStorageConfig struct {
 func newLXDStorageConfig(attrs map[string]interface{}) (*lxdStorageConfig, error) {
 	coerced, err := lxdStorageConfigChecker.Coerce(attrs, nil)
 	if err != nil {
-		return nil, errors.Annotate(err, "validating Azure storage config")
+		return nil, errors.Annotate(err, "validating LXD storage config")
 	}
 	attrs = coerced.(map[string]interface{})
 


### PR DESCRIPTION
Seems there was an upstream LXD change which means that Juju needs to add an additional "type" attribute to the disk config.

## QA steps

bootstrap lxd
juju deploy postgresql --storage pgdata=lxd,10M
juju status --storage

also check older lxd compatibility

juju deploy postgresql --storage pgdata=lxd,10M --series=trusty

## Bug reference

https://bugs.launchpad.net/juju/+bug/1904255
