### PR TITLE
Add Juju-Metadata HTTP headers for charmhub Refresh requests

### DIFF
--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -13,7 +15,7 @@ import (
 
 // createCharmhubClient creates a new charmhub Client based on this model's
 // config.
-func CharmhubClient(st *state.State, logger loggo.Logger) (*charmhub.Client, error) {
+func CharmhubClient(st *state.State, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -23,10 +25,21 @@ func CharmhubClient(st *state.State, logger loggo.Logger) (*charmhub.Client, err
 		return nil, errors.Trace(err)
 	}
 	url, _ := modelConfig.CharmHubURL()
+
 	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	keys := make([]string, 0, len(metadata))
+	for k := range metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		config.Headers.Add(charmhub.MetadataHeader, k+"="+metadata[k])
+	}
+
 	client, err := charmhub.NewClient(config)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -217,6 +217,7 @@ func fetchCharmstoreInfos(st *state.State, ids []charmstore.CharmID, apps []*sta
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	metadata["environment_uuid"] = st.ModelUUID() // duplicates model_uuid, but send to charmstore for legacy reasons
 	results, err := charmstore.LatestCharmInfo(client, ids, metadata)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -107,8 +107,8 @@ var NewCharmStoreClient = func(st *state.State) (charmstore.Client, error) {
 }
 
 // NewCharmhubClient instantiates a new charmhub client (exported for testing).
-var NewCharmhubClient = func(st *state.State) (CharmhubRefreshClient, error) {
-	return common.CharmhubClient(st, logger)
+var NewCharmhubClient = func(st *state.State, metadata map[string]string) (CharmhubRefreshClient, error) {
+	return common.CharmhubClient(st, logger, metadata)
 }
 
 type latestCharmInfo struct {
@@ -213,7 +213,7 @@ func fetchCharmstoreInfos(st *state.State, ids []charmstore.CharmID, apps []*sta
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	metadata, err := charmstoreAPIMetadata(st)
+	metadata, err := apiMetadata(st)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -246,7 +246,11 @@ func fetchCharmstoreInfos(st *state.State, ids []charmstore.CharmID, apps []*sta
 }
 
 func fetchCharmhubInfos(st *state.State, ids []charmhubID, apps []*state.Application) ([]latestCharmInfo, error) {
-	client, err := NewCharmhubClient(st)
+	metadata, err := apiMetadata(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client, err := NewCharmhubClient(st, metadata)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -279,15 +283,14 @@ func fetchCharmhubInfos(st *state.State, ids []charmhubID, apps []*state.Applica
 	return latest, nil
 }
 
-// charmstoreAPIMetadata returns a map containing metadata key/value pairs to
-// send to the charmstore API for tracking metrics.
-func charmstoreAPIMetadata(st *state.State) (map[string]string, error) {
+// apiMetadata returns a map containing metadata key/value pairs to
+// send to the charmhub or charmstore API for tracking metrics.
+func apiMetadata(st *state.State) (map[string]string, error) {
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	metadata := map[string]string{
-		"environment_uuid":   model.UUID(),
 		"model_uuid":         model.UUID(),
 		"controller_uuid":    st.ControllerUUID(),
 		"controller_version": version.Current.String(),

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -39,6 +39,8 @@ const (
 	CharmHubServerVersion = "v2"
 	CharmHubServerEntity  = "charms"
 
+	MetadataHeader = "Juju-Metadata"
+
 	RefreshTimeout = 10 * time.Second
 )
 

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -39,7 +39,7 @@ const (
 	CharmHubServerVersion = "v2"
 	CharmHubServerEntity  = "charms"
 
-	MetadataHeader = "Juju-Metadata"
+	MetadataHeader = "X-Juju-Metadata"
 
 	RefreshTimeout = 10 * time.Second
 )

--- a/charmhub/client_mock_test.go
+++ b/charmhub/client_mock_test.go
@@ -90,18 +90,18 @@ func (mr *MockRESTClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.
 }
 
 // Post mocks base method
-func (m *MockRESTClient) Post(arg0 context.Context, arg1 path.Path, arg2, arg3 interface{}) (RESTResponse, error) {
+func (m *MockRESTClient) Post(arg0 context.Context, arg1 path.Path, arg2 http.Header, arg3, arg4 interface{}) (RESTResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Post", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Post", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(RESTResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Post indicates an expected call of Post
-func (mr *MockRESTClientMockRecorder) Post(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockRESTClientMockRecorder) Post(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockRESTClient)(nil).Post), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockRESTClient)(nil).Post), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MockFileSystem is a mock of FileSystem interface

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/utils/v2"
 	"github.com/kr/pretty"
@@ -85,25 +86,25 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 		return nil, errors.Trace(err)
 	}
 
-	// Add Juju-Metadata headers for the charms' unique series and
+	// Add X-Juju-Metadata headers for the charms' unique series and
 	// architecture values, for example:
 	//
-	// Juju-Metadata: series=bionic
-	// Juju-Metadata: arch=amd64
-	// Juju-Metadata: series=focal
+	// X-Juju-Metadata: series=bionic
+	// X-Juju-Metadata: arch=amd64
+	// X-Juju-Metadata: series=focal
 	headers := make(http.Header)
-	seriesAdded := make(map[string]bool)
-	archsAdded := make(map[string]bool)
+	seriesAdded := set.NewStrings()
+	archsAdded := set.NewStrings()
 	for _, context := range req.Context {
 		series := context.Platform.Series
-		if series != "" && !seriesAdded[series] {
+		if series != "" && !seriesAdded.Contains(series) {
 			headers.Add(MetadataHeader, "series="+series)
-			seriesAdded[series] = true
+			seriesAdded.Add(series)
 		}
 		arch := context.Platform.Architecture
-		if arch != "" && !archsAdded[arch] {
+		if arch != "" && !archsAdded.Contains(arch) {
 			headers.Add(MetadataHeader, "arch="+arch)
-			archsAdded[arch] = true
+			archsAdded.Add(arch)
 		}
 	}
 

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -143,7 +143,7 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
 	c.Assert(httpTransport.requestHeaders, gc.DeepEquals, http.Header{
 		"Accept":       []string{"application/json"},
 		"Content-Type": []string{"application/json"},
-		"Juju-Metadata": []string{
+		"X-Juju-Metadata": []string{
 			"series=focal",
 			"arch=amd64",
 			"series=trusty",

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -269,7 +269,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade: charmrevision.NewAPIFacade,
 			NewWorker: charmrevision.NewWorker,
 			Logger:    config.LoggingContext.GetLogger("juju.worker.charmrevision"),
-			// No Logger defined in the charmrevision package.
 		})),
 		remoteRelationsName: ifNotMigrating(remoterelations.Manifold(remoterelations.ManifoldConfig{
 			AgentName:                agentName,


### PR DESCRIPTION
We currently add various `Juju-Metadata` HTTP headers when sending charmstore requests, but not for the new charmhub API. This adds those headers to charmhub Refresh calls as well. The model metadata is added in charmhub Client config. And the charm metadata (series and arch) is added per-charm by Refresh() itself.

## QA steps

Hard to specifically look at the headers going out, but I've added unit tests to check them. For general QA steps for the charm revision updater, see QA steps at https://github.com/juju/juju/pull/12400
