### PR TITLE
Improve messages around charm deploy and refresh.

### DIFF
--- a/featuretests/cmd_juju_deploy_test.go
+++ b/featuretests/cmd_juju_deploy_test.go
@@ -22,7 +22,7 @@ func (s *cmdDeploySuite) TestLocalDeploySuccess(c *gc.C) {
 	ch := testcharms.Repo.CharmDir("storage-filesystem-subordinate") // has hooks
 	ctx, err := runCommand(c, "deploy", ch.Path, "--series", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Deploying charm "local:bionic/storage-filesystem-subordinate-1"`)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Deploying "storage-filesystem-subordinate" from local charm "storage-filesystem-subordinate", revision 1`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	savedCh, err := s.State.Charm(charm.MustParseURL("local:bionic/storage-filesystem-subordinate-1"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -48,7 +48,7 @@ func (s *cmdDeploySuite) TestLocalDeployLXDProfileSuccess(c *gc.C) {
 	ch := testcharms.Repo.CharmDir("lxd-profile-subordinate") // has hooks
 	ctx, err := runCommand(c, "deploy", ch.Path, "--series", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Deploying charm "local:bionic/lxd-profile-subordinate-0"`)
+	c.Assert(cmdtesting.Stderr(ctx), jc.Contains, `Deploying "lxd-profile-subordinate" from local charm "lxd-profile-subordinate", revision 0`)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	savedCh, err := s.State.Charm(charm.MustParseURL("local:bionic/lxd-profile-subordinate-0"))
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Print out human friendly charm info instead of charm urls with schemas etc. 

## QA steps

```console
# Setup
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost test-pr
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"

# Deploy a charmhub charm
$ juju deploy ubuntu-devenv
Located charm "ubuntu-devenv" in charm-hub, revision 6
Deploying "ubuntu-devenv" from charm-hub charm "ubuntu-devenv", revision 6 in channel latest/stable

# Deploy a charmhub charm, specifying the application name
$ juju deploy ubuntu-devenv testme
Located charm "ubuntu-devenv" in charm-hub, revision 6
Deploying "testme" from charm-hub charm "ubuntu-devenv", revision 6 in channel latest/stable

# Deploy a local charm
$ juju deploy ./testcharms/charm-repo/bionic/lxd-profile
Located local charm "lxd-profile", revision 0
Deploying "heather" from local charm "lxd-profile", revision 0

# Refresh a local charm
$ juju refresh lxd-profile --path ./testcharms/charm-repo/bionic/lxd-profile
Added local charm "lxd-profile", revision 1, to the model
Leaving endpoints in "alpha": another, ubuntu

# Deploy a charmstore charm
$ juju deploy cs:ubuntu-13
Located charm "ubuntu" in charm-store, revision 13
Deploying "ubuntu" from charm-store charm "ubuntu", revision 13 in channel stable

# Refresh a charmstore charm
$ juju refresh ubuntu
Looking up metadata for charm-store charm "ubuntu" from channel stable
Added charm-store charm "ubuntu", revision 16 in channel stable, to the model
```
