### PR TITLE
Simplify NetworkGet for CAAS

### DIFF
--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4563,7 +4563,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
 				Results: map[string]params.NetworkInfoResult{
 					"unknown": {
 						Error: &params.Error{
-							Message: `binding name "unknown" not defined by the unit's charm`,
+							Message: `undefined for unit charm: endpoint "unknown" not valid`,
 						},
 					},
 				},

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -118,7 +118,7 @@ func (s *InterfaceSuite) TestUnitNetworkInfo(c *gc.C) {
 	c.Check(netInfo, gc.DeepEquals, map[string]params.NetworkInfoResult{
 		"unknown": {
 			Error: &params.Error{
-				Message: "binding name \"unknown\" not defined by the unit's charm",
+				Message: `undefined for unit charm: endpoint "unknown" not valid`,
 			},
 		},
 	},


### PR DESCRIPTION
This patch further clarifies `NetworkInfo` functionality by:
- Extracting binding validation logic.
- Simplifying the CAAS implementation by removing the intermediate data-structures used to record defaults and setting results directly.

This will increase the velocity at which we can work in this code. It results in unchanged functionality and so targets the 2.8 branch in case we will work it further in a point release.

More enhancements will follow

## QA steps

Changes are mechanical in nature only, and tests remain green.

## Documentation changes

None.

## Bug reference

N/A
