### PR TITLE
Remove charm hub integration feature flag

### DIFF
--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -30,7 +30,6 @@ import (
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
@@ -220,45 +219,6 @@ func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
 }
 
 func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
-	tests := []struct {
-		path string
-		url  *charm.URL
-		err  error
-	}{{
-		path: "wordpress",
-		url:  &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
-	}, {
-		path: "cs:wordpress",
-		url:  &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
-	}, {
-		path: "local:wordpress",
-		url:  &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
-	}, {
-		path: "cs:~user/series/name",
-		url:  &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
-	}, {
-		path: "~user/series/name",
-		url:  &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
-	}, {
-		path: "ch:~user/series/name",
-		err:  errors.Errorf(`unexpected charm schema: cannot parse URL "ch:~user/series/name": schema "ch" not valid`),
-	}}
-	for i, test := range tests {
-		c.Logf("%d %s", i, test.path)
-		url, err := resolveCharmURL(test.path)
-		if test.err != nil {
-			c.Assert(err, gc.ErrorMatches, test.err.Error())
-		} else {
-			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(url, gc.DeepEquals, test.url)
-		}
-	}
-}
-
-func (s *deployerSuite) TestResolveCharmURLCharmHubIntegration(c *gc.C) {
-	setFeatureFlags(feature.CharmHubIntegration)
-	defer setFeatureFlags("")
-
 	tests := []struct {
 		path string
 		url  *charm.URL

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -17,7 +17,6 @@ import (
 
 	commoncharm "github.com/juju/juju/api/common/charm"
 	corecharm "github.com/juju/juju/core/charm"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 )
 
@@ -441,9 +440,6 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithOriginChannel(c *gc.C) {
 }
 
 func (s *charmHubCharmRefresherSuite) TestAllowed(c *gc.C) {
-	setFeatureFlags(feature.CharmHubIntegration)
-	defer setFeatureFlags("")
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -466,9 +462,6 @@ func (s *charmHubCharmRefresherSuite) TestAllowed(c *gc.C) {
 }
 
 func (s *charmHubCharmRefresherSuite) TestAllowedWithSwitch(c *gc.C) {
-	setFeatureFlags(feature.CharmHubIntegration)
-	defer setFeatureFlags("")
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -494,9 +487,6 @@ func (s *charmHubCharmRefresherSuite) TestAllowedWithSwitch(c *gc.C) {
 }
 
 func (s *charmHubCharmRefresherSuite) TestAllowedError(c *gc.C) {
-	setFeatureFlags(feature.CharmHubIntegration)
-	defer setFeatureFlags("")
-
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -558,11 +558,9 @@ func registerCommands(r commandRegistry) {
 	r.Register(resource.NewCharmResourcesCommand(nil))
 
 	// CharmHub related commands
-	if featureflag.Enabled(feature.CharmHubIntegration) {
-		r.Register(charmhub.NewInfoCommand())
-		r.Register(charmhub.NewFindCommand())
-		r.Register(charmhub.NewDownloadCommand())
-	}
+	r.Register(charmhub.NewInfoCommand())
+	r.Register(charmhub.NewFindCommand())
+	r.Register(charmhub.NewDownloadCommand())
 
 	// Commands registered elsewhere.
 	for _, newCommand := range registeredCommands {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -497,7 +497,6 @@ var commandNames = []string{
 // optionalFeatures are feature flags that impact registration of commands.
 var optionalFeatures = []string{
 	feature.ActionsV2,
-	feature.CharmHubIntegration,
 }
 
 // These are the commands that are behind the `devFeatures`.

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -96,7 +96,7 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "juju help foo doesn't exist",
 		args:    []string{"help", "foo"},
 		code:    1,
-		out:     missingCommandMessage("foo", "gui"),
+		out:     missingCommandMessage("foo", "find"),
 	}, {
 		summary: "juju help deploy shows the default help without global options",
 		args:    []string{"help", "deploy"},
@@ -338,6 +338,7 @@ var commandNames = []string{
 	"disable-command",
 	"disable-user",
 	"disabled-commands",
+	"download",
 	"download-backup",
 	"enable-command",
 	"enable-destroy-controller",
@@ -346,6 +347,7 @@ var commandNames = []string{
 	"exec",
 	"export-bundle",
 	"expose",
+	"find",
 	"find-offers",
 	"firewall-rules",
 	"get-constraints",
@@ -359,6 +361,7 @@ var commandNames = []string{
 	"hook-tools",
 	"import-filesystem",
 	"import-ssh-key",
+	"info",
 	"kill-controller",
 	"list-actions",
 	"list-agreements",
@@ -502,7 +505,6 @@ var optionalFeatures = []string{
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(
 	"run", "show-task", "operations", "list-operations", "show-operation",
-	"info", "find", "download",
 )
 
 func (s *MainSuite) TestHelpCommands(c *gc.C) {

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -152,7 +152,7 @@ func (suite *PluginSuite) TestHelpPluginNameNotAPlugin(c *gc.C) {
 	expectedHelp := `ERROR juju: "foo" is not a juju command. See "juju --help".
 
 Did you mean:
-	gui
+	find
 `
 	c.Assert(output, gc.Matches, expectedHelp)
 }
@@ -162,7 +162,7 @@ func (suite *PluginSuite) TestHelpPluginNameAsPathIsNotAPlugin(c *gc.C) {
 	expectedHelp := `ERROR juju: "/foo" is not a juju command. See "juju --help".
 
 Did you mean:
-	bind
+	info
 `
 	c.Assert(output, gc.Matches, expectedHelp)
 }
@@ -172,7 +172,7 @@ func (suite *PluginSuite) TestHelpPluginNameWithSpecialPrefixWhichIsNotAPathAndP
 	expectedHelp := `ERROR juju: ".foo" is not a juju command. See "juju --help".
 
 Did you mean:
-	bind
+	info
 `
 	c.Assert(output, gc.Matches, expectedHelp)
 }

--- a/cmd/juju/commands/repl_test.go
+++ b/cmd/juju/commands/repl_test.go
@@ -207,7 +207,7 @@ func (s *ReplSuite) TestMissingCommandHelp(c *gc.C) {
 ERROR juju: "foo" is not a juju command. Type "help" to see a list of commands.
 
 Did you mean:
-	gui
+	find
 `[1:])
 }
 

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -53,7 +53,3 @@ const RawK8sSpec = "raw-k8s-spec"
 
 // ActionsV2 enables the next generation actions UX.
 const ActionsV2 = "actions-v2"
-
-// CharmHubIntegration enables the new commands and functionality related to
-// charm's in CharmHub.
-const CharmHubIntegration = "charm-hub"


### PR DESCRIPTION

With this change, charms will be deployed from charmhub by default.  To use charmstore charms, deploy with cs:<charm-name>.  No change to local charms.

## QA steps

```console
# Ensure the feature flag is not In use.
$ unset JUJU_DEV_FEATURE_FLAGS

$ juju bootstrap localhost no-feature-flag
$ juju add-model nine --config charm-hub-url="https://api.staging.snapcraft.io"

# Deploy charms from all 3 sources.
$ juju deploy ubuntu-devenv
Located charm "ubuntu-devenv" in charm-hub, revision 6
Deploying "ubuntu-devenv" from charm-hub charm "ubuntu-devenv", revision 6 in channel latest/stable
$ juju deploy cs:ubuntu
Located charm "ubuntu" in charm-store, revision 16
Deploying "ubuntu" from charm-store charm "ubuntu", revision 16 in channel stable
$ juju deploy ./acceptancetests/repository/charms/ubuntu ubuntu-test
Located local charm "ubuntu", revision 1
Deploying "ubuntu-test" from local charm "ubuntu", revision 1

# Verify charmhub only commands work without the feature flag
$ juju find ubuntu
Name                     Bundle  Version  Publisher              Summary
ubuntu                   -       17       charmers               A pristine Ubuntu Server
ubuntu-repository-cache  -       24       cloud-images           Ubuntu archive caching proxy mirror
ubuntu-devenv            -       6        kwmonroe               Simple Ubuntu development and test environment
...
$ juju info ubuntu
name: ubuntu
charm-id: 9NT4sM1gdNLkBPuXbxNu2IusUosDcmR9
summary: A pristine Ubuntu Server
publisher: charmers
supports: xenial, bionic, artful, cosmic, disco, trusty, focal
tags: misc
subordinate: false
store-url: https://staging-api.charmhub.io/ubuntu
description: |
  This simply deploys the Ubuntu Cloud/Server image
channels: |
  latest/stable:     17  2020-11-11  (17)  5MB
  latest/candidate:  ↑
  latest/beta:       ↑
  latest/edge:       ↑
```

