### PR TITLE
Adds services to service watcher.

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2129,8 +2129,12 @@ func (k *kubernetesClient) WatchService(appName string, mode caas.DeploymentMode
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	w3, err := k.newWatcher(factory.Core().V1().Services().Informer(), appName, k.clock)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
-	return watcher.NewMultiNotifyWatcher(w1, w2), nil
+	return watcher.NewMultiNotifyWatcher(w1, w2, w3), nil
 }
 
 // legacyJujuPVNameRegexp matches how Juju labels persistent volumes.


### PR DESCRIPTION
Services where not being watched as part of the Kubernetes provider service watcher. This address that by watching them so that Juju status can report LoadBalancer addresses correctly.

This happens when pods become stable before the service itself.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

- Start a new GKE cluster in a Europe region
- Bootstrap Juju
- Deploy Kubeflow

## Bug reference

https://bugs.launchpad.net/juju/+bug/1905431
