### PR TITLE
Remove NetworkInfo type from network package - return params directly

### DIFF
--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/meterstatus"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/state"
 )
@@ -46,6 +47,6 @@ func PatchGetStorageStateError(patcher patcher, err error) {
 	patcher.PatchValue(&getStorageState, func(st *state.State) (storageAccess, error) { return nil, err })
 }
 
-func (n *NetworkInfoBase) MachineNetworkInfos(spaceIDs ...string) (map[string]machineNetworkInfoResult, error) {
+func (n *NetworkInfoBase) MachineNetworkInfos(spaceIDs ...string) (map[string]params.NetworkInfoResult, error) {
 	return n.machineNetworkInfos(spaceIDs...)
 }

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -5,7 +5,6 @@ package uniter
 
 import (
 	"net"
-	"strings"
 	"time"
 
 	"github.com/juju/clock"
@@ -17,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	corenetwork "github.com/juju/juju/core/network"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -361,28 +359,6 @@ func uniqueInterfaceAddresses(addrList []params.InterfaceAddress) []params.Inter
 	}
 
 	return uniqueAddrList
-}
-
-// spaceAddressesFromNetworkInfo returns a SpaceAddresses collection
-// from a slice of NetworkInfo.
-// We need to construct sortable addresses from link-layer devices,
-// which unlike addresses from the machines collection, do not have the scope
-// information that we need.
-// The best we can do here is identify fan addresses so that they are sorted
-// after other addresses.
-func spaceAddressesFromNetworkInfo(netInfos []network.NetworkInfo) corenetwork.SpaceAddresses {
-	var addrs corenetwork.SpaceAddresses
-	for _, nwInfo := range netInfos {
-		scope := corenetwork.ScopeUnknown
-		if strings.HasPrefix(nwInfo.InterfaceName, "fan-") {
-			scope = corenetwork.ScopeFanLocal
-		}
-
-		for _, addr := range nwInfo.Addresses {
-			addrs = append(addrs, corenetwork.NewScopedSpaceAddress(addr.Address, scope))
-		}
-	}
-	return addrs
 }
 
 var defaultRetryFactory = func() retry.CallArgs {

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -117,19 +117,22 @@ func (n *NetworkInfoBase) validateEndpoints(endpoints []string) (set.Strings, pa
 	valid := set.NewStrings()
 	result := params.NetworkInfoResults{Results: make(map[string]params.NetworkInfoResult)}
 
-	// For each of the endpoints in the request, get the bound space and
-	// initialise the endpoint egress map with the model's configured
-	// egress subnets. Keep track of the spaces that we observe.
 	for _, endpoint := range endpoints {
-		if _, ok := n.bindings[endpoint]; ok {
-			valid.Add(endpoint)
-		} else {
-			err := errors.NotValidf("undefined for unit charm: endpoint %q", endpoint)
+		if err := n.validateEndpoint(endpoint); err != nil {
 			result.Results[endpoint] = params.NetworkInfoResult{Error: common.ServerError(err)}
+			continue
 		}
+		valid.Add(endpoint)
 	}
 
 	return valid, result
+}
+
+func (n *NetworkInfoBase) validateEndpoint(endpoint string) error {
+	if _, ok := n.bindings[endpoint]; !ok {
+		return errors.NotValidf("undefined for unit charm: endpoint %q", endpoint)
+	}
+	return nil
 }
 
 // getRelationAndEndpointName returns the relation for the input ID

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -465,35 +465,35 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 
 	resDefault, ok := res[spaceIDDefault]
 	c.Assert(ok, jc.IsTrue)
-	c.Check(resDefault.Error, jc.ErrorIsNil)
-	c.Assert(resDefault.NetworkInfos, gc.HasLen, 1)
-	c.Check(resDefault.NetworkInfos[0].InterfaceName, gc.Equals, "br-eth0")
-	c.Assert(resDefault.NetworkInfos[0].Addresses, gc.HasLen, 1)
-	c.Check(resDefault.NetworkInfos[0].Addresses[0].Address, gc.Equals, "10.0.0.20")
-	c.Check(resDefault.NetworkInfos[0].Addresses[0].CIDR, gc.Equals, "10.0.0.0/24")
+	c.Check(resDefault.Error, gc.IsNil)
+	c.Assert(resDefault.Info, gc.HasLen, 1)
+	c.Check(resDefault.Info[0].InterfaceName, gc.Equals, "br-eth0")
+	c.Assert(resDefault.Info[0].Addresses, gc.HasLen, 1)
+	c.Check(resDefault.Info[0].Addresses[0].Address, gc.Equals, "10.0.0.20")
+	c.Check(resDefault.Info[0].Addresses[0].CIDR, gc.Equals, "10.0.0.0/24")
 
 	resDMZ, ok := res[spaceIDDMZ]
 	c.Assert(ok, jc.IsTrue)
-	c.Check(resDMZ.Error, jc.ErrorIsNil)
-	c.Assert(resDMZ.NetworkInfos, gc.HasLen, 1)
-	c.Check(resDMZ.NetworkInfos[0].InterfaceName, gc.Equals, "eth1")
-	c.Assert(resDMZ.NetworkInfos[0].Addresses, gc.HasLen, 1)
-	c.Check(resDMZ.NetworkInfos[0].Addresses[0].Address, gc.Equals, "10.10.0.20")
-	c.Check(resDMZ.NetworkInfos[0].Addresses[0].CIDR, gc.Equals, "10.10.0.0/24")
+	c.Check(resDMZ.Error, gc.IsNil)
+	c.Assert(resDMZ.Info, gc.HasLen, 1)
+	c.Check(resDMZ.Info[0].InterfaceName, gc.Equals, "eth1")
+	c.Assert(resDMZ.Info[0].Addresses, gc.HasLen, 1)
+	c.Check(resDMZ.Info[0].Addresses[0].Address, gc.Equals, "10.10.0.20")
+	c.Check(resDMZ.Info[0].Addresses[0].CIDR, gc.Equals, "10.10.0.0/24")
 
 	resEmpty, ok := res[network.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
-	c.Check(resEmpty.Error, jc.ErrorIsNil)
-	c.Assert(resEmpty.NetworkInfos, gc.HasLen, 1)
-	c.Check(resEmpty.NetworkInfos[0].InterfaceName, gc.Equals, "eth2")
-	c.Assert(resEmpty.NetworkInfos[0].Addresses, gc.HasLen, 1)
-	c.Check(resEmpty.NetworkInfos[0].Addresses[0].Address, gc.Equals, "10.20.0.20")
-	c.Check(resEmpty.NetworkInfos[0].Addresses[0].CIDR, gc.Equals, "10.20.0.0/24")
+	c.Check(resEmpty.Error, gc.IsNil)
+	c.Assert(resEmpty.Info, gc.HasLen, 1)
+	c.Check(resEmpty.Info[0].InterfaceName, gc.Equals, "eth2")
+	c.Assert(resEmpty.Info[0].Addresses, gc.HasLen, 1)
+	c.Check(resEmpty.Info[0].Addresses[0].Address, gc.Equals, "10.20.0.20")
+	c.Check(resEmpty.Info[0].Addresses[0].CIDR, gc.Equals, "10.20.0.0/24")
 
 	resDoesNotExists, ok := res["666"]
 	c.Assert(ok, jc.IsTrue)
 	c.Check(resDoesNotExists.Error, gc.ErrorMatches, `.*machine "0" has no devices in space "666".*`)
-	c.Assert(resDoesNotExists.NetworkInfos, gc.HasLen, 0)
+	c.Assert(resDoesNotExists.Info, gc.HasLen, 0)
 }
 
 // TODO (manadart 2020-02-21): This test can be removed after universal subnet
@@ -532,12 +532,12 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 
 	resEmpty, ok := res[network.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
-	c.Check(resEmpty.Error, jc.ErrorIsNil)
-	c.Assert(resEmpty.NetworkInfos, gc.HasLen, 1)
-	c.Check(resEmpty.NetworkInfos[0].InterfaceName, gc.Equals, "eth2")
-	c.Assert(resEmpty.NetworkInfos[0].Addresses, gc.HasLen, 1)
-	c.Check(resEmpty.NetworkInfos[0].Addresses[0].Address, gc.Equals, "10.20.0.20")
-	c.Check(resEmpty.NetworkInfos[0].Addresses[0].CIDR, gc.Equals, "10.20.0.0/24")
+	c.Check(resEmpty.Error, gc.IsNil)
+	c.Assert(resEmpty.Info, gc.HasLen, 1)
+	c.Check(resEmpty.Info[0].InterfaceName, gc.Equals, "eth2")
+	c.Assert(resEmpty.Info[0].Addresses, gc.HasLen, 1)
+	c.Check(resEmpty.Info[0].Addresses[0].Address, gc.Equals, "10.20.0.20")
+	c.Check(resEmpty.Info[0].Addresses[0].CIDR, gc.Equals, "10.20.0.0/24")
 }
 
 func (s *networkInfoSuite) setupSpace(c *gc.C, spaceName, cidr string) string {

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -125,10 +125,17 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 // The ingress addresses depend on if the relation is cross-model
 // and whether the relation endpoint is bound to a space.
 func (n *NetworkInfoCAAS) NetworksForRelation(
-	_ string, rel *state.Relation, pollAddr bool,
+	endpoint string, rel *state.Relation, pollAddr bool,
 ) (string, corenetwork.SpaceAddresses, []string, error) {
 	var ingress corenetwork.SpaceAddresses
 	var err error
+
+	// If NetworksForRelation is called during ProcessAPIRequest,
+	// this is a second validation, but we need to do it for the cases
+	// where NetworksForRelation is called directly by EnterScope.
+	if err = n.validateEndpoint(endpoint); err != nil {
+		return "", nil, nil, errors.Trace(err)
+	}
 
 	if pollAddr {
 		if ingress, err = n.maybeGetUnitAddress(rel); err != nil {

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -112,6 +112,12 @@ func (n *NetworkInfoIAAS) getRelationNetworkInfo(
 func (n *NetworkInfoIAAS) NetworksForRelation(
 	endpoint string, rel *state.Relation, _ bool,
 ) (string, network.SpaceAddresses, []string, error) {
+	// If NetworksForRelation is called during ProcessAPIRequest,
+	// this is a second validation, but we need to do it for the cases
+	// where NetworksForRelation is called directly by EnterScope.
+	if err := n.validateEndpoint(endpoint); err != nil {
+		return "", nil, nil, errors.Trace(err)
+	}
 	boundSpace := n.bindings[endpoint]
 
 	// If the endpoint for this relation is not bound to a space,

--- a/network/network.go
+++ b/network/network.go
@@ -31,25 +31,6 @@ const DefaultLXDBridge = "lxdbr0"
 // Note: we don't import this from 'container' to avoid import loops
 const DefaultKVMBridge = "virbr0"
 
-// InterfaceAddress represents a single address attached to the interface.
-type InterfaceAddress struct {
-	Address string
-	CIDR    string
-}
-
-// NetworkInfo describes one interface with assigned IP addresses, it's a mirror of params.NetworkInfo.
-type NetworkInfo struct {
-	// MACAddress is the network interface's hardware MAC address
-	// (e.g. "aa:bb:cc:dd:ee:ff").
-	MACAddress string
-
-	// InterfaceName is the OS-specific interface name, eg. "eth0" or "eno1.412"
-	InterfaceName string
-
-	// Addresses contains a list of addresses configured on the interface.
-	Addresses []InterfaceAddress
-}
-
 // ProviderInterfaceInfo holds enough information to identify an
 // interface or link layer device to a provider so that it can be
 // queried or manipulated. Its initial purpose is to pass to


### PR DESCRIPTION
For the IAAS implementation of `NetworkInfo`, we previously relocated the `machineNetworkInfos` method from the `state` package as it was only used in one that place.

This used the `network.NetworkInfo` type, which mirrored `params.NetworkInfo` and there was translation logic to copy the former to the latter.

Given that this intermediate type is no longer required, it is removed and the `params` type is returned directly. Increased brevity results.

In recent modifications to this module, binding validation was removed from the CAAS implementation of `NetworksForRelation` even though everything will be bound to the `alpha` space, the validation is restored.

## QA steps

Mechanical only. Unit tests remain green.

## Documentation changes

None.

## Bug reference

N/A
