### PR TITLE
do not close reader and try to read after

### DIFF
--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -323,6 +323,7 @@ func (st resourceState) storeResource(res resource.Resource, r io.Reader) error 
 // OpenResource returns metadata about the resource, and a reader for
 // the resource.
 func (st resourceState) OpenResource(applicationID, name string) (resource.Resource, io.ReadCloser, error) {
+	rLogger.Tracef("open resource %q of %q", name, applicationID)
 	id := newResourceID(applicationID, name)
 	resourceInfo, storagePath, err := st.persist.GetResource(id)
 	if err != nil {
@@ -371,6 +372,7 @@ func (st resourceState) OpenResource(applicationID, name string) (resource.Resou
 // a reader for the resource. The resource is associated with
 // the unit once the reader is completely exhausted.
 func (st resourceState) OpenResourceForUniter(unit resource.Unit, name string) (resource.Resource, io.ReadCloser, error) {
+	rLogger.Tracef("open resource %q for uniter %q", name, unit.Name())
 	applicationID := unit.ApplicationName()
 
 	pendingID, err := newPendingID()
@@ -427,6 +429,7 @@ func (st resourceState) SetCharmStoreResources(applicationID string, info []char
 // do not have any machinery to facilitate transactions between
 // different components.
 func (st resourceState) NewResolvePendingResourcesOps(applicationID string, pendingIDs map[string]string) ([]txn.Op, error) {
+	rLogger.Tracef("resolve pending resource ops for %q", applicationID)
 	if len(pendingIDs) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
Reading from an io read closer after it has been closed causes a panic.  The resource operations repository was closing a reader then returning it to be read, eventually by a unitSetter, causing a panic.  Also let to the unit's resource doc not being set with an empty pendingID.  

Only seen on deploy, as this step put the resource into state to be found during subsequent add-units.

## QA steps

```console
$ juju bootstrap localhost resources
$ juju deploy cs:postgresql --config aws_region="us-east-1"

# wait for unit to be fully up and running
$ juju list-resources postgresql/0 --details --format yaml
- unitID: postgresql/0
  unit:
    resourceid: postgresql/wal-e
    ...
    fingerprint: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
    size: 0
   ...
  expected:
   ...
    fingerprint: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
    size: 0
    ...
  progress: -1
  unitnumber: 0
  revprogress: "0"
```

