### PR TITLE
Charmhub download resource meta

### DIFF
--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -93,13 +93,13 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			return &charmHubClient{client: chClient, id: chID}, nil
+			return newCharmHubClient(chClient, chID), nil
 		case charm.CharmStore.Matches(schema):
 			cl, err := charmstore.NewCachingClient(state.MacaroonCache{st}, controllerCfg.CharmStoreURL())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			return &charmStoreClient{client: cl, id: chID}, nil
+			return newCharmStoreClient(cl, chID), nil
 		case charm.Local.Matches(schema):
 			return &localClient{}, nil
 		default:

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -141,21 +141,18 @@ func newCharmHubClient(client CharmHub, id CharmID) *charmHubClient {
 // this logic will need refinement as work to incorporate charmhub resources continues.
 // Right now, just take the uploaded resources and add charmhub resources where resource
 // is missing
-func (ch *charmHubClient) ResolveResources(uploadedResources []charmresource.Resource) ([]charmresource.Resource, error) {
-	chResources, err := ch.listResources()
+func (ch *charmHubClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
+	storeResources, err := ch.listResources()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	for _, res := range uploadedResources {
-		chResources[res.Name] = res
+	resolved, err := ch.resolveResources(ch.id, resources, storeResources)
+	if err != nil {
+		return nil, err
 	}
-	results := make([]charmresource.Resource, len(chResources))
-	var i int
-	for _, res := range chResources {
-		results[i] = res
-		i += 1
-	}
-	return results, nil
+	// TODO(ericsnow) Ensure that the non-upload resource revisions
+	// match a previously published revision set?
+	return resolved, nil
 }
 
 func (ch *charmHubClient) ResourceInfo(_ *charm.URL, origin corecharm.Origin, name string, revision int) (charmresource.Resource, error) {

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -270,7 +270,7 @@ func DownloadOneFromRevision(id string, revision int, platform RefreshPlatform) 
 
 // DownloadOneFromChannel creates a request config using the channel and not the
 // revision for requesting only one charm.
-func DownloadOneFromChannel(name string, channel string, platform RefreshPlatform) (RefreshConfig, error) {
+func DownloadOneFromChannel(id string, channel string, platform RefreshPlatform) (RefreshConfig, error) {
 	uuid, err := utils.NewUUID()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -278,7 +278,7 @@ func DownloadOneFromChannel(name string, channel string, platform RefreshPlatfor
 	return executeOne{
 		action:      DownloadAction,
 		instanceKey: uuid.String(),
-		Name:        name,
+		ID:          id,
 		Channel:     &channel,
 		Platform:    platform,
 	}, nil
@@ -292,7 +292,7 @@ func (c executeOne) Build() (transport.RefreshRequest, error) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      string(c.action),
 			InstanceKey: c.instanceKey,
-			Name:        &c.Name,
+			ID:          &c.ID,
 			Revision:    c.Revision,
 			Channel:     c.Channel,
 			Platform: &transport.RefreshRequestPlatform{


### PR DESCRIPTION
The following ensures that we get the metadata that we want. This is
abstracted out into a client so that both charmhub and the charmstore
can get the information in the same logic, without duplication.

## QA steps

TBA

```sh
QA steps here
```
