### PR TITLE
Ensure origin with non-empty architecture for local charms

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -5,8 +5,6 @@ package application
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/juju/charm/v8"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"
@@ -91,14 +89,6 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Ap
 		asa.Constraints = args.Constraints
 	}
 	return st.AddApplication(asa)
-}
-
-func quoteStrings(vals []string) string {
-	out := make([]string, len(vals))
-	for i, val := range vals {
-		out[i] = strconv.Quote(val)
-	}
-	return strings.Join(out, ", ")
 }
 
 // addUnits starts n units of the given application using the specified placement

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -5,7 +5,6 @@ package deployer
 
 import (
 	"fmt"
-
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -333,11 +333,13 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		return errors.Trace(err)
 	}
 
-	// We know 100% that this will be a local charm, so don't attempt to
-	// deduce the origin and just use the correct one to prevent any case that
-	// the origin could be wrong.
-	origin := commoncharm.Origin{
-		Source: commoncharm.OriginLocal,
+	platform, err := utils.DeducePlatform(d.constraints, d.userCharmURL.Series)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	origin, err := utils.DeduceOrigin(userCharmURL, corecharm.Channel{}, platform)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	d.id = application.CharmID{
@@ -373,11 +375,13 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 		return errors.Trace(err)
 	}
 
-	// We know 100% that this will be a local charm, so don't attempt to
-	// deduce the origin and just use the correct one to prevent any case that
-	// the origin could be wrong.
-	origin := commoncharm.Origin{
-		Source: commoncharm.OriginLocal,
+	platform, err := utils.DeducePlatform(l.constraints, l.curl.Series)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{}, platform)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	ctx.Infof(formatLocatedText(curl, origin))

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/arch"
 	osseries "github.com/juju/os/v2/series"
 
 	commoncharm "github.com/juju/juju/api/common/charm"
@@ -31,8 +32,20 @@ func DeduceOrigin(url *charm.URL, channel corecharm.Channel, platform corecharm.
 			Series: platform.Series,
 		}, nil
 	case "local":
+		// Arch is ultimately determined for non-local cases in the API call
+		// to `ResolveCharm`. This is not called for local charms, which are
+		// simply uploaded and deployed. We satisfy the requirement for
+		// non-empty platform architecture by making our best guess here.
+		architecture := platform.Architecture
+		if architecture == "" {
+			architecture = arch.DefaultArchitecture
+		}
+
 		return commoncharm.Origin{
-			Source: commoncharm.OriginLocal,
+			Source:       commoncharm.OriginLocal,
+			Architecture: architecture,
+			OS:           platform.OS,
+			Series:       platform.Series,
 		}, nil
 	default:
 		var track *string


### PR DESCRIPTION
Model migration acceptance tests are failing during model export.

This is due to an error return from the call to `MakePlatform` in `core/charm`, when passed an empty architecture. This in turn is due to the fact that local charm applications are stored with an empty `Platform`.

This patch ensures that applications based on local charms are stored with a populated platform. This data does not inform any decisions in Juju logic, but serves to make application modelling consistent so that we can simplify any future work in the area.

## QA steps

- Bootstrap a _src_ controller.
- Deploy a local charm (such as _simple-http-resource_ in the acceptance test repo).
- Bootstrap a _dst_ controller and delete the _default_ model.
- Migrate the _default_ model from _src_ to _dst_.

## Documentation changes

None.

## Bug reference

N/A
