### PR TITLE
Hide local schema in error message

### DIFF
--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -6,6 +6,7 @@ package deployer
 import (
 	"archive/zip"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -96,6 +97,19 @@ func (d *factory) setConfig(cfg DeployerConfig) {
 	d.bundleMachines = cfg.BundleMachines
 	d.trust = cfg.Trust
 	d.flagSet = cfg.FlagSet
+}
+
+func isLocalSchema(u string) bool {
+	raw, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	switch charm.Schema(raw.Scheme) {
+	case charm.Local:
+		return true
+	}
+
+	return false
 }
 
 // DeployerDependencies are required for any deployer to be run.
@@ -291,8 +305,13 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	// below) where it is handled properly. This is just an expedient to get
 	// the correct series. A proper refactoring of the charmrepo package is
 	// needed for a more elegant fix.
+	charmOrBundle := d.charmOrBundle
+	if isLocalSchema(charmOrBundle) {
+		charmOrBundle = charmOrBundle[6:]
+	}
+
 	seriesName := d.series
-	ch, err := charm.ReadCharm(d.charmOrBundle)
+	ch, err := charm.ReadCharm(charmOrBundle)
 
 	var imageStream string
 	if err == nil {
@@ -328,7 +347,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	}
 
 	// Charm may have been supplied via a path reference.
-	ch, curl, err := charmrepo.NewCharmAtPathForceSeries(d.charmOrBundle, seriesName, d.force)
+	ch, curl, err := charmrepo.NewCharmAtPathForceSeries(charmOrBundle, seriesName, d.force)
 	// We check for several types of known error which indicate
 	// that the supplied reference was indeed a path but there was
 	// an issue reading the charm located there.
@@ -337,9 +356,9 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	} else if charm.IsUnsupportedSeriesError(err) {
 		return nil, errors.Trace(err)
 	} else if errors.Cause(err) == zip.ErrFormat {
-		return nil, errors.Errorf("invalid charm or bundle provided at %q", d.charmOrBundle)
+		return nil, errors.Errorf("invalid charm or bundle provided at %q", charmOrBundle)
 	} else if _, ok := err.(*charmrepo.NotFoundError); ok {
-		return nil, errors.Wrap(err, errors.NotFoundf("charm or bundle at %q", d.charmOrBundle))
+		return nil, errors.Wrap(err, errors.NotFoundf("charm or bundle at %q", charmOrBundle))
 	} else if err != nil && err != os.ErrNotExist {
 		// If we get a "not exists" error then we attempt to interpret
 		// the supplied charm reference as a URL elsewhere, otherwise

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -99,19 +99,6 @@ func (d *factory) setConfig(cfg DeployerConfig) {
 	d.flagSet = cfg.FlagSet
 }
 
-func isLocalSchema(u string) bool {
-	raw, err := url.Parse(u)
-	if err != nil {
-		return false
-	}
-	switch charm.Schema(raw.Scheme) {
-	case charm.Local:
-		return true
-	}
-
-	return false
-}
-
 // DeployerDependencies are required for any deployer to be run.
 type DeployerDependencies struct {
 	DeployResources      resourceadapters.DeployResourcesFunc
@@ -475,6 +462,19 @@ func resolveCharmURL(path string) (*charm.URL, error) {
 	}
 
 	return charm.ParseURL(path)
+}
+
+func isLocalSchema(u string) bool {
+	raw, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	switch charm.Schema(raw.Scheme) {
+	case charm.Local:
+		return true
+	}
+
+	return false
 }
 
 // Returns the first string that isn't empty.


### PR DESCRIPTION
We can end up with a local schema infecting the error messages,
especially considering we're trying to hide the schema from going to
stdout. This resolves that issue by removing local: prefix before
deploying the charm.

## QA steps

```sh
$ juju boostrap lxd test
$ juju deploy ./testcharms/charm-repo/bionic/dummys
ERROR no charm was found at "./testcharms/charm-repo/bionic/dummys"
```

Regression tests

```sh
$ juju deploy ./testcharms/charm-repo/bionic/dummy/. other5
WARNING dummy does not declare supported series in metadata.yml
Located local charm "dummy", revision 8
Deploying "other5" from local charm "dummy", revision 8

$ juju deploy wiki-simple
Located bundle "wiki-simple" in charm-hub, revision 4
Located charm "mysql" in charm-store, revision 55
Located charm "mediawiki" in charm-store, revision 5
Executing changes:
- upload charm cs:mysql-55 for series trusty
- deploy application mysql on trusty using cs:mysql-55
- set annotations for mysql
- upload charm cs:trusty/mediawiki-5 for series trusty
- deploy application wiki on trusty using cs:trusty/mediawiki-5
- set annotations for wiki
- add relation wiki:db - mysql:db
- add unit mysql/0 to new machine 0
- add unit wiki/0 to new machine 1
Deploy of bundle completed. 

$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 17
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 17 in channel latest/stable

$ juju deploy cs:~jameinel/ubuntu-lite-6
Located charm "ubuntu-lite" in charm-store, revision 6
Deploying "ubuntu-lite" from charm-store charm "ubuntu-lite", revision 6 in channel stable
```
