### PR TITLE
Restrict setting arch constraint

### DIFF
--- a/core/arch/arches.go
+++ b/core/arch/arches.go
@@ -10,6 +10,12 @@ import (
 	"github.com/juju/utils/arch"
 )
 
+const (
+	// DefaultArchitecture represents the default architecture we expect to use
+	// if none is present.
+	DefaultArchitecture = arch.AMD64
+)
+
 // Arch represents a platform architecture.
 type Arch = string
 

--- a/state/application.go
+++ b/state/application.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/model"
@@ -2852,7 +2853,7 @@ func (a *Application) SetConstraints(cons constraints.Value) (err error) {
 		if err != nil {
 			return errors.Annotate(err, "unable to read constraints")
 		}
-		if current.Arch == nil && cons.Arch != nil {
+		if current.Arch == nil && cons.Arch != nil && *cons.Arch != arch.DefaultArchitecture {
 			return errors.NotSupportedf("changing architecture")
 		} else if current.Arch != nil && cons.Arch != nil && *current.Arch != *cons.Arch {
 			return errors.NotSupportedf("changing architecture (%s)", *current.Arch)

--- a/state/application.go
+++ b/state/application.go
@@ -2848,14 +2848,14 @@ func (a *Application) SetConstraints(cons constraints.Value) (err error) {
 	// Note: we don't apply this check in validate constraints as we have no
 	// way to know if it's a model or an application (former we do allow
 	// changes).
-	current, err := a.Constraints()
-	if !errors.IsNotFound(err) && cons.Arch != nil {
+	if current, err := a.Constraints(); !errors.IsNotFound(err) && (cons.Arch != nil && *cons.Arch != "") {
 		if err != nil {
 			return errors.Annotate(err, "unable to read constraints")
 		}
-		if current.Arch == nil && *cons.Arch != arch.DefaultArchitecture {
+
+		if (current.Arch == nil || *current.Arch == "") && *cons.Arch != arch.DefaultArchitecture {
 			return errors.NotSupportedf("changing architecture")
-		} else if current.Arch != nil && *current.Arch != *cons.Arch {
+		} else if current.Arch != nil && *current.Arch != "" && *current.Arch != *cons.Arch {
 			return errors.NotSupportedf("changing architecture (%s)", *current.Arch)
 		}
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -2848,9 +2848,9 @@ func (a *Application) SetConstraints(cons constraints.Value) (err error) {
 	// Note: we don't apply this check in validate constraints as we have no
 	// way to know if it's a model or an application (former we do allow
 	// changes).
-	if current, err := a.Constraints(); !errors.IsNotFound(err) && (cons.Arch != nil && *cons.Arch != "") {
-		if err != nil {
-			return errors.Annotate(err, "unable to read constraints")
+	if current, consErr := a.Constraints(); !errors.IsNotFound(consErr) && (cons.Arch != nil && *cons.Arch != "") {
+		if consErr != nil {
+			return errors.Annotate(consErr, "unable to read constraints")
 		}
 
 		if (current.Arch == nil || *current.Arch == "") && *cons.Arch != arch.DefaultArchitecture {

--- a/state/application.go
+++ b/state/application.go
@@ -2849,13 +2849,13 @@ func (a *Application) SetConstraints(cons constraints.Value) (err error) {
 	// way to know if it's a model or an application (former we do allow
 	// changes).
 	current, err := a.Constraints()
-	if !errors.IsNotFound(err) {
+	if !errors.IsNotFound(err) && cons.Arch != nil {
 		if err != nil {
 			return errors.Annotate(err, "unable to read constraints")
 		}
-		if current.Arch == nil && cons.Arch != nil && *cons.Arch != arch.DefaultArchitecture {
+		if current.Arch == nil && *cons.Arch != arch.DefaultArchitecture {
 			return errors.NotSupportedf("changing architecture")
-		} else if current.Arch != nil && cons.Arch != nil && *current.Arch != *cons.Arch {
+		} else if current.Arch != nil && *current.Arch != *cons.Arch {
 			return errors.NotSupportedf("changing architecture (%s)", *current.Arch)
 		}
 	}


### PR DESCRIPTION
The aim here is to restrict an application architecture constraint once
it's been set. If the architecture is already set and it's the one being
passed in, we treat it as a no-op and move along. Removing the
application removes the constraint so can be re-applied the same as
other constraints.

Most of the time you won't be able to change an architecture unless
you have a cloud that reports back as being able to swap (manual).
In that case the error you'll generally hit is:

```sh
juju set-constraints mysql arch=amd64
ERROR invalid constraint value: arch=amd64
valid values are: [arm64]
```

The driver behind this is to prevent the deploying of a charm with a
constraint and changing the architecture under the charm with a
different constraint. This will cause a world of pain to try and
reconcile that correctly, re-downloading charms and their resources
along with any profiles that need applying... So the fix is to prevent
it and then if they have done the wrong thing, remove the application
and start again.

Architecture is becoming more pervasive so we need to ensure that we
don't allow foot guns in the codebase.

## QA steps

Bootstrap to a hybrid architecture cloud (manual, aws)

### Apply a constraint

This states that you can't change a constraint after the fact for
an application with an arch that we don't know about.

```sh
$ juju deploy redis
$ juju set-constraints redis arch=arm64
ERROR: changing architecture not supported
```

### Apply the same constraint

This should be fine as we're applying the same constraint again.

```sh
$ juju deploy redis --constraints arch=amd64
$ juju set-constraints redis arch=amd64
```

### Removing an application 

This should allow us to specify another architecture

```sh
$ juju deploy redis --constraints arch=arm64
$ juju remove-application redis
$ juju deploy redis --constraints arch=amd64
```

## Documentation changes

Attempting to update an application that has an existing architecture 
constraint with a new architecture fails if they're not the same.
