### PR TITLE
Columnise find to reduce output width

### DIFF
--- a/cmd/juju/charmhub/find_test.go
+++ b/cmd/juju/charmhub/find_test.go
@@ -34,6 +34,7 @@ func (s *findSuite) TestInitNoArgs(c *gc.C) {
 		charmHubCommand: &charmHubCommand{
 			arches: arch.AllArches(),
 		},
+		columns: "nbvps",
 	}
 	err := command.Init([]string{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -44,6 +45,7 @@ func (s *findSuite) TestInitSuccess(c *gc.C) {
 		charmHubCommand: &charmHubCommand{
 			arches: arch.AllArches(),
 		},
+		columns: "nbvps",
 	}
 	err := command.Init([]string{"test"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -42,13 +42,13 @@ type Columns map[rune]Column
 // DefaultColumns represents the default columns for the output of the find.
 func DefaultColumns() Columns {
 	return map[rune]Column{
-		'n': Column{Index: 0, Name: ColumnNameName},
-		'b': Column{Index: 1, Name: ColumnNameBundle},
-		'v': Column{Index: 2, Name: ColumnNameVersion},
-		'a': Column{Index: 3, Name: ColumnNameArchitectures},
-		'S': Column{Index: 4, Name: ColumnNameSupports},
-		'p': Column{Index: 5, Name: ColumnNamePublisher},
-		's': Column{Index: 6, Name: ColumnNameSummary},
+		'n': {Index: 0, Name: ColumnNameName},
+		'b': {Index: 1, Name: ColumnNameBundle},
+		'v': {Index: 2, Name: ColumnNameVersion},
+		'a': {Index: 3, Name: ColumnNameArchitectures},
+		'S': {Index: 4, Name: ColumnNameSupports},
+		'p': {Index: 5, Name: ColumnNamePublisher},
+		's': {Index: 6, Name: ColumnNameSummary},
 	}
 }
 

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -11,6 +11,34 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+type columnFindSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&columnFindSuite{})
+
+func (s *columnFindSuite) TestColumnNames(c *gc.C) {
+	names := DefaultColumns().Names()
+	c.Assert(names, jc.DeepEquals, []string{"Name", "Bundle", "Version", "Architectures", "Supports", "Publisher", "Summary"})
+}
+
+func (s *columnFindSuite) TestMakeColumns(c *gc.C) {
+	columns, err := MakeColumns(DefaultColumns(), "nb")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(columns.Names(), jc.DeepEquals, []string{"Name", "Bundle"})
+}
+
+func (s *columnFindSuite) TestMakeColumnsOutOfOrder(c *gc.C) {
+	columns, err := MakeColumns(DefaultColumns(), "vbn")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(columns.Names(), jc.DeepEquals, []string{"Version", "Bundle", "Name"})
+}
+
+func (s *columnFindSuite) TestMakeColumnsInvalidAlias(c *gc.C) {
+	_, err := MakeColumns(DefaultColumns(), "X")
+	c.Assert(err, gc.ErrorMatches, `unexpected column alias 'X'`)
+}
+
 type printFindSuite struct {
 	testing.IsolationSuite
 }
@@ -20,7 +48,9 @@ var _ = gc.Suite(&printFindSuite{})
 func (s *printFindSuite) TestCharmPrintFind(c *gc.C) {
 	fr := getCharmFindResponse()
 	ctx := commandContextForTest(c)
-	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, fr)
+	cols := DefaultColumns()
+
+	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, cols, fr)
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -35,6 +65,26 @@ osm        Y       3.2.3    all            bionic,xenial,trusty  charmed-osm    
 	c.Assert(obtained, gc.Equals, expected)
 }
 
+func (s *printFindSuite) TestCharmPrintFindWithColumns(c *gc.C) {
+	fr := getCharmFindResponse()
+	ctx := commandContextForTest(c)
+	cols, err := MakeColumns(DefaultColumns(), "nbvps")
+	c.Assert(err, jc.ErrorIsNil)
+
+	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, cols, fr)
+	err = fw.Print()
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained := ctx.Stdout.(*bytes.Buffer).String()
+	expected := `
+Name       Bundle  Version  Publisher          Summary
+wordpress  -       1.0.3    Wordress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
+osm        Y       3.2.3    charmed-osm        Single instance OSM bundle.
+
+`[1:]
+	c.Assert(obtained, gc.Equals, expected)
+}
+
 func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 	fr := getCharmFindResponse()
 	fr[0].Version = ""
@@ -43,7 +93,9 @@ func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 	fr[0].Summary = ""
 
 	ctx := commandContextForTest(c)
-	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, fr)
+	cols := DefaultColumns()
+
+	fw := makeFindWriter(ctx.Stdout, ctx.Warningf, cols, fr)
 	err := fw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -78,7 +78,8 @@ func (s *printFindSuite) TestCharmPrintFindWithColumns(c *gc.C) {
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `
 Name       Bundle  Version  Publisher          Summary
-wordpress  -       1.0.3    Wordress Charmers  WordPress is a full featured web blogging tool, this charm deploys it.
+wordpress  -       1.0.3    Wordress Charmers  WordPress is a full featured web blogging
+                                                   tool, this charm deploys it.
 osm        Y       3.2.3    charmed-osm        Single instance OSM bundle.
 
 `[1:]


### PR DESCRIPTION
The output find is rather large, now that we have more and more
populated fields, we're potentially showing to much information. Instead
of just removing the fields that look unimportant, we should tailor it
depending on the users needs.

This PR introduces columns for the tabular field. Using --columns flag
with the column alias seems like a decent approach. Other canonical
tools also do this, so it isn't something new (LXD).

With decent defaults it actually looks rather good as well.

## QA steps

### Default column output 

```sh
$ juju bootstrap lxd test
$ juju find kubernetes
```

### Tailoured

```sh
$ juju bootstrap lxd test
$ juju find --columns=nbvaS
```
