### PR TITLE
Merge 2.8 into 2.9

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/juju/juju/testing"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type baseLoginSuite struct {
@@ -95,8 +96,9 @@ func (s *loginSuite) TestLoginWithInvalidTag(c *gc.C) {
 	st := s.openAPIWithoutLogin(c, info)
 
 	request := &params.LoginRequest{
-		AuthTag:     "bar",
-		Credentials: "password",
+		AuthTag:       "bar",
+		Credentials:   "password",
+		ClientVersion: jujuversion.Current.String(),
 	}
 
 	var response params.LoginResult
@@ -656,7 +658,8 @@ func (s *loginSuite) TestAnonymousControllerLogin(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag: names.NewUserTag(api.AnonymousUsername).String(),
+		AuthTag:       names.NewUserTag(api.AnonymousUsername).String(),
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -912,8 +915,9 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (*state.User, param
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1020,9 +1024,10 @@ func (s *loginSuite) TestLoginAddsAuditConversationEventually(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
-		CLIArgs:     "hey you guys",
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		CLIArgs:       "hey you guys",
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1088,9 +1093,10 @@ func (s *loginSuite) TestAuditLoggingFailureOnInterestingRequest(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
-		CLIArgs:     "hey you guys",
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		CLIArgs:       "hey you guys",
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	// No error yet since logging the conversation is deferred until
@@ -1126,9 +1132,10 @@ func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 
 	var result params.LoginResult
 	request := &params.LoginRequest{
-		AuthTag:     user.Tag().String(),
-		Credentials: password,
-		CLIArgs:     "hey you guys",
+		AuthTag:       user.Tag().String(),
+		Credentials:   password,
+		CLIArgs:       "hey you guys",
+		ClientVersion: jujuversion.Current.String(),
 	}
 	err := conn.APICall("Admin", 3, "", "Login", request, &result)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -291,11 +291,11 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), false)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+1)),
+		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major)),
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, gc.ErrorMatches, `
-these models must first be upgraded to at least 2.9.0 before upgrading the controller:
+these models must first be upgraded to at least 2.9.* before upgrading the controller:
  -admin/controller`[1:])
 }
 

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -60,10 +60,10 @@ func (s *CAASOperatorSuite) SetUpTest(c *gc.C) {
 
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 	// Set up a CAAS model to replace the IAAS one.
-	// Ensure an older major version is used to prevent an upgrade
+	// Ensure major version 1 is used to prevent an upgrade
 	// from being attempted.
 	modelVers := jujuversion.Current
-	modelVers.Major--
+	modelVers.Major = 1
 	extraAttrs := coretesting.Attrs{
 		"agent-version": modelVers.String(),
 	}

--- a/featuretests/dblog_test.go
+++ b/featuretests/dblog_test.go
@@ -48,10 +48,10 @@ func (s *dblogSuite) SetUpTest(c *gc.C) {
 func (s *dblogSuite) TestControllerAgentLogsGoToDBCAAS(c *gc.C) {
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 	// Set up a CAAS model to replace the IAAS one.
-	// Ensure an older major version is used to prevent an upgrade
+	// Ensure major version 1 is used to prevent an upgrade
 	// from being attempted.
 	modelVers := jujuversion.Current
-	modelVers.Major--
+	modelVers.Major = 1
 	extraAttrs := coretesting.Attrs{
 		"agent-version": modelVers.String(),
 	}

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -72,8 +72,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 
 	s.oldVersion = coretesting.CurrentVersion(c)
-	s.oldVersion.Major = 2
-	s.oldVersion.Minor = 1
+	s.oldVersion.Major--
 
 	// Don't wait so long in tests.
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutMaster, time.Millisecond*50)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -447,8 +447,8 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 
 	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
 	err := s.runPrecheck(backend)
-	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.0 before being migrated to a controller with version 3.0.0`)
+	c.Assert(err, gc.ErrorMatches,
+		`model must be upgraded to at least version 2.9.* before being migrated to a controller with version 3.0.0`)
 
 	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
 	err = s.runPrecheck(backend)

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -107,8 +107,8 @@ func AllowedTargetVersion(
 	curVersion version.Number,
 	targetVersion version.Number,
 ) bool {
-	// Don't allow downgrading from higher major versions.
-	if curVersion.Major > targetVersion.Major {
+	// Don't allow downgrading from higher versions to version 1.x
+	if curVersion.Major >= 2 && targetVersion.Major == 1 {
 		return false
 	}
 	return true

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -483,7 +483,7 @@ func (s *AllowedTargetVersionSuite) TestAllowedTargetVersionSuite(c *gc.C) {
 	cases := []allowedTest{
 		{current: "2.7.4", target: "2.8.0", allowed: true},  // normal upgrade
 		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade caused by restore after upgrade
-		{current: "3.8.0", target: "2.2.3", allowed: false}, // can't downgrade major versions
+		{current: "3.8.0", target: "1.2.3", allowed: false}, // can't downgrade to major version 1.x
 		{current: "2.7.4", target: "2.7.5", allowed: true},  // point release
 		{current: "2.8.0", target: "2.7.4", allowed: true},  // downgrade after upgrade but before config file updated
 	}


### PR DESCRIPTION
Merge 2.8 forward to 2.9 with the following patches:
- #12386 from ycliuhw/fix/updateStrategy
- #12382 from manadart/2.8-netget-juju-info
- #12379 from ycliuhw/fix/updateStrategy