### PR TITLE
Add architecture to deploy stack

### DIFF
--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -288,6 +288,8 @@ def add_basic_testing_arguments(
                         help='Stream for retrieving agent binaries.')
     parser.add_argument('--series', action='store', default=None,
                         help='Name of the Ubuntu series to use.')
+    parser.add_argument('--arch', action='store', default=None,
+                        help='Name of the architecture to use.')
     if not using_jes:
         parser.add_argument('--upload-tools', action='store_true',
                             help='upload local version of tools to bootstrap.')


### PR DESCRIPTION
The following adds architecture to bootstrap when using acceptance
tests. I'm unsure that this covers ALL the tests as it's a bit of a
black box, but it did seem to work correctly when attempting to deploy
an amd64 box with the following args:

```
./deploy_job.py --series=xenial --arch=amd64
```

The amount of indirection in here is NUTS. We probably want to clean
this up or gut it for charmhub.


## QA steps

Follow the README docs in acceptance tests and run the following:

```sh
./deploy_job.py --series=xenial --arch=amd64
```

You'll see that we bootstrap with the correct constraints now!

```sh
2020-12-11 16:22:13 INFO juju --show-log bootstrap lxd/localhost deploystack-20201211162213-temp-env --config /tmp/tmpkwvqchtd.yaml --constraints arch=amd64 mem=6G --default-model deploystack-20201211162213-temp-env --agent-version 2.9-rc3 --bootstrap-series xenial
```
