### PR TITLE
Handle implicit endpoints in network-get

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -76,9 +76,25 @@ func NewNetworkInfoForStrategy(
 		return nil, errors.Trace(err)
 	}
 
+	// Initialise the bindings map with all application endpoints.
+	// This will include those for which there is no explicit binding,
+	// such as the juju-info endpoint.
+	endpoints, err := app.Endpoints()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	allBindings := make(map[string]string)
+	for _, ep := range endpoints {
+		allBindings[ep.Name] = corenetwork.AlphaSpaceId
+	}
+
+	// Now fill in those that are bound.
 	bindings, err := app.EndpointBindings()
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	for ep, space := range bindings.Map() {
+		allBindings[ep] = space
 	}
 
 	model, err := st.Model()
@@ -95,7 +111,7 @@ func NewNetworkInfoForStrategy(
 		st:            st,
 		unit:          unit,
 		app:           app,
-		bindings:      bindings.Map(),
+		bindings:      allBindings,
 		defaultEgress: cfg.EgressSubnets(),
 		retryFactory:  retryFactory,
 		lookupHost:    lookupHost,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -629,7 +629,7 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 
 	args := params.NetworkInfoParams{
 		Unit:      s.wordpressUnit.Tag().String(),
-		Endpoints: []string{"db"},
+		Endpoints: []string{"db", "juju-info"},
 	}
 
 	privateAddress, err := s.machine0.PrivateAddress()
@@ -651,7 +651,8 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
-			"db": expectedInfo,
+			"db":        expectedInfo,
+			"juju-info": expectedInfo,
 		},
 	})
 }


### PR DESCRIPTION
This addresses a recent change to `NetworkInfo` that inadvertently returned an error for the implicit `juju-info` endpoint.

We now pre-populate the bindings map with `application.Endpoints()`, which includes `juju-info`,  with all bound to the _alpha_ space before filling in the explicit bindings from `application.EndpointBindings()`.

## QA steps

- Bootstrap to LXD
- Deploy MySQL
- Run `juju run --unit mysql/0 "network-get juju-info"`
- The return should be valid info and not an error; example:
```
bind-addresses:
- macaddress: 00:16:3e:72:3c:f7
  interfacename: eth0
  addresses:
  - hostname: ""
    address: 10.62.163.124
    cidr: 10.62.163.0/24
egress-subnets:
- 10.62.163.124/32
ingress-addresses:
- 10.62.163.124
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1906174
