### PR TITLE
Ensure we pass arch to boot_context

### DIFF
--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -233,7 +233,7 @@ def main():
     client = make_client_from_args(args)
     with boot_context(args.temp_env_name, client,
                       bootstrap_host=args.bootstrap_host,
-                      machines=args.machine, series=args.series,
+                      machines=args.machine, series=args.series, arch=args.arch,
                       agent_url=args.agent_url, agent_stream=args.agent_stream,
                       log_dir=args.logs, keep_env=args.keep_env,
                       upload_tools=args.upload_tools,

--- a/acceptancetests/assess_multimodel.py
+++ b/acceptancetests/assess_multimodel.py
@@ -73,6 +73,7 @@ def multimodel_setup(args):
             args.bootstrap_host,
             args.machine,
             args.series,
+            args.arch,
             args.agent_url,
             args.agent_stream,
             args.logs, args.keep_env,


### PR DESCRIPTION
The boot context takes an arch argument. The arch argument was added to
allow deploying via the deploy_stack function to work. Unfortunately,
it's virtually impossible to get all the acceptance tests to run in one
click, so we have to rely on Jenkins to tell us when they're failing.

## QA steps

Follow the acceptance test README.md document for setting up the tests:

```sh
$ cd acceptancetests
$ ./assess_log_rotation.py lxd $GOPATH/bin/juju /tmp/artifacts unit
```

Followed by:

```sh
$ ./assess_multimodel.py lxd $GOPATH/bin/juju /tmp/artifacts
```
