### PR TITLE
Fix charmhub composeHeaders with multiple headers

### DIFF
--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -209,12 +209,16 @@ func (c *HTTPRESTClient) Post(ctx context.Context, path path.Path, headers http.
 func (c *HTTPRESTClient) composeHeaders(headers http.Header) http.Header {
 	result := make(http.Header)
 	// Consume the new headers.
-	for k := range headers {
-		result.Set(k, headers.Get(k))
+	for k, vs := range headers {
+		for _, v := range vs {
+			result.Add(k, v)
+		}
 	}
-	// Ensure the client headers overwrite the existing headers.
-	for k := range c.headers {
-		result.Set(k, c.headers.Get(k))
+	// Add the client's headers as well.
+	for k, vs := range c.headers {
+		for _, v := range vs {
+			result.Add(k, v)
+		}
 	}
 	return result
 }

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -152,6 +152,26 @@ func (s *RESTSuite) TestGetWithUnmarshalFailure(c *gc.C) {
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
+func (s *RESTSuite) TestComposeHeaders(c *gc.C) {
+	clientHeaders := http.Header{
+		"User-Agent":      []string{"Juju/3.14.159"},
+		"X-Juju-Metadata": []string{"cloud=cloud-9", "cloud_region=juju-land"},
+	}
+	requestHeaders := http.Header{
+		"X-Juju-Metadata": []string{"arch=amd64", "os=ubuntu", "series=focal"},
+		"Something-Else":  []string{"foo"},
+	}
+
+	client := NewHTTPRESTClient(nil, clientHeaders)
+	got := client.composeHeaders(requestHeaders)
+
+	c.Assert(got, gc.DeepEquals, http.Header{
+		"User-Agent":      []string{"Juju/3.14.159"},
+		"X-Juju-Metadata": []string{"arch=amd64", "os=ubuntu", "series=focal", "cloud=cloud-9", "cloud_region=juju-land"},
+		"Something-Else":  []string{"foo"},
+	})
+}
+
 func emptyResponse() *http.Response {
 	return &http.Response{
 		Header:     MakeContentTypeHeader("application/json"),


### PR DESCRIPTION
It currently assumes the headers are unique, but in fact you can have
multiple headers with the same key (eg: X-Juju-Metadata). This fixes
that behaviour and adds a unit test for composeHeaders.

This does change the behavior, in that headers from the client won't
override/clear headers on the request. But the headers we send are
unique, except for X-Juju-Metadata (where we don't want this behavior
anyway).

I found this during manual testing when looking at the TRACE logs.
(See QA steps for PR https://github.com/juju/juju/pull/12400).

BEFORE (note there's only one X-Juju-Metadata header from the client):

```
machine-0: 14:21:25 TRACE juju.apiserver.charmrevisionupdater.charmhub POST request POST /v2/charms/refresh HTTP/1.1
Host: api.staging.snapcraft.io
Accept: application/json
Content-Type: application/json
User-Agent: Juju/2.9-rc3.2
X-Juju-Metadata: cloud=localhost
X-Juju-Metadata: series=xenial
X-Juju-Metadata: arch=all
X-Juju-Metadata: os=ubuntu
```

AFTER (all model-related headers are present):

```
machine-0: 15:30:07 TRACE juju.apiserver.charmrevisionupdater.charmhub POST request POST /v2/charms/refresh HTTP/1.1
Host: api.staging.snapcraft.io
Accept: application/json
Content-Type: application/json
User-Agent: Juju/2.9-rc3.3
X-Juju-Metadata: cloud=localhost
X-Juju-Metadata: cloud_region=localhost
X-Juju-Metadata: controller_uuid=64e5c8c9-8076-44f2-81c1-d98b39292deb
X-Juju-Metadata: controller_version=2.9-rc3.3
X-Juju-Metadata: is_controller=false
X-Juju-Metadata: model_uuid=e45cef0d-3551-4937-8895-14b5f4c087ae
X-Juju-Metadata: provider=lxd
X-Juju-Metadata: arch=all
X-Juju-Metadata: os=ubuntu
X-Juju-Metadata: series=xenial
```
