### PR TITLE
Remove state from common client

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -108,7 +108,15 @@ var NewCharmStoreClient = func(st *state.State) (charmstore.Client, error) {
 
 // NewCharmhubClient instantiates a new charmhub client (exported for testing).
 var NewCharmhubClient = func(st *state.State, metadata map[string]string) (CharmhubRefreshClient, error) {
-	return common.CharmhubClient(st, logger, metadata)
+	return common.CharmhubClient(stateShim{State: st}, logger, metadata)
+}
+
+type stateShim struct {
+	*state.State
+}
+
+func (s stateShim) Model() (common.ConfigModel, error) {
+	return s.State.Model()
 }
 
 type latestCharmInfo struct {

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -80,15 +81,44 @@ type Config struct {
 	Logger Logger
 }
 
-// CharmHubConfig defines a charmHub client configuration for targeting the
-// snapcraft API.
-func CharmHubConfig(logger Logger) (Config, error) {
-	return CharmHubConfigFromURL(CharmHubServerURL, logger)
+// Option to be passed into charmhub construction to customize the client.
+type Option func(*options)
+
+type options struct {
+	url             *string
+	metadataHeaders map[string]string
 }
 
-// CharmHubConfigFromURL defines a charmHub client configuration with a given
-// URL for targeting the API.
-func CharmHubConfigFromURL(url string, logger Logger) (Config, error) {
+// WithURL sets the url on the option.
+func WithURL(u string) Option {
+	return func(options *options) {
+		options.url = &u
+	}
+}
+
+// WithMetadataHeaders sets the headers on the option.
+func WithMetadataHeaders(h map[string]string) Option {
+	return func(options *options) {
+		options.metadataHeaders = h
+	}
+}
+
+// Create a options instance with default values.
+func newOptions() *options {
+	u := CharmHubServerURL
+	return &options{
+		url: &u,
+	}
+}
+
+// CharmHubConfig defines a charmHub client configuration for targeting the
+// snapcraft API.
+func CharmHubConfig(logger Logger, options ...Option) (Config, error) {
+	opts := newOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
 	if logger == nil {
 		return Config{}, errors.NotValidf("nil logger")
 	}
@@ -98,13 +128,31 @@ func CharmHubConfigFromURL(url string, logger Logger) (Config, error) {
 	headers := make(http.Header)
 	headers.Set(userAgentKey, userAgentValue)
 
+	// Additionally apply any metadata headers to the headers so we can send
+	// every time we make a request.
+	m := opts.metadataHeaders
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		headers.Add(MetadataHeader, k+"="+m[k])
+	}
+
 	return Config{
-		URL:     url,
+		URL:     *opts.url,
 		Version: CharmHubServerVersion,
 		Entity:  CharmHubServerEntity,
 		Headers: headers,
 		Logger:  logger,
 	}, nil
+}
+
+// CharmHubConfigFromURL defines a charmHub client configuration with a given
+// URL for targeting the API.
+func CharmHubConfigFromURL(url string, logger Logger, options ...Option) (Config, error) {
+	return CharmHubConfig(logger, append(options, WithURL(url))...)
 }
 
 // BasePath returns the base configuration path for speaking to the server API.

--- a/charmhub/download.go
+++ b/charmhub/download.go
@@ -50,7 +50,7 @@ func WithProgressBar(pb ProgressBar) DownloadOption {
 }
 
 // Create a downloadOptions instance with default values.
-func newOptions() *downloadOptions {
+func newDownloadOptions() *downloadOptions {
 	return &downloadOptions{}
 }
 
@@ -99,7 +99,7 @@ type ProgressBar interface {
 // let the callee remove. The fact that the operations are asymmetrical can lead
 // to unexpected expectations; namely leaking of files.
 func (c *DownloadClient) Download(ctx context.Context, resourceURL *url.URL, archivePath string, options ...DownloadOption) error {
-	opts := newOptions()
+	opts := newDownloadOptions()
 	for _, option := range options {
 		option(opts)
 	}


### PR DESCRIPTION
The common client constructor was bringing in state. We REALLY do NOT
want to include state in the apiserver. It's a slow march forward and
adding more state to the apiserver is counter productive.

This cleans this up and moves the metadata headers to charmhub directly
as we get this for free for others whom are using the client.

## QA steps

Tests pass, this is a mechanical change.
