### PR TITLE
Pull in charm v8 changes to URL.

### DIFF
--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -618,7 +618,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 func (s *RefreshSuite) TestSwitchSameURL(c *gc.C) {
 	s.charmAPIClient.charmURL = s.resolvedCharmURL
 	_, err := s.runRefresh(c, "foo", "--switch="+s.resolvedCharmURL.String())
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "cs:quantal/foo-2"`)
+	c.Assert(err, gc.ErrorMatches, `already running specified charm "foo", revision 2`)
 }
 
 func (s *RefreshSuite) TestSwitchDifferentRevision(c *gc.C) {

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -272,12 +272,12 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 	// or Revision flags, discover the latest.
 	if *newURL == *r.charmURL {
 		if refURL.Revision != -1 {
-			return nil, commoncharm.Origin{}, errors.Errorf("already running specified charm %q", newURL)
+			return nil, commoncharm.Origin{}, errors.Errorf("already running specified charm %q, revision %d", newURL.Name, newURL.Revision)
 		}
 		// No point in trying to upgrade a charm store charm when
 		// we just determined that's the latest revision
 		// available.
-		return nil, commoncharm.Origin{}, errors.Errorf("already running latest charm %q", newURL)
+		return nil, commoncharm.Origin{}, errors.Errorf("already running latest charm %q", newURL.Name)
 	}
 	r.logger.Verbosef("Using channel %q", origin.CoreChannel().String())
 	return newURL, origin, nil

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -285,7 +285,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithNoUpdates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running latest charm "cs:meshuggah"`)
+	c.Assert(err, gc.ErrorMatches, `already running latest charm "meshuggah"`)
 }
 
 func (s *charmStoreCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
@@ -311,7 +311,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "cs:meshuggah-1"`)
+	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah", revision 1`)
 }
 
 type charmHubCharmRefresherSuite struct{}
@@ -397,7 +397,7 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah-1"`)
+	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah", revision 1`)
 }
 
 func (s *charmHubCharmRefresherSuite) TestRefreshWithOriginChannel(c *gc.C) {
@@ -432,7 +432,7 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithOriginChannel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah-1"`)
+	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah", revision 1`)
 }
 
 func basicRefresherConfig(curl *charm.URL, ref string) RefresherConfig {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6
-	github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0
+	github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6 h1:PmF2wWq0H
 github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6/go.mod h1:bkzD4rJvlgyr9AEKUKB0eLRpMwqMshq3t5ayQmuKOBU=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0 h1:BuNV5BMVyKI1XUupcAuC/Y2bW/izfV7Tn+uI7jMYjNk=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
+github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9 h1:e6OkRhyixqkgcycaD+aACZQMPwpJSxfbTfNc4qwOBnE=
+github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f h1:esltimJsCcUSaC9ahxBpC70Gumqnnmgm0Ah+BLVQBTY=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=


### PR DESCRIPTION
Pull in charm v8 [#324](https://github.com/juju/charm/pull/324).  To ensure that charm hub schema is included in charm URLs stored in the juju db.

## QA steps


```console
# Setup
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost test-pr
$ juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"

# Deploy one of each charms
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 17
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 17 in channel latest/stable
$ juju deploy cs:mysql
Located charm "mysql" in charm-store, revision 58
Deploying "mysql" from charm-store charm "mysql", revision 58 in channel stable
$ juju deploy ./testcharms/charm-repo/bionic/lxd-profile
Located local charm "lxd-profile", revision 0
Deploying "lxd-profile" from local charm "lxd-profile", revision 0

# Verify charmurl has the schema for all 3 charms
$ juju-db.bash
juju:PRIMARY> db.applications.find({},{"name":1,"charmurl":1}).pretty()
{
	"_id" : "5cbf5878-ff8c-41e6-86c2-7b45e8e2e664:ubuntu",
	"name" : "ubuntu",
	"charmurl" : "ch:ubuntu-17"
}
{
	"_id" : "5cbf5878-ff8c-41e6-86c2-7b45e8e2e664:mysql",
	"name" : "mysql",
	"charmurl" : "cs:mysql-58"
}
{
	"_id" : "5cbf5878-ff8c-41e6-86c2-7b45e8e2e664:lxd-profile",
	"name" : "lxd-profile",
	"charmurl" : "local:bionic/lxd-profile-0"
}
```

