### PR TITLE
Better pod status to juju status

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2174,8 +2174,14 @@ func (k *kubernetesClient) Units(appName string, mode caas.DeploymentMode) ([]ca
 				ports = append(ports, fmt.Sprintf("%v/%v", p.ContainerPort, p.Protocol))
 			}
 		}
+
+		eventGetter := func() ([]core.Event, error) {
+			return k.getEvents(p.Name, "Pod")
+		}
+
 		terminated := p.DeletionTimestamp != nil
-		statusMessage, unitStatus, since, err := k.getPODStatus(p, now)
+		statusMessage, unitStatus, since, err := podToJujuStatus(p, now, eventGetter)
+
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -2247,37 +2253,6 @@ func (k *kubernetesClient) getPod(podName string) (*core.Pod, error) {
 	return pod, nil
 }
 
-func (k *kubernetesClient) getPODStatus(pod core.Pod, now time.Time) (string, status.Status, time.Time, error) {
-	terminated := pod.DeletionTimestamp != nil
-	jujuStatus := k.jujuStatus(pod.Status.Phase, terminated)
-	statusMessage := pod.Status.Message
-	since := now
-	if statusMessage == "" {
-		for _, cond := range pod.Status.Conditions {
-			statusMessage = cond.Message
-			since = cond.LastProbeTime.Time
-			if cond.Type == core.PodScheduled && cond.Reason == core.PodReasonUnschedulable {
-				jujuStatus = status.Blocked
-				break
-			}
-		}
-	}
-
-	if statusMessage == "" {
-		// If there are any events for this pod we can use the
-		// most recent to set the status.
-		eventList, err := k.getEvents(pod.Name, "Pod")
-		if err != nil {
-			return "", "", time.Time{}, errors.Trace(err)
-		}
-		// Take the most recent event.
-		if count := len(eventList); count > 0 {
-			statusMessage = eventList[count-1].Message
-		}
-	}
-	return statusMessage, jujuStatus, since, nil
-}
-
 func (k *kubernetesClient) getStatefulSetStatus(ss *apps.StatefulSet) (string, status.Status, error) {
 	terminated := ss.DeletionTimestamp != nil
 	jujuStatus := status.Waiting
@@ -2337,6 +2312,7 @@ func (k *kubernetesClient) jujuStatus(podPhase core.PodPhase, terminated bool) s
 	if terminated {
 		return status.Terminated
 	}
+
 	switch podPhase {
 	case core.PodRunning:
 		return status.Running

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -586,8 +586,14 @@ func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 	}
 
 	opPod := podsList.Items[0]
+
+	eventGetter := func() ([]core.Event, error) {
+		return k.getEvents(opPod.Name, "Pod")
+	}
+
 	terminated := opPod.DeletionTimestamp != nil
-	statusMessage, opStatus, since, err := k.getPODStatus(opPod, k.clock.Now())
+	statusMessage, opStatus, since, err := podToJujuStatus(
+		opPod, k.clock.Now(), eventGetter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -993,8 +993,16 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 			}},
 		},
 		Status: core.PodStatus{
+			Conditions: []core.PodCondition{
+				{
+					Type:    core.PodScheduled,
+					Status:  core.ConditionFalse,
+					Reason:  "Scheduling",
+					Message: "test message",
+				},
+			},
 			Phase:   core.PodPending,
-			Message: "test message.",
+			Message: "test message",
 		},
 	}
 	ss := apps.StatefulSet{
@@ -1036,7 +1044,7 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(operator.Status.Status, gc.Equals, status.Allocating)
-	c.Assert(operator.Status.Message, gc.Equals, "test message.")
+	c.Assert(operator.Status.Message, gc.Equals, "test message")
 	c.Assert(operator.Config.Version, gc.Equals, version.MustParse("2.99.0"))
 	c.Assert(operator.Config.OperatorImagePath, gc.Equals, "test-image")
 	c.Assert(operator.Config.AgentConf, gc.DeepEquals, []byte("agent-conf-data"))

--- a/caas/kubernetes/provider/pod.go
+++ b/caas/kubernetes/provider/pod.go
@@ -1,0 +1,228 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/status"
+
+	core "k8s.io/api/core/v1"
+)
+
+type EventGetter func() ([]core.Event, error)
+
+const (
+	PodReasonCompleted                = "Completed"
+	PodReasonContainersNotInitialized = "ContainersNotInitialized"
+	PodReasonContainersNotReady       = "ContainersNotReady"
+	PodReasonCrashLoopBackoff         = "CrashLoopBackOff"
+	PodReasonError                    = "Error"
+	PodReasonImagePull                = "ErrImagePull"
+)
+
+var (
+	podContainersReadyReasonsMap = map[string]status.Status{
+		PodReasonContainersNotReady: status.Maintenance,
+	}
+
+	podInitializedReasonsMap = map[string]status.Status{
+		PodReasonContainersNotInitialized: status.Maintenance,
+	}
+
+	podReadyReasonMap = map[string]status.Status{
+		PodReasonContainersNotReady:       status.Maintenance,
+		PodReasonContainersNotInitialized: status.Maintenance,
+	}
+
+	podScheduledReasonsMap = map[string]status.Status{
+		core.PodReasonUnschedulable: status.Blocked,
+	}
+)
+
+// getPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+// These methods come directly from the Kubernetes code base. We can't import
+// them as Kubernetes forbids this. Code can be found here:
+// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/api/pod/util.go
+func getPodCondition(status *core.PodStatus, conditionType core.PodConditionType) (int, *core.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return getPodConditionFromList(status.Conditions, conditionType)
+}
+
+// getPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+// These methods come directly from the Kubernetes code base. We can't import
+// them as Kubernetes forbids this. Code can be found here:
+// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/api/pod/util.go
+func getPodConditionFromList(conditions []core.PodCondition, conditionType core.PodConditionType) (int, *core.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// podToJujuStatus takes a Kubernetes pod and translate's it to a known Juju
+// status. If this function can't determine the reason for a pod's state either
+// a status of error or unknown is returned. Function returns the status message,
+// juju status, the time of the status event and any errors that occurred.
+func podToJujuStatus(
+	pod core.Pod,
+	now time.Time,
+	events EventGetter,
+) (string, status.Status, time.Time, error) {
+	since := now
+	defaultStatusMessage := pod.Status.Message
+
+	if pod.DeletionTimestamp != nil {
+		return defaultStatusMessage, status.Terminated, since, nil
+	}
+
+	// conditionHandler tries to handle the state of the supplied condition.
+	// if the condition status is true true is returned from this function.
+	// Otherwise if the condition is unknown or false the function attempts to
+	// map the condition reason onto a known juju status
+	conditionHandler := func(
+		pc *core.PodCondition,
+		reasonMapper func(reason string) status.Status,
+	) (bool, status.Status, string) {
+		if pc.Status == core.ConditionTrue {
+			return true, "", ""
+		} else if pc.Status == core.ConditionUnknown {
+			return false, status.Unknown, pc.Message
+		}
+		return false, reasonMapper(pc.Reason), pc.Message
+	}
+
+	// reasonMapper takes a mapping of Kubernetes pod reasons to juju statuses.
+	// If no reason is found in the map the default reason supplied is returned
+	reasonMapper := func(
+		reasons map[string]status.Status,
+		def status.Status) func(string) status.Status {
+		return func(r string) status.Status {
+			if stat, ok := reasons[r]; ok {
+				return stat
+			}
+			return def
+		}
+	}
+
+	// Start by processing the pod conditions in their lifecycle order
+	// Has the pod been scheduled?
+	_, cond := getPodCondition(&pod.Status, core.PodScheduled)
+	if cond == nil { // Doesn't have scheduling information. Should not get here
+		return defaultStatusMessage, status.Unknown, since, nil
+	} else if r, s, m := conditionHandler(
+		cond, reasonMapper(podScheduledReasonsMap, status.Allocating)); !r {
+		return m, s, cond.LastProbeTime.Time, nil
+	}
+
+	// Have the init containers run?
+	if _, cond := getPodCondition(&pod.Status, core.PodInitialized); cond != nil {
+		r, s, m := conditionHandler(
+			cond, reasonMapper(podInitializedReasonsMap, status.Maintenance))
+		if errM, isErr := interrogatePodContainerStatus(pod.Status.InitContainerStatuses); !r && isErr {
+			return errM, status.Error, cond.LastProbeTime.Time, nil
+		} else if !r {
+			return m, s, cond.LastProbeTime.Time, nil
+		}
+	}
+
+	// Have the containers started/finished?
+	_, cond = getPodCondition(&pod.Status, core.ContainersReady)
+	if cond == nil {
+		return defaultStatusMessage, status.Unknown, since, nil
+	} else if r, s, m := conditionHandler(
+		cond, reasonMapper(podContainersReadyReasonsMap, status.Maintenance)); !r {
+		if errM, isErr := interrogatePodContainerStatus(pod.Status.ContainerStatuses); isErr {
+			return errM, status.Error, cond.LastProbeTime.Time, nil
+		}
+		return m, s, cond.LastProbeTime.Time, nil
+	}
+
+	// Made it this far are we ready?
+	_, cond = getPodCondition(&pod.Status, core.PodReady)
+	if cond == nil {
+		return defaultStatusMessage, status.Unknown, since, nil
+	} else if r, s, m := conditionHandler(
+		cond, reasonMapper(podReadyReasonMap, status.Maintenance)); !r {
+		return m, s, cond.LastProbeTime.Time, nil
+	} else if r {
+		return "", status.Running, since, nil
+	}
+
+	// If we have made it this far then something is very wrong in the state
+	// of the pod.
+
+	// If we can't find a status message lets take a look at the event log
+	if defaultStatusMessage == "" {
+		eventList, err := events()
+		if err != nil {
+			return "", "", time.Time{}, errors.Trace(err)
+		}
+
+		if count := len(eventList); count > 0 {
+			defaultStatusMessage = eventList[count-1].Message
+		}
+	}
+
+	return defaultStatusMessage, status.Unknown, since, nil
+}
+
+// interrogatePodContainerStatus combs a set of container statuses. If a
+// container is found to be in an error state it's error message and true are
+// returned, Otherwise an empty message and false
+func interrogatePodContainerStatus(containers []core.ContainerStatus) (string, bool) {
+	for _, c := range containers {
+		if c.State.Running != nil {
+			continue
+		}
+
+		if c.State.Waiting != nil {
+			m, isError := isContainerReasonError(c.State.Waiting.Reason)
+			if isError {
+				m = fmt.Sprintf("%s: %s", m, c.State.Waiting.Message)
+			}
+			return m, isError
+		}
+
+		if c.State.Terminated != nil {
+			m, isError := isContainerReasonError(c.State.Terminated.Reason)
+			if isError {
+				m = fmt.Sprintf("%s: %s", m, c.State.Terminated.Message)
+			}
+			return m, isError
+		}
+	}
+	return "", false
+}
+
+// isContainerReasonError decides if a reason on a container status is
+// considered to be an error. If an error is found on the reason then a
+// description of the error is returned with true. Otherwise an empty
+// description and false.
+func isContainerReasonError(reason string) (string, bool) {
+	switch reason {
+	case PodReasonError:
+		return "container error", true
+	case PodReasonImagePull:
+		return "OCI image pull error", true
+	case PodReasonCrashLoopBackoff:
+		return "crash loop backoff", true
+	case PodReasonCompleted:
+		return "", false
+	default:
+		return fmt.Sprintf("unknown container reason %q", reason), true
+	}
+}

--- a/caas/kubernetes/provider/pod_test.go
+++ b/caas/kubernetes/provider/pod_test.go
@@ -1,0 +1,316 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This test file is using go test framework as an internal test to go check.
+// Added by tlm 16/12/2020
+
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/juju/core/status"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTerminatedPodJujuStatus(t *testing.T) {
+	pod := core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			DeletionTimestamp: &meta.Time{time.Now()},
+		},
+		Status: core.PodStatus{
+			Message: "test",
+		},
+	}
+
+	testTime := time.Now()
+	message, poStatus, now, err := podToJujuStatus(
+		pod,
+		testTime,
+		func() ([]core.Event, error) {
+			return []core.Event{}, nil
+		})
+
+	if err != nil {
+		t.Fatalf("unexpected error getting pod status: %v", err)
+	}
+
+	if message != pod.Status.Message {
+		t.Errorf("pod status messages not equal %q != %q", message, pod.Status.Message)
+	}
+
+	if poStatus != status.Terminated {
+		t.Errorf("expected status %q got %q", status.Terminated, poStatus)
+	}
+
+	if !testTime.Equal(now) {
+		t.Errorf("unexpected status time received, got %q wanted %q", now, testTime)
+	}
+}
+
+func TestPodConditionListJujuStatus(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Pod     core.Pod
+		Status  status.Status
+		Message string
+	}{
+		{
+			// We are testing the juju status here when a pod is considered
+			// unschedulable. We want to see a juju status of blocked and
+			// the scheduling message echoed as this will provide the best
+			// reason.
+			Name: "pod scheduling status unschedulable",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:    core.PodScheduled,
+							Status:  core.ConditionFalse,
+							Reason:  core.PodReasonUnschedulable,
+							Message: "not enough resources",
+						},
+					},
+				},
+			},
+			Status:  status.Blocked,
+			Message: "not enough resources",
+		},
+		{
+			// We are testing the juju status here when pod scheduling is still
+			// occurring. Kubernetes is still organising where to put our pod
+			// so we expect a juju status of allocating and the pod scheduling
+			// message to be echoed.
+			Name: "pod scheduling status waiting",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:    core.PodScheduled,
+							Status:  core.ConditionFalse,
+							Reason:  "waiting",
+							Message: "waiting to be scheduled",
+						},
+					},
+				},
+			},
+			Status:  status.Allocating,
+			Message: "waiting to be scheduled",
+		},
+		{
+			// We expect that every pod has a pod scheduling condition. If it's
+			// missing our juju status should be Unknown as it's not safe for
+			// us to test anymore of the pod conditions.
+			Name: "pod scheduling status missing",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{},
+				},
+			},
+			Status:  status.Unknown,
+			Message: "",
+		},
+		{
+			// We are testing here that when the pod is in it's init stage
+			// the correct juju status of maintenance is being reported.
+			Name: "pod init status waiting",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotInitialized,
+							Message: "initializing containers",
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "initializing containers",
+		},
+		{
+			// We are testing here that when the pod is in it's init stage
+			// the correct juju status of error is displayed as one of the
+			// pods is in a crash loop backoff.
+			Name: "pod init status error",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotInitialized,
+							Message: "initializing containers",
+						},
+					},
+					InitContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-init-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason:  PodReasonCrashLoopBackoff,
+									Message: "I am broken",
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Error,
+			Message: "crash loop backoff: I am broken",
+		},
+		{
+			// We are testing here that while the main containers of the pod
+			// are still being spun up and the juju status of maintenance is
+			// still being reported
+			Name: "pod container status waiting",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "starting containers",
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "starting containers",
+		},
+		{
+			// We want to test here that when a container in the pod goes into
+			// an error state like a crash loop backoff the subsequent juju
+			// status is error
+			Name: "pod container status error",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "starting containers",
+						},
+					},
+					ContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason:  PodReasonCrashLoopBackoff,
+									Message: "I am broken",
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Error,
+			Message: "crash loop backoff: I am broken",
+		},
+		{
+			// We want to test that when the container reason is unknown we
+			// report Juju status of error and propagate the message
+			Name: "pod container unknown reason",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "starting containers",
+						},
+					},
+					ContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason:  "bad-reason",
+									Message: "I am broken",
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Error,
+			Message: "unknown container reason \"bad-reason\": I am broken",
+		},
+		{
+			// We want to test here that when the pod ready condition the juju
+			// status is running
+			Name: "pod container status running",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   core.ContainersReady,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   core.PodReady,
+							Status: core.ConditionTrue,
+						},
+					},
+				},
+			},
+			Status:  status.Running,
+			Message: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			testTime := time.Now()
+			eventGetter := func() ([]core.Event, error) {
+				return []core.Event{}, nil
+			}
+			message, poStatus, _, err := podToJujuStatus(
+				test.Pod, testTime, eventGetter)
+
+			if err != nil {
+				t.Fatalf("unexpected error getting pod status: %v", err)
+			}
+
+			if message != test.Message {
+				t.Errorf("pod status messages not equal %q != %q", message, test.Message)
+			}
+
+			if poStatus != test.Status {
+				t.Errorf("expected status %q got %q", test.Status, poStatus)
+			}
+		})
+	}
+}

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -303,6 +303,7 @@ func (aw *applicationWorker) clusterChanged(
 				}
 			}
 		}
+
 		unitParams := params.ApplicationUnitParams{
 			ProviderId: u.Id,
 			Address:    u.Address,


### PR DESCRIPTION
This fix introduces a change that interrogates the Kubernetes pod status more to establish more reliably why a problem has occurred. It does this by primarily using the status conditions.


## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps
1. Run unit tests added by PR

2. Run failed case reported in bug. You will need to checkout this commit of seldon-core https://github.com/juju-solutions/bundle-kubeflow/tree/f13305a8a8cb69bce6a905975956d737f1d02dca/charms/seldon-core

```sh
juju bootstrap microk8s
juju add-model test
juju deploy --resource oci-image=docker.io/seldonio/seldon-core-operator:1.2.1 /tmp/charm-builds/seldon-core/
```

At the end the pod should be in a crash loop backoff and reporting the error through juju status.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1906278
