### PR TITLE
Merge 2.8 into develop

### DIFF
--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -27,7 +27,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
 	coretesting "github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/version"
 )
 
 // uniqueName is generated afresh for every test run, so that
@@ -83,9 +83,9 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.UploadArches = []string{arch.AMD64, arch.I386}
 	t.BaseSuite.SetUpSuite(c)
 	t.LiveTests.SetUpSuite(c)
-	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
+	t.BaseSuite.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.DefaultSupportedLTS() })
+	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return version.DefaultSupportedLTS() })
 	// Use the real ec2 session if we are running with real creds.
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	if accessKey == "" {

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -30,7 +30,7 @@ import (
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/juju/keys"
 	coretesting "github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
+	version "github.com/juju/juju/version"
 )
 
 const maas2VersionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`
@@ -78,9 +78,9 @@ func (s *baseProviderSuite) SetUpSuite(c *gc.C) {
 func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
-	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
+	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.MustHostSeries, func() string { return jujuversion.DefaultSupportedLTS() })
+	s.PatchValue(&series.MustHostSeries, func() string { return version.DefaultSupportedLTS() })
 	s.callCtx = &context.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true


### PR DESCRIPTION
This picks up the following PR:

* https://github.com/juju/juju/pull/12324: Revert juju/os fix

Looks like a very small change, but was a bit of a dog to do -- lots of merge conflicts and issues due to series -> jujuversion import changes.