### PR TITLE
Prevent an old juju client logging into a newer controller

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1223,6 +1223,7 @@ func (s *state) APICall(facade string, vers int, id, method string, args, respon
 				}
 			}
 		}
+		logger.Debugf("%v.%v API call not supported", facade, method)
 		return errors.NewNotSupported(nil, fmt.Sprintf(
 			"juju client with major version %d used with a controller having major version %d not supported\nupdate your juju client to match the version running on the controller",
 			jujuversion.Current.Major, serverMajorVersion))

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/utils/proxy"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // PingPeriod defines how often the internal connection health check
@@ -1188,20 +1189,42 @@ var apiCallRetryStrategy = retry.LimitTime(10*time.Second,
 // This fills out the rpc.Request on the given facade, version for a given
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
-func (s *state) APICall(facade string, version int, id, method string, args, response interface{}) error {
+func (s *state) APICall(facade string, vers int, id, method string, args, response interface{}) error {
 	for a := retry.Start(apiCallRetryStrategy, s.clock); a.Next(); {
 		err := s.client.Call(rpc.Request{
 			Type:    facade,
-			Version: version,
+			Version: vers,
 			Id:      id,
 			Action:  method,
 		}, args, response)
-		if params.ErrCode(err) != params.CodeRetry {
+		if err == nil {
+			return nil
+		}
+		code := params.ErrCode(err)
+		if code == params.CodeRetry {
+			if !a.More() {
+				return errors.Annotatef(err, "too many retries")
+			}
+			continue
+		}
+		if code != params.CodeIncompatibleClient {
 			return errors.Trace(err)
 		}
-		if !a.More() {
-			return errors.Annotatef(err, "too many retries")
+		// Default to major version 2 for older servers.
+		serverMajorVersion := 2
+		err = errors.Cause(err)
+		apiErr, ok := err.(*rpc.RequestError)
+		if ok {
+			if serverVersion, ok := apiErr.Info["server-version"]; ok {
+				serverVers, err := version.Parse(fmt.Sprintf("%v", serverVersion))
+				if err == nil {
+					serverMajorVersion = serverVers.Major
+				}
+			}
 		}
+		return errors.NewNotSupported(nil, fmt.Sprintf(
+			"juju client with major version %d used with a controller having major version %d not supported\nupdate your juju client to match the version running on the controller",
+			jujuversion.Current.Major, serverMajorVersion))
 	}
 	panic("unreachable")
 }

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -418,6 +418,7 @@ func (st *state) connectStream(path string, attrs url.Values, extraHeaders http.
 	} else {
 		requestHeader = make(http.Header)
 	}
+	requestHeader.Set(params.JujuClientVersion, jujuversion.Current.String())
 	requestHeader.Set("Origin", "http://localhost/")
 	if st.nonce != "" {
 		requestHeader.Set(params.MachineNonceHeader, st.nonce)

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1234,6 +1234,24 @@ func (s *apiclientSuite) TestLoginCapturesCLIArgs(c *gc.C) {
 	c.Assert(request.CLIArgs, gc.Equals, `this is "the test" command`)
 }
 
+func (s *apiclientSuite) TestLoginIncompatibleClient(c *gc.C) {
+	clock := &fakeClock{}
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(&rpc.RequestError{
+			Code: "incompatible client",
+			Info: map[string]interface{}{"server-version": "99.0.0"},
+		}),
+		Clock: clock,
+	})
+
+	err := conn.APICall("facade", 1, "id", "method", nil, nil)
+	c.Check(clock.waits, gc.HasLen, 0)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+		"juju client with major version %d used with a controller having major version %d not supported\\n.*",
+		jujuversion.Current.Major, 99,
+	))
+}
+
 type clientDNSNameSuite struct {
 	jjtesting.JujuConnSuite
 }

--- a/api/http.go
+++ b/api/http.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // HTTPClient implements Connection.APICaller.HTTPClient and returns an HTTP
@@ -106,6 +107,7 @@ func authHTTPRequest(req *http.Request, tag, password, nonce string, macaroons [
 	if nonce != "" {
 		req.Header.Set(params.MachineNonceHeader, nonce)
 	}
+	req.Header.Set(params.JujuClientVersion, jujuversion.Current.String())
 	req.Header.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
 	for _, ms := range macaroons {
 		encoded, err := encodeMacaroonSlice(ms)

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -23,6 +23,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/version"
 )
 
 type httpSuite struct {
@@ -230,8 +231,9 @@ func (s *httpSuite) TestAuthHTTPRequest(c *gc.C) {
 	req := s.authHTTPRequest(c, apiInfo)
 	_, _, ok := req.BasicAuth()
 	c.Assert(ok, jc.IsFalse)
-	c.Assert(req.Header, gc.HasLen, 1)
+	c.Assert(req.Header, gc.HasLen, 2)
 	c.Assert(req.Header.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
+	c.Assert(req.Header.Get(params.JujuClientVersion), gc.Equals, version.Current.String())
 
 	apiInfo.Nonce = "foo"
 	req = s.authHTTPRequest(c, apiInfo)

--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -39,6 +39,7 @@ func NewAPI(connector base.StreamConnector) *API {
 // which must be closed when finished with.
 func (api *API) LogWriter() (LogWriter, error) {
 	attrs := make(url.Values)
+	// TODO(wallyworld) - remove in juju 4
 	attrs.Set("jujuclientversion", version.Current.String())
 	// Version 1 does ping/pong handling.
 	attrs.Set("version", "1")

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -179,6 +179,7 @@ func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, con
 // logs records can be fed into. The objects written should be params.LogRecords.
 func (c *Client) OpenLogTransferStream(modelUUID string) (base.Stream, error) {
 	attrs := url.Values{}
+	// TODO(wallyworld) - remove in juju 4
 	attrs.Set("jujuclientversion", jujuversion.Current.String())
 	headers := http.Header{}
 	headers.Set(params.MigrationModelHTTPHeader, modelUUID)

--- a/api/state.go
+++ b/api/state.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // Login authenticates as the entity with the given name and password
@@ -45,6 +46,7 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 		Macaroons:     macaroons,
 		BakeryVersion: bakery.LatestVersion,
 		CLIArgs:       utils.CommandString(os.Args...),
+		ClientVersion: jujuversion.Current.String(),
 	}
 	// If we are in developer mode, add the stack location as user data to the
 	// login request. This will allow the apiserver to connect connection ids

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/rpcreflect"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
@@ -128,11 +129,20 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 	if err != nil {
 		return fail, errors.Trace(err)
 	}
+
+	// Default client version to 2 since older 2.x clients
+	// don't send this field.
+	loginClientVersion := version.Number{Major: 2}
+	if clientVersion, err := version.Parse(req.ClientVersion); err == nil {
+		loginClientVersion = clientVersion
+	}
+
 	apiRoot, err = restrictAPIRoot(
 		a.srv,
 		apiRoot,
 		a.root.model,
 		*authResult,
+		loginClientVersion,
 	)
 	if err != nil {
 		return fail, errors.Trace(err)

--- a/apiserver/common/errors.go
+++ b/apiserver/common/errors.go
@@ -338,6 +338,10 @@ func ServerError(err error) *params.Error {
 		}.AsMap()
 	case errors.IsQuotaLimitExceeded(err):
 		code = params.CodeQuotaLimitExceeded
+	case params.IsIncompatibleClientError(err):
+		code = params.CodeIncompatibleClient
+		rawErr := errors.Cause(err).(*params.IncompatibleClientError)
+		info = rawErr.AsMap()
 	default:
 		code = params.ErrCode(err)
 	}

--- a/apiserver/common/http.go
+++ b/apiserver/common/http.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// JujuClientVersionFromRequest returns the Juju client version
+// number from the HTTP request.
+func JujuClientVersionFromRequest(req *http.Request) (version.Number, error) {
+	verStr := req.Header.Get(params.JujuClientVersion)
+	// TODO(wallyworld) - remove in juju 4
+	if verStr == "" {
+		verStr = req.URL.Query().Get("jujuclientversion")
+	}
+	if verStr == "" {
+		return version.Zero, errors.New(`missing "X-Juju-ClientVersion" in request headers`)
+	}
+	ver, err := version.Parse(verStr)
+	if err != nil {
+		return version.Zero, errors.Annotatef(err, "invalid X-Juju-ClientVersion %q", verStr)
+	}
+	return ver, nil
+}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -132,6 +133,13 @@ func TestingRestrictedRoot(check func(string, string) error) rpc.Root {
 func TestingAboutToRestoreRoot() rpc.Root {
 	r := TestingAPIRoot(AllFacades())
 	return restrictRoot(r, aboutToRestoreMethodsOnly)
+}
+
+// TestingUpgradeOrMigrationOnlyRoot returns a restricted srvRoot
+// as if called from a newer client.
+func TestingUpgradeOrMigrationOnlyRoot(userLogin bool, clientVersion version.Number) rpc.Root {
+	r := TestingAPIRoot(AllFacades())
+	return restrictRoot(r, checkClientVersion(userLogin, clientVersion))
 }
 
 // PatchGetMigrationBackend overrides the getMigrationBackend function

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1013,6 +1013,9 @@
                         "cli-args": {
                             "type": "string"
                         },
+                        "client-version": {
+                            "type": "string"
+                        },
                         "credentials": {
                             "type": "string"
                         },

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -135,7 +136,7 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 	// *Juju* version be provided as part of the request. Any
 	// attempt to open this endpoint to broader access must
 	// address this caveat appropriately.
-	ver, err := logsink.JujuClientVersionFromRequest(req)
+	ver, err := common.JujuClientVersionFromRequest(req)
 	if err != nil {
 		st.Release()
 		return errors.Trace(err)

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/ratelimit"
-	"github.com/juju/version"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/apiserver/httpcontext"
@@ -375,20 +374,6 @@ func (h *logSinkHandler) sendError(ws *websocket.Conn, req *http.Request, err er
 		logger.Errorf("closing websocket, %v", err)
 		ws.Close()
 	}
-}
-
-// JujuClientVersionFromRequest returns the Juju client version
-// number from the HTTP request.
-func JujuClientVersionFromRequest(req *http.Request) (version.Number, error) {
-	verStr := req.URL.Query().Get("jujuclientversion")
-	if verStr == "" {
-		return version.Zero, errors.New(`missing "jujuclientversion" in URL query`)
-	}
-	ver, err := version.Parse(verStr)
-	if err != nil {
-		return version.Zero, errors.Annotatef(err, "invalid jujuclientversion %q", verStr)
-	}
-	return ver, nil
 }
 
 // ratelimitClock adapts clock.Clock to ratelimit.Clock.

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -6,7 +6,6 @@ package apiserver_test
 import (
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,10 +49,7 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 	s.machineTag = m.Tag()
 	s.password = password
 
-	url := s.URL(
-		"/model/"+s.State.ModelUUID()+"/logsink",
-		url.Values{"jujuclientversion": {version.Current.String()}},
-	)
+	url := s.URL("/model/"+s.State.ModelUUID()+"/logsink", nil)
 	url.Scheme = "wss"
 	s.url = url.String()
 
@@ -234,5 +230,6 @@ func (s *logsinkSuite) dialWebsocket(c *gc.C) *websocket.Conn {
 func (s *logsinkSuite) makeAuthHeader() http.Header {
 	header := utils.BasicAuthHeader(s.machineTag.String(), s.password)
 	header.Add(params.MachineNonceHeader, s.nonce)
+	header.Add(params.JujuClientVersion, version.Current.String())
 	return header
 }

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -50,7 +51,7 @@ func (s *migrationLoggingStrategy) init(ctxt httpContext, req *http.Request) err
 	// passed, even though we don't use it anywhere at the moment - it
 	// provides future-proofing if we need to do some kind of
 	// conversion of log messages from an old client.
-	_, err = logsink.JujuClientVersionFromRequest(req)
+	_, err = common.JujuClientVersionFromRequest(req)
 	if err != nil {
 		st.Release()
 		return errors.Trace(err)

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -6,7 +6,6 @@ package apiserver_test
 import (
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -51,9 +50,7 @@ func (s *logtransferSuite) SetUpTest(c *gc.C) {
 	s.machinePassword = password
 	s.setUserAccess(c, permission.SuperuserAccess)
 
-	url := s.URL("/migrate/logtransfer", url.Values{
-		"jujuclientversion": {version.Current.String()},
-	})
+	url := s.URL("/migrate/logtransfer", nil)
 	url.Scheme = "wss"
 	s.url = url.String()
 
@@ -65,6 +62,7 @@ func (s *logtransferSuite) SetUpTest(c *gc.C) {
 func (s *logtransferSuite) makeAuthHeader() http.Header {
 	header := utils.BasicAuthHeader(s.userTag.String(), s.password)
 	header.Add(params.MigrationModelHTTPHeader, s.State.ModelUUID())
+	header.Add(params.JujuClientVersion, version.Current.String())
 	return header
 }
 
@@ -106,12 +104,14 @@ func (s *logtransferSuite) TestRejectsBadMigratingModelUUID(c *gc.C) {
 }
 
 func (s *logtransferSuite) TestRejectsInvalidVersion(c *gc.C) {
-	url := s.URL("/migrate/logtransfer", url.Values{"jujuclientversion": {"blah"}})
+	url := s.URL("/migrate/logtransfer", nil)
 	url.Scheme = "wss"
-	conn, _, err := dialWebsocketFromURL(c, url.String(), s.makeAuthHeader())
+	hdr := s.makeAuthHeader()
+	hdr.Set("X-Juju-ClientVersion", "blah")
+	conn, _, err := dialWebsocketFromURL(c, url.String(), hdr)
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	websockettest.AssertJSONError(c, conn, `^initialising migration logsink session: invalid jujuclientversion "blah".*`)
+	websockettest.AssertJSONError(c, conn, `^initialising migration logsink session: invalid X-Juju-ClientVersion "blah".*`)
 	websockettest.AssertWebsocketClosed(c, conn)
 }
 

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/version"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 )
@@ -22,6 +23,30 @@ var UpgradeInProgressError = errors.New(CodeUpgradeInProgress)
 
 // MigrationInProgressError signifies a migration is in progress.
 var MigrationInProgressError = errors.New(CodeMigrationInProgress)
+
+// IncompatibleClientError signifies the connecting client is not
+// compatible with the controller.
+type IncompatibleClientError struct {
+	ServerVersion version.Number
+}
+
+// Error implements error.
+func (e *IncompatibleClientError) Error() string {
+	return fmt.Sprintf("client incompatible with server %v", e.ServerVersion)
+}
+
+// AsMap returns the data for the RPC error Info field.
+func (e *IncompatibleClientError) AsMap() map[string]interface{} {
+	return map[string]interface{}{
+		"server-version": e.ServerVersion,
+	}
+}
+
+// IsIncompatibleClientError returns true if this err is a IncompatibleClientError.
+func IsIncompatibleClientError(err error) bool {
+	_, ok := errors.Cause(err).(*IncompatibleClientError)
+	return ok
+}
 
 // Error is the type of error returned by any call to the state API.
 type Error struct {
@@ -172,6 +197,7 @@ const (
 	CodeAlreadyExists             = "already exists"
 	CodeUpgradeInProgress         = "upgrade in progress"
 	CodeMigrationInProgress       = "model migration in progress"
+	CodeIncompatibleClient        = "incompatible client"
 	CodeActionNotAvailable        = "action no longer available"
 	CodeOperationBlocked          = "operation is blocked"
 	CodeLeadershipClaimDenied     = "leadership claim denied"

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -31,4 +31,7 @@ const (
 	ResolvedNoHooks    ResolvedMode = "no-hooks"
 )
 
-const MachineNonceHeader = "X-Juju-Nonce"
+const (
+	MachineNonceHeader = "X-Juju-Nonce"
+	JujuClientVersion  = "X-Juju-ClientVersion"
+)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -527,6 +527,7 @@ type LoginRequest struct {
 	BakeryVersion bakery.Version   `json:"bakery-version,omitempty"`
 	CLIArgs       string           `json:"cli-args,omitempty"`
 	UserData      string           `json:"user-data"`
+	ClientVersion string           `json:"client-version,omitempty"`
 }
 
 // LoginRequestCompat holds credentials for identifying an entity to the Login v1

--- a/apiserver/restrict_newer_client.go
+++ b/apiserver/restrict_newer_client.go
@@ -135,6 +135,9 @@ var allowedMethodsForMigrate = map[string]set.Strings{
 	"UserManager": set.NewStrings(
 		"UserInfo",
 	),
+	"ModelManager": set.NewStrings(
+		"ListModels",
+		"ModelInfo"),
 	"Controller": set.NewStrings(
 		"InitiateMigration",
 		"IdentityProviderURL",

--- a/apiserver/restrict_newer_client.go
+++ b/apiserver/restrict_newer_client.go
@@ -1,0 +1,142 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/collections/set"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/apiserver/params"
+	jujuversion "github.com/juju/juju/version"
+)
+
+// minAgentMinorVersions defines the minimum minor version
+// for a major agent version making api calls to a controller
+// with a newer major version.
+var minAgentMinorVersions = map[int]int{
+	2: 9,
+}
+
+func checkClientVersion(userLogin bool, clientVersion version.Number) func(facadeName, methodName string) error {
+	return func(facadeName, methodName string) error {
+		incompatibleClientError := &params.IncompatibleClientError{
+			ServerVersion: jujuversion.Current,
+		}
+		// If client or server versions are more than one major version apart,
+		// reject the call immediately.
+		if clientVersion.Major < jujuversion.Current.Major-1 || clientVersion.Major > jujuversion.Current.Major+1 {
+			return incompatibleClientError
+		}
+		// Connection pings always need to be allowed.
+		if facadeName == "Pinger" && methodName == "Ping" {
+			return nil
+		}
+
+		if !userLogin {
+			// Only recent older agents can make api calls.
+			if minAgentVersion, ok := minAgentMinorVersions[clientVersion.Major]; !ok || minAgentVersion > clientVersion.Minor {
+				logger.Debugf("rejected agent api all %v.%v for agent version %v", facadeName, methodName, clientVersion)
+				return incompatibleClientError
+			}
+			return nil
+		}
+
+		// Calls to manage the migration of the target controller
+		// always need to be allowed.
+		if facadeName == "MigrationTarget" {
+			return nil
+		}
+		// Some calls like status we will support always.
+		if isMethodAllowedForDifferentClients(facadeName, methodName) {
+			return nil
+		}
+
+		// The migration worker makes calls masquerading as a user
+		// so we need to treat those separately.
+		olderClient := clientVersion.Major < jujuversion.Current.Major
+		validMigrationCall := isMethodAllowedForMigrate(facadeName, methodName)
+		if olderClient && !validMigrationCall {
+			return incompatibleClientError
+		}
+
+		// Only allow calls to facilitate upgrades or migrations.
+		if !validMigrationCall && !isMethodAllowedForUpgrade(facadeName, methodName) {
+			return incompatibleClientError
+		}
+		return nil
+	}
+}
+
+func isMethodAllowedForDifferentClients(facadeName, methodName string) bool {
+	methods, ok := allowedDifferentClientMethods[facadeName]
+	if !ok {
+		return false
+	}
+	return methods.Contains(methodName)
+}
+
+func isMethodAllowedForUpgrade(facadeName, methodName string) bool {
+	upgradeOK := false
+	upgradeMethods, ok := allowedMethodsForUpgrade[facadeName]
+	if ok {
+		upgradeOK = upgradeMethods.Contains(methodName)
+	}
+	return upgradeOK
+}
+
+func isMethodAllowedForMigrate(facadeName, methodName string) bool {
+	migrateOK := false
+	migrateMethods, ok := allowedMethodsForMigrate[facadeName]
+	if ok {
+		migrateOK = migrateMethods.Contains(methodName)
+	}
+	return migrateOK
+}
+
+// These methods below are potentially called from a client with
+// a different major version to the controller.
+// As such we need to ensure we retain compatibility.
+
+// allowedDifferentClientMethods stores api calls we want to
+// allow regardless of client or controller version.
+var allowedDifferentClientMethods = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"FullStatus",
+	),
+}
+
+// allowedMethodsForUpgrade stores api calls
+// that are not blocked when the connecting client has
+// a major version greater than that of the controller.
+var allowedMethodsForUpgrade = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"SetModelAgentVersion",
+		"FindTools",
+		"AbortCurrentUpgrade",
+	),
+	"ModelManager": set.NewStrings(
+		"ValidateModelUpgrades",
+	),
+	"ModelConfig": set.NewStrings(
+		"ModelGet",
+	),
+	"Controller": set.NewStrings(
+		"ModelConfig",
+		"ControllerConfig",
+		"CloudSpec",
+	),
+}
+
+// allowedMethodsForMigrate stores api calls
+// that are not blocked when the connecting client has
+// a major version greater than that of the controller.
+var allowedMethodsForMigrate = map[string]set.Strings{
+	"UserManager": set.NewStrings(
+		"UserInfo",
+	),
+	"Controller": set.NewStrings(
+		"InitiateMigration",
+		"IdentityProviderURL",
+	),
+}

--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type restrictNewerClientSuite struct {
+	testing.BaseSuite
+
+	olderVersion version.Number
+}
+
+var _ = gc.Suite(&restrictNewerClientSuite{})
+
+func (r *restrictNewerClientSuite) SetUpTest(c *gc.C) {
+	r.BaseSuite.SetUpTest(c)
+	r.PatchValue(&jujuversion.Current, version.MustParse("3.0.0"))
+	r.olderVersion = jujuversion.Current
+	r.olderVersion.Major--
+}
+
+func (r *restrictNewerClientSuite) TestOldClientAllowedMethods(c *gc.C) {
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	checkAllowed := func(facade, method string, version int) {
+		caller, err := root.FindMethod(facade, version, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Client", "FullStatus", 1)
+	checkAllowed("Pinger", "Ping", 1)
+	// Worker calls for migrations.
+	checkAllowed("MigrationTarget", "Prechecks", 1)
+	checkAllowed("UserManager", "UserInfo", 1)
+}
+
+func (r *restrictNewerClientSuite) TestNewClientAllowedMethods(c *gc.C) {
+	r.olderVersion.Major = jujuversion.Current.Major + 1
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	checkAllowed := func(facade, method string, version int) {
+		caller, err := root.FindMethod(facade, version, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Client", "FullStatus", 1)
+	checkAllowed("Pinger", "Ping", 1)
+	// For migrations.
+	checkAllowed("MigrationTarget", "Prechecks", 1)
+	checkAllowed("UserManager", "UserInfo", 1)
+	// For upgrades.
+	checkAllowed("Client", "SetModelAgentVersion", 1)
+}
+
+func (r *restrictNewerClientSuite) TestOldClientDisallowedMethod(c *gc.C) {
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "SetModelAgentVersion")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestReallyOldClientDisallowedMethod(c *gc.C) {
+	r.olderVersion.Major--
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "FullStatus")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestReallyNewClientDisallowedMethod(c *gc.C) {
+	r.olderVersion.Major = jujuversion.Current.Major + 2
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "FullStatus")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestAlwaysDisallowedMethod(c *gc.C) {
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "ModelSet")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestAgentAllowedMethod(c *gc.C) {
+	r.olderVersion.Major = 2
+	r.olderVersion.Minor = 9
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(false, r.olderVersion)
+	checkAllowed := func(facade, method string, version int) {
+		caller, err := root.FindMethod(facade, version, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Uniter", "CurrentModel", 15)
+}
+
+func (r *restrictNewerClientSuite) TestReallyOldAgentDisallowedMethod(c *gc.C) {
+	r.olderVersion.Minor = 0
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Uniter", 15, "CurrentModel")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/version"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	"gopkg.in/macaroon.v2"
@@ -22,7 +23,6 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/httpcontext"
-	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -245,9 +245,12 @@ func LoginRequest(req *http.Request) (params.LoginRequest, error) {
 		Macaroons:     macaroons,
 		BakeryVersion: bakery.Version(bakeryVersion),
 	}
-	clientVersion, err := logsink.JujuClientVersionFromRequest(req)
-	if err == nil {
-		loginRequest.ClientVersion = clientVersion.String()
+	// Default client version to 2 since older 2.x clients
+	// don't send this field.
+	requestClientVersion := version.Number{Major: 2}
+	if clientVersion, err := common.JujuClientVersionFromRequest(req); err == nil {
+		requestClientVersion = clientVersion
 	}
+	loginRequest.ClientVersion = requestClientVersion.String()
 	return loginRequest, nil
 }

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/httpcontext"
+	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
 )
@@ -237,11 +238,16 @@ func LoginRequest(req *http.Request) (params.LoginRequest, error) {
 	}
 
 	bakeryVersion, _ := strconv.Atoi(req.Header.Get(httpbakery.BakeryProtocolHeader))
-	return params.LoginRequest{
+	loginRequest := params.LoginRequest{
 		AuthTag:       tagPass[0],
 		Credentials:   tagPass[1],
 		Nonce:         req.Header.Get(params.MachineNonceHeader),
 		Macaroons:     macaroons,
 		BakeryVersion: bakery.Version(bakeryVersion),
-	}, nil
+	}
+	clientVersion, err := logsink.JujuClientVersionFromRequest(req)
+	if err == nil {
+		loginRequest.ClientVersion = clientVersion.String()
+	}
+	return loginRequest, nil
 }

--- a/apiserver/testing/fakeapi_test.go
+++ b/apiserver/testing/fakeapi_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jtesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&fakeAPISuite{})
@@ -62,6 +63,6 @@ func (f facade) Login(req params.LoginRequest) (params.LoginResult, error) {
 			DisplayName: "foo",
 			Identity:    "user-bar",
 		},
-		ServerVersion: "1.0.0",
+		ServerVersion: version.Current.String(),
 	}, nil
 }

--- a/apiserver/testing/http.go
+++ b/apiserver/testing/http.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // httpRequestParams holds parameters for the sendHTTPRequest methods.
@@ -79,6 +80,7 @@ func SendHTTPRequest(c *gc.C, p HTTPRequestParams) *http.Response {
 		ExpectError:  p.ExpectError,
 		ExpectStatus: p.ExpectStatus,
 	}
+	hp.Header.Set(params.JujuClientVersion, jujuversion.Current.String())
 	if p.ContentType != "" {
 		hp.Header.Set("Content-Type", p.ContentType)
 	}

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -280,17 +280,21 @@ var (
 // version of the upgrade-model command may not know how to upgrade
 // an environment running juju 4.0.0.
 //
-// The exception is that a N.0.* client must be able to upgrade
+// The exception is that a N.*.* client must be able to upgrade
 // an environment one major version prior (N-1.*.*) so that
 // it can be used to upgrade the environment to N.0.*.  For
-// example, the 2.0.1 upgrade-model command must be able to upgrade
-// environments running 1.* since it must be able to upgrade
-// environments from 1.25.4 -> 2.0.*.
+// example, the 3.*.* upgrade-model command must be able to upgrade
+// environments running 2.* since it must be able to upgrade
+// environments from 2.8.7 -> 3.*.*.
+// We used to require that the minor version of a newer client had
+// to be 0 but with snap auto update, the client can be any minor
+// version so need to ensure that all N.*.* clients can upgrade
+// N-1.*.* controllers.
 func canUpgradeRunningVersion(runningAgentVer version.Number) bool {
 	if runningAgentVer.Major == jujuversion.Current.Major {
 		return true
 	}
-	if jujuversion.Current.Minor == 0 && runningAgentVer.Major == (jujuversion.Current.Major-1) {
+	if runningAgentVer.Major == (jujuversion.Current.Major - 1) {
 		return true
 	}
 	return false

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -206,6 +206,14 @@ var upgradeJujuTests = []upgradeTest{{
 	expectVersion:  "3.0.2",
 	upgradeMap:     map[int]version.Number{3: version.MustParse("2.8.2")},
 }, {
+	about:          "specified major version, later client",
+	available:      []string{"3.0.2-quantal-amd64"},
+	currentVersion: "3.9.2-quantal-amd64",
+	agentVersion:   "2.8.2",
+	args:           []string{"--agent-version", "3.0.2"},
+	expectVersion:  "3.0.2",
+	upgradeMap:     map[int]version.Number{3: version.MustParse("2.8.2")},
+}, {
 	about:          "specified version missing, but already set",
 	currentVersion: "3.0.0-quantal-amd64",
 	agentVersion:   "3.0.0",
@@ -245,13 +253,6 @@ var upgradeJujuTests = []upgradeTest{{
 	agentVersion:   "3.0.0",
 	args:           []string{"--agent-version", "3.2.0"},
 	expectErr:      "no matching agent versions available",
-}, {
-	about:          "incompatible version (minor != 0)",
-	available:      []string{"3.2.0-quantal-amd64"},
-	currentVersion: "4.2.0-quantal-amd64",
-	agentVersion:   "3.2.0",
-	args:           []string{"--agent-version", "3.2.0"},
-	expectErr:      "cannot upgrade a 3.2.0 model with a 4.2.0 client",
 }, {
 	about:          "incompatible version (model major > client major)",
 	available:      []string{"3.2.0-quantal-amd64"},


### PR DESCRIPTION
We restrict what clients with a different major version to the controller can do.
Older CLI clients can run status.
Newer CLI clients can do:
- status
- upgrade
- migrate

Older agents cannot make api calls unless they are 2.9 or greater. So all models on a controller will need to be upgraded to 2.9 before the controller can be upgraded to 3 (separate PR needed to enforce this).

This will allow facades older than the current version brought across to 3.x from 2.9 to be removed.

## QA steps

Compile a juju client with major version 3 and run against a bootstrapped 2.9 controller.
Ensure the newer client can:
- upgrade the 2.9 controller
- migrate a model off the 2.9 controller to a new 3.x controller

Ensure also an older client gets rejected trying to deploy to a newer controller.
