### PR TITLE
Charmhub find: architecture and series

### DIFF
--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -51,6 +51,7 @@ func convertCharmFindResult(resp params.FindResponse) FindResponse {
 		Publisher: resp.Publisher,
 		Summary:   resp.Summary,
 		Version:   resp.Version,
+		Arches:    resp.Arches,
 		Series:    resp.Series,
 		StoreURL:  resp.StoreURL,
 	}
@@ -143,6 +144,7 @@ type FindResponse struct {
 	Publisher string   `json:"publisher"`
 	Summary   string   `json:"summary"`
 	Version   string   `json:"version"`
+	Arches    []string `json:"architectures,omitempty"`
 	Series    []string `json:"series,omitempty"`
 	StoreURL  string   `json:"store-url"`
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12514,6 +12514,12 @@
                 "FindResponse": {
                     "type": "object",
                     "properties": {
+                        "architectures": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "id": {
                             "type": "string"
                         },
@@ -12550,7 +12556,6 @@
                         "publisher",
                         "summary",
                         "version",
-                        "series",
                         "store-url"
                     ]
                 },

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -42,7 +42,8 @@ type FindResponse struct {
 	Publisher string   `json:"publisher"`
 	Summary   string   `json:"summary"`
 	Version   string   `json:"version"`
-	Series    []string `json:"series"`
+	Arches    []string `json:"architectures,omitempty"`
+	Series    []string `json:"series,omitempty"`
 	StoreURL  string   `json:"store-url"`
 }
 

--- a/cmd/juju/charmhub/find_test.go
+++ b/cmd/juju/charmhub/find_test.go
@@ -38,32 +38,44 @@ func (s *findSuite) TestInitSuccess(c *gc.C) {
 func (s *findSuite) TestRun(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 	s.expectFind()
+
 	command := &findCommand{api: s.api, query: "test"}
-	cmdtesting.InitCommand(command, []string{})
+
+	err := cmdtesting.InitCommand(command, []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
 	ctx := commandContextForTest(c)
-	err := command.Run(ctx)
+	err = command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *findSuite) TestRunJSON(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 	s.expectFind()
+
 	command := &findCommand{api: s.api, query: "test"}
-	cmdtesting.InitCommand(command, []string{"--format", "json"})
-	ctx := commandContextForTest(c)
-	err := command.Run(ctx)
+
+	err := cmdtesting.InitCommand(command, []string{"--format", "json"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"type":"object","id":"charmCHARMcharmCHARMcharmCHARM01","name":"wordpress","publisher":"Wordress Charmers","summary":"WordPress is a full featured web blogging tool, this charm deploys it.","version":"1.0.3","series":["bionic"],"store-url":"https://someurl.com/wordpress"}]
+
+	ctx := commandContextForTest(c)
+	err = command.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `[{"type":"object","id":"charmCHARMcharmCHARMcharmCHARM01","name":"wordpress","publisher":"Wordress Charmers","summary":"WordPress is a full featured web blogging tool, this charm deploys it.","version":"1.0.3","architectures":["all"],"series":["bionic"],"store-url":"https://someurl.com/wordpress"}]
 `)
 }
 
 func (s *findSuite) TestRunYAML(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 	s.expectFind()
+
 	command := &findCommand{api: s.api, query: "test"}
-	cmdtesting.InitCommand(command, []string{"--format", "yaml"})
+
+	err := cmdtesting.InitCommand(command, []string{"--format", "yaml"})
+	c.Assert(err, jc.ErrorIsNil)
+
 	ctx := commandContextForTest(c)
-	err := command.Run(ctx)
+	err = command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 - type: object
@@ -72,6 +84,8 @@ func (s *findSuite) TestRunYAML(c *gc.C) {
   publisher: Wordress Charmers
   summary: WordPress is a full featured web blogging tool, this charm deploys it.
   version: 1.0.3
+  architectures:
+  - all
   series:
   - bionic
   store-url: https://someurl.com/wordpress
@@ -93,6 +107,7 @@ func (s *findSuite) expectFind() {
 		Publisher: "Wordress Charmers",
 		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
 		Version:   "1.0.3",
+		Arches:    []string{"all"},
 		Series:    []string{"bionic"},
 		StoreURL:  "https://someurl.com/wordpress",
 	}}, nil)

--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -31,22 +31,22 @@ type findWriter struct {
 }
 
 func (f findWriter) Print() error {
-
 	buffer := bytes.NewBufferString("")
 
 	tw := output.TabWriter(buffer)
 
-	fmt.Fprintf(tw, "Name\tBundle\tVersion\tSupports\tPublisher\tSummary\n")
+	fmt.Fprintf(tw, "Name\tBundle\tVersion\tArchitectures\tSupports\tPublisher\tSummary\n")
 	for _, result := range f.in {
 		summary, err := oneLine(result.Summary)
 		if err != nil {
 			f.warningf("%v", err)
 		}
 
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			result.Name,
 			f.bundle(result),
 			result.Version,
+			strings.Join(result.Arches, ","),
 			strings.Join(result.Series, ","),
 			result.Publisher,
 			summary,

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -26,9 +26,9 @@ func (s *printFindSuite) TestCharmPrintFind(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `
-Name       Bundle  Version  Supports              Publisher          Summary
-wordpress  -       1.0.3    bionic                Wordress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
-osm        Y       3.2.3    bionic,xenial,trusty  charmed-osm        Single instance OSM bundle.
+Name       Bundle  Version  Architectures  Supports              Publisher          Summary
+wordpress  -       1.0.3    all            bionic                Wordress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
+osm        Y       3.2.3    all            bionic,xenial,trusty  charmed-osm        Single instance OSM bundle.
 
 `[1:]
 	c.Assert(obtained, gc.Equals, expected)
@@ -37,6 +37,7 @@ osm        Y       3.2.3    bionic,xenial,trusty  charmed-osm        Single inst
 func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 	fr := getCharmFindResponse()
 	fr[0].Version = ""
+	fr[0].Arches = make([]string, 0)
 	fr[0].Series = make([]string, 0)
 	fr[0].Summary = ""
 
@@ -47,9 +48,9 @@ func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `
-Name       Bundle  Version  Supports              Publisher          Summary
-wordpress  -                                      Wordress Charmers  
-osm        Y       3.2.3    bionic,xenial,trusty  charmed-osm        Single instance OSM bundle.
+Name       Bundle  Version  Architectures  Supports              Publisher          Summary
+wordpress  -                                                     Wordress Charmers  
+osm        Y       3.2.3    all            bionic,xenial,trusty  charmed-osm        Single instance OSM bundle.
 
 `[1:]
 	c.Assert(obtained, gc.Equals, expected)
@@ -81,6 +82,7 @@ func getCharmFindResponse() []FindResponse {
 		Publisher: "Wordress Charmers",
 		Summary:   "WordPress is a full featured web blogging tool, this charm deploys it.",
 		Version:   "1.0.3",
+		Arches:    []string{"all"},
 		Series:    []string{"bionic"},
 		StoreURL:  "https://someurl.com/wordpress",
 	}, {
@@ -90,6 +92,7 @@ func getCharmFindResponse() []FindResponse {
 		Publisher: "charmed-osm",
 		Summary:   "Single instance OSM bundle.",
 		Version:   "3.2.3",
+		Arches:    []string{"all"},
 		Series:    []string{"bionic", "xenial", "trusty"},
 		StoreURL:  "https://someurl.com/osm",
 	}}


### PR DESCRIPTION
The following brings over architecture and series filtering that has
been bestowed on info. The filtering is done on the client, in the
future this should be done on the server by the API, unfortunately, the
API doesn't provide this filtering.

The changes are rather simple and mirror info. It would be nice to
generalize the filtering, but considering the vastly different types
it's actually quite hard to do so.

----

There is a question about if we should care about the changes to the
API facade. Adding architectures and omitempty on the series for a
facade that nobody uses as it doesn't really work atm.

## QA steps

First, you need to bootstrap and enable the feature flag.

```sh
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju boostrap lxd test
```

#### Test without any flags

```sh
$ juju find ubuntu
Name                     Bundle  Version  Architectures  Supports                                        Publisher     Summary
ubuntu                   -       17       all            artful,bionic,cosmic,disco,focal,trusty,xenial  charmers      A pristine Ubuntu Server
ubuntu-repository-cache  -       24       all            trusty,xenial                                   cloud-images  Ubuntu archive caching proxy mirror
ubuntu-devenv            -       6        all            bionic,trusty,xenial                            kwmonroe      Simple Ubuntu development and test environment
```

#### Test with series

```sh
$ juju find ubuntu --series=bionic
Name           Bundle  Version  Architectures  Supports                                        Publisher  Summary
ubuntu         -       17       all            artful,bionic,cosmic,disco,focal,trusty,xenial  charmers   A pristine Ubuntu Server
ubuntu-devenv  -       6        all            bionic,trusty,xenial                            kwmonroe   Simple Ubuntu development and test environment
```

#### Test with old invalid series

```sh
$ juju find ubuntu --series=eoan
No matching charms for "ubuntu"
```

#### Test with architecture

```sh
$ juju find ubuntu --arch=amd64
Name                     Bundle  Version  Architectures  Supports                                        Publisher     Summary
ubuntu                   -       17       all            artful,bionic,cosmic,disco,focal,trusty,xenial  charmers      A pristine Ubuntu Server
ubuntu-repository-cache  -       24       all            trusty,xenial                                   cloud-images  Ubuntu archive caching proxy mirror
ubuntu-devenv            -       6        all            bionic,trusty,xenial                            kwmonroe      Simple Ubuntu development and test environment
```

#### Test with unsupported architecture

```sh
$ juju find ubuntu --arch=risc
ERROR unexpected architecture flag value "risc", expected <all|amd64|arm64|ppc64|s390>
```
