### PR TITLE
Force remove relation with bad data

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -379,6 +379,8 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(life.Alive, false, "")
 
+	err = rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(life.Dying, false, "")

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1459,12 +1459,16 @@ func (s *uniterSuite) TestWatchSubordinateUnitRelations(c *gc.C) {
 
 	// We get notified about the mysql relation going away but not the
 	// wordpress one.
+	err = mysqlRel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlRel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(mysqlRel.Tag().Id())
 	wc.AssertNoChange()
 
+	err = wpRel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = wpRel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3176,6 +3176,8 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 
 	// Destroy the relation with the unit in scope, and add another; check
 	// changes.
+	err = rel2.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = rel2.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	rel3 := addRelation()

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -270,6 +270,7 @@ func (st *State) cleanupForceDestroyedRelation(prefix string) (err error) {
 	var doc struct {
 		Key string `bson:"key"`
 	}
+	haveRelationUnits := false
 	for iter.Next(&doc) {
 		scope, role, unitName, err := unpackScopeKey(doc.Key)
 		if err != nil {
@@ -285,6 +286,7 @@ func (st *State) cleanupForceDestroyedRelation(prefix string) (err error) {
 			return errors.NotFoundf("endpoint matching %q", doc.Key)
 		}
 
+		haveRelationUnits = true
 		// This is nasty but I can't see any other way to do it - we
 		// can't rely on the unit existing to determine the values of
 		// isPrincipal and isLocalUnit, and we're only using the RU to
@@ -312,7 +314,17 @@ func (st *State) cleanupForceDestroyedRelation(prefix string) (err error) {
 			return errors.Annotatef(err, "leaving scope for unit %q in relation %q", unitName, relation)
 		}
 	}
-
+	if !haveRelationUnits {
+		// We got here because a relation claimed to have units but
+		// there weren't any corresponding relation unit records.
+		// We know this should be forced, and we've already waited the
+		// required time.
+		errs, err := relation.DestroyWithForce(true, 0)
+		if len(errs) > 0 {
+			logger.Warningf("operational errors force destroying orphaned relation %q: %v", relation, errs)
+		}
+		return errors.Annotatef(err, "force destroying relation %q", relation)
+	}
 	return nil
 }
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -691,6 +691,8 @@ func (s *CleanupSuite) TestCleanupDyingUnit(c *gc.C) {
 	assertNotJoined(c, prr.pru0)
 
 	// Destroy the relation, and check it sticks around...
+	err = prr.rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = prr.rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, prr.rel, state.Dying)
@@ -1389,6 +1391,28 @@ func (s *CleanupSuite) TestForceDestroyApplicationRemovesUnitsThatAreAlreadyDyin
 	s.assertNeedsCleanup(c)
 	s.assertCleanupRuns(c)
 	assertRemoved(c, mysql)
+}
+
+func (s *CleanupSuite) TestForceDestroyRelationIncorrectUnitCount(c *gc.C) {
+	prr := newProReqRelation(c, &s.ConnSuite, charm.ScopeGlobal)
+	prr.allEnterScope(c)
+
+	rel := prr.rel
+	state.RemoveUnitRelations(c, rel)
+	err := rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rel.UnitCount(), gc.Not(gc.Equals), 0)
+
+	opErrs, err := rel.DestroyWithForce(true, dontWait)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(opErrs, gc.IsNil)
+
+	// dyingRelation schedules cleanupForceDestroyedRelation
+	s.assertCleanupRuns(c)
+	err = rel.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	s.assertCleanupCount(c, 0)
 }
 
 func (s *CleanupSuite) assertCleanupRuns(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -625,6 +625,15 @@ func RemoveRelationStatus(c *gc.C, rel *Relation) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func RemoveUnitRelations(c *gc.C, rel *Relation) {
+	st := rel.st
+	scopes, closer := st.db().GetCollection(relationScopesC)
+	defer closer()
+	scopesW := scopes.Writeable()
+	_, err := scopesW.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 // PrimeUnitStatusHistory will add count history elements, advancing the test clock by
 // one second for each entry.
 func PrimeUnitStatusHistory(
@@ -930,10 +939,6 @@ func ApplicationBranches(m *Model, appName string) ([]*Generation, error) {
 func MachinePortOps(st *State, m description.Machine) ([]txn.Op, error) {
 	resolver := &importer{st: st}
 	return resolver.machinePortsOps(m)
-}
-
-func NewBindingsForMergeTest(b map[string]string) *Bindings {
-	return &Bindings{bindingsMap: b}
 }
 
 // ModelBackendShim is required to live here in the export_test.go file because

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -844,6 +844,8 @@ func (s *RelationUnitSuite) testPrepareLeaveScope(c *gc.C, rel *state.Relation, 
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertScopeChange(c, w0, nil, []string{"wordpress/1"})
 	s.assertNoScopeChange(c, w0)
+	err = rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Refresh()

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1236,6 +1236,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 		startUniter{},
 		waitAddresses{},
 		custom{func(c *gc.C, ctx *context) {
+			c.Check(rel.Refresh(), gc.IsNil)
 			c.Assert(rel.Destroy(), gc.IsNil)
 		}},
 		waitUniterDead{},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1282,6 +1282,7 @@ func (s custom) step(c *gc.C, ctx *context) {
 }
 
 var relationDying = custom{func(c *gc.C, ctx *context) {
+	c.Check(ctx.relation.Refresh(), gc.IsNil)
 	c.Assert(ctx.relation.Destroy(), gc.IsNil)
 }}
 


### PR DESCRIPTION
It seems there can be a case where a relation claims to have a non-zero number of units in scope, but there aren't actually any corresponding database records. This happened on a controller with a cross model relation to another controller; the cause is likely a disconnect between the controllers at just the precise wrong time. See bug https://bugs.launchpad.net/juju/+bug/1871898

The fix here is based on looking at a database dump from the affected controller. remove-relation --force is enhanced to forcibly remove a relation if there are no units in scope, even if the relation doc claims there are.

## QA steps

Almost impossible to deterministically reproduce the same scenario as in the bug.
remove-relation verified to work as expected

## Bug reference

https://bugs.launchpad.net/juju/+bug/1871898
