### PR TITLE
Do not resolve host-names when determining egress subnets from ingress addresses

### DIFF
--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/network"
 )
@@ -142,10 +143,7 @@ func (w *EgressAddressWatcher) loop() error {
 			}
 			changed = false
 			if !setEquals(addresses, lastAddresses) {
-				addressesCIDR, err = network.FormatAsCIDR(addresses.Values())
-				if err != nil {
-					return errors.Trace(err)
-				}
+				addressesCIDR = corenetwork.SubnetsForAddresses(addresses.Values())
 				ready = ready || sentInitial
 			}
 		}

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -221,15 +221,15 @@ func (n *NetworkInfoBase) pollForAddress(
 	return address, retry.Call(retryArg)
 }
 
-func dedupNetworkInfoResults(info params.NetworkInfoResults) params.NetworkInfoResults {
+func uniqueNetworkInfoResults(info params.NetworkInfoResults) params.NetworkInfoResults {
 	for epName, res := range info.Results {
 		if res.Error != nil {
 			continue
 		}
-		res.IngressAddresses = dedupStringListPreservingOrder(res.IngressAddresses)
-		res.EgressSubnets = dedupStringListPreservingOrder(res.EgressSubnets)
+		res.IngressAddresses = uniqueStringsPreservingOrder(res.IngressAddresses)
+		res.EgressSubnets = uniqueStringsPreservingOrder(res.EgressSubnets)
 		for infoIdx, info := range res.Info {
-			res.Info[infoIdx].Addresses = dedupAddrList(info.Addresses)
+			res.Info[infoIdx].Addresses = uniqueInterfaceAddresses(info.Addresses)
 		}
 		info.Results[epName] = res
 	}
@@ -237,7 +237,7 @@ func dedupNetworkInfoResults(info params.NetworkInfoResults) params.NetworkInfoR
 	return info
 }
 
-func dedupStringListPreservingOrder(values []string) []string {
+func uniqueStringsPreservingOrder(values []string) []string {
 	// Ideally, we would use a set.Strings(values).Values() here but since
 	// it does not preserve the insertion order we need to do this manually.
 	seen := set.NewStrings()
@@ -253,7 +253,7 @@ func dedupStringListPreservingOrder(values []string) []string {
 	return out
 }
 
-func dedupAddrList(addrList []params.InterfaceAddress) []params.InterfaceAddress {
+func uniqueInterfaceAddresses(addrList []params.InterfaceAddress) []params.InterfaceAddress {
 	if len(addrList) <= 1 {
 		return addrList
 	}

--- a/apiserver/facades/agent/uniter/networkinfo_internal_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_internal_test.go
@@ -14,9 +14,9 @@ type networkInfoSuite struct {
 
 var _ = gc.Suite(&networkInfoSuite{})
 
-// TestNetworkInfoDedupLogic ensures that we don't get a regression for
-// LP1864072.
-func (s *networkInfoSuite) TestNetworkInfoDedupLogic(c *gc.C) {
+// TestUniqueNetworkInfoResults ensures that
+// we don't get a regression for LP1864072.
+func (s *networkInfoSuite) TestUniqueNetworkInfoResults(c *gc.C) {
 	resWithDups := params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
 			"ep0": {
@@ -134,6 +134,6 @@ func (s *networkInfoSuite) TestNetworkInfoDedupLogic(c *gc.C) {
 		},
 	}
 
-	filteredRes := dedupNetworkInfoResults(resWithDups)
+	filteredRes := uniqueNetworkInfoResults(resWithDups)
 	c.Assert(filteredRes, gc.DeepEquals, expRes)
 }

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -424,7 +424,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	prr := newProReqRelationForApps(c, st, mysql, gitlab)
 
 	// We need to instantiate this with the new CAAS model state.
-	netInfo, err := uniter.NewNetworkInfo(st, prr.pu0.UnitTag(), testingRetryFactory)
+	netInfo, err := uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), testingRetryFactory, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// First no address.
@@ -631,7 +631,7 @@ func (s *networkInfoSuite) newNetworkInfo(
 		}
 	}
 
-	ni, err := uniter.NewNetworkInfo(s.State, tag, retryFactory)
+	ni, err := uniter.NewNetworkInfoForStrategy(s.State, tag, retryFactory, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return ni
 }

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -6,12 +6,10 @@ package uniter_test
 import (
 	"fmt"
 	"math/rand"
-	"net"
 	"time"
 
 	"github.com/juju/charm/v7"
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/retry"
 	jc "github.com/juju/testing/checkers"
@@ -19,9 +17,8 @@ import (
 
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
 	"github.com/juju/juju/apiserver/params"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/juju/testing"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -58,8 +55,8 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic),
+		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -67,13 +64,13 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
-func (s *networkInfoSuite) TestNetworksForRelationEgressHostnameSuccess(c *gc.C) {
+func (s *networkInfoSuite) TestNetworksForRelationHostNameNoEgress(c *gc.C) {
 	prr := s.newProReqRelation(c, charm.ScopeGlobal)
 	err := prr.pu0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
@@ -82,73 +79,17 @@ func (s *networkInfoSuite) TestNetworksForRelationEgressHostnameSuccess(c *gc.C)
 	machine, err := s.State.Machine(id)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addr := corenetwork.NewSpaceAddress("host.goodname.somewhere")
+	addr := network.NewSpaceAddress("host.at.somewhere")
 	err = machine.SetProviderAddresses(addr)
 	c.Assert(err, jc.ErrorIsNil)
-
-	s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
-		return &net.IPAddr{IP: net.ParseIP("10.2.3.4")}, nil
-	})
 
 	netInfo := s.newNetworkInfo(c, prr.pu0.UnitTag(), testingRetryFactory)
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
-	c.Assert(ingress, gc.DeepEquals, corenetwork.SpaceAddresses{addr})
-	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
-}
-
-func (s *networkInfoSuite) TestNetworksForRelationEgressHostnameDNSErrorNoResult(c *gc.C) {
-	prr := s.newProReqRelation(c, charm.ScopeGlobal)
-	err := prr.pu0.AssignToNewMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	id, err := prr.pu0.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-
-	addr := corenetwork.NewSpaceAddress("host.badname.somewhere")
-	err = machine.SetProviderAddresses(addr)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Failure to resolve the hostname.
-	s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
-		return nil, &net.DNSError{Err: "nope"}
-	})
-
-	netInfo := s.newNetworkInfo(c, prr.pu0.UnitTag(), testingRetryFactory)
-	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
-	c.Assert(ingress, gc.DeepEquals, corenetwork.SpaceAddresses{addr})
-
-	// We return a nil slice, not an error, for DNS errors during resolution.
-	c.Assert(egress, gc.IsNil)
-}
-
-func (s *networkInfoSuite) TestNetworksForRelationEgressHostnameError(c *gc.C) {
-	prr := s.newProReqRelation(c, charm.ScopeGlobal)
-	err := prr.pu0.AssignToNewMachine()
-	c.Assert(err, jc.ErrorIsNil)
-	id, err := prr.pu0.AssignedMachineId()
-	c.Assert(err, jc.ErrorIsNil)
-	machine, err := s.State.Machine(id)
-	c.Assert(err, jc.ErrorIsNil)
-
-	addr := corenetwork.NewSpaceAddress("host.badname.somewhere")
-	err = machine.SetProviderAddresses(addr)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Non-DNS resolution error.
-	s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
-		return nil, errors.New("nope")
-	})
-
-	netInfo := s.newNetworkInfo(c, prr.pu0.UnitTag(), testingRetryFactory)
-	_, _, _, err = netInfo.NetworksForRelation("", prr.rel, true)
-	c.Assert(err, gc.ErrorMatches, "nope")
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
+	c.Assert(ingress, gc.DeepEquals, network.SpaceAddresses{addr})
+	c.Assert(egress, gc.HasLen, 0)
 }
 
 func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machine, addresses ...string) {
@@ -156,7 +97,7 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 		name := fmt.Sprintf("e%x", rand.Int31())
 		deviceArgs := state.LinkLayerDeviceArgs{
 			Name: name,
-			Type: corenetwork.EthernetDevice,
+			Type: network.EthernetDevice,
 		}
 		err := machine.SetLinkLayerDevices(deviceArgs)
 		c.Assert(err, jc.ErrorIsNil)
@@ -165,7 +106,7 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 
 		addressesArg := state.LinkLayerDeviceAddress{
 			DeviceName:   name,
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: network.StaticAddress,
 			CIDRAddress:  address,
 		}
 		err = machine.SetDevicesAddresses(addressesArg)
@@ -179,21 +120,21 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 func (s *networkInfoSuite) TestNetworksForBinding(c *gc.C) {
 	// Add subnets for the addresses that the machine will have.
 	// We are testing a space-less deployment here.
-	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{
+	_, err := s.State.AddSubnet(network.SubnetInfo{
 		CIDR:    "10.2.0.0/16",
-		SpaceID: corenetwork.AlphaSpaceId,
+		SpaceID: network.AlphaSpaceId,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
+	_, err = s.State.AddSubnet(network.SubnetInfo{
 		CIDR:    "100.2.3.0/24",
-		SpaceID: corenetwork.AlphaSpaceId,
+		SpaceID: network.AlphaSpaceId,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	bindings := map[string]string{
-		"":             corenetwork.AlphaSpaceName,
-		"server-admin": corenetwork.AlphaSpaceName,
+		"":             network.AlphaSpaceName,
+		"server-admin": network.AlphaSpaceName,
 	}
 	app := s.AddTestingApplicationWithBindings(c, "mysql", s.AddTestingCharm(c, "mysql"), bindings)
 
@@ -209,8 +150,8 @@ func (s *networkInfoSuite) TestNetworksForBinding(c *gc.C) {
 	// We need at least one address on the machine itself, because these are
 	// retrieved up-front to use as a fallback when we fail to locate addresses
 	// on link-layer devices.
-	addresses := []corenetwork.SpaceAddress{
-		corenetwork.NewSpaceAddress("10.2.3.4/16"),
+	addresses := []network.SpaceAddress{
+		network.NewSpaceAddress("10.2.3.4/16"),
 	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -259,11 +200,11 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	machine, err := s.State.Machine(id)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addresses := []corenetwork.SpaceAddress{
-		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("2.2.3.4", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic),
+	addresses := []network.SpaceAddress{
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("2.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
 	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -276,7 +217,7 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, spaceID3)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("10.2.3.4", corenetwork.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
@@ -290,8 +231,8 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic),
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -299,9 +240,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -315,7 +256,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -323,9 +264,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -346,7 +287,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic))
+					err := machine.SetProviderAddresses(network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic))
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -357,9 +298,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopePublic)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -394,7 +335,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the private address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopeCloudLocal))
+					err := machine.SetProviderAddresses(network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal))
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -405,9 +346,9 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("4.3.2.1", corenetwork.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -430,13 +371,13 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	// First no address.
 	boundSpace, ingress, egress, err := netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.HasLen, 0)
 	c.Assert(egress, gc.HasLen, 0)
 
 	// Add a application address.
-	err = mysql.UpdateCloudService("", corenetwork.SpaceAddresses{
-		corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal),
+	err = mysql.UpdateCloudService("", network.SpaceAddresses{
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
@@ -444,9 +385,9 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	boundSpace, ingress, egress, err = netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(boundSpace, gc.Equals, corenetwork.AlphaSpaceId)
+	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		corenetwork.SpaceAddresses{corenetwork.NewScopedSpaceAddress("1.2.3.4", corenetwork.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -470,19 +411,19 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createNICAndBridgeWithIP(c, machine, "eth0", "br-eth0", "10.0.0.20/24")
-	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth1", "10.10.0.20/24")
-	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth2", "10.20.0.20/24")
+	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
+	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(corenetwork.NewScopedSpaceAddress("10.0.0.20", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.10.0.20", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.10.0.30", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.20.0.20", corenetwork.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("10.0.0.20", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.10.0.20", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.10.0.30", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
 	netInfo := ni.(*uniter.NetworkInfoIAAS)
 
-	res, err := netInfo.MachineNetworkInfos(spaceIDDefault, spaceIDDMZ, "666", corenetwork.AlphaSpaceId)
+	res, err := netInfo.MachineNetworkInfos(spaceIDDefault, spaceIDDMZ, "666", network.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 4)
 
@@ -504,7 +445,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	c.Check(resDMZ.NetworkInfos[0].Addresses[0].Address, gc.Equals, "10.10.0.20")
 	c.Check(resDMZ.NetworkInfos[0].Addresses[0].CIDR, gc.Equals, "10.10.0.0/24")
 
-	resEmpty, ok := res[corenetwork.AlphaSpaceId]
+	resEmpty, ok := res[network.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
 	c.Check(resEmpty.Error, jc.ErrorIsNil)
 	c.Assert(resEmpty.NetworkInfos, gc.HasLen, 1)
@@ -537,23 +478,23 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createNICAndBridgeWithIP(c, machine, "eth0", "br-eth0", "10.0.0.20/24")
-	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth1", "10.10.0.20/24")
-	s.createNICWithIP(c, machine, corenetwork.EthernetDevice, "eth2", "10.20.0.20/24")
+	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
+	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(corenetwork.NewScopedSpaceAddress("10.0.0.20", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.10.0.20", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.10.0.30", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.20.0.20", corenetwork.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("10.0.0.20", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.10.0.20", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.10.0.30", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil)
 	netInfo := ni.(*uniter.NetworkInfoIAAS)
 
-	res, err := netInfo.MachineNetworkInfos(corenetwork.AlphaSpaceId)
+	res, err := netInfo.MachineNetworkInfos(network.AlphaSpaceId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.HasLen, 1)
 
-	resEmpty, ok := res[corenetwork.AlphaSpaceId]
+	resEmpty, ok := res[network.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
 	c.Check(resEmpty.Error, jc.ErrorIsNil)
 	c.Assert(resEmpty.NetworkInfos, gc.HasLen, 1)
@@ -564,10 +505,10 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 }
 
 func (s *networkInfoSuite) setupSpace(c *gc.C, spaceName, cidr string, public bool) string {
-	space, err := s.State.AddSpace(spaceName, corenetwork.Id(spaceName), nil, true)
+	space, err := s.State.AddSpace(spaceName, network.Id(spaceName), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
+	_, err = s.State.AddSubnet(network.SubnetInfo{
 		CIDR:    cidr,
 		SpaceID: space.Id(),
 	})
@@ -581,12 +522,12 @@ func (s *networkInfoSuite) setupSpace(c *gc.C, spaceName, cidr string, public bo
 func (s *networkInfoSuite) createNICAndBridgeWithIP(
 	c *gc.C, machine *state.Machine, deviceName, bridgeName, cidrAddress string,
 ) {
-	s.createNICWithIP(c, machine, corenetwork.BridgeDevice, bridgeName, cidrAddress)
+	s.createNICWithIP(c, machine, network.BridgeDevice, bridgeName, cidrAddress)
 
 	err := machine.SetLinkLayerDevices(
 		state.LinkLayerDeviceArgs{
 			Name:       deviceName,
-			Type:       corenetwork.EthernetDevice,
+			Type:       network.EthernetDevice,
 			ParentName: bridgeName,
 			IsUp:       true,
 		},
@@ -595,7 +536,7 @@ func (s *networkInfoSuite) createNICAndBridgeWithIP(
 }
 
 func (s *networkInfoSuite) createNICWithIP(
-	c *gc.C, machine *state.Machine, deviceType corenetwork.LinkLayerDeviceType, deviceName, cidrAddress string,
+	c *gc.C, machine *state.Machine, deviceType network.LinkLayerDeviceType, deviceName, cidrAddress string,
 ) {
 	err := machine.SetLinkLayerDevices(
 		state.LinkLayerDeviceArgs{
@@ -610,7 +551,7 @@ func (s *networkInfoSuite) createNICWithIP(
 		state.LinkLayerDeviceAddress{
 			DeviceName:   deviceName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: network.StaticAddress,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -112,9 +112,7 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		}
 
 		if len(info.EgressSubnets) == 0 {
-			if info.EgressSubnets, err = n.getEgressFromIngress(info.IngressAddresses); err != nil {
-				return result, errors.Trace(err)
-			}
+			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
 		result.Results[endpoint] = info

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -120,7 +120,7 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		result.Results[endpoint] = info
 	}
 
-	return dedupNetworkInfoResults(result), nil
+	return result, nil
 }
 
 // getRelationNetworkInfo returns the endpoint name, network space

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -84,9 +84,7 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		}
 
 		if len(info.EgressSubnets) == 0 {
-			if info.EgressSubnets, err = n.getEgressFromIngress(info.IngressAddresses); err != nil {
-				return result, errors.Trace(err)
-			}
+			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
 		result.Results[endpoint] = info

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -92,7 +92,7 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		result.Results[endpoint] = info
 	}
 
-	return dedupNetworkInfoResults(result), nil
+	return result, nil
 }
 
 // getRelationNetworkInfo returns the endpoint name, network space

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2503,7 +2503,11 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 		return params.NetworkInfoResults{}, err
 	}
 
-	return netInfo.ProcessAPIRequest(args)
+	res, err := netInfo.ProcessAPIRequest(args)
+	if err != nil {
+		return params.NetworkInfoResults{}, err
+	}
+	return uniqueNetworkInfoResults(res), nil
 }
 
 // WatchUnitRelations returns a StringsWatcher, for each given

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1558,7 +1558,7 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 			return nil
 		}
 
-		netInfo, err := NewNetworkInfo(u.st, unitTag, defaultRetryFactory)
+		netInfo, err := NewNetworkInfo(u.st, unitTag)
 		if err != nil {
 			return err
 		}
@@ -2498,7 +2498,7 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 		return params.NetworkInfoResults{}, common.ErrPerm
 	}
 
-	netInfo, err := NewNetworkInfo(u.st, unitTag, defaultRetryFactory)
+	netInfo, err := NewNetworkInfo(u.st, unitTag)
 	if err != nil {
 		return params.NetworkInfoResults{}, err
 	}
@@ -3428,7 +3428,7 @@ func (u *UniterAPI) updateUnitNetworkInfoOperation(unitTag names.UnitTag, unit *
 			return nil, errors.Trace(err)
 		}
 
-		netInfo, err := NewNetworkInfo(u.st, unitTag, defaultRetryFactory)
+		netInfo, err := NewNetworkInfo(u.st, unitTag)
 		if err != nil {
 			return nil, err
 		}

--- a/core/network/network.go
+++ b/core/network/network.go
@@ -110,8 +110,8 @@ func (s IDSet) SortedValues() []Id {
 	return values
 }
 
-// SubnetsForAddresses returns subnets corresponding to the first address
-// (if available) in the input address list.
+// SubnetsForAddresses returns subnets corresponding to the addresses
+// in the input address list.
 // There can be situations (observed for CAAS) where the addresses can
 // contain a FQDN.
 // For these cases we log a warning and eschew subnet determination.

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -102,3 +102,16 @@ func assertValues(c *gc.C, s network.IDSet, expected ...network.Id) {
 	sorted := s.SortedValues()
 	c.Assert(sorted, gc.DeepEquals, expected)
 }
+
+func (s *NetworkSuite) TestSubnetsForAddresses(c *gc.C) {
+	addrs := []string{
+		"10.10.10.10",
+		"75ae:3af:968e:3a33:55e2:6379:fa67:d790",
+		"some.host.name",
+	}
+
+	c.Check(network.SubnetsForAddresses(addrs), gc.DeepEquals, []string{
+		"10.10.10.10/32",
+		"75ae:3af:968e:3a33:55e2:6379:fa67:d790/128",
+	})
+}

--- a/network/network.go
+++ b/network/network.go
@@ -301,29 +301,3 @@ func SubnetInAnyRange(cidrs []*net.IPNet, subnet *net.IPNet) bool {
 	}
 	return false
 }
-
-// Export for testing
-var ResolverFunc = net.ResolveIPAddr
-
-// FormatAsCIDR converts the specified IP addresses to a slice of CIDRs. It
-// attempts to resolve any address represented as hostnames before formatting.
-func FormatAsCIDR(addresses []string) ([]string, error) {
-	result := make([]string, len(addresses))
-	for i, a := range addresses {
-		cidr := a
-		// If address is not already a cidr, add a /32 (ipv4) or /128 (ipv6).
-		if _, _, err := net.ParseCIDR(a); err != nil {
-			address, err := ResolverFunc("ip", a)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if address.IP.To4() != nil {
-				cidr = address.String() + "/32"
-			} else {
-				cidr = address.String() + "/128"
-			}
-		}
-		result[i] = cidr
-	}
-	return result, nil
-}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -291,35 +291,3 @@ func (s *CIDRSuite) TestSubnetInAnyRange(c *gc.C) {
 		c.Assert(result, gc.Equals, t.included)
 	}
 }
-
-// This test shows that FormatAsCIDR will resolve a resolvable hostname to an IP
-// address before formatting as a CIDR.
-func (s *CIDRSuite) TestParseCIDR(c *gc.C) {
-	exampleAddress := "10.10.10.10"
-	exampleHostname := "Hostname"
-	expectedCIDR := "10.10.10.10/32"
-	testAddresses := []struct {
-		address string
-		cidr    string
-	}{{
-		address: exampleAddress,
-		cidr:    expectedCIDR,
-	}, {
-		address: exampleHostname,
-		cidr:    expectedCIDR,
-	}}
-
-	s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
-		return &net.IPAddr{IP: net.ParseIP(exampleAddress)}, nil
-	})
-
-	for _, testAddress := range testAddresses {
-		actualCIDRs, err := network.FormatAsCIDR([]string{testAddress.address})
-		c.Assert(err, jc.ErrorIsNil)
-		if len(actualCIDRs) <= 0 {
-			c.Fail()
-		}
-		actualCIDR := actualCIDRs[0]
-		c.Assert(actualCIDR, gc.Equals, expectedCIDR)
-	}
-}

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -306,19 +306,6 @@ bind-addresses:
     cidr: 10.33.1.8/24`[1:])
 }
 
-func (s *NetworkGetSuite) TestNetworkGetDoNotResolve(c *gc.C) {
-	s.testScenario(c, []string{"resolvable-hostname", "--resolve-ingress-addresses=false"}, 0, `
-bind-addresses:
-- macaddress: "00:11:22:33:44:33"
-  interfacename: eth3
-  addresses:
-  - hostname: resolvable-hostname
-    address: 10.3.3.3
-    cidr: 10.33.1.8/24
-ingress-addresses:
-- resolvable-hostname`[1:])
-}
-
 func (s *NetworkGetSuite) testScenario(c *gc.C, args []string, code int, out string) {
 	ctx := cmdtesting.Context(c)
 


### PR DESCRIPTION
This patch does the following to `NetworkInfo` results returned to calls of the `network-get` hook tool:
- After discussion, we revert https://github.com/juju/juju/commit/e001ea43d0fbe5d43852e6f59a044d930990c40f, which added a new flag to `network-get`. This idea may be revisited in future.
- We now no longer attempt to derive egress subnets from host-names. Instead we log a warning, placing the burden on operators to configure egress subnets for the model/relation or use IP addresses.
- It introduces a host resolution dependency to `NetworkInfo` in preparation for future work. This work will follow, but we omitted here for brevity. The dependency is not recruited and results in no functional change.

## QA steps

Same as the (2nd) feature test for https://github.com/juju/juju/pull/12316, but we expect no egress subnets.
```
bind-addresses:
- macaddress: ""
  interfacename: ""
  addresses:
  - hostname: ""
    address: 10.1.74.4
    cidr: ""
ingress-addresses:
- 52.45.100.155
```
Controller logs:
```
machine-0: 15:06:00 WARNING juju.apiserver.uniter unable to determine egress subnet for "acf93085e75d540629d87d6a9c683cbe-1717529343.us-east-1.elb.amazonaws.com"
```

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1901749
