### PR TITLE
Fix cmd/jujud/agent unit tests on s390x architecture

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1164,7 +1164,7 @@ func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported([]string{constraints.CpuPower, constraints.VirtType})
 	validator.RegisterConflicts([]string{constraints.InstanceType}, []string{constraints.Mem})
-	validator.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64, arch.I386, arch.PPC64EL})
+	validator.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64, arch.I386, arch.PPC64EL, arch.S390X})
 	return validator, nil
 }
 


### PR DESCRIPTION
The unit tests on s390x have been broken since PR #12369. Now that
we're deriving the architecture from the constraints, the dummy provider
needs to support s390x as well, otherwise
MachineSuite.TestManageModelRunsInstancePoller fails.

See [this Jenkins run](https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-s390x-bionic/180/testReport/github/com_juju_juju_cmd_jujud_agent/TestPackage/) for an example of failing output.

To repro locally, I patched arch.HostArch() at the start of the test:

```
func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
	s.AgentSuite.PatchValue(&arch.HostArch, func() string {
		return "s390x"
	})
	...
```

Then run:

```
go test ./cmd/jujud/agent -check.f TestManageModelRunsInstancePoller -test.v -check.vv
```
