### PR TITLE
Add ResourcesClient for charmhub

### DIFF
--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -115,12 +115,13 @@ func (c Config) BasePath() (charmhubpath.Path, error) {
 
 // Client represents the client side of a charm store.
 type Client struct {
-	url            string
-	infoClient     *InfoClient
-	findClient     *FindClient
-	downloadClient *DownloadClient
-	refreshClient  *RefreshClient
-	logger         Logger
+	url             string
+	infoClient      *InfoClient
+	findClient      *FindClient
+	downloadClient  *DownloadClient
+	refreshClient   *RefreshClient
+	resourcesClient *ResourcesClient
+	logger          Logger
 }
 
 // NewClient creates a new charmHub client from the supplied configuration.
@@ -152,6 +153,11 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 		return nil, errors.Annotate(err, "constructing refresh path")
 	}
 
+	resourcesPath, err := base.Join("resources")
+	if err != nil {
+		return nil, errors.Annotate(err, "constructing resources path")
+	}
+
 	config.Logger.Tracef("NewClient to %q", config.URL)
 
 	httpClient := DefaultHTTPTransport()
@@ -166,8 +172,9 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 		// download client doesn't require a path here, as the download could
 		// be from any server in theory. That information is found from the
 		// refresh response.
-		downloadClient: NewDownloadClient(httpClient, fileSystem, config.Logger),
-		logger:         config.Logger,
+		downloadClient:  NewDownloadClient(httpClient, fileSystem, config.Logger),
+		resourcesClient: NewResourcesClient(resourcesPath, restClient, config.Logger),
+		logger:          config.Logger,
 	}, nil
 }
 

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/kr/pretty"
 
 	"github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
@@ -56,7 +57,7 @@ func (c *InfoClient) Info(ctx context.Context, name string) (transport.InfoRespo
 		}
 		return resp, resultErr
 	}
-
+	c.logger.Tracef("Info() unmarshalled: %s", pretty.Sprint(resp))
 	return resp, nil
 }
 

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -3,6 +3,53 @@
 
 package charmhub
 
+import (
+	"context"
+	"net/http"
+
+	"github.com/juju/errors"
+	"github.com/kr/pretty"
+
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
+)
+
+// ResourcesClient defines a client for resources requests.
+type ResourcesClient struct {
+	path   path.Path
+	client RESTClient
+	logger Logger
+}
+
+// NewResourcesClient creates a ResourcesClient for requesting
+func NewResourcesClient(path path.Path, client RESTClient, logger Logger) *ResourcesClient {
+	return &ResourcesClient{
+		path:   path,
+		client: client,
+		logger: logger,
+	}
+}
+
+// ListResourceRevisions returns a slice of resource revisions for the provided
+// resource of the given charm.
+func (c *ResourcesClient) ListResourceRevisions(ctx context.Context, charm, resource string) ([]transport.ResourceRevision, error) {
+	c.logger.Tracef("ListResourceRevisions(%s, %s)", charm, resource)
+	var resp transport.ResourcesResponse
+	path, err := c.path.Join(charm, resource, "revisions")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	restResp, err := c.client.Get(ctx, path, &resp)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if restResp.StatusCode == http.StatusNotFound {
+		return nil, errors.NotFoundf("%q for %q", charm, resource)
+	}
+	c.logger.Tracef("ListResourceRevisions(%s, %s) unmarshalled: %s", charm, resource, pretty.Sprint(resp.Revisions))
+	return resp.Revisions, nil
+}
+
 var resourceFilter = []string{
 	"download.hash-sha256",
 	"download.hash-sha3-384",

--- a/charmhub/resources_test.go
+++ b/charmhub/resources_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmhub
+
+import (
+	"context"
+	"encoding/json"
+	http "net/http"
+	"net/http/httptest"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/charmhub/path"
+	"github.com/juju/juju/charmhub/transport"
+)
+
+type ResourcesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ResourcesSuite{})
+
+func (s *ResourcesSuite) TestListResourceRevisions(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	name := "meshuggah"
+	resource := "image"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, path, name, resource)
+
+	client := NewResourcesClient(path, restClient, &FakeLogger{})
+	response, err := client.ListResourceRevisions(context.TODO(), name, resource)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response, gc.HasLen, 3)
+}
+
+func (s *ResourcesSuite) TestListResourceRevisionsFailure(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	name := "meshuggah"
+	resource := "image"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGetFailure(restClient)
+
+	client := NewResourcesClient(path, restClient, &FakeLogger{})
+	_, err := client.ListResourceRevisions(context.TODO(), name, resource)
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
+}
+
+func (s *ResourcesSuite) expectGet(c *gc.C, client *MockRESTClient, p path.Path, charm, resource string) {
+	namedPath, err := p.Join(charm, resource, "revisions")
+	c.Assert(err, jc.ErrorIsNil)
+
+	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, response *transport.ResourcesResponse) {
+		response.Revisions = make([]transport.ResourceRevision, 3)
+	}).Return(RESTResponse{}, nil)
+}
+
+func (s *ResourcesSuite) expectGetFailure(client *MockRESTClient) {
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(RESTResponse{StatusCode: http.StatusInternalServerError}, errors.Errorf("boom"))
+}
+
+func (s *ResourcesSuite) TestListResourceRevisionsRequestPayload(c *gc.C) {
+	resourcesResponse := transport.ResourcesResponse{Revisions: []transport.ResourceRevision{
+		{Name: "image", Revision: 3, Type: "image"},
+		{Name: "image", Revision: 2, Type: "image"},
+		{Name: "image", Revision: 1, Type: "image"},
+	}}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		err := json.NewEncoder(w).Encode(resourcesResponse)
+		c.Assert(err, jc.ErrorIsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := Config{
+		URL: server.URL,
+	}
+	basePath, err := config.BasePath()
+	c.Assert(err, jc.ErrorIsNil)
+
+	resourcesPath, err := basePath.Join("resources")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	restClient := NewHTTPRESTClient(apiRequester, nil)
+
+	client := NewResourcesClient(resourcesPath, restClient, &FakeLogger{})
+	response, err := client.ListResourceRevisions(context.TODO(), "wordpress", "image")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response, gc.DeepEquals, resourcesResponse.Revisions)
+}

--- a/charmhub/transport/resources.go
+++ b/charmhub/transport/resources.go
@@ -3,6 +3,10 @@
 
 package transport
 
+type ResourcesResponse struct {
+	Revisions []ResourceRevision `json:"revisions"`
+}
+
 type ResourceRevision struct {
 	Download ResourceDownload `json:"download"`
 	Name     string           `json:"name"`

--- a/core/charm/strategies.go
+++ b/core/charm/strategies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v2"
+	"github.com/kr/pretty"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/juju/juju/core/lxdprofile"
@@ -351,7 +352,7 @@ func (s StoreCharmHub) Download(curl *charm.URL, file string, origin Origin) (St
 // DownloadOrigin returns an origin with the id and hash, without
 // downloading the charm.
 func (s StoreCharmHub) DownloadOrigin(curl *charm.URL, origin Origin) (Origin, error) {
-	s.logger.Tracef("DownloadOrigin(%s) %s", curl)
+	s.logger.Tracef("DownloadOrigin(%s) %s", curl, pretty.Sprint(origin))
 	_, downloadOrigin, err := s.repository.FindDownloadURL(curl, origin, s.series)
 	return downloadOrigin, errors.Trace(err)
 }


### PR DESCRIPTION
Includes the new client, response structures and ListResourceRevisons.
A new api endpoint for charmhub from: http://api.snapcraft.io/docs/charms.html#list_resource_revisions

There may be changes up coming to have the same property names, avoid hash-sha256 vs hash-sha256.

Will be used by `juju resources` in the future.

A few drive-by debug message fixes.

## QA steps

No change to current charmhub client behavior.  
