### PR TITLE
Perform network-get hostname resolution server-side

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -183,6 +183,82 @@ func (n *NetworkInfoBase) getEgressForRelation(
 	return subnetsForAddresses(ingress.Values()), nil
 }
 
+func (n *NetworkInfoBase) resolveResultHostNames(netInfoResult params.NetworkInfoResult) params.NetworkInfoResult {
+	// Maintain a cache of host-name -> address resolutions.
+	resolved := make(map[string]string)
+	addressForHost := func(hostName string) string {
+		resolvedAddr, ok := resolved[hostName]
+		if !ok {
+			resolvedAddr = n.resolveHostAddress(hostName)
+			resolved[hostName] = resolvedAddr
+		}
+		return resolvedAddr
+	}
+
+	// Resolve addresses in Info.
+	for i, info := range netInfoResult.Info {
+		for j, addr := range info.Addresses {
+			if ip := net.ParseIP(addr.Address); ip == nil {
+				// If the address is not an IP, we assume it is a host name.
+				addr.Hostname = addr.Address
+				addr.Address = addressForHost(addr.Hostname)
+				netInfoResult.Info[i].Addresses[j] = addr
+			}
+		}
+	}
+
+	// Resolve addresses in IngressAddresses.
+	// This is slightly different to the addresses above in that we do not
+	// include anything that does not resolve to a usable address.
+	var newIngress []string
+	for _, addr := range netInfoResult.IngressAddresses {
+		if ip := net.ParseIP(addr); ip != nil {
+			newIngress = append(newIngress, addr)
+			continue
+		}
+		if ipAddr := addressForHost(addr); ipAddr != "" {
+			newIngress = append(newIngress, ipAddr)
+		}
+	}
+	netInfoResult.IngressAddresses = newIngress
+
+	return netInfoResult
+}
+
+func (n *NetworkInfoBase) resolveHostAddress(hostName string) string {
+	resolved, err := n.lookupHost(hostName)
+	if err != nil {
+		logger.Errorf("resolving %q: %v", hostName, err)
+		return ""
+	}
+
+	// This preserves prior behaviour from when resolution was done client-side
+	// within the network-get tool.
+	// This check is probably no longer necessary, but is preserved here
+	// conservatively.
+	for _, addr := range resolved {
+		if ip := net.ParseIP(addr); ip != nil && !ip.IsLoopback() {
+			return addr
+		}
+	}
+
+	if len(resolved) == 0 {
+		logger.Warningf("no addresses resolved for host %q", hostName)
+	} else {
+		// If we got results, but they were all filtered out, then we need to
+		// help out operators with some advice.
+		logger.Warningf(
+			"no usable addresses resolved for host %q\n\t"+
+				"resolved: %v\n\t"+
+				"consider editing the hosts file, or changing host resolution order via /etc/nsswitch.conf",
+			hostName,
+			resolved,
+		)
+	}
+
+	return ""
+}
+
 // subnetsForAddresses wraps the core/network method of the same name,
 // limiting the return to container at most one result.
 // TODO (manadart 2020-11-19): This preserves prior behaviour,

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -115,7 +115,7 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		result.Results[endpoint] = info
+		result.Results[endpoint] = n.resolveResultHostNames(info)
 	}
 
 	return result, nil

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -87,7 +87,7 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		result.Results[endpoint] = info
+		result.Results[endpoint] = n.resolveResultHostNames(info)
 	}
 
 	return result, nil

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -5,7 +5,6 @@ package jujuc
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -34,10 +33,6 @@ type NetworkGetCommand struct {
 
 	out cmd.Output
 }
-
-type resolver func(host string) (addrs []string, err error)
-
-var LookupHost resolver = net.LookupHost
 
 func NewNetworkGetCommand(ctx Context) (_ cmd.Command, err error) {
 	cmd := &NetworkGetCommand{ctx: ctx}

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
-	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 )
 
@@ -126,8 +125,6 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(ni.Error)
 	}
 
-	ni = resolveNetworkInfoAddresses(ni, LookupHost)
-
 	// If no specific attributes were asked for, write everything we know.
 	if !c.primaryAddress && len(c.keys) == 0 {
 		return c.out.Write(ctx, ni)
@@ -168,91 +165,4 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		return c.out.Write(ctx, keyValues[c.keys[0]])
 	}
 	return c.out.Write(ctx, keyValues)
-}
-
-// TODO(externalreality) This addresses the immediate problem of
-// https://bugs.launchpad.net/juju/+bug/1721368, but the hostname can populate
-// both the egress subnet CIDR and the ingress addresses. These too should be
-// resolved. In addition these values probably should not be stored as hostnames
-// but rather the IP, that is, it might be better to do the resolution on input
-// rather than output (network-get) as we do here.
-func resolveNetworkInfoAddresses(
-	netInfoResult params.NetworkInfoResult, lookupHost resolver,
-) params.NetworkInfoResult {
-	// Maintain a cache of host-name -> address resolutions.
-	resolved := make(map[string]string)
-	addressForHost := func(hostName string) string {
-		resolvedAddr, ok := resolved[hostName]
-		if !ok {
-			resolvedAddr = resolveHostAddress(hostName, lookupHost)
-			resolved[hostName] = resolvedAddr
-		}
-		return resolvedAddr
-	}
-
-	// Resolve addresses in Info.
-	for i, info := range netInfoResult.Info {
-		for j, addr := range info.Addresses {
-			if ip := net.ParseIP(addr.Address); ip == nil {
-				// If the address is not an IP, we assume it is a host name.
-				addr.Hostname = addr.Address
-				addr.Address = addressForHost(addr.Hostname)
-				netInfoResult.Info[i].Addresses[j] = addr
-			}
-		}
-	}
-
-	// Resolve addresses in IngressAddresses.
-	// This is slightly different to the addresses above in that we do not
-	// include anything that does not resolve to a usable address.
-	var newIngress []string
-	for _, addr := range netInfoResult.IngressAddresses {
-		if ip := net.ParseIP(addr); ip != nil {
-			newIngress = append(newIngress, addr)
-			continue
-		}
-		if ipAddr := addressForHost(addr); ipAddr != "" {
-			newIngress = append(newIngress, ipAddr)
-		}
-	}
-	netInfoResult.IngressAddresses = newIngress
-
-	return netInfoResult
-}
-
-func resolveHostAddress(hostName string, lookupHost resolver) string {
-	resolved, err := lookupHost(hostName)
-	if err != nil {
-		logger.Errorf("resolving %q: %v", hostName, err)
-		return ""
-	}
-
-	// We have seen examples of /etc/hosts entries like this:
-	//   127.0.1.1 hostname.fqdn hostname
-	//
-	// The default behaviour of net.LookupHost returns any IPs resolved via the
-	// hosts file *without* querying DNS. Given that these may include loopback
-	// addresses that are unusable by machines they might be advertised to,
-	// we avoid returning them.
-	for _, addr := range resolved {
-		if ip := net.ParseIP(addr); ip != nil && !ip.IsLoopback() {
-			return addr
-		}
-	}
-
-	if len(resolved) == 0 {
-		logger.Warningf("no addresses resolved for host %q", hostName)
-	} else {
-		// If we got results, but they were all filtered out, then we need to
-		// help out operators with some advice.
-		logger.Warningf(
-			"no usable addresses resolved for host %q\n\t"+
-				"resolved: %v\n\t"+
-				"consider editing the hosts file, or changing host resolution order via /etc/nsswitch.conf",
-			hostName,
-			resolved,
-		)
-	}
-
-	return ""
 }


### PR DESCRIPTION
Moves the resolution of host-names server-side instead of resolving within the `network-get` tool.

This will allow us in a forthcoming patch to apply host-name resolution selectively.

## QA steps

Same as for the original client-side change under https://github.com/juju/juju/pull/8672.

## Documentation changes

None

## Bug reference

N/A
