### PR TITLE
Allow pod-spec-set to run on a dying application;

### DIFF
--- a/state/podspec_ops.go
+++ b/state/podspec_ops.go
@@ -73,11 +73,8 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "setting pod spec")
 	}
-	if app.Life() != Alive {
-		return nil, errors.Annotate(
-			errors.Errorf("application %s not alive", appName),
-			"setting pod spec",
-		)
+	if app.Life() == Dead {
+		return nil, errors.NotValidf("setting pod-spec on dead application %s", appName)
 	}
 	// The app's charm may not be there yet (as is the case when migrating).
 	// This check is for checking the k8s-spec-set/k8s-raw-set call.
@@ -92,7 +89,7 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 	prereqOps = append(prereqOps, txn.Op{
 		C:      applicationsC,
 		Id:     app.doc.DocID,
-		Assert: isAliveDoc,
+		Assert: notDeadDoc,
 	})
 
 	sop := txn.Op{

--- a/state/podspec_test.go
+++ b/state/podspec_test.go
@@ -86,9 +86,24 @@ func (s *PodSpecSuite) TestSetRawK8sSpecOperationApplicationDying(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
 	err := s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, s.application, state.Dying)
 
 	err = s.applySetRawK8sSpecOperation(nil, s.application.ApplicationTag(), strPtr("foo"))
-	c.Assert(err, gc.ErrorMatches, ".*application gitlab not alive")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertRawK8sSpec(c, s.application.ApplicationTag(), "foo")
+}
+
+func (s *PodSpecSuite) TestSetRawK8sSpecOperationApplicationDead(c *gc.C) {
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
+	err := s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(unit.Remove(), jc.ErrorIsNil)
+	assertCleanupCount(c, s.State, 1)
+	assertLife(c, s.application, state.Dead)
+
+	err = s.applySetRawK8sSpecOperation(nil, s.application.ApplicationTag(), strPtr("foo"))
+	c.Assert(err, gc.ErrorMatches, "setting pod-spec on dead application gitlab not valid")
 	s.assertRawK8sSpecNotFound(c, s.application.ApplicationTag())
 }
 
@@ -136,9 +151,24 @@ func (s *PodSpecSuite) TestSetPodSpecApplicationDying(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
 	err := s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, s.application, state.Dying)
 
 	err = s.Model.SetPodSpec(nil, s.application.ApplicationTag(), strPtr("foo"))
-	c.Assert(err, gc.ErrorMatches, ".*application gitlab not alive")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertPodSpec(c, s.application.ApplicationTag(), "foo")
+}
+
+func (s *PodSpecSuite) TestSetPodSpecApplicationDead(c *gc.C) {
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
+	err := s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(unit.Remove(), jc.ErrorIsNil)
+	assertCleanupCount(c, s.State, 1)
+	assertLife(c, s.application, state.Dead)
+
+	err = s.Model.SetPodSpec(nil, s.application.ApplicationTag(), strPtr("foo"))
+	c.Assert(err, gc.ErrorMatches, "setting pod-spec on dead application gitlab not valid")
 	s.assertPodSpecNotFound(c, s.application.ApplicationTag())
 }
 


### PR DESCRIPTION
*Allow pod-spec-set to run on a dying application;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

No easy way to QA here.


## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1904606
