### PR TITLE
Relocate NoAddressError concerns from network to core/network

### DIFF
--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -9,9 +9,8 @@ import (
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/network"
 )
 
 // EgressAddressWatcher reports changes to addresses
@@ -143,7 +142,7 @@ func (w *EgressAddressWatcher) loop() error {
 			}
 			changed = false
 			if !setEquals(addresses, lastAddresses) {
-				addressesCIDR = corenetwork.SubnetsForAddresses(addresses.Values())
+				addressesCIDR = network.SubnetsForAddresses(addresses.Values())
 				ready = ready || sentInitial
 			}
 		}

--- a/apiserver/common/firewall/mock_test.go
+++ b/apiserver/common/firewall/mock_test.go
@@ -16,10 +16,9 @@ import (
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
-	corenetwork "github.com/juju/juju/core/network"
+	network "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -348,7 +347,7 @@ type mockUnit struct {
 	mu            sync.Mutex
 	name          string
 	assigned      bool
-	publicAddress corenetwork.SpaceAddress
+	publicAddress network.SpaceAddress
 	machineId     string
 }
 
@@ -364,19 +363,19 @@ func (u *mockUnit) Name() string {
 	return u.name
 }
 
-func (u *mockUnit) PublicAddress() (corenetwork.SpaceAddress, error) {
+func (u *mockUnit) PublicAddress() (network.SpaceAddress, error) {
 	u.MethodCall(u, "PublicAddress")
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
 	if err := u.NextErr(); err != nil {
-		return corenetwork.SpaceAddress{}, err
+		return network.SpaceAddress{}, err
 	}
 	if !u.assigned {
-		return corenetwork.SpaceAddress{}, errors.NotAssignedf(u.name)
+		return network.SpaceAddress{}, errors.NotAssignedf(u.name)
 	}
 	if u.publicAddress.Value == "" {
-		return corenetwork.SpaceAddress{}, network.NoAddressError("public")
+		return network.SpaceAddress{}, network.NoAddressError("public")
 	}
 	return u.publicAddress, nil
 }
@@ -396,7 +395,7 @@ func (u *mockUnit) updateAddress(value string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
-	u.publicAddress = corenetwork.NewSpaceAddress(value)
+	u.publicAddress = network.NewSpaceAddress(value)
 }
 
 type mockMachine struct {

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -307,7 +307,7 @@ func (n *NetworkInfoBase) pollForAddress(
 		return err
 	}
 	retryArg.IsFatalError = func(err error) bool {
-		return !network.IsNoAddressError(err)
+		return !corenetwork.IsNoAddressError(err)
 	}
 	return address, retry.Call(retryArg)
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -27,10 +27,9 @@ import (
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/watcher"
@@ -468,11 +467,11 @@ func (u *UniterAPI) getOneMachinePorts(canAccess common.AuthFunc, machineTag str
 		// AllPortRanges gives a map, but apis require a stable order
 		// for results, so sort the port ranges.
 		portRangesToUnits := ports.AllPortRanges()
-		portRanges := make([]corenetwork.PortRange, 0, len(portRangesToUnits))
+		portRanges := make([]network.PortRange, 0, len(portRangesToUnits))
 		for portRange := range portRangesToUnits {
 			portRanges = append(portRanges, portRange)
 		}
-		corenetwork.SortPortRanges(portRanges)
+		network.SortPortRanges(portRanges)
 		for _, portRange := range portRanges {
 			unitName := portRangesToUnits[portRange]
 			resultPorts = append(resultPorts, params.MachinePortRange{
@@ -506,7 +505,7 @@ func (u *UniterAPI) PublicAddress(args params.Entities) (params.StringResults, e
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				var address corenetwork.SpaceAddress
+				var address network.SpaceAddress
 				address, err = unit.PublicAddress()
 				if err == nil {
 					result.Results[i].Result = address.Value
@@ -540,7 +539,7 @@ func (u *UniterAPI) PrivateAddress(args params.Entities) (params.StringResults, 
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				var address corenetwork.SpaceAddress
+				var address network.SpaceAddress
 				address, err = unit.PrivateAddress()
 				if err == nil {
 					result.Results[i].Result = address.Value
@@ -1019,7 +1018,7 @@ func (u *UniterAPI) OpenPorts(args params.EntitiesPortRanges) (params.ErrorResul
 			continue
 		}
 
-		openPortRange := []corenetwork.PortRange{{
+		openPortRange := []network.PortRange{{
 			FromPort: entity.FromPort,
 			ToPort:   entity.ToPort,
 			Protocol: entity.Protocol,
@@ -1058,7 +1057,7 @@ func (u *UniterAPI) ClosePorts(args params.EntitiesPortRanges) (params.ErrorResu
 			continue
 		}
 
-		closePortRange := []corenetwork.PortRange{{
+		closePortRange := []network.PortRange{{
 			FromPort: entity.FromPort,
 			ToPort:   entity.ToPort,
 			Protocol: entity.Protocol,
@@ -2645,7 +2644,7 @@ func (u *UniterAPIV4) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 	}
 
 	var results []params.NetworkConfig
-	if boundSpace == corenetwork.AlphaSpaceId {
+	if boundSpace == network.AlphaSpaceId {
 		logger.Debugf(
 			"endpoint %q not explicitly bound to a space, using preferred private address for machine %q",
 			bindingName, machineID,
@@ -3548,13 +3547,13 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 	}
 
 	if len(changes.OpenPorts)+len(changes.ClosePorts) > 0 {
-		var openPortRanges, closePortRanges []corenetwork.PortRange
+		var openPortRanges, closePortRanges []network.PortRange
 		for _, r := range changes.OpenPorts {
 			// Ensure the tag in the port open request matches the root unit name
 			if r.Tag != changes.Tag {
 				return common.ErrPerm
 			}
-			openPortRanges = append(openPortRanges, corenetwork.PortRange{
+			openPortRanges = append(openPortRanges, network.PortRange{
 				FromPort: r.FromPort,
 				ToPort:   r.ToPort,
 				Protocol: r.Protocol,
@@ -3565,7 +3564,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 			if r.Tag != changes.Tag {
 				return common.ErrPerm
 			}
-			closePortRanges = append(closePortRanges, corenetwork.PortRange{
+			closePortRanges = append(closePortRanges, network.PortRange{
 				FromPort: r.FromPort,
 				ToPort:   r.ToPort,
 				Protocol: r.Protocol,

--- a/cmd/juju/commands/ssh_common.go
+++ b/cmd/juju/commands/ssh_common.go
@@ -23,8 +23,7 @@ import (
 	"github.com/juju/juju/api/sshclient"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/modelcmd"
-	corenetwork "github.com/juju/juju/core/network"
-	"github.com/juju/juju/network"
+	"github.com/juju/juju/core/network"
 	jujussh "github.com/juju/juju/network/ssh"
 )
 
@@ -418,7 +417,7 @@ func (c *SSHCommon) reachableAddressGetter(entity string) (string, error) {
 		}
 	}
 
-	usable := corenetwork.NewMachineHostPorts(SSHPort, addresses...).HostPorts().FilterUnusable()
+	usable := network.NewMachineHostPorts(SSHPort, addresses...).HostPorts().FilterUnusable()
 	best, err := c.hostChecker.FindHost(usable, publicKeys)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -821,3 +821,24 @@ func MergedAddresses(machineAddresses, providerAddresses []SpaceAddress) []Space
 	}
 	return merged
 }
+
+// noAddress represents an error when an address is requested but not available.
+type noAddress struct {
+	errors.Err
+}
+
+// NoAddressError returns an error which satisfies IsNoAddressError(). The given
+// addressKind specifies what kind of address(es) is(are) missing, usually
+// "private" or "public".
+func NoAddressError(addressKind string) error {
+	newErr := errors.NewErr("no %s address(es)", addressKind)
+	newErr.SetLocation(1)
+	return &noAddress{newErr}
+}
+
+// IsNoAddressError reports whether err was created with NoAddressError().
+func IsNoAddressError(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*noAddress)
+	return ok
+}

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -880,3 +880,10 @@ func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 		c.Check(got, gc.Equals, t.exp)
 	}
 }
+
+func (s *AddressSuite) TestNoAddressError(c *gc.C) {
+	err := network.NoAddressError("fake")
+	c.Assert(err, gc.ErrorMatches, `no fake address\(es\)`)
+	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
+	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
+}

--- a/network/network.go
+++ b/network/network.go
@@ -11,34 +11,12 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	corenetwork "github.com/juju/juju/core/network"
 )
 
 var logger = loggo.GetLogger("juju.network")
-
-// noAddress represents an error when an address is requested but not available.
-type noAddress struct {
-	errors.Err
-}
-
-// NoAddressError returns an error which satisfies IsNoAddressError(). The given
-// addressKind specifies what kind of address(es) is(are) missing, usually
-// "private" or "public".
-func NoAddressError(addressKind string) error {
-	newErr := errors.NewErr("no %s address(es)", addressKind)
-	newErr.SetLocation(1)
-	return &noAddress{newErr}
-}
-
-// IsNoAddressError reports whether err was created with NoAddressError().
-func IsNoAddressError(err error) bool {
-	err = errors.Cause(err)
-	_, ok := err.(*noAddress)
-	return ok
-}
 
 // UnknownId can be used whenever an Id is needed but not known.
 const UnknownId = ""

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -4,7 +4,6 @@
 package network_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"net"
 	"path/filepath"
@@ -176,13 +175,6 @@ LXC_BRIDGE="ignored"`[1:])
 		"localhost",
 	)
 	c.Assert(network.FilterBridgeAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
-}
-
-func (s *NetworkSuite) TestNoAddressError(c *gc.C) {
-	err := network.NoAddressError("fake")
-	c.Assert(err, gc.ErrorMatches, `no fake address\(es\)`)
-	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
-	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
 }
 
 func checkQuoteSpaceSet(c *gc.C, expected string, spaces ...string) {

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/worker/peergrouper"
@@ -123,16 +122,16 @@ func updateMongoEntries(newInstId instance.Id, newMachineId, oldMachineId string
 
 // updateMachineAddresses will update the machine doc to the current addresses
 func updateMachineAddresses(machine *state.Machine, privateAddress, publicAddress string) error {
-	privateAddressAddress := corenetwork.SpaceAddress{
-		MachineAddress: corenetwork.MachineAddress{
+	privateAddressAddress := network.SpaceAddress{
+		MachineAddress: network.MachineAddress{
 			Value: privateAddress,
-			Type:  corenetwork.DeriveAddressType(privateAddress),
+			Type:  network.DeriveAddressType(privateAddress),
 		},
 	}
-	publicAddressAddress := corenetwork.SpaceAddress{
-		MachineAddress: corenetwork.MachineAddress{
+	publicAddressAddress := network.SpaceAddress{
+		MachineAddress: network.MachineAddress{
 			Value: publicAddress,
-			Type:  corenetwork.DeriveAddressType(publicAddress),
+			Type:  network.DeriveAddressType(publicAddress),
 		},
 	}
 	if err := machine.SetProviderAddresses(publicAddressAddress, privateAddressAddress); err != nil {

--- a/state/machine.go
+++ b/state/machine.go
@@ -23,10 +23,9 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools"
 )
 
@@ -1541,8 +1540,8 @@ func (m *Machine) SetInstanceInfo(
 // that the machine reported with the same address value.
 // Provider-reported addresses always come before machine-reported
 // addresses. Duplicates are removed.
-func (m *Machine) Addresses() (addresses corenetwork.SpaceAddresses) {
-	return corenetwork.MergedAddresses(networkAddresses(m.doc.MachineAddresses), networkAddresses(m.doc.Addresses))
+func (m *Machine) Addresses() (addresses network.SpaceAddresses) {
+	return network.MergedAddresses(networkAddresses(m.doc.MachineAddresses), networkAddresses(m.doc.Addresses))
 }
 
 func containsAddress(addresses []address, address address) bool {
@@ -1556,7 +1555,7 @@ func containsAddress(addresses []address, address address) bool {
 
 // PublicAddress returns a public address for the machine. If no address is
 // available it returns an error that satisfies network.IsNoAddressError().
-func (m *Machine) PublicAddress() (corenetwork.SpaceAddress, error) {
+func (m *Machine) PublicAddress() (network.SpaceAddress, error) {
 	publicAddress := m.doc.PreferredPublicAddress.networkAddress()
 	var err error
 	if publicAddress.Value == "" {
@@ -1573,7 +1572,7 @@ func maybeGetNewAddress(
 	addr address,
 	providerAddresses,
 	machineAddresses []address,
-	getAddr func([]address) corenetwork.SpaceAddress,
+	getAddr func([]address) network.SpaceAddress,
 	checkScope func(address) bool,
 ) (address, bool) {
 	// For picking the best address, try provider addresses first.
@@ -1581,9 +1580,9 @@ func maybeGetNewAddress(
 	netAddr := getAddr(providerAddresses)
 	if netAddr.Value == "" {
 		netAddr = getAddr(machineAddresses)
-		newAddr = fromNetworkAddress(netAddr, corenetwork.OriginMachine)
+		newAddr = fromNetworkAddress(netAddr, network.OriginMachine)
 	} else {
-		newAddr = fromNetworkAddress(netAddr, corenetwork.OriginProvider)
+		newAddr = fromNetworkAddress(netAddr, network.OriginProvider)
 	}
 	// The order of these checks is important. If the stored address is
 	// empty we *always* want to check for a new address so we do that
@@ -1598,8 +1597,8 @@ func maybeGetNewAddress(
 	if !containsAddress(providerAddresses, addr) && !containsAddress(machineAddresses, addr) {
 		return newAddr, true
 	}
-	if corenetwork.Origin(addr.Origin) != corenetwork.OriginProvider &&
-		corenetwork.Origin(newAddr.Origin) == corenetwork.OriginProvider {
+	if network.Origin(addr.Origin) != network.OriginProvider &&
+		network.Origin(newAddr.Origin) == network.OriginProvider {
 		return newAddr, true
 	}
 	if !checkScope(addr) {
@@ -1615,7 +1614,7 @@ func maybeGetNewAddress(
 
 // PrivateAddress returns a private address for the machine. If no address is
 // available it returns an error that satisfies network.IsNoAddressError().
-func (m *Machine) PrivateAddress() (corenetwork.SpaceAddress, error) {
+func (m *Machine) PrivateAddress() (network.SpaceAddress, error) {
 	privateAddress := m.doc.PreferredPrivateAddress.networkAddress()
 	var err error
 	if privateAddress.Value == "" {
@@ -1674,11 +1673,11 @@ func (m *Machine) setPublicAddressOps(providerAddresses []address, machineAddres
 
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
-		return corenetwork.ExactScopeMatch(addr.networkAddress(), corenetwork.ScopePublic)
+		return network.ExactScopeMatch(addr.networkAddress(), network.ScopePublic)
 	}
 	// Without an exact match, prefer a fallback match.
-	getAddr := func(addresses []address) corenetwork.SpaceAddress {
-		addr, _ := networkAddresses(addresses).OneMatchingScope(corenetwork.ScopeMatchPublic)
+	getAddr := func(addresses []address) network.SpaceAddress {
+		addr, _ := networkAddresses(addresses).OneMatchingScope(network.ScopeMatchPublic)
 		return addr
 	}
 
@@ -1696,12 +1695,12 @@ func (m *Machine) setPrivateAddressOps(providerAddresses []address, machineAddre
 	privateAddress := m.doc.PreferredPrivateAddress
 	// Always prefer an exact match if available.
 	checkScope := func(addr address) bool {
-		return corenetwork.ExactScopeMatch(
-			addr.networkAddress(), corenetwork.ScopeMachineLocal, corenetwork.ScopeCloudLocal, corenetwork.ScopeFanLocal)
+		return network.ExactScopeMatch(
+			addr.networkAddress(), network.ScopeMachineLocal, network.ScopeCloudLocal, network.ScopeFanLocal)
 	}
 	// Without an exact match, prefer a fallback match.
-	getAddr := func(addresses []address) corenetwork.SpaceAddress {
-		addr, _ := networkAddresses(addresses).OneMatchingScope(corenetwork.ScopeMatchCloudLocal)
+	getAddr := func(addresses []address) network.SpaceAddress {
+		addr, _ := networkAddresses(addresses).OneMatchingScope(network.ScopeMatchCloudLocal)
 		return addr
 	}
 
@@ -1716,14 +1715,14 @@ func (m *Machine) setPrivateAddressOps(providerAddresses []address, machineAddre
 
 // SetProviderAddresses records any addresses related to the machine, sourced
 // by asking the provider.
-func (m *Machine) SetProviderAddresses(addresses ...corenetwork.SpaceAddress) error {
+func (m *Machine) SetProviderAddresses(addresses ...network.SpaceAddress) error {
 	err := m.setAddresses(nil, &addresses)
 	return errors.Annotatef(err, "cannot set addresses of machine %v", m)
 }
 
 // ProviderAddresses returns any hostnames and ips associated with a machine,
 // as determined by asking the provider.
-func (m *Machine) ProviderAddresses() (addresses corenetwork.SpaceAddresses) {
+func (m *Machine) ProviderAddresses() (addresses network.SpaceAddresses) {
 	for _, address := range m.doc.Addresses {
 		addresses = append(addresses, address.networkAddress())
 	}
@@ -1733,13 +1732,13 @@ func (m *Machine) ProviderAddresses() (addresses corenetwork.SpaceAddresses) {
 // AddressesBySpaceID groups the machine addresses by space id and
 // returns the result as a map where the space id is used a the key.
 // Loopback addresses are skipped.
-func (m *Machine) AddressesBySpaceID() (map[string][]corenetwork.SpaceAddress, error) {
+func (m *Machine) AddressesBySpaceID() (map[string][]network.SpaceAddress, error) {
 	addresses, err := m.AllAddresses()
 	if err != nil {
 		return nil, err
 	}
 
-	res := make(map[string][]corenetwork.SpaceAddress)
+	res := make(map[string][]network.SpaceAddress)
 	for _, address := range addresses {
 		// TODO(achilleasa): currently, addresses do not come with
 		// resolved space IDs (except MAAS). For the time being, we
@@ -1761,7 +1760,7 @@ func (m *Machine) AddressesBySpaceID() (map[string][]corenetwork.SpaceAddress, e
 
 // MachineAddresses returns any hostnames and ips associated with a machine,
 // determined by asking the machine itself.
-func (m *Machine) MachineAddresses() (addresses corenetwork.SpaceAddresses) {
+func (m *Machine) MachineAddresses() (addresses network.SpaceAddresses) {
 	for _, address := range m.doc.MachineAddresses {
 		addresses = append(addresses, address.networkAddress())
 	}
@@ -1770,7 +1769,7 @@ func (m *Machine) MachineAddresses() (addresses corenetwork.SpaceAddresses) {
 
 // SetMachineAddresses records any addresses related to the machine, sourced
 // by asking the machine.
-func (m *Machine) SetMachineAddresses(addresses ...corenetwork.SpaceAddress) error {
+func (m *Machine) SetMachineAddresses(addresses ...network.SpaceAddress) error {
 	err := m.setAddresses(&addresses, nil)
 	return errors.Annotatef(err, "cannot set machine addresses of machine %v", m)
 }
@@ -1779,7 +1778,7 @@ func (m *Machine) SetMachineAddresses(addresses ...corenetwork.SpaceAddress) err
 // MachineAddresses, depending on the field argument). Changes are
 // only predicated on the machine not being Dead; concurrent address
 // changes are ignored.
-func (m *Machine) setAddresses(machineAddresses, providerAddresses *[]corenetwork.SpaceAddress) error {
+func (m *Machine) setAddresses(machineAddresses, providerAddresses *[]network.SpaceAddress) error {
 	var (
 		machineStateAddresses, providerStateAddresses []address
 		newPrivate, newPublic                         *address
@@ -1827,17 +1826,17 @@ func (m *Machine) setAddresses(machineAddresses, providerAddresses *[]corenetwor
 }
 
 func (m *Machine) setAddressesOps(
-	machineAddresses, providerAddresses *[]corenetwork.SpaceAddress,
+	machineAddresses, providerAddresses *[]network.SpaceAddress,
 ) (_ []txn.Op, machineStateAddresses, providerStateAddresses []address, newPrivate, newPublic *address, _ error) {
 
 	if m.doc.Life == Dead {
 		return nil, nil, nil, nil, nil, ErrDead
 	}
 
-	fromNetwork := func(in corenetwork.SpaceAddresses, origin corenetwork.Origin) []address {
-		sorted := make(corenetwork.SpaceAddresses, len(in))
+	fromNetwork := func(in network.SpaceAddresses, origin network.Origin) []address {
+		sorted := make(network.SpaceAddresses, len(in))
 		copy(sorted, in)
-		corenetwork.SortAddresses(sorted)
+		network.SortAddresses(sorted)
 		return fromNetworkAddresses(sorted, origin)
 	}
 
@@ -1845,11 +1844,11 @@ func (m *Machine) setAddressesOps(
 	machineStateAddresses = m.doc.MachineAddresses
 	providerStateAddresses = m.doc.Addresses
 	if machineAddresses != nil {
-		machineStateAddresses = fromNetwork(*machineAddresses, corenetwork.OriginMachine)
+		machineStateAddresses = fromNetwork(*machineAddresses, network.OriginMachine)
 		set = append(set, bson.DocElem{Name: "machineaddresses", Value: machineStateAddresses})
 	}
 	if providerAddresses != nil {
-		providerStateAddresses = fromNetwork(*providerAddresses, corenetwork.OriginProvider)
+		providerStateAddresses = fromNetwork(*providerAddresses, network.OriginProvider)
 		set = append(set, bson.DocElem{Name: "addresses", Value: providerStateAddresses})
 	}
 
@@ -2307,8 +2306,8 @@ type UpdateMachineOperation struct {
 
 	AgentVersion      *version.Binary
 	Constraints       *constraints.Value
-	MachineAddresses  *[]corenetwork.SpaceAddress
-	ProviderAddresses *[]corenetwork.SpaceAddress
+	MachineAddresses  *[]network.SpaceAddress
+	ProviderAddresses *[]network.SpaceAddress
 	PasswordHash      *string
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -26,10 +26,9 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	mgoutils "github.com/juju/juju/mongo/utils"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/tools"
 )
 
@@ -366,8 +365,8 @@ func (op *UpdateUnitOperation) Build(attempt int) ([]txn.Op, error) {
 		containerInfo.ProviderId = newProviderId
 	}
 	if op.props.Address != nil {
-		networkAddr := corenetwork.NewScopedSpaceAddress(*op.props.Address, corenetwork.ScopeMachineLocal)
-		addr := fromNetworkAddress(networkAddr, corenetwork.OriginProvider)
+		networkAddr := network.NewScopedSpaceAddress(*op.props.Address, network.ScopeMachineLocal)
+		addr := fromNetworkAddress(networkAddr, network.OriginProvider)
 		containerInfo.Address = &addr
 	}
 	if op.props.Ports != nil {
@@ -1155,20 +1154,20 @@ func (u *Unit) noAssignedMachineOp() txn.Op {
 }
 
 // PublicAddress returns the public address of the unit.
-func (u *Unit) PublicAddress() (corenetwork.SpaceAddress, error) {
+func (u *Unit) PublicAddress() (network.SpaceAddress, error) {
 	if !u.ShouldBeAssigned() {
 		return u.scopedAddress("public")
 	}
 	m, err := u.machine()
 	if err != nil {
 		unitLogger.Tracef("%v", err)
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	return m.PublicAddress()
 }
 
 // PrivateAddress returns the private address of the unit.
-func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
+func (u *Unit) PrivateAddress() (network.SpaceAddress, error) {
 	if !u.ShouldBeAssigned() {
 		addr, err := u.scopedAddress("private")
 		if network.IsNoAddressError(err) {
@@ -1179,7 +1178,7 @@ func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
 	m, err := u.machine()
 	if err != nil {
 		unitLogger.Tracef("%v", err)
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	return m.PrivateAddress()
 }
@@ -1188,7 +1187,7 @@ func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
 // plus the container address of the unit (if known).
 // Only relevant for CAAS models - will return an empty
 // slice for IAAS models.
-func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
+func (u *Unit) AllAddresses() (addrs network.SpaceAddresses, _ error) {
 	if u.ShouldBeAssigned() {
 		return addrs, nil
 	}
@@ -1216,7 +1215,7 @@ func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
 
 // serviceAddresses returns the addresses of the service
 // managing the pods in which the unit workload is running.
-func (u *Unit) serviceAddresses() (corenetwork.SpaceAddresses, error) {
+func (u *Unit) serviceAddresses() (network.SpaceAddresses, error) {
 	app, err := u.Application()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1229,51 +1228,51 @@ func (u *Unit) serviceAddresses() (corenetwork.SpaceAddresses, error) {
 }
 
 // containerAddress returns the address of the pod's container.
-func (u *Unit) containerAddress() (corenetwork.SpaceAddress, error) {
+func (u *Unit) containerAddress() (network.SpaceAddress, error) {
 	containerInfo, err := u.cloudContainer()
 	if errors.IsNotFound(err) {
-		return corenetwork.SpaceAddress{}, network.NoAddressError("container")
+		return network.SpaceAddress{}, network.NoAddressError("container")
 	}
 	if err != nil {
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	addr := containerInfo.Address
 	if addr == nil {
-		return corenetwork.SpaceAddress{}, network.NoAddressError("container")
+		return network.SpaceAddress{}, network.NoAddressError("container")
 	}
 	return addr.networkAddress(), nil
 }
 
-func (u *Unit) scopedAddress(scope string) (corenetwork.SpaceAddress, error) {
+func (u *Unit) scopedAddress(scope string) (network.SpaceAddress, error) {
 	addresses, err := u.AllAddresses()
 	if err != nil {
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	if len(addresses) == 0 {
-		return corenetwork.SpaceAddress{}, network.NoAddressError(scope)
+		return network.SpaceAddress{}, network.NoAddressError(scope)
 	}
-	getStrictPublicAddr := func(addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddress, bool) {
-		addr, ok := addresses.OneMatchingScope(corenetwork.ScopeMatchPublic)
-		return addr, ok && addr.Scope == corenetwork.ScopePublic
-	}
-
-	getInternalAddr := func(addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddress, bool) {
-		return addresses.OneMatchingScope(corenetwork.ScopeMatchCloudLocal)
+	getStrictPublicAddr := func(addresses network.SpaceAddresses) (network.SpaceAddress, bool) {
+		addr, ok := addresses.OneMatchingScope(network.ScopeMatchPublic)
+		return addr, ok && addr.Scope == network.ScopePublic
 	}
 
-	var addrMatch func(corenetwork.SpaceAddresses) (corenetwork.SpaceAddress, bool)
+	getInternalAddr := func(addresses network.SpaceAddresses) (network.SpaceAddress, bool) {
+		return addresses.OneMatchingScope(network.ScopeMatchCloudLocal)
+	}
+
+	var addrMatch func(network.SpaceAddresses) (network.SpaceAddress, bool)
 	switch scope {
 	case "public":
 		addrMatch = getStrictPublicAddr
 	case "private":
 		addrMatch = getInternalAddr
 	default:
-		return corenetwork.SpaceAddress{}, errors.NotValidf("address scope %q", scope)
+		return network.SpaceAddress{}, errors.NotValidf("address scope %q", scope)
 	}
 
 	addr, found := addrMatch(addresses)
 	if !found {
-		return corenetwork.SpaceAddress{}, network.NoAddressError(scope)
+		return network.SpaceAddress{}, network.NoAddressError(scope)
 	}
 	return addr, nil
 }
@@ -1430,7 +1429,7 @@ func (u *Unit) SetStatus(unitStatus status.StatusInfo) error {
 //
 // NOTE(achilleasa): we should probably refactor this in the future to work
 // with endpoints instead of subnet IDs.
-func (u *Unit) OpenClosePortsOnSubnet(subnetID string, openPortRanges, closePortRanges []corenetwork.PortRange) error {
+func (u *Unit) OpenClosePortsOnSubnet(subnetID string, openPortRanges, closePortRanges []network.PortRange) error {
 	annotateErr := func(err error) error {
 		openIsEmpty := len(openPortRanges) == 0
 		closeIsEmpty := len(closePortRanges) == 0
@@ -1472,7 +1471,7 @@ func (u *Unit) OpenClosePortsOnSubnet(subnetID string, openPortRanges, closePort
 //
 // NOTE(achilleasa): we should probably refactor this in the future to work
 // with endpoints instead of subnet IDs.
-func (u *Unit) OpenClosePortsOnSubnetOperation(subnetID string, openPortRanges, closePortRanges []corenetwork.PortRange) (ModelOperation, error) {
+func (u *Unit) OpenClosePortsOnSubnetOperation(subnetID string, openPortRanges, closePortRanges []network.PortRange) (ModelOperation, error) {
 	machineID, err := u.AssignedMachineId()
 	if err != nil {
 		return nil, errors.Annotatef(err, "unit %q has no assigned machine", u)
@@ -1498,7 +1497,7 @@ func (u *Unit) OpenClosePortsOnSubnetOperation(subnetID string, openPortRanges, 
 	return machinePorts.OpenClosePortsOperation(openRanges, closeRanges)
 }
 
-func convertPortRange(unitName string, p corenetwork.PortRange) PortRange {
+func convertPortRange(unitName string, p network.PortRange) PortRange {
 	return PortRange{
 		UnitName: unitName,
 		FromPort: p.FromPort,
@@ -1530,7 +1529,7 @@ func (u *Unit) checkSubnetAliveWhenSet(subnetID string) error {
 // it must refer to an existing, alive subnet, otherwise an error is returned.
 // Also, when no ports are yet open for the unit on that subnet, no error and
 // empty slice is returned.
-func (u *Unit) OpenedPortsOnSubnet(subnetID string) ([]corenetwork.PortRange, error) {
+func (u *Unit) OpenedPortsOnSubnet(subnetID string) ([]network.PortRange, error) {
 	machineID, err := u.AssignedMachineId()
 	if err != nil {
 		return nil, errors.Annotatef(err, "unit %q has no assigned machine", u)
@@ -1541,7 +1540,7 @@ func (u *Unit) OpenedPortsOnSubnet(subnetID string) ([]corenetwork.PortRange, er
 	}
 
 	machinePorts, err := getPorts(u.st, machineID, subnetID)
-	var result []corenetwork.PortRange
+	var result []network.PortRange
 	if errors.IsNotFound(err) {
 		return result, nil
 	} else if err != nil {
@@ -1549,13 +1548,13 @@ func (u *Unit) OpenedPortsOnSubnet(subnetID string) ([]corenetwork.PortRange, er
 	}
 	ports := machinePorts.PortsForUnit(u.Name())
 	for _, port := range ports {
-		result = append(result, corenetwork.PortRange{
+		result = append(result, network.PortRange{
 			Protocol: port.Protocol,
 			FromPort: port.FromPort,
 			ToPort:   port.ToPort,
 		})
 	}
-	corenetwork.SortPortRanges(result)
+	network.SortPortRanges(result)
 	return result, nil
 }
 
@@ -1564,7 +1563,7 @@ func (u *Unit) OpenedPortsOnSubnet(subnetID string) ([]corenetwork.PortRange, er
 //
 // TODO(dimitern): This should be removed once we use OpenedPortsOnSubnet across
 // the board, passing subnet IDs explicitly.
-func (u *Unit) OpenedPorts() ([]corenetwork.PortRange, error) {
+func (u *Unit) OpenedPorts() ([]network.PortRange, error) {
 	return u.OpenedPortsOnSubnet("")
 }
 

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -21,10 +21,9 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	corenetwork "github.com/juju/juju/core/network"
+	network "github.com/juju/juju/core/network"
 	networktesting "github.com/juju/juju/core/network/testing"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	statetesting "github.com/juju/juju/state/testing"
@@ -798,8 +797,8 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(
-		corenetwork.NewScopedSpaceAddress("private.address.example.com", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("public.address.example.com", corenetwork.ScopePublic),
+		network.NewScopedSpaceAddress("private.address.example.com", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("public.address.example.com", network.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -830,8 +829,8 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	_, err = s.unit.PublicAddress()
 	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
-	public := corenetwork.NewScopedSpaceAddress("8.8.8.8", corenetwork.ScopePublic)
-	private := corenetwork.NewScopedSpaceAddress("127.0.0.1", corenetwork.ScopeCloudLocal)
+	public := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
+	private := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
 
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -847,12 +846,12 @@ func (s *UnitSuite) TestStablePrivateAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"), corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -867,12 +866,12 @@ func (s *UnitSuite) TestStablePublicAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"), corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"), network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -887,9 +886,9 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	publicProvider := corenetwork.NewScopedSpaceAddress("8.8.8.8", corenetwork.ScopePublic)
-	privateProvider := corenetwork.NewScopedSpaceAddress("127.0.0.1", corenetwork.ScopeCloudLocal)
-	privateMachine := corenetwork.NewSpaceAddress("127.0.0.2")
+	publicProvider := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
+	privateProvider := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
+	privateMachine := network.NewSpaceAddress("127.0.0.2")
 
 	err = machine.SetProviderAddresses(privateProvider)
 	c.Assert(err, jc.ErrorIsNil)
@@ -925,8 +924,8 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	_, err = s.unit.PrivateAddress()
 	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
-	public := corenetwork.NewScopedSpaceAddress("8.8.8.8", corenetwork.ScopePublic)
-	private := corenetwork.NewScopedSpaceAddress("127.0.0.1", corenetwork.ScopeCloudLocal)
+	public := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
+	private := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
 
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1787,7 +1786,7 @@ func (s *UnitSuite) TestOpenedPortsOnUnknownSubnet(c *gc.C) {
 func (s *UnitSuite) TestOpenedPortsOnDeadSubnet(c *gc.C) {
 	// We're adding the 0.1.2.0/24 subnet first and then setting it to Dead to
 	// check the "not alive" case.
-	subnet, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "0.1.2.0/24"})
+	subnet, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "0.1.2.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = subnet.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1796,14 +1795,14 @@ func (s *UnitSuite) TestOpenedPortsOnDeadSubnet(c *gc.C) {
 }
 
 func (s *UnitSuite) TestOpenedPortsOnAliveIPv4Subnet(c *gc.C) {
-	subnet, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "192.168.0.0/16"})
+	subnet, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "192.168.0.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.testOpenedPorts(c, subnet.ID(), "")
 }
 
 func (s *UnitSuite) TestOpenedPortsOnAliveIPv6Subnet(c *gc.C) {
-	subnet, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "2001:db8::/64"})
+	subnet, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "2001:db8::/64"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.testOpenedPorts(c, subnet.ID(), "")
@@ -1828,7 +1827,7 @@ func (s *UnitSuite) testOpenedPorts(c *gc.C, subnetID, expectedErrorCauseMatches
 
 	// Verify ports can be opened and closed only when the unit has
 	// assigned machine.
-	portRange := []corenetwork.PortRange{{FromPort: 10, ToPort: 20, Protocol: "tcp"}}
+	portRange := []network.PortRange{{FromPort: 10, ToPort: 20, Protocol: "tcp"}}
 	err := s.unit.OpenClosePortsOnSubnet(subnetID, portRange, nil)
 	c.Check(errors.Cause(err), jc.Satisfies, errors.IsNotAssigned)
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, nil, portRange)
@@ -1849,40 +1848,40 @@ func (s *UnitSuite) testOpenedPorts(c *gc.C, subnetID, expectedErrorCauseMatches
 	}
 
 	// Now open and close ports and ranges and check.
-	onePort := []corenetwork.PortRange{{FromPort: 80, ToPort: 80, Protocol: "tcp"}}
+	onePort := []network.PortRange{{FromPort: 80, ToPort: 80, Protocol: "tcp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, onePort, nil)
 	checkExpectedError(err)
 
-	portRange = []corenetwork.PortRange{{FromPort: 100, ToPort: 200, Protocol: "udp"}}
+	portRange = []network.PortRange{{FromPort: 100, ToPort: 200, Protocol: "udp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, portRange, nil)
 	checkExpectedError(err)
 
 	open, err = s.unit.OpenedPortsOnSubnet(subnetID)
 	if checkExpectedError(err) {
-		c.Check(open, gc.DeepEquals, []corenetwork.PortRange{
+		c.Check(open, gc.DeepEquals, []network.PortRange{
 			{80, 80, "tcp"},
 			{100, 200, "udp"},
 		})
 	}
 
-	onePort = []corenetwork.PortRange{{FromPort: 53, ToPort: 53, Protocol: "udp"}}
+	onePort = []network.PortRange{{FromPort: 53, ToPort: 53, Protocol: "udp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, onePort, nil)
 	checkExpectedError(err)
 	open, err = s.unit.OpenedPortsOnSubnet(subnetID)
 	if checkExpectedError(err) {
-		c.Check(open, gc.DeepEquals, []corenetwork.PortRange{
+		c.Check(open, gc.DeepEquals, []network.PortRange{
 			{80, 80, "tcp"},
 			{53, 53, "udp"},
 			{100, 200, "udp"},
 		})
 	}
 
-	portRange = []corenetwork.PortRange{{FromPort: 53, ToPort: 55, Protocol: "tcp"}}
+	portRange = []network.PortRange{{FromPort: 53, ToPort: 55, Protocol: "tcp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, portRange, nil)
 	checkExpectedError(err)
 	open, err = s.unit.OpenedPortsOnSubnet(subnetID)
 	if checkExpectedError(err) {
-		c.Check(open, gc.DeepEquals, []corenetwork.PortRange{
+		c.Check(open, gc.DeepEquals, []network.PortRange{
 			{53, 55, "tcp"},
 			{80, 80, "tcp"},
 			{53, 53, "udp"},
@@ -1890,12 +1889,12 @@ func (s *UnitSuite) testOpenedPorts(c *gc.C, subnetID, expectedErrorCauseMatches
 		})
 	}
 
-	onePort = []corenetwork.PortRange{{FromPort: 443, ToPort: 443, Protocol: "tcp"}}
+	onePort = []network.PortRange{{FromPort: 443, ToPort: 443, Protocol: "tcp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, onePort, nil)
 	checkExpectedError(err)
 	open, err = s.unit.OpenedPortsOnSubnet(subnetID)
 	if checkExpectedError(err) {
-		c.Check(open, gc.DeepEquals, []corenetwork.PortRange{
+		c.Check(open, gc.DeepEquals, []network.PortRange{
 			{53, 55, "tcp"},
 			{80, 80, "tcp"},
 			{443, 443, "tcp"},
@@ -1904,12 +1903,12 @@ func (s *UnitSuite) testOpenedPorts(c *gc.C, subnetID, expectedErrorCauseMatches
 		})
 	}
 
-	onePort = []corenetwork.PortRange{{FromPort: 80, ToPort: 80, Protocol: "tcp"}}
+	onePort = []network.PortRange{{FromPort: 80, ToPort: 80, Protocol: "tcp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, nil, onePort)
 	checkExpectedError(err)
 	open, err = s.unit.OpenedPortsOnSubnet(subnetID)
 	if checkExpectedError(err) {
-		c.Check(open, gc.DeepEquals, []corenetwork.PortRange{
+		c.Check(open, gc.DeepEquals, []network.PortRange{
 			{53, 55, "tcp"},
 			{443, 443, "tcp"},
 			{53, 53, "udp"},
@@ -1917,12 +1916,12 @@ func (s *UnitSuite) testOpenedPorts(c *gc.C, subnetID, expectedErrorCauseMatches
 		})
 	}
 
-	portRange = []corenetwork.PortRange{{FromPort: 100, ToPort: 200, Protocol: "udp"}}
+	portRange = []network.PortRange{{FromPort: 100, ToPort: 200, Protocol: "udp"}}
 	err = s.unit.OpenClosePortsOnSubnet(subnetID, nil, portRange)
 	checkExpectedError(err)
 	open, err = s.unit.OpenedPortsOnSubnet(subnetID)
 	if checkExpectedError(err) {
-		c.Check(open, gc.DeepEquals, []corenetwork.PortRange{
+		c.Check(open, gc.DeepEquals, []network.PortRange{
 			{53, 55, "tcp"},
 			{443, 443, "tcp"},
 			{53, 53, "udp"},
@@ -1938,8 +1937,8 @@ func (s *UnitSuite) TestOpenClosePortWhenDying(c *gc.C) {
 
 	preventUnitDestroyRemove(c, s.unit)
 	testWhenDying(c, s.unit, noErr, contentionErr, func() error {
-		onePort := []corenetwork.PortRange{{FromPort: 20, ToPort: 20, Protocol: "tcp"}}
-		portRange := []corenetwork.PortRange{{FromPort: 10, ToPort: 15, Protocol: "tcp"}}
+		onePort := []network.PortRange{{FromPort: 20, ToPort: 20, Protocol: "tcp"}}
+		portRange := []network.PortRange{{FromPort: 10, ToPort: 15, Protocol: "tcp"}}
 
 		err := s.unit.OpenClosePortsOnSubnet("", onePort, nil)
 		if err != nil {
@@ -2701,9 +2700,9 @@ func (s *UnitSuite) TestDestroyWithForceWorksOnDyingUnit(c *gc.C) {
 
 func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	// Create 2 spaces
-	sn1, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "10.0.0.0/24"})
+	sn1, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.0.0/24"})
 	c.Assert(err, gc.IsNil)
-	sn2, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "10.0.254.0/24"})
+	sn2, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.254.0/24"})
 	c.Assert(err, gc.IsNil)
 
 	_, err = s.State.AddSpace("public", "", []string{sn1.ID()}, false)
@@ -2719,13 +2718,13 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 	err = m1.SetLinkLayerDevices(
-		state.LinkLayerDeviceArgs{Name: "enp5s0", Type: corenetwork.EthernetDevice},
-		state.LinkLayerDeviceArgs{Name: "enp5s1", Type: corenetwork.EthernetDevice},
+		state.LinkLayerDeviceArgs{Name: "enp5s0", Type: network.EthernetDevice},
+		state.LinkLayerDeviceArgs{Name: "enp5s1", Type: network.EthernetDevice},
 	)
 	c.Assert(err, gc.IsNil)
 	err = m1.SetDevicesAddresses(
-		state.LinkLayerDeviceAddress{DeviceName: "enp5s0", CIDRAddress: "10.0.0.1/24", ConfigMethod: corenetwork.StaticAddress},
-		state.LinkLayerDeviceAddress{DeviceName: "enp5s1", CIDRAddress: "10.0.254.42/24", ConfigMethod: corenetwork.StaticAddress},
+		state.LinkLayerDeviceAddress{DeviceName: "enp5s0", CIDRAddress: "10.0.0.1/24", ConfigMethod: network.StaticAddress},
+		state.LinkLayerDeviceAddress{DeviceName: "enp5s1", CIDRAddress: "10.0.254.42/24", ConfigMethod: network.StaticAddress},
 	)
 	c.Assert(err, gc.IsNil)
 
@@ -2754,10 +2753,10 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	err = m1.SetDevicesAddresses(state.LinkLayerDeviceAddress{
 		DeviceName:   "enp5s0",
 		CIDRAddress:  "10.0.0.100/24",
-		ConfigMethod: corenetwork.StaticAddress,
+		ConfigMethod: network.StaticAddress,
 	})
 	c.Assert(err, gc.IsNil)
-	err = m1.SetProviderAddresses(corenetwork.NewSpaceAddress("10.0.0.100"))
+	err = m1.SetProviderAddresses(network.NewSpaceAddress("10.0.0.100"))
 	c.Assert(err, gc.IsNil)
 	wc.AssertChange("46ed851765a963e100161210a7b4fbb28d59b24edb580a60f86dbbaebea14d37")
 
@@ -2866,7 +2865,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitProviderId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
-	addr := corenetwork.NewScopedSpaceAddress("192.168.1.1", corenetwork.ScopeMachineLocal)
+	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal)
 	c.Assert(info.Address(), gc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
@@ -2889,7 +2888,7 @@ func (s *CAASUnitSuite) TestAddCAASUnitProviderId(c *gc.C) {
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
 	c.Check(info.Address(), gc.NotNil)
-	c.Check(*info.Address(), jc.DeepEquals, corenetwork.NewScopedSpaceAddress("192.168.1.1", corenetwork.ScopeMachineLocal))
+	c.Check(*info.Address(), jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal))
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
@@ -2911,7 +2910,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	addr := corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeMachineLocal)
+	addr := network.NewScopedSpaceAddress("192.168.1.2", network.ScopeMachineLocal)
 	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
@@ -2934,7 +2933,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	addr := corenetwork.NewScopedSpaceAddress("192.168.1.1", corenetwork.ScopeMachineLocal)
+	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal)
 	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"443"})
 }
@@ -2955,37 +2954,37 @@ func (s *CAASUnitSuite) TestRemoveUnitDeletesContainerInfo(c *gc.C) {
 func (s *CAASUnitSuite) TestPrivateAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.application.UpdateCloudService("", corenetwork.SpaceAddresses{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+	err = s.application.UpdateCloudService("", network.SpaceAddresses{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := existingUnit.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal))
+	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal))
 }
 
 func (s *CAASUnitSuite) TestPublicAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.application.UpdateCloudService("", []corenetwork.SpaceAddress{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+	err = s.application.UpdateCloudService("", []network.SpaceAddress{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := existingUnit.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic))
+	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic))
 }
 
 func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.application.UpdateCloudService("", []corenetwork.SpaceAddress{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+	err = s.application.UpdateCloudService("", []network.SpaceAddress{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -3000,10 +2999,10 @@ func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 
 	addrs, err := existingUnit.AllAddresses()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addrs, jc.DeepEquals, corenetwork.SpaceAddresses{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.0.0.1", corenetwork.ScopeMachineLocal),
+	c.Assert(addrs, jc.DeepEquals, network.SpaceAddresses{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.0.0.1", network.ScopeMachineLocal),
 	})
 }
 
@@ -3098,12 +3097,12 @@ func (s *CAASUnitSuite) TestWatchServiceAddressesHash(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Set service addresses: reported.
-	err = s.application.UpdateCloudService("1", corenetwork.SpaceAddresses{corenetwork.NewSpaceAddress("10.0.0.2")})
+	err = s.application.UpdateCloudService("1", network.SpaceAddresses{network.NewSpaceAddress("10.0.0.2")})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("7fcdfefa54c49ed9dc8132b4a28491a02ec35b03c20b2d4cc95469fead847ff8")
 
 	// Set different container addresses: reported.
-	err = s.application.UpdateCloudService("1", corenetwork.SpaceAddresses{corenetwork.NewSpaceAddress("10.0.0.3")})
+	err = s.application.UpdateCloudService("1", network.SpaceAddresses{network.NewSpaceAddress("10.0.0.3")})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("800892c5473f38623ef4856303b3458cfa81d0da803f228db69910949a13f458")
 


### PR DESCRIPTION
This is a simple relocation of error concerns for no addresses from the old `network` package to `core/network`.
It cleans up the import list and import aliasing in multiple packages.
