### PR TITLE
Adds supporting help for how to bootstrap k8s

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -126,7 +126,29 @@ agent stream is 'released' (default), then a 2.3.1 client can bootstrap:
     * 2.3.1 controller by running '... bootstrap ...';
     * 2.3.2 controller by running 'bootstrap --auto-upgrade'.
 However, if this client has a copy of codebase, then a local copy of Juju
-will be built and bootstrapped - 2.3.1.1.`
+will be built and bootstrapped - 2.3.1.1.
+
+Bootstrapping to a k8s cluster requires that the service set up to handle
+requests to the controller be accessible outside the cluster. Typically this
+means a service type of LoadBalancer is needed, and Juju does create such a
+service if it knows it is supported by the cluster. This is performed by
+interrogating the cluster for a well known managed deployment such as microk8s,
+GKE or EKS.
+
+When bootstrapping to a k8s cluster Juju does not recognise, there's no
+guarantee a load balancer is available, so Juju defaults to a controller
+service type of ClusterIP. This may not be suitable, so there's 3 bootstrap
+options available to tell Juju how to set up the controller service. Part of
+the solution may require a load balancer for the cluster to be set up manually
+first, or perhaps an external k8s service via a FQDN will be used
+(this is a cluster specific implementation decision which Juju needs to be
+informed about so it can set things up correctly). The 3 relevant bootstrap
+options are (see list of bootstrap config items below for a full explanation):
+
+- controller-service-type
+- controller-external-name
+- controller-external-ips
+`
 
 var usageBootstrapConfigTxt = `
 
@@ -145,6 +167,12 @@ Examples:
     juju bootstrap --agent-version=2.2.4 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
 
+    # For a bootstrap on k8s, setting the service type of the Juju controller service to LoadBalancer
+    juju bootstrap --config controller-service-type=LoadBalancer
+
+	# For a bootstrap on k8s, setting the service type of the Juju controller service to External
+    juju bootstrap --config controller-service-type=ExternalName,controller-service-name=controller.juju.is
+
 See also:
     add-credentials
     add-model
@@ -153,9 +181,11 @@ See also:
     set-constraints
     show-cloud`
 
-// defaultHostedModelName is the name of the hosted model created in each
-// controller for deploying workloads to, in addition to the "controller" model.
-const defaultHostedModelName = "default"
+const (
+	// defaultHostedModelName is the name of the hosted model created in each
+	// controller for deploying workloads to, in addition to the "controller" model.
+	defaultHostedModelName = "default"
+)
 
 func newBootstrapCommand() cmd.Command {
 	command := &bootstrapCommand{}
@@ -244,6 +274,12 @@ func (c *bootstrapCommand) configDetails() map[string]interface{} {
 	}
 	if controllerCgf, err := cmdcontroller.ConfigDetails(); err == nil {
 		addAll(controllerCgf)
+	}
+	for key, attr := range bootstrap.BootstrapConfigSchema {
+		result[key] = common.PrintConfigSchema{
+			Description: attr.Description,
+			Type:        fmt.Sprintf("%s", attr.Type),
+		}
 	}
 	return result
 }
@@ -877,6 +913,12 @@ See `[1:] + "`juju kill-controller`" + `.`)
 			}
 			bootstrapParams.ExtraAgentValuesForTesting[k] = v
 		}
+	}
+
+	if cloud.Type == k8sprovider.CAASProviderType &&
+		cloud.HostCloudRegion == caas.K8sCloudOther &&
+		bootstrapParams.ControllerServiceType == "" {
+		logger.Warningf("bootstrapping to an unknown kubernetes cluster should be used with option --config controller-service-type. See juju help bootstrap")
 	}
 
 	bootstrapFuncs := getBootstrapFuncs()

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/utils"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/juju/osenv"
@@ -87,6 +88,60 @@ var BootstrapConfigAttributes = []string{
 	ControllerServiceType,
 	ControllerExternalName,
 	ControllerExternalIPs,
+}
+
+// BootstrapConfigSchema defines the schema used for config items during
+// bootstrap.
+var BootstrapConfigSchema = environschema.Fields{
+	AdminSecretKey: {
+		Description: "Sets the Juju administrator password",
+		Type:        environschema.Tstring,
+	},
+	CACertKey: {
+		Description: fmt.Sprintf(
+			"Sets the bootstrapped controllers CA cert to use and issue "+
+				"certificates from, used in conjunction with %s",
+			CAPrivateKeyKey),
+		Type: environschema.Tstring,
+	},
+	CAPrivateKeyKey: {
+		Description: fmt.Sprintf(
+			"Sets the bootstrapped controllers CA cert private key to sign "+
+				"certificates with, used in conjunction with %s",
+			CACertKey),
+		Type: environschema.Tstring,
+	},
+	BootstrapTimeoutKey: {
+		Description: "Controls how long Juju will wait for a bootstrap to " +
+			"complete before considering it failed in seconds",
+		Type: environschema.Tint,
+	},
+	BootstrapRetryDelayKey: {
+		Description: "Controls the amount of time in seconds between attempts " +
+			"to connect to a bootstrap machine address",
+		Type: environschema.Tint,
+	},
+	BootstrapAddressesDelayKey: {
+		Description: "Controls the amount of time in seconds in between " +
+			"refreshing the bootstrap machine addresses",
+		Type: environschema.Tint,
+	},
+	ControllerServiceType: {
+		Description: "Controls the kubernetes service type for Juju " +
+			"controllers, see " +
+			"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core",
+		Type: environschema.Tstring,
+	},
+	ControllerExternalName: {
+		Description: "Sets the external name for a k8s controller of type " +
+			"external",
+		Type: environschema.Tstring,
+	},
+	ControllerExternalIPs: {
+		Description: "Specifies a comma separated list of external IPs for a " +
+			"k8s controller of type external",
+		Type: environschema.Tstring,
+	},
 }
 
 // IsBootstrapAttribute reports whether or not the specified


### PR DESCRIPTION
- Adds help information for bootstrapping to unknown k8s cluster around
  setting the correct service type.
- Adds a warning message for the user during bootstrap for when the
  above condition happens

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

- Run juju help bootstrap
- Bootstrap to a minikube cluster

## Bug reference

https://bugs.launchpad.net/juju/+bug/1905320
