### PR TITLE
Allow that remote LXD servers may not have a local cert

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -202,16 +202,20 @@ func (p environProviderCredentials) detectRemoteCredentials(certPEM, keyPEM []by
 	for name, remote := range config.Remotes {
 		if remote.Protocol == lxdnames.ProviderType {
 			certPath := filepath.Join(configDir, "servercerts", fmt.Sprintf("%s.crt", name))
-			serverCert, err := p.lxcConfigReader.ReadCert(certPath)
-			if err != nil {
-				logger.Errorf("unable to read certificate from %s with error %s", certPath, err)
-				continue
-			}
-			credential := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{
+			authConfig := map[string]string{
 				credAttrClientCert: string(certPEM),
 				credAttrClientKey:  string(keyPEM),
-				credAttrServerCert: string(serverCert),
-			})
+			}
+			serverCert, err := p.lxcConfigReader.ReadCert(certPath)
+			if err != nil {
+				if !os.IsNotExist(errors.Cause(err)) {
+					logger.Errorf("unable to read certificate from %s with error %s", certPath, err)
+					continue
+				}
+			} else {
+				authConfig[credAttrServerCert] = string(serverCert)
+			}
+			credential := cloud.NewCredential(cloud.CertificateAuthType, authConfig)
 			credential.Label = fmt.Sprintf("LXD credential %q", name)
 			credentials[name] = credential
 		}

--- a/provider/lxd/credentials_test.go
+++ b/provider/lxd/credentials_test.go
@@ -208,6 +208,58 @@ func (s *credentialsSuite) TestRemoteDetectCredentials(c *gc.C) {
 	})
 }
 
+func (s *credentialsSuite) TestRemoteDetectCredentialsNoRemoteCert(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	deps := s.createProvider(ctrl)
+	s.setupLocalhost(deps, c)
+
+	deps.configReader.EXPECT().ReadConfig(".config/lxc/config.yml").Return(lxd.LXCConfig{
+		DefaultRemote: "localhost",
+		Remotes: map[string]lxd.LXCRemoteConfig{
+			"nuc1": {
+				Addr:     "https://10.0.0.1:8443",
+				AuthType: "certificate",
+				Protocol: "lxd",
+				Public:   false,
+			},
+		},
+	}, nil)
+	deps.configReader.EXPECT().ReadCert(".config/lxc/servercerts/nuc1.crt").Return(nil, os.ErrNotExist)
+	deps.server.EXPECT().GetCertificate(s.clientCertFingerprint(c)).Return(nil, "", nil)
+	deps.server.EXPECT().ServerCertificate().Return(coretesting.ServerCert)
+
+	credentials, err := deps.provider.DetectCredentials()
+	c.Assert(err, jc.ErrorIsNil)
+
+	nuc1Credential := cloud.NewCredential(
+		cloud.CertificateAuthType,
+		map[string]string{
+			"client-cert": coretesting.CACert,
+			"client-key":  coretesting.CAKey,
+		},
+	)
+	nuc1Credential.Label = `LXD credential "nuc1"`
+
+	localCredential := cloud.NewCredential(
+		cloud.CertificateAuthType,
+		map[string]string{
+			"client-cert": coretesting.CACert,
+			"client-key":  coretesting.CAKey,
+			"server-cert": coretesting.ServerCert,
+		},
+	)
+	localCredential.Label = `LXD credential "localhost"`
+
+	c.Assert(credentials, jc.DeepEquals, &cloud.CloudCredential{
+		AuthCredentials: map[string]cloud.Credential{
+			"nuc1":      nuc1Credential,
+			"localhost": localCredential,
+		},
+	})
+}
+
 func (s *credentialsSuite) TestRemoteDetectCredentialsWithConfigFailure(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
#12330 tweaks LXD config handling for remote clusters to allow for the fact that a local certificate may not be needed.
This PR takes that and targets to 2.8 and adds a unit test.

## QA steps

set up a remote lxd cluster with no server cert in ~/.config/lxc
bootstrap to it
(fix also tested by Stephane who did the original PR)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1904491
