### PR TITLE
[dev] Remove k8s specific bits from caas broker interface

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -500,10 +500,10 @@ func initControllerCloudService(
 		return errors.Annotate(err, "getting environ")
 	}
 
-	broker, ok := env.(caas.ServiceGetterSetter)
+	broker, ok := env.(caas.ServiceManager)
 	if !ok {
 		// this should never happen.
-		return errors.Errorf("environ %T does not implement ServiceGetterSetter interface", env)
+		return errors.Errorf("environ %T does not implement ServiceManager interface", env)
 	}
 	svc, err := broker.GetService(k8sprovider.JujuControllerStackName, caas.ModeWorkload, true)
 	if err != nil {

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -67,9 +67,8 @@ func checkCAASModelCredential(brokerParams environs.OpenParams) (params.ErrorRes
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
-	_, err = broker.Namespaces()
-	if err != nil {
-		// If this call could not be made with provided credential, we know that the credential is invalid.
+
+	if err = broker.CheckCloudCredentials(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 	return params.ErrorResults{}, nil

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -636,3 +636,9 @@ type mockCaasBroker struct {
 func (m *mockCaasBroker) Namespaces() ([]string, error) {
 	return m.namespacesFunc()
 }
+
+func (m *mockCaasBroker) CheckCloudCredentials() error {
+	// The k8s provider implements this via a list namespaces call to the cluster
+	_, err := m.namespacesFunc()
+	return err
+}

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -56,6 +56,10 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "getting caas client")
 	}
+	containerStartWatcher, implemented := caasBroker.(CAASBrokerInterface)
+	if !implemented {
+		return nil, errors.NotSupportedf("watching for container start events")
+	}
 	leadershipRevoker, err := ctx.LeadershipRevoker(ctx.State().ModelUUID())
 	if err != nil {
 		return nil, errors.Annotate(err, "getting leadership client")
@@ -64,7 +68,7 @@ func NewStateFacade(ctx facade.Context) (*Facade, error) {
 		stateShim{ctx.StatePool().SystemState()},
 		stateShim{ctx.State()},
 		unitcommon.Backend(ctx.State()),
-		caasBroker, leadershipRevoker)
+		containerStartWatcher, leadershipRevoker)
 }
 
 // NewFacade returns a new CAASOperator facade.

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -688,9 +688,9 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 			return err
 		}
 	}
-	// Check k8s clusters.
-	if env, ok := envOrBroker.(caas.ClusterMetadataChecker); ok {
-		if _, err := env.GetClusterMetadata(""); err != nil {
+	// Check credentials against the container broker
+	if env, ok := envOrBroker.(caas.CredentialChecker); ok {
+		if err := env.CheckCloudCredentials(); err != nil {
 			return errors.Annotate(err, "cannot make API call to provider")
 		}
 	}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/controller"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -475,7 +476,7 @@ type mockBroker struct {
 	err               error
 }
 
-func (m *mockBroker) GetClusterMetadata(storageClass string) (result *caas.ClusterMetadata, err error) {
+func (m *mockBroker) GetClusterMetadata(storageClass string) (result *k8s.ClusterMetadata, err error) {
 	m.getMetadataCalled = true
 	return nil, m.err
 }

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -480,6 +480,11 @@ func (m *mockBroker) GetClusterMetadata(storageClass string) (result *caas.Clust
 	return nil, m.err
 }
 
+func (m *mockBroker) CheckCloudCredentials() error {
+	m.getMetadataCalled = true
+	return m.err
+}
+
 func (s *serverSuite) assertCheckCAASProviderAPI(c *gc.C, envError error, expectErr string) {
 	env := &mockBroker{err: envError}
 	s.newEnviron = func() (environs.BootstrapEnviron, error) {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -191,9 +191,6 @@ type Broker interface {
 	// ClusterVersionGetter provides methods to get cluster version information.
 	ClusterVersionGetter
 
-	// ClusterMetadataGetter provides an API for querying the cluster metadata.
-	ClusterMetadataGetter
-
 	// CredentialChecker provides an API for checking that the credentials
 	// used by the broker are functioning.
 	CredentialChecker
@@ -293,12 +290,6 @@ type StorageValidator interface {
 type ClusterVersionGetter interface {
 	// Version returns cluster version information.
 	Version() (*version.Number, error)
-}
-
-// ClusterMetadataGetter provides an API to query cluster metadata.
-type ClusterMetadataGetter interface {
-	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
-	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
 }
 
 // CredentialChecker provides an API for checking that the credentials

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/version"
-	core "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/core/application"
@@ -170,31 +169,56 @@ type Broker interface {
 	// Provider returns the ContainerEnvironProvider that created this Broker.
 	Provider() ContainerEnvironProvider
 
-	// APIVersion returns the master kubelet API version.
+	// InstancePrechecker provides a means of "prechecking" placement
+	// arguments before recording them in state.
+	environs.InstancePrechecker
+
+	// BootstrapEnviron defines methods for bootstrapping a controller.
+	environs.BootstrapEnviron
+
+	// ResourceAdopter defines methods for adopting resources.
+	environs.ResourceAdopter
+
+	// StorageValidator provides methods to validate storage.
+	StorageValidator
+
+	// Upgrader provides the API to perform upgrades.
+	Upgrader
+
+	// APIVersion returns the version of the container orchestration layer.
 	APIVersion() (string, error)
 
-	// EnsureModelOperator creates or updates a model operator pod for running
-	// model operations in a CAAS namespace/model
-	EnsureModelOperator(modelUUID, agentPath string, config *ModelOperatorConfig) error
+	// ClusterVersionGetter provides methods to get cluster version information.
+	ClusterVersionGetter
 
-	// ModelOperator return the model operator config used to create the current
-	// model operator for this broker
-	ModelOperator() (*ModelOperatorConfig, error)
+	// ClusterMetadataGetter provides an API for querying the cluster metadata.
+	ClusterMetadataGetter
 
-	// ModelOperatorExists indicates if the model operator for the given broker
-	// exists
-	ModelOperatorExists() (bool, error)
+	// CredentialChecker provides an API for checking that the credentials
+	// used by the broker are functioning.
+	CredentialChecker
 
-	// EnsureOperator creates or updates an operator pod for running
-	// a charm for the specified application.
-	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
+	// ApplicationBroker provides an API for accessing the broker interface
+	// for individual applications and watching their units.
+	ApplicationBroker
 
-	// OperatorExists indicates if the operator for the specified
-	// application exists, and whether the operator is terminating.
-	OperatorExists(appName string) (DeploymentState, error)
+	// ServiceManager provides an API for creating and watching services.
+	ServiceManager
 
-	// DeleteOperator deletes the specified operator.
-	DeleteOperator(appName string) error
+	// ModelOperatorManager provides an API for deploying operators for
+	// individual models.
+	ModelOperatorManager
+
+	// ApplicationOperatorManager provides an API for deploying operators
+	// for individual applications.
+	ApplicationOperatorManager
+}
+
+// ApplicationBroker provides an API for accessing the broker interface for
+// individual applications and watching their units.
+type ApplicationBroker interface {
+	// Application returns the broker interface for an Application
+	Application(string, DeploymentType) Application
 
 	// WatchUnits returns a watcher which notifies when there
 	// are changes to units of the specified application.
@@ -213,51 +237,44 @@ type Broker interface {
 	// the provider id for the unit. If containerName is empty, then the first workload container
 	// is used.
 	WatchContainerStart(appName string, containerName string) (watcher.StringsWatcher, error)
+}
 
-	// WatchOperator returns a watcher which notifies when there
-	// are changes to the operator of the specified application.
-	WatchOperator(string) (watcher.NotifyWatcher, error)
+// ModelOperatorManager provides an API for deploying operators for individual
+// models.
+type ModelOperatorManager interface {
+	// ModelOperatorExists indicates if the model operator for the given broker
+	// exists
+	ModelOperatorExists() (bool, error)
 
-	// WatchService returns a watcher which notifies when there
-	// are changes to the deployment of the specified application.
-	WatchService(appName string, mode DeploymentMode) (watcher.NotifyWatcher, error)
+	// EnsureModelOperator creates or updates a model operator pod for running
+	// model operations in a CAAS namespace/model
+	EnsureModelOperator(modelUUID, agentPath string, config *ModelOperatorConfig) error
+
+	// ModelOperator return the model operator config used to create the current
+	// model operator for this broker
+	ModelOperator() (*ModelOperatorConfig, error)
+}
+
+// ApplicationOperatorManager provides an API for deploying operators for
+// individual applications.
+type ApplicationOperatorManager interface {
+	// OperatorExists indicates if the operator for the specified
+	// application exists, and whether the operator is terminating.
+	OperatorExists(appName string) (DeploymentState, error)
+
+	// EnsureOperator creates or updates an operator pod for running
+	// a charm for the specified application.
+	EnsureOperator(appName, agentPath string, config *OperatorConfig) error
+
+	// DeleteOperator deletes the specified operator.
+	DeleteOperator(appName string) error
 
 	// Operator returns an Operator with current status and life details.
 	Operator(string) (*Operator, error)
 
-	// Application returns the broker interface for an Application
-	Application(string, DeploymentType) Application
-
-	// ClusterMetadataChecker provides an API to query cluster metadata.
-	ClusterMetadataChecker
-
-	// NamespaceWatcher provides the API to watch caas namespace.
-	NamespaceWatcher
-
-	// InstancePrechecker provides a means of "prechecking" placement
-	// arguments before recording them in state.
-	environs.InstancePrechecker
-
-	// BootstrapEnviron defines methods for bootstrapping a controller.
-	environs.BootstrapEnviron
-
-	// ResourceAdopter defines methods for adopting resources.
-	environs.ResourceAdopter
-
-	// NamespaceGetterSetter provides the API to get/set namespace.
-	NamespaceGetterSetter
-
-	// StorageValidator provides methods to validate storage.
-	StorageValidator
-
-	// ServiceGetterSetter provides the API to get/set service.
-	ServiceGetterSetter
-
-	// Upgrader provides the API to perform upgrades.
-	Upgrader
-
-	// ClusterVersionGetter provides methods to get cluster version information.
-	ClusterVersionGetter
+	// WatchOperator returns a watcher which notifies when there
+	// are changes to the operator of the specified application.
+	WatchOperator(string) (watcher.NotifyWatcher, error)
 }
 
 // Upgrader provides the API to perform upgrades.
@@ -278,8 +295,22 @@ type ClusterVersionGetter interface {
 	Version() (*version.Number, error)
 }
 
-// ServiceGetterSetter provides the API to get/set service.
-type ServiceGetterSetter interface {
+// ClusterMetadataGetter provides an API to query cluster metadata.
+type ClusterMetadataGetter interface {
+	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
+	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
+}
+
+// CredentialChecker provides an API for checking that the credentials
+// used by the broker are functioning.
+type CredentialChecker interface {
+	// CheckCloudCredentials verifies that the provided cloud credentials
+	// are still valid for the cloud.
+	CheckCloudCredentials() error
+}
+
+// ServiceManager provides the API to manipulate services.
+type ServiceManager interface {
 	// EnsureService creates or updates a service for pods with the given params.
 	EnsureService(appName string, statusCallback StatusCallbackFunc, params *ServiceParams, numUnits int, config application.ConfigAttributes) error
 
@@ -294,38 +325,10 @@ type ServiceGetterSetter interface {
 
 	// GetService returns the service for the specified application.
 	GetService(appName string, mode DeploymentMode, includeClusterIP bool) (*Service, error)
-}
 
-// NamespaceGetterSetter provides the API to get/set namespace.
-type NamespaceGetterSetter interface {
-	// Namespaces returns name names of the namespaces on the cluster.
-	Namespaces() ([]string, error)
-
-	// GetNamespace returns the namespace for the specified name or current namespace.
-	GetNamespace(name string) (*core.Namespace, error)
-
-	// GetCurrentNamespace returns current namespace name.
-	GetCurrentNamespace() string
-}
-
-// ClusterMetadataChecker provides an API to query cluster metadata.
-type ClusterMetadataChecker interface {
-	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
-	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
-
-	// CheckDefaultWorkloadStorage returns an error if the opinionated storage defined for
-	// the cluster does not match the specified storage.
-	CheckDefaultWorkloadStorage(cluster string, storageProvisioner *StorageProvisioner) error
-
-	// EnsureStorageProvisioner creates a storage provisioner with the specified config, or returns an existing one.
-	EnsureStorageProvisioner(cfg StorageProvisioner) (*StorageProvisioner, bool, error)
-}
-
-// NamespaceWatcher provides the API to watch caas namespace.
-type NamespaceWatcher interface {
-	// WatchNamespace returns a watcher which notifies when there
-	// are changes to current namespace.
-	WatchNamespace() (watcher.NotifyWatcher, error)
+	// WatchService returns a watcher which notifies when there
+	// are changes to the deployment of the specified application.
+	WatchService(appName string, mode DeploymentMode) (watcher.NotifyWatcher, error)
 }
 
 // Service represents information about the status of a caas service entity.

--- a/caas/kubernetes/metadata.go
+++ b/caas/kubernetes/metadata.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package caas
+package kubernetes
 
 import (
 	"fmt"
@@ -44,6 +44,27 @@ const (
 	MicroK8sClusterName = "microk8s-cluster"
 )
 
+// ClusterMetadataChecker provides an API to query cluster metadata.
+type ClusterMetadataChecker interface {
+	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
+	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
+
+	// CheckDefaultWorkloadStorage returns an error if the opinionated storage defined for
+	// the cluster does not match the specified storage.
+	CheckDefaultWorkloadStorage(cluster string, storageProvisioner *StorageProvisioner) error
+
+	// EnsureStorageProvisioner creates a storage provisioner with the specified config, or returns an existing one.
+	EnsureStorageProvisioner(cfg StorageProvisioner) (*StorageProvisioner, bool, error)
+}
+
+// ClusterMetadata defines metadata about a cluster.
+type ClusterMetadata struct {
+	NominatedStorageClass *StorageProvisioner
+	OperatorStorageClass  *StorageProvisioner
+	Cloud                 string
+	Regions               set.Strings
+}
+
 // PreferredStorage defines preferred storage
 // attributes on a given cluster.
 type PreferredStorage struct {
@@ -62,14 +83,6 @@ type StorageProvisioner struct {
 	Model             string
 	ReclaimPolicy     string
 	VolumeBindingMode string
-}
-
-// ClusterMetadata defines metadata about a cluster.
-type ClusterMetadata struct {
-	NominatedStorageClass *StorageProvisioner
-	OperatorStorageClass  *StorageProvisioner
-	Cloud                 string
-	Regions               set.Strings
 }
 
 // NonPreferredStorageError is raised when a cluster does not have

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	providerutils "github.com/juju/juju/caas/kubernetes/provider/utils"
@@ -76,37 +77,37 @@ type controllerServiceSpec struct {
 
 func getDefaultControllerServiceSpecs(cloudType string) *controllerServiceSpec {
 	specs := map[string]*controllerServiceSpec{
-		caas.K8sCloudAzure: {
+		k8s.K8sCloudAzure: {
 			ServiceType: core.ServiceTypeLoadBalancer,
 		},
-		caas.K8sCloudEC2: {
+		k8s.K8sCloudEC2: {
 			ServiceType: core.ServiceTypeLoadBalancer,
 			Annotations: k8sannotations.New(nil).
 				Add("service.beta.kubernetes.io/aws-load-balancer-backend-protocol", "tcp"),
 		},
-		caas.K8sCloudGCE: {
+		k8s.K8sCloudGCE: {
 			ServiceType: core.ServiceTypeLoadBalancer,
 		},
-		caas.K8sCloudMicrok8s: {
+		k8s.K8sCloudMicrok8s: {
 			ServiceType: core.ServiceTypeClusterIP,
 		},
-		caas.K8sCloudOpenStack: {
+		k8s.K8sCloudOpenStack: {
 			ServiceType: core.ServiceTypeLoadBalancer,
 		},
-		caas.K8sCloudMAAS: {
+		k8s.K8sCloudMAAS: {
 			ServiceType: core.ServiceTypeLoadBalancer, // TODO(caas): test and verify this.
 		},
-		caas.K8sCloudLXD: {
+		k8s.K8sCloudLXD: {
 			ServiceType: core.ServiceTypeClusterIP, // TODO(caas): test and verify this.
 		},
-		caas.K8sCloudOther: {
+		k8s.K8sCloudOther: {
 			ServiceType: core.ServiceTypeClusterIP, // Default svc spec for any other cloud is not listed above.
 		},
 	}
 	if out, ok := specs[cloudType]; ok {
 		return out
 	}
-	return specs[caas.K8sCloudOther]
+	return specs[k8s.K8sCloudOther]
 }
 
 type controllerStack struct {

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/v2/exec"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/cloud"
@@ -19,9 +19,9 @@ import (
 
 func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error) {
 	return attemptMicroK8sCloudInternal(cmdRunner, KubeCloudParams{
-		ClusterName:   caas.MicroK8sClusterName,
-		CloudName:     caas.K8sCloudMicrok8s,
-		CredentialUID: caas.K8sCloudMicrok8s,
+		ClusterName:   k8s.MicroK8sClusterName,
+		CloudName:     k8s.K8sCloudMicrok8s,
+		CredentialUID: k8s.K8sCloudMicrok8s,
 		CaasType:      constants.CAASProviderType,
 		ClientConfigGetter: func(caasType string) (clientconfig.ClientConfigFunc, error) {
 			return clientconfig.NewClientConfigReader(caasType)
@@ -46,7 +46,7 @@ func attemptMicroK8sCloudInternal(
 		return newCloud, jujucloud.Credential{}, "", err
 	}
 	newCloud.Regions = []jujucloud.Region{{
-		Name: caas.Microk8sRegion,
+		Name: k8s.Microk8sRegion,
 	}}
 	newCloud.Description = cloud.DefaultCloudDescription(cloud.CloudTypeCAAS)
 	return newCloud, credential, credential.Label, nil

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/utils/v2/exec"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
@@ -57,9 +57,9 @@ func (s *builtinSuite) SetUpTest(c *gc.C) {
 	var logger loggo.Logger
 	s.runner = dummyRunner{CallMocker: testing.NewCallMocker(logger)}
 	s.kubeCloudParams = provider.KubeCloudParams{
-		ClusterName:   caas.MicroK8sClusterName,
-		CloudName:     caas.K8sCloudMicrok8s,
-		CredentialUID: caas.K8sCloudMicrok8s,
+		ClusterName:   k8s.MicroK8sClusterName,
+		CloudName:     k8s.K8sCloudMicrok8s,
+		CredentialUID: k8s.K8sCloudMicrok8s,
 		CaasType:      constants.CAASProviderType,
 		ClientConfigGetter: func(caasType string) (clientconfig.ClientConfigFunc, error) {
 			return func(string, io.Reader, string, string, clientconfig.K8sCredentialResolver) (*clientconfig.ClientConfig, error) {
@@ -142,7 +142,7 @@ func (s *builtinSuite) TestAttemptMicroK8sCloud(c *gc.C) {
 	k8sCloud, credential, credentialName, err := provider.AttemptMicroK8sCloud(s.runner, s.kubeCloudParams)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(k8sCloud, gc.DeepEquals, cloud.Cloud{
-		Name:           caas.K8sCloudMicrok8s,
+		Name:           k8s.K8sCloudMicrok8s,
 		Endpoint:       "http://1.1.1.1:8080",
 		Type:           cloud.CloudTypeCAAS,
 		AuthTypes:      []cloud.AuthType{cloud.CertificateAuthType},

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -46,7 +46,7 @@ type KubeCloudParams struct {
 type KubeCloudStorageParams struct {
 	WorkloadStorage        string
 	HostCloudRegion        string
-	MetadataChecker        caas.ClusterMetadataChecker
+	MetadataChecker        ClusterMetadataChecker
 	GetClusterMetadataFunc GetClusterMetadataFunc
 }
 

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/utils/v2/exec"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -27,7 +27,7 @@ import (
 type ClientConfigFuncGetter func(string) (clientconfig.ClientConfigFunc, error)
 
 // GetClusterMetadataFunc returns the ClusterMetadata using the provided ClusterMetadataChecker
-type GetClusterMetadataFunc func(KubeCloudStorageParams) (*caas.ClusterMetadata, error)
+type GetClusterMetadataFunc func(KubeCloudStorageParams) (*k8s.ClusterMetadata, error)
 
 // KubeCloudParams defines the parameters used to extract a k8s cluster definition from kubeconfig data.
 type KubeCloudParams struct {
@@ -46,7 +46,7 @@ type KubeCloudParams struct {
 type KubeCloudStorageParams struct {
 	WorkloadStorage        string
 	HostCloudRegion        string
-	MetadataChecker        ClusterMetadataChecker
+	MetadataChecker        k8s.ClusterMetadataChecker
 	GetClusterMetadataFunc GetClusterMetadataFunc
 }
 
@@ -100,7 +100,7 @@ func newCloudCredentialFromKubeConfig(reader io.Reader, cloudParams KubeCloudPar
 	return newCloud, credential, nil
 }
 
-func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *caas.ClusterMetadata, storageMsg string) string {
+func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *k8s.ClusterMetadata, storageMsg string) string {
 	var workloadSC, operatorSC string
 	// Record the operator storage to use.
 	if clusterMetadata.OperatorStorageClass != nil {
@@ -182,8 +182,8 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 		if err == nil {
 			return
 		}
-		if caas.IsNonPreferredStorageError(err) {
-			npse := err.(*caas.NonPreferredStorageError)
+		if k8s.IsNonPreferredStorageError(err) {
+			npse := err.(*k8s.NonPreferredStorageError)
 			return "", NoRecommendedStorageError{Message: err.Error(), ProviderName: npse.Name}
 		}
 		if errors.IsNotFound(err) {
@@ -209,7 +209,7 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 		params            map[string]string
 	)
 	scName := storageParams.WorkloadStorage
-	nonPreferredStorageErr, ok := errors.Cause(err).(*caas.NonPreferredStorageError)
+	nonPreferredStorageErr, ok := errors.Cause(err).(*k8s.NonPreferredStorageError)
 	if ok {
 		provisioner = nonPreferredStorageErr.Provisioner
 		volumeBindingMode = nonPreferredStorageErr.VolumeBindingMode
@@ -220,7 +220,7 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 			scName = clusterMetadata.NominatedStorageClass.Name
 		}
 	}
-	sp, existing, err := storageParams.MetadataChecker.EnsureStorageProvisioner(caas.StorageProvisioner{
+	sp, existing, err := storageParams.MetadataChecker.EnsureStorageProvisioner(k8s.StorageProvisioner{
 		Name:              scName,
 		Provisioner:       provisioner,
 		Parameters:        params,
@@ -279,7 +279,7 @@ func BaseKubeCloudOpenParams(cloud cloud.Cloud, credential cloud.Credential) (en
 func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
 	// We special case Microk8s here as we need to query the cluster for the
 	// storage details with no input from the user
-	if cld.Name != caas.K8sCloudMicrok8s {
+	if cld.Name != k8s.K8sCloudMicrok8s {
 		return cld, nil
 	}
 
@@ -308,7 +308,7 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	}
 	storageUpdateParams := KubeCloudStorageParams{
 		MetadataChecker: broker,
-		GetClusterMetadataFunc: func(storageParams KubeCloudStorageParams) (*caas.ClusterMetadata, error) {
+		GetClusterMetadataFunc: func(storageParams KubeCloudStorageParams) (*k8s.ClusterMetadata, error) {
 			clusterMetadata, err := storageParams.MetadataChecker.GetClusterMetadata("")
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -111,7 +111,7 @@ func (s *cloudSuite) TestFinalizeCloudNotMicrok8s(c *gc.C) {
 	p := provider.NewProviderWithFakes(
 		dummyRunner{},
 		getterFunc(builtinCloudRet{}),
-		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil })
+		func(environs.OpenParams) (provider.ClusterMetadataChecker, error) { return &s.fakeBroker, nil })
 	cloudFinalizer := p.(environs.CloudFinalizer)
 
 	var ctx mockContext
@@ -193,7 +193,7 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 	return provider.NewProviderWithFakes(
 		s.runner,
 		getterFunc(builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}),
-		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
+		func(environs.OpenParams) (provider.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
 	)
 }
 
@@ -254,7 +254,7 @@ func (c *mockContext) Verbosef(f string, args ...interface{}) {
 
 type fakeK8sClusterMetadataChecker struct {
 	*testing.CallMocker
-	caas.ClusterMetadataChecker
+	provider.ClusterMetadataChecker
 }
 
 func (api *fakeK8sClusterMetadataChecker) GetClusterMetadata(storageClass string) (result *caas.ClusterMetadata, err error) {

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
@@ -81,17 +82,17 @@ type cloudSuite struct {
 }
 
 var defaultK8sCloud = jujucloud.Cloud{
-	Name:           caas.K8sCloudMicrok8s,
+	Name:           k8s.K8sCloudMicrok8s,
 	Endpoint:       "http://1.1.1.1:8080",
 	Type:           cloud.CloudTypeCAAS,
 	AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
 	CACertificates: []string{""},
 }
 
-var defaultClusterMetadata = &caas.ClusterMetadata{
-	Cloud:                caas.K8sCloudMicrok8s,
-	Regions:              set.NewStrings(caas.Microk8sRegion),
-	OperatorStorageClass: &caas.StorageProvisioner{Name: "operator-sc"},
+var defaultClusterMetadata = &k8s.ClusterMetadata{
+	Cloud:                k8s.K8sCloudMicrok8s,
+	Regions:              set.NewStrings(k8s.Microk8sRegion),
+	OperatorStorageClass: &k8s.StorageProvisioner{Name: "operator-sc"},
 }
 
 func getDefaultCredential() cloud.Credential {
@@ -111,7 +112,7 @@ func (s *cloudSuite) TestFinalizeCloudNotMicrok8s(c *gc.C) {
 	p := provider.NewProviderWithFakes(
 		dummyRunner{},
 		getterFunc(builtinCloudRet{}),
-		func(environs.OpenParams) (provider.ClusterMetadataChecker, error) { return &s.fakeBroker, nil })
+		func(environs.OpenParams) (k8s.ClusterMetadataChecker, error) { return &s.fakeBroker, nil })
 	cloudFinalizer := p.(environs.CloudFinalizer)
 
 	var ctx mockContext
@@ -137,27 +138,27 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{
-		Name:            caas.K8sCloudMicrok8s,
+		Name:            k8s.K8sCloudMicrok8s,
 		Type:            jujucloud.CloudTypeCAAS,
 		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
 		CACertificates:  []string{""},
 		Endpoint:        "http://1.1.1.1:8080",
-		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
+		HostCloudRegion: fmt.Sprintf("%s/%s", k8s.K8sCloudMicrok8s, k8s.Microk8sRegion),
 		Config:          map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": ""},
-		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
+		Regions:         []jujucloud.Region{{Name: k8s.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
 	})
 }
 
 func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 	preparedCloud := jujucloud.Cloud{
-		Name:            caas.K8sCloudMicrok8s,
+		Name:            k8s.K8sCloudMicrok8s,
 		Type:            jujucloud.CloudTypeCAAS,
 		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
 		CACertificates:  []string{""},
 		Endpoint:        "http://1.1.1.1:8080",
-		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
+		HostCloudRegion: fmt.Sprintf("%s/%s", k8s.K8sCloudMicrok8s, k8s.Microk8sRegion),
 		Config:          map[string]interface{}{"operator-storage": "something-else", "workload-storage": ""},
-		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
+		Regions:         []jujucloud.Region{{Name: k8s.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
 	}
 
 	p := s.getProvider()
@@ -176,14 +177,14 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, preparedCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloud, jc.DeepEquals, jujucloud.Cloud{
-		Name:            caas.K8sCloudMicrok8s,
+		Name:            k8s.K8sCloudMicrok8s,
 		Type:            jujucloud.CloudTypeCAAS,
 		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
 		CACertificates:  []string{""},
 		Endpoint:        "http://1.1.1.1:8080",
-		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
+		HostCloudRegion: fmt.Sprintf("%s/%s", k8s.K8sCloudMicrok8s, k8s.Microk8sRegion),
 		Config:          map[string]interface{}{"operator-storage": "something-else", "workload-storage": ""},
-		Regions:         []jujucloud.Region{{Name: caas.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
+		Regions:         []jujucloud.Region{{Name: k8s.Microk8sRegion, Endpoint: "http://1.1.1.1:8080"}},
 	})
 }
 
@@ -193,7 +194,7 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 	return provider.NewProviderWithFakes(
 		s.runner,
 		getterFunc(builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}),
-		func(environs.OpenParams) (provider.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
+		func(environs.OpenParams) (k8s.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
 	)
 }
 
@@ -254,20 +255,20 @@ func (c *mockContext) Verbosef(f string, args ...interface{}) {
 
 type fakeK8sClusterMetadataChecker struct {
 	*testing.CallMocker
-	provider.ClusterMetadataChecker
+	k8s.ClusterMetadataChecker
 }
 
-func (api *fakeK8sClusterMetadataChecker) GetClusterMetadata(storageClass string) (result *caas.ClusterMetadata, err error) {
+func (api *fakeK8sClusterMetadataChecker) GetClusterMetadata(storageClass string) (result *k8s.ClusterMetadata, err error) {
 	results := api.MethodCall(api, "GetClusterMetadata")
-	return results[0].(*caas.ClusterMetadata), testing.TypeAssertError(results[1])
+	return results[0].(*k8s.ClusterMetadata), testing.TypeAssertError(results[1])
 }
 
-func (api *fakeK8sClusterMetadataChecker) CheckDefaultWorkloadStorage(cluster string, storageProvisioner *caas.StorageProvisioner) error {
+func (api *fakeK8sClusterMetadataChecker) CheckDefaultWorkloadStorage(cluster string, storageProvisioner *k8s.StorageProvisioner) error {
 	results := api.MethodCall(api, "CheckDefaultWorkloadStorage")
 	return testing.TypeAssertError(results[0])
 }
 
-func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, bool, error) {
+func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg k8s.StorageProvisioner) (*k8s.StorageProvisioner, bool, error) {
 	results := api.MethodCall(api, "EnsureStorageProvisioner")
-	return results[0].(*caas.StorageProvisioner), false, testing.TypeAssertError(results[1])
+	return results[0].(*k8s.StorageProvisioner), false, testing.TypeAssertError(results[1])
 }

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/cloud"
@@ -131,7 +131,7 @@ func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredenti
 // RegisterCredentials is part of the environs.ProviderCredentialsRegister interface.
 func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	cloudName := cld.Name
-	if cloudName != caas.K8sCloudMicrok8s {
+	if cloudName != k8s.K8sCloudMicrok8s {
 		return make(map[string]*cloud.CloudCredential), nil
 	}
 	_, cred, _, err := p.builtinCloudGetter(p.cmdRunner)

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/utils/v2"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -103,10 +103,10 @@ func (s *credentialsSuite) TestRegisterCredentialsMicrok8s(c *gc.C) {
 	credentials, err := p.RegisterCredentials(defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)
-	c.Assert(credentials[caas.K8sCloudMicrok8s], gc.DeepEquals, &cloud.CloudCredential{
-		DefaultCredential: caas.K8sCloudMicrok8s,
+	c.Assert(credentials[k8s.K8sCloudMicrok8s], gc.DeepEquals, &cloud.CloudCredential{
+		DefaultCredential: k8s.K8sCloudMicrok8s,
 		AuthCredentials: map[string]cloud.Credential{
-			caas.K8sCloudMicrok8s: getDefaultCredential(),
+			k8s.K8sCloudMicrok8s: getDefaultCredential(),
 		},
 	})
 }

--- a/caas/kubernetes/provider/detectcloud.go
+++ b/caas/kubernetes/provider/detectcloud.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/cloud"
 )
 
@@ -27,7 +27,7 @@ func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
 
 // DetectCloud implements environs.CloudDetector.
 func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
-	if name != caas.K8sCloudMicrok8s {
+	if name != k8s.K8sCloudMicrok8s {
 		return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
 	}
 

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -49,7 +49,7 @@ func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEn
 	return provider.NewProviderWithFakes(
 		dummyRunner{},
 		getterFunc(builtin),
-		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) {
+		func(environs.OpenParams) (provider.ClusterMetadataChecker, error) {
 			return &fakeK8sClusterMetadataChecker{}, nil
 		},
 	)

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
@@ -49,7 +50,7 @@ func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEn
 	return provider.NewProviderWithFakes(
 		dummyRunner{},
 		getterFunc(builtin),
-		func(environs.OpenParams) (provider.ClusterMetadataChecker, error) {
+		func(environs.OpenParams) (k8s.ClusterMetadataChecker, error) {
 			return &fakeK8sClusterMetadataChecker{}, nil
 		},
 	)

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/cloud"
@@ -108,7 +109,7 @@ func NewProvider() caas.ContainerEnvironProvider {
 func NewProviderWithFakes(
 	runner CommandRunner,
 	getter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error),
-	brokerGetter func(environs.OpenParams) (ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
+	brokerGetter func(environs.OpenParams) (k8s.ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{
 		cmdRunner:          runner,
 		builtinCloudGetter: getter,

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -108,7 +108,7 @@ func NewProvider() caas.ContainerEnvironProvider {
 func NewProviderWithFakes(
 	runner CommandRunner,
 	getter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error),
-	brokerGetter func(environs.OpenParams) (caas.ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
+	brokerGetter func(environs.OpenParams) (ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{
 		cmdRunner:          runner,
 		builtinCloudGetter: getter,

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 )
 
@@ -15,8 +16,8 @@ const volBindModeWaitFirstConsumer = "WaitForFirstConsumer"
 
 var (
 	k8sCloudCheckers             map[string][]k8slabels.Selector
-	jujuPreferredWorkloadStorage map[string]caas.PreferredStorage
-	jujuPreferredOperatorStorage map[string]caas.PreferredStorage
+	jujuPreferredWorkloadStorage map[string]k8s.PreferredStorage
+	jujuPreferredOperatorStorage map[string]k8s.PreferredStorage
 
 	// lifecycleApplicationRemovalSelector is the label selector for removing global resources for application removal.
 	lifecycleApplicationRemovalSelector k8slabels.Selector
@@ -36,31 +37,31 @@ func init() {
 
 	// jujuPreferredWorkloadStorage defines the opinionated storage
 	// that Juju requires to be available on supported clusters.
-	jujuPreferredWorkloadStorage = map[string]caas.PreferredStorage{
+	jujuPreferredWorkloadStorage = map[string]k8s.PreferredStorage{
 		// WaitForFirstConsumer mode which will delay the binding and provisioning of a PersistentVolume until a
 		// Pod using the PersistentVolumeClaim is created.
 		// https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
-		caas.K8sCloudMicrok8s: {
+		k8s.K8sCloudMicrok8s: {
 			Name:              "hostpath",
 			Provisioner:       "microk8s.io/hostpath",
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
-		caas.K8sCloudGCE: {
+		k8s.K8sCloudGCE: {
 			Name:              "GCE Persistent Disk",
 			Provisioner:       "kubernetes.io/gce-pd",
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
-		caas.K8sCloudAzure: {
+		k8s.K8sCloudAzure: {
 			Name:              "Azure Disk",
 			Provisioner:       "kubernetes.io/azure-disk",
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
-		caas.K8sCloudEC2: {
+		k8s.K8sCloudEC2: {
 			Name:              "EBS Volume",
 			Provisioner:       "kubernetes.io/aws-ebs",
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
-		caas.K8sCloudOpenStack: {
+		k8s.K8sCloudOpenStack: {
 			Name:              "Cinder Disk",
 			Provisioner:       "csi-cinderplugin",
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
@@ -83,12 +84,12 @@ func init() {
 // cloud provider from node labels.
 func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 	return map[string][]k8slabels.Selector{
-		caas.K8sCloudMicrok8s: {
+		k8s.K8sCloudMicrok8s: {
 			newLabelRequirements(
 				requirementParams{"microk8s.io/cluster", selection.Exists, nil},
 			),
 		},
-		caas.K8sCloudGCE: {
+		k8s.K8sCloudGCE: {
 			// GKE.
 			newLabelRequirements(
 				requirementParams{"cloud.google.com/gke-nodepool", selection.Exists, nil},
@@ -99,7 +100,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 				requirementParams{"juju.is/cloud", selection.Equals, []string{"gce"}},
 			),
 		},
-		caas.K8sCloudEC2: {
+		k8s.K8sCloudEC2: {
 			// EKS.
 			newLabelRequirements(
 				requirementParams{"manufacturer", selection.Equals, []string{"amazon_ec2"}},
@@ -112,7 +113,7 @@ func compileK8sCloudCheckers() map[string][]k8slabels.Selector {
 				requirementParams{"juju.is/cloud", selection.Equals, []string{"ec2"}},
 			),
 		},
-		caas.K8sCloudAzure: {
+		k8s.K8sCloudAzure: {
 			// AKS.
 			newLabelRequirements(
 				requirementParams{"kubernetes.azure.com/cluster", selection.Exists, nil},

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2077,6 +2077,17 @@ func (k *kubernetesClient) WatchService(appName string, mode caas.DeploymentMode
 	return watcher.NewMultiNotifyWatcher(w1, w2), nil
 }
 
+// CheckCloudCredentials verifies the the cloud credentials provided to the
+// broker are functioning.
+func (k *kubernetesClient) CheckCloudCredentials() error {
+	if _, err := k.Namespaces(); err != nil {
+		// If this call could not be made with provided credential, we
+		// know that the credential is invalid.
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 // Units returns all units and any associated filesystems of the specified application.
 // Filesystems are mounted via volumes bound to the unit.
 func (k *kubernetesClient) Units(appName string, mode caas.DeploymentMode) ([]caas.Unit, error) {

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -15,7 +15,7 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	k8sannotations "github.com/juju/juju/core/annotations"
 )
 
@@ -70,8 +70,8 @@ func getCloudRegionFromNodeMeta(node core.Node) (string, string) {
 		for _, checker := range checkers {
 			if checker.Matches(k8slabels.Set(node.GetLabels())) {
 				region := node.Labels[regionLabelName]
-				if region == "" && cloudType == caas.K8sCloudMicrok8s {
-					region = caas.Microk8sRegion
+				if region == "" && cloudType == k8s.K8sCloudMicrok8s {
+					region = k8s.Microk8sRegion
 				}
 				return cloudType, region
 			}
@@ -95,8 +95,8 @@ const (
 	workloadStorageClassAnnotationKey = "juju.is/workload-storage"
 )
 
-func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner {
-	caasSc := &caas.StorageProvisioner{
+func toCaaSStorageProvisioner(sc storage.StorageClass) *k8s.StorageProvisioner {
+	caasSc := &k8s.StorageProvisioner{
 		Name:        sc.Name,
 		Provisioner: sc.Provisioner,
 		Parameters:  sc.Parameters,
@@ -111,8 +111,8 @@ func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner 
 }
 
 // GetClusterMetadata implements ClusterMetadataChecker.
-func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.ClusterMetadata, error) {
-	var result caas.ClusterMetadata
+func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*k8s.ClusterMetadata, error) {
+	var result k8s.ClusterMetadata
 	var err error
 	result.Cloud, result.Regions, err = k.listHostCloudRegions()
 	if err != nil {
@@ -136,10 +136,10 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 		return nil, errors.Annotate(err, "listing storage classes")
 	}
 
-	var possibleWorkloadStorage, possibleOperatorStorage []*caas.StorageProvisioner
+	var possibleWorkloadStorage, possibleOperatorStorage []*k8s.StorageProvisioner
 	preferredOperatorStorage, hasPreferredOperatorStorage := jujuPreferredOperatorStorage[result.Cloud]
 
-	pickOperatorSC := func(sc storage.StorageClass, maybeStorage *caas.StorageProvisioner) {
+	pickOperatorSC := func(sc storage.StorageClass, maybeStorage *k8s.StorageProvisioner) {
 		if result.OperatorStorageClass != nil {
 			return
 		}
@@ -166,7 +166,7 @@ func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*caas.Cluste
 		}
 	}
 
-	pickWorkloadSC := func(sc storage.StorageClass, maybeStorage *caas.StorageProvisioner) {
+	pickWorkloadSC := func(sc storage.StorageClass, maybeStorage *k8s.StorageProvisioner) {
 		if result.NominatedStorageClass != nil {
 			return
 		}
@@ -232,7 +232,7 @@ func (k *kubernetesClient) listHostCloudRegions() (string, set.Strings, error) {
 }
 
 // CheckDefaultWorkloadStorage implements ClusterMetadataChecker.
-func (k *kubernetesClient) CheckDefaultWorkloadStorage(cloudType string, storageProvisioner *caas.StorageProvisioner) error {
+func (k *kubernetesClient) CheckDefaultWorkloadStorage(cloudType string, storageProvisioner *k8s.StorageProvisioner) error {
 	preferredStorage, ok := jujuPreferredWorkloadStorage[cloudType]
 	if !ok {
 		return errors.NotFoundf("preferred workload storage for cloudType %q", cloudType)
@@ -240,15 +240,15 @@ func (k *kubernetesClient) CheckDefaultWorkloadStorage(cloudType string, storage
 	return storageClassMatches(preferredStorage, storageProvisioner)
 }
 
-func storageClassMatches(preferredStorage caas.PreferredStorage, storageProvisioner *caas.StorageProvisioner) error {
+func storageClassMatches(preferredStorage k8s.PreferredStorage, storageProvisioner *k8s.StorageProvisioner) error {
 	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
-		return &caas.NonPreferredStorageError{PreferredStorage: preferredStorage}
+		return &k8s.NonPreferredStorageError{PreferredStorage: preferredStorage}
 	}
 	for k, v := range preferredStorage.Parameters {
 		param, ok := storageProvisioner.Parameters[k]
 		if !ok || param != v {
 			return errors.Annotatef(
-				&caas.NonPreferredStorageError{PreferredStorage: preferredStorage},
+				&k8s.NonPreferredStorageError{PreferredStorage: preferredStorage},
 				"storage class %q requires parameter %s=%s", preferredStorage.Name, k, v)
 		}
 	}

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -16,7 +16,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
 )
 
@@ -223,7 +223,7 @@ func (s *K8sMetadataSuite) TestNoDefaultStorageClasses(c *gc.C) {
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
@@ -269,7 +269,7 @@ func (s *K8sMetadataSuite) TestPreferDefaultStorageClass(c *gc.C) {
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
@@ -294,7 +294,7 @@ func (s *K8sMetadataSuite) TestBetaDefaultStorageClass(c *gc.C) {
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
@@ -322,11 +322,11 @@ func (s *K8sMetadataSuite) TestUserSpecifiedStorageClasses(c *gc.C) {
 	)
 	metadata, err := s.broker.GetClusterMetadata("foo")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
 	})
 }
@@ -353,7 +353,7 @@ func (s *K8sMetadataSuite) TestOperatorStorageClassNoDefault(c *gc.C) {
 	// More than one match so need to be explicit for workload storage.
 	c.Check(metadata.NominatedStorageClass, gc.IsNil)
 	// Take the first match for operator storage.
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
 	})
 }
@@ -378,11 +378,11 @@ func (s *K8sMetadataSuite) TestOperatorStorageClassPrefersDefault(c *gc.C) {
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
@@ -411,12 +411,12 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadStorageClass(c *gc.C) {
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Name:        "juju-preferred-workload-storage",
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Name:        "juju-preferred-workload-storage",
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
@@ -458,12 +458,12 @@ func (s *K8sMetadataSuite) TestAnnotatedWorkloadAndOperatorStorageClass(c *gc.C)
 	)
 	metadata, err := s.broker.GetClusterMetadata("")
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Name:        "juju-preferred-workload-storage",
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
 	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
+	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
 		Name:        "juju-preferred-operator-storage",
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
@@ -482,9 +482,9 @@ func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageNonpreferred(c *gc.C) 
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.CheckDefaultWorkloadStorage("microk8s", &caas.StorageProvisioner{Provisioner: "foo"})
-	c.Assert(err, jc.Satisfies, caas.IsNonPreferredStorageError)
-	npse, ok := errors.Cause(err).(*caas.NonPreferredStorageError)
+	err := s.broker.CheckDefaultWorkloadStorage("microk8s", &k8s.StorageProvisioner{Provisioner: "foo"})
+	c.Assert(err, jc.Satisfies, k8s.IsNonPreferredStorageError)
+	npse, ok := errors.Cause(err).(*k8s.NonPreferredStorageError)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(npse.Provisioner, gc.Equals, "microk8s.io/hostpath")
 }

--- a/caas/kubernetes/provider/storage/storage.go
+++ b/caas/kubernetes/provider/storage/storage.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	constants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	resources "github.com/juju/juju/caas/kubernetes/provider/resources"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
@@ -94,7 +95,7 @@ func VolumeSourceForFilesystem(fs storage.KubernetesFilesystemParams) (*corev1.V
 }
 
 // StorageClassSpec converts storage provisioner config to k8s storage class.
-func StorageClassSpec(cfg caas.StorageProvisioner, legacyLabels bool) *storagev1.StorageClass {
+func StorageClassSpec(cfg k8s.StorageProvisioner, legacyLabels bool) *storagev1.StorageClass {
 	sc := storagev1.StorageClass{}
 	sc.Name = constants.QualifiedStorageClassName(cfg.Namespace, cfg.Name)
 	sc.Provisioner = cfg.Provisioner
@@ -241,8 +242,8 @@ func PersistentVolumeClaimSpec(params VolumeParams) *corev1.PersistentVolumeClai
 }
 
 // StorageProvisioner returns storage provisioner.
-func StorageProvisioner(namespace, model string, params VolumeParams) caas.StorageProvisioner {
-	return caas.StorageProvisioner{
+func StorageProvisioner(namespace, model string, params VolumeParams) k8s.StorageProvisioner {
+	return k8s.StorageProvisioner{
 		Name:          params.StorageConfig.StorageClass,
 		Namespace:     namespace,
 		Model:         model,

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/storage"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
@@ -143,7 +144,7 @@ func (k *kubernetesClient) ValidateStorageClass(config map[string]interface{}) e
 }
 
 // EnsureStorageProvisioner creates a storage class with the specified config, or returns an existing one.
-func (k *kubernetesClient) EnsureStorageProvisioner(cfg caas.StorageProvisioner) (*caas.StorageProvisioner, bool, error) {
+func (k *kubernetesClient) EnsureStorageProvisioner(cfg k8s.StorageProvisioner) (*k8s.StorageProvisioner, bool, error) {
 	// First see if the named storage class exists.
 	sc, err := k.getStorageClass(cfg.Name)
 	if err == nil {
@@ -205,7 +206,7 @@ func (k *kubernetesClient) maybeGetVolumeClaimSpec(params storage.VolumeParams) 
 	}
 	if !haveStorageClass {
 		params.StorageConfig.StorageClass = storageClassName
-		sc, _, err := k.EnsureStorageProvisioner(caas.StorageProvisioner{
+		sc, _, err := k.EnsureStorageProvisioner(k8s.StorageProvisioner{
 			Name:          params.StorageConfig.StorageClass,
 			Namespace:     k.namespace,
 			Provisioner:   params.StorageConfig.StorageProvisioner,

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -16,7 +16,6 @@ import (
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
-	v1 "k8s.io/api/core/v1"
 	reflect "reflect"
 )
 
@@ -115,18 +114,18 @@ func (mr *MockBrokerMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBroker)(nil).Bootstrap), arg0, arg1, arg2)
 }
 
-// CheckDefaultWorkloadStorage mocks base method
-func (m *MockBroker) CheckDefaultWorkloadStorage(arg0 string, arg1 *caas.StorageProvisioner) error {
+// CheckCloudCredentials mocks base method
+func (m *MockBroker) CheckCloudCredentials() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDefaultWorkloadStorage", arg0, arg1)
+	ret := m.ctrl.Call(m, "CheckCloudCredentials")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CheckDefaultWorkloadStorage indicates an expected call of CheckDefaultWorkloadStorage
-func (mr *MockBrokerMockRecorder) CheckDefaultWorkloadStorage(arg0, arg1 interface{}) *gomock.Call {
+// CheckCloudCredentials indicates an expected call of CheckCloudCredentials
+func (mr *MockBrokerMockRecorder) CheckCloudCredentials() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDefaultWorkloadStorage", reflect.TypeOf((*MockBroker)(nil).CheckDefaultWorkloadStorage), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCloudCredentials", reflect.TypeOf((*MockBroker)(nil).CheckCloudCredentials))
 }
 
 // Config mocks base method
@@ -270,22 +269,6 @@ func (mr *MockBrokerMockRecorder) EnsureService(arg0, arg1, arg2, arg3, arg4 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureService", reflect.TypeOf((*MockBroker)(nil).EnsureService), arg0, arg1, arg2, arg3, arg4)
 }
 
-// EnsureStorageProvisioner mocks base method
-func (m *MockBroker) EnsureStorageProvisioner(arg0 caas.StorageProvisioner) (*caas.StorageProvisioner, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureStorageProvisioner", arg0)
-	ret0, _ := ret[0].(*caas.StorageProvisioner)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// EnsureStorageProvisioner indicates an expected call of EnsureStorageProvisioner
-func (mr *MockBrokerMockRecorder) EnsureStorageProvisioner(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureStorageProvisioner", reflect.TypeOf((*MockBroker)(nil).EnsureStorageProvisioner), arg0)
-}
-
 // ExposeService mocks base method
 func (m *MockBroker) ExposeService(arg0 string, arg1 map[string]string, arg2 application.ConfigAttributes) error {
 	m.ctrl.T.Helper()
@@ -313,35 +296,6 @@ func (m *MockBroker) GetClusterMetadata(arg0 string) (*caas.ClusterMetadata, err
 func (mr *MockBrokerMockRecorder) GetClusterMetadata(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockBroker)(nil).GetClusterMetadata), arg0)
-}
-
-// GetCurrentNamespace mocks base method
-func (m *MockBroker) GetCurrentNamespace() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentNamespace")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetCurrentNamespace indicates an expected call of GetCurrentNamespace
-func (mr *MockBrokerMockRecorder) GetCurrentNamespace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentNamespace", reflect.TypeOf((*MockBroker)(nil).GetCurrentNamespace))
-}
-
-// GetNamespace mocks base method
-func (m *MockBroker) GetNamespace(arg0 string) (*v1.Namespace, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespace", arg0)
-	ret0, _ := ret[0].(*v1.Namespace)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNamespace indicates an expected call of GetNamespace
-func (mr *MockBrokerMockRecorder) GetNamespace(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockBroker)(nil).GetNamespace), arg0)
 }
 
 // GetService mocks base method
@@ -387,21 +341,6 @@ func (m *MockBroker) ModelOperatorExists() (bool, error) {
 func (mr *MockBrokerMockRecorder) ModelOperatorExists() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelOperatorExists", reflect.TypeOf((*MockBroker)(nil).ModelOperatorExists))
-}
-
-// Namespaces mocks base method
-func (m *MockBroker) Namespaces() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Namespaces")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Namespaces indicates an expected call of Namespaces
-func (mr *MockBrokerMockRecorder) Namespaces() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespaces", reflect.TypeOf((*MockBroker)(nil).Namespaces))
 }
 
 // Operator mocks base method
@@ -605,21 +544,6 @@ func (m *MockBroker) WatchContainerStart(arg0, arg1 string) (watcher.StringsWatc
 func (mr *MockBrokerMockRecorder) WatchContainerStart(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainerStart", reflect.TypeOf((*MockBroker)(nil).WatchContainerStart), arg0, arg1)
-}
-
-// WatchNamespace mocks base method
-func (m *MockBroker) WatchNamespace() (watcher.NotifyWatcher, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchNamespace")
-	ret0, _ := ret[0].(watcher.NotifyWatcher)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchNamespace indicates an expected call of WatchNamespace
-func (mr *MockBrokerMockRecorder) WatchNamespace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNamespace", reflect.TypeOf((*MockBroker)(nil).WatchNamespace))
 }
 
 // WatchOperator mocks base method

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -283,21 +283,6 @@ func (mr *MockBrokerMockRecorder) ExposeService(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExposeService", reflect.TypeOf((*MockBroker)(nil).ExposeService), arg0, arg1, arg2)
 }
 
-// GetClusterMetadata mocks base method
-func (m *MockBroker) GetClusterMetadata(arg0 string) (*caas.ClusterMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMetadata", arg0)
-	ret0, _ := ret[0].(*caas.ClusterMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterMetadata indicates an expected call of GetClusterMetadata
-func (mr *MockBrokerMockRecorder) GetClusterMetadata(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockBroker)(nil).GetClusterMetadata), arg0)
-}
-
 // GetService mocks base method
 func (m *MockBroker) GetService(arg0 string, arg1 caas.DeploymentMode, arg2 bool) (*caas.Service, error) {
 	m.ctrl.T.Helper()

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -127,7 +127,7 @@ func (api *fakeAddCloudAPI) AddCredential(tag string, credential cloud.Credentia
 
 type fakeK8sClusterMetadataChecker struct {
 	*jujutesting.CallMocker
-	jujucaas.ClusterMetadataChecker
+	caas.ClusterMetadataChecker
 	existingSC bool
 }
 
@@ -300,7 +300,7 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 		func() (caas.AddCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
-		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (jujucaas.ClusterMetadataChecker, error) {
+		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 		caas.FakeCluster(kubeConfigStr),

--- a/cmd/juju/caas/aks.go
+++ b/cmd/juju/caas/aks.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cmd/juju/interact"
 )
@@ -26,7 +26,7 @@ func newAKSCluster() k8sCluster {
 }
 
 func (a *aks) cloud() string {
-	return caas.K8sCloudAzure
+	return k8s.K8sCloudAzure
 }
 
 func (a *aks) ensureExecutable() error {

--- a/cmd/juju/caas/eks.go
+++ b/cmd/juju/caas/eks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cmd/juju/interact"
 )
@@ -31,7 +31,7 @@ func newEKSCluster() k8sCluster {
 }
 
 func (e *eks) cloud() string {
-	return caas.K8sCloudEC2
+	return k8s.K8sCloudEC2
 }
 
 func (e *eks) ensureExecutable() error {

--- a/cmd/juju/caas/gke.go
+++ b/cmd/juju/caas/gke.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cmd/juju/interact"
 )
@@ -26,7 +26,7 @@ func newGKECluster() k8sCluster {
 }
 
 func (g *gke) cloud() string {
-	return caas.K8sCloudGCE
+	return k8s.K8sCloudGCE
 }
 
 func (g *gke) ensureExecutable() error {

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -14,6 +14,7 @@ import (
 	cloudapi "github.com/juju/juju/api/cloud"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	jujucloud "github.com/juju/juju/cloud"
@@ -147,7 +148,7 @@ func (c *UpdateCAASCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential jujucloud.Credential) (ClusterMetadataChecker, error) {
+func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
 	openParams, err := provider.BaseKubeCloudOpenParams(cloud, credential)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -166,7 +167,7 @@ func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credentia
 	}
 
 	// This is k8-specific and not part of the Broker interface
-	if metaChecker, implemented := broker.(ClusterMetadataChecker); implemented {
+	if metaChecker, implemented := broker.(k8s.ClusterMetadataChecker); implemented {
 		return metaChecker, nil
 	}
 	return nil, errors.NotSupportedf("querying cluster metadata using the broker")

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -17,7 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	jujucaas "github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
@@ -110,9 +110,9 @@ func (s *updateCAASSuite) SetUpTest(c *gc.C) {
 	}
 	s.cloudMetadataStore = &fakeCloudMetadataStore{CallMocker: jujutesting.NewCallMocker(logger)}
 
-	defaultClusterMetadata := &jujucaas.ClusterMetadata{
+	defaultClusterMetadata := &k8s.ClusterMetadata{
 		Cloud: "gce", Regions: set.NewStrings("us-east1"),
-		OperatorStorageClass: &jujucaas.StorageProvisioner{Name: "operator-sc"},
+		OperatorStorageClass: &k8s.StorageProvisioner{Name: "operator-sc"},
 	}
 	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
 		CallMocker: jujutesting.NewCallMocker(logger),
@@ -135,7 +135,7 @@ func (s *updateCAASSuite) makeCommand() cmd.Command {
 		func() (caas.UpdateCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
-		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
+		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (k8s.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 	)
@@ -297,7 +297,7 @@ func (s *updateCAASSuite) TestBuiltinWithFile(c *gc.C) {
 
 func (s *updateCAASSuite) TestBuiltinToController(c *gc.C) {
 	var logger loggo.Logger
-	microk8sClusterMetadata := &jujucaas.ClusterMetadata{
+	microk8sClusterMetadata := &k8s.ClusterMetadata{
 		Cloud: "microk8s",
 	}
 	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
@@ -331,7 +331,7 @@ func (s *updateCAASSuite) TestAffectedModels(c *gc.C) {
 		ModelUUID: "uuid",
 		Errors:    []params.ErrorResult{{Error: &params.Error{Message: "error"}}},
 	}}
-	microk8sClusterMetadata := &jujucaas.ClusterMetadata{
+	microk8sClusterMetadata := &k8s.ClusterMetadata{
 		Cloud: "microk8s",
 	}
 	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
@@ -361,7 +361,7 @@ func (s *updateCAASSuite) TestUpdateCredentialError(c *gc.C) {
 		Errors:    []params.ErrorResult{{Error: &params.Error{Message: "error"}}},
 	}}
 	s.fakeCloudAPI.errorResult = &params.Error{Message: "some error"}
-	microk8sClusterMetadata := &jujucaas.ClusterMetadata{
+	microk8sClusterMetadata := &k8s.ClusterMetadata{
 		Cloud: "microk8s",
 	}
 	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -135,7 +135,7 @@ func (s *updateCAASSuite) makeCommand() cmd.Command {
 		func() (caas.UpdateCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
-		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (jujucaas.ClusterMetadataChecker, error) {
+		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (caas.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
 		},
 	)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -964,7 +964,7 @@ func (c *bootstrapCommand) controllerDataRefresher(
 		if err != nil {
 			return errors.Trace(err)
 		}
-	} else if env, ok := environ.(caas.ServiceGetterSetter); ok {
+	} else if env, ok := environ.(caas.ServiceManager); ok {
 		// CAAS.
 		var svc *caas.Service
 		svc, err = env.GetService(k8sprovider.JujuControllerStackName, caas.ModeWorkload, false)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/mgo.v2/txn"
 
 	"github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
@@ -2767,9 +2768,9 @@ type fakeBroker struct {
 	caas.Broker
 }
 
-func (f *fakeBroker) GetClusterMetadata(storageClass string) (result *caas.ClusterMetadata, err error) {
-	return &caas.ClusterMetadata{
-		NominatedStorageClass: &caas.StorageProvisioner{
+func (f *fakeBroker) GetClusterMetadata(storageClass string) (result *k8s.ClusterMetadata, err error) {
+	return &k8s.ClusterMetadata{
+		NominatedStorageClass: &k8s.StorageProvisioner{
 			Name: "storage-provisioner",
 		},
 	}, nil

--- a/worker/caasbroker/manifold.go
+++ b/worker/caasbroker/manifold.go
@@ -31,7 +31,7 @@ type ManifoldConfig struct {
 }
 
 // Manifold returns a Manifold that encapsulates a *Tracker and exposes it as
-// an caas,Broker resource.
+// a caas.Broker resource.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	manifold := dependency.Manifold{
 		Inputs: []string{

--- a/worker/caasfirewallerembedded/mocks/api_base_mock.go
+++ b/worker/caasfirewallerembedded/mocks/api_base_mock.go
@@ -6,14 +6,13 @@ package mocks
 
 import (
 	context "context"
-	http "net/http"
-	url "net/url"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	base "github.com/juju/juju/api/base"
 	names "github.com/juju/names/v4"
 	httprequest "gopkg.in/httprequest.v1"
+	http "net/http"
+	url "net/url"
+	reflect "reflect"
 )
 
 // MockAPICaller is a mock of APICaller interface

--- a/worker/caasfirewallerembedded/mocks/broker_mock.go
+++ b/worker/caasfirewallerembedded/mocks/broker_mock.go
@@ -5,10 +5,9 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	caas "github.com/juju/juju/caas"
+	reflect "reflect"
 )
 
 // MockCAASBroker is a mock of CAASBroker interface

--- a/worker/caasfirewallerembedded/mocks/client_mock.go
+++ b/worker/caasfirewallerembedded/mocks/client_mock.go
@@ -5,13 +5,12 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	charms "github.com/juju/juju/api/common/charms"
 	application "github.com/juju/juju/core/application"
 	life "github.com/juju/juju/core/life"
 	watcher "github.com/juju/juju/core/watcher"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface

--- a/worker/caasfirewallerembedded/mocks/logger_mock.go
+++ b/worker/caasfirewallerembedded/mocks/logger_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLogger is a mock of Logger interface

--- a/worker/caasfirewallerembedded/mocks/worker_mock.go
+++ b/worker/caasfirewallerembedded/mocks/worker_mock.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockWorker is a mock of Worker interface

--- a/worker/caasmodeloperator/manifold.go
+++ b/worker/caasmodeloperator/manifold.go
@@ -30,6 +30,7 @@ type ManifoldConfig struct {
 	// Logger to use in this worker
 	Logger Logger
 	// ModelUUID is the id of the model this worker is operating on
+
 	ModelUUID string
 }
 

--- a/worker/caasoperatorprovisioner/manifold.go
+++ b/worker/caasoperatorprovisioner/manifold.go
@@ -27,9 +27,8 @@ type ManifoldConfig struct {
 	APICallerName string
 	BrokerName    string
 	ClockName     string
-
-	NewWorker func(Config) (worker.Worker, error)
-	Logger    Logger
+	NewWorker     func(Config) (worker.Worker, error)
+	Logger        Logger
 }
 
 // Validate is called by start to check for bad configuration.

--- a/worker/caasoperatorprovisioner/manifold.go
+++ b/worker/caasoperatorprovisioner/manifold.go
@@ -88,12 +88,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	api := caasoperatorprovisioner.NewClient(apiCaller)
 	agentConfig := agent.CurrentConfig()
 	w, err := config.NewWorker(Config{
-		Facade:      api,
-		Broker:      broker,
-		ModelTag:    modelTag,
-		AgentConfig: agentConfig,
-		Clock:       clock,
-		Logger:      config.Logger,
+		Facade:          api,
+		OperatorManager: broker,
+		ModelTag:        modelTag,
+		AgentConfig:     agentConfig,
+		Clock:           clock,
+		Logger:          config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -71,12 +71,12 @@ func waitForStubCalls(c *gc.C, stub *jujutesting.Stub, expected []jujutesting.St
 
 func (s *CAASProvisionerSuite) assertWorker(c *gc.C) worker.Worker {
 	w, err := caasoperatorprovisioner.NewProvisionerWorker(caasoperatorprovisioner.Config{
-		Facade:      s.provisionerFacade,
-		Broker:      s.caasClient,
-		ModelTag:    s.modelTag,
-		AgentConfig: s.agentConfig,
-		Clock:       s.clock,
-		Logger:      loggo.GetLogger("test"),
+		Facade:          s.provisionerFacade,
+		OperatorManager: s.caasClient,
+		ModelTag:        s.modelTag,
+		AgentConfig:     s.agentConfig,
+		Clock:           s.clock,
+		Logger:          loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	expected := []jujutesting.StubCall{


### PR DESCRIPTION
This PR attempts to decouple some of the k8s-specific aspects of the `caas.Broker` interface and is part of the work for introducing support for ECS. 

The k8s-specific interfaces have been moved into the kubernetes provider and cast checks are used to verify that the injected broker instances complies with the interfaces (e.g. ClusterMetadataChecker) expected by the provider implementation.

In addition, a new interface called `CredentialChecker` has been introduced to the `caas.Broker` interface. The various facades call its `CheckCloudCredentials` method to verify that the cloud credentials still work. The original implementation was k8s-specific (list namespaces) and has been moved into the provider.

## QA steps

```console
$ make microk8s-operator-update
$ juju bootstrap microk8s k8s --no-gui
$ juju add-model test

# Deploy a legacy k8s charm
$ juju deploy cs:~charmed-osm/prometheus-k8s-32

# Deploy a charm that uses a sidecar container
$ git clone https://github.com/hpidcock/testing-charms
$ juju deploy ./testing-charms/cockroachdb --resource cockroachdb-image=cockroachdb/cockroach
# The latter should make it up to the install hook and error
```