### PR TITLE
platform "all" no longer needed for charmhub charms imported from the charm store

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -292,7 +292,7 @@ func normalizeCharmOrigin(origin params.CharmOrigin) (params.CharmOrigin, error)
 	}
 
 	var arc string
-	if arc != "all" {
+	if origin.Architecture != "all" {
 		arc = origin.Architecture
 	} else {
 		logger.Warningf("Architecture all detected, removing all from the origin. %s", origin.ID)

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -276,7 +276,7 @@ func normalizeCharmOrigin(origin params.CharmOrigin) (params.CharmOrigin, error)
 	var os string
 	var oSeries string
 	if origin.Series == "all" {
-		logger.Tracef("Series all detected, removing all from the origin. %s", origin.ID)
+		logger.Warningf("Series all detected, removing all from the origin. %s", origin.ID)
 	} else if origin.Series != "" {
 		// Always set the os from the series, so we know it's correctly
 		// normalized for the rest of Juju.
@@ -287,12 +287,15 @@ func normalizeCharmOrigin(origin params.CharmOrigin) (params.CharmOrigin, error)
 		// Values passed to the api are case sensitive: ubuntu succeeds and
 		// Ubuntu returns `"code": "revision-not-found"`
 		os = strings.ToLower(sys.String())
+
 		oSeries = origin.Series
 	}
 
 	var arc string
-	if origin.Architecture != "all" {
+	if arc != "all" {
 		arc = origin.Architecture
+	} else {
+		logger.Warningf("Architecture all detected, removing all from the origin. %s", origin.ID)
 	}
 
 	o := origin
@@ -338,7 +341,7 @@ func (a *API) addCharmWithAuthorization(args params.AddCharmWithAuth) (params.Ch
 		return params.CharmOriginResult{}, errors.Errorf("unknown schema for charm URL %q", args.URL)
 	}
 
-	if args.Origin.Source == "charm-hub" && args.Series == "" {
+	if args.Origin.Source == "charm-hub" && args.Origin.Series == "" {
 		return params.CharmOriginResult{}, errors.BadRequestf("series required for charm-hub charms")
 	}
 

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -81,13 +81,13 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
-	resURL, resOrigin, serie, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
+	resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
 
 	resOrigin.ID = info.ID
-	return resURL, resOrigin, serie, nil
+	return resURL, resOrigin, series, nil
 }
 
 // DownloadCharm downloads the provided download URL from CharmHub using the
@@ -174,10 +174,7 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 		err error
 
 		platform = charmhub.RefreshPlatform{
-			// TODO (stickupkid): FIX ME, charmhub ignores architecture
-			// "sometimes"...
-			// Architecture: origin.Platform.Architecture,
-			Architecture: "all",
+			Architecture: origin.Platform.Architecture,
 			OS:           origin.Platform.OS,
 			Series:       origin.Platform.Series,
 		}

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -72,6 +72,49 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	c.Assert(responses[0].Name, gc.Equals, id)
 }
 
+//	c.Assert(results.Results[0].Error, gc.ErrorMatches, `.* pool "foo" not found`)
+func (s *RefreshSuite) TestRefeshConfigValidateArch(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "ubuntu",
+		Series:       "focal",
+		Architecture: "all",
+	})
+	c.Assert(err, gc.ErrorMatches, "Architecture.*")
+}
+
+func (s *RefreshSuite) TestRefeshConfigValidateSeries(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "ubuntu",
+		Series:       "all",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, gc.ErrorMatches, "Series.*")
+}
+
+func (s *RefreshSuite) TestRefeshConfigValidateOS(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "all",
+		Series:       "focal",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, gc.ErrorMatches, "OS.*")
+}
+
+func (s *RefreshSuite) TestRefeshConfigValidate(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "all",
+		Series:       "all",
+		Architecture: "all",
+	})
+	c.Assert(err, gc.ErrorMatches, "Architecture.*, OS.*, Series.*")
+}
+
+func (s *RefreshSuite) testRefeshConfigValidate(c *gc.C, rp RefreshPlatform) error {
+	_, err := DownloadOneFromChannel("meshuggah", "latest/stable", rp)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	return err
+}
+
 type metadataTransport struct {
 	requestHeaders http.Header
 	responseBody   string

--- a/core/charm/strategies.go
+++ b/core/charm/strategies.go
@@ -44,6 +44,7 @@ type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
 	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
 
 	Child(name string) Logger
 }
@@ -279,7 +280,8 @@ func (p *Strategy) normalizePlatform(platform Platform) (Platform, error) {
 		os = strings.ToLower(sys.String())
 	}
 	arc := platform.Architecture
-	if platform.Architecture == "" {
+	if platform.Architecture == "" || platform.Architecture == "all" {
+		p.logger.Warningf("Received charm Architecture: %q, changing to %q, for charm %q", platform.Architecture, arch.DefaultArchitecture, p.charmURL)
 		arc = arch.DefaultArchitecture
 	}
 

--- a/core/charm/strategies_test.go
+++ b/core/charm/strategies_test.go
@@ -329,9 +329,10 @@ func mustWriteToTempFile(c *gc.C, mockCharm *MockStoreCharm) func(*charm.URL, st
 type fakeLogger struct {
 }
 
-func (l *fakeLogger) Errorf(_ string, _ ...interface{}) {}
-func (l *fakeLogger) Debugf(_ string, _ ...interface{}) {}
-func (l *fakeLogger) Tracef(_ string, _ ...interface{}) {}
+func (l *fakeLogger) Errorf(_ string, _ ...interface{})   {}
+func (l *fakeLogger) Debugf(_ string, _ ...interface{})   {}
+func (l *fakeLogger) Tracef(_ string, _ ...interface{})   {}
+func (l *fakeLogger) Warningf(_ string, _ ...interface{}) {}
 func (l *fakeLogger) Child(string) Logger {
 	return &fakeLogger{}
 }


### PR DESCRIPTION
The fix has been applied upstream in the charmhub server, juju no longer needs to use platform "all", removed TODO.

Added logging to charm origin platform normalization if we change the architecture from "all".  Good to know when it happens, to find out what happened later.  It's being set to the default architecture of "amd64" in that case.

Validate a charm origin platform when creating RefreshConfigs.  We do not want to send over the wire to CharmHub as it will fail.  This is code to say there is a programming error upstream.

## QA steps

```console
$ juju bootstrap localhost testing
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 17
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 17 in channel latest/stable
```