### PR TITLE
lxd: Not all remotes have a certificate

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -203,16 +203,22 @@ func (p environProviderCredentials) detectRemoteCredentials(certPEM, keyPEM []by
 	for name, remote := range config.Remotes {
 		if remote.Protocol == lxdnames.ProviderType {
 			certPath := filepath.Join(configDir, "servercerts", fmt.Sprintf("%s.crt", name))
-			serverCert, err := p.lxcConfigReader.ReadCert(certPath)
-			if err != nil {
-				logger.Errorf("unable to read certificate from %s with error %s", certPath, err)
-				continue
-			}
-			credential := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+			authConfig := map[string]string{
 				credAttrClientCert: string(certPEM),
 				credAttrClientKey:  string(keyPEM),
-				credAttrServerCert: string(serverCert),
-			})
+			}
+
+			serverCert, err := p.lxcConfigReader.ReadCert(certPath)
+			if err != nil {
+				if !os.IsNotExist(errors.Cause(err)) {
+					logger.Errorf("unable to read certificate from %s with error %s", certPath, err)
+					continue
+				}
+			} else {
+				authConfig[credAttrServerCert] = string(serverCert)
+			}
+
+			credential := cloud.NewCredential(cloud.CertificateAuthType, authConfig)
 			credential.Label = fmt.Sprintf("LXD credential %q", name)
 			credentials[name] = credential
 		}


### PR DESCRIPTION
Remotes can be running on valid TLS certificates in which case no file will be found in `servercerts`.
This is perfectly fine and should not result in an error. Instead the remote simply should not get a server certificate set at all, allowing the tls client to use the system CA.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>