### PR TITLE
Not found charm error message

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -838,6 +838,7 @@ func (c *DeployCommand) getMeteringAPIURL(controllerAPIRoot api.Connection) (str
 func (c *DeployCommand) getDeployerFactory() (deployer.DeployerFactory, deployer.DeployerConfig) {
 	dep := deployer.DeployerDependencies{
 		Model:                c,
+		FileSystem:           c.ModelCommandBase.Filesystem(),
 		NewConsumeDetailsAPI: c.NewConsumeDetailsAPI, // only used here
 		Steps:                c.Steps,
 	}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -310,7 +310,7 @@ func (s *DeploySuite) TestBlockDeploy(c *gc.C) {
 
 func (s *DeploySuite) TestInvalidPath(c *gc.C) {
 	err := s.runDeploy(c, "/home/nowhere")
-	c.Assert(err, gc.ErrorMatches, `charm or bundle URL "/home/nowhere" malformed, expected "<name>"`)
+	c.Assert(err, gc.ErrorMatches, `no charm was found at \"/home/nowhere\"`)
 }
 
 func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {


### PR DESCRIPTION
The not found charm error message was terrible, it offered no support
for users with a cryptic error about it not conforming to a URL.

The following change fixes that by checking that the file doesn't exist
and if it doesn't warn them about that, rather than a malformed url that
nobody cares about.

## QA steps

```sh
$ juju deploy ./bad.charm
ERROR no charm was found at "./bad.charm"
```
