### PR TITLE
Updates bootstrap docs to fix bad text.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -168,10 +168,10 @@ Examples:
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
 
     # For a bootstrap on k8s, setting the service type of the Juju controller service to LoadBalancer
-    juju bootstrap --config controller-service-type=LoadBalancer
+    juju bootstrap --config controller-service-type=loadbalancer
 
 	# For a bootstrap on k8s, setting the service type of the Juju controller service to External
-    juju bootstrap --config controller-service-type=ExternalName,controller-service-name=controller.juju.is
+    juju bootstrap --config controller-service-type=external --config controller-service-name=controller.juju.is
 
 See also:
     add-credentials

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -129,7 +129,8 @@ var BootstrapConfigSchema = environschema.Fields{
 	ControllerServiceType: {
 		Description: "Controls the kubernetes service type for Juju " +
 			"controllers, see " +
-			"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core",
+			"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core " +
+			"valid values are one of cluster, loadbalancer, external",
 		Type: environschema.Tstring,
 	},
 	ControllerExternalName: {


### PR DESCRIPTION
Wrong values are using in Bootstrap text for controller service type.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap to a kubernetes cluster using the bootstrap examples.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1905320
