### PR TITLE
[2.8] Set unit error state when relation created hooks fail

### DIFF
--- a/worker/uniter/relation/resolver.go
+++ b/worker/uniter/relation/resolver.go
@@ -323,6 +323,11 @@ func (r *createdRelationsResolver) NextOp(
 		return nil, resolver.ErrNoOperation
 	}
 
+	// We should only evaluate the resolver logic if there is no other pending operation
+	if localState.Kind != operation.Continue {
+		return nil, resolver.ErrNoOperation
+	}
+
 	if err := r.stateTracker.SynchronizeScopes(remoteState); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/relation/resolver_test.go
+++ b/worker/uniter/relation/resolver_test.go
@@ -1292,6 +1292,29 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationResolverFordRelationNo
 	})
 }
 
+// This is a regression test for LP1906706
+func (s *relationCreatedResolverSuite) TestCreatedRelationsResolverWithPendingHook(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	r := mocks.NewMockRelationStateTracker(ctrl)
+
+	localState := resolver.LocalState{
+		State: operation.State{
+			Installed: true,
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+		},
+	}
+	remoteState := remotestate.Snapshot{
+		Life: life.Alive,
+	}
+
+	createdRelationsResolver := relation.NewCreatedRelationResolver(r)
+	_, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation, gc.Commentf("expected to get ErrNoOperation when a RunHook operation is pending"))
+}
+
 type mockRelationResolverSuite struct {
 	mockRelStTracker *mocks.MockRelationStateTracker
 	mockSupDestroyer *mocks.MockSubordinateDestroyer


### PR DESCRIPTION
The way that the uniter worker handles RunHook errors is by dropping errors to the floor in the resolver main loop and then entering the loop once again under the assumption that the resolver will check the **local state** for a pending RunHook operation (Operation == RunHook and Step == Pending) and move the unit into an error state.

This design assumes that the individual resolvers check that the current local state is in `Continue` mode (meaning that each resolver should go ahead and figure out if it needs to emit an operation) and return `ErrNoOperation` otherwise so that the main resolver can eventually apply the above logic and set the required error state.

Unfortunately, this particular check was not applied by the recently (2.8) added CreatedRelation resolver. As a result, if a `xxx-relation-created` hook failed, the uniter would keep invoking the aforementioned resolver which would happily return a `xxx-relation-created` hook operation causing the unit to get stuck in an infinite loop.

This PR addresses this problem thus allowing the unit to reach an error state as expected. 

## QA steps

*Please replace with how we can verify that the change works.*

```sh
# apply this patch
diff --git a/acceptancetests/repository/charms/ubuntu/metadata.yaml b/acceptancetests/repository/charms/ubuntu/metadata.yaml
index 1846048417..e5b7b19648 100644
--- a/acceptancetests/repository/charms/ubuntu/metadata.yaml
+++ b/acceptancetests/repository/charms/ubuntu/metadata.yaml
@@ -12,4 +12,6 @@ series:
   - bionic
   - eoan
   - focal
-
+peers:
+  peer:
+    interface: http


# Then create this file with the specified contents
$ cat acceptancetests/repository/charms/ubuntu/hooks/peer-relation-created
#!/bin/bash
set -e
# This should fail when executed by a non-leader unit!
relation-set -r $JUJU_RELATION_ID --app foo=bar

# Finally, run the following command and check that the non-leader unit reaches an error state
$ juju deploy -n2 ./acceptancetests/repository/charms/ubuntu

$ juju status
Model    Controller  Cloud/Region            Version  SLA          Timestamp
default  test        lxd-with-cache/default  2.8.7.1  unsupported  18:33:58Z

App     Version  Status  Scale  Charm   Store  Rev  OS      Notes
ubuntu           error       2  ubuntu  local    1  ubuntu

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  unknown   idle   0        10.59.233.117
ubuntu/1   error     idle   1        10.59.233.252          hook failed: "peer-relation-created" <---- look for this

Machine  State    DNS            Inst id        Series  AZ  Message
0        started  10.59.233.117  juju-be2af9-0  bionic      Running
1        started  10.59.233.252  juju-be2af9-1  bionic      Running
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1906706