### PR TITLE
NetworkInfo - Get IAAS Machine Addresses Once

### DIFF
--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -47,6 +47,7 @@ func PatchGetStorageStateError(patcher patcher, err error) {
 	patcher.PatchValue(&getStorageState, func(st *state.State) (storageAccess, error) { return nil, err })
 }
 
-func (n *NetworkInfoBase) MachineNetworkInfos(spaceIDs ...string) (map[string]params.NetworkInfoResult, error) {
-	return n.machineNetworkInfos(spaceIDs...)
+func (n *NetworkInfoIAAS) MachineNetworkInfos() (map[string]params.NetworkInfoResult, error) {
+	err := n.populateMachineNetworkInfos()
+	return n.machineNetworkInfos, err
 }

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -17,6 +17,7 @@ import (
 type NetworkInfoCAAS struct {
 	*NetworkInfoBase
 
+	// addresses contains all services and container addresses for the unit.
 	addresses network.SpaceAddresses
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -1232,7 +1232,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			storage:           args.Storage,
 			devices:           args.Devices,
 			applicationConfig: appConfigAttrs,
-			charmConfig:       map[string]interface{}(args.CharmConfig),
+			charmConfig:       args.CharmConfig,
 		})
 		if err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
This change mirrors that made for CAAS units in https://github.com/juju/juju/pull/12351.

It mitigates inefficiencies for calls to `network-get` where interrogation of link-layer devices based on spaces can be conducted twice.

Instead, we pre-populate the info based on the unit applications space bindings, then look them up where we need them.

## QA steps

Change is mechanical in nature - unit tests are green.

## Documentation changes

None.

## Bug reference

N/A
