### PR TITLE
Use model-configured default space for NetworkInfo bindings

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -897,7 +897,8 @@ func (c *Config) validateDefaultSpace() error {
 	return nil
 }
 
-// DefaultSpace returns the default-space for unspecified default endpoint bindings.
+// DefaultSpace returns the name of the space for to be used
+// for endpoint bindings that are not explicitly set.
 func (c *Config) DefaultSpace() string {
 	return c.asString(DefaultSpace)
 }


### PR DESCRIPTION
This patch changes `NetworkInfo` initialisation so that the model config value for `default-space` is used instead of the `alpha` space as the default endpoint binding.

This mirrors the behaviour for explicit bindings, effectively applying it the the implicit `juju-info` endpoint.

## QA steps

- Bootstrap to MAAS.
- `juju model-config default-space=<suitable space for your MAAS>`
- `juju run --unit ubuntu/0 "network-get juju-info"` should return a result for the space such as:
```
bind-addresses:
- macaddress: 52:54:00:b2:df:e8
  interfacename: ens4
  addresses:
  - hostname: ""
    address: 172.16.99.3
    cidr: 172.16.99.0/24
egress-subnets:
- 172.16.99.3/32
ingress-addresses:
- 172.16.99.3
```

## Documentation changes

This should be documented. It is a subtle change from always using the alpha space for `juju-info`.

## Bug reference

N/A
