### PR TITLE
2.8 into 2.9

### DIFF
--- a/api/upgrader/upgrader_test.go
+++ b/api/upgrader/upgrader_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/tools"
 )
 
 type machineUpgraderSuite struct {
@@ -92,18 +91,16 @@ func (s *machineUpgraderSuite) TestToolsNotMachine(c *gc.C) {
 
 func (s *machineUpgraderSuite) TestTools(c *gc.C) {
 	current := coretesting.CurrentVersion(c)
-	curTools := &tools.Tools{Version: current, URL: ""}
-	curTools.Version.Minor++
-	s.rawMachine.SetAgentVersion(current)
-	// Upgrader.Tools returns the *desired* set of tools, not the currently
-	// running set. We want to be upgraded to cur.Version
+	err := s.rawMachine.SetAgentVersion(current)
+	c.Assert(err, jc.ErrorIsNil)
+
 	stateToolsList, err := s.st.Tools(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
+
 	c.Assert(stateToolsList, gc.HasLen, 1)
 	stateTools := stateToolsList[0]
 	c.Assert(stateTools.Version, gc.Equals, current)
-	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
-		s.stateAPI.Addr(), coretesting.ModelTag.Id(), current)
+	url := fmt.Sprintf("https://%s/model/%s/tools/%s", s.stateAPI.Addr(), coretesting.ModelTag.Id(), current)
 	c.Assert(stateTools.URL, gc.Equals, url)
 }
 
@@ -136,11 +133,9 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 
 func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
 	current := coretesting.CurrentVersion(c)
-	curTools := &tools.Tools{Version: current, URL: ""}
-	curTools.Version.Minor++
-	s.rawMachine.SetAgentVersion(current)
-	// Upgrader.DesiredVersion returns the *desired* set of tools, not the
-	// currently running set. We want to be upgraded to cur.Version
+	err := s.rawMachine.SetAgentVersion(current)
+	c.Assert(err, jc.ErrorIsNil)
+
 	stateVersion, err := s.st.DesiredVersion(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stateVersion, gc.Equals, current.Number)

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/utils/v2"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/juju/osenv"
@@ -87,6 +88,61 @@ var BootstrapConfigAttributes = []string{
 	ControllerServiceType,
 	ControllerExternalName,
 	ControllerExternalIPs,
+}
+
+// BootstrapConfigSchema defines the schema used for config items during
+// bootstrap.
+var BootstrapConfigSchema = environschema.Fields{
+	AdminSecretKey: {
+		Description: "Sets the Juju administrator password",
+		Type:        environschema.Tstring,
+	},
+	CACertKey: {
+		Description: fmt.Sprintf(
+			"Sets the bootstrapped controllers CA cert to use and issue "+
+				"certificates from, used in conjunction with %s",
+			CAPrivateKeyKey),
+		Type: environschema.Tstring,
+	},
+	CAPrivateKeyKey: {
+		Description: fmt.Sprintf(
+			"Sets the bootstrapped controllers CA cert private key to sign "+
+				"certificates with, used in conjunction with %s",
+			CACertKey),
+		Type: environschema.Tstring,
+	},
+	BootstrapTimeoutKey: {
+		Description: "Controls how long Juju will wait for a bootstrap to " +
+			"complete before considering it failed in seconds",
+		Type: environschema.Tint,
+	},
+	BootstrapRetryDelayKey: {
+		Description: "Controls the amount of time in seconds between attempts " +
+			"to connect to a bootstrap machine address",
+		Type: environschema.Tint,
+	},
+	BootstrapAddressesDelayKey: {
+		Description: "Controls the amount of time in seconds in between " +
+			"refreshing the bootstrap machine addresses",
+		Type: environschema.Tint,
+	},
+	ControllerServiceType: {
+		Description: "Controls the kubernetes service type for Juju " +
+			"controllers, see " +
+			"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core " +
+			"valid values are one of cluster, loadbalancer, external",
+		Type: environschema.Tstring,
+	},
+	ControllerExternalName: {
+		Description: "Sets the external name for a k8s controller of type " +
+			"external",
+		Type: environschema.Tstring,
+	},
+	ControllerExternalIPs: {
+		Description: "Specifies a comma separated list of external IPs for a " +
+			"k8s controller of type external",
+		Type: environschema.Tstring,
+	},
 }
 
 // IsBootstrapAttribute reports whether or not the specified

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
@@ -78,11 +77,6 @@ var (
 	// runtime, otherwise it panics.
 	KubernetesSeriesName = strings.ToLower(jujuos.Kubernetes.String())
 )
-
-// defaultSupportedJujuSeries is used to return canned information about what
-// juju supports in terms of the release cycle
-// see juju/os and documentation https://www.ubuntu.com/about/release-cycle
-var defaultSupportedJujuSeries = set.NewStrings("focal", "bionic", "xenial", "trusty", KubernetesSeriesName)
 
 // JujuConnSuite provides a freshly bootstrapped juju.Conn
 // for each test. It also includes testing.BaseSuite.
@@ -424,7 +418,7 @@ func (s *JujuConnSuite) OpenAPIAsNewMachine(c *gc.C, jobs ...state.MachineJob) (
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id("foo"), "", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return s.openAPIAs(c, machine.Tag(), password, "fake_nonce", false), machine
 }
@@ -440,7 +434,7 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	defaultSeries.Add(config.PreferredSeries(conf))
 
 	hostSeries, err := series.HostSeries()
-	if err != nil {
+	if err == nil {
 		defaultSeries.Add(hostSeries)
 	}
 


### PR DESCRIPTION
This is a merge of 2.8 into 2.9 bringing in several of the 2.8 bugfixes.

Bringing in:

     * Merge pull request #12447 from jameinel/2.8-statuses-upgrade-1907685
     * Merge pull request #12451 from benhoyt/fix-centos-tests
     * Merge pull request #12435 from tlm/lp-1905320 (wrong text in juju
       help bootstrap)
     * Merge pull request #12431 from achilleasa/2.8-set-unit-error-state-when-relation-created-hooks-fail
     * Merge pull request #12429 from manadart/2.8-housekeeping
     * Merge pull request #12416 from tlm/lp-1905320 (juju help bootstrap)

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

See individual PRs.

## Documentation changes

See individual PRs.

## Bug reference

 * https://bugs.launchpad.net/juju/+bug/1907685
 * https://bugs.launchpad.net/juju/+bug/1905320
 * https://bugs.launchpad.net/juju/+bug/1906706
 * https://bugs.launchpad.net/juju/+bug/1905320
