### PR TITLE
Save charm origin platform to state

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -756,27 +756,44 @@ func deployApplication(
 }
 
 func convertCharmOrigin(origin *params.CharmOrigin, curl *charm.URL, charmStoreChannel string) (corecharm.Origin, error) {
+	var (
+		originType string
+		platform   corecharm.Platform
+	)
+	if origin != nil {
+		originType = origin.Type
+		platform = corecharm.Platform{
+			Architecture: origin.Architecture,
+			OS:           origin.OS,
+			Series:       origin.Series,
+		}
+	}
+
 	switch {
 	case origin == nil || origin.Source == "" || origin.Source == "charm-store":
 		var rev *int
 		if curl.Revision != -1 {
 			rev = &curl.Revision
 		}
-		var origin *corecharm.Channel
+		var ch *corecharm.Channel
 		if charmStoreChannel != "" {
-			origin = &corecharm.Channel{
+			ch = &corecharm.Channel{
 				Risk: corecharm.Risk(charmStoreChannel),
 			}
 		}
 		return corecharm.Origin{
+			Type:     originType,
 			Source:   corecharm.CharmStore,
 			Revision: rev,
-			Channel:  origin,
+			Channel:  ch,
+			Platform: platform,
 		}, nil
 	case origin.Source == "local":
 		return corecharm.Origin{
+			Type:     originType,
 			Source:   corecharm.Local,
 			Revision: &curl.Revision,
+			Platform: platform,
 		}, nil
 	}
 
@@ -793,11 +810,13 @@ func convertCharmOrigin(origin *params.CharmOrigin, curl *charm.URL, charmStoreC
 	}
 
 	return corecharm.Origin{
+		Type:     originType,
 		Source:   corecharm.Source(origin.Source),
 		ID:       origin.ID,
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
 		Channel:  channel,
+		Platform: platform,
 	}, nil
 }
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -314,7 +314,8 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-store",
+			Source:   "charm-store",
+			Platform: &state.Platform{},
 		},
 		StorageConstraints: map[string]state.StorageConstraints{
 			"a": {},
@@ -506,7 +507,8 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-store",
+			Source:   "charm-store",
+			Platform: &state.Platform{},
 		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
@@ -528,7 +530,8 @@ postgresql:
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-store",
+			Source:   "charm-store",
+			Platform: &state.Platform{},
 		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
@@ -548,7 +551,8 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-store",
+			Source:   "charm-store",
+			Platform: &state.Platform{},
 		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
@@ -589,7 +593,8 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 	app.CheckCall(c, 2, "SetCharm", state.SetCharmConfig{
 		Charm: &state.Charm{},
 		CharmOrigin: &state.CharmOrigin{
-			Source: "charm-store",
+			Source:   "charm-store",
+			Platform: &state.Platform{},
 		},
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -176,11 +176,17 @@ func stateCharmOrigin(origin corecharm.Origin) *state.CharmOrigin {
 		}
 	}
 	stateOrigin := &state.CharmOrigin{
+		Type:     origin.Type,
 		Source:   string(origin.Source),
 		ID:       origin.ID,
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
 		Channel:  ch,
+		Platform: &state.Platform{
+			Architecture: origin.Platform.Architecture,
+			OS:           origin.Platform.OS,
+			Series:       origin.Platform.Series,
+		},
 	}
 	return stateOrigin
 }

--- a/state/charm.go
+++ b/state/charm.go
@@ -58,9 +58,9 @@ type Channel struct {
 
 // Platform identifies the platform the charm was installed on.
 type Platform struct {
-	Architecture string `bson:"architecture"`
-	OS           string `bson:"os"`
-	Series       string `bson:"series"`
+	Architecture string `bson:"architecture,omitempty"`
+	OS           string `bson:"os,omitempty"`
+	Series       string `bson:"series,omitempty"`
 }
 
 // CharmOrigin holds the original source of a charm. Information about where the

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4767,11 +4767,7 @@ func (s *upgradesSuite) TestAddCharmOriginToApplication(c *gc.C) {
 				"channel": bson.M{
 					"risk": "",
 				},
-				"platform": bson.M{
-					"architecture": "",
-					"os":           "",
-					"series":       "",
-				},
+				"platform": bson.M{},
 			},
 		},
 		{
@@ -4787,11 +4783,7 @@ func (s *upgradesSuite) TestAddCharmOriginToApplication(c *gc.C) {
 				"channel": bson.M{
 					"risk": "",
 				},
-				"platform": bson.M{
-					"architecture": "",
-					"os":           "",
-					"series":       "",
-				},
+				"platform": bson.M{},
 			},
 		},
 		{
@@ -4807,11 +4799,7 @@ func (s *upgradesSuite) TestAddCharmOriginToApplication(c *gc.C) {
 				"channel": bson.M{
 					"risk": "",
 				},
-				"platform": bson.M{
-					"architecture": "",
-					"os":           "",
-					"series":       "",
-				},
+				"platform": bson.M{},
 			},
 		},
 		{


### PR DESCRIPTION
The issue was that platform wasn't being correctly marshalled to the
state charm origin. This fixes that so that we correctly send the state
platform.

This is potentially one fix that could be lurking in deploying code.
Unfortunately, the client does so many things that attempting to fix
everything is actually quite hard.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model other --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy ubuntu
```

Check with mongo and see that platform is correctly set!

```
$ juju mongo # or how ever you login into mongo 
juju:PRIMARY> db.applications.find().pretty()
{
        "_id" : "7f02d08c-be3a-4b23-85a2-f33ff4de554a:ubuntu",
        "name" : "ubuntu",
        "model-uuid" : "7f02d08c-be3a-4b23-85a2-f33ff4de554a",
        "series" : "focal",
        "subordinate" : false,
        "charmurl" : "ch:ubuntu-17",
        "cs-channel" : "stable",
        "charm-origin" : {
                "source" : "charm-hub",
                "id" : "9NT4sM1gdNLkBPuXbxNu2IusUosDcmR9",
                "hash" : "e0a16ee2c880fe0a1942f48602377e5861d745c66f7523a0113726eb0dde7a0e",
                "revision" : 17,
                "channel" : {
                        "risk" : "stable"
                },
                "platform" : {
                        "architecture" : "all",
                        "os" : "ubuntu",
                        "series" : "focal"
                }
        },
        "charmmodifiedversion" : 0,
        "forcecharm" : false,
        "life" : 0,
        "unitcount" : 1,
        "relationcount" : 0,
        "minunits" : 0,
        "txn-revno" : NumberLong(20),
        "metric-credentials" : BinData(0,""),
        "exposed" : false,
        "scale" : 0,
        "passwordhash" : "",
        "txn-queue" : [
                "5fce6584f4d89f3fd548d47c_6dd6976b"
        ]
}
```
