### PR TITLE
Add path and description to ResourceRevision

### DIFF
--- a/apiserver/facades/client/resources/charmhubclient_test.go
+++ b/apiserver/facades/client/resources/charmhubclient_test.go
@@ -30,15 +30,16 @@ func (s *CharmHubClientSuite) TestResolveResources(c *gc.C) {
 	s.client = mocks.NewMockCharmHub(ctrl)
 	s.expectRefresh()
 
+	fp, err := charmresource.ParseFingerprint("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b")
+	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.newClient().ResolveResources(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []charmresource.Resource{{
-		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
-		Origin:   2,
-		Revision: 0,
-		Fingerprint: charmresource.Fingerprint{
-			Fingerprint: hash.Fingerprint{}},
-		Size: 0,
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Origin:      2,
+		Revision:    0,
+		Fingerprint: fp,
+		Size:        0,
 	}})
 }
 

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -112,14 +112,21 @@ func resourceFromRevision(rev transport.ResourceRevision) (charmresource.Resourc
 	if err != nil {
 		return charmresource.Resource{}, errors.Trace(err)
 	}
+	fp, err := charmresource.ParseFingerprint(rev.Download.HashSHA384)
+	if err != nil {
+		return charmresource.Resource{}, errors.Trace(err)
+	}
 	r := charmresource.Resource{
 		Meta: charmresource.Meta{
-			Name: rev.Name,
-			Type: resType,
+			Name:        rev.Name,
+			Type:        resType,
+			Path:        rev.Path,
+			Description: rev.Description,
 		},
-		Origin:   charmresource.OriginStore,
-		Revision: rev.Revision,
-		Size:     int64(rev.Download.Size),
+		Origin:      charmresource.OriginStore,
+		Revision:    rev.Revision,
+		Fingerprint: fp,
+		Size:        int64(rev.Download.Size),
 	}
 	return r, nil
 }

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -59,5 +59,9 @@ var resourceFilter = []string{
 	"download.url",
 	"name",
 	"revision",
+	// TODO (hml) 8-dec-2020
+	// Use once the api knows about them.
+	//"path",
+	//"description",
 	"type",
 }

--- a/charmhub/transport/resources.go
+++ b/charmhub/transport/resources.go
@@ -8,10 +8,12 @@ type ResourcesResponse struct {
 }
 
 type ResourceRevision struct {
-	Download ResourceDownload `json:"download"`
-	Name     string           `json:"name"`
-	Revision int              `json:"revision"`
-	Type     string           `json:"type"`
+	Download    ResourceDownload `json:"download"`
+	Description string           `json:"description"`
+	Name        string           `json:"name"`
+	Path        string           `json:"path"`
+	Revision    int              `json:"revision"`
+	Type        string           `json:"type"`
 }
 
 type ResourceDownload struct {


### PR DESCRIPTION
Add Path and Description to the transport ResourceRevision struct.  They will be used to create resource Meta for resources from charmhub.

Today they are not part of the charmhub api responses, so adding them in charmhub/resources.go would break charmhub deploy.  Left as a todo once the api knows about the object elements.

## QA steps

Test to ensure current work doesn't break.  However the resources facade piece isn't testable until #12414 lands.

```console
$ juju bootstrap localhost
$ juju add-model six --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy ubuntu
```

