### PR TITLE
Bundle YAML for bundles

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -270,22 +270,27 @@ func (a *API) getDownloadInfo(arg params.CharmURLAndOrigin) (params.DownloadInfo
 
 func normalizeCharmOrigin(origin params.CharmOrigin) (params.CharmOrigin, error) {
 	os := origin.OS
-	if origin.Series != "" {
-		sys, err := series.GetOSFromSeries(origin.Series)
+	oSeries := origin.Series
+	if origin.Series != "" && origin.Series != "all" {
+		sys, err := series.GetOSFromSeries(oSeries)
 		if err != nil {
 			return params.CharmOrigin{}, errors.Trace(err)
 		}
 		// Values passed to the api are case sensitive: ubuntu succeeds and
 		// Ubuntu returns `"code": "revision-not-found"`
 		os = strings.ToLower(sys.String())
+	} else {
+		oSeries = ""
+		os = ""
 	}
 	arc := origin.Architecture
-	if origin.Architecture == "" {
+	if origin.Architecture == "" || origin.Architecture == "all" {
 		arc = arch.DefaultArchitecture
 	}
 
 	o := origin
 	o.OS = os
+	o.Series = oSeries
 	o.Architecture = arc
 	return o, nil
 }

--- a/apiserver/facades/client/charms/clientnormalize_test.go
+++ b/apiserver/facades/client/charms/clientnormalize_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charms
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/arch"
+)
+
+type clientNormalizeOriginSuite struct {
+}
+
+var _ = gc.Suite(&clientNormalizeOriginSuite{})
+
+func (s *clientNormalizeOriginSuite) TestNormalizeCharmOriginNoAll(c *gc.C) {
+	track := "1.0"
+	origin := params.CharmOrigin{
+		Source:       "charm-hub",
+		Type:         "charm",
+		Risk:         "edge",
+		Track:        &track,
+		Architecture: "all",
+		OS:           "all",
+		Series:       "all",
+	}
+	obtained, err := normalizeCharmOrigin(origin)
+	c.Assert(err, jc.ErrorIsNil)
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = ""
+	origin.Series = ""
+	c.Assert(obtained, gc.DeepEquals, origin)
+}
+
+func (s *clientNormalizeOriginSuite) TestNormalizeCharmOriginLowerCase(c *gc.C) {
+	track := "1.0"
+	origin := params.CharmOrigin{
+		Source:       "charm-hub",
+		Type:         "charm",
+		Risk:         "edge",
+		Track:        &track,
+		Architecture: "s390",
+		OS:           "Ubuntu",
+		Series:       "focal",
+	}
+	obtained, err := normalizeCharmOrigin(origin)
+	c.Assert(err, jc.ErrorIsNil)
+	origin.OS = "ubuntu"
+	c.Assert(obtained, gc.DeepEquals, origin)
+}

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -22,9 +22,9 @@ type charmHubRepositoriesSuite struct {
 
 var _ = gc.Suite(&charmHubRepositoriesSuite{})
 
-func (s *charmHubRepositoriesSuite) TestResolveDefaultChannelMap(c *gc.C) {
+func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMap(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(nil)
+	s.expectCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress")
 	origin := params.CharmOrigin{Source: "charm-hub"}
@@ -52,7 +52,7 @@ func (s *charmHubRepositoriesSuite) TestResolveDefaultChannelMap(c *gc.C) {
 
 func (s *charmHubRepositoriesSuite) TestResolveWithRevision(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(nil)
+	s.expectCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress-13")
 	origin := params.CharmOrigin{Source: "charm-hub"}
@@ -78,9 +78,9 @@ func (s *charmHubRepositoriesSuite) TestResolveWithRevision(c *gc.C) {
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
 }
 
-func (s *charmHubRepositoriesSuite) TestResolveDefaultChannelMapWithFallbackSeries(c *gc.C) {
+func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMapWithFallbackSeries(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectAlternativeInfo(nil)
+	s.expectAlternativeCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress")
 	origin := params.CharmOrigin{Source: "charm-hub"}
@@ -106,9 +106,65 @@ func (s *charmHubRepositoriesSuite) TestResolveDefaultChannelMapWithFallbackSeri
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
 }
 
+func (s *charmHubRepositoriesSuite) TestBundleResolveDefaultChannelMap(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectBundleInfo(nil)
+
+	curl := charm.MustParseURL("ch:wordpress")
+	origin := params.CharmOrigin{Type: "bundle", Source: "charm-hub"}
+
+	resolver := &chRepo{client: s.client}
+	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
+	c.Assert(err, jc.ErrorIsNil)
+
+	track := "latest"
+	curl.Revision = 16
+
+	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
+	origin.Type = "bundle"
+	origin.Revision = &curl.Revision
+	origin.Risk = "stable"
+	origin.Track = &track
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = "ubuntu"
+	origin.Series = "bionic"
+
+	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
+	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
+}
+
+func (s *charmHubRepositoriesSuite) TestBundleResolveDefaultChannelMapWithFallbackSeries(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectAlternativeBundleInfo(nil)
+
+	curl := charm.MustParseURL("ch:wordpress")
+	origin := params.CharmOrigin{Type: "bundle", Source: "charm-hub"}
+
+	resolver := &chRepo{client: s.client}
+	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
+	c.Assert(err, jc.ErrorIsNil)
+
+	track := "1.0"
+	curl.Revision = 17
+
+	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
+	origin.Type = "bundle"
+	origin.Revision = &curl.Revision
+	origin.Risk = "edge"
+	origin.Track = &track
+	origin.Architecture = arch.DefaultArchitecture
+	origin.OS = "ubuntu"
+	origin.Series = "bionic"
+
+	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
+	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
+}
+
 func (s *charmHubRepositoriesSuite) TestResolveWithRevisionNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(nil)
+	s.expectCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress-42")
 	origin := params.CharmOrigin{Source: "charm-hub"}
@@ -120,7 +176,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithRevisionNotFound(c *gc.C) {
 
 func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(nil)
+	s.expectCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress")
 	track := "second"
@@ -146,7 +202,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 
 func (s *charmHubRepositoriesSuite) TestResolveWithChannelNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(nil)
+	s.expectCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress")
 	track := "testme"
@@ -164,7 +220,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannelNotFound(c *gc.C) {
 
 func (s *charmHubRepositoriesSuite) TestResolveWithChannelRiskOnly(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(nil)
+	s.expectCharmInfo(nil)
 
 	curl := charm.MustParseURL("ch:wordpress")
 	origin := params.CharmOrigin{Source: "charm-hub", Risk: "candidate"}
@@ -191,7 +247,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannelRiskOnly(c *gc.C) {
 
 func (s *charmHubRepositoriesSuite) TestResolveInfoError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectInfo(errors.NotSupportedf("error for test"))
+	s.expectCharmInfo(errors.NotSupportedf("error for test"))
 
 	curl := charm.MustParseURL("ch:wordpress")
 	origin := params.CharmOrigin{Source: "charm-hub"}
@@ -207,12 +263,20 @@ func (s *charmHubRepositoriesSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *charmHubRepositoriesSuite) expectInfo(err error) {
-	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getCharmHubInfoResponse(), err)
+func (s *charmHubRepositoriesSuite) expectCharmInfo(err error) {
+	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getCharmHubCharmInfoResponse(), err)
 }
 
-func (s *charmHubRepositoriesSuite) expectAlternativeInfo(err error) {
-	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getAlternativeCharmHubInfoResponse(), err)
+func (s *charmHubRepositoriesSuite) expectAlternativeCharmInfo(err error) {
+	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getAlternativeCharmHubCharmInfoResponse(), err)
+}
+
+func (s *charmHubRepositoriesSuite) expectBundleInfo(err error) {
+	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getCharmHubBundleInfoResponse(), err)
+}
+
+func (s *charmHubRepositoriesSuite) expectAlternativeBundleInfo(err error) {
+	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getAlternativeCharmHubBundleInfoResponse(), err)
 }
 
 type charmStoreResolversSuite struct {
@@ -227,8 +291,8 @@ func (s *charmStoreResolversSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func getCharmHubInfoResponse() transport.InfoResponse {
-	channelMap, defaultRelease := getCharmHubResponse()
+func getCharmHubCharmInfoResponse() transport.InfoResponse {
+	channelMap, defaultRelease := getCharmHubCharmResponse()
 	return transport.InfoResponse{
 		Name:           "wordpress",
 		Type:           "charm",
@@ -238,8 +302,8 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 	}
 }
 
-func getAlternativeCharmHubInfoResponse() transport.InfoResponse {
-	channelMap, _ := getCharmHubResponse()
+func getAlternativeCharmHubCharmInfoResponse() transport.InfoResponse {
+	channelMap, _ := getCharmHubCharmResponse()
 	defaultRelease := alternativeDefaultChannelMap()
 	return transport.InfoResponse{
 		Name:           "wordpress",
@@ -250,7 +314,30 @@ func getAlternativeCharmHubInfoResponse() transport.InfoResponse {
 	}
 }
 
-func getCharmHubResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap) {
+func getCharmHubBundleInfoResponse() transport.InfoResponse {
+	channelMap, defaultRelease := getCharmHubBundleResponse()
+	return transport.InfoResponse{
+		Name:           "wordpress",
+		Type:           "bundle",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMap,
+		DefaultRelease: defaultRelease,
+	}
+}
+
+func getAlternativeCharmHubBundleInfoResponse() transport.InfoResponse {
+	channelMap, _ := getCharmHubBundleResponse()
+	defaultRelease := alternativeDefaultChannelMap()
+	return transport.InfoResponse{
+		Name:           "wordpress",
+		Type:           "bundle",
+		ID:             "charmCHARMcharmCHARMcharmCHARM01",
+		ChannelMap:     channelMap,
+		DefaultRelease: defaultRelease,
+	}
+}
+
+func getCharmHubCharmResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap) {
 	return []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name: "stable",
@@ -399,4 +486,121 @@ provides:
 requires:
   sink:
     interface: dummy-token
+`
+
+func getCharmHubBundleResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap) {
+	return []transport.InfoChannelMap{{
+			Channel: transport.Channel{
+				Name: "stable",
+				Platform: transport.Platform{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				Risk:  "stable",
+				Track: "latest",
+			},
+			Revision: transport.InfoRevision{
+				MetadataYAML: entityMeta,
+				Platforms: []transport.Platform{{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}},
+				Revision: 18,
+				Version:  "1.0.3",
+			},
+		}, {
+			Channel: transport.Channel{
+				Name: "candidate",
+				Platform: transport.Platform{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				Risk:  "candidate",
+				Track: "latest",
+			},
+			Revision: transport.InfoRevision{
+				MetadataYAML: entityMeta,
+				Platforms: []transport.Platform{{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}},
+				Revision: 19,
+				Version:  "1.0.3",
+			},
+		}, {
+			Channel: transport.Channel{
+				Name: "edge",
+				Platform: transport.Platform{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				Risk:  "edge",
+				Track: "latest",
+			},
+			Revision: transport.InfoRevision{
+				BundleYAML: entityBundle,
+				Platforms: []transport.Platform{{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}},
+				Revision: 19,
+				Version:  "1.0.3",
+			},
+		}, {
+			Channel: transport.Channel{
+				Name: "second/stable",
+				Platform: transport.Platform{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				Risk:  "stable",
+				Track: "second",
+			},
+			Revision: transport.InfoRevision{
+				BundleYAML: entityBundle,
+				Platforms: []transport.Platform{{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}},
+				Revision: 13,
+				Version:  "1.0.3",
+			},
+		}}, transport.InfoChannelMap{
+			Channel: transport.Channel{
+				Name: "stable",
+				Platform: transport.Platform{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				},
+				Risk:  "stable",
+				Track: "latest",
+			},
+			Revision: transport.InfoRevision{
+				BundleYAML: entityBundle,
+				Platforms: []transport.Platform{{
+					Architecture: arch.DefaultArchitecture,
+					OS:           "ubuntu",
+					Series:       "bionic",
+				}},
+				Revision: 16,
+				Version:  "1.0.3",
+			},
+		}
+}
+
+const entityBundle = `
+series: bionic
+services:
+    wordpress:
+        charm: wordpress
+        num_units: 1
 `

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -119,6 +119,7 @@ var infoRevisionFilter = []string{
 	"revision.config-yaml",
 	"revision.created-at",
 	"revision.metadata-yaml",
+	"revision.bundle-yaml",
 	"revision.platforms.architecture",
 	"revision.platforms.os",
 	"revision.platforms.series",

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -28,6 +28,7 @@ type InfoRevision struct {
 	CreatedAt    string     `json:"created-at"`
 	Download     Download   `json:"download"`
 	MetadataYAML string     `json:"metadata-yaml"`
+	BundleYAML   string     `json:"bundle-yaml"`
 	Platforms    []Platform `json:"platforms"`
 	Revision     int        `json:"revision"`
 	Version      string     `json:"version"`


### PR DESCRIPTION
Charmhub API now exports bundle yaml for bundles rather than bulk
loading them into metadata yaml. This is a good fix as it means bundles
are not an after thought and it promotes bundles to first class
entities.

The change is simple it just expects the bundle-yaml json tag to be set
along with the filters and passes them through the info. The charm
facade can them check the type before performing the unmarshalling of
the data correctly.

## QA steps

```sh
$ export JUJU_DEV_FEATURE_FLAGS=charm-hub
$ juju bootstrap lxd test
$ juju add-model six --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy wiki-simple
```
