### PR TITLE
NetworkInfo - Get CAAS addresses once

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -102,10 +102,13 @@ func NewNetworkInfoForStrategy(
 		lookupHost:    lookupHost,
 	}
 
+	var netInfo NetworkInfo
 	if unit.ShouldBeAssigned() {
-		return &NetworkInfoIAAS{base}, nil
+		netInfo, err = newNetworkInfoIAAS(base)
+	} else {
+		netInfo, err = newNetworkInfoCAAS(base)
 	}
-	return &NetworkInfoCAAS{base}, nil
+	return netInfo, errors.Trace(err)
 }
 
 // getRelationAndEndpointName returns the relation for the input ID

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -413,6 +413,11 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
+
+	// We need a new instance here, because unit addresses
+	// are populated in the constructor.
+	netInfo, err = uniter.NewNetworkInfoForStrategy(st, prr.pu0.UnitTag(), nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
 	boundSpace, ingress, egress, err = netInfo.NetworksForRelation("", prr.rel, true)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -22,6 +22,10 @@ type NetworkInfoCAAS struct {
 	*NetworkInfoBase
 }
 
+func newNetworkInfoCAAS(base *NetworkInfoBase) (*NetworkInfoCAAS, error) {
+	return &NetworkInfoCAAS{base}, nil
+}
+
 // ProcessAPIRequest handles a request to the uniter API NetworkInfo method.
 func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
 	bindings := make(map[string]string)

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -22,6 +22,10 @@ type NetworkInfoIAAS struct {
 	*NetworkInfoBase
 }
 
+func newNetworkInfoIAAS(base *NetworkInfoBase) (*NetworkInfoIAAS, error) {
+	return &NetworkInfoIAAS{base}, nil
+}
+
 // ProcessAPIRequest handles a request to the uniter API NetworkInfo method.
 func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
 	spaces := set.NewStrings()


### PR DESCRIPTION
This is a mechanical change to ensure that we call `unit.AllAddresses` a single time for CAAS unit `NetworkInfo`

## QA steps

Mechanical change only - unit tests pass

## Documentation changes

None.

## Bug reference

N/A
