### PR TITLE
Fix resource name in dummy-resource charm hooks

### DIFF
--- a/testcharms/charm-repo/bionic/dummy-resource/hooks/install
+++ b/testcharms/charm-repo/bionic/dummy-resource/hooks/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RES_NAME="install-resource"
+RES_NAME="dummy"
 RES_PATH=$(2>&1 resource-get $RES_NAME)
 if [ $? -ne 0 ]; then
     RES_GET_STDERR=$RES_PATH

--- a/testcharms/charm-repo/bionic/dummy-resource/hooks/update-status
+++ b/testcharms/charm-repo/bionic/dummy-resource/hooks/update-status
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RES_NAME="upload-resource"
+RES_NAME="dummy"
 RES_PATH=$(2>&1 resource-get $RES_NAME)
 if [ $? -ne 0 ]; then
     RES_GET_STDERR=$RES_PATH

--- a/testcharms/charm-repo/bionic/dummy-resource/metadata.yaml
+++ b/testcharms/charm-repo/bionic/dummy-resource/metadata.yaml
@@ -7,7 +7,5 @@ minjujuversion: "1.0.0"
 resources:
     dummy:
         type: file
-        filename: dummy.zip
+        filename: dummy-resource.zip
         description: "One line description that is useful when operators need to push it."
-
-

--- a/testcharms/charm-repo/quantal/dummy-resource/hooks/install
+++ b/testcharms/charm-repo/quantal/dummy-resource/hooks/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RES_NAME="install-resource"
+RES_NAME="dummy"
 RES_PATH=$(2>&1 resource-get $RES_NAME)
 if [ $? -ne 0 ]; then
     RES_GET_STDERR=$RES_PATH

--- a/testcharms/charm-repo/quantal/dummy-resource/hooks/update-status
+++ b/testcharms/charm-repo/quantal/dummy-resource/hooks/update-status
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RES_NAME="upload-resource"
+RES_NAME="dummy"
 RES_PATH=$(2>&1 resource-get $RES_NAME)
 if [ $? -ne 0 ]; then
     RES_GET_STDERR=$RES_PATH

--- a/testcharms/charm-repo/quantal/dummy-resource/metadata.yaml
+++ b/testcharms/charm-repo/quantal/dummy-resource/metadata.yaml
@@ -7,7 +7,5 @@ minjujuversion: "1.0.0"
 resources:
     dummy:
         type: file
-        filename: dummy.zip
+        filename: dummy-resource.zip
         description: "One line description that is useful when operators need to push it."
-
-


### PR DESCRIPTION
This doesn't actually fix any tests, but it had me confused when I was
trying to manually deploy these charms and the resource-get in the hook
failed with the following:

```
[resource "upload-resource"] ERROR could not download resource: HTTP request failed:
Get https://10.20.46.217:17070/model/304730be-d4b3-4096-8f02-5c14bfcf839c/units/unit-dummy-resource-0/resources/upload-resource:
resource#dummy-resource/upload-resource not found
```

Deploy command to test:

```
$ cd testcharms/charm-repo/bionic/dummy-resource
$ juju deploy . --resource dummy=dummy-resource.zip
```
