### PR TITLE
Merge 2.9

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,7 +47,9 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        snap_version: ["latest/stable", "latest/beta"]
+        # TODO(wallyworld) - we can only upgrade to 3.0 from 2.9
+        # Update when 2.9 is released.
+        snap_version: ["latest/candidate", "latest/beta"]
 
     steps:
 

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
 	"github.com/juju/juju/utils/proxy"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // PingPeriod defines how often the internal connection health check
@@ -419,6 +420,7 @@ func (st *state) connectStream(path string, attrs url.Values, extraHeaders http.
 	} else {
 		requestHeader = make(http.Header)
 	}
+	requestHeader.Set(params.JujuClientVersion, jujuversion.Current.String())
 	requestHeader.Set("Origin", "http://localhost/")
 	if st.nonce != "" {
 		requestHeader.Set(params.MachineNonceHeader, st.nonce)
@@ -1190,20 +1192,43 @@ var apiCallRetryStrategy = retry.LimitTime(10*time.Second,
 // This fills out the rpc.Request on the given facade, version for a given
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
-func (s *state) APICall(facade string, version int, id, method string, args, response interface{}) error {
+func (s *state) APICall(facade string, vers int, id, method string, args, response interface{}) error {
 	for a := retry.Start(apiCallRetryStrategy, s.clock); a.Next(); {
 		err := s.client.Call(rpc.Request{
 			Type:    facade,
-			Version: version,
+			Version: vers,
 			Id:      id,
 			Action:  method,
 		}, args, response)
-		if params.ErrCode(err) != params.CodeRetry {
+		if err == nil {
+			return nil
+		}
+		code := params.ErrCode(err)
+		if code == params.CodeRetry {
+			if !a.More() {
+				return errors.Annotatef(err, "too many retries")
+			}
+			continue
+		}
+		if code != params.CodeIncompatibleClient {
 			return errors.Trace(err)
 		}
-		if !a.More() {
-			return errors.Annotatef(err, "too many retries")
+		// Default to major version 2 for older servers.
+		serverMajorVersion := 2
+		err = errors.Cause(err)
+		apiErr, ok := err.(*rpc.RequestError)
+		if ok {
+			if serverVersion, ok := apiErr.Info["server-version"]; ok {
+				serverVers, err := version.Parse(fmt.Sprintf("%v", serverVersion))
+				if err == nil {
+					serverMajorVersion = serverVers.Major
+				}
+			}
 		}
+		logger.Debugf("%v.%v API call not supported", facade, method)
+		return errors.NewNotSupported(nil, fmt.Sprintf(
+			"juju client with major version %d used with a controller having major version %d not supported\nupdate your juju client to match the version running on the controller",
+			jujuversion.Current.Major, serverMajorVersion))
 	}
 	panic("unreachable")
 }

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1234,6 +1234,24 @@ func (s *apiclientSuite) TestLoginCapturesCLIArgs(c *gc.C) {
 	c.Assert(request.CLIArgs, gc.Equals, `this is "the test" command`)
 }
 
+func (s *apiclientSuite) TestLoginIncompatibleClient(c *gc.C) {
+	clock := &fakeClock{}
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(&rpc.RequestError{
+			Code: "incompatible client",
+			Info: map[string]interface{}{"server-version": "99.0.0"},
+		}),
+		Clock: clock,
+	})
+
+	err := conn.APICall("facade", 1, "id", "method", nil, nil)
+	c.Check(clock.waits, gc.HasLen, 0)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(
+		"juju client with major version %d used with a controller having major version %d not supported\\n.*",
+		jujuversion.Current.Major, 99,
+	))
+}
+
 type clientDNSNameSuite struct {
 	jjtesting.JujuConnSuite
 }

--- a/api/http.go
+++ b/api/http.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/params"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // HTTPClient implements Connection.APICaller.HTTPClient and returns an HTTP
@@ -106,6 +107,7 @@ func authHTTPRequest(req *http.Request, tag, password, nonce string, macaroons [
 	if nonce != "" {
 		req.Header.Set(params.MachineNonceHeader, nonce)
 	}
+	req.Header.Set(params.JujuClientVersion, jujuversion.Current.String())
 	req.Header.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
 	for _, ms := range macaroons {
 		encoded, err := encodeMacaroonSlice(ms)

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -23,6 +23,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/version"
 )
 
 type httpSuite struct {
@@ -230,8 +231,9 @@ func (s *httpSuite) TestAuthHTTPRequest(c *gc.C) {
 	req := s.authHTTPRequest(c, apiInfo)
 	_, _, ok := req.BasicAuth()
 	c.Assert(ok, jc.IsFalse)
-	c.Assert(req.Header, gc.HasLen, 1)
+	c.Assert(req.Header, gc.HasLen, 2)
 	c.Assert(req.Header.Get(httpbakery.BakeryProtocolHeader), gc.Equals, "3")
+	c.Assert(req.Header.Get(params.JujuClientVersion), gc.Equals, version.Current.String())
 
 	apiInfo.Nonce = "foo"
 	req = s.authHTTPRequest(c, apiInfo)

--- a/api/logsender/logsender.go
+++ b/api/logsender/logsender.go
@@ -39,6 +39,7 @@ func NewAPI(connector base.StreamConnector) *API {
 // which must be closed when finished with.
 func (api *API) LogWriter() (LogWriter, error) {
 	attrs := make(url.Values)
+	// TODO(wallyworld) - remove in juju 4
 	attrs.Set("jujuclientversion", version.Current.String())
 	// Version 1 does ping/pong handling.
 	attrs.Set("version", "1")

--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -179,6 +179,7 @@ func (c *Client) httpPost(modelUUID string, content io.ReadSeeker, endpoint, con
 // logs records can be fed into. The objects written should be params.LogRecords.
 func (c *Client) OpenLogTransferStream(modelUUID string) (base.Stream, error) {
 	attrs := url.Values{}
+	// TODO(wallyworld) - remove in juju 4
 	attrs.Set("jujuclientversion", jujuversion.Current.String())
 	headers := http.Header{}
 	headers.Set(params.MigrationModelHTTPHeader, modelUUID)

--- a/api/state.go
+++ b/api/state.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // Login authenticates as the entity with the given name and password
@@ -45,6 +46,7 @@ func (st *state) Login(tag names.Tag, password, nonce string, macaroons []macaro
 		Macaroons:     macaroons,
 		BakeryVersion: bakery.LatestVersion,
 		CLIArgs:       utils.CommandString(os.Args...),
+		ClientVersion: jujuversion.Current.String(),
 	}
 	// If we are in developer mode, add the stack location as user data to the
 	// login request. This will allow the apiserver to connect connection ids

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/rpcreflect"
+	"github.com/juju/version"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
@@ -130,11 +131,20 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 	if err != nil {
 		return fail, errors.Trace(err)
 	}
+
+	// Default client version to 2 since older 2.x clients
+	// don't send this field.
+	loginClientVersion := version.Number{Major: 2}
+	if clientVersion, err := version.Parse(req.ClientVersion); err == nil {
+		loginClientVersion = clientVersion
+	}
+
 	apiRoot, err = restrictAPIRoot(
 		a.srv,
 		apiRoot,
 		a.root.model,
 		*authResult,
+		loginClientVersion,
 	)
 	if err != nil {
 		return fail, errors.Trace(err)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type baseLoginSuite struct {
@@ -95,8 +96,9 @@ func (s *loginSuite) TestLoginWithInvalidTag(c *gc.C) {
 	st := s.openAPIWithoutLogin(c, info)
 
 	request := &params.LoginRequest{
-		AuthTag:     "bar",
-		Credentials: "password",
+		AuthTag:       "bar",
+		Credentials:   "password",
+		ClientVersion: jujuversion.Current.String(),
 	}
 
 	var response params.LoginResult
@@ -656,7 +658,8 @@ func (s *loginSuite) TestAnonymousControllerLogin(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag: names.NewUserTag(api.AnonymousUsername).String(),
+		AuthTag:       names.NewUserTag(api.AnonymousUsername).String(),
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -912,8 +915,9 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (*state.User, param
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1020,9 +1024,10 @@ func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
-		CLIArgs:     "hey you guys",
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		CLIArgs:       "hey you guys",
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1088,9 +1093,10 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
-		CLIArgs:     "hey you guys",
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		CLIArgs:       "hey you guys",
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	// No error yet since logging the conversation is deferred until
@@ -1126,9 +1132,10 @@ func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
-		CLIArgs:     "hey you guys",
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		CLIArgs:       "hey you guys",
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/firewall/egressaddresswatcher.go
+++ b/apiserver/common/firewall/egressaddresswatcher.go
@@ -9,9 +9,8 @@ import (
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/network"
 )
 
 // EgressAddressWatcher reports changes to addresses
@@ -143,7 +142,7 @@ func (w *EgressAddressWatcher) loop() error {
 			}
 			changed = false
 			if !setEquals(addresses, lastAddresses) {
-				addressesCIDR = corenetwork.SubnetsForAddresses(addresses.Values())
+				addressesCIDR = network.SubnetsForAddresses(addresses.Values())
 				ready = ready || sentInitial
 			}
 		}

--- a/apiserver/common/firewall/mock_test.go
+++ b/apiserver/common/firewall/mock_test.go
@@ -16,10 +16,9 @@ import (
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
-	corenetwork "github.com/juju/juju/core/network"
+	network "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -348,7 +347,7 @@ type mockUnit struct {
 	mu            sync.Mutex
 	name          string
 	assigned      bool
-	publicAddress corenetwork.SpaceAddress
+	publicAddress network.SpaceAddress
 	machineId     string
 }
 
@@ -364,19 +363,19 @@ func (u *mockUnit) Name() string {
 	return u.name
 }
 
-func (u *mockUnit) PublicAddress() (corenetwork.SpaceAddress, error) {
+func (u *mockUnit) PublicAddress() (network.SpaceAddress, error) {
 	u.MethodCall(u, "PublicAddress")
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
 	if err := u.NextErr(); err != nil {
-		return corenetwork.SpaceAddress{}, err
+		return network.SpaceAddress{}, err
 	}
 	if !u.assigned {
-		return corenetwork.SpaceAddress{}, errors.NotAssignedf(u.name)
+		return network.SpaceAddress{}, errors.NotAssignedf(u.name)
 	}
 	if u.publicAddress.Value == "" {
-		return corenetwork.SpaceAddress{}, network.NoAddressError("public")
+		return network.SpaceAddress{}, network.NoAddressError("public")
 	}
 	return u.publicAddress, nil
 }
@@ -396,7 +395,7 @@ func (u *mockUnit) updateAddress(value string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
-	u.publicAddress = corenetwork.NewSpaceAddress(value)
+	u.publicAddress = network.NewSpaceAddress(value)
 }
 
 type mockMachine struct {

--- a/apiserver/common/http.go
+++ b/apiserver/common/http.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/apiserver/params"
+)
+
+// JujuClientVersionFromRequest returns the Juju client version
+// number from the HTTP request.
+func JujuClientVersionFromRequest(req *http.Request) (version.Number, error) {
+	verStr := req.Header.Get(params.JujuClientVersion)
+	// TODO(wallyworld) - remove in juju 4
+	if verStr == "" {
+		verStr = req.URL.Query().Get("jujuclientversion")
+	}
+	if verStr == "" {
+		return version.Zero, errors.New(`missing "X-Juju-ClientVersion" in request headers`)
+	}
+	ver, err := version.Parse(verStr)
+	if err != nil {
+		return version.Zero, errors.Annotatef(err, "invalid X-Juju-ClientVersion %q", verStr)
+	}
+	return ver, nil
+}

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -341,6 +341,10 @@ func ServerError(err error) *params.Error {
 		}.AsMap()
 	case errors.IsQuotaLimitExceeded(err):
 		code = params.CodeQuotaLimitExceeded
+	case params.IsIncompatibleClientError(err):
+		code = params.CodeIncompatibleClient
+		rawErr := errors.Cause(err).(*params.IncompatibleClientError)
+		info = rawErr.AsMap()
 	default:
 		code = params.ErrCode(err)
 	}

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/network"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type errorsSuite struct {
@@ -215,6 +216,22 @@ var errorTransformTests = []struct {
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeQuotaLimitExceeded,
 }, {
+	err: &params.IncompatibleClientError{
+		ServerVersion: jujuversion.Current,
+	},
+	code:   params.CodeIncompatibleClient,
+	status: http.StatusInternalServerError,
+	helperFunc: func(err error) bool {
+		err1, ok := err.(*params.Error)
+		err2 := &params.IncompatibleClientError{
+			ServerVersion: jujuversion.Current,
+		}
+		if !ok || err1.Info == nil || !reflect.DeepEqual(err1.Info, err2.AsMap()) {
+			return false
+		}
+		return true
+	},
+}, {
 	err:    nil,
 	code:   "",
 	status: http.StatusOK,
@@ -280,7 +297,8 @@ func (s *errorsSuite) TestErrorTransform(c *gc.C) {
 			params.CodeDischargeRequired,
 			params.CodeModelNotFound,
 			params.CodeRetry,
-			params.CodeRedirect:
+			params.CodeRedirect,
+			params.CodeIncompatibleClient:
 			continue
 		case params.CodeOperationBlocked:
 			// ServerError doesn't actually have a case for this code.

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -132,6 +133,13 @@ func TestingRestrictedRoot(check func(string, string) error) rpc.Root {
 func TestingAboutToRestoreRoot() rpc.Root {
 	r := TestingAPIRoot(AllFacades())
 	return restrictRoot(r, aboutToRestoreMethodsOnly)
+}
+
+// TestingUpgradeOrMigrationOnlyRoot returns a restricted srvRoot
+// as if called from a newer client.
+func TestingUpgradeOrMigrationOnlyRoot(userLogin bool, clientVersion version.Number) rpc.Root {
+	r := TestingAPIRoot(AllFacades())
+	return restrictRoot(r, checkClientVersion(userLogin, clientVersion))
 }
 
 // PatchGetMigrationBackend overrides the getMigrationBackend function

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/retry"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/params"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
@@ -109,6 +110,28 @@ func NewNetworkInfoForStrategy(
 		netInfo, err = newNetworkInfoCAAS(base)
 	}
 	return netInfo, errors.Trace(err)
+}
+
+// validateEndpoints returns the endpoints from the input slice that are
+// valid for the unit.
+// Any invalid endpoints are indicated as errors in the returned results.
+func (n *NetworkInfoBase) validateEndpoints(endpoints []string) (set.Strings, params.NetworkInfoResults) {
+	valid := set.NewStrings()
+	result := params.NetworkInfoResults{Results: make(map[string]params.NetworkInfoResult)}
+
+	// For each of the endpoints in the request, get the bound space and
+	// initialise the endpoint egress map with the model's configured
+	// egress subnets. Keep track of the spaces that we observe.
+	for _, endpoint := range endpoints {
+		if _, ok := n.bindings[endpoint]; ok {
+			valid.Add(endpoint)
+		} else {
+			err := errors.NotValidf("undefined for unit charm: endpoint %q", endpoint)
+			result.Results[endpoint] = params.NetworkInfoResult{Error: apiservererrors.ServerError(err)}
+		}
+	}
+
+	return valid, result
 }
 
 // getRelationAndEndpointName returns the relation for the input ID
@@ -284,7 +307,7 @@ func (n *NetworkInfoBase) pollForAddress(
 		return err
 	}
 	retryArg.IsFatalError = func(err error) bool {
-		return !network.IsNoAddressError(err)
+		return !corenetwork.IsNoAddressError(err)
 	}
 	return address, retry.Call(retryArg)
 }

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -4,16 +4,12 @@
 package uniter
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	k8score "k8s.io/api/core/v1"
 
-	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/params"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	corenetwork "github.com/juju/juju/core/network"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 
@@ -41,82 +37,51 @@ func newNetworkInfoCAAS(base *NetworkInfoBase) (*NetworkInfoCAAS, error) {
 
 // ProcessAPIRequest handles a request to the uniter API NetworkInfo method.
 func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (params.NetworkInfoResults, error) {
-	bindings := make(map[string]string)
-	endpointEgressSubnets := make(map[string][]string)
+	validEndpoints, result := n.validateEndpoints(args.Endpoints)
 
-	result := params.NetworkInfoResults{
-		Results: make(map[string]params.NetworkInfoResult),
-	}
-
-	// For each of the endpoints in the request, get the bound space and
-	// initialise the endpoint egress map with the model's configured
-	// egress subnets.
-	for _, endpoint := range args.Endpoints {
-		binding, ok := n.bindings[endpoint]
-		if ok {
-			// In practice this is always the alpha space in CAAS.
-			// This loop serves as validation of input until this changes.
-			bindings[endpoint] = binding
+	// We record the interface addresses as the machine local ones.
+	// These are used later as the binding addresses.
+	// For CAAS models, we need to default ingress addresses to all other
+	// address scopes so record those in the default ingress address slice.
+	var interfaceAddr []params.InterfaceAddress
+	var defaultIngressAddresses []string
+	for _, a := range n.addresses {
+		if a.Scope == corenetwork.ScopeMachineLocal {
+			interfaceAddr = append(interfaceAddr, params.InterfaceAddress{Address: a.Value})
 		} else {
-			err := errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
-			result.Results[endpoint] = params.NetworkInfoResult{Error: apiservererrors.ServerError(err)}
+			defaultIngressAddresses = append(defaultIngressAddresses, a.Value)
 		}
-		endpointEgressSubnets[endpoint] = n.defaultEgress
 	}
 
-	endpointIngressAddresses := make(map[string]corenetwork.SpaceAddresses)
-
-	// If we are working in a relation context, get the network information for
-	// the relation and set it for the relation's binding.
+	// If we are working in a relation context,
+	// get the network information for the relation
+	// and set it for the relation's binding.
 	if args.RelationId != nil {
 		endpoint, _, ingress, egress, err := n.getRelationNetworkInfo(*args.RelationId)
 		if err != nil {
 			return params.NetworkInfoResults{}, err
 		}
 
-		if len(egress) > 0 {
-			endpointEgressSubnets[endpoint] = egress
-		}
-		endpointIngressAddresses[endpoint] = ingress
-	}
-
-	// We record the interface addresses as the machine local ones - these
-	// are used later as the binding addresses.
-	// For CAAS models, we need to default ingress addresses to all available
-	// addresses so record those in the default ingress address slice.
-	var interfaceAddr []network.InterfaceAddress
-	var defaultIngressAddresses []string
-	for _, a := range n.addresses {
-		if a.Scope == corenetwork.ScopeMachineLocal {
-			interfaceAddr = append(interfaceAddr, network.InterfaceAddress{Address: a.Value})
-		} else {
-			defaultIngressAddresses = append(defaultIngressAddresses, a.Value)
+		result.Results[endpoint] = params.NetworkInfoResult{
+			Info:             []params.NetworkInfo{{Addresses: interfaceAddr}},
+			EgressSubnets:    egress,
+			IngressAddresses: ingress.Values(),
 		}
 	}
 
-	networkInfos := make(map[string]machineNetworkInfoResult)
-	networkInfos[corenetwork.AlphaSpaceId] = machineNetworkInfoResult{
-		NetworkInfos: []network.NetworkInfo{{Addresses: interfaceAddr}},
-	}
+	// For each of the requested endpoints, set any empty results to the
+	// defaults determined above.
+	for _, endpoint := range validEndpoints.Values() {
+		info, ok := result.Results[endpoint]
+		if !ok {
+			info = params.NetworkInfoResult{
+				Info:          []params.NetworkInfo{{Addresses: interfaceAddr}},
+				EgressSubnets: n.defaultEgress,
+			}
+		}
 
-	for endpoint, space := range bindings {
-		// The binding address information based on link layer devices.
-		info := machineNetworkInfoResultToNetworkInfoResult(networkInfos[space])
-
-		info.EgressSubnets = endpointEgressSubnets[endpoint]
-		info.IngressAddresses = endpointIngressAddresses[endpoint].Values()
-
-		// If there is no ingress address explicitly defined for a given
-		// binding, set the ingress addresses to either any defaults set above,
-		// or the binding addresses.
 		if len(info.IngressAddresses) == 0 {
 			info.IngressAddresses = defaultIngressAddresses
-		}
-
-		if len(info.IngressAddresses) == 0 {
-			ingress := spaceAddressesFromNetworkInfo(networkInfos[space].NetworkInfos)
-			corenetwork.SortAddresses(ingress)
-			info.IngressAddresses = ingress.Values()
 		}
 
 		if len(info.EgressSubnets) == 0 {

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -32,20 +32,15 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 	bindings := make(map[string]string)
 	endpointEgressSubnets := make(map[string][]string)
 
-	result := params.NetworkInfoResults{
-		Results: make(map[string]params.NetworkInfoResult),
-	}
-	// For each of the endpoints in the request, get the bound space and
-	// initialise the endpoint egress map with the model's configured
-	// egress subnets. Keep track of the spaces that we observe.
-	for _, endpoint := range args.Endpoints {
-		if binding, ok := n.bindings[endpoint]; ok {
-			spaces.Add(binding)
-			bindings[endpoint] = binding
-		} else {
-			err := errors.NewNotValid(nil, fmt.Sprintf("binding name %q not defined by the unit's charm", endpoint))
-			result.Results[endpoint] = params.NetworkInfoResult{Error: apiservererrors.ServerError(err)}
-		}
+	// For each of the valid endpoints in the request,
+	// get the bound space and initialise the endpoint egress
+	// map with the model's configured egress subnets.
+	// Keep track of the spaces that we observe.
+	validEndpoints, result := n.validateEndpoints(args.Endpoints)
+	for _, endpoint := range validEndpoints.Values() {
+		binding := n.bindings[endpoint]
+		spaces.Add(binding)
+		bindings[endpoint] = binding
 		endpointEgressSubnets[endpoint] = n.defaultEgress
 	}
 
@@ -170,8 +165,8 @@ func (n *NetworkInfoBase) spaceForBinding(endpoint string) (string, error) {
 	return boundSpace, nil
 }
 
-// machineNetworkInfos returns network info for the unit's machine based on
-// devices with addresses in the input spaces.
+// machineNetworkInfos returns network info for the unit's machine
+// based on devices with addresses in the input spaces.
 func (n *NetworkInfoBase) machineNetworkInfos(spaceIDs ...string) (map[string]machineNetworkInfoResult, error) {
 	machineID, err := n.unit.AssignedMachineId()
 	if err != nil {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -29,10 +29,9 @@ import (
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/feature"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/state/watcher"
@@ -588,7 +587,7 @@ func (u *UniterAPI) PublicAddress(args params.Entities) (params.StringResults, e
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				var address corenetwork.SpaceAddress
+				var address network.SpaceAddress
 				address, err = unit.PublicAddress()
 				if err == nil {
 					result.Results[i].Result = address.Value
@@ -622,7 +621,7 @@ func (u *UniterAPI) PrivateAddress(args params.Entities) (params.StringResults, 
 			var unit *state.Unit
 			unit, err = u.getUnit(tag)
 			if err == nil {
-				var address corenetwork.SpaceAddress
+				var address network.SpaceAddress
 				address, err = unit.PrivateAddress()
 				if err == nil {
 					result.Results[i].Result = address.Value
@@ -1109,7 +1108,7 @@ func (u *UniterAPI) OpenPorts(args params.EntitiesPortRanges) (params.ErrorResul
 		// subnets. Instead, it was assumed that the port range was
 		// always opened in all subnets. To emulate this behavior, we
 		// simply open the requested port range for all endpoints.
-		unitPortRanges.Open("", corenetwork.PortRange{
+		unitPortRanges.Open("", network.PortRange{
 			FromPort: entity.FromPort,
 			ToPort:   entity.ToPort,
 			Protocol: entity.Protocol,
@@ -1158,7 +1157,7 @@ func (u *UniterAPI) ClosePorts(args params.EntitiesPortRanges) (params.ErrorResu
 		// subnets. Instead, it was assumed that the port range was
 		// always opened in all subnets. To emulate this behavior, we
 		// simply close the requested port range for all endpoints.
-		unitPortRanges.Close("", corenetwork.PortRange{
+		unitPortRanges.Close("", network.PortRange{
 			FromPort: entity.FromPort,
 			ToPort:   entity.ToPort,
 			Protocol: entity.Protocol,
@@ -2753,7 +2752,7 @@ func (u *UniterAPIV4) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 	}
 
 	var results []params.NetworkConfig
-	if boundSpace == corenetwork.AlphaSpaceId {
+	if boundSpace == network.AlphaSpaceId {
 		logger.Debugf(
 			"endpoint %q not explicitly bound to a space, using preferred private address for machine %q",
 			bindingName, machineID,
@@ -3671,7 +3670,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 			// not populate the new Endpoint field; this
 			// effectively opens the port for all endpoints and
 			// emulates pre-2.9 behavior.
-			unitPortRanges.Open(r.Endpoint, corenetwork.PortRange{
+			unitPortRanges.Open(r.Endpoint, network.PortRange{
 				FromPort: r.FromPort,
 				ToPort:   r.ToPort,
 				Protocol: r.Protocol,
@@ -3687,7 +3686,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 			// not populate the new Endpoint field; this
 			// effectively closes the port for all endpoints and
 			// emulates pre-2.9 behavior.
-			unitPortRanges.Close(r.Endpoint, corenetwork.PortRange{
+			unitPortRanges.Close(r.Endpoint, network.PortRange{
 				FromPort: r.FromPort,
 				ToPort:   r.ToPort,
 				Protocol: r.Protocol,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4645,7 +4645,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoPermissions(c *gc.C) {
 				Results: map[string]params.NetworkInfoResult{
 					"unknown": {
 						Error: &params.Error{
-							Message: `binding name "unknown" not defined by the unit's charm`,
+							Message: `undefined for unit charm: endpoint "unknown" not valid`,
 						},
 					},
 				},

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -98,7 +98,7 @@ var scenarioStatus = &params.FullStatus{
 		Type:        "iaas",
 		CloudTag:    "cloud-dummy",
 		CloudRegion: "dummy-region",
-		Version:     "1.2.3",
+		Version:     "2.0.0",
 		ModelStatus: params.DetailedStatus{
 			Status: "available",
 		},
@@ -383,7 +383,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 	setDefaultPassword(c, u)
 	add(u)
 	err = s.Model.UpdateModelConfig(map[string]interface{}{
-		config.AgentVersionKey: "1.2.3"}, nil)
+		config.AgentVersionKey: "2.0.0"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	u = s.Factory.MakeUser(c, &factory.UserParams{Name: "other"})

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -291,11 +291,11 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), false)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+1)),
+		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major)),
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, gc.ErrorMatches, `
-these models must first be upgraded to at least 2.9.0 before upgrading the controller:
+these models must first be upgraded to at least 2.9.* before upgrading the controller:
  -admin/controller`[1:])
 }
 

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -55,6 +55,8 @@ import (
 	jujuversion "github.com/juju/juju/version"
 )
 
+var validVersion = version.MustParse(fmt.Sprintf("%d.66.666", jujuversion.Current.Major))
+
 type serverSuite struct {
 	baseSuite
 	client     *client.Client
@@ -278,11 +280,23 @@ func (s *serverSuite) assertModelVersion(c *gc.C, st *state.State, expected stri
 
 func (s *serverSuite) TestSetModelAgentVersion(c *gc.C) {
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertModelVersion(c, s.State, "9.8.7")
+	s.assertModelVersion(c, s.State, validVersion.String())
+}
+
+func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
+	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), false)
+	c.Assert(err, jc.ErrorIsNil)
+	args := params.SetModelAgentVersion{
+		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+1)),
+	}
+	err = s.client.SetModelAgentVersion(args)
+	c.Assert(err, gc.ErrorMatches, `
+these models must first be upgraded to at least 2.9.0 before upgrading the controller:
+ -admin/controller`[1:])
 }
 
 func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {
@@ -308,20 +322,22 @@ func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {
 
 	// This should be refused because an agent doesn't match "currentVersion"
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Check(err, gc.ErrorMatches, "some agents have not upgraded to the current model version .*: unit-wordpress-0")
 	// Version hasn't changed
 	s.assertModelVersion(c, s.State, currentVersion)
 	// But we can force it
+	to := validVersion
+	to.Minor++
 	args = params.SetModelAgentVersion{
-		Version:             version.MustParse("7.8.6"),
+		Version:             to,
 		IgnoreAgentVersions: true,
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertModelVersion(c, s.State, "7.8.6")
+	s.assertModelVersion(c, s.State, to.String())
 }
 
 func (s *serverSuite) makeMigratingModel(c *gc.C, name string, mode state.MigrationMode) {
@@ -340,7 +356,7 @@ func (s *serverSuite) TestControllerModelSetModelAgentVersionBlockedByImportingM
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "some-user"})
 	s.makeMigratingModel(c, "to-migrate", state.MigrationModeImporting)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, gc.ErrorMatches, `model "some-user/to-migrate" is importing, upgrade blocked`)
@@ -350,7 +366,7 @@ func (s *serverSuite) TestControllerModelSetModelAgentVersionBlockedByExportingM
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "some-user"})
 	s.makeMigratingModel(c, "to-migrate", state.MigrationModeExporting)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, gc.ErrorMatches, `model "some-user/to-migrate" is exporting, upgrade blocked`)
@@ -385,7 +401,7 @@ func (s *serverSuite) TestControllerModelSetModelAgentVersionChecksReplicaset(c 
 	}
 	client.OverrideClientBackendMongoSession(s.client, session)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err.Error(), gc.Equals, "checking replicaset status: boom")
@@ -432,7 +448,7 @@ func (s *serverSuite) assertCheckProviderAPI(c *gc.C, envError error, expectErr 
 		return env, nil
 	}
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(env.allInstancesCalled, jc.IsTrue)
@@ -470,7 +486,7 @@ func (s *serverSuite) assertCheckCAASProviderAPI(c *gc.C, envError error, expect
 		return env, nil
 	}
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(env.getMetadataCalled, jc.IsTrue)
@@ -491,7 +507,7 @@ func (s *serverSuite) TestCheckCAASProviderAPIFail(c *gc.C) {
 
 func (s *serverSuite) assertSetModelAgentVersion(c *gc.C) {
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -499,12 +515,12 @@ func (s *serverSuite) assertSetModelAgentVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	agentVersion, found := modelConfig.AllAttrs()["agent-version"]
 	c.Assert(found, jc.IsTrue)
-	c.Assert(agentVersion, gc.Equals, "9.8.7")
+	c.Assert(agentVersion, gc.Equals, validVersion.String())
 }
 
 func (s *serverSuite) assertSetModelAgentVersionBlocked(c *gc.C, msg string) {
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse("9.8.7"),
+		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
 	s.AssertBlocked(c, err, msg)
@@ -535,8 +551,8 @@ func (s *serverSuite) TestAbortCurrentUpgrade(c *gc.C) {
 	// Start an upgrade.
 	_, err = s.State.EnsureUpgradeInfo(
 		machine.Id(),
-		version.MustParse("1.2.3"),
-		version.MustParse("9.8.7"),
+		version.MustParse("2.0.0"),
+		version.MustParse(validVersion.String()),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	isUpgrading, err := s.State.IsUpgrading()
@@ -575,8 +591,8 @@ func (s *serverSuite) setupAbortCurrentUpgradeBlocked(c *gc.C) {
 	// Start an upgrade.
 	_, err = s.State.EnsureUpgradeInfo(
 		machine.Id(),
-		version.MustParse("1.2.3"),
-		version.MustParse("9.8.7"),
+		version.MustParse("2.0.0"),
+		version.MustParse(validVersion.String()),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	isUpgrading, err := s.State.IsUpgrading()
@@ -921,42 +937,65 @@ func (s *clientSuite) TestClientWatchAllReadPermission(c *gc.C) {
 		err := watcher.Stop()
 		c.Assert(err, jc.ErrorIsNil)
 	}()
-	deltas, err := watcher.Next()
-	c.Assert(err, jc.ErrorIsNil)
-	// Model and machine deltas returned.
-	c.Assert(len(deltas), gc.Equals, 2)
-	var d0 *params.MachineInfo
-	for _, delta := range deltas {
-		d, ok := delta.Entity.(*params.MachineInfo)
-		if ok {
-			d0 = d
-			break
+
+	deltasCh := make(chan []params.Delta)
+	go func() {
+		for {
+			deltas, err := watcher.Next()
+			if err != nil {
+				return // watcher stopped
+			}
+			deltasCh <- deltas
 		}
+	}()
+
+	machineReady := func(got *params.MachineInfo) bool {
+		equal, _ := jc.DeepEqual(got, &params.MachineInfo{
+			ModelUUID:  s.State.ModelUUID(),
+			Id:         m.Id(),
+			InstanceId: "i-0",
+			AgentStatus: params.StatusInfo{
+				Current: status.Pending,
+			},
+			InstanceStatus: params.StatusInfo{
+				Current: status.Pending,
+			},
+			Life:                    life.Alive,
+			Series:                  "quantal",
+			Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
+			Addresses:               []params.Address{},
+			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			HasVote:                 false,
+			WantsVote:               true,
+		})
+		return equal
 	}
-	c.Assert(d0, gc.NotNil)
-	d0.AgentStatus.Since = nil
-	d0.InstanceStatus.Since = nil
-	if !c.Check(d0, jc.DeepEquals, &params.MachineInfo{
-		ModelUUID:  s.State.ModelUUID(),
-		Id:         m.Id(),
-		InstanceId: "i-0",
-		AgentStatus: params.StatusInfo{
-			Current: status.Pending,
-		},
-		InstanceStatus: params.StatusInfo{
-			Current: status.Pending,
-		},
-		Life:                    life.Alive,
-		Series:                  "quantal",
-		Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
-		Addresses:               []params.Address{},
-		HardwareCharacteristics: &instance.HardwareCharacteristics{},
-		HasVote:                 false,
-		WantsVote:               true,
-	}) {
-		c.Logf("got:")
-		for _, d := range deltas {
-			c.Logf("%#v\n", d.Entity)
+
+	machineMatched := false
+	timeout := time.After(coretesting.LongWait)
+	i := 0
+	for !machineMatched {
+		select {
+		case deltas := <-deltasCh:
+			for _, delta := range deltas {
+				entity := delta.Entity
+				c.Logf("delta.Entity %d kind %s: %#v", i, entity.EntityId().Kind, entity)
+				i++
+
+				switch entity.EntityId().Kind {
+				case multiwatcher.MachineKind:
+					machine := entity.(*params.MachineInfo)
+					machine.AgentStatus.Since = nil
+					machine.InstanceStatus.Since = nil
+					if machineReady(machine) {
+						machineMatched = true
+					} else {
+						c.Log("machine delta not yet matched")
+					}
+				}
+			}
+		case <-timeout:
+			c.Fatal("timed out waiting for watcher deltas to be ready")
 		}
 	}
 }
@@ -995,92 +1034,87 @@ func (s *clientSuite) TestClientWatchAllAdminPermission(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 
-	watcherNextError := make(chan error)
-	var allDeltas []params.Delta
-
-	// Accrue deltas until we get 3 deltas - one each for model, machine
-	// and remote application.
-	// Send any error out on the result channel, because gc.C is not
-	// Goroutine safe.
+	deltasCh := make(chan []params.Delta)
 	go func() {
-		for len(allDeltas) < 3 {
+		for {
 			deltas, err := watcher.Next()
 			if err != nil {
-				watcherNextError <- err
-				return
+				return // watcher stopped
 			}
-			allDeltas = append(allDeltas, deltas...)
+			deltasCh <- deltas
 		}
-		watcherNextError <- nil
 	}()
 
-	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
-
-	select {
-	case err := <-watcherNextError:
-		c.Assert(err, jc.ErrorIsNil)
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for watcher delta accrual to complete")
+	machineReady := func(got *params.MachineInfo) bool {
+		equal, _ := jc.DeepEqual(got, &params.MachineInfo{
+			ModelUUID:  s.State.ModelUUID(),
+			Id:         m.Id(),
+			InstanceId: "i-0",
+			AgentStatus: params.StatusInfo{
+				Current: status.Pending,
+			},
+			InstanceStatus: params.StatusInfo{
+				Current: status.Pending,
+			},
+			Life:                    life.Alive,
+			Series:                  "quantal",
+			Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
+			Addresses:               []params.Address{},
+			HardwareCharacteristics: &instance.HardwareCharacteristics{},
+			HasVote:                 false,
+			WantsVote:               true,
+		})
+		return equal
 	}
 
-	// A delta each for model, machine, and remote application.
-	c.Assert(len(allDeltas), gc.Equals, 3)
-	var dMachine *params.MachineInfo
-	var dApp *params.RemoteApplicationUpdate
-	for i := 0; (dMachine == nil || dApp == nil) && i < len(allDeltas); i++ {
-		entity := allDeltas[i].Entity
-		switch entity.EntityId().Kind {
-		case multiwatcher.MachineKind:
-			dMachine = entity.(*params.MachineInfo)
-		case multiwatcher.RemoteApplicationKind:
-			dApp = entity.(*params.RemoteApplicationUpdate)
-		default:
-			// don't worry about the model
-		}
+	appReady := func(got *params.RemoteApplicationUpdate) bool {
+		equal, _ := jc.DeepEqual(got, &params.RemoteApplicationUpdate{
+			Name:      "remote-db2",
+			ModelUUID: s.State.ModelUUID(),
+			OfferUUID: "offer-uuid",
+			OfferURL:  "admin/prod.db2",
+			Life:      "alive",
+			Status: params.StatusInfo{
+				Current: status.Unknown,
+			},
+		})
+		return equal
 	}
-	c.Assert(dMachine, gc.NotNil)
-	c.Assert(dApp, gc.NotNil)
 
-	dMachine.AgentStatus.Since = nil
-	dMachine.InstanceStatus.Since = nil
-	dApp.Status.Since = nil
+	machineMatched := false
+	appMatched := false
+	timeout := time.After(coretesting.LongWait)
+	i := 0
+	for !machineMatched || !appMatched {
+		select {
+		case deltas := <-deltasCh:
+			for _, delta := range deltas {
+				entity := delta.Entity
+				c.Logf("delta.Entity %d kind %s: %#v", i, entity.EntityId().Kind, entity)
+				i++
 
-	if !c.Check(dMachine, jc.DeepEquals, &params.MachineInfo{
-		ModelUUID:  s.State.ModelUUID(),
-		Id:         m.Id(),
-		InstanceId: "i-0",
-		AgentStatus: params.StatusInfo{
-			Current: status.Pending,
-		},
-		InstanceStatus: params.StatusInfo{
-			Current: status.Pending,
-		},
-		Life:                    life.Alive,
-		Series:                  "quantal",
-		Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
-		Addresses:               []params.Address{},
-		HardwareCharacteristics: &instance.HardwareCharacteristics{},
-		HasVote:                 false,
-		WantsVote:               true,
-	}) {
-		c.Logf("got:")
-		for _, d := range allDeltas {
-			c.Logf("%#v\n", d.Entity)
-		}
-	}
-	if !c.Check(dApp, jc.DeepEquals, &params.RemoteApplicationUpdate{
-		Name:      "remote-db2",
-		ModelUUID: s.State.ModelUUID(),
-		OfferUUID: "offer-uuid",
-		OfferURL:  "admin/prod.db2",
-		Life:      "alive",
-		Status: params.StatusInfo{
-			Current: status.Unknown,
-		},
-	}) {
-		c.Logf("got:")
-		for _, d := range allDeltas {
-			c.Logf("%#v\n", d.Entity)
+				switch entity.EntityId().Kind {
+				case multiwatcher.MachineKind:
+					machine := entity.(*params.MachineInfo)
+					machine.AgentStatus.Since = nil
+					machine.InstanceStatus.Since = nil
+					if machineReady(machine) {
+						machineMatched = true
+					} else {
+						c.Log("machine delta not yet matched")
+					}
+				case multiwatcher.RemoteApplicationKind:
+					app := entity.(*params.RemoteApplicationUpdate)
+					app.Status.Since = nil
+					if appReady(app) {
+						appMatched = true
+					} else {
+						c.Log("remote application delta not yet matched")
+					}
+				}
+			}
+		case <-timeout:
+			c.Fatal("timed out waiting for watcher deltas to be ready")
 		}
 	}
 }
@@ -1799,7 +1833,7 @@ func (s *clientSuite) TestAPIHostPorts(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientAgentVersion(c *gc.C) {
-	current := version.MustParse("1.2.0")
+	current := version.MustParse("2.0.0")
 	s.PatchValue(&jujuversion.Current, current)
 	result, err := s.APIState.Client().AgentVersion()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -422,7 +422,7 @@ func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) 
 	if err != nil {
 		return func() {}, err
 	}
-	ver := version.Number{Major: 1, Minor: 2, Patch: 3}
+	ver := version.Number{Major: 2, Minor: 0, Patch: 0}
 	err = st.Client().SetModelAgentVersion(ver, false)
 	if err != nil {
 		return func() {}, err

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -823,6 +823,9 @@
                         "cli-args": {
                             "type": "string"
                         },
+                        "client-version": {
+                            "type": "string"
+                        },
                         "credentials": {
                             "type": "string"
                         },

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -135,7 +136,7 @@ func (s *agentLoggingStrategy) init(ctxt httpContext, req *http.Request) error {
 	// *Juju* version be provided as part of the request. Any
 	// attempt to open this endpoint to broader access must
 	// address this caveat appropriately.
-	ver, err := logsink.JujuClientVersionFromRequest(req)
+	ver, err := common.JujuClientVersionFromRequest(req)
 	if err != nil {
 		st.Release()
 		return errors.Trace(err)

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/ratelimit"
-	"github.com/juju/version"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/apiserver/httpcontext"
@@ -375,20 +374,6 @@ func (h *logSinkHandler) sendError(ws *websocket.Conn, req *http.Request, err er
 		logger.Errorf("closing websocket, %v", err)
 		ws.Close()
 	}
-}
-
-// JujuClientVersionFromRequest returns the Juju client version
-// number from the HTTP request.
-func JujuClientVersionFromRequest(req *http.Request) (version.Number, error) {
-	verStr := req.URL.Query().Get("jujuclientversion")
-	if verStr == "" {
-		return version.Zero, errors.New(`missing "jujuclientversion" in URL query`)
-	}
-	ver, err := version.Parse(verStr)
-	if err != nil {
-		return version.Zero, errors.Annotatef(err, "invalid jujuclientversion %q", verStr)
-	}
-	return ver, nil
 }
 
 // ratelimitClock adapts clock.Clock to ratelimit.Clock.

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -6,7 +6,6 @@ package apiserver_test
 import (
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -51,10 +50,7 @@ func (s *logsinkSuite) SetUpTest(c *gc.C) {
 	s.machineTag = m.Tag()
 	s.password = password
 
-	url := s.URL(
-		"/model/"+s.State.ModelUUID()+"/logsink",
-		url.Values{"jujuclientversion": {version.Current.String()}},
-	)
+	url := s.URL("/model/"+s.State.ModelUUID()+"/logsink", nil)
 	url.Scheme = "wss"
 	s.url = url.String()
 
@@ -235,5 +231,6 @@ func (s *logsinkSuite) dialWebsocket(c *gc.C) *websocket.Conn {
 func (s *logsinkSuite) makeAuthHeader() http.Header {
 	header := jujuhttp.BasicAuthHeader(s.machineTag.String(), s.password)
 	header.Add(params.MachineNonceHeader, s.nonce)
+	header.Add(params.JujuClientVersion, version.Current.String())
 	return header
 }

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/logsink"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/state"
@@ -50,7 +51,7 @@ func (s *migrationLoggingStrategy) init(ctxt httpContext, req *http.Request) err
 	// passed, even though we don't use it anywhere at the moment - it
 	// provides future-proofing if we need to do some kind of
 	// conversion of log messages from an old client.
-	_, err = logsink.JujuClientVersionFromRequest(req)
+	_, err = common.JujuClientVersionFromRequest(req)
 	if err != nil {
 		st.Release()
 		return errors.Trace(err)

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -6,7 +6,6 @@ package apiserver_test
 import (
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -52,9 +51,7 @@ func (s *logtransferSuite) SetUpTest(c *gc.C) {
 	s.machinePassword = password
 	s.setUserAccess(c, permission.SuperuserAccess)
 
-	url := s.URL("/migrate/logtransfer", url.Values{
-		"jujuclientversion": {version.Current.String()},
-	})
+	url := s.URL("/migrate/logtransfer", nil)
 	url.Scheme = "wss"
 	s.url = url.String()
 
@@ -66,6 +63,7 @@ func (s *logtransferSuite) SetUpTest(c *gc.C) {
 func (s *logtransferSuite) makeAuthHeader() http.Header {
 	header := jujuhttp.BasicAuthHeader(s.userTag.String(), s.password)
 	header.Add(params.MigrationModelHTTPHeader, s.State.ModelUUID())
+	header.Add(params.JujuClientVersion, version.Current.String())
 	return header
 }
 
@@ -107,12 +105,14 @@ func (s *logtransferSuite) TestRejectsBadMigratingModelUUID(c *gc.C) {
 }
 
 func (s *logtransferSuite) TestRejectsInvalidVersion(c *gc.C) {
-	url := s.URL("/migrate/logtransfer", url.Values{"jujuclientversion": {"blah"}})
+	url := s.URL("/migrate/logtransfer", nil)
 	url.Scheme = "wss"
-	conn, _, err := dialWebsocketFromURL(c, url.String(), s.makeAuthHeader())
+	hdr := s.makeAuthHeader()
+	hdr.Set("X-Juju-ClientVersion", "blah")
+	conn, _, err := dialWebsocketFromURL(c, url.String(), hdr)
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
-	websockettest.AssertJSONError(c, conn, `^initialising migration logsink session: invalid jujuclientversion "blah".*`)
+	websockettest.AssertJSONError(c, conn, `^initialising migration logsink session: invalid X-Juju-ClientVersion "blah".*`)
 	websockettest.AssertWebsocketClosed(c, conn)
 }
 

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/version"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon.v2"
 )
@@ -22,6 +23,30 @@ var UpgradeInProgressError = errors.New(CodeUpgradeInProgress)
 
 // MigrationInProgressError signifies a migration is in progress.
 var MigrationInProgressError = errors.New(CodeMigrationInProgress)
+
+// IncompatibleClientError signifies the connecting client is not
+// compatible with the controller.
+type IncompatibleClientError struct {
+	ServerVersion version.Number
+}
+
+// Error implements error.
+func (e *IncompatibleClientError) Error() string {
+	return fmt.Sprintf("client incompatible with server %v", e.ServerVersion)
+}
+
+// AsMap returns the data for the RPC error Info field.
+func (e *IncompatibleClientError) AsMap() map[string]interface{} {
+	return map[string]interface{}{
+		"server-version": e.ServerVersion,
+	}
+}
+
+// IsIncompatibleClientError returns true if this err is a IncompatibleClientError.
+func IsIncompatibleClientError(err error) bool {
+	_, ok := errors.Cause(err).(*IncompatibleClientError)
+	return ok
+}
 
 // Error is the type of error returned by any call to the state API.
 type Error struct {
@@ -172,6 +197,7 @@ const (
 	CodeAlreadyExists             = "already exists"
 	CodeUpgradeInProgress         = "upgrade in progress"
 	CodeMigrationInProgress       = "model migration in progress"
+	CodeIncompatibleClient        = "incompatible client"
 	CodeActionNotAvailable        = "action no longer available"
 	CodeOperationBlocked          = "operation is blocked"
 	CodeLeadershipClaimDenied     = "leadership claim denied"

--- a/apiserver/params/constants.go
+++ b/apiserver/params/constants.go
@@ -31,4 +31,7 @@ const (
 	ResolvedNoHooks    ResolvedMode = "no-hooks"
 )
 
-const MachineNonceHeader = "X-Juju-Nonce"
+const (
+	MachineNonceHeader = "X-Juju-Nonce"
+	JujuClientVersion  = "X-Juju-ClientVersion"
+)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -549,6 +549,7 @@ type LoginRequest struct {
 	BakeryVersion bakery.Version   `json:"bakery-version,omitempty"`
 	CLIArgs       string           `json:"cli-args,omitempty"`
 	UserData      string           `json:"user-data"`
+	ClientVersion string           `json:"client-version,omitempty"`
 }
 
 // LoginRequestCompat holds credentials for identifying an entity to the Login v1

--- a/apiserver/restrict_newer_client.go
+++ b/apiserver/restrict_newer_client.go
@@ -1,0 +1,145 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"github.com/juju/collections/set"
+	"github.com/juju/version"
+
+	"github.com/juju/juju/apiserver/params"
+	jujuversion "github.com/juju/juju/version"
+)
+
+// minAgentMinorVersions defines the minimum minor version
+// for a major agent version making api calls to a controller
+// with a newer major version.
+var minAgentMinorVersions = map[int]int{
+	2: 9,
+}
+
+func checkClientVersion(userLogin bool, clientVersion version.Number) func(facadeName, methodName string) error {
+	return func(facadeName, methodName string) error {
+		incompatibleClientError := &params.IncompatibleClientError{
+			ServerVersion: jujuversion.Current,
+		}
+		// If client or server versions are more than one major version apart,
+		// reject the call immediately.
+		if clientVersion.Major < jujuversion.Current.Major-1 || clientVersion.Major > jujuversion.Current.Major+1 {
+			return incompatibleClientError
+		}
+		// Connection pings always need to be allowed.
+		if facadeName == "Pinger" && methodName == "Ping" {
+			return nil
+		}
+
+		if !userLogin {
+			// Only recent older agents can make api calls.
+			if minAgentVersion, ok := minAgentMinorVersions[clientVersion.Major]; !ok || minAgentVersion > clientVersion.Minor {
+				logger.Debugf("rejected agent api all %v.%v for agent version %v", facadeName, methodName, clientVersion)
+				return incompatibleClientError
+			}
+			return nil
+		}
+
+		// Calls to manage the migration of the target controller
+		// always need to be allowed.
+		if facadeName == "MigrationTarget" {
+			return nil
+		}
+		// Some calls like status we will support always.
+		if isMethodAllowedForDifferentClients(facadeName, methodName) {
+			return nil
+		}
+
+		// The migration worker makes calls masquerading as a user
+		// so we need to treat those separately.
+		olderClient := clientVersion.Major < jujuversion.Current.Major
+		validMigrationCall := isMethodAllowedForMigrate(facadeName, methodName)
+		if olderClient && !validMigrationCall {
+			return incompatibleClientError
+		}
+
+		// Only allow calls to facilitate upgrades or migrations.
+		if !validMigrationCall && !isMethodAllowedForUpgrade(facadeName, methodName) {
+			return incompatibleClientError
+		}
+		return nil
+	}
+}
+
+func isMethodAllowedForDifferentClients(facadeName, methodName string) bool {
+	methods, ok := allowedDifferentClientMethods[facadeName]
+	if !ok {
+		return false
+	}
+	return methods.Contains(methodName)
+}
+
+func isMethodAllowedForUpgrade(facadeName, methodName string) bool {
+	upgradeOK := false
+	upgradeMethods, ok := allowedMethodsForUpgrade[facadeName]
+	if ok {
+		upgradeOK = upgradeMethods.Contains(methodName)
+	}
+	return upgradeOK
+}
+
+func isMethodAllowedForMigrate(facadeName, methodName string) bool {
+	migrateOK := false
+	migrateMethods, ok := allowedMethodsForMigrate[facadeName]
+	if ok {
+		migrateOK = migrateMethods.Contains(methodName)
+	}
+	return migrateOK
+}
+
+// These methods below are potentially called from a client with
+// a different major version to the controller.
+// As such we need to ensure we retain compatibility.
+
+// allowedDifferentClientMethods stores api calls we want to
+// allow regardless of client or controller version.
+var allowedDifferentClientMethods = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"FullStatus",
+	),
+}
+
+// allowedMethodsForUpgrade stores api calls
+// that are not blocked when the connecting client has
+// a major version greater than that of the controller.
+var allowedMethodsForUpgrade = map[string]set.Strings{
+	"Client": set.NewStrings(
+		"SetModelAgentVersion",
+		"FindTools",
+		"AbortCurrentUpgrade",
+	),
+	"ModelManager": set.NewStrings(
+		"ValidateModelUpgrades",
+	),
+	"ModelConfig": set.NewStrings(
+		"ModelGet",
+	),
+	"Controller": set.NewStrings(
+		"ModelConfig",
+		"ControllerConfig",
+		"CloudSpec",
+	),
+}
+
+// allowedMethodsForMigrate stores api calls
+// that are not blocked when the connecting client has
+// a major version greater than that of the controller.
+var allowedMethodsForMigrate = map[string]set.Strings{
+	"UserManager": set.NewStrings(
+		"UserInfo",
+	),
+	"ModelManager": set.NewStrings(
+		"ListModels",
+		"ModelInfo"),
+	"Controller": set.NewStrings(
+		"InitiateMigration",
+		"IdentityProviderURL",
+	),
+}

--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
+)
+
+type restrictNewerClientSuite struct {
+	testing.BaseSuite
+
+	olderVersion version.Number
+}
+
+var _ = gc.Suite(&restrictNewerClientSuite{})
+
+func (r *restrictNewerClientSuite) SetUpTest(c *gc.C) {
+	r.BaseSuite.SetUpTest(c)
+	r.PatchValue(&jujuversion.Current, version.MustParse("3.0.0"))
+	r.olderVersion = jujuversion.Current
+	r.olderVersion.Major--
+}
+
+func (r *restrictNewerClientSuite) TestOldClientAllowedMethods(c *gc.C) {
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	checkAllowed := func(facade, method string, version int) {
+		caller, err := root.FindMethod(facade, version, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Client", "FullStatus", 1)
+	checkAllowed("Pinger", "Ping", 1)
+	// Worker calls for migrations.
+	checkAllowed("MigrationTarget", "Prechecks", 1)
+	checkAllowed("UserManager", "UserInfo", 1)
+}
+
+func (r *restrictNewerClientSuite) TestNewClientAllowedMethods(c *gc.C) {
+	r.olderVersion.Major = jujuversion.Current.Major + 1
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	checkAllowed := func(facade, method string, version int) {
+		caller, err := root.FindMethod(facade, version, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Client", "FullStatus", 1)
+	checkAllowed("Pinger", "Ping", 1)
+	// For migrations.
+	checkAllowed("MigrationTarget", "Prechecks", 1)
+	checkAllowed("UserManager", "UserInfo", 1)
+	// For upgrades.
+	checkAllowed("Client", "SetModelAgentVersion", 1)
+}
+
+func (r *restrictNewerClientSuite) TestOldClientDisallowedMethod(c *gc.C) {
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "SetModelAgentVersion")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestReallyOldClientDisallowedMethod(c *gc.C) {
+	r.olderVersion.Major--
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "FullStatus")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestReallyNewClientDisallowedMethod(c *gc.C) {
+	r.olderVersion.Major = jujuversion.Current.Major + 2
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "FullStatus")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestAlwaysDisallowedMethod(c *gc.C) {
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Client", 1, "ModelSet")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}
+
+func (r *restrictNewerClientSuite) TestAgentAllowedMethod(c *gc.C) {
+	r.olderVersion.Major = 2
+	r.olderVersion.Minor = 9
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(false, r.olderVersion)
+	checkAllowed := func(facade, method string, version int) {
+		caller, err := root.FindMethod(facade, version, method)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(caller, gc.NotNil)
+	}
+	checkAllowed("Uniter", "CurrentModel", 15)
+}
+
+func (r *restrictNewerClientSuite) TestReallyOldAgentDisallowedMethod(c *gc.C) {
+	r.olderVersion.Minor = 0
+	root := apiserver.TestingUpgradeOrMigrationOnlyRoot(true, r.olderVersion)
+	caller, err := root.FindMethod("Uniter", 15, "CurrentModel")
+	c.Assert(err, jc.Satisfies, params.IsIncompatibleClientError)
+	c.Assert(caller, gc.IsNil)
+}

--- a/apiserver/testing/fakeapi_test.go
+++ b/apiserver/testing/fakeapi_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jtesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/version"
 )
 
 var _ = gc.Suite(&fakeAPISuite{})
@@ -62,6 +63,6 @@ func (f facade) Login(req params.LoginRequest) (params.LoginResult, error) {
 			DisplayName: "foo",
 			Identity:    "user-bar",
 		},
-		ServerVersion: "1.0.0",
+		ServerVersion: version.Current.String(),
 	}, nil
 }

--- a/apiserver/testing/http.go
+++ b/apiserver/testing/http.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
+	jujuversion "github.com/juju/juju/version"
 )
 
 // httpRequestParams holds parameters for the sendHTTPRequest methods.
@@ -79,6 +80,7 @@ func SendHTTPRequest(c *gc.C, p HTTPRequestParams) *http.Response {
 		ExpectError:  p.ExpectError,
 		ExpectStatus: p.ExpectStatus,
 	}
+	hp.Header.Set(params.JujuClientVersion, jujuversion.Current.String())
 	if p.ContentType != "" {
 		hp.Header.Set("Content-Type", p.ContentType)
 	}

--- a/caas/kubernetes/provider/controller_upgrade.go
+++ b/caas/kubernetes/provider/controller_upgrade.go
@@ -4,7 +4,6 @@
 package provider
 
 import (
-	"github.com/juju/names/v4"
 	"github.com/juju/version"
 	"k8s.io/client-go/kubernetes"
 
@@ -52,10 +51,11 @@ func controllerUpgrade(appName string, vers version.Number, broker UpgradeCAASCo
 		broker.Client().AppsV1().StatefulSets(broker.Namespace()))
 }
 
-func (k *kubernetesClient) upgradeController(agentTag names.Tag, vers version.Number) error {
+func (k *kubernetesClient) upgradeController(vers version.Number) error {
 	broker := &upgradeCAASControllerBridge{
 		clientFn:    k.client,
 		namespaceFn: k.GetCurrentNamespace,
+		isLegacyFn:  k.IsLegacyLabels,
 	}
 	return controllerUpgrade(bootstrap.ControllerModelName, vers, broker)
 }

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -30,7 +30,7 @@ func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
 	switch tag.Kind() {
 	case names.MachineTagKind:
 	case names.ControllerAgentTagKind:
-		return k.upgradeController(tag, vers)
+		return k.upgradeController(vers)
 	case names.ApplicationTagKind:
 		return k.upgradeOperator(tag, vers)
 	case names.ModelTagKind:

--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -22,8 +22,7 @@ import (
 
 	"github.com/juju/juju/api/sshclient"
 	"github.com/juju/juju/apiserver/params"
-	corenetwork "github.com/juju/juju/core/network"
-	"github.com/juju/juju/network"
+	"github.com/juju/juju/core/network"
 	jujussh "github.com/juju/juju/network/ssh"
 )
 
@@ -490,7 +489,7 @@ func (c *sshMachine) reachableAddressGetter(entity string) (string, error) {
 		}
 	}
 
-	usable := corenetwork.NewMachineHostPorts(SSHPort, addresses...).HostPorts().FilterUnusable()
+	usable := network.NewMachineHostPorts(SSHPort, addresses...).HostPorts().FilterUnusable()
 	best, err := c.hostChecker.FindHost(usable, publicKeys)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -60,8 +60,8 @@ See also:
     upgrade-model`
 
 func newUpgradeControllerCommand(options ...modelcmd.WrapControllerOption) cmd.Command {
-	cmd := &upgradeControllerCommand{}
-	return modelcmd.WrapController(cmd, options...)
+	command := &upgradeControllerCommand{}
+	return modelcmd.WrapController(command, options...)
 }
 
 // upgradeControllerCommand upgrades the controller agents in a juju installation.

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -84,10 +84,8 @@ var upgradeIAASControllerPassthroughTests = []upgradeTest{{
 	expectUploaded: []string{"2.7.3.1-quantal-amd64", "2.7.3.1-%LTS%-amd64", "2.7.3.1-raring-amd64"},
 }}
 
-func (s *UpgradeIAASControllerSuite) upgradeControllerCommand(minUpgradeVers map[int]version.Number) cmd.Command {
-	cmd := &upgradeControllerCommand{
-		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
-	}
+func (s *UpgradeIAASControllerSuite) upgradeControllerCommand() cmd.Command {
+	cmd := &upgradeControllerCommand{}
 	cmd.SetClientStore(s.ControllerStore)
 	return modelcmd.WrapController(cmd)
 }
@@ -105,7 +103,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgrade(c *gc.C) {
 func (s *UpgradeIAASControllerSuite) TestUpgradeWithRealUpload(c *gc.C) {
 	s.Reset(c)
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.99.99"))
-	cmd := s.upgradeControllerCommand(map[int]version.Number{2: version.MustParse("1.99.99")})
+	cmd := s.upgradeControllerCommand()
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
 	vers := coretesting.CurrentVersion(c)
@@ -116,7 +114,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeWithRealUpload(c *gc.C) {
 func (s *UpgradeIAASControllerSuite) TestUpgradeCorrectController(c *gc.C) {
 	badControllerName := "not-the-right-controller"
 	badControllerSelected := errors.New("bad controller selected")
-	upgradeCommand := func(minUpgradeVers map[int]version.Number) cmd.Command {
+	upgradeCommand := func() cmd.Command {
 		backingStore := s.ControllerStore
 		store := jujuclienttesting.WrapClientStore(backingStore)
 		store.ControllerByNameFunc = func(name string) (*jujuclient.ControllerDetails, error) {
@@ -129,11 +127,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeCorrectController(c *gc.C) {
 			return badControllerName, nil
 		}
 		s.ControllerStore = store
-		cmd := &upgradeControllerCommand{
-			baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
-		}
-		cmd.SetClientStore(s.ControllerStore)
-		return modelcmd.WrapController(cmd)
+		return s.upgradeControllerCommand()
 	}
 
 	tests := []upgradeTest{
@@ -168,7 +162,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeWrongPermissions(c *gc.C) {
 	details.LastKnownAccess = string(permission.ReadAccess)
 	err = s.ControllerStore.UpdateAccount("kontroll", *details)
 	c.Assert(err, jc.ErrorIsNil)
-	com := s.upgradeControllerCommand(nil)
+	com := s.upgradeControllerCommand()
 	err = cmdtesting.InitCommand(com, []string{})
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
@@ -198,7 +192,7 @@ func (s *UpgradeIAASControllerSuite) TestUpgradeDifferentUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmd := &upgradeControllerCommand{
-		baseUpgradeCommand: baseUpgradeCommand{minMajorUpgradeVersion: minMajorUpgradeVersion},
+		baseUpgradeCommand: baseUpgradeCommand{},
 	}
 	cmd.SetClientStore(s.ControllerStore)
 	cmdrun := modelcmd.WrapController(cmd)
@@ -273,7 +267,7 @@ var upgradeCAASControllerTests = []upgradeTest{{
 	expectVersion:  "1.21.4",
 }}
 
-func (s *UpgradeCAASControllerSuite) upgradeControllerCommand(_ map[int]version.Number) cmd.Command {
+func (s *UpgradeCAASControllerSuite) upgradeControllerCommand() cmd.Command {
 	cmd := &upgradeControllerCommand{}
 	cmd.SetClientStore(s.ControllerStore)
 	return modelcmd.WrapController(cmd)
@@ -316,7 +310,7 @@ func (s *UpgradeCAASControllerSuite) assertUpgradeTests(c *gc.C, tests []upgrade
 		// Set up apparent CLI version and initialize the command.
 		current := version.MustParse(test.currentVersion)
 		s.PatchValue(&jujuversion.Current, current)
-		com := upgradeJujuCommand(nil)
+		com := upgradeJujuCommand()
 		if err := cmdtesting.InitCommand(com, test.args); err != nil {
 			if test.expectInitErr != "" {
 				c.Check(err, gc.ErrorMatches, test.expectInitErr)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4688,7 +4688,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 			"controller": "kontroll",
 			"cloud":      "dummy",
 			"region":     "dummy-region",
-			"version":    "1.2.3",
+			"version":    "2.0.0",
 			"model-status": M{
 				"current": "busy",
 				"since":   "01 Apr 15 01:23+10:00",
@@ -4728,7 +4728,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 func (s *StatusSuite) TestMigrationInProgressTabular(c *gc.C) {
 	expected := `
 Model   Controller  Cloud/Region        Version  SLA          Timestamp       Notes
-hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  migrating: foo bar
+hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  migrating: foo bar
 
 `[1:]
 
@@ -4746,7 +4746,7 @@ hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  mi
 func (s *StatusSuite) TestMigrationInProgressAndUpgradeAvailable(c *gc.C) {
 	expected := `
 Model   Controller  Cloud/Region        Version  SLA          Timestamp       Notes
-hosted  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00  migrating: foo bar
+hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  migrating: foo bar
 
 `[1:]
 

--- a/core/arch/arches.go
+++ b/core/arch/arches.go
@@ -10,6 +10,12 @@ import (
 	"github.com/juju/utils/arch"
 )
 
+const (
+	// DefaultArchitecture represents the default architecture we expect to use
+	// if none is present.
+	DefaultArchitecture = arch.AMD64
+)
+
 // Arch represents a platform architecture.
 type Arch = string
 

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -14,8 +14,8 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 )
 

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -843,3 +843,24 @@ func CIDRAddressType(cidr string) (AddressType, error) {
 
 	return IPv6Address, nil
 }
+
+// noAddress represents an error when an address is requested but not available.
+type noAddress struct {
+	errors.Err
+}
+
+// NoAddressError returns an error which satisfies IsNoAddressError(). The given
+// addressKind specifies what kind of address(es) is(are) missing, usually
+// "private" or "public".
+func NoAddressError(addressKind string) error {
+	newErr := errors.NewErr("no %s address(es)", addressKind)
+	newErr.SetLocation(1)
+	return &noAddress{newErr}
+}
+
+// IsNoAddressError reports whether err was created with NoAddressError().
+func IsNoAddressError(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*noAddress)
+	return ok
+}

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -923,3 +923,10 @@ func (s *AddressSuite) TestCIDRAddressType(c *gc.C) {
 		}
 	}
 }
+
+func (s *AddressSuite) TestNoAddressError(c *gc.C) {
+	err := network.NoAddressError("fake")
+	c.Assert(err, gc.ErrorMatches, `no fake address\(es\)`)
+	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
+	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
+}

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -31,7 +31,9 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 	caasoperatorworker "github.com/juju/juju/worker/caasoperator"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter"
@@ -56,9 +58,16 @@ func (s *CAASOperatorSuite) SetUpSuite(c *gc.C) {
 func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 
-	// Set up a CAAS model to replace the IAAS one.
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
-	st := s.Factory.MakeCAASModel(c, nil)
+	// Set up a CAAS model to replace the IAAS one.
+	// Ensure an older major version is used to prevent an upgrade
+	// from being attempted.
+	modelVers := jujuversion.Current
+	modelVers.Major--
+	extraAttrs := coretesting.Attrs{
+		"agent-version": modelVers.String(),
+	}
+	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{ConfigAttrs: extraAttrs})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
 	s.State = st
 

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -60,10 +60,10 @@ func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
 
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 	// Set up a CAAS model to replace the IAAS one.
-	// Ensure an older major version is used to prevent an upgrade
+	// Ensure major version 1 is used to prevent an upgrade
 	// from being attempted.
 	modelVers := jujuversion.Current
-	modelVers.Major--
+	modelVers.Major = 1
 	extraAttrs := coretesting.Attrs{
 		"agent-version": modelVers.String(),
 	}

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -48,10 +48,10 @@ func (s *dblogSuite) SetUpTest(c *gc.C) {
 func (s *dblogSuite) TestControllerAgentLogsGoToDBCAAS(c *gc.C) {
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 	// Set up a CAAS model to replace the IAAS one.
-	// Ensure an older major version is used to prevent an upgrade
+	// Ensure major version 1 is used to prevent an upgrade
 	// from being attempted.
 	modelVers := jujuversion.Current
-	modelVers.Major--
+	modelVers.Major = 1
 	extraAttrs := coretesting.Attrs{
 		"agent-version": modelVers.String(),
 	}

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -46,9 +46,16 @@ func (s *dblogSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *dblogSuite) TestControllerAgentLogsGoToDBCAAS(c *gc.C) {
-	// Set up a CAAS model to replace the IAAS one.
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
-	st := s.Factory.MakeCAASModel(c, nil)
+	// Set up a CAAS model to replace the IAAS one.
+	// Ensure an older major version is used to prevent an upgrade
+	// from being attempted.
+	modelVers := jujuversion.Current
+	modelVers.Major--
+	extraAttrs := coretesting.Attrs{
+		"agent-version": modelVers.String(),
+	}
+	st := s.Factory.MakeCAASModel(c, &factory.ModelParams{ConfigAttrs: extraAttrs})
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
 	s.State = st
 	s.Factory = factory.NewFactory(st, s.StatePool)

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -72,8 +72,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 
 	s.oldVersion = coretesting.CurrentVersion(c)
-	s.oldVersion.Major = 2
-	s.oldVersion.Minor = 1
+	s.oldVersion.Major--
 
 	// Don't wait so long in tests.
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutMaster, time.Millisecond*50)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -447,8 +447,8 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 
 	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
 	err := s.runPrecheck(backend)
-	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.0 before being migrated to a controller with version 3.0.0`)
+	c.Assert(err, gc.ErrorMatches,
+		`model must be upgraded to at least version 2.9.* before being migrated to a controller with version 3.0.0`)
 
 	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
 	err = s.runPrecheck(backend)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -433,6 +433,28 @@ func (s *TargetPrecheckSuite) TestModelVersionAheadOfTarget(c *gc.C) {
 		`model has higher version than target controller (1.2.4 > 1.2.3)`)
 }
 
+func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
+	backend := newFakeBackend()
+
+	origBackendBinary := backendVersionBinary
+	origBackend := backendVersion
+	backendVersionBinary = version.MustParseBinary("3.0.0-trusty-amd64")
+	backendVersion = backendVersionBinary.Number
+	defer func() {
+		backendVersionBinary = origBackendBinary
+		backendVersion = origBackend
+	}()
+
+	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
+	err := s.runPrecheck(backend)
+	c.Assert(err.Error(), gc.Equals,
+		`model must be upgraded to at least version 2.9.0 before being migrated to a controller with version 3.0.0`)
+
+	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
+	err = s.runPrecheck(backend)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *TargetPrecheckSuite) TestSourceControllerMajorAhead(c *gc.C) {
 	backend := newFakeBackend()
 

--- a/network/network.go
+++ b/network/network.go
@@ -11,34 +11,12 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
 	corenetwork "github.com/juju/juju/core/network"
 )
 
 var logger = loggo.GetLogger("juju.network")
-
-// noAddress represents an error when an address is requested but not available.
-type noAddress struct {
-	errors.Err
-}
-
-// NoAddressError returns an error which satisfies IsNoAddressError(). The given
-// addressKind specifies what kind of address(es) is(are) missing, usually
-// "private" or "public".
-func NoAddressError(addressKind string) error {
-	newErr := errors.NewErr("no %s address(es)", addressKind)
-	newErr.SetLocation(1)
-	return &noAddress{newErr}
-}
-
-// IsNoAddressError reports whether err was created with NoAddressError().
-func IsNoAddressError(err error) bool {
-	err = errors.Cause(err)
-	_, ok := err.(*noAddress)
-	return ok
-}
 
 // UnknownId can be used whenever an Id is needed but not known.
 const UnknownId = ""

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -4,7 +4,6 @@
 package network_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"net"
 	"path/filepath"
@@ -176,13 +175,6 @@ LXC_BRIDGE="ignored"`[1:])
 		"localhost",
 	)
 	c.Assert(network.FilterBridgeAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
-}
-
-func (s *NetworkSuite) TestNoAddressError(c *gc.C) {
-	err := network.NoAddressError("fake")
-	c.Assert(err, gc.ErrorMatches, `no fake address\(es\)`)
-	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
-	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
 }
 
 func checkQuoteSpaceSet(c *gc.C, expected string, spaces ...string) {

--- a/snap/hooks/connect-plug-peers
+++ b/snap/hooks/connect-plug-peers
@@ -1,8 +1,9 @@
 #!/bin/sh
 peer="$(snapctl get --slot :peers content)"
 (
+    SNAP_INSTANCE_NAME=${SNAP_INSTANCE_NAME:-$SNAP_NAME}
     echo "hook $0 $@"
     echo "connected to peer $peer"
-    echo "$0 is starting $SNAP_NAME.fetch-oci"
-    snapctl start $SNAP_NAME.fetch-oci
+    echo "$0 is starting $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl start $SNAP_INSTANCE_NAME.fetch-oci
 ) >> $SNAP_COMMON/hook.log

--- a/snap/hooks/disconnect-plug-peers
+++ b/snap/hooks/disconnect-plug-peers
@@ -1,8 +1,9 @@
 #!/bin/sh
 peer="$(snapctl get --slot :peers content)"
 (
+    SNAP_INSTANCE_NAME=${SNAP_INSTANCE_NAME:-$SNAP_NAME}
     echo "hook $0 $@"
     echo "disconnected $peer"
-    echo "$0 is stopping $SNAP_NAME.fetch-oci"
-    snapctl stop --disable $SNAP_NAME.fetch-oci
+    echo "$0 is stopping $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl stop --disable $SNAP_INSTANCE_NAME.fetch-oci
 ) >> $SNAP_COMMON/hook.log

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,8 +1,9 @@
 #!/bin/sh
 (
+    SNAP_INSTANCE_NAME=${SNAP_INSTANCE_NAME:-$SNAP_NAME}
     echo "hook $0 $@" 
-    echo "$0 is starting $SNAP_NAME.fetch-oci"
-    snapctl start $SNAP_NAME.fetch-oci
-    echo "$0 is stopping $SNAP_NAME.fetch-oci"
-    snapctl stop --disable $SNAP_NAME.fetch-oci
+    echo "$0 is starting $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl start $SNAP_INSTANCE_NAME.fetch-oci
+    echo "$0 is stopping $SNAP_INSTANCE_NAME.fetch-oci"
+    snapctl stop --disable $SNAP_INSTANCE_NAME.fetch-oci
 ) >> $SNAP_COMMON/hook.log

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3151,6 +3151,49 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
 }
 
+func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
+	// Constraints are initially empty (for now).
+	cons, err := s.mysql.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+
+	// Constraints can not be set if it already exists and is different than
+	// the default architecture.
+	armArch := "arm64"
+	cons1 := constraints.Value{Arch: &armArch}
+	err = s.mysql.SetConstraints(cons1)
+	c.Assert(err, gc.ErrorMatches, "changing architecture not supported")
+
+	// Constraints can be set.
+	amdArch := "amd64"
+	cons2 := constraints.Value{Arch: &amdArch}
+	err = s.mysql.SetConstraints(cons2)
+	c.Assert(err, jc.ErrorIsNil)
+	cons3, err := s.mysql.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons3, gc.DeepEquals, cons2)
+
+	// Constraints error out if it's already set.
+	cons4 := constraints.Value{Arch: &armArch}
+	err = s.mysql.SetConstraints(cons4)
+	c.Assert(err, gc.ErrorMatches, "changing architecture \\(amd64\\) not supported")
+
+	// Destroy the existing application; there's no way to directly assert
+	// that the constraints are deleted...
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	assertRemoved(c, s.mysql)
+
+	// ...but we can check that old constraints do not affect new applications
+	// with matching names.
+	ch, _, err := s.mysql.Charm()
+	c.Assert(err, jc.ErrorIsNil)
+	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
+	cons6, err := mysql.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
+}
+
 func (s *ApplicationSuite) TestSetInvalidConstraints(c *gc.C) {
 	cons := constraints.MustParse("mem=4G instance-type=foo")
 	err := s.mysql.SetConstraints(cons)

--- a/state/backups/restore.go
+++ b/state/backups/restore.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/worker/peergrouper"
@@ -123,16 +122,16 @@ func updateMongoEntries(newInstId instance.Id, newMachineId, oldMachineId string
 
 // updateMachineAddresses will update the machine doc to the current addresses
 func updateMachineAddresses(machine *state.Machine, privateAddress, publicAddress string) error {
-	privateAddressAddress := corenetwork.SpaceAddress{
-		MachineAddress: corenetwork.MachineAddress{
+	privateAddressAddress := network.SpaceAddress{
+		MachineAddress: network.MachineAddress{
 			Value: privateAddress,
-			Type:  corenetwork.DeriveAddressType(privateAddress),
+			Type:  network.DeriveAddressType(privateAddress),
 		},
 	}
-	publicAddressAddress := corenetwork.SpaceAddress{
-		MachineAddress: corenetwork.MachineAddress{
+	publicAddressAddress := network.SpaceAddress{
+		MachineAddress: network.MachineAddress{
 			Value: publicAddress,
-			Type:  corenetwork.DeriveAddressType(publicAddress),
+			Type:  network.DeriveAddressType(publicAddress),
 		},
 	}
 	if err := machine.SetProviderAddresses(publicAddressAddress, privateAddressAddress); err != nil {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -23,11 +23,10 @@ import (
 	"github.com/juju/juju/core/constraints"
 	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/mongotest"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	"github.com/juju/juju/storage"
@@ -402,7 +401,7 @@ func (s *MachineSuite) TestDestroyRemovePorts(c *gc.C) {
 	err = unit.AssignToMachine(s.machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.MustOpenUnitPortRange(c, s.State, s.machine, unit.Name(), allEndpoints, corenetwork.MustParsePortRange("8080/tcp"))
+	state.MustOpenUnitPortRange(c, s.State, s.machine, unit.Name(), allEndpoints, network.MustParsePortRange("8080/tcp"))
 
 	machPortRanges, err := s.machine.OpenedPortRanges()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1722,13 +1721,13 @@ func (s *MachineSuite) TestSetProviderAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addresses := corenetwork.SpaceAddresses{
-		corenetwork.NewSpaceAddress("127.0.0.1"),
+	addresses := network.SpaceAddresses{
+		network.NewSpaceAddress("127.0.0.1"),
 		{
-			MachineAddress: corenetwork.MachineAddress{
+			MachineAddress: network.MachineAddress{
 				Value: "8.8.8.8",
-				Type:  corenetwork.IPv4Address,
-				Scope: corenetwork.ScopeCloudLocal,
+				Type:  network.IPv4Address,
+				Scope: network.ScopeCloudLocal,
 			},
 			SpaceID: "1",
 		},
@@ -1738,7 +1737,7 @@ func (s *MachineSuite) TestSetProviderAddresses(c *gc.C) {
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	corenetwork.SortAddresses(addresses)
+	network.SortAddresses(addresses)
 	c.Assert(machine.Addresses(), jc.DeepEquals, addresses)
 }
 
@@ -1749,7 +1748,7 @@ func (s *MachineSuite) TestSetProviderAddressesWithContainers(c *gc.C) {
 
 	// When setting all addresses the subnet addresses have to be
 	// filtered out.
-	addresses := corenetwork.NewSpaceAddresses(
+	addresses := network.NewSpaceAddresses(
 		"127.0.0.1",
 		"8.8.8.8",
 	)
@@ -1758,7 +1757,7 @@ func (s *MachineSuite) TestSetProviderAddressesWithContainers(c *gc.C) {
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := corenetwork.NewSpaceAddresses("8.8.8.8", "127.0.0.1")
+	expectedAddresses := network.NewSpaceAddresses("8.8.8.8", "127.0.0.1")
 	c.Assert(machine.Addresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1776,13 +1775,13 @@ func (s *MachineSuite) TestSetProviderAddressesOnContainer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// When setting all addresses the subnet address has to accepted.
-	addresses := corenetwork.NewSpaceAddresses("127.0.0.1")
+	addresses := network.NewSpaceAddresses("127.0.0.1")
 	err = container.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = container.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := corenetwork.NewSpaceAddresses("127.0.0.1")
+	expectedAddresses := network.NewSpaceAddresses("127.0.0.1")
 	c.Assert(container.Addresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1791,13 +1790,13 @@ func (s *MachineSuite) TestSetMachineAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addresses := corenetwork.NewSpaceAddresses("127.0.0.1", "8.8.8.8")
+	addresses := network.NewSpaceAddresses("127.0.0.1", "8.8.8.8")
 	err = machine.SetMachineAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	expectedAddresses := corenetwork.NewSpaceAddresses("8.8.8.8", "127.0.0.1")
+	expectedAddresses := network.NewSpaceAddresses("8.8.8.8", "127.0.0.1")
 	c.Assert(machine.MachineAddresses(), jc.DeepEquals, expectedAddresses)
 }
 
@@ -1807,7 +1806,7 @@ func (s *MachineSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
 	// Add some machine addresses initially to make sure they're removed.
-	addresses := corenetwork.NewSpaceAddresses("127.0.0.1", "8.8.8.8")
+	addresses := network.NewSpaceAddresses("127.0.0.1", "8.8.8.8")
 	err = machine.SetMachineAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.Refresh()
@@ -1828,7 +1827,7 @@ func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	providerAddresses := corenetwork.NewSpaceAddresses(
+	providerAddresses := network.NewSpaceAddresses(
 		"127.0.0.2",
 		"8.8.8.8",
 		"fc00::1",
@@ -1841,7 +1840,7 @@ func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 	err = machine.SetProviderAddresses(providerAddresses...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	machineAddresses := corenetwork.NewSpaceAddresses(
+	machineAddresses := network.NewSpaceAddresses(
 		"127.0.0.1",
 		"localhost",
 		"2001:db8::1",
@@ -1861,7 +1860,7 @@ func (s *MachineSuite) TestMergedAddresses(c *gc.C) {
 	// Duplicates are removed, then when calling Addresses() both
 	// sources are merged while preservig the provider addresses
 	// order.
-	c.Assert(machine.Addresses(), jc.DeepEquals, corenetwork.NewSpaceAddresses(
+	c.Assert(machine.Addresses(), jc.DeepEquals, network.NewSpaceAddresses(
 		"8.8.8.8",
 		"2001:db8::1",
 		"example.org",
@@ -1881,8 +1880,8 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeDifferent(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 
-	addr0 := corenetwork.NewSpaceAddress("127.0.0.1")
-	addr1 := corenetwork.NewSpaceAddress("8.8.8.8")
+	addr0 := network.NewSpaceAddress("127.0.0.1")
+	addr1 := network.NewSpaceAddress("8.8.8.8")
 
 	defer state.SetBeforeHooks(c, s.State, func() {
 		machine, err := s.State.Machine(machine.Id())
@@ -1893,7 +1892,7 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeDifferent(c *gc.C
 
 	err = machine.SetProviderAddresses(addr0, addr1)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machine.Addresses(), jc.SameContents, corenetwork.SpaceAddresses{addr0, addr1})
+	c.Assert(machine.Addresses(), jc.SameContents, network.SpaceAddresses{addr0, addr1})
 }
 
 func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
@@ -1904,8 +1903,8 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
 	revno0, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addr0 := corenetwork.NewSpaceAddress("127.0.0.1")
-	addr1 := corenetwork.NewSpaceAddress("8.8.8.8")
+	addr0 := network.NewSpaceAddress("127.0.0.1")
+	addr1 := network.NewSpaceAddress("8.8.8.8")
 
 	var revno1 int64
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -1925,7 +1924,7 @@ func (s *MachineSuite) TestSetProviderAddressesConcurrentChangeEqual(c *gc.C) {
 	revno2, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(revno2, jc.GreaterThan, revno1)
-	c.Assert(machine.Addresses(), jc.SameContents, corenetwork.SpaceAddresses{addr0, addr1})
+	c.Assert(machine.Addresses(), jc.SameContents, network.SpaceAddresses{addr0, addr1})
 }
 
 func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
@@ -1934,8 +1933,8 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	c.Assert(machine.Addresses(), gc.HasLen, 0)
 	machineDocID := state.DocID(s.State, machine.Id())
 
-	addr0 := corenetwork.NewSpaceAddress("127.0.0.1")
-	addr1 := corenetwork.NewSpaceAddress("8.8.8.8")
+	addr0 := network.NewSpaceAddress("127.0.0.1")
+	addr1 := network.NewSpaceAddress("8.8.8.8")
 
 	// Set addresses to [addr0] initially. We'll get a separate Machine
 	// object to update addresses, to ensure that the in-memory cache of
@@ -1953,39 +1952,39 @@ func (s *MachineSuite) TestSetProviderAddressesInvalidateMemory(c *gc.C) {
 	revno1, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(revno1, jc.GreaterThan, revno0)
-	c.Assert(machine.Addresses(), jc.SameContents, corenetwork.SpaceAddresses{addr0})
-	c.Assert(machine2.Addresses(), jc.SameContents, corenetwork.SpaceAddresses{addr1})
+	c.Assert(machine.Addresses(), jc.SameContents, network.SpaceAddresses{addr0})
+	c.Assert(machine2.Addresses(), jc.SameContents, network.SpaceAddresses{addr1})
 
 	err = machine.SetProviderAddresses(addr0)
 	c.Assert(err, jc.ErrorIsNil)
 	revno2, err := state.TxnRevno(s.State, "machines", machineDocID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(revno2, jc.GreaterThan, revno1)
-	c.Assert(machine.Addresses(), jc.SameContents, corenetwork.SpaceAddresses{addr0})
+	c.Assert(machine.Addresses(), jc.SameContents, network.SpaceAddresses{addr0})
 }
 
 func (s *MachineSuite) TestPublicAddressSetOnNewMachine(c *gc.C) {
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:    "quantal",
 		Jobs:      []state.MachineJob{state.JobHostUnits},
-		Addresses: corenetwork.NewSpaceAddresses("10.0.0.1", "8.8.8.8"),
+		Addresses: network.NewSpaceAddresses("10.0.0.1", "8.8.8.8"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := m.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.8.8"))
+	c.Assert(addr, jc.DeepEquals, network.NewSpaceAddress("8.8.8.8"))
 }
 
 func (s *MachineSuite) TestPrivateAddressSetOnNewMachine(c *gc.C) {
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
 		Series:    "quantal",
 		Jobs:      []state.MachineJob{state.JobHostUnits},
-		Addresses: corenetwork.NewSpaceAddresses("10.0.0.1", "8.8.8.8"),
+		Addresses: network.NewSpaceAddresses("10.0.0.1", "8.8.8.8"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := m.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.NewSpaceAddress("10.0.0.1"))
+	c.Assert(addr, jc.DeepEquals, network.NewSpaceAddress("10.0.0.1"))
 }
 
 func (s *MachineSuite) TestPublicAddressEmptyAddresses(c *gc.C) {
@@ -2012,7 +2011,7 @@ func (s *MachineSuite) TestPublicAddress(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
@@ -2024,7 +2023,7 @@ func (s *MachineSuite) TestPrivateAddress(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PrivateAddress()
@@ -2036,14 +2035,14 @@ func (s *MachineSuite) TestPublicAddressBetterMatch(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "10.0.0.1")
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PublicAddress()
@@ -2055,14 +2054,14 @@ func (s *MachineSuite) TestPrivateAddressBetterMatch(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "8.8.8.8")
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"), corenetwork.NewSpaceAddress("10.0.0.1"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PrivateAddress()
@@ -2074,14 +2073,14 @@ func (s *MachineSuite) TestPublicAddressChanges(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "8.8.8.8")
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PublicAddress()
@@ -2093,14 +2092,14 @@ func (s *MachineSuite) TestPrivateAddressChanges(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "10.0.0.2")
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PrivateAddress()
@@ -2112,7 +2111,7 @@ func (s *MachineSuite) TestAddressesDeadMachine(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("10.0.0.2"), corenetwork.NewSpaceAddress("8.8.4.4"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("10.0.0.2"), network.NewSpaceAddress("8.8.4.4"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PrivateAddress()
@@ -2140,7 +2139,7 @@ func (s *MachineSuite) TestStablePrivateAddress(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PrivateAddress()
@@ -2149,7 +2148,7 @@ func (s *MachineSuite) TestStablePrivateAddress(c *gc.C) {
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"), corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -2162,7 +2161,7 @@ func (s *MachineSuite) TestStablePublicAddress(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
@@ -2171,7 +2170,7 @@ func (s *MachineSuite) TestStablePublicAddress(c *gc.C) {
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"), corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"), network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -2186,29 +2185,29 @@ func (s *MachineSuite) TestAddressesRaceMachineFirst(c *gc.C) {
 
 	changeAddresses := jujutxn.TestHook{
 		Before: func() {
-			err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+			err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 			c.Assert(err, jc.ErrorIsNil)
 			address, err := machine.PublicAddress()
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.8.8"))
+			c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("8.8.8.8"))
 			address, err = machine.PrivateAddress()
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.8.8"))
+			c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("8.8.8.8"))
 		},
 	}
 	defer state.SetTestHooks(c, s.State, changeAddresses).Check()
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("8.8.4.4"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("8.8.4.4"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine, err = s.State.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	address, err := machine.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.8.8"))
+	c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("8.8.8.8"))
 	address, err = machine.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.8.8"))
+	c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("8.8.8.8"))
 }
 
 func (s *MachineSuite) TestAddressesRaceProviderFirst(c *gc.C) {
@@ -2217,36 +2216,36 @@ func (s *MachineSuite) TestAddressesRaceProviderFirst(c *gc.C) {
 
 	changeAddresses := jujutxn.TestHook{
 		Before: func() {
-			err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"))
+			err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"))
 			c.Assert(err, jc.ErrorIsNil)
 			address, err := machine.PublicAddress()
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("10.0.0.1"))
+			c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("10.0.0.1"))
 			address, err = machine.PrivateAddress()
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("10.0.0.1"))
+			c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("10.0.0.1"))
 		},
 	}
 	defer state.SetTestHooks(c, s.State, changeAddresses).Check()
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine, err = s.State.Machine(machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	address, err := machine.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.4.4"))
+	c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("8.8.4.4"))
 	address, err = machine.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(address, jc.DeepEquals, corenetwork.NewSpaceAddress("8.8.4.4"))
+	c.Assert(address, jc.DeepEquals, network.NewSpaceAddress("8.8.4.4"))
 }
 
 func (s *MachineSuite) TestPrivateAddressPrefersProvider(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("8.8.8.8"), corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
@@ -2256,7 +2255,7 @@ func (s *MachineSuite) TestPrivateAddressPrefersProvider(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "10.0.0.2")
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("10.0.0.1"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PublicAddress()
@@ -2271,7 +2270,7 @@ func (s *MachineSuite) TestPublicAddressPrefersProvider(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("8.8.8.8"), corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
@@ -2281,7 +2280,7 @@ func (s *MachineSuite) TestPublicAddressPrefersProvider(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "10.0.0.2")
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PublicAddress()
@@ -2296,7 +2295,7 @@ func (s *MachineSuite) TestAddressesPrefersProviderBoth(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("8.8.8.8"), corenetwork.NewSpaceAddress("10.0.0.1"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("8.8.8.8"), network.NewSpaceAddress("10.0.0.1"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := machine.PublicAddress()
@@ -2306,7 +2305,7 @@ func (s *MachineSuite) TestAddressesPrefersProviderBoth(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addr.Value, gc.Equals, "10.0.0.1")
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"), corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err = machine.PublicAddress()
@@ -2821,27 +2820,27 @@ func (s *MachineSuite) TestWatchAddresses(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Set machine addresses: reported.
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("abc"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("abc"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set provider addresses eclipsing machine addresses: reported.
-	err = machine.SetProviderAddresses(corenetwork.NewScopedSpaceAddress("abc", corenetwork.ScopePublic))
+	err = machine.SetProviderAddresses(network.NewScopedSpaceAddress("abc", network.ScopePublic))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set same machine eclipsed by provider addresses: not reported.
-	err = machine.SetMachineAddresses(corenetwork.NewScopedSpaceAddress("abc", corenetwork.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("abc", network.ScopeCloudLocal))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
 	// Set different machine addresses: reported.
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("def"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("def"))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set different provider addresses: reported.
-	err = machine.SetMachineAddresses(corenetwork.NewScopedSpaceAddress("def", corenetwork.ScopePublic))
+	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("def", network.ScopePublic))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -115,7 +115,7 @@ func (s *ModelConfigSuite) TestAgentVersion(c *gc.C) {
 	}
 	ver, err := s.Model.AgentVersion()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ver, gc.DeepEquals, version.Number{Major: 1, Minor: 2, Patch: 3})
+	c.Assert(ver, gc.DeepEquals, version.Number{Major: 2, Minor: 0, Patch: 0})
 
 	err = s.Model.UpdateModelConfig(attrs, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -25,10 +25,9 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	mgoutils "github.com/juju/juju/mongo/utils"
-	"github.com/juju/juju/network"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/tools"
 )
@@ -384,8 +383,8 @@ func (op *UpdateUnitOperation) Build(attempt int) ([]txn.Op, error) {
 		containerInfo.ProviderId = newProviderId
 	}
 	if op.props.Address != nil {
-		networkAddr := corenetwork.NewScopedSpaceAddress(*op.props.Address, corenetwork.ScopeMachineLocal)
-		addr := fromNetworkAddress(networkAddr, corenetwork.OriginProvider)
+		networkAddr := network.NewScopedSpaceAddress(*op.props.Address, network.ScopeMachineLocal)
+		addr := fromNetworkAddress(networkAddr, network.OriginProvider)
 		containerInfo.Address = &addr
 	}
 	if op.props.Ports != nil {
@@ -1163,20 +1162,20 @@ func (u *Unit) noAssignedMachineOp() txn.Op {
 }
 
 // PublicAddress returns the public address of the unit.
-func (u *Unit) PublicAddress() (corenetwork.SpaceAddress, error) {
+func (u *Unit) PublicAddress() (network.SpaceAddress, error) {
 	if !u.ShouldBeAssigned() {
 		return u.scopedAddress("public")
 	}
 	m, err := u.machine()
 	if err != nil {
 		unitLogger.Tracef("%v", err)
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	return m.PublicAddress()
 }
 
 // PrivateAddress returns the private address of the unit.
-func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
+func (u *Unit) PrivateAddress() (network.SpaceAddress, error) {
 	if !u.ShouldBeAssigned() {
 		addr, err := u.scopedAddress("private")
 		if network.IsNoAddressError(err) {
@@ -1187,7 +1186,7 @@ func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
 	m, err := u.machine()
 	if err != nil {
 		unitLogger.Tracef("%v", err)
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	return m.PrivateAddress()
 }
@@ -1196,7 +1195,7 @@ func (u *Unit) PrivateAddress() (corenetwork.SpaceAddress, error) {
 // plus the container address of the unit (if known).
 // Only relevant for CAAS models - will return an empty
 // slice for IAAS models.
-func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
+func (u *Unit) AllAddresses() (addrs network.SpaceAddresses, _ error) {
 	if u.ShouldBeAssigned() {
 		return addrs, nil
 	}
@@ -1224,7 +1223,7 @@ func (u *Unit) AllAddresses() (addrs corenetwork.SpaceAddresses, _ error) {
 
 // serviceAddresses returns the addresses of the service
 // managing the pods in which the unit workload is running.
-func (u *Unit) serviceAddresses() (corenetwork.SpaceAddresses, error) {
+func (u *Unit) serviceAddresses() (network.SpaceAddresses, error) {
 	app, err := u.Application()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1237,51 +1236,51 @@ func (u *Unit) serviceAddresses() (corenetwork.SpaceAddresses, error) {
 }
 
 // containerAddress returns the address of the pod's container.
-func (u *Unit) containerAddress() (corenetwork.SpaceAddress, error) {
+func (u *Unit) containerAddress() (network.SpaceAddress, error) {
 	containerInfo, err := u.cloudContainer()
 	if errors.IsNotFound(err) {
-		return corenetwork.SpaceAddress{}, network.NoAddressError("container")
+		return network.SpaceAddress{}, network.NoAddressError("container")
 	}
 	if err != nil {
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	addr := containerInfo.Address
 	if addr == nil {
-		return corenetwork.SpaceAddress{}, network.NoAddressError("container")
+		return network.SpaceAddress{}, network.NoAddressError("container")
 	}
 	return addr.networkAddress(), nil
 }
 
-func (u *Unit) scopedAddress(scope string) (corenetwork.SpaceAddress, error) {
+func (u *Unit) scopedAddress(scope string) (network.SpaceAddress, error) {
 	addresses, err := u.AllAddresses()
 	if err != nil {
-		return corenetwork.SpaceAddress{}, errors.Trace(err)
+		return network.SpaceAddress{}, errors.Trace(err)
 	}
 	if len(addresses) == 0 {
-		return corenetwork.SpaceAddress{}, network.NoAddressError(scope)
+		return network.SpaceAddress{}, network.NoAddressError(scope)
 	}
-	getStrictPublicAddr := func(addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddress, bool) {
-		addr, ok := addresses.OneMatchingScope(corenetwork.ScopeMatchPublic)
-		return addr, ok && addr.Scope == corenetwork.ScopePublic
-	}
-
-	getInternalAddr := func(addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddress, bool) {
-		return addresses.OneMatchingScope(corenetwork.ScopeMatchCloudLocal)
+	getStrictPublicAddr := func(addresses network.SpaceAddresses) (network.SpaceAddress, bool) {
+		addr, ok := addresses.OneMatchingScope(network.ScopeMatchPublic)
+		return addr, ok && addr.Scope == network.ScopePublic
 	}
 
-	var addrMatch func(corenetwork.SpaceAddresses) (corenetwork.SpaceAddress, bool)
+	getInternalAddr := func(addresses network.SpaceAddresses) (network.SpaceAddress, bool) {
+		return addresses.OneMatchingScope(network.ScopeMatchCloudLocal)
+	}
+
+	var addrMatch func(network.SpaceAddresses) (network.SpaceAddress, bool)
 	switch scope {
 	case "public":
 		addrMatch = getStrictPublicAddr
 	case "private":
 		addrMatch = getInternalAddr
 	default:
-		return corenetwork.SpaceAddress{}, errors.NotValidf("address scope %q", scope)
+		return network.SpaceAddress{}, errors.NotValidf("address scope %q", scope)
 	}
 
 	addr, found := addrMatch(addresses)
 	if !found {
-		return corenetwork.SpaceAddress{}, network.NoAddressError(scope)
+		return network.SpaceAddress{}, network.NoAddressError(scope)
 	}
 	return addr, nil
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -21,9 +21,8 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/network"
 	"github.com/juju/juju/state"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/state/testing"
@@ -797,8 +796,8 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(
-		corenetwork.NewScopedSpaceAddress("private.address.example.com", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("public.address.example.com", corenetwork.ScopePublic),
+		network.NewScopedSpaceAddress("private.address.example.com", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("public.address.example.com", network.ScopePublic),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -829,8 +828,8 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	_, err = s.unit.PublicAddress()
 	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
-	public := corenetwork.NewScopedSpaceAddress("8.8.8.8", corenetwork.ScopePublic)
-	private := corenetwork.NewScopedSpaceAddress("127.0.0.1", corenetwork.ScopeCloudLocal)
+	public := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
+	private := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
 
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -846,12 +845,12 @@ func (s *UnitSuite) TestStablePrivateAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetMachineAddresses(corenetwork.NewSpaceAddress("10.0.0.1"), corenetwork.NewSpaceAddress("10.0.0.2"))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.1"), network.NewSpaceAddress("10.0.0.2"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -866,12 +865,12 @@ func (s *UnitSuite) TestStablePublicAddress(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Now add an address that would previously have sorted before the
 	// default.
-	err = machine.SetProviderAddresses(corenetwork.NewSpaceAddress("8.8.4.4"), corenetwork.NewSpaceAddress("8.8.8.8"))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("8.8.4.4"), network.NewSpaceAddress("8.8.8.8"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Assert the address is unchanged.
@@ -886,9 +885,9 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	publicProvider := corenetwork.NewScopedSpaceAddress("8.8.8.8", corenetwork.ScopePublic)
-	privateProvider := corenetwork.NewScopedSpaceAddress("127.0.0.1", corenetwork.ScopeCloudLocal)
-	privateMachine := corenetwork.NewSpaceAddress("127.0.0.2")
+	publicProvider := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
+	privateProvider := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
+	privateMachine := network.NewSpaceAddress("127.0.0.2")
 
 	err = machine.SetProviderAddresses(privateProvider)
 	c.Assert(err, jc.ErrorIsNil)
@@ -924,8 +923,8 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	_, err = s.unit.PrivateAddress()
 	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
-	public := corenetwork.NewScopedSpaceAddress("8.8.8.8", corenetwork.ScopePublic)
-	private := corenetwork.NewScopedSpaceAddress("127.0.0.1", corenetwork.ScopeCloudLocal)
+	public := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
+	private := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
 
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1791,71 +1790,71 @@ func (s *UnitSuite) TesOpenedPorts(c *gc.C) {
 
 	// Now open and close ports and ranges and check that they are persisted correctly
 	s.assertPortRangesAfterOpenClose(c, s.unit,
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("80/tcp"),
-			corenetwork.MustParsePortRange("100-200/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("100-200/udp"),
 		},
 		nil, // close
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("80/tcp"),
-			corenetwork.MustParsePortRange("100-200/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("100-200/udp"),
 		},
 	)
 
 	// Open a new port (53/udp)
 	s.assertPortRangesAfterOpenClose(c, s.unit,
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("53/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("53/udp"),
 		},
 		nil, // close
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("53/udp"),
-			corenetwork.MustParsePortRange("80/tcp"),
-			corenetwork.MustParsePortRange("100-200/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("53/udp"),
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("100-200/udp"),
 		},
 	)
 
 	// Open same port but different protocol (53/tcp)
 	s.assertPortRangesAfterOpenClose(c, s.unit,
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("53/tcp"),
+		[]network.PortRange{
+			network.MustParsePortRange("53/tcp"),
 		},
 		nil, // close
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("53/tcp"),
-			corenetwork.MustParsePortRange("53/udp"),
-			corenetwork.MustParsePortRange("80/tcp"),
-			corenetwork.MustParsePortRange("100-200/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("53/tcp"),
+			network.MustParsePortRange("53/udp"),
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("100-200/udp"),
 		},
 	)
 
 	// Close an existing port (80/tcp)
 	s.assertPortRangesAfterOpenClose(c, s.unit,
 		nil, // open
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("80/tcp"),
+		[]network.PortRange{
+			network.MustParsePortRange("80/tcp"),
 		},
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("53/tcp"),
-			corenetwork.MustParsePortRange("53/udp"),
-			corenetwork.MustParsePortRange("100-200/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("53/tcp"),
+			network.MustParsePortRange("53/udp"),
+			network.MustParsePortRange("100-200/udp"),
 		},
 	)
 
 	// Close another existing port (100-200/udp)
 	s.assertPortRangesAfterOpenClose(c, s.unit,
 		nil, // open
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("100-200/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("100-200/udp"),
 		},
-		[]corenetwork.PortRange{
-			corenetwork.MustParsePortRange("53/tcp"),
-			corenetwork.MustParsePortRange("53/udp"),
+		[]network.PortRange{
+			network.MustParsePortRange("53/tcp"),
+			network.MustParsePortRange("53/udp"),
 		},
 	)
 }
 
-func (s *UnitSuite) assertPortRangesAfterOpenClose(c *gc.C, u *state.Unit, openRanges, closeRanges, exp []corenetwork.PortRange) {
+func (s *UnitSuite) assertPortRangesAfterOpenClose(c *gc.C, u *state.Unit, openRanges, closeRanges, exp []network.PortRange) {
 	unitPortRanges, err := u.OpenedPortRanges()
 	c.Assert(err, jc.ErrorIsNil)
 	for _, pr := range openRanges {
@@ -1893,7 +1892,7 @@ func (s *UnitSuite) TestOpenClosePortWhenDying(c *gc.C) {
 
 		toOpen := fmt.Sprintf("%d/tcp", nextPort)
 		nextPort++
-		unitPortRanges.Open(allEndpoints, corenetwork.MustParsePortRange(toOpen))
+		unitPortRanges.Open(allEndpoints, network.MustParsePortRange(toOpen))
 		if err = s.State.ApplyOperation(unitPortRanges.Changes()); err != nil {
 			return errors.Annotatef(err, "cannot open port ranges")
 		}
@@ -1910,7 +1909,7 @@ func (s *UnitSuite) TestOpenClosePortWhenDying(c *gc.C) {
 		if err != nil {
 			return errors.Annotatef(err, "cannot open port ranges")
 		}
-		unitPortRanges.Open(allEndpoints, corenetwork.MustParsePortRange(toOpen))
+		unitPortRanges.Open(allEndpoints, network.MustParsePortRange(toOpen))
 		if err = s.State.ApplyOperation(unitPortRanges.Changes()); err != nil {
 			return errors.Annotatef(err, "cannot open port ranges")
 		}
@@ -1928,7 +1927,7 @@ func (s *UnitSuite) TestRemoveLastUnitOnMachineRemovesAllPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machPortRanges.UniquePortRanges(), gc.HasLen, 0)
 
-	state.MustOpenUnitPortRange(c, s.State, machine, s.unit.Name(), allEndpoints, corenetwork.MustParsePortRange("100-200/tcp"))
+	state.MustOpenUnitPortRange(c, s.State, machine, s.unit.Name(), allEndpoints, network.MustParsePortRange("100-200/tcp"))
 
 	machPortRanges, err = machine.OpenedPortRanges()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1962,18 +1961,18 @@ func (s *UnitSuite) TestRemoveUnitRemovesItsPortsOnly(c *gc.C) {
 	err = otherUnit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	state.MustOpenUnitPortRange(c, s.State, machine, s.unit.Name(), allEndpoints, corenetwork.MustParsePortRange("100-200/tcp"))
-	state.MustOpenUnitPortRange(c, s.State, machine, otherUnit.Name(), allEndpoints, corenetwork.MustParsePortRange("300-400/udp"))
+	state.MustOpenUnitPortRange(c, s.State, machine, s.unit.Name(), allEndpoints, network.MustParsePortRange("100-200/tcp"))
+	state.MustOpenUnitPortRange(c, s.State, machine, otherUnit.Name(), allEndpoints, network.MustParsePortRange("300-400/udp"))
 
 	machPortRanges, err := machine.OpenedPortRanges()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machPortRanges.UniquePortRanges(), gc.HasLen, 2)
 
-	c.Assert(machPortRanges.ForUnit(s.unit.Name()).UniquePortRanges(), jc.DeepEquals, []corenetwork.PortRange{
-		corenetwork.MustParsePortRange("100-200/tcp"),
+	c.Assert(machPortRanges.ForUnit(s.unit.Name()).UniquePortRanges(), jc.DeepEquals, []network.PortRange{
+		network.MustParsePortRange("100-200/tcp"),
 	})
-	c.Assert(machPortRanges.ForUnit(otherUnit.Name()).UniquePortRanges(), jc.DeepEquals, []corenetwork.PortRange{
-		corenetwork.MustParsePortRange("300-400/udp"),
+	c.Assert(machPortRanges.ForUnit(otherUnit.Name()).UniquePortRanges(), jc.DeepEquals, []network.PortRange{
+		network.MustParsePortRange("300-400/udp"),
 	})
 
 	// Now remove the first unit and check again.
@@ -1989,8 +1988,8 @@ func (s *UnitSuite) TestRemoveUnitRemovesItsPortsOnly(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machPortRanges.UniquePortRanges(), gc.HasLen, 1)
 	c.Assert(machPortRanges.ForUnit(s.unit.Name()).UniquePortRanges(), gc.HasLen, 0)
-	c.Assert(machPortRanges.ForUnit(otherUnit.Name()).UniquePortRanges(), jc.DeepEquals, []corenetwork.PortRange{
-		corenetwork.MustParsePortRange("300-400/udp"),
+	c.Assert(machPortRanges.ForUnit(otherUnit.Name()).UniquePortRanges(), jc.DeepEquals, []network.PortRange{
+		network.MustParsePortRange("300-400/udp"),
 	})
 }
 
@@ -2652,9 +2651,9 @@ func (s *UnitSuite) TestDestroyWithForceWorksOnDyingUnit(c *gc.C) {
 
 func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	// Create 2 spaces
-	sn1, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "10.0.0.0/24"})
+	sn1, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.0.0/24"})
 	c.Assert(err, gc.IsNil)
-	sn2, err := s.State.AddSubnet(corenetwork.SubnetInfo{CIDR: "10.0.254.0/24"})
+	sn2, err := s.State.AddSubnet(network.SubnetInfo{CIDR: "10.0.254.0/24"})
 	c.Assert(err, gc.IsNil)
 
 	_, err = s.State.AddSpace("public", "", []string{sn1.ID()}, false)
@@ -2670,13 +2669,13 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 	err = m1.SetLinkLayerDevices(
-		state.LinkLayerDeviceArgs{Name: "enp5s0", Type: corenetwork.EthernetDevice},
-		state.LinkLayerDeviceArgs{Name: "enp5s1", Type: corenetwork.EthernetDevice},
+		state.LinkLayerDeviceArgs{Name: "enp5s0", Type: network.EthernetDevice},
+		state.LinkLayerDeviceArgs{Name: "enp5s1", Type: network.EthernetDevice},
 	)
 	c.Assert(err, gc.IsNil)
 	err = m1.SetDevicesAddresses(
-		state.LinkLayerDeviceAddress{DeviceName: "enp5s0", CIDRAddress: "10.0.0.1/24", ConfigMethod: corenetwork.StaticAddress},
-		state.LinkLayerDeviceAddress{DeviceName: "enp5s1", CIDRAddress: "10.0.254.42/24", ConfigMethod: corenetwork.StaticAddress},
+		state.LinkLayerDeviceAddress{DeviceName: "enp5s0", CIDRAddress: "10.0.0.1/24", ConfigMethod: network.StaticAddress},
+		state.LinkLayerDeviceAddress{DeviceName: "enp5s1", CIDRAddress: "10.0.254.42/24", ConfigMethod: network.StaticAddress},
 	)
 	c.Assert(err, gc.IsNil)
 
@@ -2705,10 +2704,10 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	err = m1.SetDevicesAddresses(state.LinkLayerDeviceAddress{
 		DeviceName:   "enp5s0",
 		CIDRAddress:  "10.0.0.100/24",
-		ConfigMethod: corenetwork.StaticAddress,
+		ConfigMethod: network.StaticAddress,
 	})
 	c.Assert(err, gc.IsNil)
-	err = m1.SetProviderAddresses(corenetwork.NewSpaceAddress("10.0.0.100"))
+	err = m1.SetProviderAddresses(network.NewSpaceAddress("10.0.0.100"))
 	c.Assert(err, gc.IsNil)
 	wc.AssertChange("46ed851765a963e100161210a7b4fbb28d59b24edb580a60f86dbbaebea14d37")
 
@@ -2817,7 +2816,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitProviderId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
-	addr := corenetwork.NewScopedSpaceAddress("192.168.1.1", corenetwork.ScopeMachineLocal)
+	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal)
 	c.Assert(info.Address(), gc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
@@ -2840,7 +2839,7 @@ func (s *CAASUnitSuite) TestAddCAASUnitProviderId(c *gc.C) {
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
 	c.Check(info.Address(), gc.NotNil)
-	c.Check(*info.Address(), jc.DeepEquals, corenetwork.NewScopedSpaceAddress("192.168.1.1", corenetwork.ScopeMachineLocal))
+	c.Check(*info.Address(), jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal))
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
@@ -2862,7 +2861,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	addr := corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeMachineLocal)
+	addr := network.NewScopedSpaceAddress("192.168.1.2", network.ScopeMachineLocal)
 	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
@@ -2885,7 +2884,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	addr := corenetwork.NewScopedSpaceAddress("192.168.1.1", corenetwork.ScopeMachineLocal)
+	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal)
 	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"443"})
 }
@@ -2906,37 +2905,37 @@ func (s *CAASUnitSuite) TestRemoveUnitDeletesContainerInfo(c *gc.C) {
 func (s *CAASUnitSuite) TestPrivateAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.application.UpdateCloudService("", corenetwork.SpaceAddresses{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+	err = s.application.UpdateCloudService("", network.SpaceAddresses{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := existingUnit.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal))
+	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal))
 }
 
 func (s *CAASUnitSuite) TestPublicAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.application.UpdateCloudService("", []corenetwork.SpaceAddress{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+	err = s.application.UpdateCloudService("", []network.SpaceAddress{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := existingUnit.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic))
+	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic))
 }
 
 func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.application.UpdateCloudService("", []corenetwork.SpaceAddress{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
+	err = s.application.UpdateCloudService("", []network.SpaceAddress{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2951,10 +2950,10 @@ func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 
 	addrs, err := existingUnit.AllAddresses()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addrs, jc.DeepEquals, corenetwork.SpaceAddresses{
-		corenetwork.NewScopedSpaceAddress("192.168.1.2", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedSpaceAddress("54.32.1.2", corenetwork.ScopePublic),
-		corenetwork.NewScopedSpaceAddress("10.0.0.1", corenetwork.ScopeMachineLocal),
+	c.Assert(addrs, jc.DeepEquals, network.SpaceAddresses{
+		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
+		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewScopedSpaceAddress("10.0.0.1", network.ScopeMachineLocal),
 	})
 }
 
@@ -3049,12 +3048,12 @@ func (s *CAASUnitSuite) TestWatchServiceAddressesHash(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Set service addresses: reported.
-	err = s.application.UpdateCloudService("1", corenetwork.SpaceAddresses{corenetwork.NewSpaceAddress("10.0.0.2")})
+	err = s.application.UpdateCloudService("1", network.SpaceAddresses{network.NewSpaceAddress("10.0.0.2")})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("7fcdfefa54c49ed9dc8132b4a28491a02ec35b03c20b2d4cc95469fead847ff8")
 
 	// Set different container addresses: reported.
-	err = s.application.UpdateCloudService("1", corenetwork.SpaceAddresses{corenetwork.NewSpaceAddress("10.0.0.3")})
+	err = s.application.UpdateCloudService("1", network.SpaceAddresses{network.NewSpaceAddress("10.0.0.3")})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("800892c5473f38623ef4856303b3458cfa81d0da803f228db69910949a13f458")
 

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -101,7 +101,7 @@ func mustUUID() string {
 // additional specified keys added.
 func CustomModelConfig(c *gc.C, extra Attrs) *config.Config {
 	attrs := FakeConfig().Merge(Attrs{
-		"agent-version": "1.2.3",
+		"agent-version": "2.0.0",
 		"charm-hub-url": charmhub.CharmHubServerURL,
 	}).Merge(extra).Delete("admin-secret")
 	cfg, err := config.New(config.NoDefaults, attrs)

--- a/upgrades/model.go
+++ b/upgrades/model.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/version"
+)
+
+// MinMajorUpgradeVersion defines the minimum version all models
+// must be running before a major version upgrade.
+var MinMajorUpgradeVersion = map[int]version.Number{
+	3: version.MustParse("2.9.0"),
+}
+
+// UpgradeAllowed returns true if a major version upgrade is allowed
+// for the specified from and to versions.
+func UpgradeAllowed(from, to version.Number) (bool, version.Number, error) {
+	if from.Major == to.Major {
+		return true, version.Number{}, nil
+	}
+	// Downgrades not allowed.
+	if from.Major > to.Major {
+		return false, version.Number{}, nil
+	}
+	minVer, ok := MinMajorUpgradeVersion[to.Major]
+	if !ok {
+		return false, version.Number{}, errors.Errorf("unknown version %q", to)
+	}
+	return from.Compare(minVer) >= 0, minVer, nil
+}

--- a/upgrades/model.go
+++ b/upgrades/model.go
@@ -11,7 +11,8 @@ import (
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	3: version.MustParse("2.9.0"),
+	// TODO(wallyworld) - change to 2.9.0 when 2.9.0 is released.
+	3: version.MustParse("2.9-rc2"),
 }
 
 // UpgradeAllowed returns true if a major version upgrade is allowed

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -163,7 +163,6 @@ func (u *Upgrader) loop() error {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
 		} else if !upgrader.AllowedTargetVersion(
-			u.config.OrigAgentVersion,
 			jujuversion.Current,
 			wantVersion,
 		) {
@@ -179,7 +178,7 @@ func (u *Upgrader) loop() error {
 		logger.Debugf("%s requested for %v from %v to %v", direction, u.tag, jujuversion.Current, wantVersion)
 		err = u.operatorUpgrader.Upgrade(u.tag.String(), wantVersion)
 		if err != nil {
-			return errors.Annotatef(err, "requesting upgrade for %f from %v to %v", u.tag, jujuversion.Current, wantVersion)
+			return errors.Annotatef(err, "requesting upgrade for %v from %v to %v", u.tag, jujuversion.Current, wantVersion)
 		}
 	}
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -118,7 +118,7 @@ func (s *InterfaceSuite) TestUnitNetworkInfo(c *gc.C) {
 	c.Check(netInfo, gc.DeepEquals, map[string]params.NetworkInfoResult{
 		"unknown": {
 			Error: &params.Error{
-				Message: "binding name \"unknown\" not defined by the unit's charm",
+				Message: `undefined for unit charm: endpoint "unknown" not valid`,
 			},
 		},
 	},

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -104,12 +104,11 @@ func (u *Upgrader) Wait() error {
 // AllowedTargetVersion checks if targetVersion is too different from
 // curVersion to allow a downgrade.
 func AllowedTargetVersion(
-	origAgentVersion version.Number,
 	curVersion version.Number,
 	targetVersion version.Number,
 ) bool {
-	// Don't allow downgrading from higher versions to version 1.x
-	if curVersion.Major >= 2 && targetVersion.Major == 1 {
+	// Don't allow downgrading from higher major versions.
+	if curVersion.Major > targetVersion.Major {
 		return false
 	}
 	return true
@@ -200,7 +199,6 @@ func (u *Upgrader) loop() error {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
 		} else if !AllowedTargetVersion(
-			u.config.OrigAgentVersion,
 			haveVersion,
 			wantVersion,
 		) {

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -107,8 +107,8 @@ func AllowedTargetVersion(
 	curVersion version.Number,
 	targetVersion version.Number,
 ) bool {
-	// Don't allow downgrading from higher major versions.
-	if curVersion.Major > targetVersion.Major {
+	// Don't allow downgrading from higher versions to version 1.x
+	if curVersion.Major >= 2 && targetVersion.Major == 1 {
 		return false
 	}
 	return true

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -474,26 +474,24 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 }
 
 type allowedTest struct {
-	original string
-	current  string
-	target   string
-	allowed  bool
+	current string
+	target  string
+	allowed bool
 }
 
 func (s *AllowedTargetVersionSuite) TestAllowedTargetVersionSuite(c *gc.C) {
 	cases := []allowedTest{
-		{original: "2.7.4", current: "2.7.4", target: "2.8.0", allowed: true},  // normal upgrade
-		{original: "2.8.0", current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade caused by restore after upgrade
-		{original: "2.8.0", current: "2.8.0", target: "1.2.3", allowed: false}, // can't downgrade to v1.x
-		{original: "2.7.4", current: "2.7.4", target: "2.7.5", allowed: true},  // point release
-		{original: "2.7.4", current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade after upgrade but before config file updated
+		{current: "2.7.4", target: "2.8.0", allowed: true},  // normal upgrade
+		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade caused by restore after upgrade
+		{current: "3.8.0", target: "2.2.3", allowed: false}, // can't downgrade major versions
+		{current: "2.7.4", target: "2.7.5", allowed: true},  // point release
+		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade after upgrade but before config file updated
 	}
 	for i, test := range cases {
 		c.Logf("test case %d, %#v", i, test)
-		original := version.MustParse(test.original)
 		current := version.MustParse(test.current)
 		target := version.MustParse(test.target)
-		result := upgrader.AllowedTargetVersion(original, current, target)
+		result := upgrader.AllowedTargetVersion(current, target)
 		c.Check(result, gc.Equals, test.allowed)
 	}
 }

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -483,7 +483,7 @@ func (s *AllowedTargetVersionSuite) TestAllowedTargetVersionSuite(c *gc.C) {
 	cases := []allowedTest{
 		{current: "2.7.4", target: "2.8.0", allowed: true},  // normal upgrade
 		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade caused by restore after upgrade
-		{current: "3.8.0", target: "2.2.3", allowed: false}, // can't downgrade major versions
+		{current: "3.8.0", target: "1.2.3", allowed: false}, // can't downgrade to major version 1.x
 		{current: "2.7.4", target: "2.7.5", allowed: true},  // point release
 		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade after upgrade but before config file updated
 	}


### PR DESCRIPTION
Merge 2.9 with these PRs:

#12356 Simplify NetworkGet for CAAS
#12355 Use snap instance name for hook scripts
#12361 Fix TestClientWatchAllAdminPermission intermittent failure
#12346 Prevent an old juju client logging into a newer controller
#12362 When upgrading to juju 3, models model be at least 2.9
#12357 Relocate NoAddressError concerns from network to core/network

No conflicts

## QA steps

See PRs

