### PR TITLE
Ensure process limits are correctly set with using juju-db snap

### DIFF
--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -70,6 +70,7 @@ func makeEnsureServerParams(dataDir string) mongo.EnsureServerParams {
 		SharedSecret: testInfo.SharedSecret,
 
 		DataDir: dataDir,
+		LogDir:  dataDir,
 	}
 }
 

--- a/mongo/service.go
+++ b/mongo/service.go
@@ -168,9 +168,12 @@ func sharedSecretPath(dataDir string) string {
 	return filepath.Join(dataDir, SharedSecretFile)
 }
 
-func logPath(dataDir string, usingMongoFromSnap bool) string {
+func logPath(logDir, dataDir string, usingMongoFromSnap bool) string {
 	if usingMongoFromSnap {
 		return filepath.Join(dataDir, "logs", "mongodb.log")
+	}
+	if logDir != "" {
+		return logDir
 	}
 	return mongoLogPath
 }
@@ -493,7 +496,7 @@ func generateConfig(mongoPath string, oplogSizeMB int, version Version, usingMon
 		// have the same permissions.
 		mongoArgs.Syslog = false
 		mongoArgs.LogAppend = true
-		mongoArgs.LogPath = logPath(args.DataDir, true)
+		mongoArgs.LogPath = logPath(args.LogDir, args.DataDir, true)
 		mongoArgs.BindToAllIP = true // TODO(tsm): disable when not needed
 	}
 

--- a/service/snap/export_test.go
+++ b/service/snap/export_test.go
@@ -7,3 +7,7 @@ var (
 	DefaultChannel           = defaultChannel
 	DefaultConfinementPolicy = defaultConfinementPolicy
 )
+
+func SetServiceConfigDir(s *Service, dir string) {
+	s.configDir = dir
+}


### PR DESCRIPTION
When using the juju-db snap for mongo, the necessary process limits were not being set.
This PR adds the necessary systemd service property overrides.
The ensureServer() func needed a little rearranging to ensure the limits were set for both the case where the snap was specified using the feature flag, and for where it comes with the series, eg focal

Also, there was a setupDataDirectory() method where the error was being ignored. Fixing that had a little test fallout.

## QA steps

juju bootstrap lxd --bootstrap-series=focal
ssh to controller and use ps to find the juju-db snap process
`cat /proc/<id>/limits`
to check the limits are as expected, eg LimitNOFILE=64000
also check /etc/systemd/system/snap.juju-db.daemon.service.d/overrides.conf is created

## Bug reference

https://bugs.launchpad.net/juju/+bug/1907139
