### PR TITLE
Fix validation for k8s updateStrategy for Recreate, OnDelete type;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1477,27 +1477,32 @@ func podAnnotations(annotations k8sannotations.Annotation) k8sannotations.Annota
 		Add("seccomp.security.beta.kubernetes.io/pod", "docker/default")
 }
 
+// https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
 func updateStrategyForDaemonSet(strategy specs.UpdateStrategy) (o apps.DaemonSetUpdateStrategy, err error) {
-	switch strategyType := apps.DaemonSetUpdateStrategyType(strategy.Type); strategyType {
-	case apps.RollingUpdateDaemonSetStrategyType, apps.OnDeleteDaemonSetStrategyType:
-		if strategy.RollingUpdate == nil {
-			return o, errors.New("rolling update spec is required")
+	strategyType := apps.DaemonSetUpdateStrategyType(strategy.Type)
+
+	o = apps.DaemonSetUpdateStrategy{Type: strategyType}
+	switch strategyType {
+	case apps.OnDeleteDaemonSetStrategyType:
+		if strategy.RollingUpdate != nil {
+			return o, errors.NewNotValid(nil, fmt.Sprintf("rolling update spec is not supported for %q", strategyType))
 		}
-		if strategy.RollingUpdate.Partition != nil || strategy.RollingUpdate.MaxSurge != nil {
-			return o, errors.NotValidf("rolling update spec for daemonset")
-		}
-		if strategy.RollingUpdate.MaxUnavailable == nil {
-			return o, errors.NewNotValid(nil, "rolling update spec maxUnavailable is missing")
-		}
-		return apps.DaemonSetUpdateStrategy{
-			Type: strategyType,
-			RollingUpdate: &apps.RollingUpdateDaemonSet{
+	case apps.RollingUpdateDaemonSetStrategyType:
+		if strategy.RollingUpdate != nil {
+			if strategy.RollingUpdate.Partition != nil || strategy.RollingUpdate.MaxSurge != nil {
+				return o, errors.NotValidf("rolling update spec for daemonset")
+			}
+			if strategy.RollingUpdate.MaxUnavailable == nil {
+				return o, errors.NewNotValid(nil, "rolling update spec maxUnavailable is missing")
+			}
+			o.RollingUpdate = &apps.RollingUpdateDaemonSet{
 				MaxUnavailable: k8sspecs.IntOrStringToK8s(*strategy.RollingUpdate.MaxUnavailable),
-			},
-		}, nil
+			}
+		}
 	default:
 		return o, errors.NotValidf("strategy type %q for daemonset", strategyType)
 	}
+	return o, nil
 }
 
 func (k *kubernetesClient) configureDaemonSet(
@@ -1532,7 +1537,7 @@ func (k *kubernetesClient) configureDaemonSet(
 				Add(annotationKeyApplicationUUID, storageUniqueID).ToMap(),
 		},
 		Spec: apps.DaemonSetSpec{
-			// TODO(caas): DaemonSetUpdateStrategy support.
+			// TODO(caas): MinReadySeconds support.
 			Selector: &v1.LabelSelector{
 				MatchLabels: k.getDaemonSetLabels(appName),
 			},
@@ -1569,32 +1574,36 @@ func (k *kubernetesClient) configureDaemonSet(
 	return cleanUps, errors.Trace(err)
 }
 
+// https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 func updateStrategyForDeployment(strategy specs.UpdateStrategy) (o apps.DeploymentStrategy, err error) {
-	switch strategyType := apps.DeploymentStrategyType(strategy.Type); strategyType {
-	case apps.RecreateDeploymentStrategyType, apps.RollingUpdateDeploymentStrategyType:
-		if strategy.RollingUpdate == nil {
-			return o, errors.New("rolling update spec is required")
+	strategyType := apps.DeploymentStrategyType(strategy.Type)
+
+	o = apps.DeploymentStrategy{Type: strategyType}
+	switch strategyType {
+	case apps.RecreateDeploymentStrategyType:
+		if strategy.RollingUpdate != nil {
+			return o, errors.NewNotValid(nil, fmt.Sprintf("rolling update spec is not supported for %q", strategyType))
 		}
-		if strategy.RollingUpdate.Partition != nil {
-			return o, errors.NotValidf("rolling update spec for deployment")
+	case apps.RollingUpdateDeploymentStrategyType:
+		if strategy.RollingUpdate != nil {
+			if strategy.RollingUpdate.Partition != nil {
+				return o, errors.NotValidf("rolling update spec for deployment")
+			}
+			if strategy.RollingUpdate.MaxSurge == nil && strategy.RollingUpdate.MaxUnavailable == nil {
+				return o, errors.NewNotValid(nil, "empty rolling update spec")
+			}
+			o.RollingUpdate = &apps.RollingUpdateDeployment{}
+			if strategy.RollingUpdate.MaxSurge != nil {
+				o.RollingUpdate.MaxSurge = k8sspecs.IntOrStringToK8s(*strategy.RollingUpdate.MaxSurge)
+			}
+			if strategy.RollingUpdate.MaxUnavailable != nil {
+				o.RollingUpdate.MaxUnavailable = k8sspecs.IntOrStringToK8s(*strategy.RollingUpdate.MaxUnavailable)
+			}
 		}
-		if strategy.RollingUpdate.MaxSurge == nil && strategy.RollingUpdate.MaxUnavailable == nil {
-			return o, errors.NewNotValid(nil, "empty rolling update spec")
-		}
-		o = apps.DeploymentStrategy{
-			Type:          strategyType,
-			RollingUpdate: &apps.RollingUpdateDeployment{},
-		}
-		if strategy.RollingUpdate.MaxSurge != nil {
-			o.RollingUpdate.MaxSurge = k8sspecs.IntOrStringToK8s(*strategy.RollingUpdate.MaxSurge)
-		}
-		if strategy.RollingUpdate.MaxUnavailable != nil {
-			o.RollingUpdate.MaxUnavailable = k8sspecs.IntOrStringToK8s(*strategy.RollingUpdate.MaxUnavailable)
-		}
-		return o, nil
 	default:
 		return o, errors.NotValidf("strategy type %q for deployment", strategyType)
 	}
+	return o, nil
 }
 
 func (k *kubernetesClient) configureDeployment(
@@ -1630,7 +1639,7 @@ func (k *kubernetesClient) configureDeployment(
 				Add(annotationKeyApplicationUUID, storageUniqueID).ToMap(),
 		},
 		Spec: apps.DeploymentSpec{
-			// TODO(caas): DeploymentStrategy support.
+			// TODO(caas): MinReadySeconds, ProgressDeadlineSeconds support.
 			Replicas:             replicas,
 			RevisionHistoryLimit: int32Ptr(deploymentRevisionHistoryLimit),
 			Selector: &v1.LabelSelector{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -5131,7 +5131,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 
 	basicPodSpec.Service = &specs.ServiceSpec{
 		UpdateStrategy: &specs.UpdateStrategy{
-			Type: "OnDelete",
+			Type: "RollingUpdate",
 			RollingUpdate: &specs.RollingUpdateSpec{
 				Partition: int32Ptr(10),
 			},
@@ -5159,7 +5159,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 	})
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	statefulSetArg.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
-		Type: apps.OnDeleteStatefulSetStrategyType,
+		Type: apps.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
 			Partition: int32Ptr(10),
 		},
@@ -7319,10 +7319,13 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 	_, err := provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{})
 	c.Assert(err, gc.ErrorMatches, `strategy type "" for daemonset not valid`)
 
-	_, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
+	o, err := provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 	})
-	c.Assert(err, gc.ErrorMatches, `rolling update spec is required`)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(o, jc.DeepEquals, apps.DaemonSetUpdateStrategy{
+		Type: apps.RollingUpdateDaemonSetStrategyType,
+	})
 
 	_, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
 		Type:          "RollingUpdate",
@@ -7346,7 +7349,7 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `rolling update spec for daemonset not valid`)
 
-	o, err := provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
+	o, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 		RollingUpdate: &specs.RollingUpdateSpec{
 			MaxUnavailable: &specs.IntOrString{IntVal: 10},
@@ -7362,17 +7365,19 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 
 	o, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
 		Type: "OnDelete",
-		RollingUpdate: &specs.RollingUpdateSpec{
-			MaxUnavailable: &specs.IntOrString{IntVal: 10},
-		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(o, jc.DeepEquals, apps.DaemonSetUpdateStrategy{
 		Type: apps.OnDeleteDaemonSetStrategyType,
-		RollingUpdate: &apps.RollingUpdateDaemonSet{
-			MaxUnavailable: &intstr.IntOrString{IntVal: 10},
+	})
+
+	o, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
+		Type: "OnDelete",
+		RollingUpdate: &specs.RollingUpdateSpec{
+			MaxUnavailable: &specs.IntOrString{IntVal: 10},
 		},
 	})
+	c.Assert(err, gc.ErrorMatches, `rolling update spec is not supported for "OnDelete"`)
 }
 
 func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
@@ -7382,10 +7387,13 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
 	_, err := provider.UpdateStrategyForDeployment(specs.UpdateStrategy{})
 	c.Assert(err, gc.ErrorMatches, `strategy type "" for deployment not valid`)
 
-	_, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
+	o, err := provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 	})
-	c.Assert(err, gc.ErrorMatches, `rolling update spec is required`)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(o, jc.DeepEquals, apps.DeploymentStrategy{
+		Type: apps.RollingUpdateDeploymentStrategyType,
+	})
 
 	_, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
 		Type:          "RollingUpdate",
@@ -7402,21 +7410,22 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `rolling update spec for deployment not valid`)
 
-	o, err := provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
+	o, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
+		Type: "Recreate",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(o, jc.DeepEquals, apps.DeploymentStrategy{
+		Type: apps.RecreateDeploymentStrategyType,
+	})
+
+	_, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
 		Type: "Recreate",
 		RollingUpdate: &specs.RollingUpdateSpec{
 			MaxUnavailable: &specs.IntOrString{IntVal: 10},
 			MaxSurge:       &specs.IntOrString{IntVal: 20},
 		},
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DeploymentStrategy{
-		Type: apps.RecreateDeploymentStrategyType,
-		RollingUpdate: &apps.RollingUpdateDeployment{
-			MaxUnavailable: &intstr.IntOrString{IntVal: 10},
-			MaxSurge:       &intstr.IntOrString{IntVal: 20},
-		},
-	})
+	c.Assert(err, gc.ErrorMatches, `rolling update spec is not supported for "Recreate"`)
 
 	o, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
 		Type: "RollingUpdate",
@@ -7442,10 +7451,13 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 	_, err := provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{})
 	c.Assert(err, gc.ErrorMatches, `strategy type "" for statefulset not valid`)
 
-	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
+	o, err := provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 	})
-	c.Assert(err, gc.ErrorMatches, `rolling update spec is required`)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(o, jc.DeepEquals, apps.StatefulSetUpdateStrategy{
+		Type: apps.RollingUpdateStatefulSetStrategyType,
+	})
 
 	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type:          "RollingUpdate",
@@ -7471,19 +7483,21 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `rolling update spec for statefulset not valid`)
 
-	o, err := provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
+	o, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
+		Type: "OnDelete",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(o, jc.DeepEquals, apps.StatefulSetUpdateStrategy{
+		Type: apps.OnDeleteStatefulSetStrategyType,
+	})
+
+	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "OnDelete",
 		RollingUpdate: &specs.RollingUpdateSpec{
 			Partition: int32Ptr(10),
 		},
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.StatefulSetUpdateStrategy{
-		Type: apps.OnDeleteStatefulSetStrategyType,
-		RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
-			Partition: int32Ptr(10),
-		},
-	})
+	c.Assert(err, gc.ErrorMatches, `rolling update spec is not supported for "OnDelete"`)
 
 	o, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -4,6 +4,8 @@
 package provider
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -21,27 +23,32 @@ func (k *kubernetesClient) getStatefulSetLabels(appName string) map[string]strin
 	}
 }
 
+// https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 func updateStrategyForStatefulSet(strategy specs.UpdateStrategy) (o apps.StatefulSetUpdateStrategy, err error) {
-	switch strategyType := apps.StatefulSetUpdateStrategyType(strategy.Type); strategyType {
-	case apps.RollingUpdateStatefulSetStrategyType, apps.OnDeleteStatefulSetStrategyType:
-		if strategy.RollingUpdate == nil {
-			return o, errors.New("rolling update spec is required")
+	strategyType := apps.StatefulSetUpdateStrategyType(strategy.Type)
+
+	o = apps.StatefulSetUpdateStrategy{Type: strategyType}
+	switch strategyType {
+	case apps.OnDeleteStatefulSetStrategyType:
+		if strategy.RollingUpdate != nil {
+			return o, errors.NewNotValid(nil, fmt.Sprintf("rolling update spec is not supported for %q", strategyType))
 		}
-		if strategy.RollingUpdate.MaxSurge != nil || strategy.RollingUpdate.MaxUnavailable != nil {
-			return o, errors.NotValidf("rolling update spec for statefulset")
-		}
-		if strategy.RollingUpdate.Partition == nil {
-			return o, errors.New("rolling update spec partition is missing")
-		}
-		return apps.StatefulSetUpdateStrategy{
-			Type: strategyType,
-			RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+	case apps.RollingUpdateStatefulSetStrategyType:
+		if strategy.RollingUpdate != nil {
+			if strategy.RollingUpdate.MaxSurge != nil || strategy.RollingUpdate.MaxUnavailable != nil {
+				return o, errors.NotValidf("rolling update spec for statefulset")
+			}
+			if strategy.RollingUpdate.Partition == nil {
+				return o, errors.New("rolling update spec partition is missing")
+			}
+			o.RollingUpdate = &apps.RollingUpdateStatefulSetStrategy{
 				Partition: strategy.RollingUpdate.Partition,
-			},
-		}, nil
+			}
+		}
 	default:
 		return o, errors.NotValidf("strategy type %q for statefulset", strategyType)
 	}
+	return o, nil
 }
 
 func (k *kubernetesClient) configureStatefulSet(


### PR DESCRIPTION
*Fix validation for k8s updateStrategy for Recreate, OnDelete type and make RollingUpdate optional for RollingUpdate type;*

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Add update strategy for stateful|stateless|daemon applications;

## QA steps

```console
## stateful - OnDelete
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateful",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "type": "OnDelete"
  }
}

$ mkubectl get -nt1 statefulset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "type": "OnDelete"
}

## stateful - RollingUpdate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateful",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "rollingUpdate": {
      "partition": 10
    },
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt1 statefulset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "rollingUpdate": {
    "partition": 10
  },
  "type": "RollingUpdate"
}

## stateless - Recreate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateless",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "type": "Recreate"
  }
}

$ mkubectl get -nt2 deployment.apps/mariadb-k8s -o json | jq .spec.strategy
{
  "type": "Recreate"
}

## stateless - RollingUpdate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateless",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "rollingUpdate": {
      "maxUnavailable": 10
    },
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt2 deployment.apps/mariadb-k8s -o json | jq .spec.strategy
{
  "rollingUpdate": {
    "maxSurge": "25%",
    "maxUnavailable": 10
  },
  "type": "RollingUpdate"
}

## daemon - OnDelete
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "daemon",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "type": "OnDelete"
  }
}

$ mkubectl get -nt4 daemonset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "type": "OnDelete"
}

## daemon - RollingUpdate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "daemon",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "rollingUpdate": {
      "maxUnavailable": 10
    },
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt4 daemonset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "rollingUpdate": {
    "maxUnavailable": 10
  },
  "type": "RollingUpdate"
}

// No `rollingUpdate` provided, default will be used.
$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt4 daemonset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "rollingUpdate": {
    "maxUnavailable": 1
  },
  "type": "RollingUpdate"
}

```

## Documentation changes

No

## Bug reference

No

