### PR TITLE
Arm64 unit test fixes with app constraint

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -281,7 +281,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 
 	// Add one unit to an application;
 	charm := s.AddTestingCharm(c, "dummy")
-	app := s.AddTestingApplication(c, "test-application", charm)
+	app := s.AddTestingApplicationWithArch(c, "test-application", charm, arch.HostArch())
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.AssignUnit(unit, state.AssignCleanEmpty)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -36,6 +36,7 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
@@ -915,6 +916,17 @@ func (s *JujuConnSuite) AddTestingApplicationWithOrigin(c *gc.C, name string, ch
 		Charm:       ch,
 		Series:      ch.URL().Series,
 		CharmOrigin: origin,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return app
+}
+
+func (s *JujuConnSuite) AddTestingApplicationWithArch(c *gc.C, name string, ch *state.Charm, arch string) *state.Application {
+	app, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:        name,
+		Charm:       ch,
+		Series:      ch.URL().Series,
+		Constraints: constraints.MustParse("arch=" + arch),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return app


### PR DESCRIPTION
The following adds a new method to the connsuite[1] to ensure that when we
create a testing application that has the correct arch constraints.
The fact that the constraints weren't set would mean that it would
default to amd64. This is obviously not what we want and so forcing it
to be the host arch when adding the application solves this.

1. I know :(

## QA steps

Two ways:

 1. Check this code out on an amd64 box and run the following:

```sh
go test -v ./cmd/jujud/agent/. -check.v -check.f=MachineSuite.TestManageModelRunsInstancePoller
```

 2. Wait for the CI unit tests to run the arm64 ones after merging.