### PR TITLE
Use juju/os v1.0.0 on 2.8 to pull in macOS Big Sur fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200424054733-9a8294627524
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438
+	github.com/juju/os v1.0.0
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdG
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
-github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438 h1:OJQkulSmv3WklByylSxQxsyQXD3ufLXa8pzcnj7JhLk=
-github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
+github.com/juju/os v1.0.0 h1:nyDqi3Oz53P9nYK+oaokCvvu+pS8N7baQ6Ri2PjgCD8=
+github.com/juju/os v1.0.0/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=


### PR DESCRIPTION
Safer replacement for https://github.com/juju/juju/pull/12319, which we reverted as it pulled in too many juju/os changes. This updates to the new v1.0.0 version of juju/os, which is the previous version used on 2.8 (8e6dd7a2b438) with the one-line Big Sur fix added.

## QA steps

Run `juju status` on macOS Big Sur and see if it works. I can't test as I don't have access to macOS Big Sur, but we'll ask the bug reporter to check. The relevant fix itself is a straight-forward one-liner in https://github.com/juju/os/commit/10720519c304290ca6b6e7586a60ce0015323cfe.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1904252
