### PR TITLE
Fixes an issue with CAData when importing k8s

### DIFF
--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -132,21 +132,18 @@ func contextsFromConfig(config *clientcmdapi.Config) (map[string]Context, error)
 }
 
 func cloudsFromConfig(config *clientcmdapi.Config, cloudName string) (map[string]CloudConfig, error) {
-
 	clusterToCloud := func(cluster *clientcmdapi.Cluster) (CloudConfig, error) {
 		attrs := map[string]interface{}{}
 
-		// TODO(axw) if the CA cert is specified by path, then we
-		// should just store the path in the cloud definition, and
-		// rely on cloud finalization to read it at time of use.
-		if cluster.CertificateAuthority != "" {
+		k8sCAData := cluster.CertificateAuthorityData
+		if len(cluster.CertificateAuthorityData) == 0 && cluster.CertificateAuthority != "" {
 			caData, err := ioutil.ReadFile(cluster.CertificateAuthority)
 			if err != nil {
 				return CloudConfig{}, errors.Trace(err)
 			}
-			cluster.CertificateAuthorityData = caData
+			k8sCAData = caData
 		}
-		attrs["CAData"] = string(cluster.CertificateAuthorityData)
+		attrs["CAData"] = string(k8sCAData)
 
 		return CloudConfig{
 			Endpoint:   cluster.Server,
@@ -295,7 +292,6 @@ func readKubeConfigFile() (reader io.Reader, err error) {
 }
 
 func parseKubeConfig(data []byte) (*clientcmdapi.Config, error) {
-
 	config, err := clientcmd.Load(data)
 	if err != nil {
 		return nil, err

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -562,6 +562,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err := checkCloudRegion(c.givenHostCloudRegion, newCloud.HostCloudRegion); err != nil {
 		return errors.Trace(err)
 	}
+
 	if newCloud.HostCloudRegion == "" {
 		newCloud.HostCloudRegion = caas.K8sCloudOther
 	}


### PR DESCRIPTION
When we import a cluster with CAData file in the config we fill out the
k8s config struct with the raw CAData as well. This causes an error to
propogate from the k8s client-go code. This change stops that from
happening by using tmp variables to pass the data around.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Follow repo steps in bug report

## Bug reference

https://bugs.launchpad.net/juju/+bug/1905321
