### PR TITLE
Fix client facade not setting CanUpgradeTo for charmhub charms

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -772,8 +772,11 @@ func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos net
 			unitMap[app.Name()] = appUnits
 			// Record the base URL for the application's charm so that
 			// the latest store revision can be looked up.
-			if charmURL.Schema == "cs" {
+			switch {
+			case charm.CharmHub.Matches(charmURL.Schema), charm.CharmStore.Matches(charmURL.Schema):
 				latestCharms[*charmURL.WithRevision(-1)] = nil
+			default:
+				// Don't look up revision for local charms
 			}
 		}
 

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -839,6 +839,7 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *statusUpgradeUnitSuite) TearDownTest(c *gc.C) {
+	s.JujuConnSuite.TearDownTest(c)
 	s.ctrl.Finish()
 }
 

--- a/testcharms/charm-hub/quantal/charmhubby/metadata.yaml
+++ b/testcharms/charm-hub/quantal/charmhubby/metadata.yaml
@@ -1,0 +1,6 @@
+name: charmhubby
+summary: "A test CharmHub charm"
+description: "Just a silly test"
+provides:
+  server:
+    interface: charmhubber

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -32,7 +32,7 @@ const (
 var Repo = testing.NewRepo(localCharmRepo, defaultSeries)
 
 // Hub provides access to the test charmhub repository.
-var Hub = testing.NewRepo(localCharmHub, "focal")
+var Hub = testing.NewRepo(localCharmHub, defaultSeries)
 
 // RepoForSeries returns a new charm repository for the specified series.
 // Note: this is a bit weird, as it ignores the series if it's NOT kubernetes


### PR DESCRIPTION
There was an 'if charmURL.Schema == "cs" { ... }' in the code, which
was originally intended to mean "if this charm is not local", but
obviously it prevents charmhub "ch" URLs from being included. Simply
update it to include both stores.

This prevented "juju status --format=yaml" showing the can-upgrade-to
information when new revisions were available.

Prior to this change the following code on
apiserver/facades/client/client/status.go:1190 didn't execute, because
the latestCharm wasn't set.

```
	if latestCharm, ok := context.allAppsUnitsCharmBindings.latestCharms[*applicationCharm.URL().WithRevision(-1)]; ok && latestCharm != nil {
		if latestCharm.Revision() > applicationCharm.URL().Revision {
			processedStatus.CanUpgradeTo = latestCharm.String()
		}
	}
```

## QA steps

Perform QA steps at https://github.com/juju/juju/pull/12400, then either update a charm on charmhub (probably not possible), or locally hack the charmrevisionupdater to return currentRevision+1, like so:

```
updater.go:299
		latest = append(latest, latestCharmInfo{
			url:       appInfo.charmURL.WithRevision(result.revision + 1),
			timestamp: result.timestamp,
			revision:  result.revision + 1,
			resources: result.resources,
			appID:     appInfo.id,
		})
```

Then when you run `juju status mysql --format=yaml` it will show no `can-upgrade-to` field before this fix, but a `can-upgrade-to` URL with the revision+1 after this fix.