### PR TITLE
Derive application arch constraint

### DIFF
--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -91,6 +91,7 @@ type StateBackend interface {
 	ExposeWildcardEndpointForExposedApplications() error
 	RemoveLinkLayerDevicesRefsCollection() error
 	RemoveUnusedLinkLayerDeviceProviderIDs() error
+	AddDerivedArchitectureApplicationConstraint() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -382,4 +383,8 @@ func (s stateBackend) RemoveLinkLayerDevicesRefsCollection() error {
 
 func (s stateBackend) RemoveUnusedLinkLayerDeviceProviderIDs() error {
 	return state.RemoveUnusedLinkLayerDeviceProviderIDs(s.pool)
+}
+
+func (s stateBackend) AddDerivedArchitectureApplicationConstraint() error {
+	return state.AddDerivedArchitectureApplicationConstraint(s.pool)
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -54,6 +54,13 @@ func stateStepsFor29() []Step {
 				return context.State().RemoveLinkLayerDevicesRefsCollection()
 			},
 		},
+		&upgradeStep{
+			description: "add dervied architecture application constraint",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AddDerivedArchitectureApplicationConstraint()
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Add a strategy for adding adding default application architecture
constraint.

This is just an idea and I'm unsure how successful it is, but
essentially the idea is to check all instances for their own arch and if
it has some the fill it in.

If we have a heterogenous set of machines then use the model to see if
that has one, otherwise use the default architecture.

## Please provide the following details to expedite review (and delete this heading)

*Replace with a description about why this change is needed, along with a description of what changed.*

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
