### PR TITLE
get resource filename from charmhub

### DIFF
--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -248,7 +248,7 @@ func resourceFromRevision(rev transport.ResourceRevision) (charmresource.Resourc
 		Meta: charmresource.Meta{
 			Name:        rev.Name,
 			Type:        resType,
-			Path:        rev.Path,
+			Path:        rev.Filename,
 			Description: rev.Description,
 		},
 		Origin:      charmresource.OriginStore,

--- a/apiserver/facades/client/resources/repository_test.go
+++ b/apiserver/facades/client/resources/repository_test.go
@@ -34,13 +34,13 @@ func (s *CharmHubClientSuite) TestResolveResources(c *gc.C) {
 	fp, err := charmresource.ParseFingerprint("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b")
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
-		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:      charmresource.OriginUpload,
 		Revision:    1,
 		Fingerprint: fp,
 		Size:        0,
 	}, {
-		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:      charmresource.OriginStore,
 		Revision:    2,
 		Fingerprint: fp,
@@ -48,13 +48,13 @@ func (s *CharmHubClientSuite) TestResolveResources(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []charmresource.Resource{{
-		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:      charmresource.OriginUpload,
 		Revision:    1,
 		Fingerprint: fp,
 		Size:        0,
 	}, {
-		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:      charmresource.OriginStore,
 		Revision:    2,
 		Fingerprint: fp,
@@ -73,14 +73,14 @@ func (s *CharmHubClientSuite) TestResolveResourcesFromStore(c *gc.C) {
 	fp, err := charmresource.ParseFingerprint("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b")
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
-		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   charmresource.OriginStore,
 		Revision: 1,
 		Size:     0,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []charmresource.Resource{{
-		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:      charmresource.OriginStore,
 		Revision:    1,
 		Fingerprint: fp,
@@ -97,7 +97,7 @@ func (s *CharmHubClientSuite) TestResolveResourcesNoMatchingRevision(c *gc.C) {
 	s.expectRefreshWithRevision(99)
 
 	_, err := s.newClient().ResolveResources([]charmresource.Resource{{
-		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   charmresource.OriginStore,
 		Revision: 1,
 		Size:     0,
@@ -112,7 +112,7 @@ func (s *CharmHubClientSuite) TestResolveResourcesUpload(c *gc.C) {
 	s.expectRefresh()
 
 	result, err := s.newClient().ResolveResources([]charmresource.Resource{{
-		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   1,
 		Revision: 3,
 		Fingerprint: charmresource.Fingerprint{
@@ -121,7 +121,7 @@ func (s *CharmHubClientSuite) TestResolveResourcesUpload(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []charmresource.Resource{{
-		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "", Description: ""},
+		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
 		Origin:   1,
 		Revision: 3,
 		Fingerprint: charmresource.Fingerprint{
@@ -173,8 +173,8 @@ func (s *CharmHubClientSuite) expectRefreshWithRevision(rev int) {
 						Name:        "wal-e",
 						Revision:    rev,
 						Type:        "file",
-						Path:        "",
-						Description: "",
+						Filename:    "wal-e.snap",
+						Description: "WAL-E Snap Package",
 					},
 				},
 				Summary: "PostgreSQL object-relational SQL database (supported version)",

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -97,8 +97,10 @@ func refreshResponseToCharmhubResult(response transport.RefreshResponse) charmhu
 		}
 		resource := resource.Resource{
 			Meta: resource.Meta{
-				Name: r.Name,
-				Type: typ,
+				Name:        r.Name,
+				Type:        typ,
+				Path:        r.Filename,
+				Description: r.Description,
 			},
 			Origin:      resource.OriginStore,
 			Revision:    r.Revision,

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -59,9 +59,7 @@ var resourceFilter = []string{
 	"download.url",
 	"name",
 	"revision",
-	// TODO (hml) 8-dec-2020
-	// Use once the api knows about them.
-	//"path",
-	//"description",
+	"filename",
+	"description",
 	"type",
 }

--- a/charmhub/transport/resources.go
+++ b/charmhub/transport/resources.go
@@ -11,7 +11,7 @@ type ResourceRevision struct {
 	Download    ResourceDownload `json:"download"`
 	Description string           `json:"description"`
 	Name        string           `json:"name"`
-	Path        string           `json:"path"`
+	Filename    string           `json:"filename"`
 	Revision    int              `json:"revision"`
 	Type        string           `json:"type"`
 }

--- a/resource/resourceadapters/charmhub.go
+++ b/resource/resourceadapters/charmhub.go
@@ -145,7 +145,7 @@ func resourceFromRevision(name string, revs []transport.ResourceRevision) (charm
 		Meta: charmresource.Meta{
 			Name:        rev.Name,
 			Type:        resType,
-			Path:        rev.Path,
+			Path:        rev.Filename,
 			Description: rev.Description,
 		},
 		Origin:   charmresource.OriginStore,


### PR DESCRIPTION
The CharmHub api now returns filepath and description in the ResourceRevision objects.  Uncomment the fields, so we receive the data.

Filename was expected to be path, so some renaming was necessary.

Added filename and description use in the resource Meta in the charmrevisionupdater facade.

## QA steps

```console
export JUJU_DEV_FEATURE_FLAGS="charm-hub"
juju bootstrap localhost
juju add-model six --config charm-hub-url="https://api.staging.snapcraft.io"

# Deploy a CharmHub charm with resources, set the region to trigger resource_get in the charm.
juju deploy postgresql --config aws_region="us-east-1"
# wait for the charm to install and try to get the resource successfully
# there will be a status message about installing the Wal-e snap
$ juju show-status-log postgresql/0
Time                   Type       Status       Message
....
08 Dec 2020 22:27:55Z  juju-unit  executing    running install hook
08 Dec 2020 22:28:52Z  workload   maintenance  Updating apt cache
08 Dec 2020 22:28:54Z  workload   maintenance  Installing wal-e snap
```

