### PR TITLE
Only include public scoped addresses for CAAS network-get calls

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -408,7 +408,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	// Add a application address.
 	err = mysql.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("1.2.3.4", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
@@ -423,7 +423,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopePublic)})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -169,6 +169,10 @@ func (n *NetworkInfoCAAS) NetworksForRelation(
 	var ingress corenetwork.SpaceAddresses
 	var err error
 
+	if err = n.setCrossModelStatus(rel); err != nil {
+		return "", nil, nil, errors.Trace(err)
+	}
+
 	if pollAddr {
 		if ingress, err = n.maybeGetUnitAddress(rel, false); err != nil {
 			return "", nil, nil, errors.Trace(err)
@@ -176,8 +180,7 @@ func (n *NetworkInfoCAAS) NetworksForRelation(
 	}
 
 	// Ingress addresses can only be public addresses for CAAS.
-	// The are always scoped explicitly and are either public or local-cloud.
-	// See: caas/kubernetes/provider/k8s.go
+	// The are always scoped explicitly. See: caas/kubernetes/provider/k8s.go.
 	if len(ingress) == 0 {
 		for _, addr := range n.addresses {
 			if addr.Scope == corenetwork.ScopePublic {

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -180,13 +180,19 @@ func (n *NetworkInfoCAAS) NetworksForRelation(
 	}
 
 	// Ingress addresses can only be public addresses for CAAS.
-	// The are always scoped explicitly. See: caas/kubernetes/provider/k8s.go.
+	// They are always scoped explicitly. See: caas/kubernetes/provider/k8s.go.
 	if len(ingress) == 0 {
 		for _, addr := range n.addresses {
 			if addr.Scope == corenetwork.ScopePublic {
 				ingress = append(ingress, addr)
 			}
 		}
+	}
+
+	// If we are working with a cross-model relation, omit any non-public scope
+	// addresses from the default egress.
+	if n.isCrossModelRelation {
+		n.defaultEgress = subnetsForAddresses(ingress.Values())
 	}
 
 	// We can pass nil as ingress here, because we have already set

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -118,6 +118,10 @@ func (n *NetworkInfoIAAS) getRelationNetworkInfo(
 func (n *NetworkInfoIAAS) NetworksForRelation(
 	binding string, rel *state.Relation, _ bool,
 ) (string, corenetwork.SpaceAddresses, []string, error) {
+	if err := n.setCrossModelStatus(rel); err != nil {
+		return "", nil, nil, errors.Trace(err)
+	}
+
 	boundSpace, err := n.spaceForBinding(binding)
 	if err != nil && !errors.IsNotValid(err) {
 		return "", nil, nil, errors.Trace(err)

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -128,7 +128,7 @@ func (n *NetworkInfoIAAS) NetworksForRelation(
 	// addresses the input relation and pollPublic flag.
 	var ingress corenetwork.SpaceAddresses
 	if boundSpace == corenetwork.AlphaSpaceId || err != nil {
-		addrs, err := n.maybeGetUnitAddress(rel)
+		addrs, err := n.maybeGetUnitAddress(rel, true)
 		if err != nil {
 			return "", nil, nil, errors.Trace(err)
 		}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -5278,7 +5278,7 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 			},
 		},
 		EgressSubnets:    []string{"54.32.1.2/32"},
-		IngressAddresses: []string{"54.32.1.2", "192.168.1.2"},
+		IngressAddresses: []string{"54.32.1.2"},
 	}
 
 	uniterAPI := s.newUniterAPI(c, st, s.authorizer)
@@ -5327,7 +5327,7 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 			},
 		},
 		EgressSubnets:    []string{"54.32.1.2/32"},
-		IngressAddresses: []string{"54.32.1.2", "192.168.1.2"},
+		IngressAddresses: []string{"54.32.1.2"},
 	}
 
 	uniterAPI := s.newUniterAPI(c, st, s.authorizer)


### PR DESCRIPTION
This patch changes `NetworkInfo` returns for CAAS units - only addresses with a scope of _public_ are included as ingress addresses.

The call to retrieve all unit addresses is now made once within a new constructor, which eliminates multiple calls to `unit.AllAddresses`, previously possible under some scenarios.

All unit addresses are used to when attempting to derive egress subnets. These are sorted public-first, so we will prefer these provided that an address in IP form is available. The exception is for cross-model relations, where we will _only_ consider public addresses.

IAAS behaviour is preserved by this patch.

## QA steps

TBC

## Documentation changes

We need to determine if/what charming resources should reflect this change.

## Bug reference

None.
