### PR TITLE
Add CharmHub to the set commonModelFacadeNames. To allow k8s controllers

### DIFF
--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -22,6 +22,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Block",
 	"CharmRevisionUpdater",
 	"Charms",
+	"CharmHub",
 	"Cleaner",
 	"Client",
 	"Cloud",


### PR DESCRIPTION
Add CharmHub to the set commonModelFacadeNames. To allow k8s controllers to deploy CharmHub charms.

## QA steps

Steps assume that microk8s and docker is setup already.

```console
$ make microk8s-operator-update
$ juju bootstrap microk8s wednesday-k8s
$ export JUJU_DEV_FEATURE_FLAGS="charm-hub"
$ juju add-model six --config charm-hub-url="https://api.staging.snapcraft.io"

# the find command should not fail
$ juju find --series kubernetes

# deploy a charmhub k8s charm
$ juju deploy postgresql-k8s
$ juju status
Model  Controller     Cloud/Region        Version  SLA          Timestamp
six    wednesday-k8s  microk8s/localhost  2.9-rc3  unsupported  14:33:24Z

App         Version       Status  Scale  Charm           Store     Rev  OS          Address  Message
postgresql  pgcharm:edge  active      1  postgresql-k8s  charmhub    5  kubernetes

Unit           Workload  Agent  Address      Ports     Message
postgresql/0*  active    idle   10.1.246.77  5432/TCP  Pod configured

$ juju show-status-log postgresql/0
Time                   Type       Status       Message
...
09 Dec 2020 14:32:45Z  juju-unit  idle
09 Dec 2020 14:32:45Z  workload   active       Pod configured
```
