### PR TITLE
complete charm origin data for previously uploaded charmhub charms

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -260,7 +260,11 @@ func (a *API) addCharmWithAuthorization(args params.AddCharmWithAuth) (params.Ch
 		return params.CharmOriginResult{}, errors.Trace(err)
 	} else if alreadyExists {
 		// Nothing to do here, as it already exists in state.
-		return params.CharmOriginResult{}, nil
+		// However we still need the origin with ID and hash for
+		// CharmHub charms.
+		return params.CharmOriginResult{
+			Origin: convertOrigin(origin),
+		}, nil
 	}
 
 	ca := CharmArchive{

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -348,7 +348,7 @@ func (s *charmsMockSuite) TestAddCharmAlreadyExists(c *gc.C) {
 	}
 	obtained, err := api.AddCharm(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtained, gc.DeepEquals, params.CharmOriginResult{})
+	c.Assert(obtained, gc.DeepEquals, params.CharmOriginResult{Origin: params.CharmOrigin{Source: "charm-store"}})
 }
 
 func (s *charmsMockSuite) TestAddCharmWithAuthorization(c *gc.C) {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -419,7 +419,6 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		return errors.Trace(err)
 	}
 	c.origin = origin
-
 	if err := c.validateCharmFlags(); err != nil {
 		return errors.Trace(err)
 	}
@@ -484,13 +483,13 @@ func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	ctx.Infof("Deploying charm %q.", formattedCharmURL)
+	c.series = series
+	c.csMac = csMac
+	c.origin = csOrigin
 	c.id = application.CharmID{
 		URL:    curl,
 		Origin: c.origin,
 	}
-	c.series = series
-	c.csMac = csMac
-	c.origin = csOrigin
 	return c.deploy(ctx, deployAPI)
 }
 

--- a/core/charm/strategies_mock_test.go
+++ b/core/charm/strategies_mock_test.go
@@ -246,6 +246,21 @@ func (mr *MockStoreMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockStore)(nil).Download), arg0, arg1, arg2)
 }
 
+// DownloadOrigin mocks base method
+func (m *MockStore) DownloadOrigin(arg0 *charm.URL, arg1 Origin) (Origin, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadOrigin", arg0, arg1)
+	ret0, _ := ret[0].(Origin)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DownloadOrigin indicates an expected call of DownloadOrigin
+func (mr *MockStoreMockRecorder) DownloadOrigin(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadOrigin", reflect.TypeOf((*MockStore)(nil).DownloadOrigin), arg0, arg1)
+}
+
 // Validate mocks base method
 func (m *MockStore) Validate(arg0 *charm.URL) error {
 	m.ctrl.T.Helper()

--- a/core/charm/strategies_test.go
+++ b/core/charm/strategies_test.go
@@ -87,6 +87,11 @@ func (s strategySuite) TestRunWithCharmAlreadyUploaded(c *gc.C) {
 	curl := charm.MustParseURL("cs:redis-0")
 
 	mockStore := NewMockStore(ctrl)
+	mockStore.EXPECT().DownloadOrigin(curl, gomock.AssignableToTypeOf(Origin{})).DoAndReturn(
+		func(curl *charm.URL, origin Origin) (Origin, error) {
+			return origin, nil
+		},
+	)
 	mockVersionValidator := NewMockJujuVersionValidator(ctrl)
 
 	mockStateCharm := NewMockStateCharm(ctrl)
@@ -100,9 +105,10 @@ func (s strategySuite) TestRunWithCharmAlreadyUploaded(c *gc.C) {
 		store:    mockStore,
 		logger:   &fakeLogger{},
 	}
-	_, alreadyExists, _, err := strategy.Run(mockState, mockVersionValidator, Origin{})
+	_, alreadyExists, obtainedOrigin, err := strategy.Run(mockState, mockVersionValidator, Origin{Source: CharmHub})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(alreadyExists, jc.IsTrue)
+	c.Assert(obtainedOrigin, jc.DeepEquals, Origin{Source: CharmHub})
 }
 
 func (s strategySuite) TestRunWithPrepareUploadError(c *gc.C) {


### PR DESCRIPTION
Previously uploaded charmhub charms, require the full charm-origin data to be put in their applications to enable refresh (upgrade-charm).  

Drive by for a small fix in the deploy code noticed during investigation.

## QA steps

QA is difficult here as we have no charms which can be refreshed charmhub currently.

```console
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju bootstrap localhost testme
$ juju add-model three --config charm-hub-url="https://api.staging.snapcraft.io"

# 
# setup, run a 2nd time with the charm store version of ubuntu.
# 
$ juju deploy ubuntu
Located charm "ubuntu-17".
Deploying charm "ubuntu-17".
$ juju deploy ubuntu ubuntu-test
Located charm "ubuntu-17".
Deploying charm "ubuntu-17".

# 
# Verify the charm origins in the db, both applications should have the same charm-origin data.
#
$ juju-db.bash
juju:PRIMARY> db.applications.find({},{"name":1,"charmurl":1,"charm-origin":1}).pretty()
{
	"_id" : "8148f84d-285b-4467-8c0f-ba21795f7956:ubuntu",
	"name" : "ubuntu",
	"charmurl" : "ubuntu-17",
	"charm-origin" : {
		"source" : "charm-hub",
		"id" : "9NT4sM1gdNLkBPuXbxNu2IusUosDcmR9",
		"hash" : "e0a16ee2c880fe0a1942f48602377e5861d745c66f7523a0113726eb0dde7a0e",
		"revision" : 17,
		"channel" : {
			"risk" : "stable"
		}
	}
}
{
	"_id" : "8148f84d-285b-4467-8c0f-ba21795f7956:ubuntu-test",
	"name" : "ubuntu-test",
	"charmurl" : "ubuntu-17",
	"charm-origin" : {
		"source" : "charm-hub",
		"id" : "9NT4sM1gdNLkBPuXbxNu2IusUosDcmR9",
		"hash" : "e0a16ee2c880fe0a1942f48602377e5861d745c66f7523a0113726eb0dde7a0e",
		"revision" : 17,
		"channel" : {
			"risk" : "stable"
		}
	}
}
```


