### PR TITLE
CAAS controller upgrade broker back-port

### DIFF
--- a/caas/kubernetes/provider/controller_upgrade.go
+++ b/caas/kubernetes/provider/controller_upgrade.go
@@ -4,7 +4,6 @@
 package provider
 
 import (
-	"github.com/juju/names/v4"
 	"github.com/juju/version"
 	"k8s.io/client-go/kubernetes"
 
@@ -52,10 +51,11 @@ func controllerUpgrade(appName string, vers version.Number, broker UpgradeCAASCo
 		broker.Client().AppsV1().StatefulSets(broker.Namespace()))
 }
 
-func (k *kubernetesClient) upgradeController(agentTag names.Tag, vers version.Number) error {
+func (k *kubernetesClient) upgradeController(vers version.Number) error {
 	broker := &upgradeCAASControllerBridge{
 		clientFn:    k.client,
 		namespaceFn: k.GetCurrentNamespace,
+		isLegacyFn:  k.IsLegacyLabels,
 	}
 	return controllerUpgrade(bootstrap.ControllerModelName, vers, broker)
 }

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -30,7 +30,7 @@ func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
 	switch tag.Kind() {
 	case names.MachineTagKind:
 	case names.ControllerAgentTagKind:
-		return k.upgradeController(tag, vers)
+		return k.upgradeController(vers)
 	case names.ApplicationTagKind:
 		return k.upgradeOperator(tag, vers)
 	case names.ModelTagKind:


### PR DESCRIPTION
This is a back-port of k8s upgrade broker fixes included in e2f8f7e, with a merge of 2.9 to develop.