### PR TITLE
Remove validation in top level for updateStrategy;

### DIFF
--- a/caas/specs/base.go
+++ b/caas/specs/base.go
@@ -187,10 +187,10 @@ func (s UpdateStrategy) Validate() error {
 	if len(s.Type) == 0 {
 		return errors.New("type is required")
 	}
-	if s.RollingUpdate == nil {
-		return errors.New("rolling update strategy is required")
+	if s.RollingUpdate != nil {
+		return s.RollingUpdate.Validate()
 	}
-	return errors.Trace(s.RollingUpdate.Validate())
+	return nil
 }
 
 // ServiceSpec contains attributes to be set on v1.Service when

--- a/caas/specs/base_test.go
+++ b/caas/specs/base_test.go
@@ -107,7 +107,7 @@ func (s *baseSuite) TestValidateServiceSpec(c *gc.C) {
 			Type: "Recreate",
 		},
 	}
-	c.Assert(spec.Validate(), gc.ErrorMatches, `rolling update strategy is required`)
+	c.Assert(spec.Validate(), jc.ErrorIsNil)
 
 	var partition int32 = 3
 	spec = specs.ServiceSpec{


### PR DESCRIPTION
*Fix validation for k8s updateStrategy for Recreate, OnDelete type and make RollingUpdate optional for RollingUpdate type;*

### Checklist

 - [ ] ~Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?~
 - [x] Do comments answer the question of why design decisions were made?

----

## Description of change

Add update strategy for stateful|stateless|daemon applications;

## QA steps

```console
## stateful - OnDelete
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateful",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "type": "OnDelete"
  }
}

$ mkubectl get -nt1 statefulset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "type": "OnDelete"
}

## stateful - RollingUpdate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateful",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "rollingUpdate": {
      "partition": 10
    },
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt1 statefulset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "rollingUpdate": {
    "partition": 10
  },
  "type": "RollingUpdate"
}

## stateless - Recreate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateless",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "type": "Recreate"
  }
}

$ mkubectl get -nt2 deployment.apps/mariadb-k8s -o json | jq .spec.strategy
{
  "type": "Recreate"
}

## stateless - RollingUpdate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "stateless",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "rollingUpdate": {
      "maxUnavailable": 10
    },
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt2 deployment.apps/mariadb-k8s -o json | jq .spec.strategy
{
  "rollingUpdate": {
    "maxSurge": "25%",
    "maxUnavailable": 10
  },
  "type": "RollingUpdate"
}

## daemon - OnDelete
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "daemon",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "type": "OnDelete"
  }
}

$ mkubectl get -nt4 daemonset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "type": "OnDelete"
}

## daemon - RollingUpdate
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq .deployment
{
  "type": "daemon",
  "min-version": "1.10.1",
  "service": "omit"
}

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
  "updateStrategy": {
    "rollingUpdate": {
      "maxUnavailable": 10
    },
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt4 daemonset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "rollingUpdate": {
    "maxUnavailable": 10
  },
  "type": "RollingUpdate"
}

// No `rollingUpdate` provided, default will be used.
$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .service
{
    "type": "RollingUpdate"
  }
}

$ mkubectl get -nt4 daemonset.apps/mariadb-k8s -o json | jq .spec.updateStrategy
{
  "rollingUpdate": {
    "maxUnavailable": 1
  },
  "type": "RollingUpdate"
}

```

## Documentation changes

No

## Bug reference

No

