### PR TITLE
Ensure NetworksForRelation never returns a CAAS container address

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -181,11 +181,13 @@ func (n *NetworkInfoBase) getRelationAndEndpointName(relationID int) (*state.Rel
 	return rel, endpoint.Name, nil
 }
 
-// maybeGetUnitAddress returns an address for the member unit if either the
-// input relation is cross-model and pollAddr is passed as true.
-// The unit public address is preferred, but we will fall back to the private
-// address if it does not become available in the polling window.
-func (n *NetworkInfoBase) maybeGetUnitAddress(rel *state.Relation) (network.SpaceAddresses, error) {
+// maybeGetUnitAddress returns an address for the member unit if the
+// input relation is cross-model.
+// The unit public address is preferred, but if directed we fall back to the
+// private address if it does not become available in the polling window.
+func (n *NetworkInfoBase) maybeGetUnitAddress(
+	rel *state.Relation, fallbackPrivate bool,
+) (network.SpaceAddresses, error) {
 	_, crossModel, err := rel.RemoteApplication()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -196,12 +198,16 @@ func (n *NetworkInfoBase) maybeGetUnitAddress(rel *state.Relation) (network.Spac
 
 	address, err := n.pollForAddress(n.unit.PublicAddress)
 	if err != nil {
-		logger.Warningf(
-			"no public address for unit %q in cross model relation %q, will use private address", n.unit.Name(), rel)
+		logger.Warningf("no public address for unit %q in cross model relation %q", n.unit.Name(), rel)
 	} else if address.Value != "" {
 		return network.SpaceAddresses{address}, nil
 	}
 
+	if !fallbackPrivate {
+		return nil, nil
+	}
+
+	logger.Warningf("attempting fallback to private address")
 	address, err = n.pollForAddress(n.unit.PrivateAddress)
 	if err != nil {
 		logger.Warningf("no private address for unit %q in relation %q", n.unit.Name(), rel)

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -54,6 +54,11 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		}
 	}
 
+	defaultEgress := n.defaultEgress
+	if len(defaultEgress) == 0 {
+		defaultEgress = subnetsForAddresses(defaultIngressAddresses)
+	}
+
 	// If we are working in a relation context,
 	// get the network information for the relation
 	// and set it for the relation's binding.
@@ -76,17 +81,10 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 		info, ok := result.Results[endpoint]
 		if !ok {
 			info = params.NetworkInfoResult{
-				Info:          []params.NetworkInfo{{Addresses: interfaceAddr}},
-				EgressSubnets: n.defaultEgress,
+				Info:             []params.NetworkInfo{{Addresses: interfaceAddr}},
+				IngressAddresses: defaultIngressAddresses,
+				EgressSubnets:    defaultEgress,
 			}
-		}
-
-		if len(info.IngressAddresses) == 0 {
-			info.IngressAddresses = defaultIngressAddresses
-		}
-
-		if len(info.EgressSubnets) == 0 {
-			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
 		result.Results[endpoint] = n.resolveResultHostNames(info)

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -139,7 +139,7 @@ func (n *NetworkInfoCAAS) NetworksForRelation(
 	}
 
 	if pollAddr {
-		if ingress, err = n.maybeGetUnitAddress(rel); err != nil {
+		if ingress, err = n.maybeGetUnitAddress(rel, false); err != nil {
 			return "", nil, nil, errors.Trace(err)
 		}
 	}

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -130,7 +130,7 @@ func (n *NetworkInfoIAAS) NetworksForRelation(
 	// addresses the input relation and pollPublic flag.
 	var ingress network.SpaceAddresses
 	if boundSpace == network.AlphaSpaceId {
-		addrs, err := n.maybeGetUnitAddress(rel)
+		addrs, err := n.maybeGetUnitAddress(rel, true)
 		if err != nil {
 			return "", nil, nil, errors.Trace(err)
 		}


### PR DESCRIPTION
This patch addresses a situation in CAAS models where we call `network-get` in a cross-model relation context and can potentially end up with a container (local-machine) address for ingress if we request a public address that is not yet available.

Now, if the only address is a private one we return nothing for ingress addresses (and accordingly egress subnets).

## QA steps

An authentic real test for this relies on timings out of our control. As a proxy, we can test red/green for the new `TestNetworksForRelationCAASModelCrossModelNoPrivate` test with this change:
```diff
diff --git a/apiserver/facades/agent/uniter/networkinfocaas.go b/apiserver/facades/agent/uniter/networkinfocaas.go
index c66813350a..bfd3e60f6a 100644
--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -137,7 +137,7 @@ func (n *NetworkInfoCAAS) NetworksForRelation(
        }

        if pollAddr {
-               if ingress, err = n.maybeGetUnitAddress(rel, false); err != nil {
+               if ingress, err = n.maybeGetUnitAddress(rel, true); err != nil {
                        return "", nil, nil, errors.Trace(err)
                }
        }
```

## Documentation changes

N/A

## Bug reference

None.
