### PR TITLE
Use snap instance name for hook scripts

### DIFF
--- a/snap/hooks/connect-plug-peers
+++ b/snap/hooks/connect-plug-peers
@@ -1,6 +1,7 @@
 #!/bin/sh
 peer="$(snapctl get --slot :peers content)"
 (
+    SNAP_INSTANCE_NAME=${SNAP_INSTANCE_NAME:-$SNAP_NAME}
     echo "hook $0 $@"
     echo "connected to peer $peer"
     echo "$0 is starting $SNAP_INSTANCE_NAME.fetch-oci"

--- a/snap/hooks/connect-plug-peers
+++ b/snap/hooks/connect-plug-peers
@@ -3,6 +3,6 @@ peer="$(snapctl get --slot :peers content)"
 (
     echo "hook $0 $@"
     echo "connected to peer $peer"
-    echo "$0 is starting $SNAP_NAME.fetch-oci"
-    snapctl start $SNAP_NAME.fetch-oci
+    echo "$0 is starting $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl start $SNAP_INSTANCE_NAME.fetch-oci
 ) >> $SNAP_COMMON/hook.log

--- a/snap/hooks/disconnect-plug-peers
+++ b/snap/hooks/disconnect-plug-peers
@@ -1,6 +1,7 @@
 #!/bin/sh
 peer="$(snapctl get --slot :peers content)"
 (
+    SNAP_INSTANCE_NAME=${SNAP_INSTANCE_NAME:-$SNAP_NAME}
     echo "hook $0 $@"
     echo "disconnected $peer"
     echo "$0 is stopping $SNAP_INSTANCE_NAME.fetch-oci"

--- a/snap/hooks/disconnect-plug-peers
+++ b/snap/hooks/disconnect-plug-peers
@@ -3,6 +3,6 @@ peer="$(snapctl get --slot :peers content)"
 (
     echo "hook $0 $@"
     echo "disconnected $peer"
-    echo "$0 is stopping $SNAP_NAME.fetch-oci"
-    snapctl stop --disable $SNAP_NAME.fetch-oci
+    echo "$0 is stopping $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl stop --disable $SNAP_INSTANCE_NAME.fetch-oci
 ) >> $SNAP_COMMON/hook.log

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,8 +1,8 @@
 #!/bin/sh
 (
     echo "hook $0 $@" 
-    echo "$0 is starting $SNAP_NAME.fetch-oci"
-    snapctl start $SNAP_NAME.fetch-oci
-    echo "$0 is stopping $SNAP_NAME.fetch-oci"
-    snapctl stop --disable $SNAP_NAME.fetch-oci
+    echo "$0 is starting $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl start $SNAP_INSTANCE_NAME.fetch-oci
+    echo "$0 is stopping $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl stop --disable $SNAP_INSTANCE_NAME.fetch-oci
 ) >> $SNAP_COMMON/hook.log

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,5 +1,6 @@
 #!/bin/sh
 (
+    SNAP_INSTANCE_NAME=${SNAP_INSTANCE_NAME:-$SNAP_NAME}
     echo "hook $0 $@" 
     echo "$0 is starting $SNAP_INSTANCE_NAME.fetch-oci"
     snapctl start $SNAP_INSTANCE_NAME.fetch-oci


### PR DESCRIPTION
For the juju snap hook scripts, use `$SNAP_INSTANCE_NAME` instead of `$SNAP_NAME`

This allows parallel snap installs to work as expected.

## QA steps

```sh
snapcraft remote-build the snap
snap install --dangerous --classic ...
snap logs juju to make sure the hooks ran
```
