### PR TITLE
Update bundle change descriptions

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v2"

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -123,8 +123,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSpaceMissi
 		"Located charm \"wordpress-extra-bindings\" in charm-store")
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/mysql-42 for series xenial\n"+
-		"- deploy application mysql on xenial using cs:xenial/mysql-42")
+		"- upload charm mysql from charm-store for series xenial\n"+
+		"- deploy application mysql from charm-store on xenial")
 	s.assertCharmsUploaded(c, "cs:xenial/mysql-42")
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{})
 	s.assertUnitsCreated(c, map[string]string{})
@@ -197,11 +197,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/mysql-42 for series xenial\n"+
-		"- deploy application mysql on xenial using cs:xenial/mysql-42\n"+
+		"- upload charm mysql from charm-store for series xenial\n"+
+		"- deploy application mysql from charm-store on xenial\n"+
 		"- set annotations for mysql\n"+
-		"- upload charm cs:xenial/wordpress-47 for series xenial\n"+
-		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n"+
+		"- upload charm wordpress from charm-store for series xenial\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
 		"- set annotations for wordpress\n"+
 		"- add relation wordpress:db - mysql:db\n"+
 		"- add unit mysql/0 to new machine 0\n"+
@@ -247,11 +247,11 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := "" +
 		"Changes to deploy bundle:\n" +
-		"- upload charm cs:xenial/mysql-42 for series xenial\n" +
-		"- deploy application mysql on xenial using cs:xenial/mysql-42\n" +
+		"- upload charm mysql from charm-store for series xenial\n" +
+		"- deploy application mysql from charm-store on xenial\n" +
 		"- set annotations for mysql\n" +
-		"- upload charm cs:xenial/wordpress-47 for series xenial\n" +
-		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n" +
+		"- upload charm wordpress from charm-store for series xenial\n" +
+		"- deploy application wordpress from charm-store on xenial\n" +
 		"- set annotations for wordpress\n" +
 		"- add relation wordpress:db - mysql:db\n" +
 		"- add unit mysql/0 to new machine 0\n" +
@@ -1034,8 +1034,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:trusty/upgrade-2 for series trusty\n"+
-		"- upgrade up to use charm cs:trusty/upgrade-2 for series trusty\n"+
+		"- upload charm upgrade from charm-store for series trusty\n"+
+		"- upgrade up from charm-store using charm upgrade for series trusty\n"+
 		"- set constraints for up to \"mem=8G\"\n"+
 		"- set application options for wordpress\n"+
 		`- set constraints for wordpress to "spaces=new cores=8"`,
@@ -1353,10 +1353,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundlePeerContainer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/django-42 for series xenial\n"+
-		"- deploy application django on xenial using cs:xenial/django-42\n"+
-		"- upload charm cs:xenial/wordpress-0 for series xenial\n"+
-		"- deploy application wordpress on xenial using cs:xenial/wordpress-0\n"+
+		"- upload charm django from charm-store for series xenial\n"+
+		"- deploy application django from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series xenial\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
 		"- add lxd container 0/lxd/0 on new machine 0\n"+
 		"- add lxd container 1/lxd/0 on new machine 1\n"+
 		"- add unit wordpress/0 to 0/lxd/0\n"+
@@ -1454,7 +1454,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSwitch(c *gc.C) {
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
 		"- set constraints for django to \"\"\n"+
-		"- deploy application node on bionic using cs:bionic/django-42\n"+
+		"- deploy application node from charm-store on bionic using django\n"+
 		"- add unit node/0 to new machine 2",
 	)
 }
@@ -1538,7 +1538,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 		"Executing changes:\n"+
 		"- set constraints for django to \"\"\n"+
 		"- set constraints for memcached to \"\"\n"+
-		"- deploy application node on bionic using cs:bionic/django-42\n"+
+		"- deploy application node from charm-store on bionic using django\n"+
 		"- add unit node/0 to 0/lxd/0 to satisfy [lxd:memcached]",
 	)
 
@@ -1588,11 +1588,11 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCo
 
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:bionic/django-42 for series bionic\n"+
-		"- deploy application django on bionic using cs:bionic/django-42\n"+
+		"- upload charm django from charm-store for series bionic\n"+
+		"- deploy application django from charm-store on bionic\n"+
 		"- set annotations for django\n"+
-		"- upload charm cs:bionic/mem-47 for series bionic\n"+
-		"- deploy application memcached on bionic using cs:bionic/mem-47\n"+
+		"- upload charm mem from charm-store for series bionic\n"+
+		"- deploy application memcached from charm-store on bionic using mem\n"+
 		"- add new machine 0 (bundle machine 1)\n"+
 		"- set annotations for new machine 0\n"+
 		"- add unit django/0 to new machine 0\n"+
@@ -1763,8 +1763,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundlePassesSequences(c *gc.C) {
     `)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/django-42 for series xenial\n"+
-		"- deploy application django on xenial using cs:xenial/django-42\n"+
+		"- upload charm django from charm-store for series xenial\n"+
+		"- deploy application django from charm-store on xenial\n"+
 		"- add unit django/2 to new machine 2\n"+
 		"- add unit django/3 to new machine 3",
 	)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
 	"github.com/juju/charmrepo/v6"

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -121,10 +121,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 		"Located charm \"mysql\" in charm-store, revision 42\n"+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-42 for series xenial\n"+
-		"- deploy application mysql on xenial using cs:mysql-42\n"+
-		"- upload charm cs:wordpress-47 for series xenial\n"+
-		"- deploy application wordpress on xenial using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series xenial\n"+
+		"- deploy application mysql from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series xenial\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -229,10 +229,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithInvalidSeriesWithForce
 		"Located charm \"mysql\" in charm-store, revision 42\n"+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-42 for series precise\n"+
-		"- deploy application mysql on precise using cs:mysql-42\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wordpress on bionic using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series precise\n"+
+		"- deploy application mysql from charm-store on precise\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wordpress from charm-store on bionic\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -302,10 +302,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 		"Located charm \"gitlab-k8s\" in charm-store\n"+
 		"Located charm \"mariadb-k8s\" in charm-store\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:~juju/gitlab-k8s for series kubernetes\n"+
-		"- deploy application gitlab with 1 unit on kubernetes using cs:~juju/gitlab-k8s\n"+
-		"- upload charm cs:~juju/mariadb-k8s for series kubernetes\n"+
-		"- deploy application mariadb with 2 units on kubernetes using cs:~juju/mariadb-k8s\n"+
+		"- upload charm gitlab-k8s from charm-store for series kubernetes\n"+
+		"- deploy application gitlab from charm-store with 1 unit on kubernetes using gitlab-k8s\n"+
+		"- upload charm mariadb-k8s from charm-store for series kubernetes\n"+
+		"- deploy application mariadb from charm-store with 2 units on kubernetes using mariadb-k8s\n"+
 		"- add relation gitlab:mysql - mariadb:server\n"+
 		"Deploy of bundle completed.\n")
 }
@@ -370,10 +370,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleStorage(c *gc.C) {
 		"Located charm \"mysql\" in charm-store, revision 42\n"+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-42 for series bionic\n"+
-		"- deploy application mysql on bionic using cs:mysql-42\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wordpress on bionic using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series bionic\n"+
+		"- deploy application mysql from charm-store on bionic\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wordpress from charm-store on bionic\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -454,10 +454,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleDevices(c *gc.C) {
 		"Located charm \"bitcoin-miner\" in charm-store\n"+
 		"Located charm \"dashboard4miner\" in charm-store\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:bitcoin-miner for series kubernetes\n"+
-		"- deploy application bitcoin-miner with 1 unit on kubernetes using cs:bitcoin-miner\n"+
-		"- upload charm cs:dashboard4miner for series kubernetes\n"+
-		"- deploy application dashboard4miner with 1 unit on kubernetes using cs:dashboard4miner\n"+
+		"- upload charm bitcoin-miner from charm-store for series kubernetes\n"+
+		"- deploy application bitcoin-miner from charm-store with 1 unit on kubernetes\n"+
+		"- upload charm dashboard4miner from charm-store for series kubernetes\n"+
+		"- deploy application dashboard4miner from charm-store with 1 unit on kubernetes\n"+
 		"- add relation dashboard4miner:miner - bitcoin-miner:miner\n"+
 		"Deploy of bundle completed.\n")
 }
@@ -517,10 +517,10 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunExistingModel(c *gc.C) {
 		"Located charm \"mysql\" in charm-store, revision 42\n" +
 		"Located charm \"wordpress\" in charm-store, revision 47\n" +
 		"Executing changes:\n" +
-		"- upload charm cs:mysql-42 for series bionic\n" +
-		"- deploy application mysql on bionic using cs:mysql-42\n" +
-		"- upload charm cs:wordpress-47 for series bionic\n" +
-		"- deploy application wordpress on bionic using cs:wordpress-47\n" +
+		"- upload charm mysql from charm-store for series bionic\n" +
+		"- deploy application mysql from charm-store on bionic\n" +
+		"- upload charm wordpress from charm-store for series bionic\n" +
+		"- deploy application wordpress from charm-store on bionic\n" +
 		"- add new machine 0\n" +
 		"- add new machine 1\n" +
 		"- add relation wordpress:db - mysql:db\n" +
@@ -639,8 +639,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wp on bionic using cs:wordpress-47\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wp from charm-store on bionic using wordpress\n"+
 		"- add new machine 0 (bundle machine 4)\n"+
 		"- add new machine 1 (bundle machine 8)\n"+
 		"- add new machine 2\n"+
@@ -691,8 +691,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleExpose(c *gc.C) {
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:wordpress-47\n"+
-		"- deploy application wordpress using cs:wordpress-47\n"+
+		"- upload charm wordpress from charm-store\n"+
+		"- deploy application wordpress from charm-store\n"+
 		"- expose all endpoints of wordpress and allow access from CIDRs 0.0.0.0/0 and ::/0\n"+
 		"- add unit wordpress/0 to new machine 0\n"+
 		"Deploy of bundle completed.\n")
@@ -769,14 +769,14 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C)
 		"Located charm \"varnish\" in charm-store\n"+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-32 for series bionic\n"+
-		"- deploy application mysql on bionic using cs:mysql-32\n"+
-		"- upload charm cs:xenial/postgres-2 for series xenial\n"+
-		"- deploy application postgres on xenial using cs:xenial/postgres-2\n"+
-		"- upload charm cs:xenial/varnish for series xenial\n"+
-		"- deploy application varnish on xenial using cs:xenial/varnish\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wordpress on bionic using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series bionic\n"+
+		"- deploy application mysql from charm-store on bionic\n"+
+		"- upload charm postgres from charm-store for series xenial\n"+
+		"- deploy application postgres from charm-store on xenial\n"+
+		"- upload charm varnish from charm-store for series xenial\n"+
+		"- deploy application varnish from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wordpress from charm-store on bionic\n"+
 		"- add relation wordpress:db - mysql:server\n"+
 		"- add relation varnish:webcache - wordpress:cache\n"+
 		"- add unit mysql/0 to new machine 0\n"+
@@ -837,16 +837,16 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	expectedOutput := "" +
 		"Executing changes:\n" +
 		"- upload charm %s for series xenial\n" +
-		"- deploy application mysql on xenial using %s\n" +
+		"- deploy application mysql on xenial\n" +
 		"- upload charm %s for series xenial\n" +
-		"- deploy application wordpress on xenial using %s\n" +
+		"- deploy application wordpress on xenial\n" +
 		"- add relation wordpress:db - mysql:server\n" +
 		"- add unit mysql/0 to new machine 0\n" +
 		"- add unit mysql/1 to new machine 1\n" +
 		"- add unit wordpress/0 to new machine 2\n" +
 		"Deploy of bundle completed.\n"
 
-	c.Check(s.output.String(), gc.Equals, fmt.Sprintf(expectedOutput, mysqlPath, mysqlPath, wordpressPath, wordpressPath))
+	c.Check(s.output.String(), gc.Equals, fmt.Sprintf(expectedOutput, mysqlPath, wordpressPath))
 }
 
 func (s *BundleDeployCharmStoreSuite) bundleDeploySpec() bundleDeploySpec {

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/charmrepo/v6"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hpidcock/juju-fake-init v0.0.0-20201026041434-e95018795575
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6
+	github.com/juju/bundlechanges/v4 v4.0.0-20201215212106-38904645b567
 	github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN7
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6 h1:PmF2wWq0H1F4O+I+KMPRtBxuupxRw5c3Gv4WXEFr2Bo=
-github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6/go.mod h1:bkzD4rJvlgyr9AEKUKB0eLRpMwqMshq3t5ayQmuKOBU=
+github.com/juju/bundlechanges/v4 v4.0.0-20201215212106-38904645b567 h1:8W66si4O0yo7UyKyHfViG1RAVSbSdJE6V5yoAtl6Vwg=
+github.com/juju/bundlechanges/v4 v4.0.0-20201215212106-38904645b567/go.mod h1:rGro4ym8B/S2wOyg4zrrtB1Kl9Yij4+zvsglsXEU1tE=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0 h1:BuNV5BMVyKI1XUupcAuC/Y2bW/izfV7Tn+uI7jMYjNk=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9 h1:e6OkRhyixqkgcycaD+aACZQMPwpJSxfbTfNc4qwOBnE=


### PR DESCRIPTION
The following updates the bundle descriptions to remove url prefixes and
include more user-friendly descriptions.

The changes just brings in the bundle changes library and fixes the tests
accordingly.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model other --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy wiki-simple
Located bundle "wiki-simple" in charm-hub, revision 4
Located charm "mysql" in charm-store, revision 55
Located charm "mediawiki" in charm-store, revision 5
Executing changes:
- upload charm mysql from charm-store for series trusty
- deploy application mysql from charm-store on trusty
- set annotations for mysql
- upload charm mediawiki from charm-store for series trusty
- deploy application wiki from charm-store on trusty using mediawiki
- set annotations for wiki
- add relation wiki:db - mysql:db
- add unit mysql/0 to new machine 0
- add unit wiki/0 to new machine 1
Deploy of bundle completed.
```
