### PR TITLE
Charmhub resources meta part 2

### DIFF
--- a/api/resources/client/client.go
+++ b/api/resources/client/client.go
@@ -240,6 +240,8 @@ func newAddPendingResourcesArgsV2(tag names.ApplicationTag, chID CharmID, csMac 
 	}
 	args.CharmOrigin = params.CharmOrigin{
 		Source:       chID.Origin.Source.String(),
+		ID:           chID.Origin.ID,
+		Hash:         chID.Origin.Hash,
 		Risk:         chID.Origin.Risk,
 		Revision:     chID.Origin.Revision,
 		Track:        chID.Origin.Track,

--- a/apiserver/facades/client/resources/base_test.go
+++ b/apiserver/facades/client/resources/base_test.go
@@ -44,10 +44,7 @@ func (s *BaseSuite) newCSClient() (CharmStore, error) {
 
 func (s *BaseSuite) newCSFactory() func(CharmID) (NewCharmRepository, error) {
 	return func(chID CharmID) (NewCharmRepository, error) {
-		return &charmStoreClient{
-			client: s.csClient,
-			id:     chID,
-		}, nil
+		return newCharmStoreClient(s.csClient, chID), nil
 	}
 }
 

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -93,13 +93,13 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			return &charmHubClient{client: chClient, id: chID}, nil
+			return newCharmHubClient(chClient, chID), nil
 		case charm.CharmStore.Matches(schema):
 			cl, err := charmstore.NewCachingClient(state.MacaroonCache{st}, controllerCfg.CharmStoreURL())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			return &charmStoreClient{client: cl, id: chID}, nil
+			return newCharmStoreClient(cl, chID), nil
 		case charm.Local.Matches(schema):
 			return &localClient{}, nil
 		default:

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -94,14 +94,17 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 				return nil, errors.Trace(err)
 			}
 			return newCharmHubClient(chClient, chID), nil
+
 		case charm.CharmStore.Matches(schema):
 			cl, err := charmstore.NewCachingClient(state.MacaroonCache{st}, controllerCfg.CharmStoreURL())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 			return newCharmStoreClient(cl, chID), nil
+
 		case charm.Local.Matches(schema):
 			return &localClient{}, nil
+
 		default:
 			return nil, errors.Errorf("unrecognized charm schema %q", chID.URL.Schema)
 		}

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -146,9 +146,7 @@ func (ch *charmHubClient) ResolveResources(resources []charmresource.Resource) (
 }
 
 func (ch *charmHubClient) ResourceInfo(curl *charm.URL, origin corecharm.Origin, name string, revision int) (charmresource.Resource, error) {
-	charmOrigin := ch.id.Origin
-
-	if charmOrigin.ID == "" {
+	if origin.ID == "" {
 		return charmresource.Resource{}, errors.Errorf("empty charm ID")
 	}
 
@@ -159,14 +157,14 @@ func (ch *charmHubClient) ResourceInfo(curl *charm.URL, origin corecharm.Origin,
 		cfg charmhub.RefreshConfig
 		err error
 
-		refPlatform = charmhub.RefreshPlatform(charmOrigin.Platform)
+		refPlatform = charmhub.RefreshPlatform(origin.Platform)
 	)
-	if charmOrigin.Revision != nil {
-		cfg, err = charmhub.DownloadOneFromRevision(charmOrigin.ID, *charmOrigin.Revision, refPlatform)
+	if origin.Revision != nil {
+		cfg, err = charmhub.DownloadOneFromRevision(origin.ID, *origin.Revision, refPlatform)
 	} else if curl.Revision >= 0 {
-		cfg, err = charmhub.DownloadOneFromRevision(charmOrigin.ID, curl.Revision, refPlatform)
+		cfg, err = charmhub.DownloadOneFromRevision(origin.ID, curl.Revision, refPlatform)
 	} else {
-		cfg, err = charmhub.DownloadOneFromChannel(charmOrigin.ID, charmOrigin.Channel.String(), refPlatform)
+		cfg, err = charmhub.DownloadOneFromChannel(origin.ID, origin.Channel.String(), refPlatform)
 	}
 	if err != nil {
 		return charmresource.Resource{}, errors.Trace(err)

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -51,13 +51,13 @@ type ResourceClient interface {
 
 type resourceClient struct {
 	client ResourceClient
+	id     CharmID
 }
 
 // resolveResources determines the resource info that should actually
 // be stored on the controller. That decision is based on the provided
 // resources along with those in the charm backend (if any).
-func (c *resourceClient) resolveResources(id CharmID,
-	resources []charmresource.Resource,
+func (c *resourceClient) resolveResources(resources []charmresource.Resource,
 	storeResources map[string]charmresource.Resource,
 ) ([]charmresource.Resource, error) {
 	allResolved := make([]charmresource.Resource, len(resources))
@@ -70,7 +70,7 @@ func (c *resourceClient) resolveResources(id CharmID,
 			continue
 		}
 
-		resolved, err := c.resolveStoreResource(id, res, storeResources)
+		resolved, err := c.resolveStoreResource(c.id, res, storeResources)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -115,21 +115,18 @@ func (c *resourceClient) resolveStoreResource(id CharmID,
 	return res, nil
 }
 
-// TODO hml 2020-12-2
-// charmHubClient needs to be "caching" like the charmstoreclient is??
 type charmHubClient struct {
 	resourceClient
 	client CharmHub
-	id     CharmID
 }
 
 func newCharmHubClient(client CharmHub, id CharmID) *charmHubClient {
 	c := &charmHubClient{
 		client: client,
-		id:     id,
 	}
 	c.resourceClient = resourceClient{
 		client: c,
+		id:     id,
 	}
 	return c
 }
@@ -142,7 +139,7 @@ func (ch *charmHubClient) ResolveResources(resources []charmresource.Resource) (
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	resolved, err := ch.resolveResources(ch.id, resources, storeResources)
+	resolved, err := ch.resolveResources(resources, storeResources)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -271,16 +268,15 @@ type CharmStore interface {
 type charmStoreClient struct {
 	resourceClient
 	client CharmStore
-	id     CharmID
 }
 
 func newCharmStoreClient(client CharmStore, id CharmID) *charmStoreClient {
 	c := &charmStoreClient{
 		client: client,
-		id:     id,
 	}
 	c.resourceClient = resourceClient{
 		client: c,
+		id:     id,
 	}
 	return c
 }
@@ -290,7 +286,7 @@ func (cs *charmStoreClient) ResolveResources(resources []charmresource.Resource)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	resolved, err := cs.resolveResources(cs.id, resources, storeResources)
+	resolved, err := cs.resolveResources(resources, storeResources)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -43,48 +43,153 @@ type CharmHub interface {
 	Refresh(ctx context.Context, config charmhub.RefreshConfig) ([]transport.RefreshResponse, error)
 }
 
+// ResourceClient requests the resource info for a given charm URL,
+// charm Origin, resource name and resource revision.
+type ResourceClient interface {
+	ResourceInfo(url *charm.URL, origin corecharm.Origin, name string, revision int) (charmresource.Resource, error)
+}
+
+type resourceClient struct {
+	client ResourceClient
+}
+
+// resolveResources determines the resource info that should actually
+// be stored on the controller. That decision is based on the provided
+// resources along with those in the charm backend (if any).
+func (c *resourceClient) resolveResources(id CharmID,
+	resources []charmresource.Resource,
+	storeResources map[string]charmresource.Resource,
+) ([]charmresource.Resource, error) {
+	allResolved := make([]charmresource.Resource, len(resources))
+	copy(allResolved, resources)
+	for i, res := range resources {
+		// Note that incoming "upload" resources take precedence over
+		// ones already known to the controller, regardless of their
+		// origin.
+		if res.Origin != charmresource.OriginStore {
+			continue
+		}
+
+		resolved, err := c.resolveStoreResource(id, res, storeResources)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		allResolved[i] = resolved
+	}
+	return allResolved, nil
+}
+
+// resolveStoreResource selects the resource info to use. It decides
+// between the provided and latest info based on the revision.
+func (c *resourceClient) resolveStoreResource(id CharmID,
+	res charmresource.Resource,
+	storeResources map[string]charmresource.Resource,
+) (charmresource.Resource, error) {
+	storeRes, ok := storeResources[res.Name]
+	if !ok {
+		// This indicates that AddPendingResources() was called for
+		// a resource the charm backend doesn't know about (for the
+		// relevant charm revision).
+		return res, nil
+	}
+
+	if res.Revision < 0 {
+		// The caller wants to use the charm backend info.
+		return storeRes, nil
+	}
+	if res.Revision == storeRes.Revision {
+		// We don't worry about if they otherwise match. Only the
+		// revision is significant here. So we use the info from the
+		// charm backend since it is authoritative.
+		return storeRes, nil
+	}
+	if res.Fingerprint.IsZero() {
+		// The caller wants resource info from the charm backend, but with
+		// a different resource revision than the one associated with
+		// the charm in the backend.
+		return c.client.ResourceInfo(id.URL, id.Origin, res.Name, res.Revision)
+	}
+	// The caller fully-specified a resource with a different resource
+	// revision than the one associated with the charm in the backend. So
+	// we use the provided info as-is.
+	return res, nil
+}
+
 // TODO hml 2020-12-2
 // charmHubClient needs to be "caching" like the charmstoreclient is??
 type charmHubClient struct {
+	resourceClient
 	client CharmHub
 	id     CharmID
 }
 
-// ResolveResources, looks at the provided, charmhub and backend (already downloaded)
-// resources to determine which to use.  Provided (uploaded) take precedence.  If
-// charmhub has a newer resource than the back end, use that.
-// TODO: (hml) 2020-12-03
-// this logic will need refinement as work to incorporate charmhub resources continues.
-// Right now, just take the uploaded resources and add charmhub resources where resource
-// is missing
-func (ch *charmHubClient) ResolveResources(uploadedResources []charmresource.Resource) ([]charmresource.Resource, error) {
-	chResources, err := ch.listResources()
+func newCharmHubClient(client CharmHub, id CharmID) *charmHubClient {
+	c := &charmHubClient{
+		client: client,
+		id:     id,
+	}
+	c.resourceClient = resourceClient{
+		client: c,
+	}
+	return c
+}
+
+// ResolveResources, looks at the provided, charmhub and backend (already
+// downloaded) resources to determine which to use. Provided (uploaded) take
+// precedence. If charmhub has a newer resource than the back end, use that.
+func (ch *charmHubClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
+	storeResources, err := ch.listResources()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	for _, res := range uploadedResources {
-		if res.Origin == charmresource.OriginUpload {
-			chResources[res.Name] = res
-			continue
-		}
-		// TODO (hml) 07-dec-2020
-		// Where to find the metadata from the charmhub api? For now,
-		// take what's in the "uploadedResources" metadata.
-		foundRes, ok := chResources[res.Name]
-		if !ok {
-			logger.Debugf("Uploaded resource %q, not found in charm", res.Name)
-			continue
-		}
-		foundRes.Meta = res.Meta
-		chResources[res.Name] = foundRes
+	resolved, err := ch.resolveResources(ch.id, resources, storeResources)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	results := make([]charmresource.Resource, len(chResources))
-	var i int
-	for _, res := range chResources {
-		results[i] = res
-		i += 1
+	return resolved, nil
+}
+
+func (ch *charmHubClient) ResourceInfo(curl *charm.URL, origin corecharm.Origin, name string, revision int) (charmresource.Resource, error) {
+	charmOrigin := ch.id.Origin
+
+	// We prefer the revision over the channel, so we attempt to locate the
+	// resource meta data for the identical one we've located. If we don't have
+	// a revision, then fall back to locating via the channel.
+	var (
+		cfg charmhub.RefreshConfig
+		err error
+	)
+	if charmOrigin.Revision != nil {
+		cfg, err = charmhub.DownloadOneFromRevision(charmOrigin.ID, *charmOrigin.Revision, charmhub.RefreshPlatform(charmOrigin.Platform))
+	} else if curl.Revision >= 0 {
+		cfg, err = charmhub.DownloadOneFromRevision(charmOrigin.ID, curl.Revision, charmhub.RefreshPlatform(charmOrigin.Platform))
+	} else {
+		cfg, err = charmhub.DownloadOneFromChannel(charmOrigin.ID, charmOrigin.Channel.String(), charmhub.RefreshPlatform(charmOrigin.Platform))
 	}
-	return results, nil
+	if err != nil {
+		return charmresource.Resource{}, errors.Trace(err)
+	}
+
+	refreshResp, err := ch.client.Refresh(context.TODO(), cfg)
+	if err != nil {
+		return charmresource.Resource{}, errors.Trace(err)
+	}
+	if len(refreshResp) == 0 {
+		return charmresource.Resource{}, errors.Errorf("no download refresh responses received")
+	}
+
+	for _, resp := range refreshResp {
+		if resp.Error != nil {
+			return charmresource.Resource{}, errors.Trace(errors.New(resp.Error.Message))
+		}
+
+		for _, entity := range resp.Entity.Resources {
+			if entity.Name == name && entity.Revision == revision {
+				return resourceFromRevision(entity)
+			}
+		}
+	}
+	return charmresource.Resource{}, errors.NotFoundf("charm resource %q at revision %d", name, revision)
 }
 
 // listResources composes, a map of details for each of the charm's
@@ -92,7 +197,8 @@ func (ch *charmHubClient) ResolveResources(uploadedResources []charmresource.Res
 // charm revision. They include the resource's metadata and revision.
 // Found via the CharmHub api.
 func (ch *charmHubClient) listResources() (map[string]charmresource.Resource, error) {
-	cfg, err := charmhub.DownloadOneFromChannel(ch.id.URL.Name, ch.id.Origin.Channel.String(), charmhub.RefreshPlatform(ch.id.Origin.Platform))
+	charmOrigin := ch.id.Origin
+	cfg, err := charmhub.DownloadOneFromChannel(charmOrigin.ID, charmOrigin.Channel.String(), charmhub.RefreshPlatform(charmOrigin.Platform))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -157,18 +263,30 @@ type CharmStore interface {
 }
 
 type charmStoreClient struct {
+	resourceClient
 	client CharmStore
 	id     CharmID
+}
+
+func newCharmStoreClient(client CharmStore, id CharmID) *charmStoreClient {
+	c := &charmStoreClient{
+		client: client,
+		id:     id,
+	}
+	c.resourceClient = resourceClient{
+		client: c,
+	}
+	return c
 }
 
 func (cs *charmStoreClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
 	storeResources, err := cs.resourcesFromCharmstore()
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	resolved, err := cs.resolveResources(resources, storeResources)
+	resolved, err := cs.resolveResources(cs.id, resources, storeResources)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	// TODO(ericsnow) Ensure that the non-upload resource revisions
 	// match a previously published revision set?
@@ -193,78 +311,6 @@ func (cs *charmStoreClient) resourcesFromCharmstore() (map[string]charmresource.
 	return storeResources, nil
 }
 
-// resolveResources determines the resource info that should actually
-// be stored on the controller. That decision is based on the provided
-// resources along with those in the charm backend (if any).
-func (cs *charmStoreClient) resolveResources(
-	resources []charmresource.Resource,
-	storeResources map[string]charmresource.Resource,
-) ([]charmresource.Resource, error) {
-	allResolved := make([]charmresource.Resource, len(resources))
-	copy(allResolved, resources)
-	for i, res := range resources {
-		// Note that incoming "upload" resources take precedence over
-		// ones already known to the controller, regardless of their
-		// origin.
-		if res.Origin != charmresource.OriginStore {
-			continue
-		}
-
-		resolved, err := cs.resolveStoreResource(res, storeResources)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		allResolved[i] = resolved
-	}
-	return allResolved, nil
-}
-
-// resolveStoreResource selects the resource info to use. It decides
-// between the provided and latest info based on the revision.
-func (cs *charmStoreClient) resolveStoreResource(
-	res charmresource.Resource,
-	storeResources map[string]charmresource.Resource,
-) (charmresource.Resource, error) {
-	storeRes, ok := storeResources[res.Name]
-	if !ok {
-		// This indicates that AddPendingResources() was called for
-		// a resource the charm backend doesn't know about (for the
-		// relevant charm revision).
-		return res, nil
-	}
-
-	if res.Revision < 0 {
-		// The caller wants to use the charm backend info.
-		return storeRes, nil
-	}
-	if res.Revision == storeRes.Revision {
-		// We don't worry about if they otherwise match. Only the
-		// revision is significant here. So we use the info from the
-		// charm backend since it is authoritative.
-		return storeRes, nil
-	}
-	if res.Fingerprint.IsZero() {
-		// The caller wants resource info from the charm backend, but with
-		// a different resource revision than the one associated with
-		// the charm in the backend.
-		req := charmstore.ResourceRequest{
-			Charm:    cs.id.URL,
-			Channel:  csparams.Channel(cs.id.Origin.Channel.String()),
-			Name:     res.Name,
-			Revision: res.Revision,
-		}
-		storeRes, err := cs.client.ResourceInfo(req)
-		if err != nil {
-			return storeRes, errors.Trace(err)
-		}
-		return storeRes, nil
-	}
-	// The caller fully-specified a resource with a different resource
-	// revision than the one associated with the charm in the backend. So
-	// we use the provided info as-is.
-	return res, nil
-}
-
 // ListResources composes, for each of the identified charms, the
 // list of details for each of the charm's resources. Those details
 // are those associated with the specific charm revision. They
@@ -280,8 +326,21 @@ func (cs *charmStoreClient) listResources(charmIDs []CharmID) ([][]charmresource
 	return cs.client.ListResources(chIDs)
 }
 
-type localClient struct {
+func (cs *charmStoreClient) ResourceInfo(url *charm.URL, origin corecharm.Origin, name string, revision int) (charmresource.Resource, error) {
+	req := charmstore.ResourceRequest{
+		Charm:    url,
+		Channel:  csparams.Channel(origin.Channel.String()),
+		Name:     name,
+		Revision: revision,
+	}
+	storeRes, err := cs.client.ResourceInfo(req)
+	if err != nil {
+		return storeRes, errors.Trace(err)
+	}
+	return storeRes, nil
 }
+
+type localClient struct{}
 
 func (lc *localClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
 	var resolved []charmresource.Resource

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -70,7 +70,7 @@ func (c *resourceClient) resolveResources(resources []charmresource.Resource,
 			continue
 		}
 
-		resolved, err := c.resolveStoreResource(c.id, res, storeResources)
+		resolved, err := c.resolveStoreResource(res, storeResources)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -81,8 +81,7 @@ func (c *resourceClient) resolveResources(resources []charmresource.Resource,
 
 // resolveStoreResource selects the resource info to use. It decides
 // between the provided and latest info based on the revision.
-func (c *resourceClient) resolveStoreResource(id CharmID,
-	res charmresource.Resource,
+func (c *resourceClient) resolveStoreResource(res charmresource.Resource,
 	storeResources map[string]charmresource.Resource,
 ) (charmresource.Resource, error) {
 	storeRes, ok := storeResources[res.Name]
@@ -107,7 +106,7 @@ func (c *resourceClient) resolveStoreResource(id CharmID,
 		// The caller wants resource info from the charm backend, but with
 		// a different resource revision than the one associated with
 		// the charm in the backend.
-		return c.client.ResourceInfo(id.URL, id.Origin, res.Name, res.Revision)
+		return c.client.ResourceInfo(c.id.URL, c.id.Origin, res.Name, res.Revision)
 	}
 	// The caller fully-specified a resource with a different resource
 	// revision than the one associated with the charm in the backend. So

--- a/apiserver/facades/client/resources/repository_test.go
+++ b/apiserver/facades/client/resources/repository_test.go
@@ -135,6 +135,9 @@ func (s *CharmHubClientSuite) newClient() NewCharmRepository {
 	channel, _ := corecharm.ParseChannel("stable")
 	c := &charmHubClient{
 		client: s.client,
+	}
+	c.resourceClient = resourceClient{
+		client: c,
 		id: CharmID{
 			URL: curl,
 			Origin: corecharm.Origin{
@@ -148,9 +151,6 @@ func (s *CharmHubClientSuite) newClient() NewCharmRepository {
 				},
 			},
 		},
-	}
-	c.resourceClient = resourceClient{
-		client: c,
 	}
 	return c
 }

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub_test.go
@@ -91,7 +91,7 @@ func (h *mockHub) Refresh(_ context.Context, config charmhub.RefreshConfig) ([]t
 		return nil, errors.Errorf("model metadata not present")
 	}
 
-	request, err := config.Build()
+	request, _, err := config.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/utils/set"
 	"github.com/juju/utils/v2"
 	"github.com/kr/pretty"
 

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/utils/set"
 	"github.com/juju/utils/v2"
 	"github.com/kr/pretty"
 
@@ -31,6 +31,10 @@ const (
 	// RefreshAction defines a refresh action.
 	RefreshAction Action = "refresh"
 )
+
+// Headers represents a series of headers that we would like to pass to the REST
+// API.
+type Headers = map[string][]string
 
 // RefreshPlatform defines a platform for selecting a specific charm.
 type RefreshPlatform struct {
@@ -69,7 +73,7 @@ func NewRefreshClient(path path.Path, client RESTClient, logger Logger) *Refresh
 // RefreshConfig defines a type for building refresh requests.
 type RefreshConfig interface {
 	// Build a refresh request for sending to the API.
-	Build() (transport.RefreshRequest, error)
+	Build() (transport.RefreshRequest, Headers, error)
 
 	// Ensure that the request back contains the information we requested.
 	Ensure([]transport.RefreshResponse) error
@@ -81,35 +85,20 @@ type RefreshConfig interface {
 // Refresh is used to refresh installed charms to a more suitable revision.
 func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
 	c.logger.Tracef("Refresh(%s)", pretty.Sprint(config))
-	req, err := config.Build()
+	req, headers, err := config.Build()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	// Add X-Juju-Metadata headers for the charms' unique series and
-	// architecture values, for example:
-	//
-	// X-Juju-Metadata: series=bionic
-	// X-Juju-Metadata: arch=amd64
-	// X-Juju-Metadata: series=focal
-	headers := make(http.Header)
-	seriesAdded := set.NewStrings()
-	archsAdded := set.NewStrings()
-	for _, context := range req.Context {
-		series := context.Platform.Series
-		if series != "" && !seriesAdded.Contains(series) {
-			headers.Add(MetadataHeader, "series="+series)
-			seriesAdded.Add(series)
-		}
-		arch := context.Platform.Architecture
-		if arch != "" && !archsAdded.Contains(arch) {
-			headers.Add(MetadataHeader, "arch="+arch)
-			archsAdded.Add(arch)
+	httpHeaders := make(http.Header)
+	for k, values := range headers {
+		for _, value := range values {
+			httpHeaders.Add(MetadataHeader, fmt.Sprintf("%s=%s", k, value))
 		}
 	}
 
 	var resp transport.RefreshResponses
-	restResp, err := c.client.Post(ctx, c.path, headers, req, &resp)
+	restResp, err := c.client.Post(ctx, c.path, httpHeaders, req, &resp)
 
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -158,7 +147,7 @@ func RefreshOne(id string, revision int, channel string, platform RefreshPlatfor
 }
 
 // Build a refresh request that can be past to the API.
-func (c refreshOne) Build() (transport.RefreshRequest, error) {
+func (c refreshOne) Build() (transport.RefreshRequest, Headers, error) {
 	return transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
 			InstanceKey: c.instanceKey,
@@ -179,7 +168,7 @@ func (c refreshOne) Build() (transport.RefreshRequest, error) {
 			InstanceKey: c.instanceKey,
 			ID:          &c.ID,
 		}},
-	}, nil
+	}, constructMetadataHeaders(c.Platform), nil
 }
 
 // Ensure that the request back contains the information we requested.
@@ -285,7 +274,7 @@ func DownloadOneFromChannel(id string, channel string, platform RefreshPlatform)
 }
 
 // Build a refresh request that can be past to the API.
-func (c executeOne) Build() (transport.RefreshRequest, error) {
+func (c executeOne) Build() (transport.RefreshRequest, Headers, error) {
 	return transport.RefreshRequest{
 		// Context is required here, even if it looks optional.
 		Context: []transport.RefreshRequestContext{},
@@ -293,6 +282,7 @@ func (c executeOne) Build() (transport.RefreshRequest, error) {
 			Action:      string(c.action),
 			InstanceKey: c.instanceKey,
 			ID:          &c.ID,
+			Name:        &c.Name,
 			Revision:    c.Revision,
 			Channel:     c.Channel,
 			Platform: &transport.RefreshRequestPlatform{
@@ -301,7 +291,7 @@ func (c executeOne) Build() (transport.RefreshRequest, error) {
 				Architecture: c.Platform.Architecture,
 			},
 		}},
-	}, nil
+	}, constructMetadataHeaders(c.Platform), nil
 }
 
 // Ensure that the request back contains the information we requested.
@@ -319,8 +309,8 @@ func (c executeOne) String() string {
 	if c.Channel != nil {
 		channel = *c.Channel
 	}
-	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using Name: %s with revision: %+v, channel %v and platform %s",
-		c.action, c.instanceKey, c.Name, c.Revision, channel, c.Platform)
+	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using ID: %s with revision: %+v, channel %v and platform %s",
+		c.action, c.instanceKey, c.ID, c.Revision, channel, c.Platform)
 }
 
 type refreshMany struct {
@@ -335,17 +325,21 @@ func RefreshMany(configs ...RefreshConfig) RefreshConfig {
 }
 
 // Build a refresh request that can be past to the API.
-func (c refreshMany) Build() (transport.RefreshRequest, error) {
-	var result transport.RefreshRequest
+func (c refreshMany) Build() (transport.RefreshRequest, Headers, error) {
+	var (
+		result          transport.RefreshRequest
+		composedHeaders Headers
+	)
 	for _, config := range c.Configs {
-		req, err := config.Build()
+		req, headers, err := config.Build()
 		if err != nil {
-			return transport.RefreshRequest{}, errors.Trace(err)
+			return transport.RefreshRequest{}, nil, errors.Trace(err)
 		}
 		result.Context = append(result.Context, req.Context...)
 		result.Actions = append(result.Actions, req.Actions...)
+		composedHeaders = composeMetadataHeaders(composedHeaders, headers)
 	}
-	return result, nil
+	return result, composedHeaders, nil
 }
 
 // Ensure that the request back contains the information we requested.
@@ -364,4 +358,38 @@ func (c refreshMany) String() string {
 		plans[i] = config.String()
 	}
 	return strings.Join(plans, "\n")
+}
+
+// constructHeaders adds X-Juju-Metadata headers for the charms' unique series
+// and architecture values, for example:
+//
+// X-Juju-Metadata: series=bionic
+// X-Juju-Metadata: arch=amd64
+// X-Juju-Metadata: series=focal
+func constructMetadataHeaders(platform RefreshPlatform) map[string][]string {
+	headers := make(map[string][]string)
+	if platform.Architecture != "" {
+		headers["arch"] = []string{platform.Architecture}
+	}
+	if platform.OS != "" {
+		headers["os"] = []string{platform.OS}
+	}
+	if platform.Series != "" {
+		headers["series"] = []string{platform.Series}
+	}
+	return headers
+}
+
+func composeMetadataHeaders(a, b Headers) Headers {
+	result := make(map[string][]string)
+	for k, v := range a {
+		result[k] = append(result[k], v...)
+	}
+	for k, v := range b {
+		result[k] = append(result[k], v...)
+	}
+	for k, v := range result {
+		result[k] = set.NewStrings(v...).SortedValues()
+	}
+	return result
 }

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -275,14 +275,22 @@ func DownloadOneFromChannel(id string, channel string, platform RefreshPlatform)
 
 // Build a refresh request that can be past to the API.
 func (c executeOne) Build() (transport.RefreshRequest, Headers, error) {
+	var id *string
+	if c.ID != "" {
+		id = &c.ID
+	}
+	var name *string
+	if c.Name != "" {
+		name = &c.Name
+	}
 	return transport.RefreshRequest{
 		// Context is required here, even if it looks optional.
 		Context: []transport.RefreshRequestContext{},
 		Actions: []transport.RefreshRequestAction{{
 			Action:      string(c.action),
 			InstanceKey: c.instanceKey,
-			ID:          &c.ID,
-			Name:        &c.Name,
+			ID:          id,
+			Name:        name,
 			Revision:    c.Revision,
 			Channel:     c.Channel,
 			Platform: &transport.RefreshRequestPlatform{
@@ -309,8 +317,14 @@ func (c executeOne) String() string {
 	if c.Channel != nil {
 		channel = *c.Channel
 	}
-	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using ID: %s with revision: %+v, channel %v and platform %s",
-		c.action, c.instanceKey, c.ID, c.Revision, channel, c.Platform)
+	var using string
+	if c.ID != "" {
+		using = fmt.Sprintf("ID %s", c.ID)
+	} else {
+		using = fmt.Sprintf("Name %s", c.Name)
+	}
+	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using %s with revision: %+v, channel %v and platform %s",
+		c.action, c.instanceKey, using, c.Revision, channel, c.Platform)
 }
 
 type refreshMany struct {

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -270,7 +270,7 @@ func DownloadOneFromRevision(id string, revision int, platform RefreshPlatform) 
 
 // DownloadOneFromChannel creates a request config using the channel and not the
 // revision for requesting only one charm.
-func DownloadOneFromChannel(name string, channel string, platform RefreshPlatform) (RefreshConfig, error) {
+func DownloadOneFromChannel(id string, channel string, platform RefreshPlatform) (RefreshConfig, error) {
 	uuid, err := utils.NewUUID()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -278,7 +278,7 @@ func DownloadOneFromChannel(name string, channel string, platform RefreshPlatfor
 	return executeOne{
 		action:      DownloadAction,
 		instanceKey: uuid.String(),
-		Name:        name,
+		ID:          id,
 		Channel:     &channel,
 		Platform:    platform,
 	}, nil
@@ -292,7 +292,7 @@ func (c executeOne) Build() (transport.RefreshRequest, error) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      string(c.action),
 			InstanceKey: c.instanceKey,
-			Name:        &c.Name,
+			ID:          &c.ID,
 			Revision:    c.Revision,
 			Channel:     c.Channel,
 			Platform: &transport.RefreshRequestPlatform{

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -33,11 +33,11 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	baseURL := MustParseURL(c, "http://api.foo.bar")
 
 	path := path.MakePath(baseURL)
-	name := "meshuggah"
+	id := "meshuggah"
 	body := transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
 			InstanceKey: "foo-bar",
-			ID:          name,
+			ID:          id,
 			Revision:    1,
 			Platform: transport.RefreshRequestPlatform{
 				OS:           "ubuntu",
@@ -49,11 +49,11 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "refresh",
 			InstanceKey: "foo-bar",
-			ID:          &name,
+			ID:          &id,
 		}},
 	}
 
-	config, err := RefreshOne(name, 1, "latest/stable", RefreshPlatform{
+	config, err := RefreshOne(id, 1, "latest/stable", RefreshPlatform{
 		OS:           "ubuntu",
 		Series:       "focal",
 		Architecture: arch.DefaultArchitecture,
@@ -63,13 +63,13 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	config = DefineInstanceKey(c, config, "foo-bar")
 
 	restClient := NewMockRESTClient(ctrl)
-	s.expectPost(c, restClient, path, name, body)
+	s.expectPost(c, restClient, path, id, body)
 
 	client := NewRefreshClient(path, restClient, &FakeLogger{})
 	responses, err := client.Refresh(context.TODO(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(responses), gc.Equals, 1)
-	c.Assert(responses[0].Name, gc.Equals, name)
+	c.Assert(responses[0].Name, gc.Equals, id)
 }
 
 type metadataTransport struct {
@@ -264,7 +264,6 @@ func (s *RefreshConfigSuite) TestRefreshOneEnsure(c *gc.C) {
 
 func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
 	revision := 1
-	emptyStr := ""
 
 	name := "foo"
 	config, err := InstallOneFromRevision(name, revision, RefreshPlatform{
@@ -283,7 +282,6 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: "foo-bar",
-			ID:          &emptyStr,
 			Name:        &name,
 			Revision:    &revision,
 			Platform: &transport.RefreshRequestPlatform{
@@ -297,7 +295,6 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
 
 func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 	channel := "latest/stable"
-	emptyStr := ""
 
 	name := "foo"
 	config, err := InstallOneFromChannel(name, channel, RefreshPlatform{
@@ -316,7 +313,6 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "install",
 			InstanceKey: "foo-bar",
-			ID:          &emptyStr,
 			Name:        &name,
 			Channel:     &channel,
 			Platform: &transport.RefreshRequestPlatform{
@@ -377,7 +373,6 @@ func (s *RefreshConfigSuite) TestDownloadOneEnsure(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
-	emptyStr := ""
 	channel := "latest/stable"
 	id := "foo"
 	config, err := DownloadOneFromChannel(id, channel, RefreshPlatform{
@@ -397,7 +392,6 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 			Action:      "download",
 			InstanceKey: "foo-bar",
 			ID:          &id,
-			Name:        &emptyStr,
 			Channel:     &channel,
 			Platform: &transport.RefreshRequestPlatform{
 				OS:           "ubuntu",
@@ -425,8 +419,6 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelEnsure(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
-	emptyStr := ""
-
 	id1 := "foo"
 	config1, err := RefreshOne(id1, 1, "latest/stable", RefreshPlatform{
 		OS:           "ubuntu",
@@ -494,7 +486,6 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 		}, {
 			Action:      "install",
 			InstanceKey: "foo-taz",
-			ID:          &emptyStr,
 			Name:        &name3,
 			Platform: &transport.RefreshRequestPlatform{
 				OS:           "ubuntu",

--- a/resource/resourceadapters/charmhub.go
+++ b/resource/resourceadapters/charmhub.go
@@ -79,7 +79,9 @@ func (ch *CharmHubClient) GetResource(req repositories.ResourceRequest) (charmst
 	ch.logger.Tracef("GetResource(%s)", pretty.Sprint(req))
 	var data charmstore.ResourceData
 
-	stChannel := req.CharmID.Origin.Channel
+	origin := req.CharmID.Origin
+
+	stChannel := origin.Channel
 	if stChannel == nil {
 		return data, errors.Errorf("Missing channel for %q", req.CharmID.URL.Name)
 	}
@@ -91,7 +93,7 @@ func (ch *CharmHubClient) GetResource(req repositories.ResourceRequest) (charmst
 	if req.CharmID.URL == nil {
 		return data, errors.Errorf("Missing charm url for resource %q", req.Name)
 	}
-	cfg, err := charmhub.DownloadOneFromChannel(req.CharmID.URL.Name, channel.String(), charmhub.RefreshPlatform(*req.CharmID.Origin.Platform))
+	cfg, err := charmhub.DownloadOneFromChannel(origin.ID, channel.String(), charmhub.RefreshPlatform(*req.CharmID.Origin.Platform))
 	if err != nil {
 		return data, errors.Trace(err)
 	}


### PR DESCRIPTION
This supersedes #12421. Requires #12414 to land first (will rebase once landed)

The following ensures that we get the metadata that we want. This is
abstracted out into a client so that both charmhub and the charmstore
can get the information in the same logic, without duplication. Adds test 
for the charmhub repository resolving. It currently doesn't work as we're 
waiting for file path to be put back into the API after they removed it.

Additionally:

Also cleaned up the charmhub headers so that we get ALL the headers for
all scenarios. Previously it only looked in the context, but the
platform could actually be in the actions as well.

It probably should be another branch, but life is too short!



## QA steps

```sh
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju bootstrap localhost
$ juju add-model six --config charm-hub-url="https://api.staging.snapcraft.io"

# Deploy a CharmHub charm with resources, set the region to trigger resource_get in the charm.
$ juju deploy postgresql --config aws_region="us-east-1"
# wait for the charm to install and try to get the resource successfully
# there will be a status message about installing the Wal-e snap
$ juju show-status-log postgresql/0
Time                   Type       Status       Message
....
08 Dec 2020 22:27:55Z  juju-unit  executing    running install hook
08 Dec 2020 22:28:52Z  workload   maintenance  Updating apt cache
08 Dec 2020 22:28:54Z  workload   maintenance  Installing wal-e snap
```
