### PR TITLE
Avoid loading all statuses during upgrade.

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -35,6 +35,12 @@ import (
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
 
+// MaxDocOps defines the number of documents to put into a single transaction,
+// if we make this number too large, mongo and client side transactions
+// struggle to complete. It is unclear what the optimum is, but without some
+// sort of cap, we've seen txns try to touch 100k docs which makes things fail.
+const MaxDocOps = 2000
+
 // runForAllModelStates will run runner function for every model passing a state
 // for that model.
 func runForAllModelStates(pool *StatePool, runner func(st *State) error) error {
@@ -2903,6 +2909,7 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
 		col, closer := st.db().GetCollection(statusesC)
 		defer closer()
+                totalOps := 0
 
 		iter := col.Find(bson.M{"neverset": bson.M{"$exists": 1}}).Iter()
 
@@ -2938,12 +2945,26 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 				Assert: txn.DocExists,
 				Update: update,
 			})
+                        if len(ops) > MaxDocOps {
+                            totalOps += len(ops)
+                            upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
+                            err = st.db().RunTransaction(ops)
+                            if err != nil {
+                                return errors.Trace(err)
+                            }
+                            ops = ops[:0]
+                        }
 		}
 		if err := iter.Close(); err != nil {
 			return errors.Trace(err)
 		}
 
-		return errors.Trace(st.db().RunTransaction(ops))
+                if len(ops) > 0 {
+                    totalOps += len(ops)
+                    upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
+                    return errors.Trace(st.db().RunTransaction(ops))
+                }
+                return nil
 	}))
 }
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2909,7 +2909,7 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
 		col, closer := st.db().GetCollection(statusesC)
 		defer closer()
-                totalOps := 0
+		totalOps := 0
 
 		iter := col.Find(bson.M{"neverset": bson.M{"$exists": 1}}).Iter()
 
@@ -2945,26 +2945,26 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 				Assert: txn.DocExists,
 				Update: update,
 			})
-                        if len(ops) > MaxDocOps {
-                            totalOps += len(ops)
-                            upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
-                            err = st.db().RunTransaction(ops)
-                            if err != nil {
-                                return errors.Trace(err)
-                            }
-                            ops = ops[:0]
-                        }
+			if len(ops) > MaxDocOps {
+				totalOps += len(ops)
+				upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
+				err = st.db().RunTransaction(ops)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				ops = ops[:0]
+			}
 		}
 		if err := iter.Close(); err != nil {
 			return errors.Trace(err)
 		}
 
-                if len(ops) > 0 {
-                    totalOps += len(ops)
-                    upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
-                    return errors.Trace(st.db().RunTransaction(ops))
-                }
-                return nil
+		if len(ops) > 0 {
+			totalOps += len(ops)
+			upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
+			return errors.Trace(st.db().RunTransaction(ops))
+		}
+		return nil
 	}))
 }
 


### PR DESCRIPTION
On Prodstack, we have 160k statuses documents (which seems too big but is
a different issue.)

This at least should allow upgrades to progress, even if it dies in the
middle, it won't have to load as many documents the next time.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

I was able to get a copy of the statuses.bson that was in prodstack (160k statuses). However, it appears that we upgrade each model's status docs one model at a time. And we won't upgrade status documents that aren't in models that we know about. So we had to massage the data to match our current models. Also, there will be some txns that no longer exist, so we need to mgopurge them.

I then did:
```
$ sudo snap install juju --channel=2.7/stable
$ /snap/bin/juju bootstrap lxd lxd
$ juju switch controller
$ juju scp ./statuses.bson 0:.
$ juju ssh 0
$$ agent=$(cd /var/lib/juju/agents; echo machine-*)
$$ pw=$(sudo grep statepassword /var/lib/juju/agents/${agent}/agent.conf | cut '-d ' -sf2)
$$ sudo systemctl stop jujud-machine-0
$$ mongorestore --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates --host localhost --port 37017 --db juju -c statuses ./statuses.bson
...
2020-12-14T15:03:47.276+0000    finished restoring juju.statuses (161023 documents)
...
$$ mongo --ssl -u ${agent} -p $pw --authenticationDatabase admin --sslAllowInvalidHostnames --sslAllowInvalidCertificates localhost:37017/juju

juju:PRIMARY> db.statuses.find({"neverset": {$exists:1}}).count()
161023
juju:PRIMARY> db.statuses.count()
161038
juju:PRIMARY> target_uuid = db.models.find().limit(1).next()._id
# find the biggest models
juju:PRIMARY> db.statuses.aggregate([{$group: {_id: {uuid: "$model-uuid"}, count: {$sum: 1}}}, {$sort: {count:-1}}])
{ "_id" : { "uuid" : "3159938e-bdb4-461c-8891-6a2cfc3d4e6a" }, "count" : 47373 }
{ "_id" : { "uuid" : "844969a0-e800-4047-887e-70119d1a0b82" }, "count" : 44435 }
...
juju:PRIMARY> db.statuses.find({"model-uuid": "3159938e-bdb4-461c-8891-6a2cfc3d4e6a"}).forEach(function(doc){
  var cp = doc; cp["model-uuid"] = target_uuid;
  cp._id = target_uuid + doc._id.substring(36);
  db.statuses.insert(cp);
})
juju:PRIMARY> db.statuses.find({"model-uuid": "844969a0-e800-4047-887e-70119d1a0b82"}).forEach(function(doc){
  var cp = doc; cp["model-uuid"] = target_uuid;
  cp._id = target_uuid + doc._id.substring(36);
  db.statuses.insert(cp);
})
# confirm the existing model is now the biggest
juju:PRIMARY> db.statuses.aggregate([{$group: {_id: {uuid: "$model-uuid"}, count: {$sum: 1}}}, {$sort: {count:-1}}])
{ "_id" : { "uuid" : "f92733d6-a9c3-4d90-8a78-f995d23b0085" }, "count" : 91814 }
{ "_id" : { "uuid" : "3159938e-bdb4-461c-8891-6a2cfc3d4e6a" }, "count" : 47373 }
{ "_id" : { "uuid" : "844969a0-e800-4047-887e-70119d1a0b82" }, "count" : 44435 }
...
$$ sudo snap install mgopurge
$$ mgopurge --username ${agent} --password ${pw} --stages purgemissing,resume
$$ sudo systemctl start jujud-machine-0
$ juju upgrade-controller --build-agent
```

With this patch in juju debug-log you should see statements like:
```
2020-12-14 17:12:19 INFO juju.state.upgrade upgrades.go:2950 flushing updated 2001 statuses (2001 total)
...
2020-12-14 17:29:25 INFO juju.state.upgrade upgrades.go:2964 updating 1769 statuses (91814 total)
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1907685
