### PR TITLE
Handle Ctrl-C during bootstrap; pass ctx to waitForAgentInitialisation

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -309,6 +309,7 @@ func (c *controllerStack) doCleanUp() {
 
 // Deploy creates all resources for controller stack.
 func (c *controllerStack) Deploy() (err error) {
+	// TODO(benhoyt) - add ctx.Done() check between each step
 	// creating namespace for controller stack, this namespace will be removed by broker.DestroyController if bootstrap failed.
 	nsName := c.broker.GetCurrentNamespace()
 	c.ctx.Infof("Creating k8s resources for controller %q", nsName)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -4,6 +4,7 @@
 package provider_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -892,7 +893,7 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 
 	errChan := make(chan error)
 	go func() {
-		errChan <- controllerStacker.Deploy()
+		errChan <- controllerStacker.Deploy(context.Background())
 	}()
 
 	err = s.clock.WaitAdvance(3*time.Second, testing.LongWait, 1)

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -409,10 +409,12 @@ func (k *kubernetesClient) Create(envcontext.ProviderCallContext, environs.Creat
 
 // Bootstrap deploys controller with mongoDB together into k8s cluster.
 func (k *kubernetesClient) Bootstrap(
-	ctx environs.BootstrapContext,
+	ctx context.Context,
+	cmdCtx environs.BootstrapContext,
 	callCtx envcontext.ProviderCallContext,
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
+	// TODO(benhoyt) - use ctx
 
 	if args.BootstrapSeries != "" {
 		return nil, errors.NotSupportedf("set series for bootstrapping to kubernetes")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -435,8 +435,7 @@ type BootstrapInterface interface {
 type bootstrapFuncs struct{}
 
 func (b bootstrapFuncs) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, env environs.BootstrapEnviron, callCtx envcontext.ProviderCallContext, args bootstrap.BootstrapParams) error {
-	// TODO: use ctx
-	return bootstrap.Bootstrap(cmdCtx, env, callCtx, args)
+	return bootstrap.Bootstrap(ctx, cmdCtx, env, callCtx, args)
 }
 
 func (b bootstrapFuncs) CloudDetector(provider environs.EnvironProvider) (environs.CloudDetector, bool) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -119,7 +119,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		panic("tests must call setupAutoUploadTest or otherwise patch envtools.BundleTools")
 	})
 
-	s.PatchValue(&waitForAgentInitialisation, func(context.Context, *cmd.Context, *modelcmd.ModelCommandBase, bool, string, string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(context.Context, *cmd.Context, *modelcmd.ModelCommandBase, bool, string) error {
 		return nil
 	})
 
@@ -2092,7 +2092,7 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 
 	// Record the controller name seen by ModelCommandBase at the end of bootstrap.
 	var seenControllerName string
-	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _ bool, controllerName, _ string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(_ context.Context, _ *cmd.Context, base *modelcmd.ModelCommandBase, _ bool, controllerName string) error {
 		seenControllerName = controllerName
 		return nil
 	})

--- a/cmd/juju/commands/mockenvirons_test.go
+++ b/cmd/juju/commands/mockenvirons_test.go
@@ -5,12 +5,13 @@
 package commands
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	version "github.com/juju/version"
@@ -41,7 +42,7 @@ func (m *MockEnviron) EXPECT() *MockEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -55,7 +56,7 @@ func (mr *MockEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) 
 }
 
 // AllInstances mocks base method
-func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -70,7 +71,7 @@ func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 }
 
 // AllRunningInstances mocks base method
-func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -85,18 +86,18 @@ func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock
 }
 
 // Bootstrap mocks base method
-func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -114,7 +115,7 @@ func (mr *MockEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -129,7 +130,7 @@ func (mr *MockEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomoc
 }
 
 // ControllerInstances mocks base method
-func (m *MockEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -144,7 +145,7 @@ func (mr *MockEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *
 }
 
 // Create mocks base method
-func (m *MockEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -158,7 +159,7 @@ func (mr *MockEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Destroy mocks base method
-func (m *MockEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -172,7 +173,7 @@ func (mr *MockEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 }
 
 // DestroyController mocks base method
-func (m *MockEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -186,7 +187,7 @@ func (mr *MockEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *go
 }
 
 // InstanceTypes mocks base method
-func (m *MockEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -201,7 +202,7 @@ func (mr *MockEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock
 }
 
 // Instances mocks base method
-func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -216,7 +217,7 @@ func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // MaintainInstance mocks base method
-func (m *MockEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -230,7 +231,7 @@ func (mr *MockEnvironMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gom
 }
 
 // PrecheckInstance mocks base method
-func (m *MockEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -286,7 +287,7 @@ func (mr *MockEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
 }
 
 // StartInstance mocks base method
-func (m *MockEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -301,7 +302,7 @@ func (mr *MockEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock
 }
 
 // StopInstances mocks base method
-func (m *MockEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {

--- a/cmd/juju/commands/mockupgradeenvirons_test.go
+++ b/cmd/juju/commands/mockupgradeenvirons_test.go
@@ -5,12 +5,13 @@
 package commands
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	version "github.com/juju/version"
@@ -41,7 +42,7 @@ func (m *MockUpgradePrecheckEnviron) EXPECT() *MockUpgradePrecheckEnvironMockRec
 }
 
 // AdoptResources mocks base method
-func (m *MockUpgradePrecheckEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockUpgradePrecheckEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -55,7 +56,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) AdoptResources(arg0, arg1, arg
 }
 
 // AllInstances mocks base method
-func (m *MockUpgradePrecheckEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockUpgradePrecheckEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -70,7 +71,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) AllInstances(arg0 interface{})
 }
 
 // AllRunningInstances mocks base method
-func (m *MockUpgradePrecheckEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockUpgradePrecheckEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -85,18 +86,18 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) AllRunningInstances(arg0 inter
 }
 
 // Bootstrap mocks base method
-func (m *MockUpgradePrecheckEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockUpgradePrecheckEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockUpgradePrecheckEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockUpgradePrecheckEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockUpgradePrecheckEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockUpgradePrecheckEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -114,7 +115,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockUpgradePrecheckEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockUpgradePrecheckEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -129,7 +130,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) ConstraintsValidator(arg0 inte
 }
 
 // ControllerInstances mocks base method
-func (m *MockUpgradePrecheckEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockUpgradePrecheckEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -144,7 +145,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) ControllerInstances(arg0, arg1
 }
 
 // Create mocks base method
-func (m *MockUpgradePrecheckEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockUpgradePrecheckEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -158,7 +159,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) Create(arg0, arg1 interface{})
 }
 
 // Destroy mocks base method
-func (m *MockUpgradePrecheckEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockUpgradePrecheckEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -172,7 +173,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) Destroy(arg0 interface{}) *gom
 }
 
 // DestroyController mocks base method
-func (m *MockUpgradePrecheckEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockUpgradePrecheckEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -186,7 +187,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) DestroyController(arg0, arg1 i
 }
 
 // InstanceTypes mocks base method
-func (m *MockUpgradePrecheckEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockUpgradePrecheckEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -201,7 +202,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) InstanceTypes(arg0, arg1 inter
 }
 
 // Instances mocks base method
-func (m *MockUpgradePrecheckEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockUpgradePrecheckEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -216,7 +217,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) Instances(arg0, arg1 interface
 }
 
 // MaintainInstance mocks base method
-func (m *MockUpgradePrecheckEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockUpgradePrecheckEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -230,7 +231,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) MaintainInstance(arg0, arg1 in
 }
 
 // PrecheckInstance mocks base method
-func (m *MockUpgradePrecheckEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockUpgradePrecheckEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -314,7 +315,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) SetConfig(arg0 interface{}) *g
 }
 
 // StartInstance mocks base method
-func (m *MockUpgradePrecheckEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockUpgradePrecheckEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -329,7 +330,7 @@ func (mr *MockUpgradePrecheckEnvironMockRecorder) StartInstance(arg0, arg1 inter
 }
 
 // StopInstances mocks base method
-func (m *MockUpgradePrecheckEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockUpgradePrecheckEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -112,8 +112,7 @@ func WaitForAgentInitialisation(
 		// isn't fully threaded through yet).
 		select {
 		case <-ctx.Done():
-			// TODO(benhoyt) - improve error message
-			return errors.Annotatef(err, "cancelled waiting for controller")
+			return errors.Annotatef(err, "contacting controller (cancelled)")
 		default:
 		}
 

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -112,6 +112,7 @@ func WaitForAgentInitialisation(
 		// isn't fully threaded through yet).
 		select {
 		case <-ctx.Done():
+			// TODO(benhoyt) - improve error message
 			return errors.Annotatef(err, "cancelled waiting for controller")
 		default:
 		}

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -97,7 +98,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
 		runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-			err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+			err := WaitForAgentInitialisation(context.Background(), ctx, base, false, "controller")
 			c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		})
 		expectedRetries := t.numRetries
@@ -116,7 +117,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C
 	s.mockBlockClient.discoveringSpacesError = 2
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		err := WaitForAgentInitialisation(context.Background(), ctx, base, false, "controller")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
@@ -128,7 +129,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C)
 	s.mockBlockClient.loginError = io.EOF
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		err := WaitForAgentInitialisation(context.Background(), ctx, base, false, "controller")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
@@ -139,7 +140,7 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		err := WaitForAgentInitialisation(context.Background(), ctx, base, false, "controller")
 		c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -189,6 +189,17 @@ func (c *CommandBase) NewAPIRoot(
 	store jujuclient.ClientStore,
 	controllerName, modelName string,
 ) (api.Connection, error) {
+	return c.NewAPIRootWithDialOpts(store, controllerName, modelName, nil)
+}
+
+// NewAPIRootWithDialOpts returns a new connection to the API server for the
+// given model or controller (the default dial options will be overridden if
+// dialOpts is not nil).
+func (c *CommandBase) NewAPIRootWithDialOpts(
+	store jujuclient.ClientStore,
+	controllerName, modelName string,
+	dialOpts *api.DialOpts,
+) (api.Connection, error) {
 	c.assertRunStarted()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
@@ -210,6 +221,9 @@ func (c *CommandBase) NewAPIRoot(
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if dialOpts != nil {
+		param.DialOpts = *dialOpts
 	}
 	conn, err := juju.NewAPIConnection(param)
 	if modelName != "" && params.ErrCode(err) == params.CodeModelNotFound {

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -4,6 +4,7 @@
 package environs
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
@@ -76,11 +77,11 @@ type BootstrapParams struct {
 
 // CloudBootstrapFinalizer is a function returned from Environ.Bootstrap.
 // The caller must pass a InstanceConfig with the Tools field set.
-type CloudBootstrapFinalizer func(BootstrapContext, *instancecfg.InstanceConfig, BootstrapDialOpts) error
+type CloudBootstrapFinalizer func(context.Context, BootstrapContext, *instancecfg.InstanceConfig, BootstrapDialOpts) error
 
 // CaasBootstrapFinalizer is a function returned from Environ.Bootstrap.
 // The caller must pass a ControllerPodConfig with the Tools field set.
-type CaasBootstrapFinalizer func(BootstrapContext, *podcfg.ControllerPodConfig, BootstrapDialOpts) error
+type CaasBootstrapFinalizer func(context.Context, BootstrapContext, *podcfg.ControllerPodConfig, BootstrapDialOpts) error
 
 // BootstrapDialOpts contains the options for the synchronous part of the
 // bootstrap procedure, where the CLI connects to the bootstrap machine

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -285,7 +285,7 @@ func bootstrapCAAS(
 	if err := finalizePodBootstrapConfig(cmdCtx, podConfig, args, environ.Config()); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}
-	if err := result.CaasBootstrapFinalizer(cmdCtx, podConfig, args.DialOpts); err != nil {
+	if err := result.CaasBootstrapFinalizer(ctx, cmdCtx, podConfig, args.DialOpts); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -600,7 +600,7 @@ func bootstrapIAAS(
 	); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}
-	if err := result.CloudBootstrapFinalizer(cmdCtx, instanceConfig, args.DialOpts); err != nil {
+	if err := result.CloudBootstrapFinalizer(ctx, cmdCtx, instanceConfig, args.DialOpts); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1604,7 +1604,7 @@ func (e *bootstrapEnviron) Bootstrap(ctx context.Context, cmdCtx environs.Bootst
 
 	e.checkToolsFunc(args.AvailableTools)
 
-	finalizer := func(_ environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
+	finalizer := func(_ context.Context, _ environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
 		e.finalizerCount++
 		e.instanceConfig = icfg
 		return nil

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -4,6 +4,7 @@
 package jujutest
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -27,7 +28,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/instances"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
@@ -103,7 +104,7 @@ type LiveTests struct {
 
 	// ProviderCallContext holds the context to be used to make
 	// calls to a cloud provider.
-	ProviderCallContext context.ProviderCallContext
+	ProviderCallContext envcontext.ProviderCallContext
 
 	prepared     bool
 	bootstrapped bool
@@ -129,7 +130,7 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
 	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, nil))
-	t.ProviderCallContext = context.NewCloudCallContext()
+	t.ProviderCallContext = envcontext.NewCloudCallContext()
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
@@ -223,7 +224,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	args := t.bootstrapParams()
 	args.BootstrapConstraints = cons
 	args.ModelConstraints = cons
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), t.Env, t.ProviderCallContext, args)
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), t.Env, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 	t.bootstrapped = true
 }
@@ -976,7 +977,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer environs.Destroy("livetests", env, t.ProviderCallContext, t.ControllerStore)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, t.ProviderCallContext, t.bootstrapParams())
+	err = bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env, t.ProviderCallContext, t.bootstrapParams())
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := t.Env.(jujutesting.GetStater).GetStateInAPIServer()

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -4,6 +4,7 @@
 package jujutest
 
 import (
+	"context"
 	"path/filepath"
 
 	jc "github.com/juju/testing/checkers"
@@ -15,7 +16,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
@@ -48,7 +49,7 @@ type Tests struct {
 
 	// ProviderCallContext holds the context to be used to make
 	// calls to a cloud provider.
-	ProviderCallContext context.ProviderCallContext
+	ProviderCallContext envcontext.ProviderCallContext
 }
 
 // Open opens an instance of the testing environment.
@@ -124,7 +125,7 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.toolsStorage = stor
 	t.ControllerStore = jujuclient.NewMemStore()
 	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
-	t.ProviderCallContext = context.NewCloudCallContext()
+	t.ProviderCallContext = envcontext.NewCloudCallContext()
 }
 
 func (t *Tests) TearDownTest(c *gc.C) {
@@ -213,7 +214,7 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	}
 
 	e := t.Prepare(c)
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), e, t.ProviderCallContext, args)
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), e, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerInstances, err := e.ControllerInstances(t.ProviderCallContext, t.ControllerUUID)
@@ -232,7 +233,7 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	// Prepare again because Destroy invalidates old environments.
 	e3 := t.Prepare(c)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), e3, t.ProviderCallContext, args)
+	err = bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), e3, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = environs.Destroy(e3.Config().Name(), e3, t.ProviderCallContext, t.ControllerStore)

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -5,8 +5,7 @@
 package mocks
 
 import (
-	reflect "reflect"
-
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	jsonschema "github.com/juju/jsonschema"
 	cloud "github.com/juju/juju/cloud"
@@ -15,12 +14,13 @@ import (
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	network0 "github.com/juju/juju/network"
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockNetworkingEnviron is a mock of NetworkingEnviron interface
@@ -47,7 +47,7 @@ func (m *MockNetworkingEnviron) EXPECT() *MockNetworkingEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockNetworkingEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -61,7 +61,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 int
 }
 
 // AllInstances mocks base method
-func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -76,7 +76,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gom
 }
 
 // AllRunningInstances mocks base method
-func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -91,7 +91,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(network.InterfaceInfos)
@@ -106,7 +106,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 }
 
 // AreSpacesRoutable mocks base method
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
+func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context0.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -121,18 +121,18 @@ func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 
 }
 
 // Bootstrap mocks base method
-func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockNetworkingEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -150,7 +150,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -165,7 +165,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ConstraintsValidator(arg0 interface
 }
 
 // ControllerInstances mocks base method
-func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockNetworkingEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -180,7 +180,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ControllerInstances(arg0, arg1 inte
 }
 
 // Create mocks base method
-func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockNetworkingEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -194,7 +194,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Create(arg0, arg1 interface{}) *gom
 }
 
 // Destroy mocks base method
-func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockNetworkingEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -208,7 +208,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.C
 }
 
 // DestroyController mocks base method
-func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockNetworkingEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -222,7 +222,7 @@ func (mr *MockNetworkingEnvironMockRecorder) DestroyController(arg0, arg1 interf
 }
 
 // InstanceTypes mocks base method
-func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockNetworkingEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -237,7 +237,7 @@ func (mr *MockNetworkingEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{
 }
 
 // Instances mocks base method
-func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -252,7 +252,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Instances(arg0, arg1 interface{}) *
 }
 
 // MaintainInstance mocks base method
-func (m *MockNetworkingEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockNetworkingEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -266,7 +266,7 @@ func (mr *MockNetworkingEnvironMockRecorder) MaintainInstance(arg0, arg1 interfa
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
 	ret0, _ := ret[0].([]network.InterfaceInfos)
@@ -281,7 +281,7 @@ func (mr *MockNetworkingEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interf
 }
 
 // PrecheckInstance mocks base method
-func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -323,7 +323,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // ProviderSpaceInfo mocks base method
-func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context0.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderSpaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(*environs.ProviderSpaceInfo)
@@ -338,7 +338,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context0.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -352,7 +352,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SSHAddresses mocks base method
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
+func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
 	ret0, _ := ret[0].(network.SpaceAddresses)
@@ -381,7 +381,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method
-func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
 	ret0, _ := ret[0].([]network.SpaceInfo)
@@ -396,7 +396,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Spaces(arg0 interface{}) *gomock.Ca
 }
 
 // StartInstance mocks base method
-func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockNetworkingEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -411,7 +411,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StartInstance(arg0, arg1 interface{
 }
 
 // StopInstances mocks base method
-func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockNetworkingEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -460,7 +460,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StorageProviderTypes() *gomock.Call
 }
 
 // Subnets mocks base method
-func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]network.SubnetInfo)
@@ -475,7 +475,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 interface{
 }
 
 // SuperSubnets mocks base method
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) ([]string, error) {
+func (m *MockNetworkingEnviron) SuperSubnets(arg0 context0.ProviderCallContext) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
 	ret0, _ := ret[0].([]string)
@@ -490,7 +490,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 interface{}) *gom
 }
 
 // SupportsContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsContainerAddresses", arg0)
 	ret0, _ := ret[0].(bool)
@@ -505,7 +505,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsContainerAddresses(arg0 int
 }
 
 // SupportsSpaceDiscovery mocks base method
-func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaceDiscovery", arg0)
 	ret0, _ := ret[0].(bool)
@@ -520,7 +520,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaceDiscovery(arg0 interfa
 }
 
 // SupportsSpaces mocks base method
-func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaces", arg0)
 	ret0, _ := ret[0].(bool)
@@ -631,7 +631,7 @@ func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0 interface{}) *gomock.C
 }
 
 // Ping mocks base method
-func (m *MockCloudEnvironProvider) Ping(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockCloudEnvironProvider) Ping(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/environs/space/environs_mock_test.go
+++ b/environs/space/environs_mock_test.go
@@ -5,20 +5,20 @@
 package space
 
 import (
-	reflect "reflect"
-
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	network0 "github.com/juju/juju/network"
 	storage "github.com/juju/juju/storage"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockBootstrapEnviron is a mock of BootstrapEnviron interface
@@ -45,18 +45,18 @@ func (m *MockBootstrapEnviron) EXPECT() *MockBootstrapEnvironMockRecorder {
 }
 
 // Bootstrap mocks base method
-func (m *MockBootstrapEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockBootstrapEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockBootstrapEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBootstrapEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -74,7 +74,7 @@ func (mr *MockBootstrapEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockBootstrapEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockBootstrapEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -89,7 +89,7 @@ func (mr *MockBootstrapEnvironMockRecorder) ConstraintsValidator(arg0 interface{
 }
 
 // Create mocks base method
-func (m *MockBootstrapEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockBootstrapEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -103,7 +103,7 @@ func (mr *MockBootstrapEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomo
 }
 
 // Destroy mocks base method
-func (m *MockBootstrapEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockBootstrapEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -117,7 +117,7 @@ func (mr *MockBootstrapEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Ca
 }
 
 // DestroyController mocks base method
-func (m *MockBootstrapEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockBootstrapEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -212,7 +212,7 @@ func (m *MockNetworkingEnviron) EXPECT() *MockNetworkingEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockNetworkingEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -226,7 +226,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 int
 }
 
 // AllInstances mocks base method
-func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -241,7 +241,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gom
 }
 
 // AllRunningInstances mocks base method
-func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -256,7 +256,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names_v3.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(network.InterfaceInfos)
@@ -271,7 +271,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 }
 
 // AreSpacesRoutable mocks base method
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
+func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context0.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -286,18 +286,18 @@ func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 
 }
 
 // Bootstrap mocks base method
-func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockNetworkingEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -315,7 +315,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -330,7 +330,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ConstraintsValidator(arg0 interface
 }
 
 // ControllerInstances mocks base method
-func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockNetworkingEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -345,7 +345,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ControllerInstances(arg0, arg1 inte
 }
 
 // Create mocks base method
-func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockNetworkingEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -359,7 +359,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Create(arg0, arg1 interface{}) *gom
 }
 
 // Destroy mocks base method
-func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockNetworkingEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -373,7 +373,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.C
 }
 
 // DestroyController mocks base method
-func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockNetworkingEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -387,7 +387,7 @@ func (mr *MockNetworkingEnvironMockRecorder) DestroyController(arg0, arg1 interf
 }
 
 // InstanceTypes mocks base method
-func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockNetworkingEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -402,7 +402,7 @@ func (mr *MockNetworkingEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{
 }
 
 // Instances mocks base method
-func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -417,7 +417,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Instances(arg0, arg1 interface{}) *
 }
 
 // MaintainInstance mocks base method
-func (m *MockNetworkingEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockNetworkingEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -431,7 +431,7 @@ func (mr *MockNetworkingEnvironMockRecorder) MaintainInstance(arg0, arg1 interfa
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
 	ret0, _ := ret[0].([]network.InterfaceInfos)
@@ -446,7 +446,7 @@ func (mr *MockNetworkingEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interf
 }
 
 // PrecheckInstance mocks base method
-func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -488,7 +488,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // ProviderSpaceInfo mocks base method
-func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context0.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderSpaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(*environs.ProviderSpaceInfo)
@@ -503,7 +503,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context0.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -517,7 +517,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SSHAddresses mocks base method
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
+func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
 	ret0, _ := ret[0].(network.SpaceAddresses)
@@ -546,7 +546,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method
-func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
 	ret0, _ := ret[0].([]network.SpaceInfo)
@@ -561,7 +561,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Spaces(arg0 interface{}) *gomock.Ca
 }
 
 // StartInstance mocks base method
-func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockNetworkingEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -576,7 +576,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StartInstance(arg0, arg1 interface{
 }
 
 // StopInstances mocks base method
-func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockNetworkingEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -625,7 +625,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StorageProviderTypes() *gomock.Call
 }
 
 // Subnets mocks base method
-func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]network.SubnetInfo)
@@ -640,7 +640,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 interface{
 }
 
 // SuperSubnets mocks base method
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) ([]string, error) {
+func (m *MockNetworkingEnviron) SuperSubnets(arg0 context0.ProviderCallContext) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
 	ret0, _ := ret[0].([]string)
@@ -655,7 +655,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 interface{}) *gom
 }
 
 // SupportsContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsContainerAddresses", arg0)
 	ret0, _ := ret[0].(bool)
@@ -670,7 +670,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsContainerAddresses(arg0 int
 }
 
 // SupportsSpaceDiscovery mocks base method
-func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaceDiscovery", arg0)
 	ret0, _ := ret[0].(bool)
@@ -685,7 +685,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaceDiscovery(arg0 interfa
 }
 
 // SupportsSpaces mocks base method
-func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaces", arg0)
 	ret0, _ := ret[0].(bool)

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -5,9 +5,7 @@
 package testing
 
 import (
-	io "io"
-	reflect "reflect"
-
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	jsonschema "github.com/juju/jsonschema"
 	cloud "github.com/juju/juju/cloud"
@@ -16,13 +14,15 @@ import (
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	network0 "github.com/juju/juju/network"
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
 	environschema "gopkg.in/juju/environschema.v1"
+	io "io"
+	reflect "reflect"
 )
 
 // MockEnvironProvider is a mock of EnvironProvider interface
@@ -107,7 +107,7 @@ func (mr *MockEnvironProviderMockRecorder) FinalizeCredential(arg0, arg1 interfa
 }
 
 // Ping mocks base method
-func (m *MockEnvironProvider) Ping(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockEnvironProvider) Ping(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -261,7 +261,7 @@ func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0 interface{}) *gomock.C
 }
 
 // Ping mocks base method
-func (m *MockCloudEnvironProvider) Ping(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockCloudEnvironProvider) Ping(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -727,7 +727,7 @@ func (m *MockCloudDestroyer) EXPECT() *MockCloudDestroyerMockRecorder {
 }
 
 // Destroy mocks base method
-func (m *MockCloudDestroyer) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockCloudDestroyer) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -764,7 +764,7 @@ func (m *MockEnviron) EXPECT() *MockEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -778,7 +778,7 @@ func (mr *MockEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) 
 }
 
 // AllInstances mocks base method
-func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -793,7 +793,7 @@ func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 }
 
 // AllRunningInstances mocks base method
-func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -808,18 +808,18 @@ func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock
 }
 
 // Bootstrap mocks base method
-func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -837,7 +837,7 @@ func (mr *MockEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -852,7 +852,7 @@ func (mr *MockEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomoc
 }
 
 // ControllerInstances mocks base method
-func (m *MockEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -867,7 +867,7 @@ func (mr *MockEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *
 }
 
 // Create mocks base method
-func (m *MockEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -881,7 +881,7 @@ func (mr *MockEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Destroy mocks base method
-func (m *MockEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -895,7 +895,7 @@ func (mr *MockEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 }
 
 // DestroyController mocks base method
-func (m *MockEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -909,7 +909,7 @@ func (mr *MockEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *go
 }
 
 // InstanceTypes mocks base method
-func (m *MockEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -924,7 +924,7 @@ func (mr *MockEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock
 }
 
 // Instances mocks base method
-func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -939,7 +939,7 @@ func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // MaintainInstance mocks base method
-func (m *MockEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -953,7 +953,7 @@ func (mr *MockEnvironMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gom
 }
 
 // PrecheckInstance mocks base method
-func (m *MockEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1009,7 +1009,7 @@ func (mr *MockEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
 }
 
 // StartInstance mocks base method
-func (m *MockEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -1024,7 +1024,7 @@ func (mr *MockEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock
 }
 
 // StopInstances mocks base method
-func (m *MockEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -1096,7 +1096,7 @@ func (m *MockInstancePrechecker) EXPECT() *MockInstancePrecheckerMockRecorder {
 }
 
 // PrecheckInstance mocks base method
-func (m *MockInstancePrechecker) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockInstancePrechecker) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1133,7 +1133,7 @@ func (m *MockFirewaller) EXPECT() *MockFirewallerMockRecorder {
 }
 
 // ClosePorts mocks base method
-func (m *MockFirewaller) ClosePorts(arg0 context.ProviderCallContext, arg1 []network0.IngressRule) error {
+func (m *MockFirewaller) ClosePorts(arg0 context0.ProviderCallContext, arg1 []network0.IngressRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClosePorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1147,7 +1147,7 @@ func (mr *MockFirewallerMockRecorder) ClosePorts(arg0, arg1 interface{}) *gomock
 }
 
 // IngressRules mocks base method
-func (m *MockFirewaller) IngressRules(arg0 context.ProviderCallContext) ([]network0.IngressRule, error) {
+func (m *MockFirewaller) IngressRules(arg0 context0.ProviderCallContext) ([]network0.IngressRule, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IngressRules", arg0)
 	ret0, _ := ret[0].([]network0.IngressRule)
@@ -1162,7 +1162,7 @@ func (mr *MockFirewallerMockRecorder) IngressRules(arg0 interface{}) *gomock.Cal
 }
 
 // OpenPorts mocks base method
-func (m *MockFirewaller) OpenPorts(arg0 context.ProviderCallContext, arg1 []network0.IngressRule) error {
+func (m *MockFirewaller) OpenPorts(arg0 context0.ProviderCallContext, arg1 []network0.IngressRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenPorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1199,7 +1199,7 @@ func (m *MockInstanceTagger) EXPECT() *MockInstanceTaggerMockRecorder {
 }
 
 // TagInstance mocks base method
-func (m *MockInstanceTagger) TagInstance(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 map[string]string) error {
+func (m *MockInstanceTagger) TagInstance(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagInstance", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1236,7 +1236,7 @@ func (m *MockInstanceTypesFetcher) EXPECT() *MockInstanceTypesFetcherMockRecorde
 }
 
 // InstanceTypes mocks base method
-func (m *MockInstanceTypesFetcher) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockInstanceTypesFetcher) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -1274,7 +1274,7 @@ func (m *MockUpgrader) EXPECT() *MockUpgraderMockRecorder {
 }
 
 // UpgradeOperations mocks base method
-func (m *MockUpgrader) UpgradeOperations(arg0 context.ProviderCallContext, arg1 environs.UpgradeOperationsParams) []environs.UpgradeOperation {
+func (m *MockUpgrader) UpgradeOperations(arg0 context0.ProviderCallContext, arg1 environs.UpgradeOperationsParams) []environs.UpgradeOperation {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeOperations", arg0, arg1)
 	ret0, _ := ret[0].([]environs.UpgradeOperation)
@@ -1325,7 +1325,7 @@ func (mr *MockUpgradeStepMockRecorder) Description() *gomock.Call {
 }
 
 // Run mocks base method
-func (m *MockUpgradeStep) Run(arg0 context.ProviderCallContext) error {
+func (m *MockUpgradeStep) Run(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0)
 	ret0, _ := ret[0].(error)
@@ -1474,7 +1474,7 @@ func (m *MockNetworkingEnviron) EXPECT() *MockNetworkingEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockNetworkingEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1488,7 +1488,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 int
 }
 
 // AllInstances mocks base method
-func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -1503,7 +1503,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gom
 }
 
 // AllRunningInstances mocks base method
-func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -1518,7 +1518,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(network.InterfaceInfos)
@@ -1533,7 +1533,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 }
 
 // AreSpacesRoutable mocks base method
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
+func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context0.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -1548,18 +1548,18 @@ func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 
 }
 
 // Bootstrap mocks base method
-func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockNetworkingEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -1577,7 +1577,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -1592,7 +1592,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ConstraintsValidator(arg0 interface
 }
 
 // ControllerInstances mocks base method
-func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockNetworkingEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -1607,7 +1607,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ControllerInstances(arg0, arg1 inte
 }
 
 // Create mocks base method
-func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockNetworkingEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1621,7 +1621,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Create(arg0, arg1 interface{}) *gom
 }
 
 // Destroy mocks base method
-func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockNetworkingEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -1635,7 +1635,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.C
 }
 
 // DestroyController mocks base method
-func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockNetworkingEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1649,7 +1649,7 @@ func (mr *MockNetworkingEnvironMockRecorder) DestroyController(arg0, arg1 interf
 }
 
 // InstanceTypes mocks base method
-func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockNetworkingEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -1664,7 +1664,7 @@ func (mr *MockNetworkingEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{
 }
 
 // Instances mocks base method
-func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -1679,7 +1679,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Instances(arg0, arg1 interface{}) *
 }
 
 // MaintainInstance mocks base method
-func (m *MockNetworkingEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockNetworkingEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1693,7 +1693,7 @@ func (mr *MockNetworkingEnvironMockRecorder) MaintainInstance(arg0, arg1 interfa
 }
 
 // NetworkInterfaces mocks base method
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
 	ret0, _ := ret[0].([]network.InterfaceInfos)
@@ -1708,7 +1708,7 @@ func (mr *MockNetworkingEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interf
 }
 
 // PrecheckInstance mocks base method
-func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1750,7 +1750,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // ProviderSpaceInfo mocks base method
-func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context0.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderSpaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(*environs.ProviderSpaceInfo)
@@ -1765,7 +1765,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context0.ProviderCallContext, arg1 []network0.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1779,7 +1779,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SSHAddresses mocks base method
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
+func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
 	ret0, _ := ret[0].(network.SpaceAddresses)
@@ -1808,7 +1808,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method
-func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
 	ret0, _ := ret[0].([]network.SpaceInfo)
@@ -1823,7 +1823,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Spaces(arg0 interface{}) *gomock.Ca
 }
 
 // StartInstance mocks base method
-func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockNetworkingEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -1838,7 +1838,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StartInstance(arg0, arg1 interface{
 }
 
 // StopInstances mocks base method
-func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockNetworkingEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -1887,7 +1887,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StorageProviderTypes() *gomock.Call
 }
 
 // Subnets mocks base method
-func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]network.SubnetInfo)
@@ -1902,7 +1902,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 interface{
 }
 
 // SuperSubnets mocks base method
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) ([]string, error) {
+func (m *MockNetworkingEnviron) SuperSubnets(arg0 context0.ProviderCallContext) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
 	ret0, _ := ret[0].([]string)
@@ -1917,7 +1917,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 interface{}) *gom
 }
 
 // SupportsContainerAddresses mocks base method
-func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsContainerAddresses", arg0)
 	ret0, _ := ret[0].(bool)
@@ -1932,7 +1932,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsContainerAddresses(arg0 int
 }
 
 // SupportsSpaceDiscovery mocks base method
-func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaceDiscovery", arg0)
 	ret0, _ := ret[0].(bool)
@@ -1947,7 +1947,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaceDiscovery(arg0 interfa
 }
 
 // SupportsSpaces mocks base method
-func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaces", arg0)
 	ret0, _ := ret[0].(bool)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -42,7 +43,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
@@ -128,7 +129,7 @@ type JujuConnSuite struct {
 	oldJujuXDGDataHome  string
 	DummyConfig         testing.Attrs
 	Factory             *factory.Factory
-	ProviderCallContext context.ProviderCallContext
+	ProviderCallContext envcontext.ProviderCallContext
 
 	idleFuncMutex       *sync.Mutex
 	txnSyncNotify       chan struct{}
@@ -569,8 +570,8 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	// Dummy provider uses a random port, which is added to cfg used to create environment.
 	apiPort := dummy.APIPort(environ.Provider())
 	s.ControllerConfig["api-port"] = apiPort
-	s.ProviderCallContext = context.NewCloudCallContext()
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
+	s.ProviderCallContext = envcontext.NewCloudCallContext()
+	err = bootstrap.Bootstrap(context.Background(), modelcmd.BootstrapContext(ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
 		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,7 +39,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/environs/sync"
@@ -117,7 +118,7 @@ type environSuite struct {
 	sshPublicKeys      []compute.SSHPublicKey
 	linuxOsProfile     compute.OSProfile
 
-	callCtx               *context.CloudCallContext
+	callCtx               *envcontext.CloudCallContext
 	invalidatedCredential bool
 }
 
@@ -281,7 +282,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
-	s.callCtx = &context.CloudCallContext{
+	s.callCtx = &envcontext.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidatedCredential = true
 			return nil
@@ -1296,7 +1297,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.sender = append(s.sender, s.startInstanceSenders(true)...)
 	s.requests = nil
 	result, err := env.Bootstrap(
-		ctx, s.callCtx, environs.BootstrapParams{
+		context.Background(), ctx, s.callCtx, environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
 			AvailableTools:           makeToolsList("bionic"),
 			BootstrapSeries:          "bionic",
@@ -1331,7 +1332,7 @@ func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 
 	c.Assert(s.invalidatedCredential, jc.IsFalse)
 	_, err := env.Bootstrap(
-		ctx, s.callCtx, environs.BootstrapParams{
+		context.Background(), ctx, s.callCtx, environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
 			AvailableTools:           makeToolsList("bionic"),
 			BootstrapSeries:          "bionic",
@@ -1360,7 +1361,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	s.sender = append(s.sender, s.startInstanceSendersNoSizes()...)
 	s.requests = nil
 	err := bootstrap.Bootstrap(
-		ctx, env, s.callCtx, bootstrap.BootstrapParams{
+		context.Background(), ctx, env, s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,
@@ -1411,7 +1412,7 @@ func (s *environSuite) TestBootstrapCustomResourceGroup(c *gc.C) {
 	s.sender = append(s.sender, s.startInstanceSendersNoSizes()...)
 	s.requests = nil
 	err := bootstrap.Bootstrap(
-		ctx, env, s.callCtx, bootstrap.BootstrapParams{
+		context.Background(), ctx, env, s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,
@@ -1462,7 +1463,7 @@ func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	config["api-port"] = 443
 	config["autocert-dns-name"] = "example.com"
 	result, err := env.Bootstrap(
-		ctx, s.callCtx, environs.BootstrapParams{
+		context.Background(), ctx, s.callCtx, environs.BootstrapParams{
 			ControllerConfig:         config,
 			AvailableTools:           makeToolsList("bionic"),
 			BootstrapSeries:          "bionic",
@@ -1745,7 +1746,7 @@ func (s *environSuite) TestConstraintsValidatorMerge(c *gc.C) {
 func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {
 	env := s.openEnviron(c)
 	s.sender = azuretesting.Senders{s.resourceSkusSender()}
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	return validator
 }

--- a/provider/cloudsigma/environ.go
+++ b/provider/cloudsigma/environ.go
@@ -4,6 +4,7 @@
 package cloudsigma
 
 import (
+	"context"
 	"sync"
 
 	"github.com/altoros/gosigma"
@@ -13,7 +14,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/provider/common"
 )
@@ -72,7 +73,7 @@ func (env *environ) PrepareForBootstrap(ctx environs.BootstrapContext, controlle
 }
 
 // Create is part of the Environ interface.
-func (env *environ) Create(context.ProviderCallContext, environs.CreateParams) error {
+func (env *environ) Create(envcontext.ProviderCallContext, environs.CreateParams) error {
 	return nil
 }
 
@@ -90,17 +91,17 @@ func (env *environ) Create(context.ProviderCallContext, environs.CreateParams) e
 // Bootstrap is responsible for selecting the appropriate tools,
 // and setting the agent-version configuration attribute prior to
 // bootstrapping the environment.
-func (env *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	return common.Bootstrap(ctx, env, callCtx, params)
+func (env *environ) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	return common.Bootstrap(ctx, cmdCtx, env, callCtx, params)
 }
 
 // ControllerInstances is part of the Environ interface.
-func (e *environ) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
+func (e *environ) ControllerInstances(ctx envcontext.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
 	return e.client.getControllerIds()
 }
 
 // AdoptResources is part of the Environ interface.
-func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
+func (e *environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }
@@ -112,13 +113,13 @@ func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 //
 // When Destroy has been called, any Environ referring to the
 // same remote environment may become invalid
-func (env *environ) Destroy(ctx context.ProviderCallContext) error {
+func (env *environ) Destroy(ctx envcontext.ProviderCallContext) error {
 	// You can probably ignore this method; the common implementation should work.
 	return common.Destroy(env, ctx)
 }
 
 // DestroyController implements the Environ interface.
-func (env *environ) DestroyController(ctx context.ProviderCallContext, controllerUUID string) error {
+func (env *environ) DestroyController(ctx envcontext.ProviderCallContext, controllerUUID string) error {
 	// TODO(wallyworld): destroy hosted model resources
 	return env.Destroy(ctx)
 }
@@ -131,7 +132,7 @@ func (env *environ) DestroyController(ctx context.ProviderCallContext, controlle
 // all invalid parameters. If PrecheckInstance returns nil, it is not
 // guaranteed that the constraints are valid; if a non-nil error is
 // returned, then the constraints are definitely invalid.
-func (env *environ) PrecheckInstance(context.ProviderCallContext, environs.PrecheckInstanceParams) error {
+func (env *environ) PrecheckInstance(envcontext.ProviderCallContext, environs.PrecheckInstanceParams) error {
 	return nil
 }
 

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -96,7 +96,7 @@ func BootstrapInstance(
 		}
 		return nil, "", nil, errors.Annotatef(err, "use --force to override")
 	}
-	// The series we're attemptting to bootstrap is empty, show a friendly
+	// The series we're attempting to bootstrap is empty, show a friendly
 	// error message, rather than the more cryptic error messages that follow
 	// onwards.
 	if selectedSeries == "" {

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -276,7 +276,7 @@ func BootstrapInstance(
 	}
 	ctx.Infof(msg)
 
-	finalizer := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, opts environs.BootstrapDialOpts) error {
+	finalizer := func(ctx context.Context, cmdCtx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, opts environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
 		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = result.Hardware
 		icfg.Bootstrap.InitialSSHHostKeys = initialSSHHostKeys
@@ -292,7 +292,7 @@ func BootstrapInstance(
 			return err
 		}
 		maybeSetBridge(icfg)
-		return FinishBootstrap(ctx, client, env, callCtx, result.Instance, icfg, opts)
+		return FinishBootstrap(cmdCtx, client, env, callCtx, result.Instance, icfg, opts)
 	}
 	return result, selectedSeries, finalizer, nil
 }

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
@@ -32,7 +33,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -46,7 +47,7 @@ type BootstrapSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	envtesting.ToolsFixture
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 }
 
 var _ = gc.Suite(&BootstrapSuite{})
@@ -63,7 +64,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		return fmt.Errorf("mock connection failure to %s", host)
 	})
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = envcontext.NewCloudCallContext()
 }
 
 func (s *BootstrapSuite) TearDownTest(c *gc.C) {
@@ -113,7 +114,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 		config:  configGetter(c),
 	}
 
-	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	startInstance := func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -150,7 +151,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 	env.startInstance = startInstance
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapConstraints:     checkCons,
 		ModelConstraints:         checkCons,
@@ -172,7 +173,7 @@ func (s *BootstrapSuite) TestBootstrapSeries(c *gc.C) {
 	bootstrapSeries := series.DefaultSupportedLTS()
 	availableTools := fakeAvailableTools()
 	availableTools[0].Version.Series = bootstrapSeries
-	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	result, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapSeries:          bootstrapSeries,
 		AvailableTools:           availableTools,
@@ -194,7 +195,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidSeries(c *gc.C) {
 	bootstrapSeries := "spock"
 	availableTools := fakeAvailableTools()
 	availableTools[0].Version.Series = bootstrapSeries
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapSeries:          bootstrapSeries,
 		AvailableTools:           availableTools,
@@ -213,7 +214,7 @@ func (s *BootstrapSuite) TestBootstrapFallbackSeries(c *gc.C) {
 	ctx := envtesting.BootstrapContext(c)
 	bootstrapSeries := ""
 	availableTools := fakeAvailableTools()
-	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	result, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapSeries:          bootstrapSeries,
 		AvailableTools:           availableTools,
@@ -235,7 +236,7 @@ func (s *BootstrapSuite) TestBootstrapSeriesWithForce(c *gc.C) {
 	bootstrapSeries := "xenial"
 	availableTools := fakeAvailableTools()
 	availableTools[0].Version.Series = bootstrapSeries
-	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	result, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapSeries:          bootstrapSeries,
 		AvailableTools:           availableTools,
@@ -265,7 +266,7 @@ func (s *BootstrapSuite) TestBootstrapSeriesWithForceAndInvalidFallback(c *gc.C)
 	ctx := envtesting.BootstrapContext(c)
 	bootstrapSeries := ""
 	availableTools := fakeAvailableTools()
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapSeries:          bootstrapSeries,
 		AvailableTools:           availableTools,
@@ -282,12 +283,12 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return []string{"derived-zone"}, nil
 		},
 	}
 
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -298,7 +299,7 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 	}
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -315,10 +316,10 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", false}
 			z2 := &mockAvailabilityZone{"z2", true}
@@ -327,7 +328,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -338,7 +339,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 	}
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -356,10 +357,10 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			z2 := &mockAvailabilityZone{"z2", true}
@@ -369,7 +370,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -380,7 +381,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 	}
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -401,10 +402,10 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			z2 := &mockAvailabilityZone{"z2", true}
@@ -414,7 +415,7 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -425,7 +426,7 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 	}
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -446,10 +447,10 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			return []common.AvailabilityZone{z0, z1}, nil
@@ -457,7 +458,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -468,7 +469,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 	}
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -484,17 +485,17 @@ func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", false}
 			return []common.AvailabilityZone{z0}, nil
 		},
 	}
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	_, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -513,7 +514,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 		id:        checkInstanceId,
 		addresses: corenetwork.NewProviderAddresses("testing.invalid"),
 	}
-	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	startInstance := func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -547,7 +548,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 		startInstance: startInstance,
 		config:        getConfig,
 		setConfig:     setConfig,
-		instances: func(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+		instances: func(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 			instancesMu.Lock()
 			defer instancesMu.Unlock()
 			return []instances.Instance{inst}, nil
@@ -555,7 +556,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 	}
 	inner := cmdtesting.Context(c)
 	ctx := modelcmd.BootstrapContext(inner)
-	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	result, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
@@ -620,7 +621,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 		id:        "i-success",
 		addresses: corenetwork.NewProviderAddresses("testing.invalid"),
 	}
-	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	startInstance := func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -635,7 +636,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	env := &mockEnviron{
 		startInstance: startInstance,
 		config:        configGetter(c),
-		instances: func(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+		instances: func(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 			instancesMu.Lock()
 			defer instancesMu.Unlock()
 			return []instances.Instance{inst}, nil
@@ -645,7 +646,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	bootstrapSeries := series.DefaultSupportedLTS()
 	availableTools := fakeAvailableTools()
 	availableTools[0].Version.Series = bootstrapSeries
-	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
+	result, err := common.Bootstrap(context.Background(), ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		BootstrapSeries:          bootstrapSeries,
 		AvailableTools:           availableTools,
@@ -681,11 +682,11 @@ package_upgrade: false
 type neverRefreshes struct {
 }
 
-func (neverRefreshes) Refresh(ctx context.ProviderCallContext) error {
+func (neverRefreshes) Refresh(ctx envcontext.ProviderCallContext) error {
 	return nil
 }
 
-func (neverRefreshes) Status(ctx context.ProviderCallContext) instance.Status {
+func (neverRefreshes) Status(ctx envcontext.ProviderCallContext) instance.Status {
 	return instance.Status{}
 }
 
@@ -693,7 +694,7 @@ type neverAddresses struct {
 	neverRefreshes
 }
 
-func (neverAddresses) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (neverAddresses) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return nil, nil
 }
 
@@ -702,7 +703,7 @@ type failsProvisioning struct {
 	message string
 }
 
-func (f failsProvisioning) Status(ctx context.ProviderCallContext) instance.Status {
+func (f failsProvisioning) Status(ctx envcontext.ProviderCallContext) instance.Status {
 	return instance.Status{
 		Status:  status.ProvisioningError,
 		Message: f.message,
@@ -755,7 +756,7 @@ type brokenAddresses struct {
 	neverRefreshes
 }
 
-func (brokenAddresses) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (brokenAddresses) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return nil, errors.Errorf("Addresses will never work")
 }
 
@@ -774,7 +775,7 @@ type neverOpensPort struct {
 	addr string
 }
 
-func (n *neverOpensPort) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (n *neverOpensPort) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return corenetwork.NewProviderAddresses(n.addr), nil
 }
 
@@ -799,7 +800,7 @@ type interruptOnDial struct {
 	returned    bool
 }
 
-func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (i *interruptOnDial) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	// kill the tomb the second time Addresses is called
 	if !i.returned {
 		i.returned = true
@@ -832,18 +833,18 @@ type addressesChange struct {
 	addrs [][]string
 }
 
-func (ac *addressesChange) Refresh(ctx context.ProviderCallContext) error {
+func (ac *addressesChange) Refresh(ctx envcontext.ProviderCallContext) error {
 	if len(ac.addrs) > 1 {
 		ac.addrs = ac.addrs[1:]
 	}
 	return nil
 }
 
-func (ac *addressesChange) Status(ctx context.ProviderCallContext) instance.Status {
+func (ac *addressesChange) Status(ctx envcontext.ProviderCallContext) instance.Status {
 	return instance.Status{}
 }
 
-func (ac *addressesChange) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (ac *addressesChange) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return corenetwork.NewProviderAddresses(ac.addrs[0]...), nil
 }
 
@@ -934,7 +935,7 @@ func fakeAvailableTools() tools.List {
 	}
 }
 
-func fakeStartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+func fakeStartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 	instances.Instance,
 	*instance.HardwareCharacteristics,
 	corenetwork.InterfaceInfos,

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -600,7 +600,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 		}
 		return nil
 	})
-	err = result.CloudBootstrapFinalizer(ctx, innerInstanceConfig, environs.BootstrapDialOpts{
+	err = result.CloudBootstrapFinalizer(context.Background(), ctx, innerInstanceConfig, environs.BootstrapDialOpts{
 		Timeout: coretesting.LongWait,
 	})
 	c.Assert(err, gc.ErrorMatches, "invalid machine configuration: .*") // icfg hasn't been finalized
@@ -655,7 +655,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result.CloudBootstrapFinalizer, gc.NotNil)
-	err = result.CloudBootstrapFinalizer(ctx, innerInstanceConfig, environs.BootstrapDialOpts{
+	err = result.CloudBootstrapFinalizer(context.Background(), ctx, innerInstanceConfig, environs.BootstrapDialOpts{
 		Timeout: coretesting.ShortWait,
 	})
 	c.Assert(err, gc.ErrorMatches, "waited for 50ms without being able to connect.*")

--- a/provider/common/mocks/availability_zone.go
+++ b/provider/common/mocks/availability_zone.go
@@ -5,9 +5,8 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockAvailabilityZone is a mock of AvailabilityZone interface
@@ -35,6 +34,7 @@ func (m *MockAvailabilityZone) EXPECT() *MockAvailabilityZoneMockRecorder {
 
 // Available mocks base method
 func (m *MockAvailabilityZone) Available() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Available")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -42,11 +42,13 @@ func (m *MockAvailabilityZone) Available() bool {
 
 // Available indicates an expected call of Available
 func (mr *MockAvailabilityZoneMockRecorder) Available() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Available", reflect.TypeOf((*MockAvailabilityZone)(nil).Available))
 }
 
 // Name mocks base method
 func (m *MockAvailabilityZone) Name() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -54,5 +56,6 @@ func (m *MockAvailabilityZone) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockAvailabilityZoneMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockAvailabilityZone)(nil).Name))
 }

--- a/provider/common/mocks/instance_configurator.go
+++ b/provider/common/mocks/instance_configurator.go
@@ -5,10 +5,9 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/network"
+	reflect "reflect"
 )
 
 // MockInstanceConfigurator is a mock of InstanceConfigurator interface
@@ -36,6 +35,7 @@ func (m *MockInstanceConfigurator) EXPECT() *MockInstanceConfiguratorMockRecorde
 
 // ChangeIngressRules mocks base method
 func (m *MockInstanceConfigurator) ChangeIngressRules(arg0 string, arg1 bool, arg2 []network.IngressRule) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeIngressRules", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +43,13 @@ func (m *MockInstanceConfigurator) ChangeIngressRules(arg0 string, arg1 bool, ar
 
 // ChangeIngressRules indicates an expected call of ChangeIngressRules
 func (mr *MockInstanceConfiguratorMockRecorder) ChangeIngressRules(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeIngressRules", reflect.TypeOf((*MockInstanceConfigurator)(nil).ChangeIngressRules), arg0, arg1, arg2)
 }
 
 // ConfigureExternalIpAddress mocks base method
 func (m *MockInstanceConfigurator) ConfigureExternalIpAddress(arg0 int) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigureExternalIpAddress", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -55,11 +57,13 @@ func (m *MockInstanceConfigurator) ConfigureExternalIpAddress(arg0 int) error {
 
 // ConfigureExternalIpAddress indicates an expected call of ConfigureExternalIpAddress
 func (mr *MockInstanceConfiguratorMockRecorder) ConfigureExternalIpAddress(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureExternalIpAddress", reflect.TypeOf((*MockInstanceConfigurator)(nil).ConfigureExternalIpAddress), arg0)
 }
 
 // DropAllPorts mocks base method
 func (m *MockInstanceConfigurator) DropAllPorts(arg0 []int, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DropAllPorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -67,11 +71,13 @@ func (m *MockInstanceConfigurator) DropAllPorts(arg0 []int, arg1 string) error {
 
 // DropAllPorts indicates an expected call of DropAllPorts
 func (mr *MockInstanceConfiguratorMockRecorder) DropAllPorts(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropAllPorts", reflect.TypeOf((*MockInstanceConfigurator)(nil).DropAllPorts), arg0, arg1)
 }
 
 // FindIngressRules mocks base method
 func (m *MockInstanceConfigurator) FindIngressRules() ([]network.IngressRule, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindIngressRules")
 	ret0, _ := ret[0].([]network.IngressRule)
 	ret1, _ := ret[1].(error)
@@ -80,5 +86,6 @@ func (m *MockInstanceConfigurator) FindIngressRules() ([]network.IngressRule, er
 
 // FindIngressRules indicates an expected call of FindIngressRules
 func (mr *MockInstanceConfiguratorMockRecorder) FindIngressRules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindIngressRules", reflect.TypeOf((*MockInstanceConfigurator)(nil).FindIngressRules))
 }

--- a/provider/common/mocks/zoned_environ.go
+++ b/provider/common/mocks/zoned_environ.go
@@ -5,19 +5,18 @@
 package mocks
 
 import (
-	"reflect"
-
-	"github.com/golang/mock/gomock"
-	"github.com/juju/version"
-
-	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/provider/common"
-	"github.com/juju/juju/storage"
+	context "context"
+	gomock "github.com/golang/mock/gomock"
+	constraints "github.com/juju/juju/core/constraints"
+	instance "github.com/juju/juju/core/instance"
+	environs "github.com/juju/juju/environs"
+	config "github.com/juju/juju/environs/config"
+	context0 "github.com/juju/juju/environs/context"
+	instances "github.com/juju/juju/environs/instances"
+	common "github.com/juju/juju/provider/common"
+	storage "github.com/juju/juju/storage"
+	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockZonedEnviron is a mock of ZonedEnviron interface
@@ -44,7 +43,8 @@ func (m *MockZonedEnviron) EXPECT() *MockZonedEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockZonedEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockZonedEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -52,11 +52,13 @@ func (m *MockZonedEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1
 
 // AdoptResources indicates an expected call of AdoptResources
 func (mr *MockZonedEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdoptResources", reflect.TypeOf((*MockZonedEnviron)(nil).AdoptResources), arg0, arg1, arg2)
 }
 
 // AllInstances mocks base method
-func (m *MockZonedEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockZonedEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -65,11 +67,13 @@ func (m *MockZonedEnviron) AllInstances(arg0 context.ProviderCallContext) ([]ins
 
 // AllInstances indicates an expected call of AllInstances
 func (mr *MockZonedEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockZonedEnviron)(nil).AllInstances), arg0)
 }
 
 // AllRunningInstances mocks base method
-func (m *MockZonedEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockZonedEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -78,11 +82,13 @@ func (m *MockZonedEnviron) AllRunningInstances(arg0 context.ProviderCallContext)
 
 // AllRunningInstances indicates an expected call of AllRunningInstances
 func (mr *MockZonedEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockZonedEnviron)(nil).AllRunningInstances), arg0)
 }
 
 // AvailabilityZones mocks base method
-func (m *MockZonedEnviron) AvailabilityZones(arg0 context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+func (m *MockZonedEnviron) AvailabilityZones(arg0 context0.ProviderCallContext) ([]common.AvailabilityZone, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AvailabilityZones", arg0)
 	ret0, _ := ret[0].([]common.AvailabilityZone)
 	ret1, _ := ret[1].(error)
@@ -91,24 +97,28 @@ func (m *MockZonedEnviron) AvailabilityZones(arg0 context.ProviderCallContext) (
 
 // AvailabilityZones indicates an expected call of AvailabilityZones
 func (mr *MockZonedEnvironMockRecorder) AvailabilityZones(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZones", reflect.TypeOf((*MockZonedEnviron)(nil).AvailabilityZones), arg0)
 }
 
 // Bootstrap mocks base method
-func (m *MockZonedEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+func (m *MockZonedEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockZonedEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockZonedEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+func (mr *MockZonedEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockZonedEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
 func (m *MockZonedEnviron) Config() *config.Config {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*config.Config)
 	return ret0
@@ -116,11 +126,13 @@ func (m *MockZonedEnviron) Config() *config.Config {
 
 // Config indicates an expected call of Config
 func (mr *MockZonedEnvironMockRecorder) Config() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockZonedEnviron)(nil).Config))
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockZonedEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockZonedEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
 	ret1, _ := ret[1].(error)
@@ -129,11 +141,13 @@ func (m *MockZonedEnviron) ConstraintsValidator(arg0 context.ProviderCallContext
 
 // ConstraintsValidator indicates an expected call of ConstraintsValidator
 func (mr *MockZonedEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsValidator", reflect.TypeOf((*MockZonedEnviron)(nil).ConstraintsValidator), arg0)
 }
 
 // ControllerInstances mocks base method
-func (m *MockZonedEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockZonedEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
@@ -142,11 +156,13 @@ func (m *MockZonedEnviron) ControllerInstances(arg0 context.ProviderCallContext,
 
 // ControllerInstances indicates an expected call of ControllerInstances
 func (mr *MockZonedEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerInstances", reflect.TypeOf((*MockZonedEnviron)(nil).ControllerInstances), arg0, arg1)
 }
 
 // Create mocks base method
-func (m *MockZonedEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockZonedEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -154,11 +170,13 @@ func (m *MockZonedEnviron) Create(arg0 context.ProviderCallContext, arg1 environ
 
 // Create indicates an expected call of Create
 func (mr *MockZonedEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockZonedEnviron)(nil).Create), arg0, arg1)
 }
 
 // DeriveAvailabilityZones mocks base method
-func (m *MockZonedEnviron) DeriveAvailabilityZones(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) ([]string, error) {
+func (m *MockZonedEnviron) DeriveAvailabilityZones(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeriveAvailabilityZones", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -167,11 +185,13 @@ func (m *MockZonedEnviron) DeriveAvailabilityZones(arg0 context.ProviderCallCont
 
 // DeriveAvailabilityZones indicates an expected call of DeriveAvailabilityZones
 func (mr *MockZonedEnvironMockRecorder) DeriveAvailabilityZones(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeriveAvailabilityZones", reflect.TypeOf((*MockZonedEnviron)(nil).DeriveAvailabilityZones), arg0, arg1)
 }
 
 // Destroy mocks base method
-func (m *MockZonedEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockZonedEnviron) Destroy(arg0 context0.ProviderCallContext) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -179,11 +199,13 @@ func (m *MockZonedEnviron) Destroy(arg0 context.ProviderCallContext) error {
 
 // Destroy indicates an expected call of Destroy
 func (mr *MockZonedEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockZonedEnviron)(nil).Destroy), arg0)
 }
 
 // DestroyController mocks base method
-func (m *MockZonedEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockZonedEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -191,11 +213,13 @@ func (m *MockZonedEnviron) DestroyController(arg0 context.ProviderCallContext, a
 
 // DestroyController indicates an expected call of DestroyController
 func (mr *MockZonedEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyController", reflect.TypeOf((*MockZonedEnviron)(nil).DestroyController), arg0, arg1)
 }
 
 // InstanceAvailabilityZoneNames mocks base method
-func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]string, error) {
+func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceAvailabilityZoneNames", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
@@ -204,11 +228,13 @@ func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context.ProviderCa
 
 // InstanceAvailabilityZoneNames indicates an expected call of InstanceAvailabilityZoneNames
 func (mr *MockZonedEnvironMockRecorder) InstanceAvailabilityZoneNames(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceAvailabilityZoneNames", reflect.TypeOf((*MockZonedEnviron)(nil).InstanceAvailabilityZoneNames), arg0, arg1)
 }
 
 // InstanceTypes mocks base method
-func (m *MockZonedEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockZonedEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
 	ret1, _ := ret[1].(error)
@@ -217,11 +243,13 @@ func (m *MockZonedEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 
 
 // InstanceTypes indicates an expected call of InstanceTypes
 func (mr *MockZonedEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceTypes", reflect.TypeOf((*MockZonedEnviron)(nil).InstanceTypes), arg0, arg1)
 }
 
 // Instances mocks base method
-func (m *MockZonedEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockZonedEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
 	ret1, _ := ret[1].(error)
@@ -230,11 +258,13 @@ func (m *MockZonedEnviron) Instances(arg0 context.ProviderCallContext, arg1 []in
 
 // Instances indicates an expected call of Instances
 func (mr *MockZonedEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instances", reflect.TypeOf((*MockZonedEnviron)(nil).Instances), arg0, arg1)
 }
 
 // MaintainInstance mocks base method
-func (m *MockZonedEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockZonedEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -242,11 +272,13 @@ func (m *MockZonedEnviron) MaintainInstance(arg0 context.ProviderCallContext, ar
 
 // MaintainInstance indicates an expected call of MaintainInstance
 func (mr *MockZonedEnvironMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaintainInstance", reflect.TypeOf((*MockZonedEnviron)(nil).MaintainInstance), arg0, arg1)
 }
 
 // PrecheckInstance mocks base method
-func (m *MockZonedEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockZonedEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -254,11 +286,13 @@ func (m *MockZonedEnviron) PrecheckInstance(arg0 context.ProviderCallContext, ar
 
 // PrecheckInstance indicates an expected call of PrecheckInstance
 func (mr *MockZonedEnvironMockRecorder) PrecheckInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrecheckInstance", reflect.TypeOf((*MockZonedEnviron)(nil).PrecheckInstance), arg0, arg1)
 }
 
 // PrepareForBootstrap mocks base method
 func (m *MockZonedEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, arg1 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareForBootstrap", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -266,11 +300,13 @@ func (m *MockZonedEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, a
 
 // PrepareForBootstrap indicates an expected call of PrepareForBootstrap
 func (mr *MockZonedEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForBootstrap", reflect.TypeOf((*MockZonedEnviron)(nil).PrepareForBootstrap), arg0, arg1)
 }
 
 // Provider mocks base method
 func (m *MockZonedEnviron) Provider() environs.EnvironProvider {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Provider")
 	ret0, _ := ret[0].(environs.EnvironProvider)
 	return ret0
@@ -278,11 +314,13 @@ func (m *MockZonedEnviron) Provider() environs.EnvironProvider {
 
 // Provider indicates an expected call of Provider
 func (mr *MockZonedEnvironMockRecorder) Provider() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockZonedEnviron)(nil).Provider))
 }
 
 // SetConfig mocks base method
 func (m *MockZonedEnviron) SetConfig(arg0 *config.Config) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -290,11 +328,13 @@ func (m *MockZonedEnviron) SetConfig(arg0 *config.Config) error {
 
 // SetConfig indicates an expected call of SetConfig
 func (mr *MockZonedEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockZonedEnviron)(nil).SetConfig), arg0)
 }
 
 // StartInstance mocks base method
-func (m *MockZonedEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockZonedEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
 	ret1, _ := ret[1].(error)
@@ -303,11 +343,13 @@ func (m *MockZonedEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 
 
 // StartInstance indicates an expected call of StartInstance
 func (mr *MockZonedEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockZonedEnviron)(nil).StartInstance), arg0, arg1)
 }
 
 // StopInstances mocks base method
-func (m *MockZonedEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockZonedEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -319,12 +361,14 @@ func (m *MockZonedEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockZonedEnvironMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockZonedEnviron)(nil).StopInstances), varargs...)
 }
 
 // StorageProvider mocks base method
 func (m *MockZonedEnviron) StorageProvider(arg0 storage.ProviderType) (storage.Provider, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProvider", arg0)
 	ret0, _ := ret[0].(storage.Provider)
 	ret1, _ := ret[1].(error)
@@ -333,11 +377,13 @@ func (m *MockZonedEnviron) StorageProvider(arg0 storage.ProviderType) (storage.P
 
 // StorageProvider indicates an expected call of StorageProvider
 func (mr *MockZonedEnvironMockRecorder) StorageProvider(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProvider", reflect.TypeOf((*MockZonedEnviron)(nil).StorageProvider), arg0)
 }
 
 // StorageProviderTypes mocks base method
 func (m *MockZonedEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProviderTypes")
 	ret0, _ := ret[0].([]storage.ProviderType)
 	ret1, _ := ret[1].(error)
@@ -346,5 +392,6 @@ func (m *MockZonedEnviron) StorageProviderTypes() ([]storage.ProviderType, error
 
 // StorageProviderTypes indicates an expected call of StorageProviderTypes
 func (mr *MockZonedEnvironMockRecorder) StorageProviderTypes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProviderTypes", reflect.TypeOf((*MockZonedEnviron)(nil).StorageProviderTypes))
 }

--- a/provider/common/provider.go
+++ b/provider/common/provider.go
@@ -4,10 +4,12 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 )
 
 // DefaultProvider exposes the various common implementations found in
@@ -19,8 +21,8 @@ type DefaultProvider struct {
 }
 
 // BootstrapEnv bootstraps the Juju environment.
-func (dp DefaultProvider) BootstrapEnv(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	result, err := Bootstrap(ctx, dp.Env, callCtx, args)
+func (dp DefaultProvider) BootstrapEnv(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	result, err := Bootstrap(ctx, cmdCtx, dp.Env, callCtx, args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -28,7 +30,7 @@ func (dp DefaultProvider) BootstrapEnv(ctx environs.BootstrapContext, callCtx co
 }
 
 // DestroyEnv destroys the Juju environment.
-func (dp DefaultProvider) DestroyEnv(ctx context.ProviderCallContext) error {
+func (dp DefaultProvider) DestroyEnv(ctx envcontext.ProviderCallContext) error {
 	if err := Destroy(dp.Env, ctx); err != nil {
 		return errors.Trace(err)
 	}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -833,7 +833,7 @@ func (e *environ) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContex
 	estate.bootstrapped = true
 	estate.ops <- OpBootstrap{Context: cmdCtx, Env: e.name, Args: args}
 
-	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) (err error) {
+	finalize := func(ctx context.Context, cmdCtx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) (err error) {
 		if e.ecfg().controller() {
 			icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
 			if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
@@ -1023,7 +1023,7 @@ func (e *environ) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContex
 				apiServer.Wait()
 			}(estate.apiServer)
 		}
-		estate.ops <- OpFinalizeBootstrap{Context: ctx, Env: e.name, InstanceConfig: icfg}
+		estate.ops <- OpFinalizeBootstrap{Context: cmdCtx, Env: e.name, InstanceConfig: icfg}
 		return nil
 	}
 

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -4,6 +4,7 @@
 package dummy_test
 
 import (
+	"context"
 	"strings"
 	stdtesting "testing"
 	"time"
@@ -18,7 +19,7 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/jujutest"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -87,7 +88,7 @@ type suite struct {
 	gitjujutesting.MgoSuite
 	jujutest.Tests
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 }
 
 func (s *suite) SetUpSuite(c *gc.C) {
@@ -107,7 +108,7 @@ func (s *suite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 	s.PatchValue(&dummy.LogDir, c.MkDir())
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = envcontext.NewCloudCallContext()
 }
 
 func (s *suite) TearDownTest(c *gc.C) {
@@ -136,8 +137,8 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 	netenv, supported := environs.SupportsNetworking(env)
 	c.Assert(supported, jc.IsTrue)
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv,
-		context.NewCloudCallContext(), bootstrap.BootstrapParams{
+	err = bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), netenv,
+		envcontext.NewCloudCallContext(), bootstrap.BootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			Cloud: cloud.Cloud{
 				Name:      "dummy",

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -4,6 +4,8 @@
 package gce_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -77,7 +79,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 		ControllerConfig:         testing.FakeControllerConfig(),
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
 	}
-	result, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
+	result, err := s.Env.Bootstrap(context.Background(), ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Arch, gc.Equals, "amd64")
@@ -93,7 +95,7 @@ func (s *environSuite) TestBootstrapInvalidCredentialError(c *gc.C) {
 		ControllerConfig:         testing.FakeControllerConfig(),
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
 	}
-	_, err := s.Env.Bootstrap(envtesting.BootstrapContext(c), s.CallCtx, params)
+	_, err := s.Env.Bootstrap(context.Background(), envtesting.BootstrapContext(c), s.CallCtx, params)
 	c.Check(err, gc.NotNil)
 	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
@@ -121,7 +123,7 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 		ControllerConfig:         config,
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
 	}
-	_, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
+	_, err := s.Env.Bootstrap(context.Background(), ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	called, calls := s.FakeConn.WasCalled("OpenPorts")
@@ -142,7 +144,7 @@ func (s *environSuite) TestBootstrapCommon(c *gc.C) {
 		ControllerConfig:         testing.FakeControllerConfig(),
 		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
 	}
-	_, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
+	_, err := s.Env.Bootstrap(context.Background(), ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.FakeCommon.CheckCalls(c, []gce.FakeCall{{

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -69,7 +69,7 @@ func (s *environSuite) TestConfig(c *gc.C) {
 func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.FakeCommon.Arch = "amd64"
 	s.FakeCommon.Series = "trusty"
-	finalizer := func(environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
+	finalizer := func(context.Context, environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
 		return nil
 	}
 	s.FakeCommon.BSFinalizer = finalizer
@@ -113,7 +113,7 @@ func (s *environSuite) TestBootstrapOpensAPIPortsWithAutocert(c *gc.C) {
 }
 
 func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expectedPorts []int) {
-	finalizer := func(environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
+	finalizer := func(context.Context, environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
 		return nil
 	}
 	s.FakeCommon.BSFinalizer = finalizer

--- a/provider/joyent/local_test.go
+++ b/provider/joyent/local_test.go
@@ -4,6 +4,7 @@
 package joyent_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 
@@ -17,7 +18,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	imagetesting "github.com/juju/juju/environs/imagemetadata/testing"
 	"github.com/juju/juju/environs/jujutest"
@@ -116,7 +117,7 @@ type localServerSuite struct {
 	jujutest.Tests
 	cSrv localCloudAPIServer
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 }
 
 func (s *localServerSuite) SetUpSuite(c *gc.C) {
@@ -152,7 +153,7 @@ func (s *localServerSuite) SetUpTest(c *gc.C) {
 	joyent.UseExternalTestImageMetadata(c, creds)
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "test://host")
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = envcontext.NewCloudCallContext()
 }
 
 func (s *localServerSuite) TearDownTest(c *gc.C) {
@@ -170,7 +171,7 @@ func bootstrapContext(c *gc.C) environs.BootstrapContext {
 // allocate a public address.
 func (s *localServerSuite) TestStartInstance(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), bootstrapContext(c), env,
 		s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -185,7 +186,7 @@ func (s *localServerSuite) TestStartInstance(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), bootstrapContext(c), env,
 		s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -202,7 +203,7 @@ func (s *localServerSuite) TestStartInstanceAvailabilityZone(c *gc.C) {
 
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), bootstrapContext(c), env,
 		s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -318,7 +319,7 @@ func (s *localServerSuite) TestInstancesGathering(c *gc.C) {
 // It should be moved to environs.jujutests.Tests.
 func (s *localServerSuite) TestBootstrapInstanceUserDataAndState(c *gc.C) {
 	env := s.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), bootstrapContext(c), env,
 		s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -4,6 +4,8 @@
 package lxd_test
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v7"
 	"github.com/juju/cmd/cmdtesting"
@@ -18,7 +20,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
 	coretesting "github.com/juju/juju/testing"
@@ -29,7 +31,7 @@ var errTestUnAuth = errors.New("not authorized")
 type environSuite struct {
 	lxd.BaseSuite
 
-	callCtx           context.ProviderCallContext
+	callCtx           envcontext.ProviderCallContext
 	invalidCredential bool
 }
 
@@ -37,7 +39,7 @@ var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = &context.CloudCallContext{
+	s.callCtx = &envcontext.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -93,7 +95,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 	}
-	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(ctx), s.callCtx, params)
+	result, err := s.Env.Bootstrap(context.Background(), modelcmd.BootstrapContext(ctx), s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Arch, gc.Equals, "amd64")
@@ -106,18 +108,20 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 }
 
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {
-	ctx := envtesting.BootstrapContext(c)
+	cmdCtx := envtesting.BootstrapContext(c)
 	params := environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 	}
-	_, err := s.Env.Bootstrap(ctx, s.callCtx, params)
+	ctx := context.Background()
+	_, err := s.Env.Bootstrap(ctx, cmdCtx, s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
 		FuncName: "Bootstrap",
 		Args: []interface{}{
 			ctx,
+			cmdCtx,
 			s.callCtx,
 			params,
 		},
@@ -378,7 +382,7 @@ func (s *environSuite) TestInstanceAvailabilityZoneNamesInvalidCredentials(c *gc
 type environCloudProfileSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 
 	svr          *lxd.MockServer
 	cloudSpecEnv environs.CloudSpecSetter
@@ -441,7 +445,7 @@ func (s *environCloudProfileSuite) expectCreateProfile(name string, err error) {
 type environProfileSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 
 	svr    *lxd.MockServer
 	lxdEnv environs.LXDProfiler

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -85,7 +85,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 	s.Common.BootstrapResult = &environs.BootstrapResult{
 		Arch:   "amd64",
 		Series: "trusty",
-		CloudBootstrapFinalizer: func(environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
+		CloudBootstrapFinalizer: func(context.Context, environs.BootstrapContext, *instancecfg.InstanceConfig, environs.BootstrapDialOpts) error {
 			return nil
 		},
 	}

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	"net"
 	"os"
 	"strconv"
@@ -29,7 +30,7 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/network"
@@ -399,8 +400,8 @@ type stubCommon struct {
 	BootstrapResult *environs.BootstrapResult
 }
 
-func (sc *stubCommon) BootstrapEnv(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	sc.stub.AddCall("Bootstrap", ctx, callCtx, params)
+func (sc *stubCommon) BootstrapEnv(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	sc.stub.AddCall("Bootstrap", ctx, cmdCtx, callCtx, params)
 	if err := sc.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -408,7 +409,7 @@ func (sc *stubCommon) BootstrapEnv(ctx environs.BootstrapContext, callCtx contex
 	return sc.BootstrapResult, nil
 }
 
-func (sc *stubCommon) DestroyEnv(callCtx context.ProviderCallContext) error {
+func (sc *stubCommon) DestroyEnv(callCtx envcontext.ProviderCallContext) error {
 	sc.stub.AddCall("Destroy", callCtx)
 	if err := sc.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -180,7 +180,8 @@ func (env *maasEnviron) Bootstrap(ctx context.Context, cmdCtx environs.Bootstrap
 	}()
 
 	waitingFinalizer := func(
-		ctx environs.BootstrapContext,
+		ctx context.Context,
+		cmdCtx environs.BootstrapContext,
 		icfg *instancecfg.InstanceConfig,
 		dialOpts environs.BootstrapDialOpts,
 	) error {
@@ -188,7 +189,7 @@ func (env *maasEnviron) Bootstrap(ctx context.Context, cmdCtx environs.Bootstrap
 		if err := env.waitForNodeDeployment(callCtx, result.Instance.Id(), dialOpts.Timeout); err != nil {
 			return errors.Annotate(err, "bootstrap instance started but did not change to Deployed state")
 		}
-		return finalizer(ctx, icfg, dialOpts)
+		return finalizer(ctx, cmdCtx, icfg, dialOpts)
 	}
 
 	bsResult := &environs.BootstrapResult{

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -165,7 +165,7 @@ func (env *maasEnviron) Create(ctx envcontext.ProviderCallContext, p environs.Cr
 
 // Bootstrap is part of the Environ interface.
 func (env *maasEnviron) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	result, series, finalizer, err := common.BootstrapInstance(cmdCtx, env, callCtx, args)
+	result, series, finalizer, err := common.BootstrapInstance(ctx, cmdCtx, env, callCtx, args)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -5,6 +5,7 @@ package maas
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -30,7 +31,7 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	envstorage "github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -155,7 +156,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 	// Create node 0: it will be used as the bootstrap node.
 	suite.newNode(c, "node0", "host0", nil)
 	suite.addSubnet(c, 9, 9, "node0")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -227,7 +228,7 @@ func (suite *environSuite) TestStartInstanceStartsInstance(c *gc.C) {
 func (suite *environSuite) getInstance(systemId string) *maas1Instance {
 	input := fmt.Sprintf(`{"system_id": %q}`, systemId)
 	node := suite.testMAASObject.TestServer.NewNode(input)
-	statusGetter := func(context.ProviderCallContext, instance.Id) (string, string) {
+	statusGetter := func(envcontext.ProviderCallContext, instance.Id) (string, string) {
 		return "unknown", "FAKE"
 	}
 
@@ -358,7 +359,7 @@ func (suite *environSuite) TestBootstrapSucceeds(c *gc.C) {
 	env := suite.makeEnviron()
 	suite.newNode(c, "thenode", "host", nil)
 	suite.addSubnet(c, 9, 9, "thenode")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -376,7 +377,7 @@ func (suite *environSuite) TestBootstrapNodeNotDeployed(c *gc.C) {
 	suite.addSubnet(c, 9, 9, "thenode")
 	// Ensure node will not be reported as deployed by changing its status.
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "4")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -394,7 +395,7 @@ func (suite *environSuite) TestBootstrapNodeFailedDeploy(c *gc.C) {
 	suite.addSubnet(c, 9, 9, "thenode")
 	// Set the node status to "Failed deployment"
 	suite.testMAASObject.TestServer.ChangeNode("thenode", "status", "11")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -408,7 +409,7 @@ func (suite *environSuite) TestBootstrapNodeFailedDeploy(c *gc.C) {
 func (suite *environSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	env := suite.makeEnviron()
 	vers := version.MustParse("1.2.3")
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			AdminSecret:      testing.AdminSecret,
@@ -424,7 +425,7 @@ func (suite *environSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 func (suite *environSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron()
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,
@@ -970,7 +971,7 @@ func (s *environSuite) bootstrap(c *gc.C) environs.Environ {
 	s.addSubnet(c, 9, 9, "node0")
 	s.setupFakeTools(c)
 	env := s.makeEnviron()
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envtesting.BootstrapContext(c), env,
 		s.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			Placement:                "bootstrap-host",

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -676,7 +677,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envjujutesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              jujutesting.AdminSecret,
@@ -697,7 +698,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentRetry(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+	bootstrap.Bootstrap(context.Background(), envjujutesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              jujutesting.AdminSecret,
@@ -718,7 +719,7 @@ func (suite *maas2EnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	suite.injectController(controller)
 	suite.setupFakeTools(c)
 	env := suite.makeEnviron(c, nil)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envjujutesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              jujutesting.AdminSecret,
@@ -2167,7 +2168,7 @@ func (suite *maas2EnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	}
 
 	env := suite.makeEnviron(c, controller)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envjujutesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              jujutesting.AdminSecret,
@@ -2293,7 +2294,7 @@ func (suite *maas2EnvironSuite) TestDestroy(c *gc.C) {
 func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 	env := suite.makeEnviron(c, newFakeController())
 	vers := version.MustParse("1.2.3")
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envjujutesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
@@ -2311,7 +2312,7 @@ func (suite *maas2EnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	controller := newFakeController()
 	controller.allocateMachineError = gomaasapi.NewNoMatchError("oops")
 	env := suite.makeEnviron(c, controller)
-	err := bootstrap.Bootstrap(envjujutesting.BootstrapContext(c), env,
+	err := bootstrap.Bootstrap(context.Background(), envjujutesting.BootstrapContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              jujutesting.AdminSecret,

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -124,13 +124,13 @@ func (e *manualEnviron) Bootstrap(ctx context.Context, cmdCtx environs.Bootstrap
 	if err != nil {
 		return nil, err
 	}
-	finalize := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
+	finalize := func(ctx context.Context, cmdCtx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, _ environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = BootstrapInstanceId
 		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = hw
 		if err := instancecfg.FinishInstanceConfig(icfg, e.Config()); err != nil {
 			return err
 		}
-		return common.ConfigureMachine(ctx, ssh.DefaultClient, e.host, icfg, nil)
+		return common.ConfigureMachine(cmdCtx, ssh.DefaultClient, e.host, icfg, nil)
 	}
 
 	result := &environs.BootstrapResult{

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -5,6 +5,7 @@ package manual
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -26,7 +27,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/manual"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
@@ -63,25 +64,25 @@ var errNoStartInstance = errors.New("manual provider cannot start instances")
 var errNoStopInstance = errors.New("manual provider cannot stop instances")
 
 // MaintainInstance is specified in the InstanceBroker interface.
-func (*manualEnviron) MaintainInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) error {
+func (*manualEnviron) MaintainInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) error {
 	return nil
 }
 
-func (*manualEnviron) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (*manualEnviron) StartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	return nil, errNoStartInstance
 }
 
-func (*manualEnviron) StopInstances(context.ProviderCallContext, ...instance.Id) error {
+func (*manualEnviron) StopInstances(envcontext.ProviderCallContext, ...instance.Id) error {
 	return errNoStopInstance
 }
 
 // AllInstances implements environs.InstanceBroker.
-func (e *manualEnviron) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *manualEnviron) AllInstances(ctx envcontext.ProviderCallContext) ([]instances.Instance, error) {
 	return e.Instances(ctx, []instance.Id{BootstrapInstanceId})
 }
 
 // AllRunningInstances implements environs.InstanceBroker.
-func (e *manualEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *manualEnviron) AllRunningInstances(ctx envcontext.ProviderCallContext) ([]instances.Instance, error) {
 	// All instances and all running instance is the same for manual.
 	return e.AllInstances(ctx)
 }
@@ -106,12 +107,12 @@ func (e *manualEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, contr
 }
 
 // Create is part of the Environ interface.
-func (e *manualEnviron) Create(context.ProviderCallContext, environs.CreateParams) error {
+func (e *manualEnviron) Create(envcontext.ProviderCallContext, environs.CreateParams) error {
 	return nil
 }
 
 // Bootstrap is part of the Environ interface.
-func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (e *manualEnviron) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	provisioned, err := sshprovisioner.CheckProvisioned(e.host)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to check provisioned status")
@@ -141,7 +142,7 @@ func (e *manualEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context
 }
 
 // ControllerInstances is specified in the Environ interface.
-func (e *manualEnviron) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
+func (e *manualEnviron) ControllerInstances(ctx envcontext.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
 	if !isRunningController() {
 		// Not running inside the controller, so we must
 		// verify the host.
@@ -184,7 +185,7 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 }
 
 // AdoptResources is part of the Environ interface.
-func (e *manualEnviron) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
+func (e *manualEnviron) AdoptResources(ctx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	// This provider doesn't track instance -> controller.
 	return nil
 }
@@ -205,7 +206,7 @@ func (e *manualEnviron) SetConfig(cfg *config.Config) error {
 // This method will only ever return an Instance for the Id
 // BootstrapInstanceId. If any others are specified, then
 // ErrPartialInstances or ErrNoInstances will result.
-func (e *manualEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+func (e *manualEnviron) Instances(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 	result := make([]instances.Instance, len(ids))
 	var found bool
 	var err error
@@ -239,7 +240,7 @@ var runSSHCommand = func(host string, command []string, stdin string) (stdout, s
 }
 
 // Destroy implements the Environ interface.
-func (e *manualEnviron) Destroy(ctx context.ProviderCallContext) error {
+func (e *manualEnviron) Destroy(ctx envcontext.ProviderCallContext) error {
 	// There is nothing we can do for manual environments,
 	// except when destroying the controller as a whole
 	// (see DestroyController below).
@@ -247,7 +248,7 @@ func (e *manualEnviron) Destroy(ctx context.ProviderCallContext) error {
 }
 
 // DestroyController implements the Environ interface.
-func (e *manualEnviron) DestroyController(ctx context.ProviderCallContext, controllerUUID string) error {
+func (e *manualEnviron) DestroyController(ctx envcontext.ProviderCallContext, controllerUUID string) error {
 	script := `
 # Signal the jujud process to stop, then check it has done so.
 set -x
@@ -309,7 +310,7 @@ exit 0
 	return err
 }
 
-func (e *manualEnviron) PrecheckInstance(ctx context.ProviderCallContext, params environs.PrecheckInstanceParams) error {
+func (e *manualEnviron) PrecheckInstance(ctx envcontext.ProviderCallContext, params environs.PrecheckInstanceParams) error {
 	validator, err := e.ConstraintsValidator(ctx)
 	if err != nil {
 		return err
@@ -335,7 +336,7 @@ var unsupportedConstraints = []string{
 }
 
 // ConstraintsValidator is defined on the Environs interface.
-func (e *manualEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+func (e *manualEnviron) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	if isRunningController() {
@@ -366,15 +367,15 @@ func (e *manualEnviron) seriesAndHardwareCharacteristics() (_ *instance.Hardware
 	return e.hw, e.series, nil
 }
 
-func (e *manualEnviron) OpenPorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
+func (e *manualEnviron) OpenPorts(ctx envcontext.ProviderCallContext, rules []network.IngressRule) error {
 	return nil
 }
 
-func (e *manualEnviron) ClosePorts(ctx context.ProviderCallContext, rules []network.IngressRule) error {
+func (e *manualEnviron) ClosePorts(ctx envcontext.ProviderCallContext, rules []network.IngressRule) error {
 	return nil
 }
 
-func (e *manualEnviron) IngressRules(ctx context.ProviderCallContext) ([]network.IngressRule, error) {
+func (e *manualEnviron) IngressRules(ctx envcontext.ProviderCallContext) ([]network.IngressRule, error) {
 	return nil, nil
 }
 

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -306,8 +306,8 @@ func (e *Environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerN
 }
 
 // Bootstrap implements environs.Environ.
-func (e *Environ) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	return common.Bootstrap(ctx, e, callCtx, params)
+func (e *Environ) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	return common.Bootstrap(ctx, cmdCtx, e, callCtx, params)
 }
 
 // Create implements environs.Environ.

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -927,7 +927,7 @@ func (e *environSuite) TestBootstrap(c *gc.C) {
 	e.setupStartInstanceExpectations(true)
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := e.env.Bootstrap(ctx, nil,
+	_, err := e.env.Bootstrap(context.Background(), ctx, nil,
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
 			AvailableTools:           makeToolsList("trusty"),
@@ -956,7 +956,7 @@ func (e *environSuite) TestBootstrapNoMatchingTools(c *gc.C) {
 	e.setupListSubnetsExpectations(vcnId, "fakeRouteTableId", machineTags, 0)
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err := e.env.Bootstrap(ctx, nil,
+	_, err := e.env.Bootstrap(context.Background(), ctx, nil,
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
 			AvailableTools:           makeToolsList("trusty"),

--- a/provider/oracle/environ_test.go
+++ b/provider/oracle/environ_test.go
@@ -4,6 +4,7 @@
 package oracle_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -18,7 +19,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/oracle"
 	oracletesting "github.com/juju/juju/provider/oracle/testing"
@@ -30,7 +31,7 @@ type environSuite struct {
 	gitjujutesting.IsolationSuite
 	env *oracle.OracleEnviron
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 }
 
 func (e *environSuite) SetUpTest(c *gc.C) {
@@ -54,7 +55,7 @@ func (e *environSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	testEnvironAPI.FakeInstance.All.Result[0].Name = fmt.Sprintf("/Compute-a432100/sgiulitti@cloudbase.com/%s/ebc4ce91-56bb-4120-ba78-13762597f837", hostname)
 	oracle.SetEnvironAPI(e.env, testEnvironAPI)
-	e.callCtx = context.NewCloudCallContext()
+	e.callCtx = envcontext.NewCloudCallContext()
 }
 
 var _ = gc.Suite(&environSuite{})
@@ -171,7 +172,7 @@ func (e *environSuite) TestBootstrap(c *gc.C) {
 	c.Assert(environ, gc.NotNil)
 
 	ctx := envtesting.BootstrapContext(c)
-	_, err = environ.Bootstrap(ctx, e.callCtx,
+	_, err = environ.Bootstrap(context.Background(), ctx, e.callCtx,
 		environs.BootstrapParams{
 			ControllerConfig:         testing.FakeControllerConfig(),
 			AvailableTools:           makeToolsList("xenial"),

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -6,7 +6,6 @@ package rackspace
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"time"
 
 	"github.com/juju/errors"
@@ -50,15 +49,14 @@ func (e environ) StartInstance(ctx envcontext.ProviderCallContext, args environs
 		return nil, errors.Trace(err)
 	}
 	if fwmode != config.FwNone {
-		interrupted := make(chan os.Signal, 1)
 		timeout := environs.BootstrapDialOpts{
 			Timeout:        time.Minute * 5,
 			RetryDelay:     time.Second * 5,
 			AddressesDelay: time.Second * 20,
 		}
 		addr, err := waitSSH(
+			context.Background(),
 			ioutil.Discard,
-			interrupted,
 			ssh.DefaultClient,
 			common.GetCheckNonceCommand(args.InstanceConfig),
 			&common.RefreshableInstance{r.Instance, e},

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -4,6 +4,7 @@
 package rackspace
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"time"
@@ -15,7 +16,7 @@ import (
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/common"
 )
 
@@ -26,15 +27,15 @@ type environ struct {
 var bootstrap = common.Bootstrap
 
 // Bootstrap implements environs.Environ.
-func (e environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (e environ) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	// can't redirect to openstack provider as usually, because correct environ should be passed for common.Bootstrap
-	return bootstrap(ctx, e, callCtx, params)
+	return bootstrap(ctx, cmdCtx, e, callCtx, params)
 }
 
 var waitSSH = common.WaitSSH
 
 // StartInstance implements environs.Environ.
-func (e environ) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (e environ) StartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	osString, err := series.GetOSFromSeries(args.Tools.OneSeries())
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -4,6 +4,7 @@
 package rackspace_test
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -21,7 +22,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/provider/common"
@@ -36,7 +37,7 @@ type environSuite struct {
 	environ      environs.Environ
 	innerEnviron *fakeEnviron
 
-	callCtx           *context.CloudCallContext
+	callCtx           *envcontext.CloudCallContext
 	invalidCredential bool
 }
 
@@ -46,7 +47,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.innerEnviron = new(fakeEnviron)
 	s.environ = rackspace.NewEnviron(s.innerEnviron)
-	s.callCtx = &context.CloudCallContext{
+	s.callCtx = &envcontext.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -60,10 +61,10 @@ func (s *environSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *environSuite) TestBootstrap(c *gc.C) {
-	s.PatchValue(rackspace.Bootstrap, func(ctx environs.BootstrapContext, env environs.Environ, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
-		return s.innerEnviron.Bootstrap(ctx, callCtx, args)
+	s.PatchValue(rackspace.Bootstrap, func(ctx context.Context, cmdCtx environs.BootstrapContext, env environs.Environ, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+		return s.innerEnviron.Bootstrap(ctx, cmdCtx, callCtx, args)
 	})
-	s.environ.Bootstrap(nil, s.callCtx, environs.BootstrapParams{
+	s.environ.Bootstrap(context.Background(), nil, s.callCtx, environs.BootstrapParams{
 		ControllerConfig: testing.FakeControllerConfig(),
 	})
 	c.Check(s.innerEnviron.Pop().name, gc.Equals, "Bootstrap")
@@ -77,7 +78,7 @@ func (s *environSuite) TestStartInstance(c *gc.C) {
 		client ssh.Client,
 		checkHostScript string,
 		inst common.InstanceRefresher,
-		callCtx context.ProviderCallContext,
+		callCtx envcontext.ProviderCallContext,
 		timeout environs.BootstrapDialOpts,
 		hostSSHOptions common.HostSSHOptionsFunc,
 	) (addr string, err error) {
@@ -127,7 +128,7 @@ func (s *environSuite) TestStartInstanceInvalidCredential(c *gc.C) {
 		client ssh.Client,
 		checkHostScript string,
 		inst common.InstanceRefresher,
-		callCtx context.ProviderCallContext,
+		callCtx envcontext.ProviderCallContext,
 		timeout environs.BootstrapDialOpts,
 		hostSSHOptions common.HostSSHOptionsFunc,
 	) (addr string, err error) {
@@ -191,7 +192,7 @@ func (p *fakeEnviron) Open(cfg *config.Config) (environs.Environ, error) {
 	return nil, nil
 }
 
-func (e *fakeEnviron) Create(callCtx context.ProviderCallContext, args environs.CreateParams) error {
+func (e *fakeEnviron) Create(callCtx envcontext.ProviderCallContext, args environs.CreateParams) error {
 	e.Push("Create", callCtx, args)
 	return nil
 }
@@ -201,34 +202,34 @@ func (e *fakeEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, control
 	return nil
 }
 
-func (e *fakeEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
-	e.Push("Bootstrap", ctx, callCtx, params)
+func (e *fakeEnviron) Bootstrap(ctx context.Context, cmdCtx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	e.Push("Bootstrap", ctx, cmdCtx, callCtx, params)
 	return nil, nil
 }
 
-func (e *fakeEnviron) StartInstance(callCtx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (e *fakeEnviron) StartInstance(callCtx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	e.Push("StartInstance", callCtx, args)
 	return &environs.StartInstanceResult{
 		Instance: &fakeInstance{},
 	}, nil
 }
 
-func (e *fakeEnviron) StopInstances(callCtx context.ProviderCallContext, ids ...instance.Id) error {
+func (e *fakeEnviron) StopInstances(callCtx envcontext.ProviderCallContext, ids ...instance.Id) error {
 	e.Push("StopInstances", callCtx, ids)
 	return nil
 }
 
-func (e *fakeEnviron) AllInstances(callCtx context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *fakeEnviron) AllInstances(callCtx envcontext.ProviderCallContext) ([]instances.Instance, error) {
 	e.Push("AllInstances", callCtx)
 	return nil, nil
 }
 
-func (e *fakeEnviron) AllRunningInstances(callCtx context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *fakeEnviron) AllRunningInstances(callCtx envcontext.ProviderCallContext) ([]instances.Instance, error) {
 	e.Push("AllRunningInstances", callCtx)
 	return nil, nil
 }
 
-func (e *fakeEnviron) MaintainInstance(callCtx context.ProviderCallContext, args environs.StartInstanceParams) error {
+func (e *fakeEnviron) MaintainInstance(callCtx envcontext.ProviderCallContext, args environs.StartInstanceParams) error {
 	e.Push("MaintainInstance", callCtx, args)
 	return nil
 }
@@ -237,7 +238,7 @@ func (e *fakeEnviron) Config() *config.Config {
 	return e.config
 }
 
-func (e *fakeEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+func (e *fakeEnviron) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	e.Push("ConstraintsValidator", ctx)
 	return nil, nil
 }
@@ -247,42 +248,42 @@ func (e *fakeEnviron) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-func (e *fakeEnviron) Instances(callCtx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+func (e *fakeEnviron) Instances(callCtx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 	e.Push("Instances", callCtx, ids)
 	return []instances.Instance{&fakeInstance{}}, nil
 }
 
-func (e *fakeEnviron) ControllerInstances(callCtx context.ProviderCallContext, st string) ([]instance.Id, error) {
+func (e *fakeEnviron) ControllerInstances(callCtx envcontext.ProviderCallContext, st string) ([]instance.Id, error) {
 	e.Push("ControllerInstances", callCtx, st)
 	return nil, nil
 }
 
-func (e *fakeEnviron) AdoptResources(callCtx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
+func (e *fakeEnviron) AdoptResources(callCtx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	e.Push("AdoptResources", callCtx, controllerUUID, fromVersion)
 	return nil
 }
 
-func (e *fakeEnviron) Destroy(callCtx context.ProviderCallContext) error {
+func (e *fakeEnviron) Destroy(callCtx envcontext.ProviderCallContext) error {
 	e.Push("Destroy", callCtx)
 	return nil
 }
 
-func (e *fakeEnviron) DestroyController(callCtx context.ProviderCallContext, controllerUUID string) error {
+func (e *fakeEnviron) DestroyController(callCtx envcontext.ProviderCallContext, controllerUUID string) error {
 	e.Push("Destroy", callCtx, controllerUUID)
 	return nil
 }
 
-func (e *fakeEnviron) OpenPorts(callCtx context.ProviderCallContext, rules []network.IngressRule) error {
+func (e *fakeEnviron) OpenPorts(callCtx envcontext.ProviderCallContext, rules []network.IngressRule) error {
 	e.Push("OpenPorts", callCtx, rules)
 	return nil
 }
 
-func (e *fakeEnviron) ClosePorts(callCtx context.ProviderCallContext, rules []network.IngressRule) error {
+func (e *fakeEnviron) ClosePorts(callCtx envcontext.ProviderCallContext, rules []network.IngressRule) error {
 	e.Push("ClosePorts", callCtx, rules)
 	return nil
 }
 
-func (e *fakeEnviron) IngressRules(callCtx context.ProviderCallContext) ([]network.IngressRule, error) {
+func (e *fakeEnviron) IngressRules(callCtx envcontext.ProviderCallContext) ([]network.IngressRule, error) {
 	e.Push("Ports", callCtx)
 	return nil, nil
 }
@@ -292,7 +293,7 @@ func (e *fakeEnviron) Provider() environs.EnvironProvider {
 	return nil
 }
 
-func (e *fakeEnviron) PrecheckInstance(callCtx context.ProviderCallContext, args environs.PrecheckInstanceParams) error {
+func (e *fakeEnviron) PrecheckInstance(callCtx envcontext.ProviderCallContext, args environs.PrecheckInstanceParams) error {
 	e.Push("PrecheckInstance", callCtx, args)
 	return nil
 }
@@ -307,7 +308,7 @@ func (e *fakeEnviron) StorageProvider(t storage.ProviderType) (storage.Provider,
 	return nil, errors.NotImplementedf("StorageProvider")
 }
 
-func (e *fakeEnviron) InstanceTypes(context.ProviderCallContext, constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (e *fakeEnviron) InstanceTypes(envcontext.ProviderCallContext, constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	return instances.InstanceTypesWithCostMetadata{}, nil
 }
 
@@ -369,7 +370,7 @@ func (e *fakeInstance) Id() instance.Id {
 	return instance.Id("")
 }
 
-func (e *fakeInstance) Status(callCtx context.ProviderCallContext) instance.Status {
+func (e *fakeInstance) Status(callCtx envcontext.ProviderCallContext) instance.Status {
 	e.Push("Status", callCtx)
 	return instance.Status{
 		Status:  status.Provisioning,
@@ -377,12 +378,12 @@ func (e *fakeInstance) Status(callCtx context.ProviderCallContext) instance.Stat
 	}
 }
 
-func (e *fakeInstance) Refresh(callCtx context.ProviderCallContext) error {
+func (e *fakeInstance) Refresh(callCtx envcontext.ProviderCallContext) error {
 	e.Push("Refresh", callCtx)
 	return nil
 }
 
-func (e *fakeInstance) Addresses(callCtx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (e *fakeInstance) Addresses(callCtx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	e.Push("Addresses", callCtx)
 	return []corenetwork.ProviderAddress{{
 		MachineAddress: corenetwork.MachineAddress{
@@ -393,17 +394,17 @@ func (e *fakeInstance) Addresses(callCtx context.ProviderCallContext) (corenetwo
 	}}, nil
 }
 
-func (e *fakeInstance) OpenPorts(callCtx context.ProviderCallContext, machineId string, ports []network.IngressRule) error {
+func (e *fakeInstance) OpenPorts(callCtx envcontext.ProviderCallContext, machineId string, ports []network.IngressRule) error {
 	e.Push("OpenPorts", callCtx, machineId, ports)
 	return nil
 }
 
-func (e *fakeInstance) ClosePorts(callCtx context.ProviderCallContext, machineId string, ports []network.IngressRule) error {
+func (e *fakeInstance) ClosePorts(callCtx envcontext.ProviderCallContext, machineId string, ports []network.IngressRule) error {
 	e.Push("ClosePorts", callCtx, machineId, ports)
 	return nil
 }
 
-func (e *fakeInstance) IngressRules(callCtx context.ProviderCallContext, machineId string) ([]network.IngressRule, error) {
+func (e *fakeInstance) IngressRules(callCtx envcontext.ProviderCallContext, machineId string) ([]network.IngressRule, error) {
 	e.Push("Ports", callCtx, machineId)
 	return nil, nil
 }

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -6,7 +6,6 @@ package rackspace_test
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -73,8 +72,8 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 func (s *environSuite) TestStartInstance(c *gc.C) {
 	configurator := &fakeConfigurator{}
 	s.PatchValue(rackspace.WaitSSH, func(
+		ctx context.Context,
 		stdErr io.Writer,
-		interrupted <-chan os.Signal,
 		client ssh.Client,
 		checkHostScript string,
 		inst common.InstanceRefresher,
@@ -123,8 +122,8 @@ func (s *environSuite) TestStartInstanceInvalidCredential(c *gc.C) {
 		},
 	}
 	s.PatchValue(rackspace.WaitSSH, func(
+		ctx context.Context,
 		stdErr io.Writer,
-		interrupted <-chan os.Signal,
 		client ssh.Client,
 		checkHostScript string,
 		inst common.InstanceRefresher,

--- a/worker/instancemutater/mocks/environs_mock.go
+++ b/worker/instancemutater/mocks/environs_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v7"
 	constraints "github.com/juju/juju/core/constraints"
@@ -12,7 +13,7 @@ import (
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	version "github.com/juju/version"
@@ -43,7 +44,7 @@ func (m *MockEnviron) EXPECT() *MockEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method
-func (m *MockEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -57,7 +58,7 @@ func (mr *MockEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) 
 }
 
 // AllInstances mocks base method
-func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -72,7 +73,7 @@ func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 }
 
 // AllRunningInstances mocks base method
-func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -87,18 +88,18 @@ func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock
 }
 
 // Bootstrap mocks base method
-func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockEnviron) Bootstrap(arg0 context.Context, arg1 environs.BootstrapContext, arg2 context0.ProviderCallContext, arg3 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockEnvironMockRecorder) Bootstrap(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockEnviron)(nil).Bootstrap), arg0, arg1, arg2, arg3)
 }
 
 // Config mocks base method
@@ -116,7 +117,7 @@ func (mr *MockEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method
-func (m *MockEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -131,7 +132,7 @@ func (mr *MockEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomoc
 }
 
 // ControllerInstances mocks base method
-func (m *MockEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -146,7 +147,7 @@ func (mr *MockEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *
 }
 
 // Create mocks base method
-func (m *MockEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -160,7 +161,7 @@ func (mr *MockEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Destroy mocks base method
-func (m *MockEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -174,7 +175,7 @@ func (mr *MockEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 }
 
 // DestroyController mocks base method
-func (m *MockEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -188,7 +189,7 @@ func (mr *MockEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *go
 }
 
 // InstanceTypes mocks base method
-func (m *MockEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -203,7 +204,7 @@ func (mr *MockEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock
 }
 
 // Instances mocks base method
-func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -218,7 +219,7 @@ func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // MaintainInstance mocks base method
-func (m *MockEnviron) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockEnviron) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -232,7 +233,7 @@ func (mr *MockEnvironMockRecorder) MaintainInstance(arg0, arg1 interface{}) *gom
 }
 
 // PrecheckInstance mocks base method
-func (m *MockEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -288,7 +289,7 @@ func (mr *MockEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
 }
 
 // StartInstance mocks base method
-func (m *MockEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -303,7 +304,7 @@ func (mr *MockEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock
 }
 
 // StopInstances mocks base method
-func (m *MockEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -442,7 +443,7 @@ func (m *MockInstanceBroker) EXPECT() *MockInstanceBrokerMockRecorder {
 }
 
 // AllInstances mocks base method
-func (m *MockInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockInstanceBroker) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -457,7 +458,7 @@ func (mr *MockInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock
 }
 
 // AllRunningInstances mocks base method
-func (m *MockInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockInstanceBroker) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -472,7 +473,7 @@ func (mr *MockInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) 
 }
 
 // MaintainInstance mocks base method
-func (m *MockInstanceBroker) MaintainInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) error {
+func (m *MockInstanceBroker) MaintainInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintainInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -486,7 +487,7 @@ func (mr *MockInstanceBrokerMockRecorder) MaintainInstance(arg0, arg1 interface{
 }
 
 // StartInstance mocks base method
-func (m *MockInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockInstanceBroker) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -501,7 +502,7 @@ func (mr *MockInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) 
 }
 
 // StopInstances mocks base method
-func (m *MockInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockInstanceBroker) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {


### PR DESCRIPTION
Bootstrap is a bit of a pain to stop/cancel half way through, even if it's obviously failing it keeps retrying stuff for a long time (eg: waitForAgentInitialization would take 10 hours before it gave up). Need to handle Ctrl-C and terminate/cleanup.

This PR threads context through parts of the bootstrap process and checks `ctx.Done()` in retry loops and at various points (except in WaitSSH, where we can actually select on `ctx.Done()` properly). We're doing it in this relatively hacky way for now to avoid wiring `ctx` up through *everything*, e.g., providers, the old AWS library, etc.

In any case, Ctrl-C is now handled in several parts of the bootstrap:

* BootstrapInstance
* WaitSSH
* waitForAgentInitialization
* K8s Deploy() step

Sample output of interrupting `waitForAgentInitialization`:

```
# set up minikube as per https://discourse.charmhub.io/t/using-juju-with-minikube/3975/3
$ juju bootstrap kubernetes k8s
Creating Juju controller "k8s" on kubernetes
WARNING bootstrapping to an unknown kubernetes cluster should be used with option --config controller-service-type. See juju help bootstrap
Fetching Juju Dashboard 0.3.0
Creating k8s resources for controller "controller-k8s"
Starting controller pod
Bootstrap agent now started
Contacting Juju controller at 10.99.3.123 to verify accessibility...
    # hangs due to load balancer error
^C Ctrl-C pressed, stopping bootstrap and cleaning up resources
    # max 3 second delay here
ERROR contacting controller (cancelled): dial tcp 10.99.3.123:17070: i/o timeout
    # during cleanup, I pressed Ctrl-C a couple more times just for kicks
^C Ctrl-C pressed, cleaning up failed bootstrap
^C Ctrl-C pressed, cleaning up failed bootstrap
    # takes about 20s to clean up (on minikube)
```

For reference, https://github.com/juju/juju/commit/c946eff768c2b5f536da1fc71321b68a273db727 is the commit where Ctrl-C "handling" was introduced (basically to ignore it).