### PR TITLE
Parse charm platform

### DIFF
--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -137,7 +137,7 @@ func ParseChannel(s string) (Channel, error) {
 func ParseChannelNormalize(s string) (Channel, error) {
 	ch, err := ParseChannel(s)
 	if err != nil {
-		return Channel{}, err
+		return Channel{}, errors.Trace(err)
 	}
 	return ch.Normalize(), nil
 }

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -3,6 +3,13 @@
 
 package charm
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
 // Source represents the source of the charm.
 type Source string
 
@@ -32,4 +39,122 @@ type Origin struct {
 	// we should model that correctly here.
 	Revision *int
 	Channel  *Channel
+}
+
+// Platform describes the platform used to install the charm with.
+type Platform struct {
+	Architecture string
+	OS           string
+	Series       string
+}
+
+// MustParsePlatform parses a given string or returns a panic.
+func MustParsePlatform(s string) Platform {
+	p, err := ParsePlatformNormalize(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// ParsePlatform parses a string representing a store platform.
+// Serialized version of platform can be expected to conform to the following:
+//
+//  1. Architecture is mandatory.
+//  2. OS is optional and can be dropped. Series is mandatory if OS wants
+//  to be displayed.
+//  3. Series is also optional.
+//
+// To indicate something is missing `unknown` can be used in place.
+//
+// Examples:
+//
+//  1. `<arch>/<os>/<series>`
+//  2. `<arch>`
+//  3. `<arch>/<series>`
+//  4. `<arch>/unknown/<series>`
+//
+func ParsePlatform(s string) (Platform, error) {
+	if s == "" {
+		return Platform{}, errors.Errorf("platform cannot be empty")
+	}
+
+	p := strings.Split(s, "/")
+
+	var arch, os, series *string
+	switch len(p) {
+	case 1:
+		arch = &p[0]
+	case 2:
+		arch = &p[0]
+		series = &p[1]
+	case 3:
+		arch, os, series = &p[0], &p[1], &p[2]
+	default:
+		return Platform{}, errors.Errorf("platform is malformed and has too many components %q", s)
+	}
+
+	platform := Platform{}
+	if arch != nil {
+		if *arch == "" {
+			return Platform{}, errors.NotValidf("architecture in platform %q", s)
+		}
+		platform.Architecture = *arch
+	}
+	if os != nil {
+		if *os == "" {
+			return Platform{}, errors.NotValidf("os in platform %q", s)
+		}
+		platform.OS = *os
+	}
+	if series != nil {
+		if *series == "" {
+			return Platform{}, errors.NotValidf("series in platform %q", s)
+		}
+		platform.Series = *series
+	}
+
+	return platform, nil
+}
+
+// ParsePlatformNormalize parses a string presenting a store platform.
+// The returned platform's architecture, os and series are normalized.
+func ParsePlatformNormalize(s string) (Platform, error) {
+	platform, err := ParsePlatform(s)
+	if err != nil {
+		return Platform{}, errors.Trace(err)
+	}
+	return platform.Normalize(), nil
+}
+
+// Normalize the platform with normalized architecture, os and series.
+func (p Platform) Normalize() Platform {
+	os := p.OS
+	if os == "unknown" {
+		os = ""
+	}
+
+	series := p.Series
+	if series == "unknown" {
+		os = ""
+		series = ""
+	}
+
+	return Platform{
+		Architecture: p.Architecture,
+		OS:           os,
+		Series:       series,
+	}
+}
+
+func (p Platform) String() string {
+	path := p.Architecture
+	if os := p.OS; os != "" {
+		path = fmt.Sprintf("%s/%s", path, os)
+	}
+	if series := p.Series; series != "" {
+		path = fmt.Sprintf("%s/%s", path, series)
+	}
+
+	return path
 }

--- a/core/charm/origin_test.go
+++ b/core/charm/origin_test.go
@@ -1,0 +1,119 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/charm"
+)
+
+type platformSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&platformSuite{})
+
+func (s platformSuite) TestParsePlatform(c *gc.C) {
+	tests := []struct {
+		Name        string
+		Value       string
+		Expected    charm.Platform
+		ExpectedErr string
+	}{{
+		Name:        "empty",
+		Value:       "",
+		ExpectedErr: "platform cannot be empty",
+	}, {
+		Name:        "empty components",
+		Value:       "//",
+		ExpectedErr: `architecture in platform "//" not valid`,
+	}, {
+		Name:        "too many components",
+		Value:       "////",
+		ExpectedErr: `platform is malformed and has too many components "////"`,
+	}, {
+		Name:  "architecture",
+		Value: "amd64",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+		},
+	}, {
+		Name:  "architecture and series",
+		Value: "amd64/series",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			Series:       "series",
+		},
+	}, {
+		Name:  "architecture, os and series",
+		Value: "amd64/os/series",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "os",
+			Series:       "series",
+		},
+	}, {
+		Name:  "architecture, unknown os and series",
+		Value: "amd64/unknown/series",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "",
+			Series:       "series",
+		},
+	}, {
+		Name:  "architecture, unknown os and unknown series",
+		Value: "amd64/unknown/unknown",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "",
+			Series:       "",
+		},
+	}, {
+		Name:  "architecture and unknown series",
+		Value: "amd64/unknown",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "",
+			Series:       "",
+		},
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		ch, err := charm.ParsePlatformNormalize(test.Value)
+		if test.ExpectedErr != "" {
+			c.Assert(err, gc.ErrorMatches, test.ExpectedErr)
+		} else {
+			c.Assert(ch, gc.DeepEquals, test.Expected)
+			c.Assert(err, gc.IsNil)
+		}
+	}
+}
+
+func (s platformSuite) TestString(c *gc.C) {
+	tests := []struct {
+		Name     string
+		Value    string
+		Expected string
+	}{{
+		Name:     "architecture",
+		Value:    "amd64",
+		Expected: "amd64",
+	}, {
+		Name:     "architecture and series",
+		Value:    "amd64/series",
+		Expected: "amd64/series",
+	}, {
+		Name:     "architecture, os and series",
+		Value:    "amd64/os/series",
+		Expected: "amd64/os/series",
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		platform, err := charm.ParsePlatformNormalize(test.Value)
+		c.Assert(err, gc.IsNil)
+		c.Assert(platform.String(), gc.DeepEquals, test.Expected)
+	}
+}


### PR DESCRIPTION
The following introduces the parsing of platform so that importing and
exporting works as expected for the description package. Originally the
description package expected `os/series/arch`, but in reality it should
be `arch/os/series`, with arch being the non-optional value making it
consistent between the lack of optional values.

The rules for platform are the following:

 1. Architecture is mandatory.
 2. OS is optional and can be dropped. Series is mandatory if OS wants
 to be displayed.
 3. Series is also optional.

To indicate something is missing `unknown` can be used in place. Using
Normalize can clean up the output of the Platform output to ensure
consistency.

Examples of this would be:

 1. `<arch>/<os>/<series>`
 2. `<arch>`
 3. `<arch>/<series>`
 4. `<arch>/unknown/<series>`

The code is rather simple as it just splits over a string and plucks the
right parts based on the amount visible.

## QA steps

Test pass, this is being used in #12376 and was a piece that could be broken off
as a separate isolated chunk of work.