### PR TITLE
update charms in PG integration tests, charmhub feature flag no more.

### DIFF
--- a/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
@@ -4,7 +4,7 @@ saas:
     url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.mysql
 applications:
   wordpress:
-    charm: wordpress
+    charm: cs:wordpress
     num_units: 1
 relations:
 - - wordpress:db

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -18,7 +18,7 @@ run_deploy_specific_series() {
 
     ensure "test-deploy-specific-series" "${file}"
 
-    juju deploy postgresql --series bionic
+    juju deploy cs:postgresql --series bionic
     series=$(juju status --format=json | jq ".applications.postgresql.series")
 
     destroy_model "test-deploy-specific-series"

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -82,12 +82,12 @@ run_reboot_monitor_state_cleanup() {
 
     ensure "${model_name}" "${file}"
 
-    # Deploy mysql/rsyslog-forwarder. The latter is a subordinate
+    # Deploy mysql/rsyslog-forwarder-ha. The latter is a subordinate
     juju deploy mysql
-    juju deploy rsyslog-forwarder
-    juju add-relation rsyslog-forwarder mysql
+    juju deploy rsyslog-forwarder-ha
+    juju add-relation rsyslog-forwarder-ha mysql
     wait_for "mysql" "$(idle_condition "mysql")"
-    wait_for "rsyslog-forwarder" "$(idle_subordinate_condition "rsyslog-forwarder" "mysql")"
+    wait_for "rsyslog-forwarder-ha" "$(idle_subordinate_condition "rsyslog-forwarder-ha" "mysql")"
 
     # Check that the reboot flag files have been created for both the charm and
     # the subordinate. Note: juju ssh adds whitespace which we need to trim
@@ -103,7 +103,7 @@ run_reboot_monitor_state_cleanup() {
 
     # Remove subordinate and ensure that the state file for its monitor got purged
     echo "[+] Verifying that reboot monitor state files are removed once a subordinate gets removed"
-    juju remove-relation rsyslog-forwarder mysql
+    juju remove-relation rsyslog-forwarder-ha mysql
     wait_for "mysql" "$(idle_condition "mysql")"
 
     wait_for_subordinate_count "mysql"

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -6,7 +6,7 @@ test_log_permissions() {
   file="${TEST_DIR}/test_log_permissions.log"
   ensure "correct-log" "${file}"
 
-  juju deploy postgresql
+  juju deploy cs:postgresql
 
   wait_for "started" '.machines."0"."juju-status".current'
 

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -8,7 +8,6 @@ run_network_health() {
     # Deploy some applications for different series.
     juju deploy mongodb --series xenial
     juju deploy ubuntu ubuntu-bionic --series bionic
-    juju deploy ubuntu ubuntu-focal --series focal
 
     # Now the testing charm for each series.
     # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
@@ -19,18 +18,15 @@ run_network_health() {
 
     juju expose network-health-xenial
     juju expose network-health-bionic
-    juju expose network-health-focal
 
     juju add-relation network-health-xenial mongodb
     juju add-relation network-health-bionic ubuntu-bionic
-    juju add-relation network-health-focal ubuntu-focal
 
     wait_for "mongodb" "$(idle_condition "mongodb")"
     wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 4)"
     wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 5)"
     wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "mongodb")"
     wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu-bionic")"
-    wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "ubuntu-focal")"
 
     check_default_routes
     check_accessibility

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -7,7 +7,7 @@ run_relation_data_exchange() {
     ensure "${model_name}" "${file}"
 
     # Deploy 2 wordpress instances and one mysql instance
-    juju deploy wordpress -n 2
+    juju deploy cs:wordpress -n 2
     wait_for "wordpress" "$(idle_condition "wordpress" 0 0)"
     wait_for "wordpress" "$(idle_condition "wordpress" 0 1)"
     juju deploy mysql

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -7,7 +7,7 @@ run_relation_list_app() {
     ensure "${model_name}" "${file}"
 
     # Deploy 2 departer instances
-    juju deploy wordpress
+    juju deploy cs:wordpress
     juju deploy mysql
     juju relate wordpress mysql
     wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"


### PR DESCRIPTION
With the charm hub integration feature flag removed, we are now using CharmHub charms by default. However CharmStore and CharmHub charms are not necessarily the same.  Some now require k8s by default, some have been renamed.  Update charm names so these tests run.

Remove focal from network health so the test will run until the charm can be updated for focal.

## QA steps

```console
$ juju bootstrap localhost testme
$ (cd tests ; ./main.sh -l testme deploy)
$ (cd tests ; ./main.sh -l testme machine)
$ (cd tests ; ./main.sh -l testme network)
$ (cd tests ; ./main.sh -l testme hooks)
$ (cd tests ; ./main.sh -l testme relations)
```
