### PR TITLE
Ensure we normalize the channel

### DIFF
--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -209,7 +209,11 @@ func makeChannel(origin params.CharmOrigin) (corecharm.Channel, error) {
 	if track == "" && origin.Risk == "" {
 		return corecharm.Channel{}, nil
 	}
-	return corecharm.MakeChannel(track, origin.Risk, "")
+	ch, err := corecharm.MakeChannel(track, origin.Risk, "")
+	if err != nil {
+		return corecharm.Channel{}, errors.Trace(err)
+	}
+	return ch.Normalize(), nil
 }
 
 func findChannelMap(rev int, preferredChannel corecharm.Channel, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, error) {


### PR DESCRIPTION
Although generally not required for speaking to the charmhub API we
should ensure that we present a normalized channel for the request. The
change is really simple and I'm starting to question if we shouldn't
just normalize everywhere, except that you have to really know that
"latest/stable" == "stable". "latest" is a special keyword that is
dropped from a track and it makes it very confusing if you're not aware
of that.

## QA steps

Save this bundle.yaml:

```yaml
services:
    ntp:
        charm: ntp
    mysql:
        charm: mysql
        num_units: 1
relations:
    - ["ntp:juju-info", "mysql:juju-info"]
```

```sh
$ juju bootstrap lxd test
$ juju deploy ./bundle.yaml
Resolving charm via charmhub: ch:mysql
Resolving charm via charmhub: ch:ntp
Executing changes:
- upload charm ch:mysql-58
- deploy application mysql using ch:mysql-58
- add relation ntp:juju-info - mysql:juju-info
- add unit mysql/0 to new machine 1
Deploy of bundle completed.
```
