### PR TITLE
Make UpdateLatestRevisions controller facade work with charmhub

### DIFF
--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/state"
@@ -12,7 +13,7 @@ import (
 
 // createCharmhubClient creates a new charmhub Client based on this model's
 // config.
-func CharmhubClient(st *state.State) (*charmhub.Client, error) {
+func CharmhubClient(st *state.State, logger loggo.Logger) (*charmhub.Client, error) {
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/charmhub"
+	"github.com/juju/juju/state"
+)
+
+// createCharmhubClient creates a new charmhub Client based on this model's
+// config.
+func CharmhubClient(st *state.State) (*charmhub.Client, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	modelConfig, err := model.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	url, _ := modelConfig.CharmHubURL()
+	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client, err := charmhub.NewClient(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return client, nil
+}

--- a/apiserver/facades/client/resources/charmhubclient_test.go
+++ b/apiserver/facades/client/resources/charmhubclient_test.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
@@ -89,7 +91,7 @@ func (s *CharmHubClientSuite) expectRefresh() {
 	resp := []transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{
-				CreatedAt: "2020-07-07T09:39:44.132000+00:00",
+				CreatedAt: time.Date(2020, 7, 7, 9, 39, 44, 132000000, time.UTC),
 				Download:  transport.Download{HashSHA256: "c97e1efc5367d2fdcfdf29f4a2243b13765cc9cbdfad19627a29ac903c01ae63", Size: 5487460, URL: "https://api.staging.charmhub.io/api/v1/charms/download/jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD_208.charm"},
 				ID:        "jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD",
 				Name:      "ubuntu",

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -1,0 +1,145 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmrevisionupdater
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/juju/charm/v8/resource"
+	"github.com/juju/errors"
+	"github.com/juju/juju/charmhub"
+	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/state"
+)
+
+const (
+	// TODO(benhoyt) - also add caching and retries
+	charmhubAPITimeout = 10 * time.Second
+)
+
+// charmhubID holds identifying information for several charms for a
+// charmhubLatestCharmInfo call.
+type charmhubID struct {
+	id       string
+	revision int
+	channel  string
+	os       string
+	series   string
+	arch     string
+}
+
+// charmhubResult is the type charmhubLatestCharmInfo returns: information
+// about a charm revision and its resources.
+type charmhubResult struct {
+	name      string
+	timestamp time.Time
+	revision  int
+	resources []resource.Resource
+	error     error
+}
+
+// createCharmhubClient creates a new charmhub Client based on this model's
+// config.
+func createCharmhubClient(st *state.State) (*charmhub.Client, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	modelConfig, err := model.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	url, _ := modelConfig.CharmHubURL()
+	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client, err := charmhub.NewClient(config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return client, nil
+}
+
+// charmhubLatestCharmInfo fetches the latest information about the given
+// charms from charmhub's "charm_refresh" API.
+func charmhubLatestCharmInfo(client *charmhub.Client, ids []charmhubID) ([]charmhubResult, error) {
+	cfgs := make([]charmhub.RefreshConfig, len(ids))
+	for i, id := range ids {
+		platform := charmhub.RefreshPlatform{
+			Architecture: id.arch,
+			OS:           id.os,
+			Series:       id.series,
+		}
+		cfg, err := charmhub.RefreshOne(id.id, id.revision, id.channel, platform)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		logger.Infof("TODO charmhubLatestCharmInfo cfg %d = %#v", i, cfg)
+		cfgs[i] = cfg
+	}
+	config := charmhub.RefreshMany(cfgs...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), charmhubAPITimeout)
+	defer cancel()
+	responses, err := client.Refresh(ctx, config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	results := make([]charmhubResult, len(responses))
+	for i, response := range responses {
+		logger.Infof("TODO charmhubLatestCharmInfo response %d = %#v", i, response)
+		results[i] = refreshResponseToCharmhubResult(response)
+	}
+	return results, nil
+}
+
+// refreshResponseToCharmhubResult converts a raw RefreshResponse from the
+// charmhub API into a charmhubResult.
+func refreshResponseToCharmhubResult(response transport.RefreshResponse) charmhubResult {
+	if response.Error != nil {
+		return charmhubResult{
+			error: errors.Errorf("charmhub API error %s: %s", response.Error.Code, response.Error.Message),
+		}
+	}
+	revision, err := strconv.Atoi(response.Entity.Version)
+	if err != nil || revision <= 0 {
+		return charmhubResult{
+			error: errors.NotValidf("entity version %q", response.Entity.Version),
+		}
+	}
+	var resources []resource.Resource
+	for _, r := range response.Entity.Resources {
+		fingerprint, err := resource.ParseFingerprint(r.Download.HashSHA384)
+		if err != nil {
+			logger.Errorf("invalid resource fingerprint %q", r.Download.HashSHA384)
+			continue
+		}
+		typ, err := resource.ParseType(r.Type)
+		if err != nil {
+			logger.Errorf("invalid resource type %q", r.Type)
+			continue
+		}
+		resource := resource.Resource{
+			Meta: resource.Meta{
+				Name: r.Name,
+				Type: typ,
+			},
+			Origin:      resource.OriginStore,
+			Revision:    r.Revision,
+			Fingerprint: fingerprint,
+			Size:        int64(r.Download.Size),
+		}
+		resources = append(resources, resource)
+	}
+	return charmhubResult{
+		name:      response.Name,
+		timestamp: response.Entity.CreatedAt,
+		revision:  revision,
+		resources: resources,
+	}
+}

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -57,7 +57,6 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		logger.Infof("TODO charmhubLatestCharmInfo cfg %d = %#v", i, cfg)
 		cfgs[i] = cfg
 	}
 	config := charmhub.RefreshMany(cfgs...)
@@ -71,7 +70,6 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]
 
 	results := make([]charmhubResult, len(responses))
 	for i, response := range responses {
-		logger.Infof("TODO charmhubLatestCharmInfo response %d = %#v", i, response)
 		results[i] = refreshResponseToCharmhubResult(response)
 	}
 	return results, nil

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 )
@@ -37,9 +38,15 @@ type charmhubResult struct {
 	error     error
 }
 
+// CharmhubRefreshClient is an interface for the methods of the charmhub
+// client that we need.
+type CharmhubRefreshClient interface {
+	Refresh(ctx context.Context, config charmhub.RefreshConfig) ([]transport.RefreshResponse, error)
+}
+
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client *charmhub.Client, ids []charmhubID) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		platform := charmhub.RefreshPlatform{

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub_test.go
@@ -1,0 +1,202 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmrevisionupdater_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/juju/charm/v8"
+	"github.com/juju/errors"
+	"github.com/juju/juju/testcharms"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater"
+	"github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/charmhub"
+	"github.com/juju/juju/charmhub/transport"
+	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/state"
+)
+
+type charmhubSuite struct {
+	jujutesting.JujuConnSuite
+
+	updater *charmrevisionupdater.CharmRevisionUpdaterAPI
+	charms  map[string]*state.Charm
+}
+
+var _ = gc.Suite(&charmhubSuite{})
+
+func (s *charmhubSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+}
+
+func (s *charmhubSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	resources := common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
+	authorizer := testing.FakeAuthorizer{
+		Controller: true,
+		Tag:        names.NewMachineTag("99"),
+	}
+	var err error
+	s.updater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPI(s.State, resources, authorizer)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Patch the charmhub initializer function
+	s.PatchValue(&charmrevisionupdater.NewCharmhubClient, func(st *state.State) (charmrevisionupdater.CharmhubRefreshClient, error) {
+		charms := map[string]hubCharm{
+			//"000": {
+			//	id: "000",
+			//	name: "postgresql",
+			//	version: "10",
+			//	resources: []transport.ResourceRevision{
+			//		{Name: "wal-e", Revision: 2, Type: "file"},
+			//	},
+			//},
+			"001": {
+				id:      "001",
+				name:    "mysql",
+				version: "23",
+			},
+		}
+		return &mockHub{charms: charms}, nil
+	})
+
+	s.charms = make(map[string]*state.Charm)
+}
+
+type hubCharm struct {
+	id        string
+	name      string
+	version   string
+	resources []transport.ResourceRevision
+}
+
+type mockHub struct {
+	charms map[string]hubCharm
+}
+
+func (h *mockHub) Refresh(_ context.Context, config charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
+	request, err := config.Build()
+	if err != nil {
+		return nil, err
+	}
+	responses := make([]transport.RefreshResponse, len(request.Context))
+	for i, context := range request.Context {
+		action := request.Actions[i]
+		if action.Action != "refresh" {
+			return nil, errors.Errorf("unexpected action %q", action.Action)
+		}
+		if *action.ID != context.ID {
+			return nil, errors.Errorf("action ID %q doesn't match context ID %q", *action.ID, context.ID)
+		}
+		charm, ok := h.charms[context.ID]
+		if !ok {
+			return nil, errors.Errorf("charm ID %q not found", context.ID)
+		}
+		response := transport.RefreshResponse{
+			Entity: transport.RefreshEntity{
+				CreatedAt: time.Now(),
+				ID:        context.ID,
+				Name:      charm.name,
+				Resources: charm.resources,
+				Version:   charm.version,
+			},
+			EffectiveChannel: context.TrackingChannel,
+			ID:               context.ID,
+			InstanceKey:      context.InstanceKey,
+			Name:             charm.name,
+			Result:           "refresh",
+		}
+		responses[i] = response
+	}
+	return responses, nil
+}
+
+func (s *charmhubSuite) addMachine(c *gc.C, machineId string, job state.MachineJob) {
+	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		Series: "quantal",
+		Jobs:   []state.MachineJob{job},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.Id(), gc.Equals, machineId)
+	cons, err := m.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	controllerCfg, err := s.State.ControllerConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	inst, hc := jujutesting.AssertStartInstanceWithConstraints(c, s.Environ, s.ProviderCallContext, controllerCfg.ControllerUUID(), m.Id(), cons)
+	err = m.SetProvisioned(inst.Id(), "", "fake_nonce", hc)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *charmhubSuite) addCharmWithRevision(c *gc.C, charmName string, rev int) {
+	ch := testcharms.Repo.CharmDir(charmName)
+	name := ch.Meta().Name
+	curl := &charm.URL{
+		Schema:   "ch",
+		Name:     charmName,
+		Revision: rev,
+		Series:   "quantal",
+	}
+	info := state.CharmInfo{
+		Charm:       ch,
+		ID:          curl,
+		StoragePath: "dummy-path",
+		SHA256:      fmt.Sprintf("%s-%d-sha256", name, rev),
+	}
+	dummy, err := s.State.AddCharm(info)
+	c.Assert(err, jc.ErrorIsNil)
+	s.charms[name] = dummy
+}
+
+func (s *charmhubSuite) addApplication(c *gc.C, charmName, serviceName string) {
+	ch, ok := s.charms[charmName]
+	c.Assert(ok, jc.IsTrue)
+	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: serviceName, Charm: ch})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *charmhubSuite) addUnit(c *gc.C, serviceName, machineId string) {
+	svc, err := s.State.Application(serviceName)
+	c.Assert(err, jc.ErrorIsNil)
+	u, err := svc.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	m, err := s.State.Machine(machineId)
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.AssignToMachine(m)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *charmhubSuite) TestUpdateRevisions(c *gc.C) {
+	s.addMachine(c, "0", state.JobManageModel)
+
+	s.addMachine(c, "1", state.JobHostUnits)
+	s.addMachine(c, "2", state.JobHostUnits)
+	s.addMachine(c, "3", state.JobHostUnits)
+
+	// mysql is out of date
+	s.addCharmWithRevision(c, "mysql", 22)
+	s.addApplication(c, "mysql", "mysql")
+	s.addUnit(c, "mysql", "1")
+
+	curl := charm.MustParseURL("ch:mysql")
+	_, err := s.State.LatestPlaceholderCharm(curl)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	result, err := s.updater.UpdateLatestRevisions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+
+	curl = charm.MustParseURL("ch:mysql")
+	pending, err := s.State.LatestPlaceholderCharm(curl)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(pending.String(), gc.Equals, "ch:mysql-23")
+}

--- a/apiserver/facades/controller/charmrevisionupdater/handlers.go
+++ b/apiserver/facades/controller/charmrevisionupdater/handlers.go
@@ -5,11 +5,12 @@ package charmrevisionupdater
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/state"
 )
 
@@ -18,7 +19,7 @@ import (
 type LatestCharmHandler interface {
 	// HandleLatest deals with the given charm info, treating it as the
 	// most up-to-date information for the charms most recent revision.
-	HandleLatest(names.ApplicationTag, charmstore.CharmInfo) error
+	HandleLatest(names.ApplicationTag, []resource.Resource, time.Time) error
 }
 
 type newHandlerFunc func(*state.State) (LatestCharmHandler, error)

--- a/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
+++ b/apiserver/facades/controller/charmrevisionupdater/testing/suite.go
@@ -117,7 +117,7 @@ func (s *CharmSuite) SetUpTest(c *gc.C) {
 			"Juju-Metadata": headers,
 		})
 	}
-	// Patch the charm repo initializer function: it is replaced with a charm
+	// Patch the charmstore initializer function: it is replaced with a charm
 	// store repo pointing to the testing server.
 	s.jcSuite.PatchValue(&charmrevisionupdater.NewCharmStoreClient, func(st *state.State) (jujucharmstore.Client, error) {
 		return jujucharmstore.NewCustomClient(s.store), nil

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/os/v2/series"
 
+	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
@@ -139,7 +140,7 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		case "ch":
 			origin := application.CharmOrigin()
 			if origin == nil || origin.Revision == nil {
-				logger.Errorf("charm %s has no revision, skipping", curl)
+				logger.Debugf("charm %s has no revision, skipping", curl)
 				continue
 			}
 			os, err := series.GetOSFromSeries(application.Series())
@@ -226,7 +227,7 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 
 	// Fetch info for any charmhub charms.
 	if len(charmhubIDs) > 0 {
-		client, err := createCharmhubClient(st)
+		client, err := common.CharmhubClient(st)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -122,7 +122,6 @@ type latestCharmInfo struct {
 // retrieveLatestCharmInfo looks up the charm store to return the charm URLs for the
 // latest revision of the deployed charms.
 func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
-	logger.Infof("TODO retrieveLatestCharmInfo")
 	applications, err := st.AllApplications()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -218,7 +217,6 @@ func fetchCharmstoreInfos(st *state.State, ids []charmstore.CharmID, apps []*sta
 		return nil, errors.Trace(err)
 	}
 	results, err := charmstore.LatestCharmInfo(client, ids, metadata)
-	logger.Infof("TODO LatestCharmInfo results=%#v, error=%v", results, err)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -106,6 +106,11 @@ var NewCharmStoreClient = func(st *state.State) (charmstore.Client, error) {
 	return charmstore.NewCachingClient(state.MacaroonCache{State: st}, controllerCfg.CharmStoreURL())
 }
 
+// NewCharmhubClient instantiates a new charmhub client (exported for testing).
+var NewCharmhubClient = func(st *state.State) (CharmhubRefreshClient, error) {
+	return common.CharmhubClient(st)
+}
+
 type latestCharmInfo struct {
 	url         *charm.URL
 	timestamp   time.Time
@@ -227,7 +232,7 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 
 	// Fetch info for any charmhub charms.
 	if len(charmhubIDs) > 0 {
-		client, err := common.CharmhubClient(st)
+		client, err := NewCharmhubClient(st)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -144,11 +144,12 @@ func retrieveLatestCharmInfo(st *state.State) ([]latestCharmInfo, error) {
 		case charm.CharmHub.Matches(curl.Schema):
 			origin := application.CharmOrigin()
 			if origin == nil {
-				logger.Debugf("charm %s has no origin, skipping", curl)
+				// If this fails, we have big problems, so make this Errorf
+				logger.Errorf("charm %s has no origin, skipping", curl)
 				continue
 			}
 			if origin.Revision == nil || origin.Channel == nil || origin.Platform == nil {
-				logger.Debugf("charm %s has no revision (%p), channel (%p), or platform (%p), skipping",
+				logger.Errorf("charm %s has missing revision (%p), channel (%p), or platform (%p), skipping",
 					curl, origin.Revision, origin.Channel, origin.Platform)
 				continue
 			}

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
@@ -37,6 +38,8 @@ const (
 	CharmHubServerURL     = "https://api.snapcraft.io"
 	CharmHubServerVersion = "v2"
 	CharmHubServerEntity  = "charms"
+
+	RefreshTimeout = 10 * time.Second
 )
 
 var (

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -58,7 +58,7 @@ type RefreshResponse struct {
 }
 
 type RefreshEntity struct {
-	CreatedAt string             `json:"created-at"`
+	CreatedAt time.Time          `json:"created-at"`
 	Download  Download           `json:"download"`
 	ID        string             `json:"id"`
 	License   string             `json:"license"`

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -65,6 +65,7 @@ type RefreshEntity struct {
 	Name      string             `json:"name"`
 	Publisher map[string]string  `json:"publisher,omitempty"`
 	Resources []ResourceRevision `json:"resources"`
+	Revision  int                `json:"revision"`
 	Summary   string             `json:"summary"`
 	Version   string             `json:"version"`
 }

--- a/cmd/juju/resource/list.go
+++ b/cmd/juju/resource/list.go
@@ -118,7 +118,7 @@ func (c *ListCommand) Run(ctx *cmd.Context) error {
 	v := vals[0]
 
 	// It's a lot easier to read and to digest a list of resources
-	// when  they are ordered.
+	// when they are ordered.
 	sort.Sort(charmResourceList(v.CharmStoreResources))
 	sort.Sort(resourceList(v.Resources))
 	for _, u := range v.UnitResources {

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -89,6 +89,7 @@ import (
 	psworker "github.com/juju/juju/worker/pubsub"
 	"github.com/juju/juju/worker/upgradedatabase"
 	"github.com/juju/juju/worker/upgradesteps"
+	"github.com/juju/juju/wrench"
 )
 
 var (
@@ -1100,6 +1101,12 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewContainerBrokerFunc:      newCAASBroker,
 		NewMigrationMaster:          migrationmaster.NewWorker,
 	}
+	if wrench.IsActive("charmrevision", "shortinterval") {
+		interval := 10 * time.Second
+		logger.Infof("setting short charmrevision worker interval: %v", interval)
+		manifoldsCfg.CharmRevisionUpdateInterval = interval
+	}
+
 	applyTestingOverrides(currentConfig, &manifoldsCfg)
 
 	var manifolds dependency.Manifolds

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -268,6 +268,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 			NewFacade: charmrevision.NewAPIFacade,
 			NewWorker: charmrevision.NewWorker,
+			Logger:    config.LoggingContext.GetLogger("juju.worker.charmrevision"),
 			// No Logger defined in the charmrevision package.
 		})),
 		remoteRelationsName: ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{

--- a/resource/workers/charmstorepoller.go
+++ b/resource/workers/charmstorepoller.go
@@ -6,18 +6,16 @@ package workers
 import (
 	"time"
 
-	charmresource "github.com/juju/charm/v8/resource"
+	"github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-
-	"github.com/juju/juju/charmstore"
 )
 
 // DataStore exposes the functionality of Juju state needed here.
 type DataStore interface {
 	// SetCharmStoreResources sets the "polled from the charm store"
 	// resources for the application to the provided values.
-	SetCharmStoreResources(applicationID string, info []charmresource.Resource, lastPolled time.Time) error
+	SetCharmStoreResources(applicationID string, info []resource.Resource, lastPolled time.Time) error
 }
 
 // LatestCharmHandler implements apiserver/facades/controller/charmrevisionupdater.LatestCharmHandler.
@@ -33,10 +31,13 @@ func NewLatestCharmHandler(store DataStore) *LatestCharmHandler {
 	}
 }
 
+// TODO(benhoyt) - get rid of this whole mess, and just call SetCharmStoreResources
+// directly from updateLatestRevisions()
+
 // HandleLatest implements apiserver/facades/controller/charmrevisionupdater.LatestCharmHandler
 // by storing the charm's resources in state.
-func (handler LatestCharmHandler) HandleLatest(applicationID names.ApplicationTag, info charmstore.CharmInfo) error {
-	if err := handler.store.SetCharmStoreResources(applicationID.Id(), info.LatestResources, info.Timestamp); err != nil {
+func (handler LatestCharmHandler) HandleLatest(applicationID names.ApplicationTag, resources []resource.Resource, timestamp time.Time) error {
+	if err := handler.store.SetCharmStoreResources(applicationID.Id(), resources, timestamp); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/resource/workers/charmstorepoller_test.go
+++ b/resource/workers/charmstorepoller_test.go
@@ -6,7 +6,6 @@ package workers_test
 import (
 	"time"
 
-	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -14,7 +13,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/resource/resourcetesting"
 	"github.com/juju/juju/resource/workers"
 )
@@ -37,21 +35,17 @@ func (s *LatestCharmHandlerSuite) SetUpTest(c *gc.C) {
 
 func (s *LatestCharmHandlerSuite) TestSuccess(c *gc.C) {
 	applicationID := names.NewApplicationTag("a-application")
-	info := charmstore.CharmInfo{
-		OriginalURL:    &charm.URL{},
-		Timestamp:      time.Now().UTC(),
-		LatestRevision: 2,
-		LatestResources: []charmresource.Resource{
-			resourcetesting.NewCharmResource(c, "spam", "<some data>"),
-		},
+	timestamp := time.Now().UTC()
+	resources := []charmresource.Resource{
+		resourcetesting.NewCharmResource(c, "spam", "<some data>"),
 	}
 	handler := workers.NewLatestCharmHandler(s.store)
 
-	err := handler.HandleLatest(applicationID, info)
+	err := handler.HandleLatest(applicationID, resources, timestamp)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "SetCharmStoreResources")
-	s.stub.CheckCall(c, 0, "SetCharmStoreResources", "a-application", info.LatestResources, info.Timestamp)
+	s.stub.CheckCall(c, 0, "SetCharmStoreResources", "a-application", resources, timestamp)
 }
 
 type stubDataStore struct {

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -119,7 +119,7 @@ func (st resourceState) ListResources(applicationID string) (resource.Applicatio
 	return resources, nil
 }
 
-// ListPendinglResources returns the resource data for the given
+// ListPendingResources returns the resource data for the given
 // application ID for pending resources only.
 func (st resourceState) ListPendingResources(applicationID string) ([]resource.Resource, error) {
 	resources, err := st.persist.ListPendingResources(applicationID)
@@ -131,7 +131,7 @@ func (st resourceState) ListPendingResources(applicationID string) ([]resource.R
 
 // RemovePendingResources removes the pending application-level
 // resources for a specific application, normally in the case that the
-// application couln't be deployed.
+// application couldn't be deployed.
 func (st resourceState) RemovePendingAppResources(applicationID string, pendingIDs map[string]string) error {
 	return errors.Trace(st.persist.RemovePendingAppResources(applicationID, pendingIDs))
 }
@@ -406,6 +406,7 @@ func (st resourceState) OpenResourceForUniter(unit resource.Unit, name string) (
 // SetCharmStoreResources sets the "polled" resources for the
 // application to the provided values.
 func (st resourceState) SetCharmStoreResources(applicationID string, info []charmresource.Resource, lastPolled time.Time) error {
+	logger.Infof("TODO SetCharmStoreResources app=%q, info=%#v lastPolled=%v", applicationID, info, lastPolled)
 	for _, chRes := range info {
 		id := newResourceID(applicationID, chRes.Name)
 		if err := st.persist.SetCharmStoreResource(id, applicationID, chRes, lastPolled); err != nil {

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -406,7 +406,6 @@ func (st resourceState) OpenResourceForUniter(unit resource.Unit, name string) (
 // SetCharmStoreResources sets the "polled" resources for the
 // application to the provided values.
 func (st resourceState) SetCharmStoreResources(applicationID string, info []charmresource.Resource, lastPolled time.Time) error {
-	logger.Infof("TODO SetCharmStoreResources app=%q, info=%#v lastPolled=%v", applicationID, info, lastPolled)
 	for _, chRes := range info {
 		id := newResourceID(applicationID, chRes.Name)
 		if err := st.persist.SetCharmStoreResource(id, applicationID, chRes, lastPolled); err != nil {

--- a/testcharms/charm-hub/focal/mysql/metadata.yaml
+++ b/testcharms/charm-hub/focal/mysql/metadata.yaml
@@ -1,0 +1,8 @@
+name: mysql
+summary: "Database engine"
+description: "A pretty popular database"
+provides:
+  server:
+    interface: mysql
+series:
+  - focal

--- a/testcharms/charm-hub/focal/postgresql/metadata.yaml
+++ b/testcharms/charm-hub/focal/postgresql/metadata.yaml
@@ -1,0 +1,8 @@
+name: postgresql
+summary: "PGSQL"
+description: "The PostgreSQL database engine"
+provides:
+  server:
+    interface: postgresql
+series:
+  - focal

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -22,11 +22,17 @@ import (
 	jtesting "github.com/juju/juju/testing"
 )
 
-const defaultSeries = "quantal"
-const localCharmRepo = "charm-repo"
+const (
+	defaultSeries  = "quantal"
+	localCharmRepo = "charm-repo"
+	localCharmHub  = "charm-hub"
+)
 
 // Repo provides access to the test charm repository.
 var Repo = testing.NewRepo(localCharmRepo, defaultSeries)
+
+// Hub provides access to the test charmhub repository.
+var Hub = testing.NewRepo(localCharmHub, "focal")
 
 // RepoForSeries returns a new charm repository for the specified series.
 // Note: this is a bit weird, as it ignores the series if it's NOT kubernetes

--- a/testing/logger.go
+++ b/testing/logger.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+type NoopLogger struct{}
+
+func (NoopLogger) Criticalf(string, ...interface{}) {}
+func (NoopLogger) Errorf(string, ...interface{})    {}
+func (NoopLogger) Warningf(string, ...interface{})  {}
+func (NoopLogger) Infof(string, ...interface{})     {}
+func (NoopLogger) Debugf(string, ...interface{})    {}
+func (NoopLogger) Tracef(string, ...interface{})    {}
+
+func (NoopLogger) IsErrorEnabled() bool   { return false }
+func (NoopLogger) IsWarningEnabled() bool { return false }
+func (NoopLogger) IsInfoEnabled() bool    { return false }
+func (NoopLogger) IsDebugEnabled() bool   { return false }
+func (NoopLogger) IsTraceEnabled() bool   { return false }

--- a/worker/charmrevision/manifold.go
+++ b/worker/charmrevision/manifold.go
@@ -30,6 +30,7 @@ type ManifoldConfig struct {
 	Period    time.Duration
 	NewFacade func(base.APICaller) (Facade, error)
 	NewWorker func(Config) (worker.Worker, error)
+	Logger    Logger
 }
 
 // Manifold returns a dependency.Manifold that runs a charm revision worker
@@ -56,6 +57,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				RevisionUpdater: facade,
 				Clock:           config.Clock,
 				Period:          config.Period,
+				Logger:          config.Logger,
 			})
 			if err != nil {
 				return nil, errors.Annotatef(err, "cannot create worker")

--- a/worker/charmrevision/validate_test.go
+++ b/worker/charmrevision/validate_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/charmrevision"
 )
 
@@ -29,7 +29,7 @@ func (s *ValidateSuite) SetUpTest(c *gc.C) {
 		RevisionUpdater: struct{ charmrevision.RevisionUpdater }{},
 		Clock:           struct{ clock.Clock }{},
 		Period:          time.Hour,
-		Logger:          loggo.GetLogger("test"),
+		Logger:          coretesting.NoopLogger{},
 	}
 }
 

--- a/worker/charmrevision/validate_test.go
+++ b/worker/charmrevision/validate_test.go
@@ -28,6 +28,7 @@ func (s *ValidateSuite) SetUpTest(c *gc.C) {
 		RevisionUpdater: struct{ charmrevision.RevisionUpdater }{},
 		Clock:           struct{ clock.Clock }{},
 		Period:          time.Hour,
+		Logger:          &blackholeLogger{},
 	}
 }
 
@@ -44,6 +45,11 @@ func (s *ValidateSuite) TestNilRevisionUpdater(c *gc.C) {
 func (s *ValidateSuite) TestNilClock(c *gc.C) {
 	s.config.Clock = nil
 	s.checkNotValid(c, "nil Clock not valid")
+}
+
+func (s *ValidateSuite) TestNilLogger(c *gc.C) {
+	s.config.Logger = nil
+	s.checkNotValid(c, "nil Logger not valid")
 }
 
 func (s *ValidateSuite) TestBadPeriods(c *gc.C) {

--- a/worker/charmrevision/validate_test.go
+++ b/worker/charmrevision/validate_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -28,7 +29,7 @@ func (s *ValidateSuite) SetUpTest(c *gc.C) {
 		RevisionUpdater: struct{ charmrevision.RevisionUpdater }{},
 		Clock:           struct{ clock.Clock }{},
 		Period:          time.Hour,
-		Logger:          &blackholeLogger{},
+		Logger:          loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/charmrevision/worker_test.go
+++ b/worker/charmrevision/worker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -111,16 +112,12 @@ func (fix workerFixture) dirtyTest(c *gc.C, test testFunc) {
 	fix.runTest(c, test, false)
 }
 
-type blackholeLogger struct{}
-
-func (l *blackholeLogger) Debugf(string, ...interface{}) {}
-
 func (fix workerFixture) runTest(c *gc.C, test testFunc, checkWaitErr bool) {
 	w, err := charmrevision.NewWorker(charmrevision.Config{
 		RevisionUpdater: fix.revisionUpdater,
 		Clock:           fix.clock,
 		Period:          fix.period,
-		Logger:          &blackholeLogger{},
+		Logger:          loggo.GetLogger("test"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {

--- a/worker/charmrevision/worker_test.go
+++ b/worker/charmrevision/worker_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -117,7 +116,7 @@ func (fix workerFixture) runTest(c *gc.C, test testFunc, checkWaitErr bool) {
 		RevisionUpdater: fix.revisionUpdater,
 		Clock:           fix.clock,
 		Period:          fix.period,
-		Logger:          loggo.GetLogger("test"),
+		Logger:          coretesting.NoopLogger{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {

--- a/worker/charmrevision/worker_test.go
+++ b/worker/charmrevision/worker_test.go
@@ -111,11 +111,16 @@ func (fix workerFixture) dirtyTest(c *gc.C, test testFunc) {
 	fix.runTest(c, test, false)
 }
 
+type blackholeLogger struct{}
+
+func (l *blackholeLogger) Debugf(string, ...interface{}) {}
+
 func (fix workerFixture) runTest(c *gc.C, test testFunc, checkWaitErr bool) {
 	w, err := charmrevision.NewWorker(charmrevision.Config{
 		RevisionUpdater: fix.revisionUpdater,
 		Clock:           fix.clock,
 		Period:          fix.period,
+		Logger:          &blackholeLogger{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {


### PR DESCRIPTION
Currently it only pulls new charm revision info from the charmstore;
make it pull from the new charmhub API as well (using Refresh). We
partition the list of the model's charms into charmstore vs charmhub
so we can call each API in bulk. Most of the new charmhub-specific
code is in the new charmhub.go file.

Change RefreshEntity.CreatedAt to a time.Time instead of a string. May
want to do this for other *At fields in there as well?

For testing, I've added a wrench charmrevision/shortinterval that
is checked when the controller starts up. If you create
/var/lib/juju/wrench/charmrevision on the controller with contents
"shortinterval" and then restart the controller it'll set the poll
interval to 10 seconds (!) instead of 24 hours.

Other things:
* Added a debug logger to the charmrevision worker so you can see when
  it fires.
* A few drive-by typo fixes.

## QA steps

```
# create the wrench and restart controller
juju ssh -m controller 0
sudo mkdir /var/lib/juju/wrench
echo shortinterval | sudo tee /var/lib/juju/wrench/charmrevision
sudo systemctl restart jujud-machine-0
```

```sh
export JUJU_DEV_FEATURE_FLAGS=charm-hub
juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"
juju deploy postgresql
juju deploy cs:mysql  # try a charmstore charm as well
juju debug-log -m controller --include-module juju.apiserver.charmrevisionupdater --include-module juju.worker.charmrevision
```
