### PR TITLE
When upgrading to juju 3, models model be at least 2.9

### DIFF
--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -98,7 +98,7 @@ var scenarioStatus = &params.FullStatus{
 		Type:        "iaas",
 		CloudTag:    "cloud-dummy",
 		CloudRegion: "dummy-region",
-		Version:     "1.2.3",
+		Version:     "2.0.0",
 		ModelStatus: params.DetailedStatus{
 			Status: "available",
 		},
@@ -383,7 +383,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	setDefaultPassword(c, u)
 	add(u)
 	err = s.Model.UpdateModelConfig(map[string]interface{}{
-		config.AgentVersionKey: "1.2.3"}, nil)
+		config.AgentVersionKey: "2.0.0"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u = s.Factory.MakeUser(c, &factory.UserParams{Name: "other"})

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/os"
 	"github.com/juju/os/series"
 	"github.com/juju/replicaset"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
@@ -35,6 +36,7 @@ import (
 	"github.com/juju/juju/environs/manual/winrmprovisioner"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
+	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -693,6 +695,8 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 	}
 	// If this is the controller model, also check to make sure that there are
 	// no running migrations.  All models should have migration mode of None.
+	// For major version upgrades, also check that all models are at a version high
+	// enough to allow the upgrade.
 	if c.api.stateAccessor.IsController() {
 		// Check to ensure that the replicaset is happy.
 		if err := c.CheckMongoStatusForUpgrade(c.api.stateAccessor.MongoSession()); err != nil {
@@ -704,16 +708,34 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 			return errors.Trace(err)
 		}
 
+		var oldModels []string
+		var requiredVersion version.Number
 		for _, modelUUID := range modelUUIDs {
 			model, release, err := c.api.pool.GetModel(modelUUID)
 			if err != nil {
 				return errors.Trace(err)
+			}
+			vers, err := model.AgentVersion()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			allowed, minVer, err := upgrades.UpgradeAllowed(vers, args.Version)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !allowed {
+				requiredVersion = minVer
+				oldModels = append(oldModels, fmt.Sprintf("%s/%s", model.Owner().Name(), model.Name()))
 			}
 			if mode := model.MigrationMode(); mode != state.MigrationModeNone {
 				release()
 				return errors.Errorf("model \"%s/%s\" is %s, upgrade blocked", model.Owner().Name(), model.Name(), mode)
 			}
 			release()
+		}
+		if len(oldModels) > 0 {
+			return errors.Errorf("these models must first be upgraded to at least %v before upgrading the controller:\n -%s",
+				requiredVersion, strings.Join(oldModels, "\n -"))
 		}
 	}
 

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -442,7 +442,7 @@ func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) 
 	if err != nil {
 		return func() {}, err
 	}
-	ver := version.Number{Major: 1, Minor: 2, Patch: 3}
+	ver := version.Number{Major: 2, Minor: 0, Patch: 0}
 	err = st.Client().SetModelAgentVersion(ver, false)
 	if err != nil {
 		return func() {}, err

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -60,8 +60,8 @@ See also:
     upgrade-model`
 
 func newUpgradeControllerCommand(options ...modelcmd.WrapControllerOption) cmd.Command {
-	cmd := &upgradeControllerCommand{}
-	return modelcmd.WrapController(cmd, options...)
+	command := &upgradeControllerCommand{}
+	return modelcmd.WrapController(command, options...)
 }
 
 // upgradeControllerCommand upgrades the controller agents in a juju installation.

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -84,10 +84,8 @@ var upgradeIAASControllerPassthroughTests = []upgradeTest{{
 	expectUploaded: []string{"2.7.3.1-quantal-amd64", "2.7.3.1-%LTS%-amd64", "2.7.3.1-raring-amd64"},
 }}
 
-func (s *UpgradeIAASControllerSuite) upgradeControllerCommand(minUpgradeVers map[int]version.Number) cmd.Command {
-	cmd := &upgradeControllerCommand{
-		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
-	}
+func (s *UpgradeIAASControllerSuite) upgradeControllerCommand() cmd.Command {
+	cmd := &upgradeControllerCommand{}
 	cmd.SetClientStore(s.ControllerStore)
 	return modelcmd.WrapController(cmd)
 }
@@ -105,7 +103,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgrade(c *gc.C) {
 func (s *UpgradeIAASControllerSuite) TestUpgradeWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	cmd := s.upgradeControllerCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
+	cmd := s.upgradeControllerCommand()
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
 	vers := coretesting.CurrentVersion(c)
@@ -116,7 +114,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeWithRealUpload(c *gc.C) {
 func (s *UpgradeIAASControllerSuite) TestUpgradeCorrectController(c *gc.C) {
 	badControllerName := "not-the-right-controller"
 	badControllerSelected := errors.New("bad controller selected")
-	upgradeCommand := func(minUpgradeVers map[int]version.Number) cmd.Command {
+	upgradeCommand := func() cmd.Command {
 		backingStore := s.ControllerStore
 		store := jujuclienttesting.WrapClientStore(backingStore)
 		store.ControllerByNameFunc = func(name string) (*jujuclient.ControllerDetails, error) {
@@ -129,11 +127,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeCorrectController(c *gc.C) {
 			return badControllerName, nil
 		}
 		s.ControllerStore = store
-		cmd := &upgradeControllerCommand{
-			baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
-		}
-		cmd.SetClientStore(s.ControllerStore)
-		return modelcmd.WrapController(cmd)
+		return s.upgradeControllerCommand()
 	}
 
 	tests := []upgradeTest{
@@ -168,7 +162,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeWrongPermissions(c *gc.C) {
 	details.LastKnownAccess = string(permission.ReadAccess)
 	err = s.ControllerStore.UpdateAccount("kontroll", *details)
 	c.Assert(err, jc.ErrorIsNil)
-	com := s.upgradeControllerCommand(nil)
+	com := s.upgradeControllerCommand()
 	err = cmdtesting.InitCommand(com, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
@@ -198,7 +192,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeDifferentUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmd := &upgradeControllerCommand{
-		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
+		baseUpgradeCommand: baseUpgradeCommand{},
 	}
 	cmd.SetClientStore(s.ControllerStore)
 	cmdrun := modelcmd.WrapController(cmd)
@@ -273,7 +267,7 @@ var upgradeCAASControllerTests = []upgradeTest{{
 	expectVersion:  "1.21.4",
 }}
 
-func (s *UpgradeCAASControllerSuite) upgradeControllerCommand(_ map[int]version.Number) cmd.Command {
+func (s *UpgradeCAASControllerSuite) upgradeControllerCommand() cmd.Command {
 	cmd := &upgradeControllerCommand{}
 	cmd.SetClientStore(s.ControllerStore)
 	return modelcmd.WrapController(cmd)
@@ -316,7 +310,7 @@ func (s *UpgradeCAASControllerSuite) assertUpgradeTests(c *gc.C, tests []upgrade
 		// Set up apparent CLI version and initialize the command.
 		current := version.MustParse(test.currentVersion)
 		s.PatchValue(&jujuversion.Current, current)
-		com := upgradeJujuCommand(nil)
+		com := upgradeJujuCommand()
 		if err := cmdtesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
 				c.Check(err, gc.ErrorMatches, test.expectInitErr)

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/jujuclient"
 	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -76,28 +77,22 @@ See also:
     sync-agent-binaries`
 
 func newUpgradeJujuCommand() cmd.Command {
-	command := &upgradeJujuCommand{
-		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion}}
+	command := &upgradeJujuCommand{}
 	return modelcmd.Wrap(command)
 }
 
 func newUpgradeJujuCommandForTest(
 	store jujuclient.ClientStore,
-	minUpgradeVers map[int]version.Number,
 	jujuClientAPI jujuClientAPI,
 	modelConfigAPI modelConfigAPI,
 	modelManagerAPI modelManagerAPI,
 	controllerAPI controllerAPI,
 	options ...modelcmd.WrapOption) cmd.Command {
-	if minUpgradeVers == nil {
-		minUpgradeVers = minMajorUpgradeVersion
-	}
 	command := &upgradeJujuCommand{
 		baseUpgradeCommand: baseUpgradeCommand{
-			minMajorUpgradeVersion: minUpgradeVers,
-			modelConfigAPI:         modelConfigAPI,
-			modelManagerAPI:        modelManagerAPI,
-			controllerAPI:          controllerAPI,
+			modelConfigAPI:  modelConfigAPI,
+			modelManagerAPI: modelManagerAPI,
+			controllerAPI:   controllerAPI,
 		},
 		jujuClientAPI: jujuClientAPI,
 	}
@@ -123,12 +118,6 @@ type baseUpgradeCommand struct {
 
 	rawArgs        []string
 	upgradeMessage string
-
-	// minMajorUpgradeVersion maps known major numbers to
-	// the minimum version that can be upgraded to that
-	// major version.  For example, users must be running
-	// 1.25.4 or later in order to upgrade to 2.0.
-	minMajorUpgradeVersion map[int]version.Number
 
 	modelConfigAPI  modelConfigAPI
 	modelManagerAPI modelManagerAPI
@@ -212,22 +201,13 @@ func (c *baseUpgradeCommand) precheckVersion(ctx *cmd.Context, agentVersion vers
 		// User is requesting an upgrade to a new major number
 		// Only upgrade to a different major number if:
 		// 1 - Explicitly requested with --agent-version or using --build-agent, and
-		// 2 - The environment is running a valid version to upgrade from, and
-		// 3 - The upgrade is to a minor version of 0.
-		if c.minMajorUpgradeVersion == nil {
-			break
-		}
-		minVer, ok := c.minMajorUpgradeVersion[c.Version.Major]
-		if !ok {
-			return false, errors.Errorf("unknown version %q", c.Version)
+		// 2 - The model is running a valid version to upgrade from.
+		allowed, minVer, err := upgrades.UpgradeAllowed(agentVersion, c.Version)
+		if err != nil {
+			return false, errors.Trace(err)
 		}
 		retErr := false
-		if c.Version.Minor != 0 {
-			ctx.Infof("upgrades to %s must first go through juju %d.0",
-				c.Version, c.Version.Major)
-			retErr = true
-		}
-		if comp := agentVersion.Compare(minVer); comp < 0 {
+		if !allowed {
 			ctx.Infof("upgrades to a new major version must first go through %s",
 				minVer)
 			retErr = true
@@ -262,11 +242,8 @@ func (c *upgradeJujuCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 var (
-	errUpToDate            = stderrors.New("no upgrades available")
-	downgradeErrMsg        = "cannot change version from %s to lower version %s"
-	minMajorUpgradeVersion = map[int]version.Number{
-		2: version.MustParse("1.25.4"),
-	}
+	errUpToDate     = stderrors.New("no upgrades available")
+	downgradeErrMsg = "cannot change version from %s to lower version %s"
 )
 
 // canUpgradeRunningVersion determines if the version of the running

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -344,22 +345,19 @@ var upgradeJujuTests = []upgradeTest{{
 	expectVersion:  "1.21.3",
 }}
 
-type upgradeCommandFunc func(minUpgradeVers map[int]version.Number) cmd.Command
+type upgradeCommandFunc func() cmd.Command
 
 func (s *UpgradeJujuSuite) upgradeJujuCommand(
-	minUpgradeVers map[int]version.Number,
 	jujuClientAPI jujuClientAPI,
 	modelConfigAPI modelConfigAPI,
 	modelManagerAPI modelManagerAPI,
 	controllerAPI controllerAPI,
 ) cmd.Command {
-	return newUpgradeJujuCommandForTest(s.ControllerStore, minUpgradeVers, jujuClientAPI, modelConfigAPI, modelManagerAPI, controllerAPI)
+	return newUpgradeJujuCommandForTest(s.ControllerStore, jujuClientAPI, modelConfigAPI, modelManagerAPI, controllerAPI)
 }
 
-func (s *UpgradeJujuSuite) upgradeJujuCommandNoAPI(
-	minUpgradeVers map[int]version.Number,
-) cmd.Command {
-	return newUpgradeJujuCommandForTest(s.ControllerStore, minUpgradeVers, nil, nil, nil, nil)
+func (s *UpgradeJujuSuite) upgradeJujuCommandNoAPI() cmd.Command {
+	return newUpgradeJujuCommandForTest(s.ControllerStore, nil, nil, nil, nil)
 }
 
 func (s *UpgradeJujuSuite) TestUpgradeJuju(c *gc.C) {
@@ -420,7 +418,8 @@ func (s *UpgradeBaseSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgr
 		s.PatchValue(&jujuversion.Current, current.Number)
 		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
 		s.PatchValue(&series.HostSeries, func() (string, error) { return current.Series, nil })
-		com := upgradeJujuCommand(test.upgradeMap)
+		s.PatchValue(&upgrades.MinMajorUpgradeVersion, test.upgradeMap)
+		com := upgradeJujuCommand()
 		if err := cmdtesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
 				c.Check(err, gc.ErrorMatches, test.expectInitErr)
@@ -547,7 +546,7 @@ func (s *UpgradeBaseSuite) Reset(c *gc.C) {
 func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	command := s.upgradeJujuCommandNoAPI(map[int]version.Number{2: version.MustParse("1.99.99")})
+	command := s.upgradeJujuCommandNoAPI()
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
 	vers := coretesting.CurrentVersion(c)
@@ -564,7 +563,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadDevAgent(c *gc.C) {
 		agentVersion:   "1.99.99.1",
 	}
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, nil)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
 	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
@@ -580,7 +579,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNewerClient(c *gc.C)
 		agentVersion:   "1.99.99",
 	}
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.100.0"))
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, nil)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
 	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
@@ -598,7 +597,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNonController(c *gc.
 		agentVersion:   "1.99.99.1",
 	}
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, nil)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
 	_, err := cmdtesting.RunCommand(c, command)
 	c.Assert(err, gc.ErrorMatches, "no more recent supported versions available")
 	c.Assert(fakeAPI.ignoreAgentVersions, jc.IsFalse)
@@ -607,7 +606,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithImplicitUploadNonController(c *gc.
 func (s *UpgradeJujuSuite) TestBlockUpgradeJujuWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	command := s.upgradeJujuCommandNoAPI(map[int]version.Number{2: version.MustParse("1.99.99")})
+	command := s.upgradeJujuCommandNoAPI()
 	// Block operation
 	s.BlockAllChanges(c, "TestBlockUpgradeJujuWithRealUpload")
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
@@ -621,7 +620,7 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 		controllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 		agentVersion:   "1.99.99",
 	}
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, nil)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent", "-m", "dummy-model")
 	c.Assert(err, gc.ErrorMatches, "--build-agent can only be used with the controller model")
 }
@@ -629,7 +628,7 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 func (s *UpgradeJujuSuite) TestFailUploadNoControllerModelPermission(c *gc.C) {
 	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
 	fakeAPI.modelConfigErr = params.Error{Code: params.CodeUnauthorized}
-	command := s.upgradeJujuCommand(nil, nil, nil, nil, fakeAPI)
+	command := s.upgradeJujuCommand(nil, nil, nil, fakeAPI)
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
 	c.Assert(err, gc.ErrorMatches, "--build-agent can only be used with the controller model but you don't have permission to access that model")
 }
@@ -643,7 +642,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithIgnoreAgentVersions(c *gc.C) {
 		agentVersion:   "1.99.99",
 	}
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.100.0"))
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, nil)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
 	_, err := cmdtesting.RunCommand(c, command, "--ignore-agent-versions")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.Not(gc.HasLen), 0)
@@ -713,7 +712,7 @@ upgrade to this version by running
 
 		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
 
-		com := upgradeJujuCommand(nil)
+		com := upgradeJujuCommand()
 		err := cmdtesting.InitCommand(com, test.cmdArgs)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -828,27 +827,6 @@ func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
 		expectedCmdOutput: "upgrades to a new major version must first go through 6.7.8\n",
 		expectedErr:       "unable to upgrade to requested version",
 		upgradeMap:        map[int]version.Number{7: version.MustParse("6.7.8")},
-	}, {
-		about:             "upgrade fails if not a minor of 0",
-		cmdArgs:           []string{"--agent-version=7.1.1"},
-		tools:             []string{"7.0.1-trusty-amd64", "7.1.1-trusty-amd64"},
-		currentVersion:    "7.0.1-trusty-amd64",
-		agentVersion:      "6.7.8",
-		expectedVersion:   "6.7.8",
-		expectedCmdOutput: "upgrades to 7.1.1 must first go through juju 7.0\n",
-		expectedErr:       "unable to upgrade to requested version",
-		upgradeMap:        map[int]version.Number{7: version.MustParse("6.7.8")},
-	}, {
-		about:           "upgrade fails if not at minimum version and not a minor of 0",
-		cmdArgs:         []string{"--agent-version=7.1.1"},
-		tools:           []string{"7.0.1-trusty-amd64", "7.1.1-trusty-amd64"},
-		currentVersion:  "7.0.1-trusty-amd64",
-		agentVersion:    "6.0.0",
-		expectedVersion: "6.0.0",
-		expectedCmdOutput: "upgrades to 7.1.1 must first go through juju 7.0\n" +
-			"upgrades to a new major version must first go through 6.7.8\n",
-		expectedErr: "unable to upgrade to requested version",
-		upgradeMap:  map[int]version.Number{7: version.MustParse("6.7.8")},
 	}}
 	for i, test := range tests {
 		c.Logf("\ntest %d: %s", i, test.about)
@@ -857,7 +835,8 @@ func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
 
 		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
 
-		command := s.upgradeJujuCommandNoAPI(test.upgradeMap)
+		s.PatchValue(&upgrades.MinMajorUpgradeVersion, test.upgradeMap)
+		command := s.upgradeJujuCommandNoAPI()
 		err := cmdtesting.InitCommand(command, test.cmdArgs)
 		c.Assert(err, jc.ErrorIsNil)
 
@@ -892,7 +871,7 @@ func (s *UpgradeJujuSuite) TestUpgradeUnknownSeriesInStreams(c *gc.C) {
 	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
 	fakeAPI.addTools("2.1.0-weird-amd64")
 
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, fakeAPI)
 	err := cmdtesting.InitCommand(command, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -911,7 +890,7 @@ func (s *UpgradeJujuSuite) TestUpgradeValidateModel(c *gc.C) {
 		Code:    params.CodeAlreadyExists,
 	}
 
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, fakeAPI)
 	err := cmdtesting.InitCommand(command, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -924,7 +903,7 @@ func (s *UpgradeJujuSuite) TestUpgradeValidateModelNotImplementedNoError(c *gc.C
 
 	fakeAPI.setUpgradeErr = errors.NotImplementedf("")
 
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, fakeAPI)
 	err := cmdtesting.InitCommand(command, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -939,7 +918,7 @@ func (s *UpgradeJujuSuite) TestUpgradeInProgress(c *gc.C) {
 		Code:    params.CodeUpgradeInProgress,
 	}
 
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, fakeAPI)
 	err := cmdtesting.InitCommand(command, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -956,7 +935,7 @@ func (s *UpgradeJujuSuite) TestBlockUpgradeInProgress(c *gc.C) {
 	fakeAPI := NewFakeUpgradeJujuAPI(c, s.State)
 	fakeAPI.setVersionErr = common.OperationBlockedError("the operation has been blocked")
 
-	command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, fakeAPI)
 	err := cmdtesting.InitCommand(command, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -981,7 +960,7 @@ func (s *UpgradeJujuSuite) TestResetPreviousUpgrade(c *gc.C) {
 
 		fakeAPI.reset()
 
-		command := s.upgradeJujuCommand(nil, fakeAPI, fakeAPI, fakeAPI, fakeAPI)
+		command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, fakeAPI)
 		err := cmdtesting.InitCommand(command,
 			append([]string{"--reset-previous-upgrade"}, args...))
 		c.Assert(err, jc.ErrorIsNil)
@@ -1239,8 +1218,8 @@ var upgradeCAASModelTests = []upgradeTest{{
 	expectVersion:  "1.21.4",
 }}
 
-func (s *UpgradeCAASModelSuite) upgradeModelCommand(minUpgradeVers map[int]version.Number) cmd.Command {
-	return newUpgradeJujuCommandForTest(s.ControllerStore, minUpgradeVers, nil, nil, nil, nil)
+func (s *UpgradeCAASModelSuite) upgradeModelCommand() cmd.Command {
+	return newUpgradeJujuCommandForTest(s.ControllerStore, nil, nil, nil, nil)
 }
 
 func (s *UpgradeCAASModelSuite) TestUpgrade(c *gc.C) {
@@ -1274,7 +1253,7 @@ func (s *UpgradeCAASModelSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest,
 		// Set up apparent CLI version and initialize the command.
 		current := version.MustParse(test.currentVersion)
 		s.PatchValue(&jujuversion.Current, current)
-		com := upgradeJujuCommand(nil)
+		com := upgradeJujuCommand()
 		args := append(test.args, "-m", "admin/dummy-model")
 		if err := cmdtesting.InitCommand(com, args); err != nil {
 			if test.expectInitErr != "" {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4652,7 +4652,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 			"controller": "kontroll",
 			"cloud":      "dummy",
 			"region":     "dummy-region",
-			"version":    "1.2.3",
+			"version":    "2.0.0",
 			"model-status": M{
 				"current": "busy",
 				"since":   "01 Apr 15 01:23+10:00",
@@ -4692,7 +4692,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
 Model   Controller  Cloud/Region        Version  SLA          Timestamp       Notes
-hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  migrating: foo bar
+hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  migrating: foo bar
 
 `[1:]
 
@@ -4710,7 +4710,7 @@ hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  mi
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
 Model   Controller  Cloud/Region        Version  SLA          Timestamp       Notes
-hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  migrating: foo bar
+hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  migrating: foo bar
 
 `[1:]
 

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 	caasoperatorworker "github.com/juju/juju/worker/caasoperator"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter"
@@ -54,7 +56,14 @@ func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 
 	// Set up a CAAS model to replace the IAAS one.
-	st := s.Factory.MakeCAASModel(c, nil)
+	// Ensure an older major version is used to prevent an upgrade
+	// from being attempted.
+	modelVers := jujuversion.Current
+	modelVers.Major--
+	extraAttrs := coretesting.Attrs{
+		"agent-version": modelVers.String(),
+	}
+	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{ConfigAttrs: extraAttrs})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
 	s.State = st
 

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/cmd/cmdtesting"
-	"github.com/juju/juju/controller"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jujutesting "github.com/juju/testing"
@@ -17,6 +16,8 @@ import (
 	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/juju/controller"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/common"
@@ -43,7 +44,14 @@ func (s *dblogSuite) SetUpTest(c *gc.C) {
 
 func (s *dblogSuite) TestControllerAgentLogsGoToDBCAAS(c *gc.C) {
 	// Set up a CAAS model to replace the IAAS one.
-	st := s.Factory.MakeCAASModel(c, nil)
+	// Ensure an older major version is used to prevent an upgrade
+	// from being attempted.
+	modelVers := jujuversion.Current
+	modelVers.Major--
+	extraAttrs := coretesting.Attrs{
+		"agent-version": modelVers.String(),
+	}
+	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{ConfigAttrs: extraAttrs})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
 	s.State = st
 	s.Factory = factory.NewFactory(st, s.StatePool)

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/resource"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
+	"github.com/juju/juju/upgrades"
 )
 
 // PrecheckBackend defines the interface to query Juju's state
@@ -216,6 +217,16 @@ func TargetPrecheck(backend PrecheckBackend, pool Pool, modelInfo coremigration.
 	if !controllerVersionCompatible(modelInfo.ControllerAgentVersion, controllerVersion) {
 		return errors.Errorf("source controller has higher version than target controller (%s > %s)",
 			modelInfo.ControllerAgentVersion, controllerVersion)
+	}
+
+	// The UpgradeAllowed check is the same as validating if a model can be migrated
+	// to a controller running a newer Juju version.
+	allowed, minVer, err := upgrades.UpgradeAllowed(modelInfo.AgentVersion, controllerVersion)
+	if err != nil {
+		return errors.Maskf(err, "unknown target controller version %v", controllerVersion)
+	}
+	if !allowed {
+		return errors.Errorf("model must be upgraded to at least version %s before being migrated to a controller with version %s", minVer, controllerVersion)
 	}
 
 	controllerCtx := precheckContext{backend, presence}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -433,6 +433,28 @@ func (s *TargetPrecheckSuite) TestModelVersionAheadOfTarget(c *gc.C) {
 		`model has higher version than target controller (1.2.4 > 1.2.3)`)
 }
 
+func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
+	backend := newFakeBackend()
+
+	origBackendBinary := backendVersionBinary
+	origBackend := backendVersion
+	backendVersionBinary = version.MustParseBinary("3.0.0-trusty-amd64")
+	backendVersion = backendVersionBinary.Number
+	defer func() {
+		backendVersionBinary = origBackendBinary
+		backendVersion = origBackend
+	}()
+
+	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
+	err := s.runPrecheck(backend)
+	c.Assert(err.Error(), gc.Equals,
+		`model must be upgraded to at least version 2.9.0 before being migrated to a controller with version 3.0.0`)
+
+	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
+	err = s.runPrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *TargetPrecheckSuite) TestSourceControllerMajorAhead(c *gc.C) {
 	backend := newFakeBackend()
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -115,7 +115,7 @@ func (s *ModelConfigSuite) TestAgentVersion(c *gc.C) {
 	}
 	ver, err := s.Model.AgentVersion()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ver, gc.DeepEquals, version.Number{Major: 1, Minor: 2, Patch: 3})
+	c.Assert(ver, gc.DeepEquals, version.Number{Major: 2, Minor: 0, Patch: 0})
 
 	err = s.Model.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -100,7 +100,7 @@ func mustUUID() string {
 // additional specified keys added.
 func CustomModelConfig(c *gc.C, extra Attrs) *config.Config {
 	attrs := FakeConfig().Merge(Attrs{
-		"agent-version": "1.2.3",
+		"agent-version": "2.0.0",
 	}).Merge(extra).Delete("admin-secret")
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/upgrades/model.go
+++ b/upgrades/model.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/version"
+)
+
+// MinMajorUpgradeVersion defines the minimum version all models
+// must be running before a major version upgrade.
+var MinMajorUpgradeVersion = map[int]version.Number{
+	3: version.MustParse("2.9.0"),
+}
+
+// UpgradeAllowed returns true if a major version upgrade is allowed
+// for the specified from and to versions.
+func UpgradeAllowed(from, to version.Number) (bool, version.Number, error) {
+	if from.Major == to.Major {
+		return true, version.Number{}, nil
+	}
+	// Downgrades not allowed.
+	if from.Major > to.Major {
+		return false, version.Number{}, nil
+	}
+	minVer, ok := MinMajorUpgradeVersion[to.Major]
+	if !ok {
+		return false, version.Number{}, errors.Errorf("unknown version %q", to)
+	}
+	return from.Compare(minVer) >= 0, minVer, nil
+}

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -163,7 +163,6 @@ func (u *Upgrader) loop() error {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
 		} else if !upgrader.AllowedTargetVersion(
-			u.config.OrigAgentVersion,
 			jujuversion.Current,
 			wantVersion,
 		) {
@@ -179,7 +178,7 @@ func (u *Upgrader) loop() error {
 		logger.Debugf("%s requested for %v from %v to %v", direction, u.tag, jujuversion.Current, wantVersion)
 		err = u.operatorUpgrader.Upgrade(u.tag.String(), wantVersion)
 		if err != nil {
-			return errors.Annotatef(err, "requesting upgrade for %f from %v to %v", u.tag, jujuversion.Current, wantVersion)
+			return errors.Annotatef(err, "requesting upgrade for %v from %v to %v", u.tag, jujuversion.Current, wantVersion)
 		}
 	}
 }

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -113,12 +113,11 @@ func (u *Upgrader) Stop() error {
 // AllowedTargetVersion checks if targetVersion is too different from
 // curVersion to allow a downgrade.
 func AllowedTargetVersion(
-	origAgentVersion version.Number,
 	curVersion version.Number,
 	targetVersion version.Number,
 ) bool {
-	// Don't allow downgrading from higher versions to version 1.x
-	if curVersion.Major >= 2 && targetVersion.Major == 1 {
+	// Don't allow downgrading from higher major versions.
+	if curVersion.Major > targetVersion.Major {
 		return false
 	}
 	return true
@@ -204,7 +203,6 @@ func (u *Upgrader) loop() error {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
 		} else if !AllowedTargetVersion(
-			u.config.OrigAgentVersion,
 			haveVersion,
 			wantVersion,
 		) {

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -489,26 +489,24 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 }
 
 type allowedTest struct {
-	original string
-	current  string
-	target   string
-	allowed  bool
+	current string
+	target  string
+	allowed bool
 }
 
 func (s *AllowedTargetVersionSuite) TestAllowedTargetVersionSuite(c *gc.C) {
 	cases := []allowedTest{
-		{original: "2.7.4", current: "2.7.4", target: "2.8.0", allowed: true},  // normal upgrade
-		{original: "2.8.0", current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade caused by restore after upgrade
-		{original: "2.8.0", current: "2.8.0", target: "1.2.3", allowed: false}, // can't downgrade to v1.x
-		{original: "2.7.4", current: "2.7.4", target: "2.7.5", allowed: true},  // point release
-		{original: "2.7.4", current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade after upgrade but before config file updated
+		{current: "2.7.4", target: "2.8.0", allowed: true},  // normal upgrade
+		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade caused by restore after upgrade
+		{current: "3.8.0", target: "2.2.3", allowed: false}, // can't downgrade major versions
+		{current: "2.7.4", target: "2.7.5", allowed: true},  // point release
+		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade after upgrade but before config file updated
 	}
 	for i, test := range cases {
 		c.Logf("test case %d, %#v", i, test)
-		original := version.MustParse(test.original)
 		current := version.MustParse(test.current)
 		target := version.MustParse(test.target)
-		result := upgrader.AllowedTargetVersion(original, current, target)
+		result := upgrader.AllowedTargetVersion(current, target)
 		c.Check(result, gc.Equals, test.allowed)
 	}
 }


### PR DESCRIPTION
Do not allow models or controllers older than 2.9 to be upgraded to juju 3.
Same for migration - add precheck to prevent old model being migrated to a 3.x controller.

## QA steps

bootstrap a 2.8 controller
attempt to upgrade-controller to agent version 3.0.0 -> error

bootstrap a 2.8 controller
add a model
upgrade controller to 2.9
attempt to upgrade-controller to agent version 3.0.0 -> error

bootstrap a 2.8 controller
add a model
bootstrap a 3.0 controller
attempt to migrate model to new controller -> error
