### PR TITLE
Add an arg to the webscale tests to allow the mongo snap channel to be selected

### DIFF
--- a/acceptancetests/assess
+++ b/acceptancetests/assess
@@ -218,6 +218,8 @@ def parse_args():
                               help="Path/URL to a .snap file that will be used as the MongoDB instance under test (Only relevant for webscale_deploy test)")
     pass_through.add_argument("--db-asserts-path",
                               help="Path/URL to a .assert file that will be used as the MongoDB instance under test (Only relevant for webscale_deploy test)")
+    pass_through.add_argument("--db-snap-channel",
+                              help="snap track/channel to use for installing MongoDB instance under test (Only relevant for webscale_deploy test)")
     pass_through.add_argument("--mongo-memory-profile",
                               help="Name of a the memory profile to set MongoDB to (Only relevant for webscale_deploy test)",
                               choices=["low", "default"], default="default")
@@ -480,7 +482,7 @@ def main():
         if args.logging_module:
             testrun_argv.extend(["--logging-module", args.logging_module])
         if args.reporting_uri:
-            testrun_argv.extend(["--reporting-uri"])
+            testrun_argv.extend(["--reporting-uri", args.reporting_uri])
         if args.report_git_sha:
             testrun_argv.extend(["--git-sha", args.report_git_sha])
         if args.report_juju_version:
@@ -490,6 +492,8 @@ def main():
         if args.db_asserts_path:
             testrun_argv.extend(["--db-asserts-path", args.db_asserts_path])
         testrun_argv.extend(["--mongo-memory-profile", args.mongo_memory_profile])
+        if args.db_snap_channel:
+            testrun_argv.extend(["--db-snap-channel", args.db_snap_channel])
         if args.mongo_server_side_txns:
             testrun_argv.extend(["--with-mongo-server-side-txns", "true"])
     elif assess == "log_rotation":

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -181,7 +181,7 @@ def extract_mongo_details(client):
 
     ctrl_config = client.get_controller_config(client.env.controller.name)
 
-    return ctrl_details.mongo_version, ctrl_config.mongo_memory_profile
+    return ctrl_details.mongo_version, ctrl_config.db_snap_channel, ctrl_config.mongo_memory_profile
 
 
 def get_stack_client(stack_type, path, client, timeout=3600, charm=False):
@@ -245,6 +245,11 @@ def parse_args(argv):
     parser.add_argument(
         '--mongo-memory-profile',
         help="the name of a mongo profile to use when bootstrapping",
+        default="",
+    )
+    parser.add_argument(
+        '--db-snap-channel',
+        help="the track/channel to use for the mongo4 snap",
         default="",
     )
     parser.add_argument(
@@ -319,11 +324,12 @@ def main(argv=None):
         db_snap_path=db_snap_path,
         db_snap_asserts_path=db_snap_asserts_path,
         mongo_memory_profile=args.mongo_memory_profile,
+        db_snap_channel=args.db_snap_channel,
     ):
         client = bs_manager.client
-        mongo_version, mongo_profile = extract_mongo_details(client)
-        log.info("MongoVersion used for deployment: {} (profile: {})".format(
-            mongo_version, mongo_profile))
+        mongo_version, db_snap_channel, mongo_profile = extract_mongo_details(client)
+        log.info("MongoVersion used for deployment: {} from {} (profile: {})".format(
+            mongo_version, db_snap_channel, mongo_profile))
 
         deploy_bundle(
                 client,

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -977,10 +977,12 @@ class ModelClient:
         })
 
     @contextmanager
-    def _bootstrap_config(self, mongo_memory_profile=None, caas_image_repo=None):
+    def _bootstrap_config(self, mongo_memory_profile=None, db_snap_channel=None, caas_image_repo=None):
         cfg = self.make_model_config()
         if mongo_memory_profile:
             cfg['mongo-memory-profile'] = mongo_memory_profile
+        if db_snap_channel:
+            cfg['juju-db-snap-channel'] = db_snap_channel
         if caas_image_repo:
             cfg['caas-image-repo'] = caas_image_repo
         with temp_yaml_file(cfg) as config_filename:
@@ -998,11 +1000,11 @@ class ModelClient:
                   credential=None, auto_upgrade=False, metadata_source=None,
                   no_gui=False, agent_version=None, db_snap_path=None,
                   db_snap_asserts_path=None, mongo_memory_profile=None, caas_image_repo=None, force=False,
-                  config_options=None):
+                  db_snap_channel=None, config_options=None):
         """Bootstrap a controller."""
         self._check_bootstrap()
         with self._bootstrap_config(
-                mongo_memory_profile, caas_image_repo,
+                mongo_memory_profile, db_snap_channel, caas_image_repo,
         ) as config_filename:
             args = self.get_bootstrap_args(
                 upload_tools=upload_tools,

--- a/acceptancetests/jujupy/controller.py
+++ b/acceptancetests/jujupy/controller.py
@@ -86,3 +86,9 @@ class ControllerConfig:
         if 'mongo-memory-profile' in self.cfg:
             return self.cfg["mongo-memory-profile"]
         return "low"
+
+    @property
+    def db_snap_channel(self):
+        if 'juju-db-snap-channel' in self.cfg:
+            return self.cfg["juju-db-snap-channel"]
+        return "4.0/stable"


### PR DESCRIPTION
Add an arg to the webscale tests so we can choose which mongo snap to use and evaluate how 4.4 performs.
Also driveby fix for a missing reporting-uri arg.

## QA steps

./assess deploy_webscale --db-snap-channel latest/candidate 
