### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/api/upgrader/unitupgrader_test.go
+++ b/api/upgrader/unitupgrader_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/upgrader"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/watcher/watchertest"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -55,6 +57,15 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 func (s *unitUpgraderSuite) addMachineApplicationCharmAndUnit(c *gc.C, appName string) (*state.Machine, *state.Application, *state.Charm, *state.Unit) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	arch := arch.DefaultArchitecture
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &arch,
+	}
+	instId := instance.Id("i-host-machine")
+	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	charm := s.AddTestingCharm(c, appName)
 	app := s.AddTestingApplication(c, appName, charm)
 	unit, err := app.AddUnit(state.AddUnitParams{})

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/controller"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
@@ -182,7 +183,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 	results, err := s.controller.ModelStatus(req)
 	c.Assert(err, jc.ErrorIsNil)
 
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	mem := uint64(64 * 1024 * 1024 * 1024)
 	stdHw := &params.MachineHardware{
 		Arch: &arch,

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -633,7 +633,7 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 
 	args := params.NetworkInfoParams{
 		Unit:      s.wordpressUnit.Tag().String(),
-		Endpoints: []string{"db"},
+		Endpoints: []string{"db", "juju-info"},
 	}
 
 	privateAddress, err := s.machine0.PrivateAddress()
@@ -655,7 +655,8 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, params.NetworkInfoResults{
 		Results: map[string]params.NetworkInfoResult{
-			"db": expectedInfo,
+			"db":        expectedInfo,
+			"juju-info": expectedInfo,
 		},
 	})
 }

--- a/apiserver/facades/agent/upgrader/unitupgrader_test.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/upgrader"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/instance"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
@@ -45,9 +47,17 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	// Create a machine and unit to work with
-	var err error
-	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
+	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	arch := arch.DefaultArchitecture
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &arch,
+	}
+	instId := instance.Id("i-host-machine")
+	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	app := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	s.rawUnit, err = app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -402,7 +403,7 @@ func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		},
 	}
 
-	var cons constraints.Value
+	cons := constraints.MustParse("arch=amd64")
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -483,7 +484,7 @@ func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	var cons constraints.Value
+	cons := constraints.MustParse("arch=amd64")
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -516,7 +517,7 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	var cons constraints.Value
+	cons := constraints.MustParse("arch=amd64")
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -682,7 +683,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	var cons constraints.Value
+	cons := constraints.MustParse("arch=amd64")
 	config := map[string]string{"trust": "true"}
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
@@ -720,7 +721,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	var cons constraints.Value
+	cons := constraints.MustParse("arch=amd64")
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -1388,13 +1389,13 @@ func (s *applicationSuite) assertApplicationDeployPrincipalBlocked(c *gc.C, msg 
 }
 
 func (s *applicationSuite) TestBlockDestroyApplicationDeployPrincipal(c *gc.C) {
-	curl, bundle, cons := s.setupApplicationDeploy(c, "mem=4G")
+	curl, bundle, cons := s.setupApplicationDeploy(c, "arch=amd64 mem=4G")
 	s.BlockDestroyModel(c, "TestBlockDestroyApplicationDeployPrincipal")
 	s.assertApplicationDeployPrincipal(c, curl, bundle, cons)
 }
 
 func (s *applicationSuite) TestBlockRemoveApplicationDeployPrincipal(c *gc.C) {
-	curl, bundle, cons := s.setupApplicationDeploy(c, "mem=4G")
+	curl, bundle, cons := s.setupApplicationDeploy(c, "arch=amd64 mem=4G")
 	s.BlockRemoveObject(c, "TestBlockRemoveApplicationDeployPrincipal")
 	s.assertApplicationDeployPrincipal(c, curl, bundle, cons)
 }
@@ -1502,6 +1503,15 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 
 	machine, err := s.State.AddMachine("precise", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	arch := arch.DefaultArchitecture
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &arch,
+	}
+	instId := instance.Id("i-host-machine")
+	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
@@ -1545,6 +1555,15 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	arch := arch.DefaultArchitecture
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &arch,
+	}
+	instId := instance.Id("i-host-machine")
+	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
@@ -1603,6 +1622,15 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	arch := arch.DefaultArchitecture
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &arch,
+	}
+	instId := instance.Id("i-host-machine")
+	err = machine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
@@ -3165,12 +3193,12 @@ func (s *applicationSuite) TestBlockChangesSetApplicationConstraints(c *gc.C) {
 }
 
 func (s *applicationSuite) TestClientGetApplicationConstraints(c *gc.C) {
-	fooConstraints := constraints.MustParse("mem=4G")
+	fooConstraints := constraints.MustParse("arch=amd64", "mem=4G")
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:        "foo",
 		Constraints: fooConstraints,
 	})
-	barConstraints := constraints.MustParse("mem=128G", "cores=64")
+	barConstraints := constraints.MustParse("arch=amd64", "mem=128G", "cores=64")
 	s.Factory.MakeApplication(c, &factory.ApplicationParams{
 		Name:        "bar",
 		Constraints: barConstraints,

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -57,7 +57,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, app, s.charm.URL())
 	s.assertSettings(c, app, charm.Settings{})
 	s.assertApplicationConfig(c, app, coreapplication.ConfigAttributes(nil))
-	s.assertConstraints(c, app, constraints.Value{})
+	s.assertConstraints(c, app, constraints.MustParse("arch=amd64"))
 	s.assertMachines(c, app, constraints.Value{})
 }
 
@@ -306,7 +306,7 @@ func (s *DeployLocalSuite) TestDeployWithApplicationConfig(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
-	applicationCons := constraints.MustParse("cores=2")
+	applicationCons := constraints.MustParse("arch=amd64 cores=2")
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -92,6 +92,7 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
+		Constraints: constraints.MustParse("arch=amd64"),
 		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     true,
@@ -128,6 +129,7 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
+		Constraints: constraints.MustParse("arch=amd64"),
 		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     "My Title",
@@ -149,6 +151,7 @@ func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
+		Constraints: constraints.MustParse("arch=amd64"),
 		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     "My Title",
@@ -355,8 +358,9 @@ var getTests = []struct {
 		},
 	},
 }, {
-	about: "deployed application  #2",
-	charm: "dummy",
+	about:       "deployed application  #2",
+	charm:       "dummy",
+	constraints: "arch=amd64",
 	config: charm.Settings{
 		// Set title to default.
 		"title": nil,

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/cache"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -416,7 +417,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithSubordinate(c *gc.C) {
 }
 
 func (s *charmsMockSuite) TestCheckCharmPlacementWithConstraintArch(c *gc.C) {
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	appName := "winnie"
 
 	curl, err := charm.ParseURL("ch:poo")
@@ -470,7 +471,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArch(c *gc.C) {
 }
 
 func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchMachine(c *gc.C) {
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	appName := "winnie"
 
 	curl, err := charm.ParseURL("ch:poo")
@@ -742,7 +743,7 @@ func (s *charmsMockSuite) expectMachineConstraints(cons constraints.Value) {
 }
 
 func (s *charmsMockSuite) expectHardwareCharacteristics() {
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	s.machine.EXPECT().HardwareCharacteristics().Return(&instance.HardwareCharacteristics{
 		Arch: &arch,
 	}, nil)

--- a/caas/specs/base.go
+++ b/caas/specs/base.go
@@ -187,10 +187,10 @@ func (s UpdateStrategy) Validate() error {
 	if len(s.Type) == 0 {
 		return errors.New("type is required")
 	}
-	if s.RollingUpdate == nil {
-		return errors.New("rolling update strategy is required")
+	if s.RollingUpdate != nil {
+		return s.RollingUpdate.Validate()
 	}
-	return errors.Trace(s.RollingUpdate.Validate())
+	return nil
 }
 
 // ServiceSpec contains attributes to be set on v1.Service when

--- a/caas/specs/base_test.go
+++ b/caas/specs/base_test.go
@@ -107,7 +107,7 @@ func (s *baseSuite) TestValidateServiceSpec(c *gc.C) {
 			Type: "Recreate",
 		},
 	}
-	c.Assert(spec.Validate(), gc.ErrorMatches, `rolling update strategy is required`)
+	c.Assert(spec.Validate(), jc.ErrorIsNil)
 
 	var partition int32 = 3
 	spec = specs.ServiceSpec{

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -145,8 +145,16 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSuccess(c 
 	s.assertCharmsUploaded(c, "cs:xenial/mysql-42", "cs:xenial/wordpress-extra-bindings-47")
 
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"mysql":                    {charm: "cs:xenial/mysql-42", config: mysqlch.Config().DefaultSettings()},
-		"wordpress-extra-bindings": {charm: "cs:xenial/wordpress-extra-bindings-47", config: wpch.Config().DefaultSettings()},
+		"mysql": {
+			charm:       "cs:xenial/mysql-42",
+			config:      mysqlch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
+		"wordpress-extra-bindings": {
+			charm:       "cs:xenial/wordpress-extra-bindings-47",
+			config:      wpch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 	s.assertDeployedApplicationBindings(c, map[string]applicationInfo{
 		"mysql": {
@@ -155,7 +163,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSuccess(c 
 				"db":             network.AlphaSpaceId,
 				"server":         dbSpace.Id(),
 				"server-admin":   network.AlphaSpaceId,
-				"metrics-client": network.AlphaSpaceId},
+				"metrics-client": network.AlphaSpaceId,
+			},
 		},
 		"wordpress-extra-bindings": {
 			endpointBindings: map[string]string{
@@ -206,11 +215,15 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 	)
 	stdOut, stdErr, err = s.runDeployWithOutput(c, "cs:bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
-	// Nothing to do...
-	c.Check(stdOut, gc.Equals, "")
+	// Nothing to do... not quite...
+	c.Check(stdOut, gc.Equals, ""+
+		"Executing changes:\n"+
+		"- set constraints for mysql to \"\"\n"+
+		"- set constraints for wordpress to \"\"",
+	)
 	c.Check(stdErr, gc.Equals, ""+
 		"Located bundle \"cs:bundle/wordpress-simple-1\"\n"+
-		"No changes to apply.",
+		"Deploy of bundle completed.",
 	)
 
 	s.assertCharmsUploaded(c, "cs:xenial/mysql-42", "cs:xenial/wordpress-47")
@@ -275,7 +288,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
 	ch, err := s.State.Charm(charm.MustParseURL("local:xenial/dummy-1"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"dummy": {charm: "local:xenial/dummy-1", config: ch.Config().DefaultSettings()},
+		"dummy": {
+			charm:       "local:xenial/dummy-1",
+			config:      ch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 }
 
@@ -314,7 +331,11 @@ func (s *BundleDeployCharmStoreSuite) assertDeployBundleLocalPathInvalidSeriesWi
 	ch, err := s.State.Charm(charm.MustParseURL("local:quantal/dummy-1"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"dummy": {charm: "local:quantal/dummy-1", config: ch.Config().DefaultSettings()},
+		"dummy": {
+			charm:       "local:quantal/dummy-1",
+			config:      ch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 }
 
@@ -340,7 +361,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
 	ch, err := s.State.Charm(charm.MustParseURL("local:bionic/dummy-resource-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"dummy-resource": {charm: "local:bionic/dummy-resource-0", config: ch.Config().DefaultSettings()},
+		"dummy-resource": {
+			charm:       "local:bionic/dummy-resource-0",
+			config:      ch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 }
 
@@ -363,7 +388,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNoSeriesInCharmURL(c *gc.C
 	ch, err := s.State.Charm(charm.MustParseURL("cs:~who/multi-series-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"dummy": {charm: "cs:~who/multi-series-0", config: ch.Config().DefaultSettings()},
+		"dummy": {
+			charm:       "cs:~who/multi-series-0",
+			config:      ch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 }
 
@@ -734,7 +763,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(
 	lxdProfile, err := s.State.Charm(charm.MustParseURL("local:bionic/lxd-profile-0"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"lxd-profile": {charm: "local:bionic/lxd-profile-0", config: lxdProfile.Config().DefaultSettings()},
+		"lxd-profile": {
+			charm:       "local:bionic/lxd-profile-0",
+			config:      lxdProfile.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 	s.assertUnitsCreated(c, map[string]string{
 		"lxd-profile/0": "0",
@@ -854,8 +887,16 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c
 	mysqlch, err := s.State.Charm(charm.MustParseURL("local:xenial/mysql-1"))
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"mysql":     {charm: "local:xenial/mysql-1", config: mysqlch.Config().DefaultSettings()},
-		"wordpress": {charm: "cs:xenial/wordpress-42", config: wpch.Config().DefaultSettings()},
+		"mysql": {
+			charm:       "local:xenial/mysql-1",
+			config:      mysqlch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
+		"wordpress": {
+			charm:       "cs:xenial/wordpress-42",
+			config:      wpch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 	s.assertRelationsEstablished(c, "wordpress:db mysql:server")
 	s.assertUnitsCreated(c, map[string]string{
@@ -885,12 +926,14 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationOptions(c *gc.C
 	s.assertCharmsUploaded(c, "cs:bionic/dummy-0", "cs:xenial/wordpress-42")
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"customized": {
-			charm:  "cs:bionic/dummy-0",
-			config: s.combinedSettings(dch, charm.Settings{"username": "who", "skill-level": int64(47)}),
+			charm:       "cs:bionic/dummy-0",
+			config:      s.combinedSettings(dch, charm.Settings{"username": "who", "skill-level": int64(47)}),
+			constraints: constraints.MustParse("arch=amd64"),
 		},
 		"wordpress": {
-			charm:  "cs:xenial/wordpress-42",
-			config: s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
+			charm:       "cs:xenial/wordpress-42",
+			config:      s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
+			constraints: constraints.MustParse("arch=amd64"),
 		},
 	})
 	s.assertUnitsCreated(c, map[string]string{
@@ -923,7 +966,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstraints(c *
 		},
 		"wordpress": {
 			charm:       "cs:xenial/wordpress-42",
-			constraints: constraints.MustParse("mem=4G cores=2"),
+			constraints: constraints.MustParse("arch=amd64 mem=4G cores=2"),
 			config:      wpch.Config().DefaultSettings(),
 		},
 	})
@@ -993,6 +1036,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 		"Executing changes:\n"+
 		"- upload charm cs:trusty/upgrade-2 for series trusty\n"+
 		"- upgrade up to use charm cs:trusty/upgrade-2 for series trusty\n"+
+		"- set constraints for up to \"mem=8G\"\n"+
 		"- set application options for wordpress\n"+
 		`- set constraints for wordpress to "spaces=new cores=8"`,
 	)
@@ -1073,6 +1117,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNewRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
+		"- set constraints for mysql to \"\"\n"+
+		"- set constraints for varnish to \"\"\n"+
+		"- set constraints for wp to \"\"\n"+
 		"- add relation varnish:webcache - wp:cache",
 	)
 	s.assertRelationsEstablished(c, "wp:db mysql:server", "wp:cache varnish:webcache")
@@ -1111,10 +1158,15 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachinesUnitsPlacement(c *
 	err := s.DeployBundleYAML(c, content)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"sql": {charm: "cs:xenial/mysql-2", config: mysqlch.Config().DefaultSettings()},
+		"sql": {
+			charm:       "cs:xenial/mysql-2",
+			config:      mysqlch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 		"wp": {
-			charm:  "cs:xenial/wordpress-0",
-			config: s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
+			charm:       "cs:xenial/wordpress-0",
+			config:      s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
+			constraints: constraints.MustParse("arch=amd64"),
 		},
 	})
 	s.assertRelationsEstablished(c)
@@ -1211,7 +1263,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
     `)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
-		"django": {charm: "cs:xenial/django-42", config: ch.Config().DefaultSettings()},
+		"django": {
+			charm:       "cs:xenial/django-42",
+			config:      ch.Config().DefaultSettings(),
+			constraints: constraints.MustParse("arch=amd64"),
+		},
 	})
 	s.assertRelationsEstablished(c)
 	s.assertUnitsCreated(c, map[string]string{
@@ -1381,8 +1437,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSwitch(c *gc.C) {
 		"ror/0":    "1",
 	})
 
-	logger.Tracef("--------------------------------------------------------------------------")
-
 	// Redeploy a very similar bundle with another application unit. The new unit
 	// is placed on the first unit of memcached. Due to ordering of the applications
 	// there is no deterministic way to determine "least crowded" in a meaningful way.
@@ -1399,6 +1453,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSwitch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
+		"- set constraints for django to \"\"\n"+
 		"- deploy application node on bionic using cs:bionic/django-42\n"+
 		"- add unit node/0 to new machine 2",
 	)
@@ -1481,6 +1536,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
+		"- set constraints for django to \"\"\n"+
+		"- set constraints for memcached to \"\"\n"+
 		"- deploy application node on bionic using cs:bionic/django-42\n"+
 		"- add unit node/0 to 0/lxd/0 to satisfy [lxd:memcached]",
 	)
@@ -1488,7 +1545,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	// Redeploy the same bundle again and check that nothing happens.
 	stdOut, _, err = s.DeployBundleYAMLWithOutput(c, content)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stdOut, gc.Equals, "")
+	c.Assert(stdOut, gc.Equals, ""+
+		"Executing changes:\n"+
+		"- set constraints for node to \"\"",
+	)
 	s.assertUnitsCreated(c, map[string]string{
 		"django/0":    "0",
 		"django/1":    "0/lxd/0",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -607,7 +607,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	app, _ := s.AssertApplication(c, "multi-series", curl, 1, 0)
 	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2"))
+	c.Assert(cons, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=2G cores=2"))
 }
 
 func (s *DeploySuite) TestResources(c *gc.C) {

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -137,7 +137,7 @@ func ParseChannel(s string) (Channel, error) {
 func ParseChannelNormalize(s string) (Channel, error) {
 	ch, err := ParseChannel(s)
 	if err != nil {
-		return Channel{}, err
+		return Channel{}, errors.Trace(err)
 	}
 	return ch.Normalize(), nil
 }

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -3,6 +3,13 @@
 
 package charm
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
 // Source represents the source of the charm.
 type Source string
 
@@ -32,4 +39,122 @@ type Origin struct {
 	// we should model that correctly here.
 	Revision *int
 	Channel  *Channel
+}
+
+// Platform describes the platform used to install the charm with.
+type Platform struct {
+	Architecture string
+	OS           string
+	Series       string
+}
+
+// MustParsePlatform parses a given string or returns a panic.
+func MustParsePlatform(s string) Platform {
+	p, err := ParsePlatformNormalize(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// ParsePlatform parses a string representing a store platform.
+// Serialized version of platform can be expected to conform to the following:
+//
+//  1. Architecture is mandatory.
+//  2. OS is optional and can be dropped. Series is mandatory if OS wants
+//  to be displayed.
+//  3. Series is also optional.
+//
+// To indicate something is missing `unknown` can be used in place.
+//
+// Examples:
+//
+//  1. `<arch>/<os>/<series>`
+//  2. `<arch>`
+//  3. `<arch>/<series>`
+//  4. `<arch>/unknown/<series>`
+//
+func ParsePlatform(s string) (Platform, error) {
+	if s == "" {
+		return Platform{}, errors.Errorf("platform cannot be empty")
+	}
+
+	p := strings.Split(s, "/")
+
+	var arch, os, series *string
+	switch len(p) {
+	case 1:
+		arch = &p[0]
+	case 2:
+		arch = &p[0]
+		series = &p[1]
+	case 3:
+		arch, os, series = &p[0], &p[1], &p[2]
+	default:
+		return Platform{}, errors.Errorf("platform is malformed and has too many components %q", s)
+	}
+
+	platform := Platform{}
+	if arch != nil {
+		if *arch == "" {
+			return Platform{}, errors.NotValidf("architecture in platform %q", s)
+		}
+		platform.Architecture = *arch
+	}
+	if os != nil {
+		if *os == "" {
+			return Platform{}, errors.NotValidf("os in platform %q", s)
+		}
+		platform.OS = *os
+	}
+	if series != nil {
+		if *series == "" {
+			return Platform{}, errors.NotValidf("series in platform %q", s)
+		}
+		platform.Series = *series
+	}
+
+	return platform, nil
+}
+
+// ParsePlatformNormalize parses a string presenting a store platform.
+// The returned platform's architecture, os and series are normalized.
+func ParsePlatformNormalize(s string) (Platform, error) {
+	platform, err := ParsePlatform(s)
+	if err != nil {
+		return Platform{}, errors.Trace(err)
+	}
+	return platform.Normalize(), nil
+}
+
+// Normalize the platform with normalized architecture, os and series.
+func (p Platform) Normalize() Platform {
+	os := p.OS
+	if os == "unknown" {
+		os = ""
+	}
+
+	series := p.Series
+	if series == "unknown" {
+		os = ""
+		series = ""
+	}
+
+	return Platform{
+		Architecture: p.Architecture,
+		OS:           os,
+		Series:       series,
+	}
+}
+
+func (p Platform) String() string {
+	path := p.Architecture
+	if os := p.OS; os != "" {
+		path = fmt.Sprintf("%s/%s", path, os)
+	}
+	if series := p.Series; series != "" {
+		path = fmt.Sprintf("%s/%s", path, series)
+	}
+
+	return path
 }

--- a/core/charm/origin_test.go
+++ b/core/charm/origin_test.go
@@ -1,0 +1,119 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/charm"
+)
+
+type platformSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&platformSuite{})
+
+func (s platformSuite) TestParsePlatform(c *gc.C) {
+	tests := []struct {
+		Name        string
+		Value       string
+		Expected    charm.Platform
+		ExpectedErr string
+	}{{
+		Name:        "empty",
+		Value:       "",
+		ExpectedErr: "platform cannot be empty",
+	}, {
+		Name:        "empty components",
+		Value:       "//",
+		ExpectedErr: `architecture in platform "//" not valid`,
+	}, {
+		Name:        "too many components",
+		Value:       "////",
+		ExpectedErr: `platform is malformed and has too many components "////"`,
+	}, {
+		Name:  "architecture",
+		Value: "amd64",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+		},
+	}, {
+		Name:  "architecture and series",
+		Value: "amd64/series",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			Series:       "series",
+		},
+	}, {
+		Name:  "architecture, os and series",
+		Value: "amd64/os/series",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "os",
+			Series:       "series",
+		},
+	}, {
+		Name:  "architecture, unknown os and series",
+		Value: "amd64/unknown/series",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "",
+			Series:       "series",
+		},
+	}, {
+		Name:  "architecture, unknown os and unknown series",
+		Value: "amd64/unknown/unknown",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "",
+			Series:       "",
+		},
+	}, {
+		Name:  "architecture and unknown series",
+		Value: "amd64/unknown",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "",
+			Series:       "",
+		},
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		ch, err := charm.ParsePlatformNormalize(test.Value)
+		if test.ExpectedErr != "" {
+			c.Assert(err, gc.ErrorMatches, test.ExpectedErr)
+		} else {
+			c.Assert(ch, gc.DeepEquals, test.Expected)
+			c.Assert(err, gc.IsNil)
+		}
+	}
+}
+
+func (s platformSuite) TestString(c *gc.C) {
+	tests := []struct {
+		Name     string
+		Value    string
+		Expected string
+	}{{
+		Name:     "architecture",
+		Value:    "amd64",
+		Expected: "amd64",
+	}, {
+		Name:     "architecture and series",
+		Value:    "amd64/series",
+		Expected: "amd64/series",
+	}, {
+		Name:     "architecture, os and series",
+		Value:    "amd64/os/series",
+		Expected: "amd64/os/series",
+	}}
+	for k, test := range tests {
+		c.Logf("test %q at %d", test.Name, k)
+		platform, err := charm.ParsePlatformNormalize(test.Value)
+		c.Assert(err, gc.IsNil)
+		c.Assert(platform.String(), gc.DeepEquals, test.Expected)
+	}
+}

--- a/environs/manual/winrmprovisioner/winrmprovisioner_test.go
+++ b/environs/manual/winrmprovisioner/winrmprovisioner_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/environs/manual/winrmprovisioner"
 )
@@ -50,7 +51,7 @@ func (w *winrmprovisionerSuite) TestInitAdministratorError(c *gc.C) {
 }
 
 func (w *winrmprovisionerSuite) TestDetectSeriesAndHardwareCharacteristics(c *gc.C) {
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	mem := uint64(16)
 	series := "win2012r2"
 	cores := uint64(4)

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -69,6 +69,8 @@ func (s *cmdApplicationSuite) TestShowApplicationOne(c *gc.C) {
 wordpress:
   charm: wordpress
   series: quantal
+  constraints:
+    arch: amd64
   principal: true
   exposed: false
   remote: false
@@ -106,6 +108,8 @@ logging:
 wordpress:
   charm: wordpress
   series: quantal
+  constraints:
+    arch: amd64
   principal: true
   exposed: false
   remote: false

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -78,6 +78,7 @@ applications:
       logging-directory: alpha
   wordpress:
     charm: cs:quantal/wordpress-23
+    constraints: arch=amd64
     bindings:
       "": alpha
       admin-api: alpha

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
@@ -709,7 +710,7 @@ func (s *environSuite) assertStartInstance(c *gc.C, wantedRootDisk *int, rootDis
 	c.Assert(result.Volumes, gc.HasLen, 0)
 	c.Assert(result.VolumeAttachments, gc.HasLen, 0)
 
-	arch := "amd64"
+	arch := corearch.DefaultArchitecture
 	mem := uint64(1792)
 	cpuCores := uint64(1)
 	c.Assert(result.Hardware, jc.DeepEquals, &instance.HardwareCharacteristics{

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -56,6 +56,7 @@ import (
 	"github.com/juju/juju/apiserver/stateauthenticator"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/constraints"
@@ -1247,7 +1248,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		}
 		// Fill in some expected instance hardware characteristics if constraints not specified.
 		if hc.Arch == nil {
-			arch := "amd64"
+			arch := corearch.DefaultArchitecture
 			hc.Arch = &arch
 		}
 		if hc.Mem == nil {

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloudconfig/instancecfg"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
@@ -303,7 +304,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceCustomConstraintsApplied(c *
 	res, err := s.env.StartInstance(s.callCtx, startInstArgs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	arch := "amd64"
+	arch := corearch.DefaultArchitecture
 	c.Assert(res.Hardware, jc.DeepEquals, &instance.HardwareCharacteristics{
 		Arch:           &arch,
 		CpuCores:       &cpuCores,

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -187,7 +187,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpress.SetMinUnits(units)
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpress.SetConstraints(constraints.MustParse("mem=100M"))
+	err = wordpress.SetConstraints(constraints.MustParse("arch=amd64 mem=100M"))
 	c.Assert(err, jc.ErrorIsNil)
 	setApplicationConfigAttr(c, wordpress, "blog-title", "boring")
 	pairs := map[string]string{"x": "12", "y": "99"}
@@ -198,7 +198,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		CharmURL:    applicationCharmURL(wordpress).String(),
 		Life:        life.Alive,
 		MinUnits:    units,
-		Constraints: constraints.MustParse("mem=100M"),
+		Constraints: constraints.MustParse("arch=amd64 mem=100M"),
 		Annotations: pairs,
 		Config:      charm.Settings{"blog-title": "boring"},
 		Subordinate: false,
@@ -382,11 +382,12 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	mysql := AddTestingApplication(c, st, "mysql", AddTestingCharm(c, st, "mysql"))
 	curl := applicationCharmURL(mysql)
 	add(&multiwatcher.ApplicationInfo{
-		ModelUUID: modelUUID,
-		Name:      "mysql",
-		CharmURL:  curl.String(),
-		Life:      life.Alive,
-		Config:    charm.Settings{},
+		ModelUUID:   modelUUID,
+		Name:        "mysql",
+		CharmURL:    curl.String(),
+		Life:        life.Alive,
+		Config:      charm.Settings{},
+		Constraints: constraints.MustParse("arch=amd64"),
 		Status: multiwatcher.StatusInfo{
 			Current: "unset",
 			Message: "",
@@ -2115,13 +2116,14 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ApplicationInfo{
-						ModelUUID: st.ModelUUID(),
-						Name:      "wordpress",
-						Exposed:   true,
-						CharmURL:  "local:quantal/quantal-wordpress-3",
-						Life:      life.Alive,
-						MinUnits:  42,
-						Config:    charm.Settings{},
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress",
+						Exposed:     true,
+						CharmURL:    "local:quantal/quantal-wordpress-3",
+						Life:        life.Alive,
+						MinUnits:    42,
+						Config:      charm.Settings{},
+						Constraints: constraints.MustParse("arch=amd64"),
 						Status: multiwatcher.StatusInfo{
 							Current: "unset",
 							Message: "",

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3114,10 +3114,12 @@ func uint64p(val uint64) *uint64 {
 }
 
 func (s *ApplicationSuite) TestConstraints(c *gc.C) {
-	// Constraints are initially empty (for now).
+	amdArch := "amd64"
 	cons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &amdArch,
+	})
 
 	// Constraints can be set.
 	cons2 := constraints.Value{Mem: uint64p(4096)}
@@ -3148,24 +3150,28 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(cons6, jc.DeepEquals, constraints.Value{
+		Arch: &amdArch,
+	})
 }
 
 func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
-	// Constraints are initially empty (for now).
+	amdArch := "amd64"
 	cons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &amdArch,
+	})
 
 	// Constraints can not be set if it already exists and is different than
 	// the default architecture.
 	armArch := "arm64"
 	cons1 := constraints.Value{Arch: &armArch}
 	err = s.mysql.SetConstraints(cons1)
-	c.Assert(err, gc.ErrorMatches, "changing architecture not supported")
+	c.Assert(err, gc.ErrorMatches, "changing architecture \\(amd64\\) not supported")
 
 	// Constraints can be set.
-	amdArch := "amd64"
+
 	cons2 := constraints.Value{Arch: &amdArch}
 	err = s.mysql.SetConstraints(cons2)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3191,7 +3197,9 @@ func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(cons6, jc.DeepEquals, constraints.Value{
+		Arch: &amdArch,
+	})
 }
 
 func (s *ApplicationSuite) TestSetInvalidConstraints(c *gc.C) {
@@ -3226,12 +3234,18 @@ func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, s.mysql, state.Dying)
+
 	cons1 := constraints.MustParse("mem=1G")
 	err = s.mysql.SetConstraints(cons1)
 	c.Assert(err, gc.ErrorMatches, `cannot set constraints: application is not found or not alive`)
+
 	scons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&scons, jc.Satisfies, constraints.IsEmpty)
+
+	amdArch := "amd64"
+	c.Assert(scons, jc.DeepEquals, constraints.Value{
+		Arch: &amdArch,
+	})
 
 	// Removed (== Dead, for a application).
 	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -689,6 +689,11 @@ func (s *assignCleanSuite) assertMachineNotEmpty(c *gc.C, machine *state.Machine
 
 // setupMachines creates a combination of machines with which to test.
 func (s *assignCleanSuite) setupMachines(c *gc.C) (hostMachine *state.Machine, container *state.Machine, cleanEmptyMachine *state.Machine) {
+	amdArch := "amd64"
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &amdArch,
+	}
+
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -708,6 +713,11 @@ func (s *assignCleanSuite) setupMachines(c *gc.C) (hostMachine *state.Machine, c
 	// Create a new, clean machine but add containers so it is not empty.
 	hostMachine, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	instId := instance.Id("i-host-machine")
+	err = hostMachine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	container, err = s.State.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -716,11 +726,20 @@ func (s *assignCleanSuite) setupMachines(c *gc.C) (hostMachine *state.Machine, c
 	c.Assert(hostMachine.Clean(), jc.IsTrue)
 	s.assertMachineNotEmpty(c, hostMachine)
 
+	instId = instance.Id("i-container")
+	err = container.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	// Create a new, clean, empty machine.
 	cleanEmptyMachine, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cleanEmptyMachine.Clean(), jc.IsTrue)
 	s.assertMachineEmpty(c, cleanEmptyMachine)
+
+	instId = instance.Id("i-clean-empty-machine")
+	err = cleanEmptyMachine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	return hostMachine, container, cleanEmptyMachine
 }
 
@@ -821,90 +840,162 @@ var assignUsingConstraintsTests = []struct {
 	assignOk                bool
 }{
 	{
-		unitConstraints:         "",
-		hardwareCharacteristics: "",
-		assignOk:                true,
-	}, {
-		unitConstraints:         "arch=amd64",
-		hardwareCharacteristics: "none",
-		assignOk:                false,
-	}, {
-		unitConstraints:         "arch=amd64",
-		hardwareCharacteristics: "cores=1",
-		assignOk:                false,
-	}, {
+		// 0
 		unitConstraints:         "arch=amd64",
 		hardwareCharacteristics: "arch=amd64",
 		assignOk:                true,
 	}, {
+		// 1
+		unitConstraints:         "arch=amd64",
+		hardwareCharacteristics: "none",
+		assignOk:                false,
+	}, {
+		// 2
+		unitConstraints:         "arch=amd64",
+		hardwareCharacteristics: "cores=1",
+		assignOk:                false,
+	}, {
+		// 3
 		unitConstraints:         "arch=amd64",
 		hardwareCharacteristics: "arch=i386",
 		assignOk:                false,
 	}, {
+		// 4
 		unitConstraints:         "mem=4G",
 		hardwareCharacteristics: "none",
 		assignOk:                false,
 	}, {
+		// 5
 		unitConstraints:         "mem=4G",
 		hardwareCharacteristics: "cores=1",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "mem=4G",
-		hardwareCharacteristics: "mem=4G",
+		// 6
+		unitConstraints:         "arch=amd64 mem=4G",
+		hardwareCharacteristics: "arch=amd64 mem=4G",
 		assignOk:                true,
 	}, {
+		// 7
+		unitConstraints:         "mem=4G",
+		hardwareCharacteristics: "mem=4G",
+		assignOk:                false,
+	}, {
+		// 8
+		unitConstraints:         "arch=amd64 mem=4G",
+		hardwareCharacteristics: "arch=amd64 mem=2G",
+		assignOk:                false,
+	}, {
+		// 9
 		unitConstraints:         "mem=4G",
 		hardwareCharacteristics: "mem=2G",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "cores=2",
-		hardwareCharacteristics: "cores=2",
+		// 10
+		unitConstraints:         "arch=amd64 cores=2",
+		hardwareCharacteristics: "arch=amd64 cores=2",
 		assignOk:                true,
 	}, {
+		// 11
+		unitConstraints:         "cores=2",
+		hardwareCharacteristics: "cores=2",
+		assignOk:                false,
+	}, {
+		// 12
+		unitConstraints:         "arch=amd64 cores=2",
+		hardwareCharacteristics: "arch=amd64 cores=1",
+		assignOk:                false,
+	}, {
+		// 13
 		unitConstraints:         "cores=2",
 		hardwareCharacteristics: "cores=1",
 		assignOk:                false,
 	}, {
+		// 14
+		unitConstraints:         "arch=amd64 cores=2",
+		hardwareCharacteristics: "arch=amd64 mem=4G",
+		assignOk:                false,
+	}, {
+		// 15
 		unitConstraints:         "cores=2",
 		hardwareCharacteristics: "mem=4G",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "cpu-power=50",
-		hardwareCharacteristics: "cpu-power=50",
+		// 16
+		unitConstraints:         "arch=amd64 cpu-power=50",
+		hardwareCharacteristics: "arch=amd64 cpu-power=50",
 		assignOk:                true,
 	}, {
+		// 17
+		unitConstraints:         "cpu-power=50",
+		hardwareCharacteristics: "cpu-power=50",
+		assignOk:                false,
+	}, {
+		// 18
+		unitConstraints:         "arch=amd64 cpu-power=100",
+		hardwareCharacteristics: "arch=amd64 cpu-power=50",
+		assignOk:                false,
+	}, {
+		// 19
 		unitConstraints:         "cpu-power=100",
 		hardwareCharacteristics: "cpu-power=50",
 		assignOk:                false,
 	}, {
+		// 20
+		unitConstraints:         "arch=amd64 cpu-power=50",
+		hardwareCharacteristics: "arch=amd64 mem=4G",
+		assignOk:                false,
+	}, {
+		// 21
 		unitConstraints:         "cpu-power=50",
 		hardwareCharacteristics: "mem=4G",
 		assignOk:                false,
 	}, {
+		// 22
+		unitConstraints:         "arch=amd64 root-disk=8192",
+		hardwareCharacteristics: "arch=amd64 cpu-power=50",
+		assignOk:                false,
+	}, {
+		// 23
 		unitConstraints:         "root-disk=8192",
 		hardwareCharacteristics: "cpu-power=50",
 		assignOk:                false,
 	}, {
+		// 24
+		unitConstraints:         "arch=amd64 root-disk=8192",
+		hardwareCharacteristics: "arch=amd64 root-disk=4096",
+		assignOk:                false,
+	}, {
+		// 25
 		unitConstraints:         "root-disk=8192",
 		hardwareCharacteristics: "root-disk=4096",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "root-disk=8192",
-		hardwareCharacteristics: "root-disk=8192",
+		// 26
+		unitConstraints:         "arch=amd64 root-disk=8192",
+		hardwareCharacteristics: "arch=amd64 root-disk=8192",
 		assignOk:                true,
 	}, {
+		// 27
+		unitConstraints:         "root-disk=8192",
+		hardwareCharacteristics: "root-disk=8192",
+		assignOk:                false,
+	}, {
+		// 28
 		unitConstraints:         "root-disk-source=place1",
 		hardwareCharacteristics: "root-disk-source=place2",
 		assignOk:                false,
 	}, {
-		unitConstraints:         "root-disk-source=place1",
-		hardwareCharacteristics: "root-disk-source=place1",
+		// 29
+		unitConstraints:         "arch=amd64 root-disk-source=place1",
+		hardwareCharacteristics: "arch=amd64 root-disk-source=place1",
 		assignOk:                true,
 	}, {
+		// 30
 		unitConstraints:         "arch=amd64 mem=4G cores=2 root-disk=8192",
 		hardwareCharacteristics: "arch=amd64 mem=8G cores=2 root-disk=8192 root-disk-source=donk cpu-power=50",
 		assignOk:                true,
 	}, {
+		// 31
 		unitConstraints:         "arch=amd64 mem=4G cores=2 root-disk=8192 root-disk-source=donk",
 		hardwareCharacteristics: "arch=amd64 mem=8G cores=1 root-disk=4096 root-disk-source=donk cpu-power=50",
 		assignOk:                false,
@@ -977,9 +1068,19 @@ func (s *assignCleanSuite) TestAssignUnitToMachineWithRemovedUnit(c *gc.C) {
 }
 
 func (s *assignCleanSuite) TestAssignUnitToMachineWorksWithMachine0(c *gc.C) {
+	amdArch := "amd64"
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &amdArch,
+	}
+
 	m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
+
+	instId := instance.Id("i-host-machine")
+	err = m.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	unit, err := s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	assignedTo, err := s.assignUnit(unit)
@@ -1113,6 +1214,11 @@ func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageAndZonePlacementDi
 }
 
 func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.C) {
+	amdArch := "amd64"
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &amdArch,
+	}
+
 	_, unit, _ := s.setupSingleStorage(c, "filesystem", "loop-pool")
 	sb, err := state.NewStorageBackend(s.State)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1122,6 +1228,10 @@ func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.
 
 	// Add a clean machine.
 	clean, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	instId := instance.Id("i-host-machine")
+	err = clean.SetProvisioned(instId, "", "fake-nonce", hwChar)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// assign the unit to a machine, requesting clean/empty
@@ -1149,6 +1259,11 @@ func (s *assignCleanSuite) TestAssignUnitWithDynamicStorageCleanAvailable(c *gc.
 }
 
 func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
+	amdArch := "amd64"
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &amdArch,
+	}
+
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1194,6 +1309,11 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 	// Create a new, clean machine but add containers so it is not empty.
 	hostMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	instId := instance.Id("i-host-machine")
+	err = hostMachine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -1201,6 +1321,11 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostMachine.Clean(), jc.IsTrue)
 	s.assertMachineNotEmpty(c, hostMachine)
+
+	instId = instance.Id("i-container")
+	err = container.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	if s.policy == state.AssignClean {
 		expectedMachines = append(expectedMachines, hostMachine.Id())
 	}
@@ -1210,6 +1335,11 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 	for i := 0; i < 4; i++ {
 		m, err := s.State.AddMachine("quantal", state.JobHostUnits)
 		c.Assert(err, jc.ErrorIsNil)
+
+		instId = instance.Id(fmt.Sprintf("i-machine-%d", i))
+		err = m.SetProvisioned(instId, "", "fake-nonce", hwChar)
+		c.Assert(err, jc.ErrorIsNil)
+
 		expectedMachines = append(expectedMachines, m.Id())
 	}
 
@@ -1230,12 +1360,22 @@ func (s *assignCleanSuite) TestAssignUnitPolicy(c *gc.C) {
 }
 
 func (s *assignCleanSuite) TestAssignUnitPolicyWithContainers(c *gc.C) {
+	amdArch := "amd64"
+	hwChar := &instance.HardwareCharacteristics{
+		Arch: &amdArch,
+	}
+
 	_, err := s.State.AddMachine("quantal", state.JobManageModel) // bootstrap machine
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a machine and add a new container.
 	hostMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+
+	instId := instance.Id("i-host-machine")
+	err = hostMachine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	container, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
 		Series: "quantal",
 		Jobs:   []state.MachineJob{state.JobHostUnits},
@@ -1245,6 +1385,10 @@ func (s *assignCleanSuite) TestAssignUnitPolicyWithContainers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hostMachine.Clean(), jc.IsTrue)
 	s.assertMachineNotEmpty(c, hostMachine)
+
+	instId = instance.Id("i-container")
+	err = container.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
 
 	// Set up constraints to specify we want to install into a container.
 	econs := constraints.MustParse("container=lxd")
@@ -1288,6 +1432,10 @@ func (s *assignCleanSuite) TestAssignUnitPolicyWithContainers(c *gc.C) {
 	// Create a new, clean instance and check that the next container creation uses it.
 	hostMachine, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
+	instId = instance.Id("i-host-machine")
+	err = hostMachine.SetProvisioned(instId, "", "fake-nonce", hwChar)
+	c.Assert(err, jc.ErrorIsNil)
+
 	unit, err = s.wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, s.policy)

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -306,7 +306,7 @@ func (s *applicationConstraintsSuite) TestAddApplicationValidConstraints(c *gc.C
 }
 
 func (s *applicationConstraintsSuite) TestConstraintsRetrieval(c *gc.C) {
-	posCons := constraints.MustParse("spaces=db")
+	posCons := constraints.MustParse("arch=amd64 spaces=db")
 	application, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        s.applicationName,
 		Series:      "",
@@ -316,7 +316,7 @@ func (s *applicationConstraintsSuite) TestConstraintsRetrieval(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(application, gc.NotNil)
 
-	negCons := constraints.MustParse("spaces=^db2")
+	negCons := constraints.MustParse("arch=amd64 spaces=^db2")
 	negApplication, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name:        "unimportant",
 		Series:      "",

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
@@ -560,7 +561,7 @@ func (s *MachineSuite) TestDestroyFailsWhenNewContainerAdded(c *gc.C) {
 }
 
 func (s *MachineSuite) TestRemove(c *gc.C) {
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	char := &instance.HardwareCharacteristics{
 		Arch: &arch,
 	}
@@ -782,7 +783,7 @@ func (s *MachineSuite) TestMachineSetProvisionedUpdatesCharacteristics(c *gc.C) 
 	// Before provisioning, there is no hardware characteristics.
 	_, err := s.machine.HardwareCharacteristics()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	mem := uint64(4096)
 	expected := &instance.HardwareCharacteristics{
 		Arch: &arch,

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
@@ -440,7 +441,7 @@ func (s *ModelSummariesSuite) TestContainsMachineInformation(c *gc.C) {
 	// Instance data, but no core count
 	m4, err := shared.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	arch := "amd64"
+	arch := arch.DefaultArchitecture
 	err = m4.SetInstanceInfo("i-78901", "", "nonce", &instance.HardwareCharacteristics{
 		Arch: &arch,
 	}, nil, nil, nil, nil, nil)

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -261,7 +261,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationNoPlacement(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": failed for some reason`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
 		Series:      "quantal",
-		Constraints: constraints.MustParse("root-disk=20G"),
+		Constraints: constraints.MustParse("arch=amd64 root-disk=20G"),
 	})
 }
 
@@ -310,7 +310,8 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationMixedPlacement(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": hey now`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
-		Series:    "precise",
-		Placement: "somewhere",
+		Series:      "precise",
+		Placement:   "somewhere",
+		Constraints: constraints.MustParse("arch=amd64"),
 	})
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/application"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -1266,7 +1267,7 @@ func (s *StateSuite) TestInjectMachineErrors(c *gc.C) {
 
 func (s *StateSuite) TestInjectMachine(c *gc.C) {
 	cons := constraints.MustParse("mem=4G")
-	arch := "amd64"
+	arch := corearch.DefaultArchitecture
 	mem := uint64(1024)
 	disk := uint64(1024)
 	source := "loveshack"

--- a/state/unit.go
+++ b/state/unit.go
@@ -2455,7 +2455,6 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 	// be that when the machine is provisioned it will be found to
 	// be suitable, but we don't know that right now and it's best
 	// to err on the side of caution and exclude such machines.
-	var suitableInstanceData []instanceData
 	var suitableTerms bson.D
 	if cons.HasArch() {
 		suitableTerms = append(suitableTerms, bson.DocElem{"arch", *cons.Arch})
@@ -2484,6 +2483,8 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 	if len(suitableTerms) > 0 {
 		instanceDataCollection, closer := db.GetCollection(instanceDataC)
 		defer closer()
+
+		var suitableInstanceData []instanceData
 		err := instanceDataCollection.Find(suitableTerms).Select(bson.M{"_id": 1}).All(&suitableInstanceData)
 		if err != nil {
 			return nil, err
@@ -2624,7 +2625,7 @@ func (u *Unit) assignToCleanMaybeEmptyMachineOps(requireEmpty bool) (_ *Machine,
 	// TODO(axw) 2014-05-30 #1253704
 	// We should not select a machine that is in the process
 	// of being provisioned. There's no point asserting that
-	// the machine hasn't been provisioned, as there'll still
+	// the machine hasn't been provisioned, as there will still
 	// be a period of time during which the machine may be
 	// provisioned without the fact having yet been recorded
 	// in state.

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/application"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
@@ -283,7 +284,7 @@ func (factory *Factory) paramsFillDefaults(c *gc.C, params *MachineParams) *Mach
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	if params.Characteristics == nil {
-		arch := "amd64"
+		arch := corearch.DefaultArchitecture
 		mem := uint64(64 * 1024 * 1024 * 1024)
 		hardware := instance.HardwareCharacteristics{
 			Arch: &arch,


### PR DESCRIPTION
Zero conflict forward-merge of 2.9 with these patches:
- #12387 from manadart/2.8-into-2.9
- #12381 from SimonRichardson/charm-platform-parse
- #12369 from SimonRichardson/derive-architecture