### PR TITLE
Improve bundle output, make it more like deploy charm.

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -118,9 +118,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSpaceMissi
 		"cannot deploy bundle: cannot deploy application \"mysql\": "+
 		"space not found")
 	c.Assert(stdErr, gc.Equals, ""+
-		`Located bundle "cs:bundle/wordpress-with-endpoint-bindings-1"`+"\n"+
-		"Resolving charm via charmstore: cs:mysql\n"+
-		"Resolving charm via charmstore: cs:wordpress-extra-bindings")
+		`Located bundle "wordpress-with-endpoint-bindings" in charm-store, revision 1`+"\n"+
+		"Located charm \"mysql\" in charm-store\n"+
+		"Located charm \"wordpress-extra-bindings\" in charm-store")
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
 		"- upload charm cs:xenial/mysql-42 for series xenial\n"+
@@ -208,9 +208,9 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 		"- add unit wordpress/0 to new machine 1",
 	)
 	c.Check(stdErr, gc.Equals, ""+
-		"Located bundle \"cs:bundle/wordpress-simple-1\"\n"+
-		"Resolving charm via charmstore: cs:mysql\n"+
-		"Resolving charm via charmstore: cs:wordpress\n"+
+		"Located bundle \"wordpress-simple\" in charm-store, revision 1\n"+
+		"Located charm \"mysql\" in charm-store\n"+
+		"Located charm \"wordpress\" in charm-store\n"+
 		"Deploy of bundle completed.",
 	)
 	stdOut, stdErr, err = s.runDeployWithOutput(c, "cs:bundle/wordpress-simple")
@@ -222,7 +222,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 		"- set constraints for wordpress to \"\"",
 	)
 	c.Check(stdErr, gc.Equals, ""+
-		"Located bundle \"cs:bundle/wordpress-simple-1\"\n"+
+		"Located bundle \"wordpress-simple\" in charm-store, revision 1\n"+
 		"Deploy of bundle completed.",
 	)
 
@@ -420,7 +420,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleResources(c *gc.C) {
 	)
 	// Info messages go to stdErr.
 	c.Check(stdErr, gc.Equals, ""+
-		"Resolving charm via charmstore: cs:starsay\n"+
+		"Located charm \"startsay\" in charm-store\n"+
 		"  added resource install-resource\n"+
 		"  added resource store-resource\n"+
 		"  added resource upload-resource\n"+
@@ -1599,8 +1599,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCo
 		"- add unit memcached/0 to new machine 1",
 	)
 	c.Check(stdErr, gc.Equals, ""+
-		"Resolving charm via charmstore: cs:django\n"+
-		"Resolving charm via charmstore: cs:bionic/mem-47\n"+
+		"Located charm \"django\" in charm-store\n"+
+		"Located charm \"mem\" in charm-store, revision 47\n"+
 		"Deploy of bundle completed.",
 	)
 }

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -246,6 +246,10 @@ func (d *charmstoreBundle) String() string {
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.
 func (d *charmstoreBundle) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
-	ctx.Infof("Located bundle %q", d.bundleURL)
+	var revision string
+	if d.bundleURL.Revision != -1 {
+		revision = fmt.Sprintf(", revision %d", d.bundleURL.Revision)
+	}
+	ctx.Infof("Located bundle %q in %s%s", d.bundleURL.Name, d.origin.Source, revision)
 	return d.deploy(ctx, deployAPI, resolver, macaroonGetter)
 }

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -329,22 +329,8 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Trace(err)
 		}
 
-		var via string
-		switch {
-		case charm.CharmHub.Matches(ch.Schema):
-			via = "via charmhub: "
-		case charm.CharmStore.Matches(ch.Schema):
-			via = "via charmstore: "
-		case charm.Local.Matches(ch.Schema):
-			via = "via local filesystem: "
-		default:
-			via = ": "
-		}
-
-		var fromChannel string
 		var channel corecharm.Channel
 		if spec.Channel != "" {
-			fromChannel = fmt.Sprintf(" from channel %s", spec.Channel)
 			channel, err = corecharm.ParseChannelNormalize(spec.Channel)
 			if err != nil {
 				return errors.Trace(err)
@@ -356,7 +342,6 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Trace(err)
 		}
 
-		h.ctx.Infof("Resolving charm %s%s%s", via, ch.FullPath(), fromChannel)
 		origin, err := utils.DeduceOrigin(ch, channel, platform)
 		if err != nil {
 			return errors.Trace(err)
@@ -365,6 +350,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
+		h.ctx.Infof(formatLocatedText(ch, origin))
 		if url.Series == "bundle" {
 			return errors.Errorf("expected charm URL, got bundle URL %q", spec.Charm)
 		}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -118,8 +118,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "xenial")
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-42\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:mysql-42 for series xenial\n"+
 		"- deploy application mysql on xenial using cs:mysql-42\n"+
@@ -226,8 +226,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithInvalidSeriesWithForce
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "precise")
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-42\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:mysql-42 for series precise\n"+
 		"- deploy application mysql on precise using cs:mysql-42\n"+
@@ -299,8 +299,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.assertDeployArgsStorage(c, "mariadb", map[string]storage.Constraints{"database": {Pool: "mariadb-pv", Size: 0x14, Count: 0x1}})
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:~juju/gitlab-k8s\n"+
-		"Resolving charm via charmstore: cs:~juju/mariadb-k8s\n"+
+		"Located charm \"gitlab-k8s\" in charm-store\n"+
+		"Located charm \"mariadb-k8s\" in charm-store\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:~juju/gitlab-k8s for series kubernetes\n"+
 		"- deploy application gitlab with 1 unit on kubernetes using cs:~juju/gitlab-k8s\n"+
@@ -367,8 +367,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleStorage(c *gc.C) {
 	s.assertDeployArgsStorage(c, "mysql", map[string]storage.Constraints{"database": {Pool: "mysql-pv", Size: 0x14, Count: 0x1}})
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-42\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:mysql-42 for series bionic\n"+
 		"- deploy application mysql on bionic using cs:mysql-42\n"+
@@ -451,8 +451,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleDevices(c *gc.C) {
 	)
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:bitcoin-miner\n"+
-		"Resolving charm via charmstore: cs:dashboard4miner\n"+
+		"Located charm \"bitcoin-miner\" in charm-store\n"+
+		"Located charm \"dashboard4miner\" in charm-store\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:bitcoin-miner for series kubernetes\n"+
 		"- deploy application bitcoin-miner with 1 unit on kubernetes using cs:bitcoin-miner\n"+
@@ -514,8 +514,8 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunExistingModel(c *gc.C) {
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "bionic")
 
 	expectedOutput := "" +
-		"Resolving charm via charmstore: cs:mysql-42\n" +
-		"Resolving charm via charmstore: cs:wordpress-47\n" +
+		"Located charm \"mysql\" in charm-store, revision 42\n" +
+		"Located charm \"wordpress\" in charm-store, revision 47\n" +
 		"Executing changes:\n" +
 		"- upload charm cs:mysql-42 for series bionic\n" +
 		"- deploy application mysql on bionic using cs:mysql-42\n" +
@@ -637,7 +637,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc
 	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:wordpress-47 for series bionic\n"+
 		"- deploy application wp on bionic using cs:wordpress-47\n"+
@@ -689,7 +689,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleExpose(c *gc.C) {
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:wordpress-47\n"+
 		"- deploy application wordpress using cs:wordpress-47\n"+
@@ -764,10 +764,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C)
 	s.assertDeployArgs(c, varnishCurl.String(), "varnish", "xenial")
 	s.assertDeployArgs(c, pgresCurl.String(), "postgres", "xenial")
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-32\n"+
-		"Resolving charm via charmstore: cs:xenial/postgres-2\n"+
-		"Resolving charm via charmstore: cs:xenial/varnish\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 32\n"+
+		"Located charm \"postgres\" in charm-store, revision 2\n"+
+		"Located charm \"varnish\" in charm-store\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
 		"- upload charm cs:mysql-32 for series bionic\n"+
 		"- deploy application mysql on bionic using cs:mysql-32\n"+

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -541,5 +541,9 @@ func formatLocatedText(curl *charm.URL, origin commoncharm.Origin) string {
 	if repository == "" || repository == commoncharm.OriginLocal {
 		return fmt.Sprintf("Located local charm %q, revision %d", curl.Name, curl.Revision)
 	}
-	return fmt.Sprintf("Located charm %q in %s, revision %d", curl.Name, repository, curl.Revision)
+	var revision string
+	if curl.Revision != -1 {
+		revision = fmt.Sprintf(", revision %d", curl.Revision)
+	}
+	return fmt.Sprintf("Located charm %q in %s%s", curl.Name, repository, revision)
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -420,6 +420,7 @@ func (d *factory) maybeReadCharmstoreBundle(resolver Resolver) (Deployer, error)
 	db := d.newDeployBundle(store.NewResolvedBundle(bundle))
 	db.bundleURL = bundleURL
 	db.bundleOverlayFile = d.bundleOverlayFile
+	db.origin = bundleOrigin
 	return &charmstoreBundle{deployBundle: db}, nil
 }
 

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -215,7 +215,7 @@ func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
 	factory := s.newDeployerFactory()
 	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store bundle: %s", bundle.String()))
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store bundle: %s from channel edge", bundle.String()))
 }
 
 func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {


### PR DESCRIPTION
Update bundle deployment text to be more like charm deployment and not include "ch:", "cs:" etc.

## QA steps

```console
$ juju bootstrap localhost
juju add-model test --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy --dry-run wiki-simple
Located bundle "wiki-simple" in charm-hub, revision 4
Located charm "mysql" in charm-store, revision 55
Located charm "mediawiki" in charm-store, revision 5
Changes to deploy bundle:
...
$ juju deploy --dry-run cs:wiki-simple
Located bundle "wiki-simple" in charm-store, revision 4
Located charm "mysql" in charm-store, revision 55
Located charm "mediawiki" in charm-store, revision 5
Changes to deploy bundle:
...
$ juju deploy --dry-run ./testcharms/charm-repo/bundle/lxd-profile
Located charm "lxd-profile" in charm-store, revision 0
Changes to deploy bundle:
...
```

