### PR TITLE
Thread kubeconfig insecure-skip-tls-verify option through juju

### DIFF
--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -144,6 +144,7 @@ func cloudsFromConfig(config *clientcmdapi.Config, cloudName string) (map[string
 			k8sCAData = caData
 		}
 		attrs["CAData"] = string(k8sCAData)
+		attrs["InsecureSkipTLSVerify"] = cluster.InsecureSkipTLSVerify
 
 		return CloudConfig{
 			Endpoint:   cluster.Server,

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -91,6 +91,11 @@ func newCloudCredentialFromKubeConfig(reader io.Reader, cloudParams KubeCloudPar
 	newCloud.AuthTypes = []cloud.AuthType{credential.AuthType()}
 	currentCloud := caasConfig.Clouds[context.CloudName]
 	newCloud.Endpoint = currentCloud.Endpoint
+	insecureSkipTLSVerify, ok := currentCloud.Attributes["InsecureSkipTLSVerify"].(bool)
+	if !ok {
+		return fail(errors.Errorf("InsecureSkipTLSVerify attribute should be a bool"))
+	}
+	newCloud.InsecureSkipTLSVerify = insecureSkipTLSVerify
 
 	cloudCAData, ok := currentCloud.Attributes["CAData"].(string)
 	if !ok {

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -108,6 +108,7 @@ func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Conf
 			CertData: []byte(credentialAttrs[CredAttrClientCertificateData]),
 			KeyData:  []byte(credentialAttrs[CredAttrClientKeyData]),
 			CAData:   CAData,
+			Insecure: cloudSpec.InsecureSkipTLSVerify,
 		},
 	}, nil
 }

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -134,6 +134,10 @@ type Cloud struct {
 	// overridden by a region.
 	Endpoint string
 
+	// InsecureTLSNoVerify determines whether TLS verification must be enforced
+	// for the above endpoint
+	InsecureSkipTLSVerify bool
+
 	// IdentityEndpoint is the default identity endpoint for the cloud
 	// regions, may be overridden by a region.
 	IdentityEndpoint string

--- a/environs/cloudspec/cloudspec.go
+++ b/environs/cloudspec/cloudspec.go
@@ -26,6 +26,10 @@ type CloudSpec struct {
 	// Endpoint is the endpoint for the cloud (region).
 	Endpoint string
 
+	// InsecureTLSNoVerify indicates whether TLS verification must be enforced
+	// for the above endpoint.
+	InsecureSkipTLSVerify bool
+
 	// IdentityEndpoint is the identity endpoint for the cloud (region).
 	IdentityEndpoint string
 
@@ -60,14 +64,15 @@ func (cs CloudSpec) Validate() error {
 // Cloud, cloud and region names, and credential.
 func MakeCloudSpec(cloud jujucloud.Cloud, cloudRegionName string, credential *jujucloud.Credential) (CloudSpec, error) {
 	cloudSpec := CloudSpec{
-		Type:             cloud.Type,
-		Name:             cloud.Name,
-		Region:           cloudRegionName,
-		Endpoint:         cloud.Endpoint,
-		IdentityEndpoint: cloud.IdentityEndpoint,
-		StorageEndpoint:  cloud.StorageEndpoint,
-		CACertificates:   cloud.CACertificates,
-		Credential:       credential,
+		Type:                  cloud.Type,
+		Name:                  cloud.Name,
+		Region:                cloudRegionName,
+		Endpoint:              cloud.Endpoint,
+		InsecureSkipTLSVerify: cloud.InsecureSkipTLSVerify,
+		IdentityEndpoint:      cloud.IdentityEndpoint,
+		StorageEndpoint:       cloud.StorageEndpoint,
+		CACertificates:        cloud.CACertificates,
+		Credential:            credential,
 	}
 	if cloudRegionName != "" {
 		cloudRegion, err := jujucloud.RegionByName(cloud.Regions, cloudRegionName)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/juju/+bug/1905977, allowing kubeconfigs with `insecure-skip-tls-verify` option set to work with Juju like they work with `kubectl` etc.

Haven't added tests or docs yet, putting this up for design review and initial PR feedback first.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Try to access a kube cluster using a different hostname or IP address to the one it was provisioned with in its TLS Common Name field, and the `insecure-skip-tls-verify` flag set to `true` in the `clusters` section of your `kubeconfig`. For convenience, https://testfaster.ci/ (currently) hands out such clusters for free on the public internet. So, first follow the steps shown in https://testfaster.ci/access_token, then run:

```sh
testctl get
export KUBECONFIG=$(pwd)/kubeconfig
juju add-k8s myk8scloud
```
Observe that it fails like
```
: cannot determine cluster region: listing nodes: Get "https://51.210.209.124:40383/api/v1/nodes?limit=5": x509: certificate is valid for 127.0.0.1, 172.17.0.1, 10.96.0.1, 127.0.0.1, 10.0.0.1, not 51.210.209.124
```

Then run the new version of the code, and observe that it succeeds:
```
luke@light:~/pc/charms$ ../juju/_build/linux_amd64/bin/juju add-k8s myk8scloud
This operation can be applied to both a copy on this client and to the one on a controller.
No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.

k8s substrate added as cloud "myk8scloud" with storage provisioned
by the existing "standard" storage class.
You can now bootstrap to this cloud by running 'juju bootstrap myk8scloud'.
```

The key part of the kubeconfig that is now being respected is:
```
[snip]
apiVersion: v1
clusters:
- cluster:
    server: https://51.210.209.124:40383
    insecure-skip-tls-verify: true # <-- this flag
  name: minikube
[snip]
```

## Documentation changes

Should enable users to start using kubeconfigs with `insecure-skip-tls-verify` with no further changes to UX.

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1905977