### PR TITLE
Merge 2.8

### DIFF
--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -88,6 +88,7 @@ func (api *CloudSpecAPI) MakeCloudSpec(pSpec *params.CloudSpec) (environscloudsp
 		IdentityEndpoint: pSpec.IdentityEndpoint,
 		StorageEndpoint:  pSpec.StorageEndpoint,
 		CACertificates:   pSpec.CACertificates,
+		SkipTLSVerify:    pSpec.SkipTLSVerify,
 		Credential:       credential,
 	}
 	if err := spec.Validate(); err != nil {

--- a/api/common/cloudspec/cloudspec_test.go
+++ b/api/common/cloudspec/cloudspec_test.go
@@ -50,6 +50,7 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 						Attributes: map[string]string{"k": "v"},
 					},
 					CACertificates: []string{coretesting.CACert},
+					SkipTLSVerify:  true,
 				},
 			}},
 		}
@@ -72,6 +73,7 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 		StorageEndpoint:  "storage-endpoint",
 		Credential:       &credential,
 		CACertificates:   []string{coretesting.CACert},
+		SkipTLSVerify:    true,
 	})
 }
 

--- a/apiserver/common/cloud.go
+++ b/apiserver/common/cloud.go
@@ -38,6 +38,7 @@ func CloudToParams(cloud jujucloud.Cloud) params.Cloud {
 		StorageEndpoint:  cloud.StorageEndpoint,
 		Regions:          regions,
 		CACertificates:   cloud.CACertificates,
+		SkipTLSVerify:    cloud.SkipTLSVerify,
 		Config:           cloud.Config,
 		RegionConfig:     regionConfig,
 	}
@@ -73,6 +74,7 @@ func CloudFromParams(cloudName string, p params.Cloud) jujucloud.Cloud {
 		StorageEndpoint:  p.StorageEndpoint,
 		Regions:          regions,
 		CACertificates:   p.CACertificates,
+		SkipTLSVerify:    p.SkipTLSVerify,
 		Config:           p.Config,
 		RegionConfig:     regionConfig,
 	}

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -104,6 +104,7 @@ func (s cloudSpecAPI) GetCloudSpec(tag names.ModelTag) params.CloudSpecResult {
 		StorageEndpoint:  spec.StorageEndpoint,
 		Credential:       paramsCloudCredential,
 		CACertificates:   spec.CACertificates,
+		SkipTLSVerify:    spec.SkipTLSVerify,
 	}
 	return result
 }

--- a/apiserver/common/cloudspec/cloudspec_test.go
+++ b/apiserver/common/cloudspec/cloudspec_test.go
@@ -54,6 +54,7 @@ func (s *CloudSpecSuite) SetUpTest(c *gc.C) {
 		StorageEndpoint:  "storage-endpoint",
 		Credential:       &credential,
 		CACertificates:   []string{coretesting.CACert},
+		SkipTLSVerify:    true,
 	}
 }
 
@@ -104,6 +105,7 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 				Attributes: map[string]string{"k": "v"},
 			},
 			CACertificates: []string{coretesting.CACert},
+			SkipTLSVerify:  true,
 		},
 	}, {
 		Error: &params.Error{
@@ -188,6 +190,7 @@ func (s *CloudSpecSuite) TestCloudSpecNilCredential(c *gc.C) {
 			StorageEndpoint:  "storage-endpoint",
 			Credential:       nil,
 			CACertificates:   []string{coretesting.CACert},
+			SkipTLSVerify:    true,
 		},
 	}})
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1361,6 +1361,9 @@
                         "region": {
                             "type": "string"
                         },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
                         "storage-endpoint": {
                             "type": "string"
                         },
@@ -6256,6 +6259,9 @@
                         },
                         "region": {
                             "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
                         },
                         "storage-endpoint": {
                             "type": "string"
@@ -16447,6 +16453,9 @@
                                 "$ref": "#/definitions/CloudRegion"
                             }
                         },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
                         "storage-endpoint": {
                             "type": "string"
                         },
@@ -17628,6 +17637,9 @@
                         },
                         "region": {
                             "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
                         },
                         "storage-endpoint": {
                             "type": "string"
@@ -21293,6 +21305,9 @@
                         },
                         "region": {
                             "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
                         },
                         "storage-endpoint": {
                             "type": "string"
@@ -43112,6 +43127,9 @@
                         },
                         "region": {
                             "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
                         },
                         "storage-endpoint": {
                             "type": "string"

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -13,6 +13,7 @@ type Cloud struct {
 	StorageEndpoint  string                            `json:"storage-endpoint,omitempty"`
 	Regions          []CloudRegion                     `json:"regions,omitempty"`
 	CACertificates   []string                          `json:"ca-certificates,omitempty"`
+	SkipTLSVerify    bool                              `json:"skip-tls-verify,omitempty"`
 	Config           map[string]interface{}            `json:"config,omitempty"`
 	RegionConfig     map[string]map[string]interface{} `json:"region-config,omitempty"`
 }
@@ -198,6 +199,7 @@ type CloudSpec struct {
 	StorageEndpoint  string           `json:"storage-endpoint,omitempty"`
 	Credential       *CloudCredential `json:"credential,omitempty"`
 	CACertificates   []string         `json:"cacertificates,omitempty"`
+	SkipTLSVerify    bool             `json:"skip-tls-verify,omitempty"`
 }
 
 // CloudSpecResult contains a CloudSpec or an error.

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -146,8 +146,9 @@ func cloudsFromConfig(config *clientcmdapi.Config, cloudName string) (map[string
 		attrs["CAData"] = string(k8sCAData)
 
 		return CloudConfig{
-			Endpoint:   cluster.Server,
-			Attributes: attrs,
+			Endpoint:      cluster.Server,
+			SkipTLSVerify: cluster.InsecureSkipTLSVerify,
+			Attributes:    attrs,
 		}, nil
 	}
 

--- a/caas/kubernetes/clientconfig/types.go
+++ b/caas/kubernetes/clientconfig/types.go
@@ -35,8 +35,9 @@ func (c Context) isEmpty() bool {
 
 // CloudConfig stores information about how to connect to a Cloud.
 type CloudConfig struct {
-	Endpoint   string
-	Attributes map[string]interface{}
+	Endpoint      string
+	SkipTLSVerify bool
+	Attributes    map[string]interface{}
 }
 
 // If existing CAAS cloud has Cluster_A and User_A, here's what happens when we try to define a new CAAS cloud:

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -91,6 +91,7 @@ func newCloudCredentialFromKubeConfig(reader io.Reader, cloudParams KubeCloudPar
 	newCloud.AuthTypes = []cloud.AuthType{credential.AuthType()}
 	currentCloud := caasConfig.Clouds[context.CloudName]
 	newCloud.Endpoint = currentCloud.Endpoint
+	newCloud.SkipTLSVerify = currentCloud.SkipTLSVerify
 
 	cloudCAData, ok := currentCloud.Attributes["CAData"].(string)
 	if !ok {
@@ -296,6 +297,9 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	mk8sCloud, credential, _, err := p.builtinCloudGetter(p.cmdRunner)
 	if err != nil {
 		return cloud.Cloud{}, errors.Trace(err)
+	}
+	if mk8sCloud.SkipTLSVerify {
+		logger.Warningf("k8s cloud %v is configured to skip server certificate validity checks", mk8sCloud.Name)
 	}
 
 	openParams, err := BaseKubeCloudOpenParams(mk8sCloud, credential)

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -86,6 +86,7 @@ var defaultK8sCloud = jujucloud.Cloud{
 	Type:           cloud.CloudTypeCAAS,
 	AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
 	CACertificates: []string{""},
+	SkipTLSVerify:  true,
 }
 
 var defaultClusterMetadata = &caas.ClusterMetadata{
@@ -141,6 +142,7 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 		Type:            jujucloud.CloudTypeCAAS,
 		AuthTypes:       []jujucloud.AuthType{jujucloud.UserPassAuthType},
 		CACertificates:  []string{""},
+		SkipTLSVerify:   true,
 		Endpoint:        "http://1.1.1.1:8080",
 		HostCloudRegion: fmt.Sprintf("%s/%s", caas.K8sCloudMicrok8s, caas.Microk8sRegion),
 		Config:          map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": ""},

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -108,6 +108,7 @@ func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Conf
 			CertData: []byte(credentialAttrs[CredAttrClientCertificateData]),
 			KeyData:  []byte(credentialAttrs[CredAttrClientKeyData]),
 			CAData:   CAData,
+			Insecure: cloudSpec.SkipTLSVerify,
 		},
 	}, nil
 }

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -165,6 +165,11 @@ type Cloud struct {
 	// of cloud infrastructure components
 	// The contents are Base64 encoded x.509 certs.
 	CACertificates []string
+
+	// SkipTLSVerify is true if the client should be asked not to
+	// validate certificates. It is not recommended for production clouds.
+	// It is secure (false) by default.
+	SkipTLSVerify bool
 }
 
 // SplitHostCloudRegion splits host cloud region to cloudType and region.
@@ -233,6 +238,7 @@ type cloud struct {
 	Config           map[string]interface{} `yaml:"config,omitempty"`
 	RegionConfig     RegionConfig           `yaml:"region-config,omitempty"`
 	CACertificates   []string               `yaml:"ca-certificates,omitempty"`
+	SkipTLSVerify    bool                   `yaml:"skip-tls-verify,omitempty"`
 }
 
 // regions is a collection of regions, either as a map and/or
@@ -492,6 +498,7 @@ func cloudToInternal(in Cloud, withName bool) *cloud {
 		Config:           in.Config,
 		RegionConfig:     in.RegionConfig,
 		CACertificates:   in.CACertificates,
+		SkipTLSVerify:    in.SkipTLSVerify,
 	}
 }
 
@@ -528,6 +535,7 @@ func cloudFromInternal(in *cloud) Cloud {
 		RegionConfig:     in.RegionConfig,
 		Description:      in.Description,
 		CACertificates:   in.CACertificates,
+		SkipTLSVerify:    in.SkipTLSVerify,
 	}
 	meta.denormaliseMetadata()
 	return meta

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -300,6 +300,7 @@ func (s *cloudSuite) TestMarshalCloud(c *gc.C) {
 		AuthTypes:      []cloud.AuthType{"baz"},
 		Endpoint:       "qux",
 		CACertificates: []string{"fakecacert"},
+		SkipTLSVerify:  true,
 	}
 	marshalled, err := cloud.MarshalCloud(in)
 	c.Assert(err, jc.ErrorIsNil)
@@ -310,6 +311,7 @@ auth-types: [baz]
 endpoint: qux
 ca-certificates:
 - fakecacert
+skip-tls-verify: true
 `[1:])
 }
 
@@ -320,6 +322,7 @@ type: bar
 auth-types: [baz]
 endpoint: qux
 ca-certificates: [fakecacert]
+skip-tls-verify: true
 `)
 	out, err := cloud.UnmarshalCloud(in)
 	c.Assert(err, jc.ErrorIsNil)
@@ -329,6 +332,7 @@ ca-certificates: [fakecacert]
 		AuthTypes:      []cloud.AuthType{"baz"},
 		Endpoint:       "qux",
 		CACertificates: []string{"fakecacert"},
+		SkipTLSVerify:  true,
 	})
 }
 

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -500,6 +500,12 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if newCloud.SkipTLSVerify {
+		if len(newCloud.CACertificates) > 0 && newCloud.CACertificates[0] != "" {
+			return errors.NotValidf("cloud with both skip-TLS-verify=true and CA certificates")
+		}
+		logger.Warningf("k8s cloud %v is configured to skip server certificate validity checks", newCloud.Name)
+	}
 	newcredential, err = ensureCredentialUID(credentialName, credentialUID, newcredential)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -423,6 +423,7 @@ func cloudFromLocal(store jujuclient.CredentialGetter, cloudName string) (*jujuc
 		IdentityEndpoint: cloudDetails.IdentityEndpoint,
 		StorageEndpoint:  cloudDetails.StorageEndpoint,
 		CACertificates:   cloudDetails.CACredentials,
+		SkipTLSVerify:    cloudDetails.SkipTLSVerify,
 		Config:           cloudDetails.Config,
 		RegionConfig:     cloudDetails.RegionConfig,
 	}

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -147,7 +147,8 @@ var (
           garage-maas:
             type: maas
             auth-types: [oauth1]
-            endpoint: "http://garagemaas"`
+            endpoint: "http://garagemaas"
+            skip-tls-verify: true`
 
 	manyCloudsYamlFile = `
         clouds:
@@ -161,10 +162,11 @@ var (
             endpoint: "http://garagemaas"`
 
 	garageMAASCloud = jujucloud.Cloud{
-		Name:      "garage-maas",
-		Type:      "maas",
-		AuthTypes: []jujucloud.AuthType{"oauth1"},
-		Endpoint:  "http://garagemaas",
+		Name:          "garage-maas",
+		Type:          "maas",
+		AuthTypes:     []jujucloud.AuthType{"oauth1"},
+		Endpoint:      "http://garagemaas",
+		SkipTLSVerify: true,
 	}
 
 	manualCloud = jujucloud.Cloud{
@@ -417,12 +419,13 @@ func (s *addSuite) asssertAddToController(c *gc.C, force bool) {
 	api.CheckCallNames(c, "AddCloud", "AddCredential", "Close")
 	api.CheckCall(c, 0, "AddCloud",
 		jujucloud.Cloud{
-			Name:        "garage-maas",
-			Type:        "maas",
-			Description: "Metal As A Service",
-			AuthTypes:   jujucloud.AuthTypes{"oauth1"},
-			Endpoint:    "http://garagemaas",
-			Regions:     []jujucloud.Region{{Name: "default"}},
+			Name:          "garage-maas",
+			Type:          "maas",
+			Description:   "Metal As A Service",
+			AuthTypes:     jujucloud.AuthTypes{"oauth1"},
+			Endpoint:      "http://garagemaas",
+			Regions:       []jujucloud.Region{{Name: "default"}},
+			SkipTLSVerify: true,
 		},
 		force)
 	api.CheckCall(c, 1, "AddCredential", "cloudcred-garage-maas_fred_default", cred)
@@ -445,12 +448,13 @@ func (s *addSuite) TestAddToControllerIncompatibleCloud(c *gc.C) {
 	api.CheckCallNames(c, "AddCloud", "Close")
 	api.CheckCall(c, 0, "AddCloud",
 		jujucloud.Cloud{
-			Name:        "garage-maas",
-			Type:        "maas",
-			Description: "Metal As A Service",
-			AuthTypes:   jujucloud.AuthTypes{"oauth1"},
-			Endpoint:    "http://garagemaas",
-			Regions:     []jujucloud.Region{{Name: "default"}},
+			Name:          "garage-maas",
+			Type:          "maas",
+			Description:   "Metal As A Service",
+			AuthTypes:     jujucloud.AuthTypes{"oauth1"},
+			Endpoint:      "http://garagemaas",
+			Regions:       []jujucloud.Region{{Name: "default"}},
+			SkipTLSVerify: true,
 		},
 		false)
 	out := cmdtesting.Stderr(ctx)

--- a/cmd/juju/cloud/show.go
+++ b/cmd/juju/cloud/show.go
@@ -271,6 +271,7 @@ type CloudDetails struct {
 	RegionConfig  jujucloud.RegionConfig   `yaml:"region-config,omitempty" json:"region-config,omitempty"`
 	CACredentials []string                 `yaml:"ca-credentials,omitempty" json:"ca-credentials,omitempty"`
 	Users         map[string]CloudUserInfo `json:"users,omitempty" yaml:"users,omitempty"`
+	SkipTLSVerify bool                     `yaml:"skip-tls-verify,omitempty" json:"skip-tls-verify,omitempty"`
 }
 
 func makeCloudDetails(store jujuclient.CredentialGetter, cloud jujucloud.Cloud) *CloudDetails {
@@ -289,6 +290,7 @@ func makeCloudDetailsForUser(store jujuclient.CredentialGetter, cloud cloudapi.C
 		CloudDescription: cloud.Description,
 		CACredentials:    cloud.CACertificates,
 		Users:            make(map[string]CloudUserInfo),
+		SkipTLSVerify:    cloud.SkipTLSVerify,
 	}
 	result.AuthTypes = make([]string, len(cloud.AuthTypes))
 	for i, at := range cloud.AuthTypes {

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -105,6 +105,7 @@ func (s *showSuite) TestShowKubernetes(c *gc.C) {
 				Endpoint: "http://cluster/default",
 			},
 		},
+		SkipTLSVerify: true,
 	}
 	command := cloud.NewShowCloudCommandForTest(
 		s.store,
@@ -131,6 +132,7 @@ users:
   fred:
     display-name: Fred
     access: admin
+skip-tls-verify: true
 `[1:])
 }
 

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -108,11 +108,12 @@ func (s *updateCloudSuite) TestUpdateControllerFromFile(c *gc.C) {
 	s.api.CheckCallNames(c, "UpdateCloud", "Close")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	s.api.CheckCall(c, 0, "UpdateCloud", jujucloud.Cloud{
-		Name:        "garage-maas",
-		Type:        "maas",
-		Description: "Metal As A Service",
-		AuthTypes:   jujucloud.AuthTypes{"oauth1"},
-		Endpoint:    "http://garagemaas",
+		Name:          "garage-maas",
+		Type:          "maas",
+		Description:   "Metal As A Service",
+		AuthTypes:     jujucloud.AuthTypes{"oauth1"},
+		Endpoint:      "http://garagemaas",
+		SkipTLSVerify: true,
 	})
 	out := cmdtesting.Stderr(ctx)
 	out = strings.Replace(out, "\n", "", -1)
@@ -138,11 +139,12 @@ func (s *updateCloudSuite) TestUpdateControllerFromLocalCache(c *gc.C) {
 	s.api.CheckCallNames(c, "UpdateCloud", "Close")
 	c.Assert(command.ControllerName, gc.Equals, "mycontroller")
 	s.api.CheckCall(c, 0, "UpdateCloud", jujucloud.Cloud{
-		Name:        "garage-maas",
-		Type:        "maas",
-		Description: "Metal As A Service",
-		AuthTypes:   jujucloud.AuthTypes{"oauth1"},
-		Endpoint:    "http://garagemaas",
+		Name:          "garage-maas",
+		Type:          "maas",
+		Description:   "Metal As A Service",
+		AuthTypes:     jujucloud.AuthTypes{"oauth1"},
+		Endpoint:      "http://garagemaas",
+		SkipTLSVerify: true,
 	})
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -724,6 +724,7 @@ to create a new model to deploy %sworkloads.
 			StorageEndpoint:  region.StorageEndpoint,
 			Credential:       credentials.credential,
 			CACertificates:   cloud.CACertificates,
+			SkipTLSVerify:    cloud.SkipTLSVerify,
 		},
 		CredentialName: credentials.name,
 		AdminSecret:    bootstrapCfg.bootstrap.AdminSecret,

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -682,6 +682,7 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 			StorageEndpoint:  bootstrapConfig.CloudStorageEndpoint,
 			Credential:       credential,
 			CACertificates:   bootstrapConfig.CloudCACertificates,
+			SkipTLSVerify:    bootstrapConfig.SkipTLSVerify,
 		},
 		Config: cfg,
 	}, nil

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -225,6 +225,7 @@ func (NewGetBootstrapConfigParamsFuncSuite) TestCloudCACert(c *gc.C) {
 			"type": "cloud-type",
 		},
 		CloudCACertificates: []string{fakeCert},
+		SkipTLSVerify:       true,
 	}
 	var registry mockProviderRegistry
 
@@ -236,6 +237,7 @@ func (NewGetBootstrapConfigParamsFuncSuite) TestCloudCACert(c *gc.C) {
 	_, params, err := f("foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(params.Cloud.CACertificates, jc.SameContents, []string{fakeCert})
+	c.Assert(params.Cloud.SkipTLSVerify, jc.IsTrue)
 }
 
 type mockProviderRegistry struct {

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -236,10 +236,18 @@ func prepare(
 	details.BootstrapConfig.Cloud = args.Cloud.Name
 	details.BootstrapConfig.CloudRegion = args.Cloud.Region
 	details.BootstrapConfig.CloudCACertificates = args.Cloud.CACertificates
+	details.BootstrapConfig.SkipTLSVerify = args.Cloud.SkipTLSVerify
 	details.CloudEndpoint = args.Cloud.Endpoint
 	details.CloudIdentityEndpoint = args.Cloud.IdentityEndpoint
 	details.CloudStorageEndpoint = args.Cloud.StorageEndpoint
 	details.Credential = args.CredentialName
+
+	if args.Cloud.SkipTLSVerify {
+		if len(args.Cloud.CACertificates) > 0 && args.Cloud.CACertificates[0] != "" {
+			return cfg, details, errors.NotValidf("cloud with both skip-TLS-verify=true and CA certificates")
+		}
+		logger.Warningf("controller %v is configured to skip validity checks on the server's certificate", args.ControllerName)
+	}
 
 	return cfg, details, nil
 }

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -38,7 +38,15 @@ func (s *PrepareSuite) TearDownTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.TearDownTest(c)
 }
 
-func (*PrepareSuite) TestPrepare(c *gc.C) {
+func (s *PrepareSuite) TestPrepare(c *gc.C) {
+	s.assertPrepare(c, false)
+}
+
+func (s *PrepareSuite) TestPrepareSkipVerify(c *gc.C) {
+	s.assertPrepare(c, true)
+}
+
+func (s *PrepareSuite) assertPrepare(c *gc.C, skipVerify bool) {
 	baselineAttrs := dummy.SampleConfig().Merge(testing.Attrs{
 		"controller": false,
 		"name":       "erewhemos",
@@ -57,9 +65,13 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 		controller.StatePort:               1234,
 		controller.SetNUMAControlPolicyKey: true,
 	}
-	fakeCert := testing.CACert
 	cloudSpec := dummy.SampleCloudSpec()
-	cloudSpec.CACertificates = []string{fakeCert}
+	cloudSpec.SkipTLSVerify = skipVerify
+	var caCerts []string
+	if !skipVerify {
+		caCerts = []string{testing.CACert}
+		cloudSpec.CACertificates = caCerts
+	}
 	_, err = bootstrap.PrepareController(false, ctx, controllerStore, bootstrap.PrepareParams{
 		ControllerConfig: controllerCfg,
 		ControllerName:   cfg.Name(),
@@ -106,7 +118,8 @@ func (*PrepareSuite) TestPrepare(c *gc.C) {
 		CloudEndpoint:         "dummy-endpoint",
 		CloudIdentityEndpoint: "dummy-identity-endpoint",
 		CloudStorageEndpoint:  "dummy-storage-endpoint",
-		CloudCACertificates:   []string{fakeCert},
+		CloudCACertificates:   caCerts,
+		SkipTLSVerify:         skipVerify,
 	})
 
 	// Check we cannot call Prepare again.

--- a/environs/cloudspec/cloudspec.go
+++ b/environs/cloudspec/cloudspec.go
@@ -42,6 +42,11 @@ type CloudSpec struct {
 	// of cloud infrastructure components
 	// The contents are Base64 encoded x.509 certs.
 	CACertificates []string
+
+	// SkipTLSVerify is true if the client should be asked not to
+	// validate certificates. It is not recommended for production clouds.
+	// It is secure (false) by default.
+	SkipTLSVerify bool
 }
 
 // Validate validates that the CloudSpec is well-formed. It does
@@ -67,6 +72,7 @@ func MakeCloudSpec(cloud jujucloud.Cloud, cloudRegionName string, credential *ju
 		IdentityEndpoint: cloud.IdentityEndpoint,
 		StorageEndpoint:  cloud.StorageEndpoint,
 		CACertificates:   cloud.CACertificates,
+		SkipTLSVerify:    cloud.SkipTLSVerify,
 		Credential:       credential,
 	}
 	if cloudRegionName != "" {

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -147,6 +147,11 @@ type BootstrapConfig struct {
 	// CloudCACertificates contains the CACertificates necessary to
 	// communicate with the cloud infrastructure.
 	CloudCACertificates []string `yaml:"ca-certificates,omitempty"`
+
+	// SkipTLSVerify is true if the client should be asked not to
+	// validate certificates. It is not recommended for production clouds.
+	// It is secure (false) by default.
+	SkipTLSVerify bool `yaml:"skip-tls-verify,omitempty"`
 }
 
 // ControllerUpdater stores controller details.

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -38,6 +38,7 @@ type cloudDoc struct {
 	StorageEndpoint  string                       `bson:"storage-endpoint,omitempty"`
 	Regions          map[string]cloudRegionSubdoc `bson:"regions,omitempty"`
 	CACertificates   []string                     `bson:"ca-certificates,omitempty"`
+	SkipTLSVerify    bool                         `bson:"skip-tls-verify,omitempty"`
 }
 
 // cloudRegionSubdoc records information about cloud regions.
@@ -75,6 +76,7 @@ func createCloudOp(cloud cloud.Cloud) txn.Op {
 			StorageEndpoint:  cloud.StorageEndpoint,
 			Regions:          regions,
 			CACertificates:   cloud.CACertificates,
+			SkipTLSVerify:    cloud.SkipTLSVerify,
 		},
 	}
 }
@@ -104,6 +106,7 @@ func updateCloudOps(cloud cloud.Cloud) txn.Op {
 		StorageEndpoint:  cloud.StorageEndpoint,
 		Regions:          regions,
 		CACertificates:   cloud.CACertificates,
+		SkipTLSVerify:    cloud.SkipTLSVerify,
 	}
 	return txn.Op{
 		C:      cloudsC,
@@ -180,6 +183,7 @@ func (d cloudDoc) toCloud() cloud.Cloud {
 		StorageEndpoint:  d.StorageEndpoint,
 		Regions:          regions,
 		CACertificates:   d.CACertificates,
+		SkipTLSVerify:    d.SkipTLSVerify,
 	}
 }
 
@@ -297,6 +301,10 @@ func validateCloud(cloud cloud.Cloud) error {
 	// TODO(axw) we should ensure that the cloud auth-types is a subset
 	// of the auth-types supported by the provider. To do that, we'll
 	// need a new "policy".
+
+	if cloud.SkipTLSVerify && len(cloud.CACertificates) > 0 && cloud.CACertificates[0] != "" {
+		return errors.NotValidf("cloud with both skip-TLS-verify=true and CA certificates")
+	}
 	return nil
 }
 

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -86,6 +86,17 @@ func (s *CloudSuite) TestAddCloud(c *gc.C) {
 	c.Assert(settings.Map(), jc.DeepEquals, map[string]interface{}{"foo": "baz"})
 }
 
+func (s *CloudSuite) TestAddCloudSkipTLSVerify(c *gc.C) {
+	cloudToAdd := lowCloud
+	cloudToAdd.SkipTLSVerify = true
+	cloudToAdd.CACertificates = []string{""}
+	err := s.State.AddCloud(cloudToAdd, s.Owner.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	cloud, err := s.State.Cloud("stratus")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cloud, jc.DeepEquals, cloudToAdd)
+}
+
 func (s *CloudSuite) TestAddCloudDuplicate(c *gc.C) {
 	err := s.State.AddCloud(cloud.Cloud{
 		Name:      "stratus",
@@ -125,8 +136,20 @@ func (s *CloudSuite) TestAddCloudNoAuthTypes(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `invalid cloud: empty auth-types not valid`)
 }
 
+func (s *CloudSuite) TestAddInvalidTLSNoVerify(c *gc.C) {
+	err := s.State.AddCloud(cloud.Cloud{
+		Name:           "stratus",
+		Type:           "low",
+		AuthTypes:      cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+		SkipTLSVerify:  true,
+		CACertificates: []string{"cert"},
+	}, s.Owner.Name())
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
 func (s *CloudSuite) TestUpdateCloud(c *gc.C) {
-	err := s.State.AddCloud(lowCloud, s.Owner.Name())
+	cloudToAdd := lowCloud
+	err := s.State.AddCloud(cloudToAdd, s.Owner.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	updatedCloud := lowCloud


### PR DESCRIPTION
Merge 2.8 with these PRs:

#12389 Support k8s clusters with insecure-tls-skip-verify
#12390 When doing pre upgrade checks, allow for k8s models

```
# Conflicts:
#       cmd/juju/cloud/show.go
#       cmd/juju/cloud/show_test.go
```

## QA steps

See PRs

