### PR TITLE
Charmhub info optional flag

### DIFF
--- a/api/charmhub/client.go
+++ b/api/charmhub/client.go
@@ -35,8 +35,11 @@ func newClientFromFacade(frontend base.ClientFacade, backend base.FacadeCaller) 
 }
 
 // Info queries the CharmHub API for information for a given name.
-func (c *Client) Info(name string) (InfoResponse, error) {
-	args := params.Entity{Tag: names.NewApplicationTag(name).String()}
+func (c *Client) Info(name, channel string) (InfoResponse, error) {
+	args := params.Info{
+		Tag:     names.NewApplicationTag(name).String(),
+		Channel: channel,
+	}
 	var result params.CharmHubEntityInfoResult
 	if err := c.facade.FacadeCall("Info", args, &result); err != nil {
 		return InfoResponse{}, errors.Trace(err)

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -24,13 +24,13 @@ var _ = gc.Suite(&charmHubSuite{})
 func (s charmHubSuite) TestInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	arg := params.Entity{Tag: names.NewApplicationTag("wordpress").String()}
+	arg := params.Info{Tag: names.NewApplicationTag("wordpress").String()}
 	resultSource := params.CharmHubEntityInfoResult{
 		Result: getParamsInfoResponse(),
 	}
 	s.facade.EXPECT().FacadeCall("Info", arg, gomock.Any()).SetArg(2, resultSource)
 
-	obtained, err := s.newClientFromFacadeForTest().Info("wordpress")
+	obtained, err := s.newClientFromFacadeForTest().Info("wordpress", "")
 	c.Assert(err, jc.ErrorIsNil)
 	assertInfoResponseSameContents(c, obtained, getInfoResponse())
 }

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -86,7 +86,7 @@ func (api *CharmHubAPI) Info(arg params.Info) (params.CharmHubEntityInfoResult, 
 		return params.CharmHubEntityInfoResult{}, errors.BadRequestf("tag value is empty")
 	}
 
-	var options []charmhub.Option
+	var options []charmhub.InfoOption
 	if arg.Channel != "" {
 		ch, err := charm.ParseChannelNormalize(arg.Channel)
 		if err != nil {

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -90,7 +90,7 @@ func (api *CharmHubAPI) Info(arg params.Info) (params.CharmHubEntityInfoResult, 
 	if arg.Channel != "" {
 		ch, err := charm.ParseChannelNormalize(arg.Channel)
 		if err != nil {
-			return params.CharmHubEntityInfoResult{}, errors.BadRequestf("channel value is invalid")
+			return params.CharmHubEntityInfoResult{}, errors.BadRequestf("channel %q is invalid", arg.Channel)
 		}
 		options = append(options, charmhub.WithChannel(ch.String()))
 	}

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -34,7 +34,7 @@ type ClientFactory interface {
 // Client represents a CharmHub Client for making queries to the CharmHub API.
 type Client interface {
 	URL() string
-	Info(ctx context.Context, name string) (transport.InfoResponse, error)
+	Info(ctx context.Context, name string, options ...charmhub.InfoOption) (transport.InfoResponse, error)
 	Find(ctx context.Context, query string) ([]transport.FindResponse, error)
 }
 

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/core/charm"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -77,16 +78,25 @@ func newCharmHubAPI(backend Backend, authorizer facade.Authorizer, clientFactory
 }
 
 // Info queries the CharmHub API with a given entity ID.
-func (api *CharmHubAPI) Info(arg params.Entity) (params.CharmHubEntityInfoResult, error) {
+func (api *CharmHubAPI) Info(arg params.Info) (params.CharmHubEntityInfoResult, error) {
 	logger.Tracef("Info(%v)", arg.Tag)
 
 	tag, err := names.ParseApplicationTag(arg.Tag)
 	if err != nil {
-		return params.CharmHubEntityInfoResult{}, errors.BadRequestf("arg value is empty")
+		return params.CharmHubEntityInfoResult{}, errors.BadRequestf("tag value is empty")
+	}
+
+	var options []charmhub.Option
+	if arg.Channel != "" {
+		ch, err := charm.ParseChannelNormalize(arg.Channel)
+		if err != nil {
+			return params.CharmHubEntityInfoResult{}, errors.BadRequestf("channel value is invalid")
+		}
+		options = append(options, charmhub.WithChannel(ch.String()))
 	}
 
 	// TODO (stickupkid): Create a proper context to be used here.
-	info, err := api.client.Info(context.TODO(), tag.Id())
+	info, err := api.client.Info(context.TODO(), tag.Id(), options...)
 	if err != nil {
 		return params.CharmHubEntityInfoResult{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -28,7 +28,17 @@ type charmHubAPISuite struct {
 func (s *charmHubAPISuite) TestInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectInfo()
-	arg := params.Entity{Tag: names.NewApplicationTag("wordpress").String()}
+	arg := params.Info{Tag: names.NewApplicationTag("wordpress").String()}
+	obtained, err := s.newCharmHubAPIForTest(c).Info(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	assertInfoResponseSameContents(c, obtained.Result, getParamsInfoResponse())
+}
+
+func (s *charmHubAPISuite) TestInfoWithChannel(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectInfo()
+	arg := params.Info{Tag: names.NewApplicationTag("wordpress").String(), Channel: "stable"}
 	obtained, err := s.newCharmHubAPIForTest(c).Info(arg)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -84,7 +94,7 @@ func (s *charmHubAPISuite) expectClient() {
 }
 
 func (s *charmHubAPISuite) expectInfo() {
-	s.client.EXPECT().Info(gomock.Any(), "wordpress").Return(getCharmHubInfoResponse(), nil)
+	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getCharmHubInfoResponse(), nil)
 }
 
 func (s *charmHubAPISuite) expectFind() {

--- a/apiserver/facades/client/charmhub/package_mock_test.go
+++ b/apiserver/facades/client/charmhub/package_mock_test.go
@@ -7,6 +7,7 @@ package charmhub
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
+	charmhub0 "github.com/juju/juju/charmhub"
 	transport "github.com/juju/juju/charmhub/transport"
 	config "github.com/juju/juju/environs/config"
 	reflect "reflect"
@@ -127,18 +128,23 @@ func (mr *MockClientMockRecorder) Find(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Info mocks base method
-func (m *MockClient) Info(arg0 context.Context, arg1 string) (transport.InfoResponse, error) {
+func (m *MockClient) Info(arg0 context.Context, arg1 string, arg2 ...charmhub0.InfoOption) (transport.InfoResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Info", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Info", varargs...)
 	ret0, _ := ret[0].(transport.InfoResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Info indicates an expected call of Info
-func (mr *MockClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Info(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockClient)(nil).Info), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockClient)(nil).Info), varargs...)
 }
 
 // URL mocks base method

--- a/apiserver/facades/client/charms/mocks/repositories_mock.go
+++ b/apiserver/facades/client/charms/mocks/repositories_mock.go
@@ -6,14 +6,15 @@ package mocks
 
 import (
 	context "context"
+	url "net/url"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	params "github.com/juju/charmrepo/v6/csclient/params"
 	charmhub "github.com/juju/juju/charmhub"
 	transport "github.com/juju/juju/charmhub/transport"
 	charm0 "github.com/juju/juju/core/charm"
-	url "net/url"
-	reflect "reflect"
 )
 
 // MockCSRepository is a mock of CSRepository interface
@@ -115,18 +116,23 @@ func (mr *MockCharmHubClientMockRecorder) DownloadAndRead(arg0, arg1, arg2 inter
 }
 
 // Info mocks base method
-func (m *MockCharmHubClient) Info(arg0 context.Context, arg1 string) (transport.InfoResponse, error) {
+func (m *MockCharmHubClient) Info(arg0 context.Context, arg1 string, arg2 ...charmhub.InfoOption) (transport.InfoResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Info", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Info", varargs...)
 	ret0, _ := ret[0].(transport.InfoResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Info indicates an expected call of Info
-func (mr *MockCharmHubClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCharmHubClientMockRecorder) Info(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockCharmHubClient)(nil).Info), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockCharmHubClient)(nil).Info), varargs...)
 }
 
 // Refresh mocks base method

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -180,7 +180,7 @@ func (s *charmHubRepositoriesSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *charmHubRepositoriesSuite) expectInfo(err error) {
-	s.client.EXPECT().Info(gomock.Any(), "wordpress").Return(getCharmHubInfoResponse(), err)
+	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getCharmHubInfoResponse(), err)
 }
 
 type charmStoreResolversSuite struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12317,7 +12317,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/Entity"
+                            "$ref": "#/definitions/Info"
                         },
                         "Result": {
                             "$ref": "#/definitions/CharmHubEntityInfoResult"
@@ -12544,18 +12544,6 @@
                         "type"
                     ]
                 },
-                "Entity": {
-                    "type": "object",
-                    "properties": {
-                        "tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "tag"
-                    ]
-                },
                 "ErrorResponse": {
                     "type": "object",
                     "properties": {
@@ -12614,6 +12602,21 @@
                         "summary",
                         "version",
                         "store-url"
+                    ]
+                },
+                "Info": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
                     ]
                 },
                 "InfoResponse": {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -9,6 +9,12 @@ type Query struct {
 	Query string `json:"query"`
 }
 
+// Info tag represents a info query for a given tag and channel.
+type Info struct {
+	Tag     string `json:"tag"`
+	Channel string `json:"channel,omitempty"`
+}
+
 type CharmHubEntityInfoResult struct {
 	Result InfoResponse  `json:"result"`
 	Errors ErrorResponse `json:"errors"`

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -189,8 +189,8 @@ func (c *Client) URL() string {
 }
 
 // Info returns charm info on the provided charm name from CharmHub API.
-func (c *Client) Info(ctx context.Context, name string) (transport.InfoResponse, error) {
-	return c.infoClient.Info(ctx, name)
+func (c *Client) Info(ctx context.Context, name string, options ...InfoOption) (transport.InfoResponse, error) {
+	return c.infoClient.Info(ctx, name, options...)
 }
 
 // Find searches for a given charm for a given name from CharmHub API.

--- a/charmhub/download.go
+++ b/charmhub/download.go
@@ -50,7 +50,7 @@ func WithProgressBar(pb ProgressBar) DownloadOption {
 }
 
 // Create a downloadOptions instance with default values.
-func newOptions() *downloadOptions {
+func newDownloadOptions() *downloadOptions {
 	return &downloadOptions{}
 }
 
@@ -99,7 +99,7 @@ type ProgressBar interface {
 // let the callee remove. The fact that the operations are asymmetrical can lead
 // to unexpected expectations; namely leaking of files.
 func (c *DownloadClient) Download(ctx context.Context, resourceURL *url.URL, archivePath string, options ...DownloadOption) error {
-	opts := newOptions()
+	opts := newDownloadOptions()
 	for _, option := range options {
 		option(opts)
 	}

--- a/charmhub/info_integration_test.go
+++ b/charmhub/info_integration_test.go
@@ -40,3 +40,25 @@ func (s *InfoClientSuite) TestLiveInfoRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Name, gc.Equals, "ubuntu")
 }
+
+func (s *InfoClientSuite) TestLiveInfoRequestWithChannelOption(c *gc.C) {
+	c.Skip("This test only works on staging currently.")
+
+	logger := &charmhub.FakeLogger{}
+
+	config, err := charmhub.CharmHubConfigFromURL("https://api.staging.snapcraft.io", logger)
+	c.Assert(err, jc.ErrorIsNil)
+	basePath, err := config.BasePath()
+	c.Assert(err, jc.ErrorIsNil)
+
+	infoPath, err := basePath.Join("info")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apiRequester := charmhub.NewAPIRequester(charmhub.DefaultHTTPTransport(), logger)
+	restClient := charmhub.NewHTTPRESTClient(apiRequester, nil)
+
+	client := charmhub.NewInfoClient(infoPath, restClient, logger)
+	response, err := client.Info(context.TODO(), "ubuntu", charmhub.WithChannel("stable"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(response.Name, gc.Equals, "ubuntu")
+}

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -317,7 +317,7 @@ func (s *infoSuite) setUpMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *infoSuite) expectInfo() {
-	s.infoCommandAPI.EXPECT().Info("test").Return(charmhub.InfoResponse{
+	s.infoCommandAPI.EXPECT().Info("test", gomock.Any()).Return(charmhub.InfoResponse{
 		Name:        "wordpress",
 		Type:        "charm",
 		ID:          "charmCHARMcharmCHARMcharmCHARM01",

--- a/cmd/juju/charmhub/interface.go
+++ b/cmd/juju/charmhub/interface.go
@@ -35,7 +35,7 @@ type FindCommandAPI interface {
 // DownloadCommandAPI describes API methods required to execute the download
 // command.
 type DownloadCommandAPI interface {
-	Info(context.Context, string) (transport.InfoResponse, error)
+	Info(context.Context, string, ...charmhub.InfoOption) (transport.InfoResponse, error)
 	Download(context.Context, *url.URL, string, ...charmhub.DownloadOption) error
 }
 

--- a/cmd/juju/charmhub/interface.go
+++ b/cmd/juju/charmhub/interface.go
@@ -22,7 +22,7 @@ type Log = func(format string, params ...interface{})
 
 // InfoCommandAPI describes API methods required to execute the info command.
 type InfoCommandAPI interface {
-	Info(string) (apicharmhub.InfoResponse, error)
+	Info(string, string) (apicharmhub.InfoResponse, error)
 	Close() error
 }
 

--- a/cmd/juju/charmhub/mocks/api_mock.go
+++ b/cmd/juju/charmhub/mocks/api_mock.go
@@ -57,18 +57,23 @@ func (mr *MockDownloadCommandAPIMockRecorder) Download(arg0, arg1, arg2 interfac
 }
 
 // Info mocks base method
-func (m *MockDownloadCommandAPI) Info(arg0 context.Context, arg1 string) (transport.InfoResponse, error) {
+func (m *MockDownloadCommandAPI) Info(arg0 context.Context, arg1 string, arg2 ...charmhub0.InfoOption) (transport.InfoResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Info", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Info", varargs...)
 	ret0, _ := ret[0].(transport.InfoResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Info indicates an expected call of Info
-func (mr *MockDownloadCommandAPIMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDownloadCommandAPIMockRecorder) Info(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockDownloadCommandAPI)(nil).Info), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockDownloadCommandAPI)(nil).Info), varargs...)
 }
 
 // MockInfoCommandAPI is a mock of InfoCommandAPI interface

--- a/cmd/juju/charmhub/mocks/api_mock.go
+++ b/cmd/juju/charmhub/mocks/api_mock.go
@@ -114,18 +114,18 @@ func (mr *MockInfoCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // Info mocks base method
-func (m *MockInfoCommandAPI) Info(arg0 string) (charmhub.InfoResponse, error) {
+func (m *MockInfoCommandAPI) Info(arg0, arg1 string) (charmhub.InfoResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Info", arg0)
+	ret := m.ctrl.Call(m, "Info", arg0, arg1)
 	ret0, _ := ret[0].(charmhub.InfoResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Info indicates an expected call of Info
-func (mr *MockInfoCommandAPIMockRecorder) Info(arg0 interface{}) *gomock.Call {
+func (mr *MockInfoCommandAPIMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockInfoCommandAPI)(nil).Info), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockInfoCommandAPI)(nil).Info), arg0, arg1)
 }
 
 // MockFindCommandAPI is a mock of FindCommandAPI interface


### PR DESCRIPTION
Charmhub info now requires a "optional" flag to get the metadata for the
given channel. This is required atm as we use it to use the computed
series.

We currently error out if we can't find it, but I'm starting to think we
should just use the channel map for the same series/revision/arch to
compute that ourselves. That way we don't ever end up in a messed up
state where Juju requests the info but we can't use it because the
stupid metadata isn't there!

----

We don't need to bounce the API server facade as we omitempty. 
Nothing else is aware of the charmhub API, so we're free to do
what we want with this. This all changes when we release though!

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model other --config charm-hub-url="https://api.staging.snapcraft.io" 
$ juju info ubuntu --channel="stable"
name: ubuntu
charm-id: 9NT4sM1gdNLkBPuXbxNu2IusUosDcmR9
summary: A pristine Ubuntu Server
publisher: charmers
supports: xenial, bionic, artful, cosmic, disco, trusty, focal
tags: misc
subordinate: false
store-url: https://staging-api.charmhub.io/ubuntu
description: |
  This simply deploys the Ubuntu Cloud/Server image
channels: |
  latest/stable:     17  2020-11-11  (17)  5MB
  latest/candidate:  ↑
  latest/beta:       ↑
  latest/edge:       ↑
```
