### PR TITLE
Fix tests on CentOS (invert err test)

### DIFF
--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -432,7 +432,7 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	defaultSeries.Add(config.PreferredSeries(conf))
 
 	hostSeries, err := series.HostSeries()
-	if err != nil {
+	if err == nil {
 		defaultSeries.Add(hostSeries)
 	}
 


### PR DESCRIPTION
@manadart [pointed out](https://github.com/juju/juju/pull/12341#issuecomment-741724626) that PR #12341 broke the unit tests on CentOS. Turned out to be a trivial logic bug that I'd introduced. Typed `if err != nil` one too any times, I guess. :-)

I've tested this locally by using gohack on `github.com/juju/os/v2` and overriding `hostSeries()` to return `centos8` -- breaks before the fix and works fine after, so hopefully it'll fix CentOS CI.
