### PR TITLE
Merge 2.8 into develop

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/shell"
 	"github.com/juju/version"
@@ -43,11 +42,11 @@ const (
 
 // These are base values used for the corresponding defaults.
 var (
-	logDir           = paths.MustSucceed(paths.LogDir(series.MustHostSeries()))
-	dataDir          = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
-	transientDataDir = paths.MustSucceed(paths.TransientDataDir(series.MustHostSeries()))
-	confDir          = paths.MustSucceed(paths.ConfDir(series.MustHostSeries()))
-	metricsSpoolDir  = paths.MustSucceed(paths.MetricsSpoolDir(series.MustHostSeries()))
+	logDir           = paths.LogDir(paths.CurrentOS())
+	dataDir          = paths.DataDir(paths.CurrentOS())
+	transientDataDir = paths.TransientDataDir(paths.CurrentOS())
+	confDir          = paths.ConfDir(paths.CurrentOS())
+	metricsSpoolDir  = paths.MetricsSpoolDir(paths.CurrentOS())
 )
 
 // Agent exposes the agent's configuration to other components. This

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
@@ -292,7 +291,7 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
 	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
-	c.Assert(m.Series(), gc.Equals, series.MustHostSeries())
+	c.Assert(m.Series(), gc.Equals, testing.HostSeries(c))
 	c.Assert(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
 	c.Assert(m.Addresses(), jc.DeepEquals, filteredAddrs)
 	gotBootstrapConstraints, err := m.Constraints()

--- a/agent/tools/symlinks_test.go
+++ b/agent/tools/symlinks_test.go
@@ -9,17 +9,14 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/utils/v2/symlink"
-	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/juju/names"
-	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/juju/testing"
 )
 
 type SymlinksSuite struct {
@@ -30,11 +27,7 @@ var _ = gc.Suite(&SymlinksSuite{})
 
 func (s *SymlinksSuite) SetUpTest(c *gc.C) {
 	s.dataDir = c.MkDir()
-	s.toolsDir = tools.SharedToolsDir(s.dataDir, version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	})
+	s.toolsDir = tools.SharedToolsDir(s.dataDir, testing.CurrentVersion(c))
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("created %s", s.toolsDir)

--- a/api/certpool.go
+++ b/api/certpool.go
@@ -10,13 +10,12 @@ import (
 	"path/filepath"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/utils/v2/cert"
 
 	"github.com/juju/juju/core/paths"
 )
 
-var certDir = filepath.FromSlash(paths.MustSucceed(paths.CertDir(series.MustHostSeries())))
+var certDir = filepath.FromSlash(paths.CertDir(paths.CurrentOS()))
 
 // CreateCertPool creates a new x509.CertPool and adds in the caCert passed
 // in.  All certs from the cert directory (/etc/juju/cert.d on ubuntu) are

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/arch"
-	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -774,11 +772,7 @@ func (s *provisionerSuite) TestFindToolsLogicError(c *gc.C) {
 }
 
 func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logicError error) {
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	var toolsList = coretools.List{&coretools.Tools{Version: current}}
 	var called bool
 	var a string
@@ -793,7 +787,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 		c.Assert(request, gc.Equals, "FindTools")
 		expected := params.FindToolsParams{
 			Number:       jujuversion.Current,
-			Series:       series.MustHostSeries(),
+			Series:       current.Series,
 			Arch:         a,
 			MinorVersion: -1,
 			MajorVersion: -1,
@@ -806,7 +800,7 @@ func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logi
 		}
 		return apiError
 	})
-	apiList, err := s.provisioner.FindTools(jujuversion.Current, series.MustHostSeries(), a)
+	apiList, err := s.provisioner.FindTools(jujuversion.Current, current.Series, a)
 	c.Assert(called, jc.IsTrue)
 	if apiError != nil {
 		c.Assert(err, gc.Equals, apiError)

--- a/api/upgrader/unitupgrader_test.go
+++ b/api/upgrader/unitupgrader_test.go
@@ -5,10 +5,8 @@ package upgrader_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -18,8 +16,8 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type unitUpgraderSuite struct {
@@ -36,12 +34,6 @@ type unitUpgraderSuite struct {
 }
 
 var _ = gc.Suite(&unitUpgraderSuite{})
-
-var current = version.Binary{
-	Number: jujuversion.Current,
-	Arch:   arch.HostArch(),
-	Series: series.MustHostSeries(),
-}
 
 func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
@@ -73,18 +65,19 @@ func (s *unitUpgraderSuite) addMachineApplicationCharmAndUnit(c *gc.C, appName s
 }
 
 func (s *unitUpgraderSuite) TestSetVersionWrongUnit(c *gc.C) {
-	err := s.st.SetVersion("unit-wordpress-42", current)
+	err := s.st.SetVersion("unit-wordpress-42", testing.CurrentVersion(c))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *unitUpgraderSuite) TestSetVersionNotUnit(c *gc.C) {
-	err := s.st.SetVersion("foo-42", current)
+	err := s.st.SetVersion("foo-42", testing.CurrentVersion(c))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *unitUpgraderSuite) TestSetVersion(c *gc.C) {
+	current := testing.CurrentVersion(c)
 	agentTools, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
@@ -111,6 +104,7 @@ func (s *unitUpgraderSuite) TestToolsNotUnit(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestTools(c *gc.C) {
+	current := testing.CurrentVersion(c)
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)
@@ -157,6 +151,7 @@ func (s *unitUpgraderSuite) TestWatchAPIVersionNotUnit(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersion(c *gc.C) {
+	current := testing.CurrentVersion(c)
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)

--- a/api/upgrader/upgrader_test.go
+++ b/api/upgrader/upgrader_test.go
@@ -52,18 +52,19 @@ func (s *machineUpgraderSuite) TestNew(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestSetVersionWrongMachine(c *gc.C) {
-	err := s.st.SetVersion("machine-42", current)
+	err := s.st.SetVersion("machine-42", coretesting.CurrentVersion(c))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersionNotMachine(c *gc.C) {
-	err := s.st.SetVersion("foo-42", current)
+	err := s.st.SetVersion("foo-42", coretesting.CurrentVersion(c))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersion(c *gc.C) {
+	current := coretesting.CurrentVersion(c)
 	agentTools, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
@@ -90,6 +91,7 @@ func (s *machineUpgraderSuite) TestToolsNotMachine(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestTools(c *gc.C) {
+	current := coretesting.CurrentVersion(c)
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)
@@ -133,6 +135,7 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
+	current := coretesting.CurrentVersion(c)
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)

--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/network"
 )
@@ -142,10 +143,7 @@ func (w *EgressAddressWatcher) loop() error {
 			}
 			changed = false
 			if !setEquals(addresses, lastAddresses) {
-				addressesCIDR, err = network.FormatAsCIDR(addresses.Values())
-				if err != nil {
-					return errors.Trace(err)
-				}
+				addressesCIDR = corenetwork.SubnetsForAddresses(addresses.Values())
 				ready = ready || sentInitial
 			}
 		}

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -264,8 +264,8 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 
 	caCert, _ := controllerConfig.CACert()
 	version, _ := f.model.AgentVersion()
-	dataDir, _ := paths.DataDir("kubernetes")
-	logDir, _ := paths.LogDir("kubernetes")
+	dataDir := paths.DataDir(paths.OSUnixLike)
+	logDir := paths.LogDir(paths.OSUnixLike)
 
 	conf, err := agent.NewAgentConfig(
 		agent.AgentConfigParams{

--- a/apiserver/facades/agent/uniter/networkinfo_internal_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_internal_test.go
@@ -14,9 +14,9 @@ type networkInfoSuite struct {
 
 var _ = gc.Suite(&networkInfoSuite{})
 
-// TestNetworkInfoDedupLogic ensures that we don't get a regression for
-// LP1864072.
-func (s *networkInfoSuite) TestNetworkInfoDedupLogic(c *gc.C) {
+// TestUniqueNetworkInfoResults ensures that
+// we don't get a regression for LP1864072.
+func (s *networkInfoSuite) TestUniqueNetworkInfoResults(c *gc.C) {
 	resWithDups := params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
 			"ep0": {
@@ -134,6 +134,6 @@ func (s *networkInfoSuite) TestNetworkInfoDedupLogic(c *gc.C) {
 		},
 	}
 
-	filteredRes := dedupNetworkInfoResults(resWithDups)
+	filteredRes := uniqueNetworkInfoResults(resWithDups)
 	c.Assert(filteredRes, gc.DeepEquals, expRes)
 }

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -95,14 +95,8 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		// The binding address information based on link layer devices.
 		info := machineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
 
-		// Set egress and ingress address information.
 		info.EgressSubnets = endpointEgressSubnets[endpoint]
-
-		ingressAddrs := make([]string, len(endpointIngressAddresses[endpoint]))
-		for i, addr := range endpointIngressAddresses[endpoint] {
-			ingressAddrs[i] = addr.Value
-		}
-		info.IngressAddresses = ingressAddrs
+		info.IngressAddresses = endpointIngressAddresses[endpoint].Values()
 
 		// If there is no ingress address explicitly defined for a given
 		// binding, set the ingress addresses to either any defaults set above,
@@ -114,27 +108,17 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		if len(info.IngressAddresses) == 0 {
 			ingress := spaceAddressesFromNetworkInfo(networkInfos[space].NetworkInfos)
 			corenetwork.SortAddresses(ingress)
-			info.IngressAddresses = make([]string, len(ingress))
-			for i, addr := range ingress {
-				info.IngressAddresses[i] = addr.Value
-			}
+			info.IngressAddresses = ingress.Values()
 		}
 
-		// If there is no egress subnet explicitly defined for a given binding,
-		// default to the first ingress address. This matches the behaviour when
-		// there's a relation in place.
-		if len(info.EgressSubnets) == 0 && len(info.IngressAddresses) > 0 {
-			var err error
-			info.EgressSubnets, err = network.FormatAsCIDR([]string{info.IngressAddresses[0]})
-			if err != nil {
-				return result, errors.Trace(err)
-			}
+		if len(info.EgressSubnets) == 0 {
+			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		result.Results[endpoint] = info
+		result.Results[endpoint] = n.resolveResultHostNames(info)
 	}
 
-	return dedupNetworkInfoResults(result), nil
+	return result, nil
 }
 
 // getRelationNetworkInfo returns the endpoint name, network space
@@ -170,12 +154,9 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 func (n *NetworkInfoBase) NetworksForRelation(
 	_ string, rel *state.Relation, pollAddr bool,
 ) (string, corenetwork.SpaceAddresses, []string, error) {
-	egress, err := n.getRelationEgressSubnets(rel)
-	if err != nil {
-		return "", nil, nil, errors.Trace(err)
-	}
-
 	var ingress corenetwork.SpaceAddresses
+	var err error
+
 	if pollAddr {
 		if ingress, err = n.maybeGetUnitAddress(rel); err != nil {
 			return "", nil, nil, errors.Trace(err)
@@ -197,12 +178,10 @@ func (n *NetworkInfoBase) NetworksForRelation(
 
 	corenetwork.SortAddresses(ingress)
 
-	// If no egress subnets defined, We default to the ingress address.
-	if len(egress) == 0 && len(ingress) > 0 {
-		egress, err = network.FormatAsCIDR([]string{ingress[0].Value})
-		if err != nil {
-			return "", nil, nil, errors.Trace(err)
-		}
+	egress, err := n.getEgressForRelation(rel, ingress)
+	if err != nil {
+		return "", nil, nil, errors.Trace(err)
 	}
+
 	return corenetwork.AlphaSpaceId, ingress, egress, nil
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1666,7 +1666,7 @@ func (u *UniterAPI) EnterScope(args params.RelationUnits) (params.ErrorResults, 
 			return nil
 		}
 
-		netInfo, err := NewNetworkInfo(u.st, unitTag, defaultRetryFactory)
+		netInfo, err := NewNetworkInfo(u.st, unitTag)
 		if err != nil {
 			return err
 		}
@@ -2606,12 +2606,16 @@ func (u *UniterAPI) NetworkInfo(args params.NetworkInfoParams) (params.NetworkIn
 		return params.NetworkInfoResults{}, apiservererrors.ErrPerm
 	}
 
-	netInfo, err := NewNetworkInfo(u.st, unitTag, defaultRetryFactory)
+	netInfo, err := NewNetworkInfo(u.st, unitTag)
 	if err != nil {
 		return params.NetworkInfoResults{}, err
 	}
 
-	return netInfo.ProcessAPIRequest(args)
+	res, err := netInfo.ProcessAPIRequest(args)
+	if err != nil {
+		return params.NetworkInfoResults{}, err
+	}
+	return uniqueNetworkInfoResults(res), nil
 }
 
 // WatchUnitRelations returns a StringsWatcher, for each given
@@ -3536,7 +3540,7 @@ func (u *UniterAPI) updateUnitNetworkInfoOperation(unitTag names.UnitTag, unit *
 			return nil, errors.Trace(err)
 		}
 
-		netInfo, err := NewNetworkInfo(u.st, unitTag, defaultRetryFactory)
+		netInfo, err := NewNetworkInfo(u.st, unitTag)
 		if err != nil {
 			return nil, err
 		}

--- a/apiserver/facades/agent/upgrader/unitupgrader_test.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader_test.go
@@ -6,9 +6,7 @@ package upgrader_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -19,6 +17,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -39,12 +38,6 @@ type unitUpgraderSuite struct {
 }
 
 var _ = gc.Suite(&unitUpgraderSuite{})
-
-var current = version.Binary{
-	Number: jujuversion.Current,
-	Arch:   arch.HostArch(),
-	Series: series.MustHostSeries(),
-}
 
 func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
@@ -163,6 +156,7 @@ func (s *unitUpgraderSuite) TestToolsForAgent(c *gc.C) {
 	// The machine must have its existing tools set before we query for the
 	// next tools. This is so that we can grab Arch and Series without
 	// having to pass it in again
+	current := testing.CurrentVersion(c)
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -195,11 +189,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: s.rawUnit.Tag().String(),
 			Tools: &params.Version{
-				Version: version.Binary{
-					Number: jujuversion.Current,
-					Arch:   arch.HostArch(),
-					Series: series.MustHostSeries(),
-				},
+				Version: testing.CurrentVersion(c),
 			},
 		}},
 	}
@@ -211,11 +201,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestSetTools(c *gc.C) {
-	cur := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	cur := testing.CurrentVersion(c)
 	_, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	args := params.EntitiesVersion{
@@ -269,11 +255,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
@@ -294,11 +276,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}}}

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -209,11 +207,7 @@ func (s *upgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	agent := params.Entity{Tag: s.rawMachine.Tag().String()}
 
 	// The machine must have its existing tools set before we query for the
@@ -253,11 +247,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: s.rawMachine.Tag().String(),
 			Tools: &params.Version{
-				Version: version.Binary{
-					Number: jujuversion.Current,
-					Arch:   arch.HostArch(),
-					Series: series.MustHostSeries(),
-				},
+				Version: coretesting.CurrentVersion(c),
 			},
 		}},
 	}
@@ -269,11 +259,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *upgraderSuite) TestSetTools(c *gc.C) {
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	_, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	args := params.EntitiesVersion{
@@ -353,11 +339,7 @@ func (s *upgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
 func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	// In order to call SetModelAgentVersion we have to first SetTools on
 	// all the existing machines
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	s.apiMachine.SetAgentVersion(current)
 	s.rawMachine.SetAgentVersion(current)
 	newer := current

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -16,10 +16,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -29,9 +27,9 @@ import (
 	toolstesting "github.com/juju/juju/environs/tools/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/binarystorage"
+	"github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type toolsSuite struct {
@@ -380,13 +378,8 @@ func (s *toolsSuite) TestUploadSeriesExpanded(c *gc.C) {
 }
 
 func (s *toolsSuite) TestDownloadModelUUIDPath(c *gc.C) {
-	v := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
-		Version: v.String(),
+		Version: testing.CurrentVersion(c).String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
@@ -397,13 +390,8 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 	newSt := s.Factory.MakeModel(c, nil)
 	defer newSt.Close()
 
-	v := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
 	tools := s.storeFakeTools(c, newSt, "abc", binarystorage.Metadata{
-		Version: v.String(),
+		Version: testing.CurrentVersion(c).String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
@@ -411,13 +399,8 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 }
 
 func (s *toolsSuite) TestDownloadTopLevelPath(c *gc.C) {
-	v := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
-		Version: v.String(),
+		Version: testing.CurrentVersion(c).String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -855,10 +855,7 @@ func (a *app) Units() ([]caas.Unit, error) {
 func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec, error) {
 	appSecret := a.secretName()
 
-	jujuDataDir, err := paths.DataDir("kubernetes")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 
 	containerNames := []string(nil)
 	containers := []caas.ContainerConfig(nil)

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -204,8 +204,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, deploymentType caas.DeploymentT
 }
 
 func getPodSpec(c *gc.C) corev1.PodSpec {
-	jujuDataDir, err := paths.DataDir("kubernetes")
-	c.Assert(err, jc.ErrorIsNil)
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
 		AutomountServiceAccountToken: application.BoolPtr(false),
 		InitContainers: []corev1.Container{{

--- a/caas/kubernetes/provider/constants/storage.go
+++ b/caas/kubernetes/provider/constants/storage.go
@@ -46,9 +46,5 @@ var (
 )
 
 func getK8sStorageBaseDir() string {
-	s, err := paths.StorageDir(CAASProviderType)
-	if err != nil {
-		panic(err)
-	}
-	return s
+	return paths.StorageDir(paths.OSUnixLike)
 }

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1372,14 +1372,8 @@ func ensureJujuInitContainer(podSpec *core.PodSpec, operatorImagePath string) er
 }
 
 func getJujuInitContainerAndStorageInfo(operatorImagePath string) (container core.Container, vol core.Volume, volMounts []core.VolumeMount, err error) {
-	dataDir, err := paths.DataDir(constants.CAASProviderType)
-	if err != nil {
-		return container, vol, volMounts, errors.Trace(err)
-	}
-	jujuRun, err := paths.JujuRun(constants.CAASProviderType)
-	if err != nil {
-		return container, vol, volMounts, errors.Trace(err)
-	}
+	dataDir := paths.DataDir(paths.OSUnixLike)
+	jujuRun := paths.JujuRun(paths.OSUnixLike)
 	jujudCmd := `
 initCmd=$($JUJU_TOOLS_DIR/jujud help commands | grep caas-unit-init)
 if test -n "$initCmd"; then

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -271,10 +271,7 @@ func modelOperatorDeployment(
 	volumeMounts []core.VolumeMount,
 ) (*apps.Deployment, error) {
 	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud model --model-uuid=%s", modelUUID)
-	jujuDataDir, err := paths.DataDir("kubernetes")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 
 	return &apps.Deployment{
 		ObjectMeta: meta.ObjectMeta{

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -721,10 +721,7 @@ func operatorPod(
 
 	appTag := names.NewApplicationTag(appName)
 	jujudCmd := fmt.Sprintf("$JUJU_TOOLS_DIR/jujud caasoperator --application-name=%s --debug", appName)
-	jujuDataDir, err := paths.DataDir("kubernetes")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	mountToken := true
 	return &core.Pod{
 		ObjectMeta: v1.ObjectMeta{

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -726,31 +726,16 @@ func NewInstanceConfig(
 	series string,
 	apiInfo *api.Info,
 ) (*InstanceConfig, error) {
-	dataDir, err := paths.DataDir(series)
-	if err != nil {
-		return nil, err
-	}
-	logDir, err := paths.LogDir(series)
-	if err != nil {
-		return nil, err
-	}
-	metricsSpoolDir, err := paths.MetricsSpoolDir(series)
-	if err != nil {
-		return nil, err
-	}
-	transientDataDir, err := paths.TransientDataDir(series)
-	if err != nil {
-		return nil, err
-	}
-	cloudInitOutputLog := path.Join(logDir, "cloud-init-output.log")
+	osType := paths.SeriesToOS(series)
+	logDir := paths.LogDir(osType)
 	icfg := &InstanceConfig{
 		// Fixed entries.
-		DataDir:                 dataDir,
+		DataDir:                 paths.DataDir(osType),
 		LogDir:                  path.Join(logDir, "juju"),
-		MetricsSpoolDir:         metricsSpoolDir,
+		MetricsSpoolDir:         paths.MetricsSpoolDir(osType),
 		Jobs:                    []model.MachineJob{model.JobHostUnits},
-		CloudInitOutputLog:      cloudInitOutputLog,
-		TransientDataDir:        transientDataDir,
+		CloudInitOutputLog:      path.Join(logDir, "cloud-init-output.log"),
+		TransientDataDir:        paths.TransientDataDir(osType),
 		MachineAgentServiceName: "jujud-" + names.NewMachineTag(machineID).String(),
 		Series:                  series,
 		Tags:                    map[string]string{},

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -61,24 +61,12 @@ type MachineInitReader struct {
 // NewMachineInitReader creates and returns a new MachineInitReader for the
 // input series.
 func NewMachineInitReader(series string) (InitReader, error) {
-	cloudInitConfigDir, err := paths.CloudInitCfgDir(series)
-	if err != nil {
-		return nil, errors.Annotate(err, "determining CloudInitCfgDir for the machine")
-	}
-	cloudInitInstanceConfigDir, err := paths.MachineCloudInitDir(series)
-	if err != nil {
-		return nil, errors.Annotate(err, "determining MachineCloudInitDir for the machine")
-	}
-	curtinInstallConfigFile, err := paths.CurtinInstallConfig(series)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
+	osType := paths.SeriesToOS(series)
 	cfg := MachineInitReaderConfig{
 		Series:                     series,
-		CloudInitConfigDir:         cloudInitConfigDir,
-		CloudInitInstanceConfigDir: cloudInitInstanceConfigDir,
-		CurtinInstallConfigFile:    curtinInstallConfigFile,
+		CloudInitConfigDir:         paths.CloudInitCfgDir(osType),
+		CloudInitInstanceConfigDir: paths.MachineCloudInitDir(osType),
+		CurtinInstallConfigFile:    paths.CurtinInstallConfig(osType),
 	}
 	return NewMachineInitReaderFromConfig(cfg), nil
 }
@@ -100,7 +88,8 @@ func (r *MachineInitReader) GetInitConfig() (map[string]interface{}, error) {
 	}
 	switch containerOS {
 	case utilsos.Ubuntu, utilsos.CentOS, utilsos.OpenSUSE:
-		if series != utilsseries.MustHostSeries() {
+		hostSeries, err := utilsseries.HostSeries()
+		if err != nil || series != hostSeries {
 			logger.Debugf("not attempting to get init config for %s, series of machine and container differ", series)
 			return nil, nil
 		}

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -28,7 +28,7 @@ type fromHostSuite struct {
 var _ = gc.Suite(&fromHostSuite{})
 
 func (s *fromHostSuite) SetUpTest(c *gc.C) {
-	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "xenial" })
+	s.PatchValue(&utilsseries.HostSeries, func() (string, error) { return "xenial", nil })
 
 	// Pre-seed /etc/cloud/cloud.cfg.d replacement for testing
 	s.tempCloudCfgDir = c.MkDir() // will clean up
@@ -112,7 +112,7 @@ var cloudinitDataVerifyTests = []cloudinitDataVerifyTest{
 func (s *fromHostSuite) TestGetMachineCloudInitDataVerifySeries(c *gc.C) {
 	for i, test := range cloudinitDataVerifyTests {
 		c.Logf("Test %d of %d: %s", i, len(cloudinitDataVerifyTests), test.description)
-		s.PatchValue(&utilsseries.MustHostSeries, func() string { return test.machineSeries })
+		s.PatchValue(&utilsseries.HostSeries, func() (string, error) { return test.machineSeries, nil })
 		obtained, err := s.newMachineInitReader(test.containerSeries).GetInitConfig()
 		c.Assert(err, gc.IsNil)
 		if test.result != nil {
@@ -189,7 +189,7 @@ func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritProperties(c *gc
 }
 
 func (s *fromHostSuite) TestCloudConfigVersionV077(c *gc.C) {
-	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "trusty" })
+	s.PatchValue(&utilsseries.HostSeries, func() (string, error) { return "trusty", nil })
 	seedData(c, s.tempCloudCfgDir, "90_dpkg_local_cloud_config.cfg", dpkgLocalCloudConfigLegacy)
 
 	reader := s.newMachineInitReader("trusty")
@@ -215,7 +215,7 @@ func (s *fromHostSuite) TestCloudConfigVersionNoContainerInheritPropertiesLegacy
 }
 
 func (s *fromHostSuite) TestCurtinConfigAptProperties(c *gc.C) {
-	s.PatchValue(&utilsseries.MustHostSeries, func() string { return "bionic" })
+	s.PatchValue(&utilsseries.HostSeries, func() (string, error) { return "bionic", nil })
 
 	// Seed the curtin install config as for MAAS 2.5+
 	curtinDir := c.MkDir()

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -258,23 +258,12 @@ func NewControllerPodConfig(
 	series string,
 	apiInfo *api.Info,
 ) (*ControllerPodConfig, error) {
-	dataDir, err := paths.DataDir(series)
-	if err != nil {
-		return nil, err
-	}
-	logDir, err := paths.LogDir(series)
-	if err != nil {
-		return nil, err
-	}
-	metricsSpoolDir, err := paths.MetricsSpoolDir(series)
-	if err != nil {
-		return nil, err
-	}
+	osType := paths.SeriesToOS(series)
 	pcfg := &ControllerPodConfig{
 		// Fixed entries.
-		DataDir:         dataDir,
-		LogDir:          path.Join(logDir, "juju"),
-		MetricsSpoolDir: metricsSpoolDir,
+		DataDir:         paths.DataDir(osType),
+		LogDir:          path.Join(paths.LogDir(osType), "juju"),
+		MetricsSpoolDir: paths.MetricsSpoolDir(osType),
 		Tags:            map[string]string{},
 		// Parameter entries.
 		ControllerTag:  controllerTag,

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -48,14 +48,6 @@ type CloudInitSuite struct {
 
 var _ = gc.Suite(&CloudInitSuite{})
 
-// TODO: add this to the utils package
-func must(s string, err error) string {
-	if err != nil {
-		panic(err)
-	}
-	return s
-}
-
 func (s *CloudInitSuite) TestFinishInstanceConfig(c *gc.C) {
 
 	userTag := names.NewLocalUserTag("not-touched")
@@ -142,9 +134,9 @@ func (s *CloudInitSuite) TestControllerUserDataPrecise(c *gc.C) {
 
 func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 	// Use actual series paths instead of local defaults
-	logDir := must(paths.LogDir(series))
-	metricsSpoolDir := must(paths.MetricsSpoolDir(series))
-	dataDir := must(paths.DataDir(series))
+	logDir := paths.LogDir(paths.SeriesToOS(series))
+	metricsSpoolDir := paths.MetricsSpoolDir(paths.SeriesToOS(series))
+	dataDir := paths.DataDir(paths.SeriesToOS(series))
 	toolsList := tools.List{
 		&tools.Tools{
 			URL:     "http://tools.testing/tools/released/juju.tgz",
@@ -281,7 +273,7 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 
 func (s *CloudInitSuite) TestWindowsUserdataEncoding(c *gc.C) {
 	series := "win8"
-	metricsSpoolDir := must(paths.MetricsSpoolDir("win8"))
+	metricsSpoolDir := paths.MetricsSpoolDir(paths.SeriesToOS(series))
 	toolsList := tools.List{
 		&tools.Tools{
 			URL:     "http://foo.com/tools/released/juju1.2.3-win8-amd64.tgz",
@@ -290,10 +282,8 @@ func (s *CloudInitSuite) TestWindowsUserdataEncoding(c *gc.C) {
 			SHA256:  "1234",
 		},
 	}
-	dataDir, err := paths.DataDir(series)
-	c.Assert(err, jc.ErrorIsNil)
-	logDir, err := paths.LogDir(series)
-	c.Assert(err, jc.ErrorIsNil)
+	dataDir := paths.DataDir(paths.SeriesToOS(series))
+	logDir := paths.LogDir(paths.SeriesToOS(series))
 
 	cfg := instancecfg.InstanceConfig{
 		ControllerTag:    testing.ControllerTag,
@@ -315,7 +305,7 @@ func (s *CloudInitSuite) TestWindowsUserdataEncoding(c *gc.C) {
 		MetricsSpoolDir:         metricsSpoolDir,
 		CloudInitOutputLog:      path.Join(logDir, "cloud-init-output.log"),
 	}
-	err = cfg.SetTools(toolsList)
+	err := cfg.SetTools(toolsList)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ci, err := cloudinit.New("win8")

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -61,15 +61,15 @@ var (
 )
 
 func jujuLogDir(series string) string {
-	return path.Join(must(paths.LogDir(series)), "juju")
+	return path.Join(paths.LogDir(paths.SeriesToOS(series)), "juju")
 }
 
 func jujuDataDir(series string) string {
-	return must(paths.DataDir(series))
+	return paths.DataDir(paths.SeriesToOS(series))
 }
 
 func jujuTransientDataDir(series string) string {
-	return must(paths.TransientDataDir(series))
+	return paths.TransientDataDir(paths.SeriesToOS(series))
 }
 
 func cloudInitOutputLog(logDir string) string {
@@ -77,15 +77,7 @@ func cloudInitOutputLog(logDir string) string {
 }
 
 func metricsSpoolDir(series string) string {
-	return must(paths.MetricsSpoolDir(series))
-}
-
-// TODO: add this to the utils package
-func must(s string, err error) string {
-	if err != nil {
-		panic(err)
-	}
-	return s
+	return paths.MetricsSpoolDir(paths.SeriesToOS(series))
 }
 
 var stateServingInfo = controller.StateServingInfo{

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -50,12 +50,7 @@ func (w *windowsConfigure) Configure() error {
 
 // ConfigureBasic implements UserdataConfig.ConfigureBasic
 func (w *windowsConfigure) ConfigureBasic() error {
-
-	tmpDir, err := paths.TempDir(w.icfg.Series)
-	if err != nil {
-		return err
-	}
-
+	tmpDir := paths.TempDir(paths.SeriesToOS(w.icfg.Series))
 	renderer := w.conf.ShellRenderer()
 	dataDir := renderer.FromSlash(w.icfg.DataDir)
 	transientDataDir := renderer.FromSlash(w.icfg.TransientDataDir)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -107,7 +107,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	// override this.
 	s.PatchValue(&jujuversion.Current, v100p64.Number)
 	s.PatchValue(&arch.HostArch, func() string { return v100p64.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return v100p64.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return v100p64.Series, nil })
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
 
 	// Set up a local source with tools.
@@ -215,7 +215,7 @@ type bootstrapTest struct {
 
 func (s *BootstrapSuite) patchVersionAndSeries(c *gc.C, hostSeries string) {
 	resetJujuXDGDataHome(c)
-	s.PatchValue(&series.MustHostSeries, func() string { return hostSeries })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return hostSeries, nil })
 	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
 		return set.NewStrings(hostSeries).Union(defaultSupportedJujuSeries), nil
 	})
@@ -247,7 +247,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		bootstrapVersion = version.MustParseBinary(useVersion)
 		restore = restore.Add(testing.PatchValue(&jujuversion.Current, bootstrapVersion.Number))
 		restore = restore.Add(testing.PatchValue(&arch.HostArch, func() string { return bootstrapVersion.Arch }))
-		restore = restore.Add(testing.PatchValue(&series.MustHostSeries, func() string { return bootstrapVersion.Series }))
+		restore = restore.Add(testing.PatchValue(&series.HostSeries, func() (string, error) { return bootstrapVersion.Series, nil }))
 		bootstrapVersion.Build = 1
 		if test.upload != "" {
 			uploadVers := version.MustParseBinary(test.upload)
@@ -1390,7 +1390,7 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 	// Set the current version to be something for which there are no tools
 	// so we can test that an upload is forced.
 	s.PatchValue(&jujuversion.Current, version.MustParse(vers))
-	s.PatchValue(&series.MustHostSeries, func() string { return ser })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return ser, nil })
 	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
 		return set.NewStrings(ser).Union(defaultSupportedJujuSeries), nil
 	})

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
-	"github.com/juju/os/v2/series"
+	jujuos "github.com/juju/os"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
-	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	jujucloud "github.com/juju/juju/cloud"
@@ -33,7 +31,6 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type MainSuite struct {
@@ -159,20 +156,12 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "check version command returns a fully qualified version string",
 		args:    []string{"version"},
 		code:    0,
-		out: version.Binary{
-			Number: jujuversion.Current,
-			Arch:   arch.HostArch(),
-			Series: series.MustHostSeries(),
-		}.String() + "\n",
+		out:     testing.CurrentVersion(c).String() + "\n",
 	}, {
 		summary: "check --version command returns a fully qualified version string",
 		args:    []string{"--version"},
 		code:    0,
-		out: version.Binary{
-			Number: jujuversion.Current,
-			Arch:   arch.HostArch(),
-			Series: series.MustHostSeries(),
-		}.String() + "\n",
+		out:     testing.CurrentVersion(c).String() + "\n",
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		out := badrun(c, t.code, t.args...)
@@ -209,7 +198,7 @@ func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
 func (s *MainSuite) TestNoWarn2xFirstRun(c *gc.C) {
 	// Code should only rnu on ubuntu series, so patch out the series for
 	// when non-ubuntu OSes run this test.
-	s.PatchValue(&series.MustHostSeries, func() string { return "trusty" })
+	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
 
 	argChan := make(chan []string, 1)
 	// we shouldn't actually be running anything, but if we do, this will
@@ -281,12 +270,7 @@ func (s *MainSuite) TestRunNoUpdateCloud(c *gc.C) {
 }
 
 func checkVersionOutput(c *gc.C, output string) {
-	ver := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
-
+	ver := testing.CurrentVersion(c)
 	c.Check(output, gc.Equals, ver.String()+"\n")
 }
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
-	jujuos "github.com/juju/os"
+	jujuos "github.com/juju/os/v2"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -26,7 +24,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type syncToolsSuite struct {
@@ -264,11 +261,7 @@ func (s *syncToolsSuite) TestAPIAdapterFindToolsAPIError(c *gc.C) {
 
 func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 	uploadToolsErr := errors.New("uh oh")
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	fake := fakeSyncToolsAPI{
 		uploadTools: func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error) {
 			data, err := ioutil.ReadAll(r)

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -110,11 +108,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeWithRealUpload(c *gc.C) {
 	cmd := s.upgradeControllerCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	vers.Build = 1
 	s.checkToolsUploaded(c, vers, vers.Number)
 }

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -419,7 +419,7 @@ func (s *UpgradeBaseSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgr
 		current := version.MustParseBinary(test.currentVersion)
 		s.PatchValue(&jujuversion.Current, current.Number)
 		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-		s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
+		s.PatchValue(&series.HostSeries, func() (string, error) { return current.Series, nil })
 		com := upgradeJujuCommand(test.upgradeMap)
 		if err := cmdtesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
@@ -486,7 +486,7 @@ func (s *UpgradeBaseSuite) checkToolsUploaded(c *gc.C, vers version.Binary, agen
 	expectContent := version.Binary{
 		Number: agentVersion,
 		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
+		Series: coretesting.HostSeries(c),
 	}
 	checkToolsContent(c, data, "jujud contents "+expectContent.String())
 }
@@ -550,11 +550,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	command := s.upgradeJujuCommandNoAPI(map[int]version.Number{2: version.MustParse("1.99.99")})
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	vers.Build = 1
 	s.checkToolsUploaded(c, vers, vers.Number)
 }
@@ -740,7 +736,7 @@ func (s *UpgradeBaseSuite) setUpEnvAndTools(c *gc.C, currentVersion string, agen
 	current := version.MustParseBinary(currentVersion)
 	s.PatchValue(&jujuversion.Current, current.Number)
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return current.Series, nil })
 
 	tmpDir := c.MkDir()
 	updateAttrs := map[string]interface{}{
@@ -1029,11 +1025,7 @@ func (s *UpgradeJujuSuite) TestResetPreviousUpgrade(c *gc.C) {
 }
 
 func NewFakeUpgradeJujuAPI(c *gc.C, st *state.State) *fakeUpgradeJujuAPI {
-	nextVersion := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	nextVersion := coretesting.CurrentVersion(c)
 	nextVersion.Minor++
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/version.go
+++ b/cmd/juju/commands/version.go
@@ -74,10 +74,14 @@ func (v *versionCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (v *versionCommand) Init(args []string) error {
+	ser, err := series.HostSeries()
+	if err != nil {
+		ser = "unknown"
+	}
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
+		Series: ser,
 	}
 	detail := versionDetail{
 		Version:       current,

--- a/cmd/juju/commands/version_test.go
+++ b/cmd/juju/commands/version_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/os/v2/series"
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/arch"
@@ -30,7 +30,7 @@ func (s *VersionSuite) TestVersion(c *gc.C) {
 	cctx, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, jc.ErrorIsNil)
 	output := fmt.Sprintf("2.99.0-%s-%s\n",
-		series.MustHostSeries(), arch.HostArch())
+		coretesting.HostSeries(c), arch.HostArch())
 
 	c.Assert(cctx.Stdout.(*bytes.Buffer).String(), gc.Equals, output)
 	c.Assert(cctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
@@ -50,7 +50,7 @@ git-commit: 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 git-tree-state: clean
 compiler: gc
 `[1:]
-	output := fmt.Sprintf(outputTemplate, series.MustHostSeries(), arch.HostArch())
+	output := fmt.Sprintf(outputTemplate, coretesting.HostSeries(c), arch.HostArch())
 
 	c.Assert(cctx.Stdout.(*bytes.Buffer).String(), gc.Equals, output)
 	c.Assert(cctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
@@ -67,7 +67,7 @@ func (s *VersionSuite) TestVersionDetailJSON(c *gc.C) {
 	outputTemplate := `
 {"version":"2.99.0-%s-%s","git-commit":"0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f","git-tree-state":"clean","compiler":"gc"}
 `[1:]
-	output := fmt.Sprintf(outputTemplate, series.MustHostSeries(), arch.HostArch())
+	output := fmt.Sprintf(outputTemplate, coretesting.HostSeries(c), arch.HostArch())
 
 	c.Assert(cctx.Stdout.(*bytes.Buffer).String(), gc.Equals, output)
 	c.Assert(cctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")
@@ -87,7 +87,7 @@ git-commit: 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 git-tree-state: clean
 compiler: gc
 `[1:]
-	output := fmt.Sprintf(outputTemplate, series.MustHostSeries(), arch.HostArch())
+	output := fmt.Sprintf(outputTemplate, coretesting.HostSeries(c), arch.HostArch())
 
 	c.Assert(cctx.Stdout.(*bytes.Buffer).String(), gc.Equals, output)
 	c.Assert(cctx.Stderr.(*bytes.Buffer).String(), gc.Equals, "")

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -12,11 +12,9 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/replicaset"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
@@ -36,7 +34,6 @@ import (
 	"github.com/juju/juju/state/stateenvirons"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/peergrouper"
 )
 
@@ -120,11 +117,7 @@ type AgentSuite struct {
 // with the given entity name. It returns the agent's configuration and the
 // current tools.
 func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	return s.PrimeAgentVersion(c, tag, password, vers)
 }
 
@@ -172,11 +165,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 // a state agent with the given entity name. It returns the agent's
 // configuration and the current tools.
 func (s *AgentSuite) PrimeStateAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	return s.PrimeStateAgentVersion(c, tag, password, vers)
 }
 

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -24,7 +24,6 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
@@ -122,11 +121,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.makeTestModel(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	toolsDir := filepath.FromSlash(agenttools.SharedToolsDir(s.dataDir, current))
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
@@ -677,12 +672,8 @@ func (s *BootstrapSuite) TestDownloadedToolsMetadata(c *gc.C) {
 func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
 	// Tools uploaded over ssh.
 	s.writeDownloadedTools(c, &tools.Tools{
-		Version: version.Binary{
-			Number: jujuversion.Current,
-			Arch:   arch.HostArch(),
-			Series: series.MustHostSeries(),
-		},
-		URL: "file:///does/not/matter",
+		Version: testing.CurrentVersion(c),
+		URL:     "file:///does/not/matter",
 	})
 	s.testToolsMetadata(c, true)
 }
@@ -711,14 +702,14 @@ func (s *BootstrapSuite) testToolsMetadata(c *gc.C, exploded bool) {
 		for _, ser := range series.SupportedSeries() {
 			os, err := series.GetOSFromSeries(ser)
 			c.Assert(err, jc.ErrorIsNil)
-			hostos, err := series.GetOSFromSeries(series.MustHostSeries())
+			hostos, err := series.GetOSFromSeries(testing.HostSeries(c))
 			c.Assert(err, jc.ErrorIsNil)
 			if os == hostos || os.IsLinux() && hostos.IsLinux() {
 				expectedSeries.Add(ser)
 			}
 		}
 	} else {
-		expectedSeries.Add(series.MustHostSeries())
+		expectedSeries.Add(testing.HostSeries(c))
 	}
 
 	storage, err := st.ToolsStorage()

--- a/cmd/jujud/agent/config/config.go
+++ b/cmd/jujud/agent/config/config.go
@@ -4,12 +4,10 @@
 package config
 
 import (
-	"github.com/juju/os/v2/series"
-
 	"github.com/juju/juju/core/paths"
 )
 
 var (
-	DataDir = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
-	LogDir  = paths.MustSucceed(paths.LogDir(series.MustHostSeries()))
+	DataDir = paths.DataDir(paths.CurrentOS())
+	LogDir  = paths.LogDir(paths.CurrentOS())
 )

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/pubsub"
 	"github.com/juju/replicaset"
 	"github.com/juju/utils/v2"
@@ -94,9 +93,9 @@ import (
 
 var (
 	logger            = loggo.GetLogger("juju.cmd.jujud")
-	jujuRun           = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
-	jujuDumpLogs      = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
-	jujuIntrospect    = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
+	jujuRun           = paths.JujuRun(paths.CurrentOS())
+	jujuDumpLogs      = paths.JujuDumpLogs(paths.CurrentOS())
+	jujuIntrospect    = paths.JujuIntrospect(paths.CurrentOS())
 	jujudSymlinks     = []string{jujuRun, jujuDumpLogs, jujuIntrospect}
 	caasJujudSymlinks = []string{jujuRun, jujuDumpLogs, jujuIntrospect}
 

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
@@ -375,11 +374,7 @@ func (s *MachineSuite) waitProvisioned(c *gc.C, unit *state.Unit) (*state.Machin
 }
 
 func (s *MachineSuite) testUpgradeRequest(c *gc.C, agent runner, tag string, currentTools *tools.Tools) {
-	newVers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	newVers := coretesting.CurrentVersion(c)
 	newVers.Patch++
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)[0]
@@ -598,11 +593,7 @@ func readAuditLog(c *gc.C, logPath string) []auditlog.Record {
 }
 
 func (s *MachineSuite) assertAgentSetsToolsVersion(c *gc.C, job state.MachineJob) {
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	vers.Minor--
 	m, _, _ := s.primeAgentVersion(c, vers, job)
 	a := s.newAgent(c, m)
@@ -1001,11 +992,7 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	s.primeAgentWithMachine(c, m, vers)
 	a := s.newAgent(c, m)
 	defer a.Stop()

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -13,11 +13,8 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/utils/v2/voyeur"
-	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -178,11 +175,7 @@ func (s *UnitSuite) TestRunStop(c *gc.C) {
 func (s *UnitSuite) TestUpgrade(c *gc.C) {
 	machine, unit, _, currentTools := s.primeAgent(c)
 	agent := s.newAgent(c, unit)
-	newVers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	newVers := coretesting.CurrentVersion(c)
 	newVers.Patch++
 	envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)
@@ -214,11 +207,7 @@ func (s *UnitSuite) TestUpgrade(c *gc.C) {
 func (s *UnitSuite) TestUpgradeFailsWithoutTools(c *gc.C) {
 	machine, unit, _, _ := s.primeAgent(c)
 	agent := s.newAgent(c, unit)
-	newVers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	newVers := coretesting.CurrentVersion(c)
 	newVers.Patch++
 	err := machine.SetAgentVersion(newVers)
 	c.Assert(err, jc.ErrorIsNil)
@@ -256,11 +245,7 @@ func (s *UnitSuite) TestOpenStateFails(c *gc.C) {
 
 func (s *UnitSuite) TestAgentSetsToolsVersion(c *gc.C) {
 	_, unit, _, _ := s.primeAgent(c)
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	vers.Minor++
 	err := unit.SetAgentVersion(vers)
 	c.Assert(err, jc.ErrorIsNil)
@@ -282,11 +267,7 @@ func (s *UnitSuite) TestAgentSetsToolsVersion(c *gc.C) {
 			if agentTools.Version.Minor != jujuversion.Current.Minor {
 				continue
 			}
-			current := version.Binary{
-				Number: jujuversion.Current,
-				Arch:   arch.HostArch(),
-				Series: series.MustHostSeries(),
-			}
+			current := coretesting.CurrentVersion(c)
 			c.Assert(agentTools.Version, gc.DeepEquals, current)
 			done = true
 		}

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"fmt"
-
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -15,9 +14,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	"github.com/juju/worker/v2"
 	gc "gopkg.in/check.v1"
@@ -119,11 +116,7 @@ func (s *commonMachineSuite) TearDownTest(c *gc.C) {
 // machine agent's directory.  It returns the new machine, the
 // agent's configuration and the tools currently running.
 func (s *commonMachineSuite) primeAgent(c *gc.C, jobs ...state.MachineJob) (m *state.Machine, agentConfig agent.ConfigSetterWriter, tools *tools.Tools) {
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := coretesting.CurrentVersion(c)
 	return s.primeAgentVersion(c, vers, jobs...)
 }
 

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -232,10 +232,14 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 		return 1, errors.Trace(err)
 	}
 
+	ser, err := series.HostSeries()
+	if err != nil {
+		ser = "unknown"
+	}
 	current := version.Binary{
 		Number: jujuversion.Current,
 		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
+		Series: ser,
 	}
 	detail := versionDetail{
 		Version:       current.String(),

--- a/cmd/jujud/run/run.go
+++ b/cmd/jujud/run/run.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jujuos "github.com/juju/os/v2"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/exec"
 	"gopkg.in/yaml.v2"
@@ -197,10 +196,7 @@ func (c *RunCommand) Init(args []string) error {
 func (c *RunCommand) maybeGetUnitTag() (names.UnitTag, error) {
 	dataDir := c.dataDir
 	if dataDir == "" {
-		// We don't care about errors here. This is a fallback and
-		// if there's an issue, we'll exit back to the use anyway.
-		hostSeries, _ := series.HostSeries()
-		dataDir, _ = paths.DataDir(hostSeries)
+		dataDir = paths.DataDir(paths.CurrentOS())
 	}
 	agentDir := filepath.Join(dataDir, "agents")
 	files, _ := ioutil.ReadDir(agentDir)

--- a/cmd/k8sagent/config/config.go
+++ b/cmd/k8sagent/config/config.go
@@ -4,14 +4,12 @@
 package config
 
 import (
-	"github.com/juju/os/v2/series"
-
 	"github.com/juju/juju/core/paths"
 )
 
 var (
-	JujuRun        = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
-	JujuDumpLogs   = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
-	JujuIntrospect = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
-	LogDir         = paths.MustSucceed(paths.LogDir(series.MustHostSeries()))
+	JujuRun        = paths.JujuRun(paths.CurrentOS())
+	JujuDumpLogs   = paths.JujuDumpLogs(paths.CurrentOS())
+	JujuIntrospect = paths.JujuIntrospect(paths.CurrentOS())
+	LogDir         = paths.LogDir(paths.CurrentOS())
 )

--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -26,7 +26,7 @@ type kvmContainer struct {
 	// value if we already know it (like in the list situation).
 	started *bool
 
-	pathfinder func(string) (string, error)
+	pathfinder pathfinderFunc
 	runCmd     runFunc
 }
 

--- a/container/kvm/export_test.go
+++ b/container/kvm/export_test.go
@@ -16,7 +16,7 @@ var KVMPath = &kvmPath
 
 // MakeCreateMachineParamsTestable adds test values to non exported values on
 // CreateMachineParams.
-func MakeCreateMachineParamsTestable(params *CreateMachineParams, pathfinder func(string) (string, error), runCmd runFunc, arch string) {
+func MakeCreateMachineParamsTestable(params *CreateMachineParams, pathfinder pathfinderFunc, runCmd runFunc, arch string) {
 	params.findPath = pathfinder
 	params.runCmd = runCmd
 	params.runCmdAsRoot = runCmd
@@ -30,7 +30,7 @@ func NewEmptyKvmContainer() *kvmContainer {
 }
 
 // NewTestContainer returns a new container for testing.
-func NewTestContainer(name string, runCmd runFunc, pathfinder func(string) (string, error)) *kvmContainer {
+func NewTestContainer(name string, runCmd runFunc, pathfinder pathfinderFunc) *kvmContainer {
 	return &kvmContainer{name: name, runCmd: runCmd, pathfinder: pathfinder}
 }
 

--- a/container/kvm/initialisation.go
+++ b/container/kvm/initialisation.go
@@ -57,11 +57,13 @@ func ensureDependencies() error {
 	return nil
 }
 
+type pathfinderFunc func(paths.OS) string
+
 // ensurePool creates the libvirt storage pool and ensures its is active.
 // runCmd and chownFunc are here for testing. runCmd so we can check the
 // right shell out calls are made, and chownFunc because we cannot chown
 // unless we are root.
-func ensurePool(poolInfo *libvirtPool, pathfinder func(string) (string, error), runCmd runFunc, chownFunc func(string) error) error {
+func ensurePool(poolInfo *libvirtPool, pathfinder pathfinderFunc, runCmd runFunc, chownFunc func(string) error) error {
 	poolDir, err := guestPath(pathfinder)
 	if err != nil {
 		return errors.Trace(err)

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/packaging"
 	"github.com/juju/juju/packaging/dependency"
 	"github.com/juju/testing"
@@ -30,8 +31,8 @@ func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
 		}
 	}()
 	c.Check(err, jc.ErrorIsNil)
-	pathfinder := func(s string) (string, error) {
-		return tmpDir, nil
+	pathfinder := func(_ paths.OS) string {
+		return tmpDir
 	}
 	stub := runStub{}
 	chown := func(string) error { return nil }
@@ -54,8 +55,8 @@ func (initialisationInternalSuite) TestStartPool(c *gc.C) {
 		}
 	}()
 	c.Check(err, jc.ErrorIsNil)
-	pathfinder := func(s string) (string, error) {
-		return tmpDir, nil
+	pathfinder := func(_ paths.OS) string {
+		return tmpDir
 	}
 	poolInfo := &libvirtPool{Name: "juju-pool", Autostart: "no", State: "inactive"}
 	stub := runStub{}
@@ -78,8 +79,8 @@ func (initialisationInternalSuite) TestAutoStartPool(c *gc.C) {
 		}
 	}()
 	c.Check(err, jc.ErrorIsNil)
-	pathfinder := func(s string) (string, error) {
-		return tmpDir, nil
+	pathfinder := func(_ paths.OS) string {
+		return tmpDir
 	}
 	poolInfo := &libvirtPool{Name: "juju-pool", Autostart: "no", State: "running"}
 	stub := runStub{}

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -17,8 +17,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
-
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/environs/imagedownloads"
 	"github.com/juju/juju/environs/simplestreams"
@@ -53,10 +51,7 @@ func (p syncParams) One() (*imagedownloads.Metadata, error) {
 
 func (p syncParams) exists() error {
 	fName := backingFileName(p.series, p.arch)
-	baseDir, err := paths.DataDir(series.MustHostSeries())
-	if err != nil {
-		return errors.Trace(err)
-	}
+	baseDir := paths.DataDir(paths.CurrentOS())
 	imagePath := filepath.Join(baseDir, kvm, guestDir, fName)
 
 	if _, err := os.Stat(imagePath); err == nil {
@@ -268,7 +263,7 @@ func (i *Image) cleanupAll() {
 	}
 }
 
-func newDefaultFetcher(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder func(string) (string, error), callback ProgressCallback) (*fetcher, error) {
+func newDefaultFetcher(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder pathfinderFunc, callback ProgressCallback) (*fetcher, error) {
 	i, err := newImage(md, imageDownloadURL, pathfinder, callback)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -285,16 +280,13 @@ func newDefaultFetcher(md *imagedownloads.Metadata, imageDownloadURL string, pat
 	return &fetcher{metadata: md, image: i, client: client, req: req, imageDownloadURL: imageDownloadURL}, nil
 }
 
-func newImage(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder func(string) (string, error), callback ProgressCallback) (*Image, error) {
+func newImage(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder pathfinderFunc, callback ProgressCallback) (*Image, error) {
 	// Setup names and paths.
 	dlURL, err := md.DownloadURL(imageDownloadURL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	baseDir, err := pathfinder(series.MustHostSeries())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	baseDir := pathfinder(paths.CurrentOS())
 
 	// Closing this is deferred in Image.write.
 	fh, err := ioutil.TempFile("", fmt.Sprintf("juju-kvm-%s-", path.Base(dlURL.String())))

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -192,12 +193,12 @@ func newTestServer() *httptest.Server {
 
 // newTmpdir creates a tmpdir and returns pathfinder func that returns the
 // tmpdir.
-func newTmpdir() (string, func(string) (string, error), bool) {
+func newTmpdir() (string, pathfinderFunc, bool) {
 	td, err := ioutil.TempDir("", "juju-test-kvm-internalSuite")
 	if err != nil {
 		return "", nil, false
 	}
-	pathfinder := func(string) (string, error) { return td, nil }
+	pathfinder := func(_ paths.OS) string { return td }
 	return td, pathfinder, true
 }
 

--- a/container/kvm/wrappedcmds.go
+++ b/container/kvm/wrappedcmds.go
@@ -75,7 +75,7 @@ type CreateMachineParams struct {
 	Interfaces        []libvirt.InterfaceInfo
 
 	disks    []libvirt.DiskInfo
-	findPath func(string) (string, error)
+	findPath pathfinderFunc
 
 	runCmd       runFunc
 	runCmdAsRoot runFunc
@@ -311,11 +311,8 @@ func ListMachines(runCmd runFunc) (map[string]string, error) {
 
 // guestPath returns the path to the guest directory from the given
 // pathfinder.
-func guestPath(pathfinder func(string) (string, error)) (string, error) {
-	baseDir, err := pathfinder(series.MustHostSeries())
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+func guestPath(pathfinder pathfinderFunc) (string, error) {
+	baseDir := pathfinder(paths.CurrentOS())
 	return filepath.Join(baseDir, kvm, guestDir), nil
 }
 

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/pkg/errors"
@@ -152,8 +153,8 @@ func assertCreateMachineSuccess(c *gc.C, tmpDir string, expCommands []string) {
 			c.Errorf("failed removing %q in test %s", tmpDir, err)
 		}
 	}()
-	pathfinder := func(s string) (string, error) {
-		return tmpDir, nil
+	pathfinder := func(_ paths.OS) string {
+		return tmpDir
 	}
 
 	hostname := "host00"
@@ -199,8 +200,8 @@ func (commandWrapperSuite) TestDestroyMachineSuccess(c *gc.C) {
 	err = ioutil.WriteFile(filepath.Join(guestBase, "aname-ds.iso"), []byte("diskcontents"), 0700)
 	c.Check(err, jc.ErrorIsNil)
 
-	pathfinder := func(_ string) (string, error) {
-		return tmpDir, nil
+	pathfinder := func(_ paths.OS) string {
+		return tmpDir
 	}
 
 	stub := NewRunStub("success", nil)

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -539,6 +539,20 @@ func NewSpaceAddresses(inAddresses ...string) (outAddresses SpaceAddresses) {
 	return outAddresses
 }
 
+// Values returns a slice of strings containing the IP/host-name of each of
+// the receiver addresses.
+func (sas SpaceAddresses) Values() []string {
+	if sas == nil {
+		return nil
+	}
+
+	values := make([]string, len(sas))
+	for i, a := range sas {
+		values[i] = a.Value
+	}
+	return values
+}
+
 // ToProviderAddresses transforms the SpaceAddresses to ProviderAddresses by using
 // the input lookup for conversion of space ID to space info.
 func (sas SpaceAddresses) ToProviderAddresses(lookup SpaceLookup) (ProviderAddresses, error) {

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -850,6 +850,12 @@ func (s *AddressSuite) TestSpaceAddressesToProviderAddresses(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *AddressSuite) TestSpaceAddressesValues(c *gc.C) {
+	values := []string{"1.2.3.4", "2.3.4.5", "3.4.5.6"}
+	addrs := network.NewSpaceAddresses(values...)
+	c.Check(addrs.Values(), gc.DeepEquals, values)
+}
+
 func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 	type test struct {
 		IP   string

--- a/core/network/network.go
+++ b/core/network/network.go
@@ -6,6 +6,7 @@ package network
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"sort"
 
 	"github.com/juju/loggo"
@@ -107,4 +108,32 @@ func (s IDSet) SortedValues() []Id {
 		return values[i] < values[j]
 	})
 	return values
+}
+
+// SubnetsForAddresses returns subnets corresponding to the addresses
+// in the input address list.
+// There can be situations (observed for CAAS) where the addresses can
+// contain a FQDN.
+// For these cases we log a warning and eschew subnet determination.
+func SubnetsForAddresses(addrs []string) []string {
+	var subs []string
+	for _, a := range addrs {
+		// We don't expect this to be the case, but guard conservatively.
+		if _, _, err := net.ParseCIDR(a); err == nil {
+			subs = append(subs, a)
+			continue
+		}
+
+		if addr := net.ParseIP(a); addr != nil {
+			if addr.To4() != nil {
+				subs = append(subs, addr.String()+"/32")
+			} else {
+				subs = append(subs, addr.String()+"/128")
+			}
+			continue
+		}
+
+		logger.Warningf("unable to determine egress subnet for %q", a)
+	}
+	return subs
 }

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -102,3 +102,16 @@ func assertValues(c *gc.C, s network.IDSet, expected ...network.Id) {
 	sorted := s.SortedValues()
 	c.Assert(sorted, gc.DeepEquals, expected)
 }
+
+func (s *NetworkSuite) TestSubnetsForAddresses(c *gc.C) {
+	addrs := []string{
+		"10.10.10.10",
+		"75ae:3af:968e:3a33:55e2:6379:fa67:d790",
+		"some.host.name",
+	}
+
+	c.Check(network.SubnetsForAddresses(addrs), gc.DeepEquals, []string{
+		"10.10.10.10/32",
+		"75ae:3af:968e:3a33:55e2:6379:fa67:d790/128",
+	})
+}

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -6,9 +6,18 @@ package paths
 
 import (
 	"os"
+	"runtime"
+	"strings"
 
 	jujuos "github.com/juju/os/v2"
 	"github.com/juju/os/v2/series"
+)
+
+type OS int // strongly typed runtime.GOOS value to help with refactoring
+
+const (
+	OSWindows  OS = 1
+	OSUnixLike OS = 2
 )
 
 type osVarType int
@@ -80,111 +89,128 @@ var winVals = map[osVarType]string{
 // Agents run as root, but users don't.
 var Chown = os.Chown
 
-// osVal will lookup the value of the key valname
-// in the appropriate map, based on the series. This will
-// help reduce boilerplate code
-func osVal(ser string, valname osVarType) (string, error) {
-	os, err := series.GetOSFromSeries(ser)
-	if err != nil {
-		return "", err
-	}
-	switch os {
-	case jujuos.Windows:
-		return winVals[valname], nil
+// CurrentOS returns the OS value for the currently-running system.
+func CurrentOS() OS {
+	switch runtime.GOOS {
+	case "windows":
+		return OSWindows
 	default:
-		return nixVals[valname], nil
+		return OSUnixLike
+	}
+}
+
+// SeriesToOS converts the given series to an OS value.
+func SeriesToOS(ser string) OS {
+	osType, err := series.GetOSFromSeries(ser)
+	if err != nil {
+		// We shouldn't get here in normal operation, as the series should be
+		// valid at this point, but handle in a reasonable way in any case.
+		if strings.HasPrefix(ser, "win") {
+			return OSWindows
+		}
+		return OSUnixLike
+	}
+	switch osType {
+	case jujuos.Windows:
+		return OSWindows
+	default:
+		return OSUnixLike
+	}
+}
+
+// osVal will lookup the value of the key valname
+// in the appropriate map, based on the OS value.
+func osVal(os OS, valname osVarType) string {
+	switch os {
+	case OSWindows:
+		return winVals[valname]
+	default:
+		return nixVals[valname]
 	}
 }
 
 // TempDir returns the path on disk to the correct tmp directory
 // for the series. This value will be the same on virtually
 // all linux systems, but will differ on windows
-func TempDir(series string) (string, error) {
-	return osVal(series, tmpDir)
+func TempDir(os OS) string {
+	return osVal(os, tmpDir)
 }
 
 // LogDir returns filesystem path the directory where juju may
 // save log files.
-func LogDir(series string) (string, error) {
-	return osVal(series, logDir)
+func LogDir(os OS) string {
+	return osVal(os, logDir)
 }
 
 // DataDir returns a filesystem path to the folder used by juju to
 // store tools, charms, locks, etc
-func DataDir(series string) (string, error) {
-	return osVal(series, dataDir)
+func DataDir(os OS) string {
+	return osVal(os, dataDir)
 }
 
 // TransientDataDir returns a filesystem path to the folder used by juju to
 // store transient data that will not survive a reboot.
-func TransientDataDir(series string) (string, error) {
-	return osVal(series, transientDataDir)
+func TransientDataDir(os OS) string {
+	return osVal(os, transientDataDir)
 }
 
 // MetricsSpoolDir returns a filesystem path to the folder used by juju
 // to store metrics.
-func MetricsSpoolDir(series string) (string, error) {
-	return osVal(series, metricsSpoolDir)
+func MetricsSpoolDir(os OS) string {
+	return osVal(os, metricsSpoolDir)
 }
 
 // CertDir returns a filesystem path to the folder used by juju to
 // store certificates that are added by default to the Juju client
 // api certificate pool.
-func CertDir(series string) (string, error) {
-	return osVal(series, certDir)
+func CertDir(os OS) string {
+	return osVal(os, certDir)
 }
 
 // StorageDir returns a filesystem path to the folder used by juju to
 // mount machine-level storage.
-func StorageDir(series string) (string, error) {
-	return osVal(series, storageDir)
+func StorageDir(os OS) string {
+	return osVal(os, storageDir)
 }
 
 // ConfDir returns the path to the directory where Juju may store
 // configuration files.
-func ConfDir(series string) (string, error) {
-	return osVal(series, confDir)
+func ConfDir(os OS) string {
+	return osVal(os, confDir)
 }
 
 // JujuRun returns the absolute path to the juju-run binary for
 // a particular series.
-func JujuRun(series string) (string, error) {
-	return osVal(series, jujuRun)
+func JujuRun(os OS) string {
+	return osVal(os, jujuRun)
 }
 
 // JujuDumpLogs returns the absolute path to the juju-dumplogs binary
 // for a particular series.
-func JujuDumpLogs(series string) (string, error) {
-	return osVal(series, jujuDumpLogs)
+func JujuDumpLogs(os OS) string {
+	return osVal(os, jujuDumpLogs)
 }
 
 // JujuIntrospect returns the absolute path to the juju-introspect
 // binary for a particular series.
-func JujuIntrospect(series string) (string, error) {
-	return osVal(series, jujuIntrospect)
+func JujuIntrospect(os OS) string {
+	return osVal(os, jujuIntrospect)
 }
 
 // MachineCloudInitDir returns the absolute path to the instance
 // cloudinit directory for a particular series.
-func MachineCloudInitDir(series string) (string, error) {
-	return osVal(series, instanceCloudInitDir)
+func MachineCloudInitDir(os OS) string {
+	return osVal(os, instanceCloudInitDir)
 }
 
 // CurtinInstallConfig returns the absolute path the configuration file
 // written by Curtin during machine provisioning.
-func CurtinInstallConfig(series string) (string, error) {
-	return osVal(series, curtinInstallConfig)
+func CurtinInstallConfig(os OS) string {
+	return osVal(os, curtinInstallConfig)
 }
 
 // CloudInitCfgDir returns the absolute path to the instance
 // cloud config directory for a particular series.
-func CloudInitCfgDir(series string) (string, error) {
-	return osVal(series, cloudInitCfgDir)
-}
-
-func MustSucceed(s string, e error) string {
-	if e != nil {
-		panic(e)
-	}
-	return s
+func CloudInitCfgDir(os OS) string {
+	return osVal(os, cloudInitCfgDir)
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -367,7 +367,7 @@ func intPtr(i uint64) *uint64 {
 }
 
 func (s *bootstrapSuite) TestBootstrapImage(c *gc.C) {
-	s.PatchValue(&series.MustHostSeries, func() string { return "precise" })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return "precise", nil })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	metadataDir, metadata := createImageMetadata(c)
@@ -450,7 +450,7 @@ type testImageMetadata struct {
 // setupImageMetadata returns architecture for which metadata was setup
 func (s *bootstrapSuite) setupImageMetadata(c *gc.C) testImageMetadata {
 	testArch := arch.S390X
-	s.PatchValue(&series.MustHostSeries, func() string { return "precise" })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return "precise", nil })
 	s.PatchValue(&arch.HostArch, func() string { return testArch })
 
 	metadataDir, metadata := createImageMetadataForArch(c, testArch)
@@ -554,7 +554,7 @@ func (s *bootstrapSuite) setupProviderWithNoSupportedArches(c *gc.C) bootstrapEn
 // despite image metadata in other data sources compatible with the same configuration as well.
 // Related to bug#1560625.
 func (s *bootstrapSuite) TestBootstrapImageMetadataFromAllSources(c *gc.C) {
-	s.PatchValue(&series.MustHostSeries, func() string { return "raring" })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return "raring", nil })
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 
 	// Ensure that we can find at least one image metadata

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -187,11 +187,7 @@ func (s *toolsSuite) TestFindAvailableToolsNoUpload(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
-	currentVersion := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	currentVersion := coretesting.CurrentVersion(c)
 	currentVersion.Major = 2
 	currentVersion.Minor = 3
 	s.PatchValue(&jujuversion.Current, currentVersion.Number)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
-	"github.com/juju/os/v2/series"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
@@ -946,11 +945,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		c.Skip("HasProvisioner is false; cannot test deployment")
 	}
 
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	other := current
 	other.Series = "quantal"
 	if current == other {

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -247,7 +247,7 @@ func (s *uploadSuite) patchBundleTools(c *gc.C, v *version.Number) {
 }
 
 func (s *uploadSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	c.Assert(v, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.MustHostSeries()})
+	c.Assert(v, gc.Equals, coretesting.CurrentVersion(c))
 }
 
 func (s *uploadSuite) TearDownTest(c *gc.C) {
@@ -261,18 +261,18 @@ func (s *uploadSuite) TestUpload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEqualsCurrentVersion(c, t.Version)
 	c.Assert(t.URL, gc.Not(gc.Equals), "")
-	s.assertUploadedTools(c, t, []string{series.MustHostSeries()}, "released")
+	s.assertUploadedTools(c, t, []string{coretesting.HostSeries(c)}, "released")
 }
 
 func (s *uploadSuite) TestUploadFakeSeries(c *gc.C) {
 	s.patchBundleTools(c, nil)
 	seriesToUpload := "precise"
-	if seriesToUpload == series.MustHostSeries() {
+	if seriesToUpload == coretesting.HostSeries(c) {
 		seriesToUpload = "raring"
 	}
 	t, err := sync.Upload(s.targetStorage, "released", nil, "quantal", seriesToUpload)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", series.MustHostSeries()}, "released")
+	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", coretesting.HostSeries(c)}, "released")
 }
 
 func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
@@ -281,7 +281,7 @@ func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
 	s.patchBundleTools(c, &vers)
 	t, err := sync.Upload(s.targetStorage, "released", &vers)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(t.Version, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.MustHostSeries()})
+	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion(c))
 }
 
 func (s *uploadSuite) TestSyncTools(c *gc.C) {
@@ -297,7 +297,7 @@ func (s *uploadSuite) TestSyncTools(c *gc.C) {
 func (s *uploadSuite) TestSyncToolsFakeSeries(c *gc.C) {
 	s.patchBundleTools(c, nil)
 	seriesToUpload := "precise"
-	if seriesToUpload == series.MustHostSeries() {
+	if seriesToUpload == coretesting.HostSeries(c) {
 		seriesToUpload = "raring"
 	}
 	builtTools, err := sync.BuildAgentTarball(true, nil, "testing")
@@ -305,7 +305,7 @@ func (s *uploadSuite) TestSyncToolsFakeSeries(c *gc.C) {
 
 	t, err := sync.SyncBuiltTools(s.targetStorage, "testing", builtTools, "quantal", seriesToUpload)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", series.MustHostSeries()}, "testing")
+	s.assertUploadedTools(c, t, []string{seriesToUpload, "quantal", coretesting.HostSeries(c)}, "testing")
 }
 
 func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {
@@ -317,7 +317,7 @@ func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {
 	t, err := sync.SyncBuiltTools(s.targetStorage, "released", builtTools)
 	c.Assert(err, jc.ErrorIsNil)
 	// Reported version from build call matches the real jujud version.
-	c.Assert(t.Version, gc.Equals, version.Binary{Number: jujuversion.Current, Arch: arch.HostArch(), Series: series.MustHostSeries()})
+	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion(c))
 }
 
 func (s *uploadSuite) assertUploadedTools(c *gc.C, t *coretools.Tools, expectSeries []string, stream string) {
@@ -412,11 +412,7 @@ func (s *badBuildSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *badBuildSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	c.Assert(v, gc.Equals, current)
 }
 
@@ -525,7 +521,7 @@ func (s *uploadSuite) TestMockBuildTools(c *gc.C) {
 	current := version.MustParseBinary("1.9.1-trusty-amd64")
 	s.PatchValue(&jujuversion.Current, current.Number)
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return current.Series, nil })
 	buildToolsFunc := toolstesting.GetMockBuildTools(c)
 	builtTools, err := buildToolsFunc(true, nil, "released")
 	c.Assert(err, jc.ErrorIsNil)
@@ -560,13 +556,9 @@ func (s *uploadSuite) testStorageToolsUploaderWriteMirrors(c *gc.C, writeMirrors
 		"released",
 		"released",
 		&coretools.Tools{
-			Version: version.Binary{
-				Number: jujuversion.Current,
-				Arch:   arch.HostArch(),
-				Series: series.MustHostSeries(),
-			},
-			Size:   7,
-			SHA256: "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
+			Version: coretesting.CurrentVersion(c),
+			Size:    7,
+			SHA256:  "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
 		}, []byte("content"))
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	"github.com/juju/http"
 	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
@@ -274,7 +275,11 @@ func MustUploadFakeToolsVersions(stor storage.Storage, stream string, versions .
 
 func uploadFakeTools(stor storage.Storage, toolsDir, stream string) error {
 	toolsSeries := set.NewStrings(toolsLtsSeries...)
-	toolsSeries.Add(series.MustHostSeries())
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	toolsSeries.Add(hostSeries)
 	var versions []version.Binary
 	for _, series := range toolsSeries.Values() {
 		vers := version.Binary{
@@ -309,16 +314,12 @@ func MustUploadFakeTools(stor storage.Storage, toolsDir, stream string) {
 // RemoveFakeTools deletes the fake tools from the supplied storage.
 func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	c.Logf("removing fake tools")
-	toolsVersion := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	toolsVersion := coretesting.CurrentVersion(c)
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)
 	defaultSeries := jujuversion.DefaultSupportedLTS()
-	if series.MustHostSeries() != defaultSeries {
+	if coretesting.HostSeries(c) != defaultSeries {
 		toolsVersion.Series = defaultSeries
 		name := envtools.StorageName(toolsVersion, toolsDir)
 		err := stor.Remove(name)

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -16,7 +16,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/juju/os/v2/series"
 	exttest "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/arch"
@@ -302,7 +301,7 @@ func listDir(c *gc.C, dir string) []string {
 
 func (b *buildSuite) TestBundleToolsMatchesBinaryUsingSeriesArch(c *gc.C) {
 	thisArch := arch.HostArch()
-	thisSeries := series.MustHostSeries()
+	thisSeries := testing.HostSeries(c)
 	dir := b.setUpFakeBinaries(c, fmt.Sprintf(seriesArchMatchVersionFile, thisSeries, thisArch))
 
 	bundleFile, err := os.Create(filepath.Join(dir, "bundle"))

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -70,10 +70,14 @@ func setupSimpleStreamsTests(t *testing.T) {
 			keys := reflect.ValueOf(liveURLs).MapKeys()
 			t.Fatalf("Unknown vendor %s. Must be one of %s", *vendor, keys)
 		}
+		hostSeries, err := series.HostSeries()
+		if err != nil {
+			t.Fatalf("fetching host series: %v", err)
+		}
 		registerLiveSimpleStreamsTests(testData.baseURL,
 			tools.NewVersionedToolsConstraint(version.MustParse("1.13.0"), simplestreams.LookupParams{
 				CloudSpec: testData.validCloudSpec,
-				Series:    []string{series.MustHostSeries()},
+				Series:    []string{hostSeries},
 				Arches:    []string{"amd64"},
 				Stream:    "released",
 			}), testData.requireSigned)

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -34,7 +33,6 @@ import (
 	"github.com/juju/juju/juju/names"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 func GetMockBundleTools(c *gc.C, expectedForceVersion *version.Number) tools.BundleToolsFunc {
@@ -44,11 +42,7 @@ func GetMockBundleTools(c *gc.C, expectedForceVersion *version.Number) tools.Bun
 		} else {
 			c.Assert(forceVersion, gc.IsNil)
 		}
-		vers := version.Binary{
-			Number: jujuversion.Current,
-			Arch:   arch.HostArch(),
-			Series: series.MustHostSeries(),
-		}
+		vers := coretesting.CurrentVersion(c)
 		sha256Hash := fmt.Sprintf("%x", sha256.New().Sum(nil))
 		return vers, false, sha256Hash, nil
 	}
@@ -58,11 +52,7 @@ func GetMockBundleTools(c *gc.C, expectedForceVersion *version.Number) tools.Bun
 // a fake tools tarball.
 func GetMockBuildTools(c *gc.C) sync.BuildAgentTarballFunc {
 	return func(build bool, forceVersion *version.Number, stream string) (*sync.BuiltAgent, error) {
-		vers := version.Binary{
-			Number: jujuversion.Current,
-			Arch:   arch.HostArch(),
-			Series: series.MustHostSeries(),
-		}
+		vers := coretesting.CurrentVersion(c)
 		if forceVersion != nil {
 			vers.Number = *forceVersion
 		}

--- a/featuretests/cmd_juju_upgrade_test.go
+++ b/featuretests/cmd_juju_upgrade_test.go
@@ -39,7 +39,7 @@ func (s *cmdUpgradeSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
 	supported := series.SupportedLts()
-	supported = append(supported, series.MustHostSeries())
+	supported = append(supported, testing.HostSeries(c))
 	for _, aSeries := range supported {
 		s.AddToolsToState(c, version.MustParseBinary(fmt.Sprintf("%v-%v-amd64", newVersion, aSeries)))
 	}

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/arch"
@@ -69,11 +68,7 @@ func (s *introspectionSuite) startMachineAgent(c *gc.C) (*agentcmd.MachineAgent,
 	err := m.SetMongoPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	vers := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	vers := testing.CurrentVersion(c)
 	return s.startAgent(c, m.Tag(), password, vers, false)
 }
 

--- a/featuretests/tools_test.go
+++ b/featuretests/tools_test.go
@@ -15,9 +15,7 @@ import (
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -113,11 +111,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader("!"), 1)
 	c.Assert(err, jc.ErrorIsNil)
@@ -132,11 +126,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	sameSize := strings.Repeat("!", int(tools.Size))
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader(sameSize), tools.Size)

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	pacman "github.com/juju/packaging/manager"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -73,11 +71,7 @@ func (s *upgradeSuite) SetUpSuite(c *gc.C) {
 func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 
-	s.oldVersion = version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	s.oldVersion = coretesting.CurrentVersion(c)
 	s.oldVersion.Major = 2
 	s.oldVersion.Minor = 1
 
@@ -219,11 +213,7 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 			c.Fatalf("didn't see UpgradeReadyError, instead got: %v", agentErr)
 		}
 		// Confirm that the downgrade is back to the previous version.
-		current := version.Binary{
-			Number: jujuversion.Current,
-			Arch:   arch.HostArch(),
-			Series: series.MustHostSeries(),
-		}
+		current := coretesting.CurrentVersion(c)
 		c.Assert(upgradeReadyErr.OldTools, gc.Equals, current)
 		c.Assert(upgradeReadyErr.NewTools, gc.Equals, s.oldVersion)
 

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
 	github.com/juju/os v0.0.0-20191022170002-da411304426c
-	github.com/juju/os/v2 v2.0.0
+	github.com/juju/os/v2 v2.1.0
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
@@ -163,5 +163,3 @@ replace (
 	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.0.0 => k8s.io/client-go v0.18.6
 )
-
-replace github.com/juju/os/v2 => /home/ben/gohack/github.com/juju/os/v2

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,6 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os v0.0.0-20191022170002-da411304426c
 	github.com/juju/os/v2 v2.1.0
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
+	github.com/juju/os v0.0.0-20191022170002-da411304426c
 	github.com/juju/os/v2 v2.0.0
 	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
@@ -162,3 +163,5 @@ replace (
 	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.0.0 => k8s.io/client-go v0.18.6
 )
+
+replace github.com/juju/os/v2 => /home/ben/gohack/github.com/juju/os/v2

--- a/go.sum
+++ b/go.sum
@@ -476,8 +476,9 @@ github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGk
 github.com/juju/os v0.0.0-20190625135142-88a4c6ac59c1/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
 github.com/juju/os v0.0.0-20191022170002-da411304426c h1:iJZl5krsl2AqkgU7IiJ2/jNAchctLFa3BiKdyOUvK+g=
 github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/TKE8ZlS/nRR3keo+hjVqV+VR4ns=
-github.com/juju/os/v2 v2.0.0 h1:Fy+tcT7NMPhqGRaV6JVOgTblp9yvk6ys/lcT9LAgNyM=
 github.com/juju/os/v2 v2.0.0/go.mod h1:S/AadPYIeAZtep7zu519c+eWGWV7dVR+Hb8RTGBR1+I=
+github.com/juju/os/v2 v2.1.0 h1:zh3amMFUUOMRJPZtF781vxnHDEQiQ4oIslTQtOaAwPY=
+github.com/juju/os/v2 v2.1.0/go.mod h1:S/AadPYIeAZtep7zu519c+eWGWV7dVR+Hb8RTGBR1+I=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/http"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	jujuos "github.com/juju/os/v2"
 	"github.com/juju/os/v2/series"
 	"github.com/juju/pubsub"
 	gitjujutesting "github.com/juju/testing"
@@ -74,7 +75,7 @@ const (
 var (
 	// KubernetesSeriesName is the kubernetes series name that is validated at
 	// runtime, otherwise it panics.
-	KubernetesSeriesName = strings.ToLower(series.MustOSFromSeries("kubernetes").String())
+	KubernetesSeriesName = strings.ToLower(jujuos.Kubernetes.String())
 )
 
 // defaultSupportedJujuSeries is used to return canned information about what
@@ -436,7 +437,12 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	supported := series.SupportedLts()
 	defaultSeries := set.NewStrings(supported...)
 	defaultSeries.Add(config.PreferredSeries(conf))
-	defaultSeries.Add(series.MustHostSeries())
+
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		defaultSeries.Add(hostSeries)
+	}
+
 	agentVersion, set := conf.AgentVersion()
 	if !set {
 		agentVersion = jujuversion.Current

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -461,7 +461,10 @@ func ensureServer(args EnsureServerParams, mongoKernelTweaks map[string]string) 
 	var zeroVersion Version
 	tweakSysctlForMongo(mongoKernelTweaks)
 
-	hostSeries := series.MustHostSeries()
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return zeroVersion, errors.Trace(err)
+	}
 	mongoDep := dependency.Mongo(args.SetNUMAControlPolicy, args.JujuDBSnapChannel)
 	usingMongoFromSnap := providesMongoAsSnap(mongoDep, hostSeries) || featureflag.Enabled(feature.MongoDbSnap)
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -121,7 +121,7 @@ func (s *MongoSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *MongoSuite) patchSeries(ser string) {
-	s.PatchValue(&series.MustHostSeries, func() string { return ser })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return ser, nil })
 }
 
 func (s *MongoSuite) TestJujuMongodPath(c *gc.C) {

--- a/network/network.go
+++ b/network/network.go
@@ -284,29 +284,3 @@ func SubnetInAnyRange(cidrs []*net.IPNet, subnet *net.IPNet) bool {
 	}
 	return false
 }
-
-// Export for testing
-var ResolverFunc = net.ResolveIPAddr
-
-// FormatAsCIDR converts the specified IP addresses to a slice of CIDRs. It
-// attempts to resolve any address represented as hostnames before formatting.
-func FormatAsCIDR(addresses []string) ([]string, error) {
-	result := make([]string, len(addresses))
-	for i, a := range addresses {
-		cidr := a
-		// If address is not already a cidr, add a /32 (ipv4) or /128 (ipv6).
-		if _, _, err := net.ParseCIDR(a); err != nil {
-			address, err := ResolverFunc("ip", a)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if address.IP.To4() != nil {
-				cidr = address.String() + "/32"
-			} else {
-				cidr = address.String() + "/128"
-			}
-		}
-		result[i] = cidr
-	}
-	return result, nil
-}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -291,35 +291,3 @@ func (s *CIDRSuite) TestSubnetInAnyRange(c *gc.C) {
 		c.Assert(result, gc.Equals, t.included)
 	}
 }
-
-// This test shows that FormatAsCIDR will resolve a resolvable hostname to an IP
-// address before formatting as a CIDR.
-func (s *CIDRSuite) TestParseCIDR(c *gc.C) {
-	exampleAddress := "10.10.10.10"
-	exampleHostname := "Hostname"
-	expectedCIDR := "10.10.10.10/32"
-	testAddresses := []struct {
-		address string
-		cidr    string
-	}{{
-		address: exampleAddress,
-		cidr:    expectedCIDR,
-	}, {
-		address: exampleHostname,
-		cidr:    expectedCIDR,
-	}}
-
-	s.PatchValue(&network.ResolverFunc, func(string, hostname string) (*net.IPAddr, error) {
-		return &net.IPAddr{IP: net.ParseIP(exampleAddress)}, nil
-	})
-
-	for _, testAddress := range testAddresses {
-		actualCIDRs, err := network.FormatAsCIDR([]string{testAddress.address})
-		c.Assert(err, jc.ErrorIsNil)
-		if len(actualCIDRs) <= 0 {
-			c.Fail()
-		}
-		actualCIDR := actualCIDRs[0]
-		c.Assert(actualCIDR, gc.Equals, expectedCIDR)
-	}
-}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -652,7 +652,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
-	s.PatchValue(&series.MustHostSeries, func() string { return "xenial" })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return "xenial", nil })
 	checkHardware := instance.MustParseHardware("arch=ppc64el mem=2T")
 
 	var innerInstanceConfig *instancecfg.InstanceConfig

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -85,7 +85,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.LiveTests.SetUpSuite(c)
 	t.BaseSuite.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return version.DefaultSupportedLTS() })
+	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return version.DefaultSupportedLTS(), nil })
 	// Use the real ec2 session if we are running with real creds.
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	if accessKey == "" {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -240,7 +240,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
 	t.BaseSuite.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	t.BaseSuite.PatchValue(&series.MustHostSeries, func() string { return jujuversion.DefaultSupportedLTS() })
+	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return jujuversion.DefaultSupportedLTS(), nil })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
 	t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2iface.EC2API {
 		c.Assert(region, gc.Equals, "test")

--- a/provider/lxd/upgrades.go
+++ b/provider/lxd/upgrades.go
@@ -8,10 +8,8 @@ import (
 	"path"
 
 	"github.com/juju/errors"
-
 	"github.com/juju/juju/cloud"
 	jujupaths "github.com/juju/juju/core/paths"
-	"github.com/juju/juju/version"
 )
 
 // ReadLegacyCloudCredentials reads cloud credentials off disk for an old
@@ -22,7 +20,7 @@ import (
 // satisfying errors.IsNotFound will be returned.
 func ReadLegacyCloudCredentials(readFile func(string) ([]byte, error)) (cloud.Credential, error) {
 	var (
-		jujuConfDir    = jujupaths.MustSucceed(jujupaths.ConfDir(version.DefaultSupportedLTS()))
+		jujuConfDir    = jujupaths.ConfDir(jujupaths.OSUnixLike)
 		clientCertPath = path.Join(jujuConfDir, "lxd-client.crt")
 		clientKeyPath  = path.Join(jujuConfDir, "lxd-client.key")
 		serverCertPath = path.Join(jujuConfDir, "lxd-server.crt")

--- a/provider/maas/maas_test.go
+++ b/provider/maas/maas_test.go
@@ -80,7 +80,7 @@ func (s *baseProviderSuite) SetUpTest(c *gc.C) {
 	s.ToolsFixture.SetUpTest(c)
 	s.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	s.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
-	s.PatchValue(&series.MustHostSeries, func() string { return version.DefaultSupportedLTS() })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return version.DefaultSupportedLTS(), nil })
 	s.callCtx = &context.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true

--- a/provider/maas/util.go
+++ b/provider/maas/util.go
@@ -9,13 +9,12 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/v2"
+	"github.com/juju/utils"
 	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/paths"
-	"github.com/juju/juju/version"
 )
 
 // extractSystemId extracts the 'system_id' part from an InstanceId.
@@ -48,17 +47,14 @@ type machineInfo struct {
 	Hostname string `yaml:",omitempty"`
 }
 
-var maasDataDir = paths.MustSucceed(paths.DataDir(version.DefaultSupportedLTS()))
+var maasDataDir = paths.DataDir(paths.OSUnixLike)
 var _MAASInstanceFilename = path.Join(maasDataDir, "MAASmachine.txt")
 
 // cloudinitRunCmd returns the shell command that, when run, will create the
 // "machine info" file containing the hostname of a machine.
 // That command is destined to be used by cloudinit.
 func (info *machineInfo) cloudinitRunCmd(cloudcfg cloudinit.CloudConfig) (string, error) {
-	dataDir, err := paths.DataDir(cloudcfg.GetSeries())
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+	dataDir := paths.DataDir(paths.SeriesToOS(cloudcfg.GetSeries()))
 	yaml, err := goyaml.Marshal(info)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/provider/maas/util_test.go
+++ b/provider/maas/util_test.go
@@ -41,8 +41,7 @@ func (*utilSuite) TestMachineInfoCloudinitRunCmd(c *gc.C) {
 	hostname := "hostname"
 	info := machineInfo{hostname}
 	filename := "/var/lib/juju/MAASmachine.txt"
-	dataDir, err := paths.DataDir("quantal")
-	c.Assert(err, jc.ErrorIsNil)
+	dataDir := paths.DataDir(paths.OSUnixLike)
 	cloudcfg, err := cloudinit.New("quantal")
 	c.Assert(err, jc.ErrorIsNil)
 	script, err := info.cloudinitRunCmd(cloudcfg)

--- a/service/discovery.go
+++ b/service/discovery.go
@@ -23,7 +23,11 @@ import (
 // DiscoverService returns an interface to a service appropriate
 // for the current system
 func DiscoverService(name string, conf common.Conf) (Service, error) {
-	initName, err := discoverInitSystem(series.MustHostSeries())
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	initName, err := discoverInitSystem(hostSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/featureflag"
 	"github.com/juju/juju/testing"
-	jujuos "github.com/juju/os"
+	jujuos "github.com/juju/os/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/exec"
 	"github.com/juju/version"

--- a/service/discovery_test.go
+++ b/service/discovery_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/featureflag"
-	jujuos "github.com/juju/os/v2"
-	"github.com/juju/os/v2/series"
+	"github.com/juju/juju/testing"
+	jujuos "github.com/juju/os"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/exec"
 	"github.com/juju/version"
@@ -182,13 +182,13 @@ func (s *discoverySuite) TestDiscoverServiceLocalHost(c *gc.C) {
 	case "windows":
 		localInitSystem = service.InitSystemWindows
 	case "linux":
-		localInitSystem, err = service.VersionInitSystem(series.MustHostSeries())
+		localInitSystem, err = service.VersionInitSystem(testing.HostSeries(c))
 	}
 	c.Assert(err, gc.IsNil)
 
 	test := discoveryTest{
 		os:       jujuos.HostOS(),
-		series:   series.MustHostSeries(),
+		series:   testing.HostSeries(c),
 		expected: localInitSystem,
 	}
 	test.disableVersionDiscovery(s)
@@ -346,7 +346,7 @@ func (s *discoverySuite) TestDiscoverInitSystemScriptBash(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
+	initSystem, err := service.DiscoverInitSystem(testing.HostSeries(c))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)
@@ -365,7 +365,7 @@ func (s *discoverySuite) TestDiscoverInitSystemScriptPosix(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
+	initSystem, err := service.DiscoverInitSystem(testing.HostSeries(c))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)
@@ -407,7 +407,7 @@ func (s *discoverySuite) TestNewShellSelectCommandBash(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
+	initSystem, err := service.DiscoverInitSystem(testing.HostSeries(c))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)
@@ -432,7 +432,7 @@ func (s *discoverySuite) TestNewShellSelectCommandPosix(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	initSystem, err := service.DiscoverInitSystem(series.MustHostSeries())
+	initSystem, err := service.DiscoverInitSystem(testing.HostSeries(c))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(response.Code, gc.Equals, 0)
 	c.Check(string(response.Stdout), gc.Equals, initSystem)

--- a/service/systemd/service_test.go
+++ b/service/systemd/service_test.go
@@ -72,9 +72,7 @@ var _ = gc.Suite(&initSystemSuite{})
 func (s *initSystemSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	dataDir, err := paths.DataDir("vivid")
-	c.Assert(err, jc.ErrorIsNil)
-	s.dataDir = dataDir
+	s.dataDir = paths.DataDir(paths.OSUnixLike)
 
 	// Set up the service config.
 	tagStr := "machine-0"

--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -77,7 +77,7 @@ func (s *BaseSuite) PatchAttempts(retries int) {
 }
 
 func (s *BaseSuite) PatchSeries(ser string) {
-	s.PatchValue(&series.MustHostSeries, func() string { return ser })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return ser, nil })
 }
 
 func NewDiscoveryCheck(name string, running bool, failure error) discoveryCheck {

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -96,10 +96,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 
 	// The path for the config file might change if the tag changed
 	// and also the rest of the path, so we assume as little as possible.
-	oldDatadir, err := paths.DataDir(args.NewInstSeries)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot determine DataDir for the restored machine")
-	}
+	oldDatadir := paths.DataDir(paths.SeriesToOS(args.NewInstSeries))
 
 	var oldAgentConfig agent.ConfigSetterWriter
 	oldAgentConfigFile := agent.ConfigPath(oldDatadir, args.NewInstTag)
@@ -126,10 +123,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	var agentConfig agent.ConfigSetterWriter
 	// The path for the config file might change if the tag changed
 	// and also the rest of the path, so we assume as little as possible.
-	datadir, err := paths.DataDir(args.NewInstSeries)
-	if err != nil {
-		return nil, errors.Annotate(err, "cannot determine DataDir for the restored machine")
-	}
+	datadir := paths.DataDir(paths.SeriesToOS(args.NewInstSeries))
 	agentConfigFile := agent.ConfigPath(datadir, backupMachine)
 	if agentConfig, err = agent.ReadConfig(agentConfigFile); err != nil {
 		return nil, errors.Annotate(err, "cannot load agent config from disk")
@@ -157,7 +151,7 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 		aInfo := service.NewMachineAgentInfo(
 			agentConfig.Tag().Id(),
 			dataDir,
-			paths.MustSucceed(paths.LogDir(args.NewInstSeries)),
+			paths.LogDir(paths.SeriesToOS(args.NewInstSeries)),
 		)
 
 		// TODO(perrito666) renderer should have a RendererForSeries, for the moment

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -1389,10 +1389,7 @@ func FilesystemMountPoint(
 	tag names.StorageTag,
 	series string,
 ) (string, error) {
-	storageDir, err := paths.StorageDir(series)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
+	storageDir := paths.StorageDir(paths.SeriesToOS(series))
 	if strings.HasPrefix(meta.Location, storageDir) {
 		return "", errors.Errorf(
 			"invalid location %q: must not fall within %q",

--- a/state/podspec_ops.go
+++ b/state/podspec_ops.go
@@ -73,11 +73,8 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "setting pod spec")
 	}
-	if app.Life() != Alive {
-		return nil, errors.Annotate(
-			errors.Errorf("application %s not alive", appName),
-			"setting pod spec",
-		)
+	if app.Life() == Dead {
+		return nil, errors.NotValidf("setting pod-spec on dead application %s", appName)
 	}
 	// The app's charm may not be there yet (as is the case when migrating).
 	// This check is for checking the k8s-spec-set/k8s-raw-set call.
@@ -92,7 +89,7 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 	prereqOps = append(prereqOps, txn.Op{
 		C:      applicationsC,
 		Id:     app.doc.DocID,
-		Assert: isAliveDoc,
+		Assert: notDeadDoc,
 	})
 
 	sop := txn.Op{

--- a/state/podspec_test.go
+++ b/state/podspec_test.go
@@ -86,9 +86,24 @@ func (s *PodSpecSuite) TestSetRawK8sSpecOperationApplicationDying(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
 	err := s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, s.application, state.Dying)
 
 	err = s.applySetRawK8sSpecOperation(nil, s.application.ApplicationTag(), strPtr("foo"))
-	c.Assert(err, gc.ErrorMatches, ".*application gitlab not alive")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertRawK8sSpec(c, s.application.ApplicationTag(), "foo")
+}
+
+func (s *PodSpecSuite) TestSetRawK8sSpecOperationApplicationDead(c *gc.C) {
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
+	err := s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(unit.Remove(), jc.ErrorIsNil)
+	assertCleanupCount(c, s.State, 1)
+	assertLife(c, s.application, state.Dead)
+
+	err = s.applySetRawK8sSpecOperation(nil, s.application.ApplicationTag(), strPtr("foo"))
+	c.Assert(err, gc.ErrorMatches, "setting pod-spec on dead application gitlab not valid")
 	s.assertRawK8sSpecNotFound(c, s.application.ApplicationTag())
 }
 
@@ -136,9 +151,24 @@ func (s *PodSpecSuite) TestSetPodSpecApplicationDying(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
 	err := s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, s.application, state.Dying)
 
 	err = s.Model.SetPodSpec(nil, s.application.ApplicationTag(), strPtr("foo"))
-	c.Assert(err, gc.ErrorMatches, ".*application gitlab not alive")
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertPodSpec(c, s.application.ApplicationTag(), "foo")
+}
+
+func (s *PodSpecSuite) TestSetPodSpecApplicationDead(c *gc.C) {
+	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application})
+	err := s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)
+	c.Assert(unit.Remove(), jc.ErrorIsNil)
+	assertCleanupCount(c, s.State, 1)
+	assertLife(c, s.application, state.Dead)
+
+	err = s.Model.SetPodSpec(nil, s.application.ApplicationTag(), strPtr("foo"))
+	c.Assert(err, gc.ErrorMatches, "setting pod-spec on dead application gitlab not valid")
 	s.assertPodSpecNotFound(c, s.application.ApplicationTag())
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3861,7 +3861,7 @@ func (s *StateSuite) TestSetModelAgentVersionOnOtherModel(c *gc.C) {
 	current := version.MustParseBinary("1.24.7-trusty-amd64")
 	s.PatchValue(&jujuversion.Current, current.Number)
 	s.PatchValue(&arch.HostArch, func() string { return current.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return current.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return current.Series, nil })
 
 	otherSt := s.Factory.MakeModel(c, nil)
 	defer otherSt.Close()

--- a/testing/base.go
+++ b/testing/base.go
@@ -21,11 +21,13 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/arch"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/wrench"
 )
 
@@ -328,4 +330,20 @@ func GetExportedFields(arg interface{}) set.Strings {
 	}
 
 	return result
+}
+
+// CurrentVersion returns the current Juju version, asserting on error.
+func CurrentVersion(c *gc.C) version.Binary {
+	return version.Binary{
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		Series: HostSeries(c),
+	}
+}
+
+// HostSeries returns series.HostSeries(), asserting on error.
+func HostSeries(c *gc.C) string {
+	hostSeries, err := series.HostSeries()
+	c.Assert(err, jc.ErrorIsNil)
+	return hostSeries
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/arch"
@@ -315,11 +314,7 @@ func (factory *Factory) MakeMachineNested(c *gc.C, parentId string, params *Mach
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetProvisioned(params.InstanceId, params.DisplayName, params.Nonce, params.Characteristics)
 	c.Assert(err, jc.ErrorIsNil)
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	return m
@@ -385,11 +380,7 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 		err := machine.SetProviderAddresses(params.Addresses...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := testing.CurrentVersion(c)
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine, params.Password

--- a/version/current_test.go
+++ b/version/current_test.go
@@ -17,8 +17,8 @@ type CurrentSuite struct{}
 var _ = gc.Suite(&CurrentSuite{})
 
 func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
-	s := series.MustHostSeries()
-	if s == "unknown" {
+	s, err := series.HostSeries()
+	if err != nil || s == "unknown" {
 		s = "n/a"
 	}
 	out, err := exec.Command("lsb_release", "-c").CombinedOutput()
@@ -32,20 +32,20 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 		case "windows":
 			c.Check(s, gc.Matches, `win2012hvr2|win2012hv|win2012|win2012r2|win8|win81|win7`)
 		default:
-			current_os, err := series.GetOSFromSeries(s)
+			currentOS, err := series.GetOSFromSeries(s)
 			c.Assert(err, gc.IsNil)
 			if s != "n/a" {
 				// There is no lsb_release command on CentOS.
-				if current_os == os.CentOS {
+				if currentOS == os.CentOS {
 					c.Check(s, gc.Matches, `centos7|centos8`)
 				}
 			}
 		}
 	} else {
 		//OpenSUSE lsb-release returns n/a
-		current_os, err := series.GetOSFromSeries(s)
+		currentOS, err := series.GetOSFromSeries(s)
 		c.Assert(err, gc.IsNil)
-		if string(out) == "n/a" && current_os == os.OpenSUSE {
+		if string(out) == "n/a" && currentOS == os.OpenSUSE {
 			c.Check(s, gc.Matches, "opensuseleap")
 		} else {
 			c.Assert(string(out), gc.Equals, "Codename:\t"+s+"\n")

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -7,15 +7,12 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	semversion "github.com/juju/version"
 	gc "gopkg.in/check.v1"
 )
 
-type suite struct {
-	testing.IsolationSuite
-}
+type suite struct{}
 
 var _ = gc.Suite(&suite{})
 

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -48,9 +48,9 @@ import (
 var logger interface{}
 
 var (
-	jujuRun        = paths.MustSucceed(paths.JujuRun(series.MustHostSeries()))
-	jujuDumpLogs   = paths.MustSucceed(paths.JujuDumpLogs(series.MustHostSeries()))
-	jujuIntrospect = paths.MustSucceed(paths.JujuIntrospect(series.MustHostSeries()))
+	jujuRun        = paths.JujuRun(paths.CurrentOS())
+	jujuDumpLogs   = paths.JujuDumpLogs(paths.CurrentOS())
+	jujuIntrospect = paths.JujuIntrospect(paths.CurrentOS())
 
 	jujudSymlinks = []string{
 		jujuRun,
@@ -315,11 +315,11 @@ func (op *caasOperator) removeUnitDir(unitTag names.UnitTag) error {
 	return os.RemoveAll(unitAgentDir)
 }
 
-func toBinaryVersion(vers version.Number) version.Binary {
+func toBinaryVersion(vers version.Number, hostSeries string) version.Binary {
 	outVers := version.Binary{
 		Number: vers,
 		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
+		Series: hostSeries,
 	}
 	return outVers
 }
@@ -406,8 +406,12 @@ func (op *caasOperator) loop() (err error) {
 	logger.Infof("operator %q started", op.config.Application)
 
 	// Start by reporting current tools (which includes arch/series).
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if err := op.config.VersionSetter.SetVersion(
-		op.config.Application, toBinaryVersion(jujuversion.Current)); err != nil {
+		op.config.Application, toBinaryVersion(jujuversion.Current, hostSeries)); err != nil {
 		return errors.Annotate(err, "cannot set agent version")
 	}
 

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -15,13 +15,10 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/utils/v2/symlink"
-	"github.com/juju/version"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
@@ -39,7 +36,6 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/caasoperator"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/remotestate"
@@ -275,11 +271,7 @@ func (s *WorkerSuite) TestWorkerDownloadsCharm(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "WatchContainerStart", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", version.Binary{
-		Number: jujuversion.Current,
-		Series: series.MustHostSeries(),
-		Arch:   arch.HostArch(),
-	})
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 4, "WatchContainerStart", "gitlab", "(?:juju-pod-init|)")
 	s.client.CheckCall(c, 6, "Watch", "gitlab")
@@ -536,11 +528,7 @@ func (s *WorkerSuite) TestContainerStart(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "WatchContainerStart", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", version.Binary{
-		Number: jujuversion.Current,
-		Series: series.MustHostSeries(),
-		Arch:   arch.HostArch(),
-	})
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 4, "WatchContainerStart", "gitlab", "(?:juju-pod-init|)")
 	s.client.CheckCall(c, 6, "Watch", "gitlab")
@@ -585,11 +573,7 @@ func (s *WorkerSuite) TestOperatorNoWaitContainerStart(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", version.Binary{
-		Number: jujuversion.Current,
-		Series: series.MustHostSeries(),
-		Arch:   arch.HostArch(),
-	})
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 5, "Watch", "gitlab")
 }

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -88,8 +88,12 @@ func (u *Upgrader) Wait() error {
 
 func (u *Upgrader) loop() error {
 	// Only controllers set their version here - agents do it in the main agent worker loop.
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if agent.IsAllowedControllerTag(u.tag.Kind()) {
-		if err := u.upgraderClient.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current)); err != nil {
+		if err := u.upgraderClient.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostSeries)); err != nil {
 			return errors.Annotate(err, "cannot set agent version")
 		}
 	}
@@ -180,11 +184,11 @@ func (u *Upgrader) loop() error {
 	}
 }
 
-func toBinaryVersion(vers version.Number) version.Binary {
+func toBinaryVersion(vers version.Number, hostSeries string) version.Binary {
 	outVers := version.Binary{
 		Number: vers,
 		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
+		Series: hostSeries,
 	}
 	return outVers
 }

--- a/worker/caasupgrader/upgrader_test.go
+++ b/worker/caasupgrader/upgrader_test.go
@@ -45,7 +45,7 @@ func (s *UpgraderSuite) SetUpTest(c *gc.C) {
 
 func (s *UpgraderSuite) patchVersion(v version.Binary) {
 	s.PatchValue(&arch.HostArch, func() string { return v.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return v.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return v.Series, nil })
 	s.PatchValue(&jujuversion.Current, v.Number)
 }
 

--- a/worker/deployer/package_test.go
+++ b/worker/deployer/package_test.go
@@ -11,17 +11,13 @@ import (
 	"runtime"
 	stdtesting "testing"
 
-	"github.com/juju/os/v2/series"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2/arch"
-	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent/tools"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
-	jv "github.com/juju/juju/version"
 )
 
 func TestPackage(t *stdtesting.T) {
@@ -39,11 +35,7 @@ type BaseSuite struct {
 func (s *BaseSuite) InitializeCurrentToolsDir(c *gc.C, dataDir string) {
 	// Initialize the tools directory for the agent.
 	// This should be <DataDir>/tools/<version>-<series>-<arch>.
-	current := version.Binary{
-		Number: jv.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	toolsDir := tools.SharedToolsDir(dataDir, current)
 	// Make that directory.
 	err := os.MkdirAll(toolsDir, 0755)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -173,11 +173,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Id(), gc.Equals, "0")
 
-	current := version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	current := coretesting.CurrentVersion(c)
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -571,7 +567,7 @@ func (s *ProvisionerSuite) TestPossibleTools(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.PatchValue(&arch.HostArch, func() string { return currentVersion.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return currentVersion.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return currentVersion.Series, nil })
 
 	// Upload some plausible matches, and some that should be filtered out.
 	compatibleVersion := version.MustParseBinary("1.2.3-quantal-arm64")

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/packaging/commands"
 	pacconfig "github.com/juju/packaging/config"
 	"github.com/juju/proxy"
@@ -246,7 +245,7 @@ func (s *ProxyUpdaterSuite) TestInitialStateLegacyProxy(c *gc.C) {
 	s.waitForFile(c, s.proxyEnvFile, proxySettings.AsScriptEnvironment())
 	s.waitForFile(c, s.proxySystemdFile, proxySettings.AsSystemdDefaultEnv())
 
-	paccmder, err := commands.NewPackageCommander(series.MustHostSeries())
+	paccmder, err := commands.NewPackageCommander(coretesting.HostSeries(c))
 	c.Assert(err, jc.ErrorIsNil)
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
 }
@@ -265,7 +264,7 @@ func (s *ProxyUpdaterSuite) TestInitialStateJujuProxy(c *gc.C) {
 	s.waitForFile(c, s.proxyEnvFile, empty.AsScriptEnvironment())
 	s.waitForFile(c, s.proxySystemdFile, empty.AsSystemdDefaultEnv())
 
-	paccmder, err := commands.NewPackageCommander(series.MustHostSeries())
+	paccmder, err := commands.NewPackageCommander(coretesting.HostSeries(c))
 	c.Assert(err, jc.ErrorIsNil)
 	s.waitForFile(c, pacconfig.AptProxyConfigFile, paccmder.ProxyConfigContents(aptProxySettings)+"\n")
 }

--- a/worker/uniter/runner/context/env.go
+++ b/worker/uniter/runner/context/env.go
@@ -49,7 +49,8 @@ func ubuntuEnv(paths Paths, getEnv GetEnvFunc) []string {
 
 	env = append(env, path...)
 
-	if series.MustHostSeries() == "trusty" {
+	hostSeries, err := series.HostSeries()
+	if err == nil && hostSeries == "trusty" {
 		// Trusty is in ESM at the time of writing and it does not have patch 20150502 for ncurses 5.9
 		// with terminal definitions for "tmux" and "tmux-256color"
 		env = append(env, "TERM=screen-256color")
@@ -71,7 +72,8 @@ func centosEnv(paths Paths, getEnv GetEnvFunc) []string {
 
 	// versions older than 7 are not supported and centos7 does not have patch 20150502 for ncurses 5.9
 	// with terminal definitions for "tmux" and "tmux-256color"
-	if series.MustHostSeries() == "centos7" {
+	hostSeries, err := series.HostSeries()
+	if err == nil && hostSeries == "centos7" {
 		env = append(env, "TERM=screen-256color")
 	} else {
 		env = append(env, "TERM=tmux-256color")
@@ -91,7 +93,8 @@ func opensuseEnv(paths Paths, getEnv GetEnvFunc) []string {
 
 	// OpenSUSE 42 does not include patch 20150502 for ncurses 5.9 with
 	// with terminal definitions for "tmux" and "tmux-256color"
-	if series.MustHostSeries() == "opensuseleap" {
+	hostSeries, err := series.HostSeries()
+	if err == nil && hostSeries == "opensuseleap" {
 		env = append(env, "TERM=screen-256color")
 	} else {
 		env = append(env, "TERM=tmux-256color")

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -206,7 +206,7 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 
 	// As TERM is series-specific we need to make sure all supported versions are covered.
 	for _, testSeries := range series.OSSupportedSeries(jujuos.Ubuntu) {
-		s.PatchValue(&series.MustHostSeries, func() string { return testSeries })
+		s.PatchValue(&series.HostSeries, func() (string, error) { return testSeries, nil })
 		ubuntuVars := []string{
 			"APT_LISTCHANGES_FRONTEND=none",
 			"DEBIAN_FRONTEND=noninteractive",
@@ -255,7 +255,7 @@ func (s *EnvSuite) TestEnvCentos(c *gc.C) {
 
 	// As TERM is series-specific we need to make sure all supported versions are covered.
 	for _, testSeries := range series.OSSupportedSeries(jujuos.CentOS) {
-		s.PatchValue(&series.MustHostSeries, func() string { return testSeries })
+		s.PatchValue(&series.HostSeries, func() (string, error) { return testSeries, nil })
 		centosVars := []string{
 			"LANG=C.UTF-8",
 			"PATH=path-to-tools:foo:bar",
@@ -302,7 +302,7 @@ func (s *EnvSuite) TestEnvOpenSUSE(c *gc.C) {
 
 	// As TERM is series-specific we need to make sure all supported versions are covered.
 	for _, testSeries := range series.OSSupportedSeries(jujuos.OpenSUSE) {
-		s.PatchValue(&series.MustHostSeries, func() string { return testSeries })
+		s.PatchValue(&series.HostSeries, func() (string, error) { return testSeries, nil })
 		openSUSEVars := []string{
 			"LANG=C.UTF-8",
 			"PATH=path-to-tools:foo:bar",

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -119,7 +119,11 @@ func (u *Upgrader) loop() error {
 	logger := u.config.Logger
 	// Start by reporting current tools (which includes arch/series, and is
 	// used by the controller in communicating the desired version below).
-	if err := u.st.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current)); err != nil {
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := u.st.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostSeries)); err != nil {
 		return errors.Annotate(err, "cannot set agent version")
 	}
 
@@ -214,9 +218,9 @@ func (u *Upgrader) loop() error {
 		logger.Infof("%s requested from %v to %v", direction, haveVersion, wantVersion)
 
 		// Check if tools have already been downloaded.
-		wantVersionBinary := toBinaryVersion(wantVersion)
+		wantVersionBinary := toBinaryVersion(wantVersion, hostSeries)
 		if u.toolsAlreadyDownloaded(wantVersionBinary) {
-			return u.newUpgradeReadyError(haveVersion, wantVersionBinary)
+			return u.newUpgradeReadyError(haveVersion, wantVersionBinary, hostSeries)
 		}
 
 		// Check if tools are available for download.
@@ -239,7 +243,7 @@ func (u *Upgrader) loop() error {
 			}
 			err = u.ensureTools(wantTools)
 			if err == nil {
-				return u.newUpgradeReadyError(haveVersion, wantTools.Version)
+				return u.newUpgradeReadyError(haveVersion, wantTools.Version, hostSeries)
 			}
 			logger.Errorf("failed to fetch agent binaries from %q: %v", wantTools.URL, err)
 		}
@@ -247,11 +251,11 @@ func (u *Upgrader) loop() error {
 	}
 }
 
-func toBinaryVersion(vers version.Number) version.Binary {
+func toBinaryVersion(vers version.Number, hostSeries string) version.Binary {
 	outVers := version.Binary{
 		Number: vers,
 		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
+		Series: hostSeries,
 	}
 	return outVers
 }
@@ -261,9 +265,9 @@ func (u *Upgrader) toolsAlreadyDownloaded(wantVersion version.Binary) bool {
 	return err == nil
 }
 
-func (u *Upgrader) newUpgradeReadyError(haveVersion version.Number, newVersion version.Binary) *agenterrors.UpgradeReadyError {
+func (u *Upgrader) newUpgradeReadyError(haveVersion version.Number, newVersion version.Binary, hostSeries string) *agenterrors.UpgradeReadyError {
 	return &agenterrors.UpgradeReadyError{
-		OldTools:  toBinaryVersion(haveVersion),
+		OldTools:  toBinaryVersion(haveVersion, hostSeries),
 		NewTools:  newVersion,
 		AgentName: u.tag.String(),
 		DataDir:   u.dataDir,

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -74,7 +74,7 @@ func (s *UpgraderSuite) SetUpTest(c *gc.C) {
 
 func (s *UpgraderSuite) patchVersion(v version.Binary) {
 	s.PatchValue(&arch.HostArch, func() string { return v.Arch })
-	s.PatchValue(&series.MustHostSeries, func() string { return v.Series })
+	s.PatchValue(&series.HostSeries, func() (string, error) { return v.Series, nil })
 	vers := v.Number
 	vers.Build = 666
 	s.PatchValue(&jujuversion.Current, vers)

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/utils/v2/arch"
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
@@ -60,11 +58,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	// wedged, so dump the logs.
 	coretesting.DumpTestLogsAfter(time.Minute, c, s)
 
-	s.oldVersion = version.Binary{
-		Number: jujuversion.Current,
-		Arch:   arch.HostArch(),
-		Series: series.MustHostSeries(),
-	}
+	s.oldVersion = coretesting.CurrentVersion(c)
 	s.oldVersion.Major = 1
 	s.oldVersion.Minor = 16
 

--- a/wrench/wrench.go
+++ b/wrench/wrench.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/juju/loggo"
-	"github.com/juju/os/v2/series"
 
 	"github.com/juju/juju/core/paths"
 )
@@ -21,7 +20,7 @@ var (
 	enabledMu sync.Mutex
 	enabled   = true
 
-	dataDir   = paths.MustSucceed(paths.DataDir(series.MustHostSeries()))
+	dataDir   = paths.DataDir(paths.CurrentOS())
 	wrenchDir = filepath.Join(dataDir, "wrench")
 	jujuUid   = os.Getuid()
 )


### PR DESCRIPTION
Merge the following PRs from 2.8 into develop:

* https://github.com/juju/juju/pull/12343 Perform network-get hostname resolution server-side
* https://github.com/juju/juju/pull/12341 Avoid panic on startup when host OS series is not recognized
* https://github.com/juju/juju/pull/12342 Do not resolve host-names when determining egress subnets from ingress addresses
* https://github.com/juju/juju/pull/12316 Log vs throw for host-name resolution when deriving egress subnets from ingress addresses
* https://github.com/juju/juju/pull/12337 Allow pod-spec-set to run on a dying application