### PR TITLE
Do not resolve ingress address host-names for CAAS unit network-get calls

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -247,24 +247,13 @@ func (n *NetworkInfoBase) getEgressForRelation(
 }
 
 func (n *NetworkInfoBase) resolveResultHostNames(netInfoResult params.NetworkInfoResult) params.NetworkInfoResult {
-	// Maintain a cache of host-name -> address resolutions.
-	resolved := make(map[string]string)
-	addressForHost := func(hostName string) string {
-		resolvedAddr, ok := resolved[hostName]
-		if !ok {
-			resolvedAddr = n.resolveHostAddress(hostName)
-			resolved[hostName] = resolvedAddr
-		}
-		return resolvedAddr
-	}
-
 	// Resolve addresses in Info.
 	for i, info := range netInfoResult.Info {
 		for j, addr := range info.Addresses {
 			if ip := net.ParseIP(addr.Address); ip == nil {
 				// If the address is not an IP, we assume it is a host name.
 				addr.Hostname = addr.Address
-				addr.Address = addressForHost(addr.Hostname)
+				addr.Address = n.resolveHostAddress(addr.Hostname)
 				netInfoResult.Info[i].Addresses[j] = addr
 			}
 		}
@@ -279,7 +268,7 @@ func (n *NetworkInfoBase) resolveResultHostNames(netInfoResult params.NetworkInf
 			newIngress = append(newIngress, addr)
 			continue
 		}
-		if ipAddr := addressForHost(addr); ipAddr != "" {
+		if ipAddr := n.resolveHostAddress(addr); ipAddr != "" {
 			newIngress = append(newIngress, ipAddr)
 		}
 	}

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -87,7 +87,10 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			}
 		}
 
-		result.Results[endpoint] = n.resolveResultHostNames(info)
+		// We only resolve the `Info` member addresses for CAAS.
+		// Host names in `IngressAddresses` are preserved,
+		// which diverges from the IAAS implementation.
+		result.Results[endpoint] = n.resolveResultInfoHostNames(info)
 	}
 
 	return result, nil

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -90,7 +90,7 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		result.Results[endpoint] = n.resolveResultHostNames(info)
+		result.Results[endpoint] = n.resolveResultIngressHostNames(n.resolveResultInfoHostNames(info))
 	}
 
 	return result, nil


### PR DESCRIPTION
This patch makes divergent the resolution of hostnames in `NetworkInfoResult` between CAAS and IAAS.

IAAS units retain the prior behaviour, which is to resolve host-names to IP addresses for both the `Info` member addresses and `IngressAddresses`.

CAAS no no longer resolves `IngressAddresses` host-names to IP addresses.
 
## QA steps

- Bootstrap to AWS.
- Save [this](https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/aws-overlay.yaml) as aws-integrator.yaml
- `juju deploy charmed-kubernetes --overlay aws-integrator.yaml --trust`.
- `juju scp kubernetes-master/0:/home/ubuntu/config ~/.kube/config`.
- Add the k8s as a cloud to the same controller: `juju juju add-k8s k8s`.
- `juju add-model qa k8s/us-east-1 --config logging-config="<root>=DEBUG"`.
- `juju deploy cs:ambassador`.
- `juju config ambassador juju-external-hostname=<app service address>`.
- `juju run --unit ambassador/0 "network-get ambassador"`
- The ingress address should remain the configured FQDN.
```
bind-addresses:
- macaddress: ""
  interfacename: ""
  addresses:
  - hostname: ""
    address: 10.1.57.4
    cidr: ""
ingress-addresses:
- af9e186bcdc214fe58c8261d64c775d4-968168728.us-east-1.elb.amazonaws.com
```

## Documentation changes

Not sure the particular behaviour of the `network-get` hook tool goes into this detail, but if it does we should reflect the change in behaviour.

## Bug reference

N/A
