### PR TITLE
Add introspection endpoint to revoke leases

### DIFF
--- a/cmd/jujud/agent/addons/addons.go
+++ b/cmd/jujud/agent/addons/addons.go
@@ -43,6 +43,7 @@ type IntrospectionConfig struct {
 	PresenceRecorder   presence.Recorder
 	Clock              clock.Clock
 	LocalHub           *pubsub.SimpleHub
+	CentralHub         *pubsub.StructuredHub
 	LeaseFSM           *raftlease.FSM
 
 	NewSocketName func(names.Tag) string
@@ -71,7 +72,8 @@ func StartIntrospection(cfg IntrospectionConfig) error {
 		PrometheusGatherer: cfg.PrometheusGatherer,
 		Presence:           cfg.PresenceRecorder,
 		Clock:              cfg.Clock,
-		Hub:                cfg.LocalHub,
+		LocalHub:           cfg.LocalHub,
+		CentralHub:         cfg.CentralHub,
 		Leases:             cfg.LeaseFSM,
 	})
 	if err != nil {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -623,6 +623,7 @@ func (a *MachineAgent) makeEngineCreator(
 			WorkerFunc:         introspection.NewWorker,
 			Clock:              clock.WallClock,
 			LocalHub:           localHub,
+			CentralHub:         a.centralHub,
 			LeaseFSM:           manifoldsCfg.LeaseFSM,
 		}); err != nil {
 			// If the introspection worker failed to start, we just log error

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/pubsub/lease"
 	"github.com/juju/juju/state"
 	proxyconfig "github.com/juju/juju/utils/proxy"
 	jworker "github.com/juju/juju/worker"
@@ -101,10 +102,6 @@ const (
 	// globalClockUpdaterUpdateInterval is the interval between
 	// global clock updates.
 	globalClockUpdaterUpdateInterval = 1 * time.Second
-
-	// leaseRequestTopic is the pubsub topic that lease FSM updates
-	// will be published on.
-	leaseRequestTopic = "lease.request"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
@@ -795,7 +792,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			RaftName:             raftName,
 			StateName:            stateName,
 			CentralHubName:       centralHubName,
-			RequestTopic:         leaseRequestTopic,
+			RequestTopic:         lease.LeaseRequestTopic,
 			Logger:               loggo.GetLogger("juju.worker.raft.raftforwarder"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            raftforwarder.NewWorker,
@@ -810,7 +807,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			CentralHubName:       centralHubName,
 			StateName:            stateName,
 			FSM:                  config.LeaseFSM,
-			RequestTopic:         leaseRequestTopic,
+			RequestTopic:         lease.LeaseRequestTopic,
 			Logger:               loggo.GetLogger("juju.worker.lease.raft"),
 			LogDir:               agentConfig.LogDir(),
 			PrometheusRegisterer: config.PrometheusRegisterer,

--- a/pubsub/lease/messages.go
+++ b/pubsub/lease/messages.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lease
+
+const (
+	// LeaseRequestTopic is the pubsub topic that lease FSM updates
+	// will be published on.
+	LeaseRequestTopic = "lease.request"
+)

--- a/worker/introspection/leases.go
+++ b/worker/introspection/leases.go
@@ -5,36 +5,48 @@ package introspection
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
+
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/raftlease"
-	"gopkg.in/yaml.v2"
 )
 
 type leaseHandler struct {
 	leases Leases
+	hub    StructuredHub
+	clock  Clock
+
+	runID     int32
+	requestID uint64
 }
 
-// ServeHTTP is part of the http.Handler interface.
-func (h leaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *leaseHandler) snapshot() (*raftlease.Snapshot, error) {
 	ss, err := h.leases.Snapshot()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "error: %v\n", err)
-		return
+		return nil, errors.Annotate(err, "snapshot")
 	}
 	snapshot, ok := ss.(*raftlease.Snapshot)
 	if !ok {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "expected *raftlease.Snapshot\n")
-		return
+		return nil, errors.New("expected *raftlease.Snapshot")
 	}
 	if snapshot.Version != 1 {
+		return nil, errors.New("only understand how to show version 1 snapshots")
+	}
+	return snapshot, nil
+}
+
+func (h *leaseHandler) list(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := h.snapshot()
+	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "only understand how to show version 1 snapshots\n")
+		fmt.Fprintln(w, err.Error())
 		return
 	}
 
@@ -73,7 +85,7 @@ type leaseInfo struct {
 	expires  time.Duration
 }
 
-func (h leaseHandler) translateSnapshot(snapshot *raftlease.Snapshot) *leases {
+func (h *leaseHandler) translateSnapshot(snapshot *raftlease.Snapshot) *leases {
 	result := &leases{
 		controller: make(map[string]leaseInfo),
 		models:     make(map[string]map[string]leaseInfo),
@@ -110,7 +122,7 @@ func (h leaseHandler) translateSnapshot(snapshot *raftlease.Snapshot) *leases {
 	return result
 }
 
-func (h leaseHandler) filterModel(data *leases, partialModelUUID string) *leases {
+func (h *leaseHandler) filterModel(data *leases, partialModelUUID string) *leases {
 	result := &leases{
 		controller: make(map[string]leaseInfo),
 		models:     make(map[string]map[string]leaseInfo),
@@ -129,7 +141,7 @@ func (h leaseHandler) filterModel(data *leases, partialModelUUID string) *leases
 	return result
 }
 
-func (h leaseHandler) filterApp(data *leases, partialAppNames []string) *leases {
+func (h *leaseHandler) filterApp(data *leases, partialAppNames []string) *leases {
 	result := &leases{
 		models: make(map[string]map[string]leaseInfo),
 	}
@@ -152,7 +164,7 @@ func (h leaseHandler) filterApp(data *leases, partialAppNames []string) *leases 
 	return result
 }
 
-func (h leaseHandler) format(leases *leases) map[string]interface{} {
+func (h *leaseHandler) format(leases *leases) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	// Since we are just making a map for YAML to output, we don't
@@ -186,4 +198,139 @@ func (h leaseHandler) format(leases *leases) map[string]interface{} {
 		result["model-leases"] = models
 	}
 	return result
+}
+
+// ServeHTTP is part of the http.Handler interface.
+func (h *leaseHandler) revoke(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprintln(w, "revoking a lease requires a POST request")
+		return
+	}
+
+	leaseKey, err := h.parseRevokeForm(r)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(w, err.Error())
+		return
+	}
+
+	snapshot, err := h.snapshot()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err.Error())
+		return
+	}
+
+	holder, ok := snapshot.Entries[leaseKey]
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		if leaseKey.Namespace == lease.SingularControllerNamespace {
+			fmt.Fprintf(w, "singular lease for model %q not found\n", leaseKey.ModelUUID)
+		} else {
+			fmt.Fprintf(w, "application lease for model %q and app %q not found\n", leaseKey.ModelUUID, leaseKey.Lease)
+		}
+		return
+	}
+
+	if err := h.revokeLeadership(leaseKey, holder.Holder); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err.Error())
+		return
+	}
+
+	if leaseKey.Namespace == lease.SingularControllerNamespace {
+		fmt.Fprintf(w, "singular lease for model %q revoked\n", leaseKey.ModelUUID)
+	} else {
+		fmt.Fprintf(w, "application lease for model %q and app %q revoked\n", leaseKey.ModelUUID, leaseKey.Lease)
+	}
+}
+
+func (h *leaseHandler) revokeLeadership(key raftlease.SnapshotKey, holder string) error {
+	command := &raftlease.Command{
+		Version:   raftlease.CommandVersion,
+		Operation: raftlease.OperationRevoke,
+		Namespace: key.Namespace,
+		ModelUUID: key.ModelUUID,
+		Lease:     key.Lease,
+		Holder:    holder,
+	}
+
+	bytes, err := command.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if h.runID == 0 {
+		source := rand.NewSource(h.clock.Now().UnixNano())
+		h.runID = rand.New(source).Int31()
+	}
+
+	// TODO(wallyworld): this should really be in a shared messages.go file under
+	// the top level pubsub package.
+	leaseRequestTopic := "lease.request"
+	requestID := atomic.AddUint64(&h.requestID, 1)
+	responseTopic := fmt.Sprintf("%s.%08x.%d", leaseRequestTopic, h.runID, requestID)
+
+	responseChan := make(chan raftlease.ForwardResponse, 1)
+	errChan := make(chan error)
+	unsubscribe, err := h.hub.Subscribe(
+		responseTopic,
+		func(_ string, resp raftlease.ForwardResponse, err error) {
+			if err != nil {
+				errChan <- err
+				return
+			}
+			responseChan <- resp
+		},
+	)
+	if err != nil {
+		return errors.Annotatef(err, "running %s", command)
+	}
+	defer unsubscribe()
+
+	_, err = h.hub.Publish(leaseRequestTopic, raftlease.ForwardRequest{
+		Command:       string(bytes),
+		ResponseTopic: responseTopic,
+	})
+	if err != nil {
+		return errors.Annotatef(err, "publishing %s", command)
+	}
+
+	select {
+	case <-h.clock.After(15 * time.Second):
+		return lease.ErrTimeout
+	case err := <-errChan:
+		return errors.Trace(err)
+	case response := <-responseChan:
+		return raftlease.RecoverError(response.Error)
+	}
+}
+
+func (h *leaseHandler) parseRevokeForm(r *http.Request) (raftlease.SnapshotKey, error) {
+	var result raftlease.SnapshotKey
+	if err := r.ParseForm(); err != nil {
+		return result, errors.Annotate(err, "parse form")
+	}
+
+	result.ModelUUID = r.Form.Get("model")
+	if result.ModelUUID == "" {
+		return result, errors.New("missing model")
+	}
+	result.Lease = r.Form.Get("lease")
+	// Default namespace to application, unless overridden.
+	result.Namespace = lease.ApplicationLeadershipNamespace
+	switch ns := r.Form.Get("ns"); ns {
+	case lease.SingularControllerNamespace:
+		result.Namespace = ns
+		result.Lease = result.ModelUUID
+	case "", lease.ApplicationLeadershipNamespace:
+		if result.Lease == "" {
+			return result, errors.New("missing lease")
+		}
+	default:
+		return result, errors.Errorf("unknown namespace: %q\n", ns)
+	}
+
+	return result, nil
 }

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -174,6 +174,41 @@ juju_leases () {
   fi
 }
 
+juju_revoke_lease () {
+  # This requires some arguments.
+  local model
+  local lease
+  local ns
+
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+
+    case $key in
+      -m|--model)
+        model="$2"; shift; shift
+      ;;
+      -n|--ns)
+        ns="$2"; shift; shift
+      ;;
+      -l|--lease)
+        lease="$2"; shift; shift
+      ;;
+      *)
+        echo "usage: juju_revoke_lease -m <model-uuid> -l <lease> [-n <namespace>]"
+        return 1
+      ;;
+    esac
+  done
+
+  if [ -z "$model" ] | [ -z "$lease" ]; then
+    echo "usage: juju_revoke_lease -m <model-uuid> -l <lease> [-n <namespace>]"
+    return 1
+  fi  
+
+  juju_agent --post leases/revoke model="$model" lease="$lease" ns="$ns"
+}
+
 
 # This asks for the command of the current pid.
 # Can't use $0 nor $SHELL due to this being wrong in various situations.
@@ -197,5 +232,7 @@ if [ "$shell" = "bash" ]; then
   export -f juju_unit_status
   export -f juju_start_unit
   export -f juju_stop_unit
+  export -f juju_leases
+  export -f juju_revoke_lease
 fi
 `

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -44,13 +44,21 @@ type Reporter interface {
 
 // Clock represents the ability to wait for a bit.
 type Clock interface {
+	Now() time.Time
 	After(time.Duration) <-chan time.Time
 }
 
-// Hub is a pubsub hub used for internal messaging.
-type Hub interface {
+// SimpleHub is a pubsub hub used for internal messaging.
+type SimpleHub interface {
 	Publish(topic string, data interface{}) <-chan struct{}
 	Subscribe(topic string, handler func(string, interface{})) func()
+}
+
+// StructuredHub is a pubsub hub used for messaging within the HA
+// controller applications.
+type StructuredHub interface {
+	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Subscribe(topic string, handler interface{}) (func(), error)
 }
 
 // Leases provides the methods needed to expose the lease internals.
@@ -68,7 +76,8 @@ type Config struct {
 	PrometheusGatherer prometheus.Gatherer
 	Presence           presence.Recorder
 	Clock              Clock
-	Hub                Hub
+	LocalHub           SimpleHub
+	CentralHub         StructuredHub
 	Leases             Leases
 }
 
@@ -95,7 +104,8 @@ type socketListener struct {
 	presence           presence.Recorder
 	leases             Leases
 	clock              Clock
-	hub                Hub
+	localHub           SimpleHub
+	centralHub         StructuredHub
 	done               chan struct{}
 }
 
@@ -131,7 +141,8 @@ func NewWorker(config Config) (worker.Worker, error) {
 		presence:           config.Presence,
 		leases:             config.Leases,
 		clock:              config.Clock,
-		hub:                config.Hub,
+		localHub:           config.LocalHub,
+		centralHub:         config.CentralHub,
 		done:               make(chan struct{}),
 	}
 	go w.serve()
@@ -202,10 +213,18 @@ func (w *socketListener) RegisterHTTPHandlers(
 		handle("/presence", presenceHandler{w.presence})
 	}
 	handle("/machinelock", machineLockHandler{w.machineLock})
-	if w.hub != nil {
-		handle("/units", unitsHandler{w.clock, w.hub, w.done})
+	if w.localHub != nil {
+		handle("/units", unitsHandler{w.clock, w.localHub, w.done})
 	}
-	handle("/leases", leaseHandler{w.leases})
+	leases := leaseHandler{
+		leases: w.leases,
+		hub:    w.centralHub,
+		clock:  w.clock,
+	}
+	handle("/leases", http.HandlerFunc(leases.list))
+	if w.centralHub != nil {
+		handle("/leases/revoke", http.HandlerFunc(leases.revoke))
+	}
 }
 
 type depengineHandler struct {
@@ -342,7 +361,7 @@ func (a ValueSort) Less(i, j int) bool {
 
 type unitsHandler struct {
 	clock Clock
-	hub   Hub
+	hub   SimpleHub
 	done  <-chan struct{}
 }
 

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -234,14 +234,12 @@ type depengineHandler struct {
 // ServeHTTP is part of the http.Handler interface.
 func (h depengineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.reporter == nil {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, "missing dependency engine reporter")
+		http.Error(w, "missing dependency engine reporter", http.StatusNotFound)
 		return
 	}
 	bytes, err := yaml.Marshal(h.reporter.Report())
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "error: %v\n", err)
+		http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 		return
 	}
 
@@ -258,8 +256,7 @@ type machineLockHandler struct {
 // ServeHTTP is part of the http.Handler interface.
 func (h machineLockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.lock == nil {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, "missing machine lock reporter")
+		http.Error(w, "missing machine lock reporter", http.StatusNotFound)
 		return
 	}
 	var args []machinelock.ReportOption
@@ -276,8 +273,7 @@ func (h machineLockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	content, err := h.lock.Report(args...)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "error: %v\n", err)
+		http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 		return
 	}
 
@@ -293,8 +289,7 @@ type introspectionReporterHandler struct {
 // ServeHTTP is part of the http.Handler interface.
 func (h introspectionReporterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.reporter == nil {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, "%s: missing reporter\n", h.name)
+		http.Error(w, fmt.Sprintf("%s: missing reporter", h.name), http.StatusNotFound)
 		return
 	}
 
@@ -311,8 +306,7 @@ type presenceHandler struct {
 // ServeHTTP is part of the http.Handler interface.
 func (h presenceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.presence == nil || !h.presence.IsEnabled() {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("agent is not an apiserver\n"))
+		http.Error(w, "agent is not an apiserver", http.StatusNotFound)
 		return
 	}
 
@@ -368,15 +362,13 @@ type unitsHandler struct {
 // ServeHTTP is part of the http.Handler interface.
 func (h unitsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "%s\n", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	switch action := r.Form.Get("action"); action {
 	case "":
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, "missing action")
+		http.Error(w, "missing action", http.StatusBadRequest)
 	case "start":
 		h.publishUnitsAction(w, r, "start", agent.StartUnitTopic, agent.StartUnitResponseTopic)
 	case "stop":
@@ -384,23 +376,20 @@ func (h unitsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "status":
 		h.status(w, r)
 	default:
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "unknown action: %q\n", action)
+		http.Error(w, fmt.Sprintf("unknown action: %q", action), http.StatusBadRequest)
 	}
 }
 
 func (h unitsHandler) publishUnitsAction(w http.ResponseWriter, r *http.Request,
 	action, topic, responseTopic string) {
 	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		fmt.Fprintf(w, "%s requires a POST request\n", action)
+		http.Error(w, fmt.Sprintf("%s requires a POST request, got %q", action, r.Method), http.StatusMethodNotAllowed)
 		return
 	}
 
 	units := r.Form["unit"]
 	if len(units) == 0 {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, "missing unit")
+		http.Error(w, "missing unit", http.StatusBadRequest)
 		return
 	}
 
@@ -427,16 +416,14 @@ func (h unitsHandler) publishAndAwaitResponse(w http.ResponseWriter, topic, resp
 	case message := <-response:
 		bytes, err := yaml.Marshal(message)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "error: %v\n", err)
+			http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 			return
 		}
 		w.Write(bytes)
 	case <-h.done:
-		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprintln(w, "introspection worker stopping")
+		http.Error(w, "introspection worker stopping", http.StatusServiceUnavailable)
 	case <-h.clock.After(10 * time.Second):
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, "response timed out")
+		http.Error(w, "response timed out", http.StatusInternalServerError)
+
 	}
 }

--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -281,7 +281,7 @@ func (s *introspectionSuite) TestUnitUnknownAction(c *gc.C) {
 func (s *introspectionSuite) TestUnitStartWithGet(c *gc.C) {
 	response := s.call(c, "/units?action=start")
 	c.Assert(response.StatusCode, gc.Equals, http.StatusMethodNotAllowed)
-	s.assertBody(c, response, "start requires a POST request")
+	s.assertBody(c, response, `start requires a POST request, got "GET"`)
 }
 
 func (s *introspectionSuite) TestUnitStartMissingUnits(c *gc.C) {
@@ -312,7 +312,7 @@ func (s *introspectionSuite) TestUnitStartUnits(c *gc.C) {
 func (s *introspectionSuite) TestUnitStopWithGet(c *gc.C) {
 	response := s.call(c, "/units?action=stop")
 	c.Assert(response.StatusCode, gc.Equals, http.StatusMethodNotAllowed)
-	s.assertBody(c, response, "stop requires a POST request")
+	s.assertBody(c, response, `stop requires a POST request, got "GET"`)
 }
 
 func (s *introspectionSuite) TestUnitStopMissingUnits(c *gc.C) {
@@ -561,7 +561,7 @@ func (s *introspectionSuite) TestRevokeLeaseMissingModel(c *gc.C) {
 
 	response := s.post(c, "/leases/revoke", url.Values{"lease": {"mysql"}})
 	c.Assert(response.StatusCode, gc.Equals, http.StatusBadRequest)
-	s.assertBody(c, response, `missing model`)
+	s.assertBody(c, response, `missing model uuid`)
 }
 
 func (s *introspectionSuite) setLeaseData() {

--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -63,14 +63,15 @@ func (s *suite) TestStartStop(c *gc.C) {
 type introspectionSuite struct {
 	testing.IsolationSuite
 
-	name     string
-	worker   worker.Worker
-	reporter introspection.DepEngineReporter
-	gatherer prometheus.Gatherer
-	recorder presence.Recorder
-	hub      *pubsub.SimpleHub
-	clock    *testclock.Clock
-	leases   *fakeLeases
+	name       string
+	worker     worker.Worker
+	reporter   introspection.DepEngineReporter
+	gatherer   prometheus.Gatherer
+	recorder   presence.Recorder
+	localHub   *pubsub.SimpleHub
+	centralHub introspection.StructuredHub
+	clock      *testclock.Clock
+	leases     *fakeLeases
 }
 
 var _ = gc.Suite(&introspectionSuite{})
@@ -84,7 +85,8 @@ func (s *introspectionSuite) SetUpTest(c *gc.C) {
 	s.worker = nil
 	s.recorder = nil
 	s.gatherer = newPrometheusGatherer()
-	s.hub = pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{Logger: loggo.GetLogger("test.hub")})
+	s.localHub = pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{Logger: loggo.GetLogger("test.localhub")})
+	s.centralHub = pubsub.NewStructuredHub(&pubsub.StructuredHubConfig{Logger: loggo.GetLogger("test.centralhub")})
 	s.clock = testclock.NewClock(time.Now())
 	s.leases = &fakeLeases{}
 	s.startWorker(c)
@@ -98,7 +100,8 @@ func (s *introspectionSuite) startWorker(c *gc.C) {
 		PrometheusGatherer: s.gatherer,
 		Presence:           s.recorder,
 		Clock:              s.clock,
-		Hub:                s.hub,
+		LocalHub:           s.localHub,
+		CentralHub:         s.centralHub,
 		Leases:             s.leases,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -288,13 +291,13 @@ func (s *introspectionSuite) TestUnitStartMissingUnits(c *gc.C) {
 }
 
 func (s *introspectionSuite) TestUnitStartUnits(c *gc.C) {
-	unsub := s.hub.Subscribe(agent.StartUnitTopic, func(topic string, data interface{}) {
+	unsub := s.localHub.Subscribe(agent.StartUnitTopic, func(topic string, data interface{}) {
 		_, ok := data.(agent.Units)
 		if !ok {
 			c.Fatalf("bad data type: %T", data)
 			return
 		}
-		s.hub.Publish(agent.StartUnitResponseTopic, agent.StartStopResponse{
+		s.localHub.Publish(agent.StartUnitResponseTopic, agent.StartStopResponse{
 			"one": "started",
 			"two": "not found",
 		})
@@ -319,13 +322,13 @@ func (s *introspectionSuite) TestUnitStopMissingUnits(c *gc.C) {
 }
 
 func (s *introspectionSuite) TestUnitStopUnits(c *gc.C) {
-	unsub := s.hub.Subscribe(agent.StopUnitTopic, func(topic string, data interface{}) {
+	unsub := s.localHub.Subscribe(agent.StopUnitTopic, func(topic string, data interface{}) {
 		_, ok := data.(agent.Units)
 		if !ok {
 			c.Fatalf("bad data type: %T", data)
 			return
 		}
-		s.hub.Publish(agent.StopUnitResponseTopic, agent.StartStopResponse{
+		s.localHub.Publish(agent.StopUnitResponseTopic, agent.StartStopResponse{
 			"one": "stopped",
 			"two": "not found",
 		})
@@ -338,8 +341,8 @@ func (s *introspectionSuite) TestUnitStopUnits(c *gc.C) {
 }
 
 func (s *introspectionSuite) TestUnitStatus(c *gc.C) {
-	unsub := s.hub.Subscribe(agent.UnitStatusTopic, func(string, interface{}) {
-		s.hub.Publish(agent.UnitStatusResponseTopic, agent.Status{
+	unsub := s.localHub.Subscribe(agent.UnitStatusTopic, func(string, interface{}) {
+		s.localHub.Publish(agent.UnitStatusResponseTopic, agent.Status{
 			"one": "running",
 			"two": "stopped",
 		})
@@ -354,7 +357,7 @@ two: stopped`[1:])
 }
 
 func (s *introspectionSuite) TestUnitStatusTimeout(c *gc.C) {
-	unsub := s.hub.Subscribe(agent.UnitStatusTopic, func(string, interface{}) {
+	unsub := s.localHub.Subscribe(agent.UnitStatusTopic, func(string, interface{}) {
 		s.clock.WaitAdvance(10*time.Second, time.Second, 1)
 	})
 	defer unsub()
@@ -368,7 +371,7 @@ func (s *introspectionSuite) TestLeasesErr(c *gc.C) {
 	s.leases.err = errors.New("boom")
 	response := s.call(c, "/leases")
 	c.Assert(response.StatusCode, gc.Equals, http.StatusInternalServerError)
-	s.assertBody(c, response, "error: boom")
+	s.assertBody(c, response, "snapshot: boom")
 }
 
 func (s *introspectionSuite) TestLeasesNewerVersion(c *gc.C) {
@@ -470,6 +473,95 @@ model-leases:
       holder: wordpress/1
       lease-acquired: 10s ago
       lease-expires: 50s`[1:])
+}
+
+func (s *introspectionSuite) TestRevokeApplicationLease(c *gc.C) {
+	s.assertRevokeLease(c, "")
+	s.assertRevokeLease(c, "application-leadership")
+}
+
+func (s *introspectionSuite) assertRevokeLease(c *gc.C, ns string) {
+	s.setLeaseData()
+	unsub, err := s.centralHub.Subscribe("lease.request", func(topic string, data map[string]interface{}) {
+		responseTopic, _ := data["ResponseTopic"].(string)
+		c.Assert(strings.HasPrefix(responseTopic, "lease.request"), jc.IsTrue)
+		delete(data, "ResponseTopic")
+		c.Assert(data, gc.DeepEquals, map[string]interface{}{
+			"Command": `
+version: 1
+operation: revoke
+namespace: application-leadership
+model-uuid: some-uuid
+lease: mysql
+holder: mysql/0
+`[1:],
+		})
+		_, err := s.centralHub.Publish(responseTopic, raftlease.ForwardResponse{
+			Error: nil,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer unsub()
+
+	response := s.post(c, "/leases/revoke", url.Values{"model": {"some-uuid"}, "lease": {"mysql"}, "ns": {ns}})
+	c.Assert(response.StatusCode, gc.Equals, http.StatusOK)
+	s.assertBody(c, response, `application lease for model "some-uuid" and app "mysql" revoked`)
+}
+
+func (s *introspectionSuite) TestRevokeControllerLease(c *gc.C) {
+	s.setLeaseData()
+	unsub, err := s.centralHub.Subscribe("lease.request", func(topic string, data map[string]interface{}) {
+		responseTopic, _ := data["ResponseTopic"].(string)
+		c.Assert(strings.HasPrefix(responseTopic, "lease.request"), jc.IsTrue)
+		delete(data, "ResponseTopic")
+		c.Assert(data, gc.DeepEquals, map[string]interface{}{
+			"Command": `
+version: 1
+operation: revoke
+namespace: singular-controller
+model-uuid: some-uuid
+lease: some-uuid
+holder: controller-0
+`[1:],
+		})
+		_, err := s.centralHub.Publish(responseTopic, raftlease.ForwardResponse{
+			Error: nil,
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer unsub()
+
+	response := s.post(c, "/leases/revoke", url.Values{"model": {"some-uuid"}, "lease": {"some-uuid"}, "ns": {"singular-controller"}})
+	c.Assert(response.StatusCode, gc.Equals, http.StatusOK)
+	s.assertBody(c, response, `singular lease for model "some-uuid" revoked`)
+}
+
+func (s *introspectionSuite) TestRevokeLeaseBadApp(c *gc.C) {
+	s.setLeaseData()
+	unsub, err := s.centralHub.Subscribe("lease.request", func(topic string, data map[string]interface{}) {
+		c.Fail()
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer unsub()
+
+	response := s.post(c, "/leases/revoke", url.Values{"model": {"some-uuid"}, "lease": {"mariadb"}})
+	c.Assert(response.StatusCode, gc.Equals, http.StatusBadRequest)
+	s.assertBody(c, response, `application lease for model "some-uuid" and app "mariadb" not found`)
+}
+
+func (s *introspectionSuite) TestRevokeLeaseMissingModel(c *gc.C) {
+	s.setLeaseData()
+	unsub, err := s.centralHub.Subscribe("lease.request", func(topic string, data map[string]interface{}) {
+		c.Fail()
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer unsub()
+
+	response := s.post(c, "/leases/revoke", url.Values{"lease": {"mysql"}})
+	c.Assert(response.StatusCode, gc.Equals, http.StatusBadRequest)
+	s.assertBody(c, response, `missing model`)
 }
 
 func (s *introspectionSuite) setLeaseData() {


### PR DESCRIPTION
PR #11905 started the work to add an introspection endpoint to support lease revocation.
This PR adds tests and updates the bash script to use the endpoint.

## QA steps

bootstrap and deploy some units
ssh to the controller
$ juju_leases will show the current leases
revoke a lease:
$ juju_revoke_lease -m modeluuid -l appname
$ juju_leases will show the lease get allocated to a new unit
