### PR TITLE
Deploy charmhub bundle with charmhub charms

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -522,9 +522,10 @@ func (a *API) resolveOneCharm(arg params.ResolveCharmWithChannel, mac *macaroon.
 	}
 	result.URL = resultURL.String()
 
-	// We have an issue where the charmhub API can return "all" for architecture
-	// and this can cause us issues. To try and solve that, we will use the
-	// model constraints to resolve it.
+	// The charmhub API can return "all" for architecture as it's not a real
+	// arch we don't know how to correctly model it. "all " doesn't mean use the
+	// default arch, it means use any arch which isn't quite the same. So if we
+	// do get "all" we should see if there is a clean way to resolve it.
 	archOrigin := origin
 	if origin.Architecture == "all" {
 		cons, err := a.backendState.ModelConstraints()

--- a/apiserver/facades/client/charms/interfaces/state.go
+++ b/apiserver/facades/client/charms/interfaces/state.go
@@ -36,6 +36,7 @@ type BackendState interface {
 	Machine(string) (Machine, error)
 	state.MongoSessioner
 	ModelUUID() string
+	ModelConstraints() (constraints.Value, error)
 }
 
 // Application defines a subset of the functionality provided by the

--- a/apiserver/facades/client/charms/mocks/state_mock.go
+++ b/apiserver/facades/client/charms/mocks/state_mock.go
@@ -131,6 +131,21 @@ func (mr *MockBackendStateMockRecorder) Machine(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockBackendState)(nil).Machine), arg0)
 }
 
+// ModelConstraints mocks base method
+func (m *MockBackendState) ModelConstraints() (constraints.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModelConstraints")
+	ret0, _ := ret[0].(constraints.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModelConstraints indicates an expected call of ModelConstraints
+func (mr *MockBackendStateMockRecorder) ModelConstraints() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConstraints", reflect.TypeOf((*MockBackendState)(nil).ModelConstraints))
+}
+
 // ModelUUID mocks base method
 func (m *MockBackendState) ModelUUID() string {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -58,13 +58,13 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	// If no revision nor channel specified, use the default release.
 	if curl.Revision == -1 && channel.String() == "" {
 		logger.Debugf("Resolving charm with default release")
-		resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, info.DefaultRelease)
+		resURL, resOrigin, serie, err := c.resolveViaChannelMap(info.Type, curl, origin, info.DefaultRelease)
 		if err != nil {
 			return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 		}
 
 		resOrigin.ID = info.ID
-		return resURL, resOrigin, series, nil
+		return resURL, resOrigin, serie, nil
 	}
 
 	logger.Debugf("Resolving charm with revision %d and/or channel %s", curl.Revision, channel.String())
@@ -73,13 +73,13 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
-	resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
+	resURL, resOrigin, serie, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
 
 	resOrigin.ID = info.ID
-	return resURL, resOrigin, series, nil
+	return resURL, resOrigin, serie, nil
 }
 
 // DownloadCharm downloads the provided download URL from CharmHub using the

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -88,6 +88,7 @@ func (c *chRepo) DownloadCharm(resourceURL string, archivePath string) (*charm.C
 // to be downloaded.  If the provided charm origin has no ID, it is
 // assumed that the charm is being installed, not refreshed.
 func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
+	logger.Tracef("FindDownloadURL %v %v", curl, origin)
 	if origin.Type == "bundle" {
 		return c.findBundleDownloadURL(curl, origin)
 	}
@@ -235,7 +236,7 @@ func findByRevisionAndChannel(rev int, preferredChannel corecharm.Channel, chann
 }
 
 func matchChannel(one corecharm.Channel, two transport.Channel) bool {
-	return one.String() == two.Name
+	return one.Normalize().String() == two.Name
 }
 
 func (c *chRepo) resolveViaChannelMap(t transport.Type, curl *charm.URL, origin params.CharmOrigin, channelMap transport.InfoChannelMap) (*charm.URL, params.CharmOrigin, []string, error) {
@@ -248,6 +249,10 @@ func (c *chRepo) resolveViaChannelMap(t transport.Type, curl *charm.URL, origin 
 	origin.Revision = &mapRevision.Revision
 	origin.Risk = mapChannel.Risk
 	origin.Track = &mapChannel.Track
+
+	origin.Architecture = mapChannel.Platform.Architecture
+	origin.OS = mapChannel.Platform.OS
+	origin.Series = mapChannel.Platform.Series
 
 	// `metadata.yaml` is a requirement to be a valid charm or bundle. The charm
 	// repo expects that one exists even if it contains minimal information.

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -58,7 +58,13 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	// If no revision nor channel specified, use the default release.
 	if curl.Revision == -1 && channel.String() == "" {
 		logger.Debugf("Resolving charm with default release")
-		return c.resolveViaChannelMap(info.Type, curl, origin, info.DefaultRelease)
+		resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, info.DefaultRelease)
+		if err != nil {
+			return nil, params.CharmOrigin{}, nil, errors.Trace(err)
+		}
+
+		resOrigin.ID = info.ID
+		return resURL, resOrigin, series, nil
 	}
 
 	logger.Debugf("Resolving charm with revision %d and/or channel %s", curl.Revision, channel.String())
@@ -67,7 +73,13 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
-	return c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
+	resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
+	if err != nil {
+		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
+	}
+
+	resOrigin.ID = info.ID
+	return resURL, resOrigin, series, nil
 }
 
 // DownloadCharm downloads the provided download URL from CharmHub using the

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
-	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/arch"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/facades/client/charms/mocks"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/core/arch"
 )
 
 type charmHubRepositoriesSuite struct {

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/arch"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -32,12 +33,18 @@ func (s *charmHubRepositoriesSuite) TestResolveDefaultChannelMap(c *gc.C) {
 	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
+	track := "latest"
 	curl.Revision = 16
+
+	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"
-	track := "latest"
 	origin.Track = &track
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = "ubuntu"
+	origin.Series = "bionic"
+
 	c.Assert(obtainedCurl, jc.DeepEquals, curl)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
@@ -54,12 +61,18 @@ func (s *charmHubRepositoriesSuite) TestResolveWithRevision(c *gc.C) {
 	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
+	track := "second"
 	curl.Revision = 13
+
+	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"
-	track := "second"
 	origin.Track = &track
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = "ubuntu"
+	origin.Series = "bionic"
+
 	c.Assert(obtainedCurl, jc.DeepEquals, curl)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
@@ -90,8 +103,14 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	curl.Revision = 13
+
+	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = "ubuntu"
+	origin.Series = "bionic"
+
 	c.Assert(obtainedCurl, jc.DeepEquals, curl)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
@@ -126,11 +145,17 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannelRiskOnly(c *gc.C) {
 	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
 	c.Assert(err, jc.ErrorIsNil)
 
+	track := "latest"
 	curl.Revision = 19
+
+	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
-	track := "latest"
 	origin.Track = &track
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = "ubuntu"
+	origin.Series = "bionic"
+
 	c.Assert(obtainedCurl, jc.DeepEquals, curl)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
@@ -190,7 +215,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Channel: transport.Channel{
 				Name: "stable",
 				Platform: transport.Platform{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				},
@@ -200,7 +225,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				}},
@@ -211,7 +236,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Channel: transport.Channel{
 				Name: "candidate",
 				Platform: transport.Platform{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				},
@@ -221,7 +246,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				}},
@@ -232,7 +257,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Channel: transport.Channel{
 				Name: "edge",
 				Platform: transport.Platform{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				},
@@ -242,7 +267,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				}},
@@ -253,7 +278,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Channel: transport.Channel{
 				Name: "second/stable",
 				Platform: transport.Platform{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				},
@@ -263,7 +288,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				}},
@@ -274,7 +299,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Channel: transport.Channel{
 				Name: "stable",
 				Platform: transport.Platform{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				},
@@ -284,7 +309,7 @@ func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap
 			Revision: transport.InfoRevision{
 				MetadataYAML: entityMeta,
 				Platforms: []transport.Platform{{
-					Architecture: "all",
+					Architecture: arch.DefaultArchitecture,
 					OS:           "ubuntu",
 					Series:       "bionic",
 				}},

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -16,6 +16,14 @@ const (
 	DefaultChannelString = "latest/stable"
 )
 
+var (
+	// DefaultChannel represents the default track and risk.
+	DefaultChannel = Channel{
+		Track: "latest",
+		Risk:  Risk("stable"),
+	}
+)
+
 // Risk describes the type of risk in a current channel.
 type Risk string
 
@@ -62,6 +70,15 @@ type Channel struct {
 	Track  string
 	Risk   Risk
 	Branch string
+}
+
+// MakeRiskOnlyChannel creates a charm channel that is backwards compatible with
+// old style charm store channels. This creates a risk aware channel only.
+// No validation is performed on the risk and is just accepted as is.
+func MakeRiskOnlyChannel(risk string) Channel {
+	return Channel{
+		Risk: Risk(risk),
+	}
 }
 
 // MakeChannel creates a core charm Channel from a set of component parts.

--- a/testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
+++ b/testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
@@ -1,0 +1,9 @@
+services:
+    wordpress:
+        charm: wordpress
+        num_units: 1
+    mysql:
+        charm: mysql
+        num_units: 1
+relations:
+    - ["wordpress:db", "mysql:db"]


### PR DESCRIPTION
When attempting to resolve an origin we should populate all the fields
of the origin so that we can correctly send them to and from the server.
These items were missed because of the changes to the architecture, but
have now been correctly filled in.

Deploying a local charmhub charm is now possible thanks to this.

## QA steps

```sh
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju bootstrap lxd test --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy ./testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
Resolving charm via charmhub: ch:mysql
Resolving charm via charmhub: ch:wordpress
Executing changes:
- upload charm ch:wordpress-9
- deploy application wordpress using ch:wordpress-9
ERROR cannot deploy bundle: cannot deploy application "wordpress": cannot add application "wordpress": series "kubernetes" in a non container model not valid
```

Ensure that mysql got installed correctly.

```sh
$ juju status
Model    Controller  Cloud/Region  Version    SLA          Timestamp
default  test        lxd/default   2.9-rc3.1  unsupported  15:54:57Z

App    Version  Status   Scale  Charm  Store     Rev  OS      Message
mysql           unknown      0  mysql  charmhub   58  ubuntu
```
