### PR TITLE
Update the upgrade step for 2.9 for charm origin

### DIFF
--- a/state/constraints.go
+++ b/state/constraints.go
@@ -175,7 +175,7 @@ func readConstraints(mb modelBackend, id string) (constraints.Value, error) {
 	constraintsCollection, closer := mb.db().GetCollection(constraintsC)
 	defer closer()
 
-	doc := constraintsDoc{}
+	var doc constraintsDoc
 	if err := constraintsCollection.FindId(id).One(&doc); err == mgo.ErrNotFound {
 		return constraints.Value{}, errors.NotFoundf("constraints")
 	} else if err != nil {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/v2/series"
 	"github.com/juju/replicaset"
 	"github.com/kr/pretty"
 	"gopkg.in/mgo.v2"
@@ -3141,6 +3142,22 @@ func AddCharmOriginToApplications(pool *StatePool) error {
 				return errors.Errorf("charmurl is empty")
 			}
 
+			var arch string
+			cons, err := readConstraints(st, applicationGlobalKey(application.Name))
+			if err == nil && cons.HasArch() {
+				arch = *cons.Arch
+			}
+			var serie string
+			if charmURL.Series != "bundle" {
+				serie = charmURL.Series
+			}
+			var os string
+			if serie != "" {
+				if osType, err := series.GetOSFromSeries(serie); err == nil {
+					os = strings.ToLower(osType.String())
+				}
+			}
+
 			var source string
 			switch charmURL.Schema {
 			case "local":
@@ -3153,6 +3170,7 @@ func AddCharmOriginToApplications(pool *StatePool) error {
 			// Set the CharmOrigin on the application.
 			origin := CharmOrigin{
 				Source: source,
+				Type:   "charm",
 				ID:     charmURL.String(),
 				Channel: &Channel{
 					// This is only ever set via the charm-store data, but as
@@ -3161,6 +3179,11 @@ func AddCharmOriginToApplications(pool *StatePool) error {
 					Risk: application.Channel,
 				},
 				Revision: &charmURL.Revision,
+				Platform: &Platform{
+					Architecture: arch,
+					OS:           os,
+					Series:       serie,
+				},
 			}
 
 			ops = append(ops, txn.Op{


### PR DESCRIPTION
Now that more fields have been added to charm-origin, the upgrade steps
should also be added to better reflect that.

There is a worrying part that I'm unsure how to solve and that is around
people who are already trying out RC1 and RC2 of 2.9. Officially this
won't re-run for them, but is that a bad thing?

 - The items that actually are mandatory are source, revision, channel
 and id. These were already in version 1 of the upgrade step.
 - Platform although important will fallback to the logic to find out
 what it should be if it's missing.
 - Type isn't required for charms and is a requirement for bundles,
 considering we don't store bundles this should be fine.

If what I say holds we should be ok.

## QA steps

Bootstrap a 2.8.6 and upgrade to 2.9
Deploy a charm...