### PR TITLE
Merge 2.9 develop

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -853,9 +853,10 @@ class ModelClient:
 
     def get_bootstrap_args(
             self, upload_tools, config_filename, bootstrap_series=None,
-            credential=None, auto_upgrade=False, metadata_source=None,
-            no_gui=False, agent_version=None, db_snap_path=None,
-            db_snap_asserts_path=None, force=False, config_options=None):
+            arch=None, credential=None, auto_upgrade=False,
+            metadata_source=None, no_gui=False, agent_version=None,
+            db_snap_path=None, db_snap_asserts_path=None, force=False,
+            config_options=None):
         """Return the bootstrap arguments for the substrate."""
         cloud_region = self.get_cloud_region(self.env.get_cloud(),
                                              self.env.get_region())
@@ -868,7 +869,7 @@ class ModelClient:
             return tuple(args)
 
         args += [
-            '--constraints', self._get_substrate_constraints(),
+            '--constraints', self._get_substrate_constraints(arch),
             '--default-model', self.env.environment
         ]
         if force:
@@ -996,11 +997,12 @@ class ModelClient:
     def update_user_name(self):
         self.env.user_name = 'admin'
 
-    def bootstrap(self, upload_tools=False, bootstrap_series=None,
+    def bootstrap(self, upload_tools=False, bootstrap_series=None, arch=None,
                   credential=None, auto_upgrade=False, metadata_source=None,
                   no_gui=False, agent_version=None, db_snap_path=None,
-                  db_snap_asserts_path=None, mongo_memory_profile=None, caas_image_repo=None, force=False,
-                  db_snap_channel=None, config_options=None):
+                  db_snap_asserts_path=None, mongo_memory_profile=None,
+                  caas_image_repo=None, force=False, db_snap_channel=None, 
+                  config_options=None):
         """Bootstrap a controller."""
         self._check_bootstrap()
         with self._bootstrap_config(
@@ -1010,6 +1012,7 @@ class ModelClient:
                 upload_tools=upload_tools,
                 config_filename=config_filename,
                 bootstrap_series=bootstrap_series,
+                arch=arch,
                 credential=credential,
                 auto_upgrade=auto_upgrade,
                 metadata_source=metadata_source,
@@ -1494,17 +1497,19 @@ class ModelClient:
     def _maas_spaces_enabled():
         return not os.environ.get("JUJU_CI_SPACELESSNESS")
 
-    def _get_substrate_constraints(self):
+    def _get_substrate_constraints(self, arch):
+        cons = []
+        if arch is not None:
+            cons.append("arch={}".format(arch))
         if self.env.maas and self._maas_spaces_enabled():
             # For now only maas support spaces in a meaningful way.
-            return 'spaces={}'.format(','.join(
-                '^' + space for space in sorted(self.excluded_spaces)))
+            cons.append('spaces={}'.format(','.join(
+                '^' + space for space in sorted(self.excluded_spaces))))
         elif self.env.lxd:
             # LXD should be constrained by memory when running in HA, otherwise
             # mongo just eats everything.
-            return 'mem=6G'
-        else:
-            return ''
+            cons.append('mem=6G')
+        return ' '.join(cons)
 
     def quickstart(self, bundle_template, upload_tools=False):
         bundle = self.format_bundle(bundle_template)

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -288,6 +288,8 @@ def add_basic_testing_arguments(
                         help='Stream for retrieving agent binaries.')
     parser.add_argument('--series', action='store', default=None,
                         help='Name of the Ubuntu series to use.')
+    parser.add_argument('--arch', action='store', default=None,
+                        help='Name of the architecture to use.')
     if not using_jes:
         parser.add_argument('--upload-tools', action='store_true',
                             help='upload local version of tools to bootstrap.')

--- a/api/upgrader/upgrader_test.go
+++ b/api/upgrader/upgrader_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/tools"
 )
 
 type machineUpgraderSuite struct {
@@ -92,18 +91,16 @@ func (s *machineUpgraderSuite) TestToolsNotMachine(c *gc.C) {
 
 func (s *machineUpgraderSuite) TestTools(c *gc.C) {
 	current := coretesting.CurrentVersion(c)
-	curTools := &tools.Tools{Version: current, URL: ""}
-	curTools.Version.Minor++
-	s.rawMachine.SetAgentVersion(current)
-	// Upgrader.Tools returns the *desired* set of tools, not the currently
-	// running set. We want to be upgraded to cur.Version
+	err := s.rawMachine.SetAgentVersion(current)
+	c.Assert(err, jc.ErrorIsNil)
+
 	stateToolsList, err := s.st.Tools(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
+
 	c.Assert(stateToolsList, gc.HasLen, 1)
 	stateTools := stateToolsList[0]
 	c.Assert(stateTools.Version, gc.Equals, current)
-	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
-		s.stateAPI.Addr(), coretesting.ModelTag.Id(), current)
+	url := fmt.Sprintf("https://%s/model/%s/tools/%s", s.stateAPI.Addr(), coretesting.ModelTag.Id(), current)
 	c.Assert(stateTools.URL, gc.Equals, url)
 }
 
@@ -136,11 +133,9 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 
 func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
 	current := coretesting.CurrentVersion(c)
-	curTools := &tools.Tools{Version: current, URL: ""}
-	curTools.Version.Minor++
-	s.rawMachine.SetAgentVersion(current)
-	// Upgrader.DesiredVersion returns the *desired* set of tools, not the
-	// currently running set. We want to be upgraded to cur.Version
+	err := s.rawMachine.SetAgentVersion(current)
+	c.Assert(err, jc.ErrorIsNil)
+
 	stateVersion, err := s.st.DesiredVersion(s.rawMachine.Tag().String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stateVersion, gc.Equals, current.Number)

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -379,6 +379,8 @@ func (s *watcherSuite) TestRelationStatusWatcher(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(life.Alive, false, "")
 
+	err = rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	assertChange(life.Dying, false, "")

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1466,12 +1466,16 @@ func (s *uniterSuite) TestWatchSubordinateUnitRelations(c *gc.C) {
 
 	// We get notified about the mysql relation going away but not the
 	// wordpress one.
+	err = mysqlRel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = mysqlRel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(mysqlRel.Tag().Id())
 	wc.AssertNoChange()
 
+	err = wpRel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = wpRel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v2"

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -276,7 +276,7 @@ func normalizeCharmOrigin(origin params.CharmOrigin) (params.CharmOrigin, error)
 	var os string
 	var oSeries string
 	if origin.Series == "all" {
-		logger.Tracef("Series all detected, removing all from the origin. %s", origin.ID)
+		logger.Warningf("Series all detected, removing all from the origin. %s", origin.ID)
 	} else if origin.Series != "" {
 		// Always set the os from the series, so we know it's correctly
 		// normalized for the rest of Juju.
@@ -287,12 +287,15 @@ func normalizeCharmOrigin(origin params.CharmOrigin) (params.CharmOrigin, error)
 		// Values passed to the api are case sensitive: ubuntu succeeds and
 		// Ubuntu returns `"code": "revision-not-found"`
 		os = strings.ToLower(sys.String())
+
 		oSeries = origin.Series
 	}
 
 	var arc string
 	if origin.Architecture != "all" {
 		arc = origin.Architecture
+	} else {
+		logger.Warningf("Architecture all detected, removing all from the origin. %s", origin.ID)
 	}
 
 	o := origin
@@ -338,7 +341,7 @@ func (a *API) addCharmWithAuthorization(args params.AddCharmWithAuth) (params.Ch
 		return params.CharmOriginResult{}, errors.Errorf("unknown schema for charm URL %q", args.URL)
 	}
 
-	if args.Origin.Source == "charm-hub" && args.Series == "" {
+	if args.Origin.Source == "charm-hub" && args.Origin.Series == "" {
 		return params.CharmOriginResult{}, errors.BadRequestf("series required for charm-hub charms")
 	}
 

--- a/apiserver/facades/client/charms/repositories.go
+++ b/apiserver/facades/client/charms/repositories.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/charmrepo/v6"
@@ -18,6 +19,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	"gopkg.in/macaroon.v2"
 
+	apicharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/selector"
@@ -72,7 +74,11 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 		}
 
 		resOrigin.ID = info.ID
-		return resURL, resOrigin, serie, nil
+		outputOrigin, err := sanitizeCharmOrigin(resOrigin, origin)
+		if err != nil {
+			return nil, params.CharmOrigin{}, nil, errors.Trace(err)
+		}
+		return resURL, outputOrigin, serie, nil
 	}
 
 	logger.Debugf("Resolving charm with revision %d and/or channel %s", curl.Revision, channel.String())
@@ -81,13 +87,17 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
-	resURL, resOrigin, serie, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
+	resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap)
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
 
 	resOrigin.ID = info.ID
-	return resURL, resOrigin, serie, nil
+	outputOrigin, err := sanitizeCharmOrigin(resOrigin, origin)
+	if err != nil {
+		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
+	}
+	return resURL, outputOrigin, series, nil
 }
 
 // DownloadCharm downloads the provided download URL from CharmHub using the
@@ -110,7 +120,12 @@ func (c *chRepo) DownloadCharm(resourceURL string, archivePath string) (*charm.C
 func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
 	logger.Tracef("FindDownloadURL %v %v", curl, origin)
 	if origin.Type == "bundle" {
-		return c.findBundleDownloadURL(curl, origin)
+		durl, resOrigin, err := c.findBundleDownloadURL(curl, origin)
+		if err != nil {
+			return nil, corecharm.Origin{}, errors.Trace(err)
+		}
+		outputOrigin, err := sanitizeCoreCharmOrigin(resOrigin, origin)
+		return durl, outputOrigin, errors.Trace(err)
 	}
 
 	cfg, err := refreshConfig(curl, origin)
@@ -132,11 +147,16 @@ func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url
 		return nil, corecharm.Origin{}, errors.Errorf("%s: %s", findResult.Error.Code, findResult.Error.Message)
 	}
 
-	origin.ID = findResult.Entity.ID
-	origin.Hash = findResult.Entity.Download.HashSHA256
+	resOrigin := origin
+	resOrigin.ID = findResult.Entity.ID
+	resOrigin.Hash = findResult.Entity.Download.HashSHA256
 
 	durl, err := url.Parse(findResult.Entity.Download.URL)
-	return durl, origin, errors.Trace(err)
+	if err != nil {
+		return nil, corecharm.Origin{}, errors.Trace(err)
+	}
+	outputOrigin, err := sanitizeCoreCharmOrigin(resOrigin, origin)
+	return durl, outputOrigin, errors.Trace(err)
 }
 
 func (c *chRepo) findBundleDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
@@ -149,6 +169,55 @@ func (c *chRepo) findBundleDownloadURL(curl *charm.URL, origin corecharm.Origin)
 
 	selector := selector.NewSelectorForBundle(series.SupportedJujuControllerSeries())
 	return selector.Locate(info, origin)
+}
+
+// sanitizeCharmOrigin attempts to ensure that any fields we receive from
+// the API are valid and juju knows about them.
+func sanitizeCharmOrigin(received, requested params.CharmOrigin) (params.CharmOrigin, error) {
+	// Platform is generally the problem at hand. We want to ensure if they
+	// send "all" back for Architecture, OS or Series that we either use the
+	// requested origin using that as the hint or we unset it from the requested
+	// origin.
+	result := received
+
+	if result.Architecture == "all" {
+		result.Architecture = ""
+		if requested.Architecture != "all" {
+			result.Architecture = requested.Architecture
+		}
+	}
+
+	if result.OS == "all" {
+		result.OS = ""
+	}
+
+	if result.Series == "all" {
+		result.Series = ""
+
+		if requested.Series != "all" {
+			result.Series = requested.Series
+		}
+	}
+
+	if result.Series != "" {
+		os, err := series.GetOSFromSeries(result.Series)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+		result.OS = strings.ToLower(os.String())
+	}
+
+	return result, nil
+}
+
+func sanitizeCoreCharmOrigin(received, requested corecharm.Origin) (corecharm.Origin, error) {
+	a := apicharm.CoreCharmOrigin(received)
+	b := apicharm.CoreCharmOrigin(requested)
+	res, err := sanitizeCharmOrigin(a.ParamsCharmOrigin(), b.ParamsCharmOrigin())
+	if err != nil {
+		return corecharm.Origin{}, errors.Trace(err)
+	}
+	return apicharm.APICharmOrigin(res).CoreCharmOrigin(), nil
 }
 
 // refreshConfig creates a RefreshConfig for the given input.
@@ -174,10 +243,7 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 		err error
 
 		platform = charmhub.RefreshPlatform{
-			// TODO (stickupkid): FIX ME, charmhub ignores architecture
-			// "sometimes"...
-			// Architecture: origin.Platform.Architecture,
-			Architecture: "all",
+			Architecture: origin.Platform.Architecture,
 			OS:           origin.Platform.OS,
 			Series:       origin.Platform.Series,
 		}

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -642,3 +642,127 @@ services:
         charm: wordpress
         num_units: 1
 `
+
+type sanitizeCharmOriginSuite struct{}
+
+var _ = gc.Suite(&sanitizeCharmOriginSuite{})
+
+func (s *sanitizeCharmOriginSuite) TestSanitize(c *gc.C) {
+	received := params.CharmOrigin{
+		Architecture: "all",
+		OS:           "all",
+		Series:       "all",
+	}
+	requested := params.CharmOrigin{
+		Architecture: "amd64",
+		OS:           "Ubuntu",
+		Series:       "focal",
+	}
+	got, err := sanitizeCharmOrigin(received, requested)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
+		Architecture: "amd64",
+		OS:           "ubuntu",
+		Series:       "focal",
+	})
+}
+
+func (s *sanitizeCharmOriginSuite) TestSanitizeWithValues(c *gc.C) {
+	received := params.CharmOrigin{
+		Architecture: "arm64",
+		OS:           "windows",
+		Series:       "win8",
+	}
+	requested := params.CharmOrigin{
+		Architecture: "amd64",
+		OS:           "Ubuntu",
+		Series:       "focal",
+	}
+	got, err := sanitizeCharmOrigin(received, requested)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
+		Architecture: "arm64",
+		OS:           "windows",
+		Series:       "win8",
+	})
+}
+
+func (s *sanitizeCharmOriginSuite) TestSanitizeWithEmptyValues(c *gc.C) {
+	received := params.CharmOrigin{
+		Architecture: "",
+		OS:           "",
+		Series:       "",
+	}
+	requested := params.CharmOrigin{
+		Architecture: "amd64",
+		OS:           "Ubuntu",
+		Series:       "focal",
+	}
+	got, err := sanitizeCharmOrigin(received, requested)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
+		Architecture: "",
+		OS:           "",
+		Series:       "",
+	})
+}
+
+func (s *sanitizeCharmOriginSuite) TestSanitizeWithRequestedEmptyValues(c *gc.C) {
+	received := params.CharmOrigin{
+		Architecture: "all",
+		OS:           "all",
+		Series:       "all",
+	}
+	requested := params.CharmOrigin{
+		Architecture: "",
+		OS:           "",
+		Series:       "",
+	}
+	got, err := sanitizeCharmOrigin(received, requested)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
+		Architecture: "",
+		OS:           "",
+		Series:       "",
+	})
+}
+
+func (s *sanitizeCharmOriginSuite) TestSanitizeWithRequestedEmptyValuesAlt(c *gc.C) {
+	received := params.CharmOrigin{
+		Architecture: "all",
+		OS:           "all",
+		Series:       "focal",
+	}
+	requested := params.CharmOrigin{
+		Architecture: "",
+		OS:           "",
+		Series:       "",
+	}
+	got, err := sanitizeCharmOrigin(received, requested)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
+		Architecture: "",
+		OS:           "ubuntu",
+		Series:       "focal",
+	})
+}
+
+func (s *sanitizeCharmOriginSuite) TestSanitizeWithRequestedEmptyValuesOSVersusSeries(c *gc.C) {
+	received := params.CharmOrigin{
+		Architecture: "all",
+		OS:           "ubuntu",
+		Series:       "all",
+	}
+	requested := params.CharmOrigin{
+		Architecture: "",
+		OS:           "",
+		Series:       "",
+	}
+	got, err := sanitizeCharmOrigin(received, requested)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
+		Architecture: "",
+		OS:           "ubuntu",
+		Series:       "",
+	})
+}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2121,8 +2121,14 @@ func (k *kubernetesClient) Units(appName string, mode caas.DeploymentMode) ([]ca
 				ports = append(ports, fmt.Sprintf("%v/%v", p.ContainerPort, p.Protocol))
 			}
 		}
+
+		eventGetter := func() ([]core.Event, error) {
+			return k.getEvents(p.Name, "Pod")
+		}
+
 		terminated := p.DeletionTimestamp != nil
-		statusMessage, unitStatus, since, err := k.getPODStatus(p, now)
+		statusMessage, unitStatus, since, err := podToJujuStatus(p, now, eventGetter)
+
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -2194,37 +2200,6 @@ func (k *kubernetesClient) getPod(podName string) (*core.Pod, error) {
 	return pod, nil
 }
 
-func (k *kubernetesClient) getPODStatus(pod core.Pod, now time.Time) (string, status.Status, time.Time, error) {
-	terminated := pod.DeletionTimestamp != nil
-	jujuStatus := k.jujuStatus(pod.Status.Phase, terminated)
-	statusMessage := pod.Status.Message
-	since := now
-	if statusMessage == "" {
-		for _, cond := range pod.Status.Conditions {
-			statusMessage = cond.Message
-			since = cond.LastProbeTime.Time
-			if cond.Type == core.PodScheduled && cond.Reason == core.PodReasonUnschedulable {
-				jujuStatus = status.Blocked
-				break
-			}
-		}
-	}
-
-	if statusMessage == "" {
-		// If there are any events for this pod we can use the
-		// most recent to set the status.
-		eventList, err := k.getEvents(pod.Name, "Pod")
-		if err != nil {
-			return "", "", time.Time{}, errors.Trace(err)
-		}
-		// Take the most recent event.
-		if count := len(eventList); count > 0 {
-			statusMessage = eventList[count-1].Message
-		}
-	}
-	return statusMessage, jujuStatus, since, nil
-}
-
 func (k *kubernetesClient) getStatefulSetStatus(ss *apps.StatefulSet) (string, status.Status, error) {
 	terminated := ss.DeletionTimestamp != nil
 	jujuStatus := status.Waiting
@@ -2284,6 +2259,7 @@ func (k *kubernetesClient) jujuStatus(podPhase core.PodPhase, terminated bool) s
 	if terminated {
 		return status.Terminated
 	}
+
 	switch podPhase {
 	case core.PodRunning:
 		return status.Running

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -653,8 +653,14 @@ func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 	}
 
 	opPod := podsList.Items[0]
+
+	eventGetter := func() ([]core.Event, error) {
+		return k.getEvents(opPod.Name, "Pod")
+	}
+
 	terminated := opPod.DeletionTimestamp != nil
-	statusMessage, opStatus, since, err := k.getPODStatus(opPod, k.clock.Now())
+	statusMessage, opStatus, since, err := podToJujuStatus(
+		opPod, k.clock.Now(), eventGetter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -992,8 +992,16 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 			}},
 		},
 		Status: core.PodStatus{
+			Conditions: []core.PodCondition{
+				{
+					Type:    core.PodScheduled,
+					Status:  core.ConditionFalse,
+					Reason:  "Scheduling",
+					Message: "test message",
+				},
+			},
 			Phase:   core.PodPending,
-			Message: "test message.",
+			Message: "test message",
 		},
 	}
 	ss := apps.StatefulSet{
@@ -1035,7 +1043,7 @@ func (s *K8sBrokerSuite) TestOperator(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(operator.Status.Status, gc.Equals, status.Allocating)
-	c.Assert(operator.Status.Message, gc.Equals, "test message.")
+	c.Assert(operator.Status.Message, gc.Equals, "test message")
 	c.Assert(operator.Config.Version, gc.Equals, version.MustParse("2.99.0"))
 	c.Assert(operator.Config.OperatorImagePath, gc.Equals, "test-image")
 	c.Assert(operator.Config.AgentConf, gc.DeepEquals, []byte("agent-conf-data"))

--- a/caas/kubernetes/provider/pod.go
+++ b/caas/kubernetes/provider/pod.go
@@ -1,0 +1,231 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/status"
+
+	core "k8s.io/api/core/v1"
+)
+
+type EventGetter func() ([]core.Event, error)
+
+const (
+	PodReasonCompleted                = "Completed"
+	PodReasonContainersNotInitialized = "ContainersNotInitialized"
+	PodReasonContainersNotReady       = "ContainersNotReady"
+	PodReasonCrashLoopBackoff         = "CrashLoopBackOff"
+	PodReasonError                    = "Error"
+	PodReasonImagePull                = "ErrImagePull"
+	PodReasonInitializing             = "PodInitializing"
+)
+
+var (
+	podContainersReadyReasonsMap = map[string]status.Status{
+		PodReasonContainersNotReady: status.Maintenance,
+	}
+
+	podInitializedReasonsMap = map[string]status.Status{
+		PodReasonContainersNotInitialized: status.Maintenance,
+	}
+
+	podReadyReasonMap = map[string]status.Status{
+		PodReasonContainersNotReady:       status.Maintenance,
+		PodReasonContainersNotInitialized: status.Maintenance,
+	}
+
+	podScheduledReasonsMap = map[string]status.Status{
+		core.PodReasonUnschedulable: status.Blocked,
+	}
+)
+
+// getPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+// These methods come directly from the Kubernetes code base. We can't import
+// them as Kubernetes forbids this. Code can be found here:
+// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/api/pod/util.go
+func getPodCondition(status *core.PodStatus, conditionType core.PodConditionType) (int, *core.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return getPodConditionFromList(status.Conditions, conditionType)
+}
+
+// getPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+// These methods come directly from the Kubernetes code base. We can't import
+// them as Kubernetes forbids this. Code can be found here:
+// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/api/pod/util.go
+func getPodConditionFromList(conditions []core.PodCondition, conditionType core.PodConditionType) (int, *core.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// podToJujuStatus takes a Kubernetes pod and translate's it to a known Juju
+// status. If this function can't determine the reason for a pod's state either
+// a status of error or unknown is returned. Function returns the status message,
+// juju status, the time of the status event and any errors that occurred.
+func podToJujuStatus(
+	pod core.Pod,
+	now time.Time,
+	events EventGetter,
+) (string, status.Status, time.Time, error) {
+	since := now
+	defaultStatusMessage := pod.Status.Message
+
+	if pod.DeletionTimestamp != nil {
+		return defaultStatusMessage, status.Terminated, since, nil
+	}
+
+	// conditionHandler tries to handle the state of the supplied condition.
+	// if the condition status is true true is returned from this function.
+	// Otherwise if the condition is unknown or false the function attempts to
+	// map the condition reason onto a known juju status
+	conditionHandler := func(
+		pc *core.PodCondition,
+		reasonMapper func(reason string) status.Status,
+	) (bool, status.Status, string) {
+		if pc.Status == core.ConditionTrue {
+			return true, "", ""
+		} else if pc.Status == core.ConditionUnknown {
+			return false, status.Unknown, pc.Message
+		}
+		return false, reasonMapper(pc.Reason), pc.Message
+	}
+
+	// reasonMapper takes a mapping of Kubernetes pod reasons to juju statuses.
+	// If no reason is found in the map the default reason supplied is returned
+	reasonMapper := func(
+		reasons map[string]status.Status,
+		def status.Status) func(string) status.Status {
+		return func(r string) status.Status {
+			if stat, ok := reasons[r]; ok {
+				return stat
+			}
+			return def
+		}
+	}
+
+	// Start by processing the pod conditions in their lifecycle order
+	// Has the pod been scheduled?
+	_, cond := getPodCondition(&pod.Status, core.PodScheduled)
+	if cond == nil { // Doesn't have scheduling information. Should not get here
+		return defaultStatusMessage, status.Unknown, since, nil
+	} else if r, s, m := conditionHandler(
+		cond, reasonMapper(podScheduledReasonsMap, status.Allocating)); !r {
+		return m, s, cond.LastProbeTime.Time, nil
+	}
+
+	// Have the init containers run?
+	if _, cond := getPodCondition(&pod.Status, core.PodInitialized); cond != nil {
+		r, s, m := conditionHandler(
+			cond, reasonMapper(podInitializedReasonsMap, status.Maintenance))
+		if errM, isErr := interrogatePodContainerStatus(pod.Status.InitContainerStatuses); !r && isErr {
+			return errM, status.Error, cond.LastProbeTime.Time, nil
+		} else if !r {
+			return m, s, cond.LastProbeTime.Time, nil
+		}
+	}
+
+	// Have the containers started/finished?
+	_, cond = getPodCondition(&pod.Status, core.ContainersReady)
+	if cond == nil {
+		return defaultStatusMessage, status.Unknown, since, nil
+	} else if r, s, m := conditionHandler(
+		cond, reasonMapper(podContainersReadyReasonsMap, status.Maintenance)); !r {
+		if errM, isErr := interrogatePodContainerStatus(pod.Status.ContainerStatuses); isErr {
+			return errM, status.Error, cond.LastProbeTime.Time, nil
+		}
+		return m, s, cond.LastProbeTime.Time, nil
+	}
+
+	// Made it this far are we ready?
+	_, cond = getPodCondition(&pod.Status, core.PodReady)
+	if cond == nil {
+		return defaultStatusMessage, status.Unknown, since, nil
+	} else if r, s, m := conditionHandler(
+		cond, reasonMapper(podReadyReasonMap, status.Maintenance)); !r {
+		return m, s, cond.LastProbeTime.Time, nil
+	} else if r {
+		return "", status.Running, since, nil
+	}
+
+	// If we have made it this far then something is very wrong in the state
+	// of the pod.
+
+	// If we can't find a status message lets take a look at the event log
+	if defaultStatusMessage == "" {
+		eventList, err := events()
+		if err != nil {
+			return "", "", time.Time{}, errors.Trace(err)
+		}
+
+		if count := len(eventList); count > 0 {
+			defaultStatusMessage = eventList[count-1].Message
+		}
+	}
+
+	return defaultStatusMessage, status.Unknown, since, nil
+}
+
+// interrogatePodContainerStatus combs a set of container statuses. If a
+// container is found to be in an error state it's error message and true are
+// returned, Otherwise an empty message and false
+func interrogatePodContainerStatus(containers []core.ContainerStatus) (string, bool) {
+	for _, c := range containers {
+		if c.State.Running != nil {
+			continue
+		}
+
+		if c.State.Waiting != nil {
+			m, isError := isContainerReasonError(c.State.Waiting.Reason)
+			if isError {
+				m = fmt.Sprintf("%s: %s", m, c.State.Waiting.Message)
+			}
+			return m, isError
+		}
+
+		if c.State.Terminated != nil {
+			m, isError := isContainerReasonError(c.State.Terminated.Reason)
+			if isError {
+				m = fmt.Sprintf("%s: %s", m, c.State.Terminated.Message)
+			}
+			return m, isError
+		}
+	}
+	return "", false
+}
+
+// isContainerReasonError decides if a reason on a container status is
+// considered to be an error. If an error is found on the reason then a
+// description of the error is returned with true. Otherwise an empty
+// description and false.
+func isContainerReasonError(reason string) (string, bool) {
+	switch reason {
+	case PodReasonError:
+		return "container error", true
+	case PodReasonImagePull:
+		return "OCI image pull error", true
+	case PodReasonCrashLoopBackoff:
+		return "crash loop backoff", true
+	case PodReasonCompleted:
+		return "", false
+	case PodReasonInitializing:
+		return "pod initializing", false
+	default:
+		return fmt.Sprintf("unknown container reason %q", reason), true
+	}
+}

--- a/caas/kubernetes/provider/pod_test.go
+++ b/caas/kubernetes/provider/pod_test.go
@@ -1,0 +1,339 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This test file is using go test framework as an internal test to go check.
+// Added by tlm 16/12/2020
+
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/juju/core/status"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTerminatedPodJujuStatus(t *testing.T) {
+	pod := core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			DeletionTimestamp: &meta.Time{time.Now()},
+		},
+		Status: core.PodStatus{
+			Message: "test",
+		},
+	}
+
+	testTime := time.Now()
+	message, poStatus, now, err := podToJujuStatus(
+		pod,
+		testTime,
+		func() ([]core.Event, error) {
+			return []core.Event{}, nil
+		})
+
+	if err != nil {
+		t.Fatalf("unexpected error getting pod status: %v", err)
+	}
+
+	if message != pod.Status.Message {
+		t.Errorf("pod status messages not equal %q != %q", message, pod.Status.Message)
+	}
+
+	if poStatus != status.Terminated {
+		t.Errorf("expected status %q got %q", status.Terminated, poStatus)
+	}
+
+	if !testTime.Equal(now) {
+		t.Errorf("unexpected status time received, got %q wanted %q", now, testTime)
+	}
+}
+
+func TestPodConditionListJujuStatus(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Pod     core.Pod
+		Status  status.Status
+		Message string
+	}{
+		{
+			// We are testing the juju status here when a pod is considered
+			// unschedulable. We want to see a juju status of blocked and
+			// the scheduling message echoed as this will provide the best
+			// reason.
+			Name: "pod scheduling status unschedulable",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:    core.PodScheduled,
+							Status:  core.ConditionFalse,
+							Reason:  core.PodReasonUnschedulable,
+							Message: "not enough resources",
+						},
+					},
+				},
+			},
+			Status:  status.Blocked,
+			Message: "not enough resources",
+		},
+		{
+			// We are testing the juju status here when pod scheduling is still
+			// occurring. Kubernetes is still organising where to put our pod
+			// so we expect a juju status of allocating and the pod scheduling
+			// message to be echoed.
+			Name: "pod scheduling status waiting",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:    core.PodScheduled,
+							Status:  core.ConditionFalse,
+							Reason:  "waiting",
+							Message: "waiting to be scheduled",
+						},
+					},
+				},
+			},
+			Status:  status.Allocating,
+			Message: "waiting to be scheduled",
+		},
+		{
+			// We expect that every pod has a pod scheduling condition. If it's
+			// missing our juju status should be Unknown as it's not safe for
+			// us to test anymore of the pod conditions.
+			Name: "pod scheduling status missing",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{},
+				},
+			},
+			Status:  status.Unknown,
+			Message: "",
+		},
+		{
+			// We are testing here that when the pod is in it's init stage
+			// the correct juju status of maintenance is being reported.
+			Name: "pod init status waiting",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotInitialized,
+							Message: "initializing containers",
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "initializing containers",
+		},
+		{
+			// We are testing here that when the pod is running the init steps
+			// the correct status of maintenance is being reported.
+			Name: "pod init status running",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonInitializing,
+							Message: "initializing containers",
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "initializing containers",
+		},
+		{
+			// We are testing here that when the pod is in it's init stage
+			// the correct juju status of error is displayed as one of the
+			// pods is in a crash loop backoff.
+			Name: "pod init status error",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotInitialized,
+							Message: "initializing containers",
+						},
+					},
+					InitContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-init-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason:  PodReasonCrashLoopBackoff,
+									Message: "I am broken",
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Error,
+			Message: "crash loop backoff: I am broken",
+		},
+		{
+			// We are testing here that while the main containers of the pod
+			// are still being spun up and the juju status of maintenance is
+			// still being reported
+			Name: "pod container status waiting",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "starting containers",
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "starting containers",
+		},
+		{
+			// We want to test here that when a container in the pod goes into
+			// an error state like a crash loop backoff the subsequent juju
+			// status is error
+			Name: "pod container status error",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "starting containers",
+						},
+					},
+					ContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason:  PodReasonCrashLoopBackoff,
+									Message: "I am broken",
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Error,
+			Message: "crash loop backoff: I am broken",
+		},
+		{
+			// We want to test that when the container reason is unknown we
+			// report Juju status of error and propagate the message
+			Name: "pod container unknown reason",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "starting containers",
+						},
+					},
+					ContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason:  "bad-reason",
+									Message: "I am broken",
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Error,
+			Message: "unknown container reason \"bad-reason\": I am broken",
+		},
+		{
+			// We want to test here that when the pod ready condition the juju
+			// status is running
+			Name: "pod container status running",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   core.ContainersReady,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:   core.PodReady,
+							Status: core.ConditionTrue,
+						},
+					},
+				},
+			},
+			Status:  status.Running,
+			Message: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			testTime := time.Now()
+			eventGetter := func() ([]core.Event, error) {
+				return []core.Event{}, nil
+			}
+			message, poStatus, _, err := podToJujuStatus(
+				test.Pod, testTime, eventGetter)
+
+			if err != nil {
+				t.Fatalf("unexpected error getting pod status: %v", err)
+			}
+
+			if message != test.Message {
+				t.Errorf("pod status messages not equal %q != %q", message, test.Message)
+			}
+
+			if poStatus != test.Status {
+				t.Errorf("expected status %q got %q", test.Status, poStatus)
+			}
+		})
+	}
+}

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -72,6 +72,49 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	c.Assert(responses[0].Name, gc.Equals, id)
 }
 
+//	c.Assert(results.Results[0].Error, gc.ErrorMatches, `.* pool "foo" not found`)
+func (s *RefreshSuite) TestRefeshConfigValidateArch(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "ubuntu",
+		Series:       "focal",
+		Architecture: "all",
+	})
+	c.Assert(err, gc.ErrorMatches, "Architecture.*")
+}
+
+func (s *RefreshSuite) TestRefeshConfigValidateSeries(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "ubuntu",
+		Series:       "all",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, gc.ErrorMatches, "Series.*")
+}
+
+func (s *RefreshSuite) TestRefeshConfigValidateOS(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "all",
+		Series:       "focal",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, gc.ErrorMatches, "OS.*")
+}
+
+func (s *RefreshSuite) TestRefeshConfigValidate(c *gc.C) {
+	err := s.testRefeshConfigValidate(c, RefreshPlatform{
+		OS:           "all",
+		Series:       "all",
+		Architecture: "all",
+	})
+	c.Assert(err, gc.ErrorMatches, "Architecture.*, OS.*, Series.*")
+}
+
+func (s *RefreshSuite) testRefeshConfigValidate(c *gc.C, rp RefreshPlatform) error {
+	_, err := DownloadOneFromChannel("meshuggah", "latest/stable", rp)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+	return err
+}
+
 type metadataTransport struct {
 	requestHeaders http.Header
 	responseBody   string

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -118,13 +118,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSpaceMissi
 		"cannot deploy bundle: cannot deploy application \"mysql\": "+
 		"space not found")
 	c.Assert(stdErr, gc.Equals, ""+
-		`Located bundle "cs:bundle/wordpress-with-endpoint-bindings-1"`+"\n"+
-		"Resolving charm via charmstore: cs:mysql\n"+
-		"Resolving charm via charmstore: cs:wordpress-extra-bindings")
+		`Located bundle "wordpress-with-endpoint-bindings" in charm-store, revision 1`+"\n"+
+		"Located charm \"mysql\" in charm-store\n"+
+		"Located charm \"wordpress-extra-bindings\" in charm-store")
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/mysql-42 for series xenial\n"+
-		"- deploy application mysql on xenial using cs:xenial/mysql-42")
+		"- upload charm mysql from charm-store for series xenial\n"+
+		"- deploy application mysql from charm-store on xenial")
 	s.assertCharmsUploaded(c, "cs:xenial/mysql-42")
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{})
 	s.assertUnitsCreated(c, map[string]string{})
@@ -197,20 +197,20 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/mysql-42 for series xenial\n"+
-		"- deploy application mysql on xenial using cs:xenial/mysql-42\n"+
+		"- upload charm mysql from charm-store for series xenial\n"+
+		"- deploy application mysql from charm-store on xenial\n"+
 		"- set annotations for mysql\n"+
-		"- upload charm cs:xenial/wordpress-47 for series xenial\n"+
-		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n"+
+		"- upload charm wordpress from charm-store for series xenial\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
 		"- set annotations for wordpress\n"+
 		"- add relation wordpress:db - mysql:db\n"+
 		"- add unit mysql/0 to new machine 0\n"+
 		"- add unit wordpress/0 to new machine 1",
 	)
 	c.Check(stdErr, gc.Equals, ""+
-		"Located bundle \"cs:bundle/wordpress-simple-1\"\n"+
-		"Resolving charm via charmstore: cs:mysql\n"+
-		"Resolving charm via charmstore: cs:wordpress\n"+
+		"Located bundle \"wordpress-simple\" in charm-store, revision 1\n"+
+		"Located charm \"mysql\" in charm-store\n"+
+		"Located charm \"wordpress\" in charm-store\n"+
 		"Deploy of bundle completed.",
 	)
 	stdOut, stdErr, err = s.runDeployWithOutput(c, "cs:bundle/wordpress-simple")
@@ -222,7 +222,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 		"- set constraints for wordpress to \"\"",
 	)
 	c.Check(stdErr, gc.Equals, ""+
-		"Located bundle \"cs:bundle/wordpress-simple-1\"\n"+
+		"Located bundle \"wordpress-simple\" in charm-store, revision 1\n"+
 		"Deploy of bundle completed.",
 	)
 
@@ -247,11 +247,11 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunTwice(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected := "" +
 		"Changes to deploy bundle:\n" +
-		"- upload charm cs:xenial/mysql-42 for series xenial\n" +
-		"- deploy application mysql on xenial using cs:xenial/mysql-42\n" +
+		"- upload charm mysql from charm-store for series xenial\n" +
+		"- deploy application mysql from charm-store on xenial\n" +
 		"- set annotations for mysql\n" +
-		"- upload charm cs:xenial/wordpress-47 for series xenial\n" +
-		"- deploy application wordpress on xenial using cs:xenial/wordpress-47\n" +
+		"- upload charm wordpress from charm-store for series xenial\n" +
+		"- deploy application wordpress from charm-store on xenial\n" +
 		"- set annotations for wordpress\n" +
 		"- add relation wordpress:db - mysql:db\n" +
 		"- add unit mysql/0 to new machine 0\n" +
@@ -420,7 +420,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleResources(c *gc.C) {
 	)
 	// Info messages go to stdErr.
 	c.Check(stdErr, gc.Equals, ""+
-		"Resolving charm via charmstore: cs:starsay\n"+
+		"Located charm \"startsay\" in charm-store\n"+
 		"  added resource install-resource\n"+
 		"  added resource store-resource\n"+
 		"  added resource upload-resource\n"+
@@ -1034,8 +1034,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:trusty/upgrade-2 for series trusty\n"+
-		"- upgrade up to use charm cs:trusty/upgrade-2 for series trusty\n"+
+		"- upload charm upgrade from charm-store for series trusty\n"+
+		"- upgrade up from charm-store using charm upgrade for series trusty\n"+
 		"- set constraints for up to \"mem=8G\"\n"+
 		"- set application options for wordpress\n"+
 		`- set constraints for wordpress to "spaces=new cores=8"`,
@@ -1353,10 +1353,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundlePeerContainer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/django-42 for series xenial\n"+
-		"- deploy application django on xenial using cs:xenial/django-42\n"+
-		"- upload charm cs:xenial/wordpress-0 for series xenial\n"+
-		"- deploy application wordpress on xenial using cs:xenial/wordpress-0\n"+
+		"- upload charm django from charm-store for series xenial\n"+
+		"- deploy application django from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series xenial\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
 		"- add lxd container 0/lxd/0 on new machine 0\n"+
 		"- add lxd container 1/lxd/0 on new machine 1\n"+
 		"- add unit wordpress/0 to 0/lxd/0\n"+
@@ -1454,7 +1454,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSwitch(c *gc.C) {
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
 		"- set constraints for django to \"\"\n"+
-		"- deploy application node on bionic using cs:bionic/django-42\n"+
+		"- deploy application node from charm-store on bionic using django\n"+
 		"- add unit node/0 to new machine 2",
 	)
 }
@@ -1538,7 +1538,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 		"Executing changes:\n"+
 		"- set constraints for django to \"\"\n"+
 		"- set constraints for memcached to \"\"\n"+
-		"- deploy application node on bionic using cs:bionic/django-42\n"+
+		"- deploy application node from charm-store on bionic using django\n"+
 		"- add unit node/0 to 0/lxd/0 to satisfy [lxd:memcached]",
 	)
 
@@ -1588,19 +1588,19 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithAnnotations_OutputIsCo
 
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:bionic/django-42 for series bionic\n"+
-		"- deploy application django on bionic using cs:bionic/django-42\n"+
+		"- upload charm django from charm-store for series bionic\n"+
+		"- deploy application django from charm-store on bionic\n"+
 		"- set annotations for django\n"+
-		"- upload charm cs:bionic/mem-47 for series bionic\n"+
-		"- deploy application memcached on bionic using cs:bionic/mem-47\n"+
+		"- upload charm mem from charm-store for series bionic\n"+
+		"- deploy application memcached from charm-store on bionic using mem\n"+
 		"- add new machine 0 (bundle machine 1)\n"+
 		"- set annotations for new machine 0\n"+
 		"- add unit django/0 to new machine 0\n"+
 		"- add unit memcached/0 to new machine 1",
 	)
 	c.Check(stdErr, gc.Equals, ""+
-		"Resolving charm via charmstore: cs:django\n"+
-		"Resolving charm via charmstore: cs:bionic/mem-47\n"+
+		"Located charm \"django\" in charm-store\n"+
+		"Located charm \"mem\" in charm-store, revision 47\n"+
 		"Deploy of bundle completed.",
 	)
 }
@@ -1763,8 +1763,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundlePassesSequences(c *gc.C) {
     `)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- upload charm cs:xenial/django-42 for series xenial\n"+
-		"- deploy application django on xenial using cs:xenial/django-42\n"+
+		"- upload charm django from charm-store for series xenial\n"+
+		"- deploy application django from charm-store on xenial\n"+
 		"- add unit django/2 to new machine 2\n"+
 		"- add unit django/3 to new machine 3",
 	)

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -246,6 +246,10 @@ func (d *charmstoreBundle) String() string {
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.
 func (d *charmstoreBundle) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
-	ctx.Infof("Located bundle %q", d.bundleURL)
+	var revision string
+	if d.bundleURL.Revision != -1 {
+		revision = fmt.Sprintf(", revision %d", d.bundleURL.Revision)
+	}
+	ctx.Infof("Located bundle %q in %s%s", d.bundleURL.Name, d.origin.Source, revision)
 	return d.deploy(ctx, deployAPI, resolver, macaroonGetter)
 }

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
 	"github.com/juju/charmrepo/v6"
@@ -329,22 +329,8 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Trace(err)
 		}
 
-		var via string
-		switch {
-		case charm.CharmHub.Matches(ch.Schema):
-			via = "via charmhub: "
-		case charm.CharmStore.Matches(ch.Schema):
-			via = "via charmstore: "
-		case charm.Local.Matches(ch.Schema):
-			via = "via local filesystem: "
-		default:
-			via = ": "
-		}
-
-		var fromChannel string
 		var channel corecharm.Channel
 		if spec.Channel != "" {
-			fromChannel = fmt.Sprintf(" from channel %s", spec.Channel)
 			channel, err = corecharm.ParseChannelNormalize(spec.Channel)
 			if err != nil {
 				return errors.Trace(err)
@@ -356,7 +342,6 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Trace(err)
 		}
 
-		h.ctx.Infof("Resolving charm %s%s%s", via, ch.FullPath(), fromChannel)
 		origin, err := utils.DeduceOrigin(ch, channel, platform)
 		if err != nil {
 			return errors.Trace(err)
@@ -365,6 +350,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve URL %q", spec.Charm)
 		}
+		h.ctx.Infof(formatLocatedText(ch, origin))
 		if url.Series == "bundle" {
 			return errors.Errorf("expected charm URL, got bundle URL %q", spec.Charm)
 		}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -118,13 +118,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "xenial")
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-42\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-42 for series xenial\n"+
-		"- deploy application mysql on xenial using cs:mysql-42\n"+
-		"- upload charm cs:wordpress-47 for series xenial\n"+
-		"- deploy application wordpress on xenial using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series xenial\n"+
+		"- deploy application mysql from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series xenial\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -226,13 +226,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithInvalidSeriesWithForce
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "precise")
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-42\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-42 for series precise\n"+
-		"- deploy application mysql on precise using cs:mysql-42\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wordpress on bionic using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series precise\n"+
+		"- deploy application mysql from charm-store on precise\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wordpress from charm-store on bionic\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -299,13 +299,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.assertDeployArgsStorage(c, "mariadb", map[string]storage.Constraints{"database": {Pool: "mariadb-pv", Size: 0x14, Count: 0x1}})
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:~juju/gitlab-k8s\n"+
-		"Resolving charm via charmstore: cs:~juju/mariadb-k8s\n"+
+		"Located charm \"gitlab-k8s\" in charm-store\n"+
+		"Located charm \"mariadb-k8s\" in charm-store\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:~juju/gitlab-k8s for series kubernetes\n"+
-		"- deploy application gitlab with 1 unit on kubernetes using cs:~juju/gitlab-k8s\n"+
-		"- upload charm cs:~juju/mariadb-k8s for series kubernetes\n"+
-		"- deploy application mariadb with 2 units on kubernetes using cs:~juju/mariadb-k8s\n"+
+		"- upload charm gitlab-k8s from charm-store for series kubernetes\n"+
+		"- deploy application gitlab from charm-store with 1 unit on kubernetes using gitlab-k8s\n"+
+		"- upload charm mariadb-k8s from charm-store for series kubernetes\n"+
+		"- deploy application mariadb from charm-store with 2 units on kubernetes using mariadb-k8s\n"+
 		"- add relation gitlab:mysql - mariadb:server\n"+
 		"Deploy of bundle completed.\n")
 }
@@ -367,13 +367,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleStorage(c *gc.C) {
 	s.assertDeployArgsStorage(c, "mysql", map[string]storage.Constraints{"database": {Pool: "mysql-pv", Size: 0x14, Count: 0x1}})
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-42\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-42 for series bionic\n"+
-		"- deploy application mysql on bionic using cs:mysql-42\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wordpress on bionic using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series bionic\n"+
+		"- deploy application mysql from charm-store on bionic\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wordpress from charm-store on bionic\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -451,13 +451,13 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleDevices(c *gc.C) {
 	)
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:bitcoin-miner\n"+
-		"Resolving charm via charmstore: cs:dashboard4miner\n"+
+		"Located charm \"bitcoin-miner\" in charm-store\n"+
+		"Located charm \"dashboard4miner\" in charm-store\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:bitcoin-miner for series kubernetes\n"+
-		"- deploy application bitcoin-miner with 1 unit on kubernetes using cs:bitcoin-miner\n"+
-		"- upload charm cs:dashboard4miner for series kubernetes\n"+
-		"- deploy application dashboard4miner with 1 unit on kubernetes using cs:dashboard4miner\n"+
+		"- upload charm bitcoin-miner from charm-store for series kubernetes\n"+
+		"- deploy application bitcoin-miner from charm-store with 1 unit on kubernetes\n"+
+		"- upload charm dashboard4miner from charm-store for series kubernetes\n"+
+		"- deploy application dashboard4miner from charm-store with 1 unit on kubernetes\n"+
 		"- add relation dashboard4miner:miner - bitcoin-miner:miner\n"+
 		"Deploy of bundle completed.\n")
 }
@@ -514,13 +514,13 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunExistingModel(c *gc.C) {
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "bionic")
 
 	expectedOutput := "" +
-		"Resolving charm via charmstore: cs:mysql-42\n" +
-		"Resolving charm via charmstore: cs:wordpress-47\n" +
+		"Located charm \"mysql\" in charm-store, revision 42\n" +
+		"Located charm \"wordpress\" in charm-store, revision 47\n" +
 		"Executing changes:\n" +
-		"- upload charm cs:mysql-42 for series bionic\n" +
-		"- deploy application mysql on bionic using cs:mysql-42\n" +
-		"- upload charm cs:wordpress-47 for series bionic\n" +
-		"- deploy application wordpress on bionic using cs:wordpress-47\n" +
+		"- upload charm mysql from charm-store for series bionic\n" +
+		"- deploy application mysql from charm-store on bionic\n" +
+		"- upload charm wordpress from charm-store for series bionic\n" +
+		"- deploy application wordpress from charm-store on bionic\n" +
 		"- add new machine 0\n" +
 		"- add new machine 1\n" +
 		"- add relation wordpress:db - mysql:db\n" +
@@ -637,10 +637,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc
 	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wp on bionic using cs:wordpress-47\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wp from charm-store on bionic using wordpress\n"+
 		"- add new machine 0 (bundle machine 4)\n"+
 		"- add new machine 1 (bundle machine 8)\n"+
 		"- add new machine 2\n"+
@@ -689,10 +689,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleExpose(c *gc.C) {
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:wordpress-47\n"+
-		"- deploy application wordpress using cs:wordpress-47\n"+
+		"- upload charm wordpress from charm-store\n"+
+		"- deploy application wordpress from charm-store\n"+
 		"- expose all endpoints of wordpress and allow access from CIDRs 0.0.0.0/0 and ::/0\n"+
 		"- add unit wordpress/0 to new machine 0\n"+
 		"Deploy of bundle completed.\n")
@@ -764,19 +764,19 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C)
 	s.assertDeployArgs(c, varnishCurl.String(), "varnish", "xenial")
 	s.assertDeployArgs(c, pgresCurl.String(), "postgres", "xenial")
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Resolving charm via charmstore: cs:mysql-32\n"+
-		"Resolving charm via charmstore: cs:xenial/postgres-2\n"+
-		"Resolving charm via charmstore: cs:xenial/varnish\n"+
-		"Resolving charm via charmstore: cs:wordpress-47\n"+
+		"Located charm \"mysql\" in charm-store, revision 32\n"+
+		"Located charm \"postgres\" in charm-store, revision 2\n"+
+		"Located charm \"varnish\" in charm-store\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
 		"Executing changes:\n"+
-		"- upload charm cs:mysql-32 for series bionic\n"+
-		"- deploy application mysql on bionic using cs:mysql-32\n"+
-		"- upload charm cs:xenial/postgres-2 for series xenial\n"+
-		"- deploy application postgres on xenial using cs:xenial/postgres-2\n"+
-		"- upload charm cs:xenial/varnish for series xenial\n"+
-		"- deploy application varnish on xenial using cs:xenial/varnish\n"+
-		"- upload charm cs:wordpress-47 for series bionic\n"+
-		"- deploy application wordpress on bionic using cs:wordpress-47\n"+
+		"- upload charm mysql from charm-store for series bionic\n"+
+		"- deploy application mysql from charm-store on bionic\n"+
+		"- upload charm postgres from charm-store for series xenial\n"+
+		"- deploy application postgres from charm-store on xenial\n"+
+		"- upload charm varnish from charm-store for series xenial\n"+
+		"- deploy application varnish from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series bionic\n"+
+		"- deploy application wordpress from charm-store on bionic\n"+
 		"- add relation wordpress:db - mysql:server\n"+
 		"- add relation varnish:webcache - wordpress:cache\n"+
 		"- add unit mysql/0 to new machine 0\n"+
@@ -837,16 +837,16 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	expectedOutput := "" +
 		"Executing changes:\n" +
 		"- upload charm %s for series xenial\n" +
-		"- deploy application mysql on xenial using %s\n" +
+		"- deploy application mysql on xenial\n" +
 		"- upload charm %s for series xenial\n" +
-		"- deploy application wordpress on xenial using %s\n" +
+		"- deploy application wordpress on xenial\n" +
 		"- add relation wordpress:db - mysql:server\n" +
 		"- add unit mysql/0 to new machine 0\n" +
 		"- add unit mysql/1 to new machine 1\n" +
 		"- add unit wordpress/0 to new machine 2\n" +
 		"Deploy of bundle completed.\n"
 
-	c.Check(s.output.String(), gc.Equals, fmt.Sprintf(expectedOutput, mysqlPath, mysqlPath, wordpressPath, wordpressPath))
+	c.Check(s.output.String(), gc.Equals, fmt.Sprintf(expectedOutput, mysqlPath, wordpressPath))
 }
 
 func (s *BundleDeployCharmStoreSuite) bundleDeploySpec() bundleDeploySpec {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -541,5 +541,9 @@ func formatLocatedText(curl *charm.URL, origin commoncharm.Origin) string {
 	if repository == "" || repository == commoncharm.OriginLocal {
 		return fmt.Sprintf("Located local charm %q, revision %d", curl.Name, curl.Revision)
 	}
-	return fmt.Sprintf("Located charm %q in %s, revision %d", curl.Name, repository, curl.Revision)
+	var revision string
+	if curl.Revision != -1 {
+		revision = fmt.Sprintf(", revision %d", curl.Revision)
+	}
+	return fmt.Sprintf("Located charm %q in %s%s", curl.Name, repository, revision)
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -6,6 +6,7 @@ package deployer
 import (
 	"archive/zip"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -291,8 +292,13 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	// below) where it is handled properly. This is just an expedient to get
 	// the correct series. A proper refactoring of the charmrepo package is
 	// needed for a more elegant fix.
+	charmOrBundle := d.charmOrBundle
+	if isLocalSchema(charmOrBundle) {
+		charmOrBundle = charmOrBundle[6:]
+	}
+
 	seriesName := d.series
-	ch, err := charm.ReadCharm(d.charmOrBundle)
+	ch, err := charm.ReadCharm(charmOrBundle)
 
 	var imageStream string
 	if err == nil {
@@ -328,7 +334,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	}
 
 	// Charm may have been supplied via a path reference.
-	ch, curl, err := charmrepo.NewCharmAtPathForceSeries(d.charmOrBundle, seriesName, d.force)
+	ch, curl, err := charmrepo.NewCharmAtPathForceSeries(charmOrBundle, seriesName, d.force)
 	// We check for several types of known error which indicate
 	// that the supplied reference was indeed a path but there was
 	// an issue reading the charm located there.
@@ -337,9 +343,9 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	} else if charm.IsUnsupportedSeriesError(err) {
 		return nil, errors.Trace(err)
 	} else if errors.Cause(err) == zip.ErrFormat {
-		return nil, errors.Errorf("invalid charm or bundle provided at %q", d.charmOrBundle)
+		return nil, errors.Errorf("invalid charm or bundle provided at %q", charmOrBundle)
 	} else if _, ok := err.(*charmrepo.NotFoundError); ok {
-		return nil, errors.Wrap(err, errors.NotFoundf("charm or bundle at %q", d.charmOrBundle))
+		return nil, errors.Wrap(err, errors.NotFoundf("charm or bundle at %q", charmOrBundle))
 	} else if err != nil && err != os.ErrNotExist {
 		// If we get a "not exists" error then we attempt to interpret
 		// the supplied charm reference as a URL elsewhere, otherwise
@@ -420,6 +426,7 @@ func (d *factory) maybeReadCharmstoreBundle(resolver Resolver) (Deployer, error)
 	db := d.newDeployBundle(store.NewResolvedBundle(bundle))
 	db.bundleURL = bundleURL
 	db.bundleOverlayFile = d.bundleOverlayFile
+	db.origin = bundleOrigin
 	return &charmstoreBundle{deployBundle: db}, nil
 }
 
@@ -455,6 +462,19 @@ func resolveCharmURL(path string) (*charm.URL, error) {
 	}
 
 	return charm.ParseURL(path)
+}
+
+func isLocalSchema(u string) bool {
+	raw, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	switch charm.Schema(raw.Scheme) {
+	case charm.Local:
+		return true
+	}
+
+	return false
 }
 
 // Returns the first string that isn't empty.

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -215,7 +215,7 @@ func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
 	factory := s.newDeployerFactory()
 	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store bundle: %s", bundle.String()))
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store bundle: %s from channel edge", bundle.String()))
 }
 
 func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/bundlechanges/v3"
+	"github.com/juju/bundlechanges/v4"
 	"github.com/juju/charm/v8"
 	"github.com/juju/charmrepo/v6"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/version"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	jujucloud "github.com/juju/juju/cloud"
@@ -947,7 +948,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 	}
 
 	if cloud.Type == k8sconstants.CAASProviderType &&
-		cloud.HostCloudRegion == caas.K8sCloudOther &&
+		cloud.HostCloudRegion == kubernetes.K8sCloudOther &&
 		bootstrapParams.ControllerServiceType == "" {
 		logger.Warningf("bootstrapping to an unknown kubernetes cluster should be used with option --config controller-service-type. See juju help bootstrap")
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
@@ -132,8 +133,30 @@ agent stream is 'released' (default), then a 2.3.1 client can bootstrap:
 However, if this client has a copy of codebase, then a local copy of Juju
 will be built and bootstrapped - 2.3.1.1.
 
+Bootstrapping to a k8s cluster requires that the service set up to handle
+requests to the controller be accessible outside the cluster. Typically this
+means a service type of LoadBalancer is needed, and Juju does create such a
+service if it knows it is supported by the cluster. This is performed by
+interrogating the cluster for a well known managed deployment such as microk8s,
+GKE or EKS.
+
+When bootstrapping to a k8s cluster Juju does not recognise, there's no
+guarantee a load balancer is available, so Juju defaults to a controller
+service type of ClusterIP. This may not be suitable, so there's 3 bootstrap
+options available to tell Juju how to set up the controller service. Part of
+the solution may require a load balancer for the cluster to be set up manually
+first, or perhaps an external k8s service via a FQDN will be used
+(this is a cluster specific implementation decision which Juju needs to be
+informed about so it can set things up correctly). The 3 relevant bootstrap
+options are (see list of bootstrap config items below for a full explanation):
+
+- controller-service-type
+- controller-external-name
+- controller-external-ips
+
 If a storage pool is specified using --storage-pool, this will be created
-in the controller model.`
+in the controller model.
+`
 
 var usageBootstrapConfigTxt = `
 
@@ -153,6 +176,12 @@ Examples:
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
     juju bootstrap aws --storage-pool name=secret --storage-pool type=ebs --storage-pool encrypted=true
 
+    # For a bootstrap on k8s, setting the service type of the Juju controller service to LoadBalancer
+    juju bootstrap --config controller-service-type=loadbalancer
+
+	# For a bootstrap on k8s, setting the service type of the Juju controller service to External
+    juju bootstrap --config controller-service-type=external --config controller-service-name=controller.juju.is
+
 See also:
     add-credentials
     add-model
@@ -161,9 +190,11 @@ See also:
     set-constraints
     show-cloud`
 
-// defaultHostedModelName is the name of the hosted model created in each
-// controller for deploying workloads to, in addition to the "controller" model.
-const defaultHostedModelName = "default"
+const (
+	// defaultHostedModelName is the name of the hosted model created in each
+	// controller for deploying workloads to, in addition to the "controller" model.
+	defaultHostedModelName = "default"
+)
 
 func newBootstrapCommand() cmd.Command {
 	command := &bootstrapCommand{}
@@ -253,6 +284,12 @@ func (c *bootstrapCommand) configDetails() map[string]interface{} {
 	}
 	if controllerCgf, err := cmdcontroller.ConfigDetails(); err == nil {
 		addAll(controllerCgf)
+	}
+	for key, attr := range bootstrap.BootstrapConfigSchema {
+		result[key] = common.PrintConfigSchema{
+			Description: attr.Description,
+			Type:        fmt.Sprintf("%s", attr.Type),
+		}
 	}
 	return result
 }
@@ -907,6 +944,12 @@ See `[1:] + "`juju kill-controller`" + `.`)
 			}
 			bootstrapParams.ExtraAgentValuesForTesting[k] = v
 		}
+	}
+
+	if cloud.Type == k8sconstants.CAASProviderType &&
+		cloud.HostCloudRegion == caas.K8sCloudOther &&
+		bootstrapParams.ControllerServiceType == "" {
+		logger.Warningf("bootstrapping to an unknown kubernetes cluster should be used with option --config controller-service-type. See juju help bootstrap")
 	}
 
 	bootstrapFuncs := getBootstrapFuncs()

--- a/cmd/plugins/juju-wait-for/application_test.go
+++ b/cmd/plugins/juju-wait-for/application_test.go
@@ -54,6 +54,7 @@ func (s *applicationScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := ApplicationScope{
+			ctx:             MakeScopeContext(),
 			ApplicationInfo: test.ApplicationInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -64,6 +65,7 @@ func (s *applicationScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *applicationScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := ApplicationScope{
+		ctx:             MakeScopeContext(),
 		ApplicationInfo: &params.ApplicationInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/cmd/plugins/juju-wait-for/machine_test.go
+++ b/cmd/plugins/juju-wait-for/machine_test.go
@@ -57,6 +57,7 @@ func (s *machineScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := MachineScope{
+			ctx:         MakeScopeContext(),
 			MachineInfo: test.MachineInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -67,6 +68,7 @@ func (s *machineScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *machineScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := MachineScope{
+		ctx:         MakeScopeContext(),
 		MachineInfo: &params.MachineInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/cmd/plugins/juju-wait-for/model_test.go
+++ b/cmd/plugins/juju-wait-for/model_test.go
@@ -47,6 +47,7 @@ func (s *modelScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := ModelScope{
+			ctx:       MakeScopeContext(),
 			ModelInfo: test.ModelInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -57,6 +58,7 @@ func (s *modelScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *modelScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := ModelScope{
+		ctx:       MakeScopeContext(),
 		ModelInfo: &params.ModelUpdate{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/cmd/plugins/juju-wait-for/unit_test.go
+++ b/cmd/plugins/juju-wait-for/unit_test.go
@@ -81,6 +81,7 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d: GetIdentValue %q", i, test.Field)
 		scope := UnitScope{
+			ctx:      MakeScopeContext(),
 			UnitInfo: test.UnitInfo,
 		}
 		result, err := scope.GetIdentValue(test.Field)
@@ -91,6 +92,7 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 
 func (s *unitScopeSuite) TestGetIdentValueError(c *gc.C) {
 	scope := UnitScope{
+		ctx:      MakeScopeContext(),
 		UnitInfo: &params.UnitInfo{},
 	}
 	result, err := scope.GetIdentValue("bad")

--- a/core/charm/strategies.go
+++ b/core/charm/strategies.go
@@ -44,6 +44,7 @@ type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
 	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
 
 	Child(name string) Logger
 }
@@ -279,7 +280,8 @@ func (p *Strategy) normalizePlatform(platform Platform) (Platform, error) {
 		os = strings.ToLower(sys.String())
 	}
 	arc := platform.Architecture
-	if platform.Architecture == "" {
+	if platform.Architecture == "" || platform.Architecture == "all" {
+		p.logger.Warningf("Received charm Architecture: %q, changing to %q, for charm %q", platform.Architecture, arch.DefaultArchitecture, p.charmURL)
 		arc = arch.DefaultArchitecture
 	}
 

--- a/core/charm/strategies_test.go
+++ b/core/charm/strategies_test.go
@@ -329,9 +329,10 @@ func mustWriteToTempFile(c *gc.C, mockCharm *MockStoreCharm) func(*charm.URL, st
 type fakeLogger struct {
 }
 
-func (l *fakeLogger) Errorf(_ string, _ ...interface{}) {}
-func (l *fakeLogger) Debugf(_ string, _ ...interface{}) {}
-func (l *fakeLogger) Tracef(_ string, _ ...interface{}) {}
+func (l *fakeLogger) Errorf(_ string, _ ...interface{})   {}
+func (l *fakeLogger) Debugf(_ string, _ ...interface{})   {}
+func (l *fakeLogger) Tracef(_ string, _ ...interface{})   {}
+func (l *fakeLogger) Warningf(_ string, _ ...interface{}) {}
 func (l *fakeLogger) Child(string) Logger {
 	return &fakeLogger{}
 }

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/utils/v2"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/juju/osenv"
@@ -87,6 +88,61 @@ var BootstrapConfigAttributes = []string{
 	ControllerServiceType,
 	ControllerExternalName,
 	ControllerExternalIPs,
+}
+
+// BootstrapConfigSchema defines the schema used for config items during
+// bootstrap.
+var BootstrapConfigSchema = environschema.Fields{
+	AdminSecretKey: {
+		Description: "Sets the Juju administrator password",
+		Type:        environschema.Tstring,
+	},
+	CACertKey: {
+		Description: fmt.Sprintf(
+			"Sets the bootstrapped controllers CA cert to use and issue "+
+				"certificates from, used in conjunction with %s",
+			CAPrivateKeyKey),
+		Type: environschema.Tstring,
+	},
+	CAPrivateKeyKey: {
+		Description: fmt.Sprintf(
+			"Sets the bootstrapped controllers CA cert private key to sign "+
+				"certificates with, used in conjunction with %s",
+			CACertKey),
+		Type: environschema.Tstring,
+	},
+	BootstrapTimeoutKey: {
+		Description: "Controls how long Juju will wait for a bootstrap to " +
+			"complete before considering it failed in seconds",
+		Type: environschema.Tint,
+	},
+	BootstrapRetryDelayKey: {
+		Description: "Controls the amount of time in seconds between attempts " +
+			"to connect to a bootstrap machine address",
+		Type: environschema.Tint,
+	},
+	BootstrapAddressesDelayKey: {
+		Description: "Controls the amount of time in seconds in between " +
+			"refreshing the bootstrap machine addresses",
+		Type: environschema.Tint,
+	},
+	ControllerServiceType: {
+		Description: "Controls the kubernetes service type for Juju " +
+			"controllers, see " +
+			"https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core " +
+			"valid values are one of cluster, loadbalancer, external",
+		Type: environschema.Tstring,
+	},
+	ControllerExternalName: {
+		Description: "Sets the external name for a k8s controller of type " +
+			"external",
+		Type: environschema.Tstring,
+	},
+	ControllerExternalIPs: {
+		Description: "Specifies a comma separated list of external IPs for a " +
+			"k8s controller of type external",
+		Type: environschema.Tstring,
+	},
 }
 
 // IsBootstrapAttribute reports whether or not the specified

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hpidcock/juju-fake-init v0.0.0-20201026041434-e95018795575
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6
+	github.com/juju/bundlechanges/v4 v4.0.0-20201215212106-38904645b567
 	github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN7
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6 h1:PmF2wWq0H1F4O+I+KMPRtBxuupxRw5c3Gv4WXEFr2Bo=
-github.com/juju/bundlechanges/v3 v3.0.0-20201118044951-0e6ce11ef6c6/go.mod h1:bkzD4rJvlgyr9AEKUKB0eLRpMwqMshq3t5ayQmuKOBU=
+github.com/juju/bundlechanges/v4 v4.0.0-20201215212106-38904645b567 h1:8W66si4O0yo7UyKyHfViG1RAVSbSdJE6V5yoAtl6Vwg=
+github.com/juju/bundlechanges/v4 v4.0.0-20201215212106-38904645b567/go.mod h1:rGro4ym8B/S2wOyg4zrrtB1Kl9Yij4+zvsglsXEU1tE=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0 h1:BuNV5BMVyKI1XUupcAuC/Y2bW/izfV7Tn+uI7jMYjNk=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9 h1:e6OkRhyixqkgcycaD+aACZQMPwpJSxfbTfNc4qwOBnE=

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -37,7 +37,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
@@ -78,11 +77,6 @@ var (
 	// runtime, otherwise it panics.
 	KubernetesSeriesName = strings.ToLower(jujuos.Kubernetes.String())
 )
-
-// defaultSupportedJujuSeries is used to return canned information about what
-// juju supports in terms of the release cycle
-// see juju/os and documentation https://www.ubuntu.com/about/release-cycle
-var defaultSupportedJujuSeries = set.NewStrings("focal", "bionic", "xenial", "trusty", KubernetesSeriesName)
 
 // JujuConnSuite provides a freshly bootstrapped juju.Conn
 // for each test. It also includes testing.BaseSuite.
@@ -424,7 +418,7 @@ func (s *JujuConnSuite) OpenAPIAsNewMachine(c *gc.C, jobs ...state.MachineJob) (
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
-	err = machine.SetProvisioned(instance.Id("foo"), "", "fake_nonce", nil)
+	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	return s.openAPIAs(c, machine.Tag(), password, "fake_nonce", false), machine
 }
@@ -440,7 +434,7 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	defaultSeries.Add(config.PreferredSeries(conf))
 
 	hostSeries, err := series.HostSeries()
-	if err != nil {
+	if err == nil {
 		defaultSeries.Add(hostSeries)
 	}
 

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3424,6 +3424,8 @@ func (s *ApplicationSuite) TestWatchRelations(c *gc.C) {
 
 	// Destroy the relation with the unit in scope, and add another; check
 	// changes.
+	err = rel2.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = rel2.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	rel3 := addRelation()

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -644,6 +644,15 @@ func RemoveRelationStatus(c *gc.C, rel *Relation) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func RemoveUnitRelations(c *gc.C, rel *Relation) {
+	st := rel.st
+	scopes, closer := st.db().GetCollection(relationScopesC)
+	defer closer()
+	scopesW := scopes.Writeable()
+	_, err := scopesW.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 // PrimeUnitStatusHistory will add count history elements, advancing the test clock by
 // one second for each entry.
 func PrimeUnitStatusHistory(
@@ -949,10 +958,6 @@ func ApplicationBranches(m *Model, appName string) ([]*Generation, error) {
 func MachinePortOps(st *State, m description.Machine) ([]txn.Op, error) {
 	resolver := &importer{st: st}
 	return []txn.Op{resolver.machinePortsOp(m)}, nil
-}
-
-func NewBindingsForMergeTest(b map[string]string) *Bindings {
-	return &Bindings{bindingsMap: b}
 }
 
 // ModelBackendShim is required to live here in the export_test.go file because

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -845,6 +845,8 @@ func (s *RelationUnitSuite) testPrepareLeaveScope(c *gc.C, rel *state.Relation, 
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertScopeChange(c, w0, nil, []string{"wordpress/1"})
 	s.assertNoScopeChange(c, w0)
+	err = rel.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	err = rel.Refresh()

--- a/state/resources_state_resource.go
+++ b/state/resources_state_resource.go
@@ -323,6 +323,7 @@ func (st resourceState) storeResource(res resource.Resource, r io.Reader) error 
 // OpenResource returns metadata about the resource, and a reader for
 // the resource.
 func (st resourceState) OpenResource(applicationID, name string) (resource.Resource, io.ReadCloser, error) {
+	rLogger.Tracef("open resource %q of %q", name, applicationID)
 	id := newResourceID(applicationID, name)
 	resourceInfo, storagePath, err := st.persist.GetResource(id)
 	if err != nil {
@@ -371,6 +372,7 @@ func (st resourceState) OpenResource(applicationID, name string) (resource.Resou
 // a reader for the resource. The resource is associated with
 // the unit once the reader is completely exhausted.
 func (st resourceState) OpenResourceForUniter(unit resource.Unit, name string) (resource.Resource, io.ReadCloser, error) {
+	rLogger.Tracef("open resource %q for uniter %q", name, unit.Name())
 	applicationID := unit.ApplicationName()
 
 	pendingID, err := newPendingID()
@@ -427,6 +429,7 @@ func (st resourceState) SetCharmStoreResources(applicationID string, info []char
 // do not have any machinery to facilitate transactions between
 // different components.
 func (st resourceState) NewResolvePendingResourcesOps(applicationID string, pendingIDs map[string]string) ([]txn.Op, error) {
+	rLogger.Tracef("resolve pending resource ops for %q", applicationID)
 	if len(pendingIDs) == 0 {
 		return nil, nil
 	}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -41,6 +41,12 @@ import (
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
 
+// MaxDocOps defines the number of documents to put into a single transaction,
+// if we make this number too large, mongo and client side transactions
+// struggle to complete. It is unclear what the optimum is, but without some
+// sort of cap, we've seen txns try to touch 100k docs which makes things fail.
+const MaxDocOps = 2000
+
 // runForAllModelStates will run runner function for every model passing a state
 // for that model.
 func runForAllModelStates(pool *StatePool, runner func(st *State) error) error {
@@ -2926,15 +2932,13 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
 		col, closer := st.db().GetCollection(statusesC)
 		defer closer()
+		totalOps := 0
 
-		var docs []bson.M
-		err := col.Find(nil).All(&docs)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		iter := col.Find(bson.M{"neverset": bson.M{"$exists": 1}}).Iter()
 
 		var ops []txn.Op
-		for _, oldDoc := range docs {
+		var oldDoc bson.M
+		for iter.Next(&oldDoc) {
 			// For docs where "neverset" is true, we update the
 			// Status and StatusInfo. For all others, we just remove
 			// the "neverset attribute".
@@ -2964,9 +2968,26 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 				Assert: txn.DocExists,
 				Update: update,
 			})
+			if len(ops) > MaxDocOps {
+				totalOps += len(ops)
+				upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
+				err = st.db().RunTransaction(ops)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				ops = ops[:0]
+			}
+		}
+		if err := iter.Close(); err != nil {
+			return errors.Trace(err)
 		}
 
-		return errors.Trace(st.db().RunTransaction(ops))
+		if len(ops) > 0 {
+			totalOps += len(ops)
+			upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
+			return errors.Trace(st.db().RunTransaction(ops))
+		}
+		return nil
 	}))
 }
 

--- a/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
@@ -4,7 +4,7 @@ saas:
     url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.mysql
 applications:
   wordpress:
-    charm: wordpress
+    charm: cs:wordpress
     num_units: 1
 relations:
 - - wordpress:db

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -18,7 +18,7 @@ run_deploy_specific_series() {
 
     ensure "test-deploy-specific-series" "${file}"
 
-    juju deploy postgresql --series bionic
+    juju deploy cs:postgresql --series bionic
     series=$(juju status --format=json | jq ".applications.postgresql.series")
 
     destroy_model "test-deploy-specific-series"

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -82,12 +82,12 @@ run_reboot_monitor_state_cleanup() {
 
     ensure "${model_name}" "${file}"
 
-    # Deploy mysql/rsyslog-forwarder. The latter is a subordinate
+    # Deploy mysql/rsyslog-forwarder-ha. The latter is a subordinate
     juju deploy mysql
-    juju deploy rsyslog-forwarder
-    juju add-relation rsyslog-forwarder mysql
+    juju deploy rsyslog-forwarder-ha
+    juju add-relation rsyslog-forwarder-ha mysql
     wait_for "mysql" "$(idle_condition "mysql")"
-    wait_for "rsyslog-forwarder" "$(idle_subordinate_condition "rsyslog-forwarder" "mysql")"
+    wait_for "rsyslog-forwarder-ha" "$(idle_subordinate_condition "rsyslog-forwarder-ha" "mysql")"
 
     # Check that the reboot flag files have been created for both the charm and
     # the subordinate. Note: juju ssh adds whitespace which we need to trim
@@ -103,7 +103,7 @@ run_reboot_monitor_state_cleanup() {
 
     # Remove subordinate and ensure that the state file for its monitor got purged
     echo "[+] Verifying that reboot monitor state files are removed once a subordinate gets removed"
-    juju remove-relation rsyslog-forwarder mysql
+    juju remove-relation rsyslog-forwarder-ha mysql
     wait_for "mysql" "$(idle_condition "mysql")"
 
     wait_for_subordinate_count "mysql"

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -6,7 +6,7 @@ test_log_permissions() {
   file="${TEST_DIR}/test_log_permissions.log"
   ensure "correct-log" "${file}"
 
-  juju deploy postgresql
+  juju deploy cs:postgresql
 
   wait_for "started" '.machines."0"."juju-status".current'
 

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -8,7 +8,6 @@ run_network_health() {
     # Deploy some applications for different series.
     juju deploy mongodb --series xenial
     juju deploy ubuntu ubuntu-bionic --series bionic
-    juju deploy ubuntu ubuntu-focal --series focal
 
     # Now the testing charm for each series.
     # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
@@ -19,18 +18,15 @@ run_network_health() {
 
     juju expose network-health-xenial
     juju expose network-health-bionic
-    juju expose network-health-focal
 
     juju add-relation network-health-xenial mongodb
     juju add-relation network-health-bionic ubuntu-bionic
-    juju add-relation network-health-focal ubuntu-focal
 
     wait_for "mongodb" "$(idle_condition "mongodb")"
     wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 4)"
     wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 5)"
     wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "mongodb")"
     wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu-bionic")"
-    wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "ubuntu-focal")"
 
     check_default_routes
     check_accessibility

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -7,7 +7,7 @@ run_relation_data_exchange() {
     ensure "${model_name}" "${file}"
 
     # Deploy 2 wordpress instances and one mysql instance
-    juju deploy wordpress -n 2
+    juju deploy cs:wordpress -n 2
     wait_for "wordpress" "$(idle_condition "wordpress" 0 0)"
     wait_for "wordpress" "$(idle_condition "wordpress" 0 1)"
     juju deploy mysql

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -7,7 +7,7 @@ run_relation_list_app() {
     ensure "${model_name}" "${file}"
 
     # Deploy 2 departer instances
-    juju deploy wordpress
+    juju deploy cs:wordpress
     juju deploy mysql
     juju relate wordpress mysql
     wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -303,6 +303,7 @@ func (aw *applicationWorker) clusterChanged(
 				}
 			}
 		}
+
 		unitParams := params.ApplicationUnitParams{
 			ProviderId: u.Id,
 			Address:    u.Address,

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1236,6 +1236,7 @@ func (s *UniterSuite) TestSubordinateDying(c *gc.C) {
 		startUniter{},
 		waitAddresses{},
 		custom{func(c *gc.C, ctx *context) {
+			c.Check(rel.Refresh(), gc.IsNil)
 			c.Assert(rel.Destroy(), gc.IsNil)
 		}},
 		waitUniterDead{},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1282,6 +1282,7 @@ func (s custom) step(c *gc.C, ctx *context) {
 }
 
 var relationDying = custom{func(c *gc.C, ctx *context) {
+	c.Check(ctx.relation.Refresh(), gc.IsNil)
 	c.Assert(ctx.relation.Destroy(), gc.IsNil)
 }}
 


### PR DESCRIPTION
This is a merge from 2.9 into develop.

This wasn't a clean merge:
 - version numbers conflict: moved to 3.0-beta1
 - conflict around where caas/metadata.go file was located, this wasn't picked up in the merge but a build after-wards.

c1cb4aab4d (upstream/2.9, origin/2.9, 2.9) Merge pull request #12471 from wallyworld/merge-2.8-20201217a
551e1be182 Merge pull request #12469 from jujubot/increment-to-2.9-rc4
c5305d8fbe Merge pull request #12468 from wallyworld/merge-2.8-20201217
0f9a02959a Merge pull request #12465 from SimonRichardson/charmhub-hide-local-schema-in-errors-messages
4b2d0f8bf8 Merge pull request #12271 from SimonRichardson/wait-for-summary
2002602a86 Merge pull request #12461 from SimonRichardson/charmhub-bundle-descriptions
b4037cb9ec Merge pull request #12460 from hmlanigan/bundle-output
97933e4090 Merge pull request #12455 from SimonRichardson/charmhub-ensure-charmorigin-output
9f56bc9f7f Merge pull request #12457 from hmlanigan/unit-resource-doc-not-local
9c119e3c7e (manadart/2.9) Merge pull request #12448 from SimonRichardson/acceptance-tests-architecture
5b260dbbb2 Merge pull request #12449 from hmlanigan/charmhub-no-all
236efd7279 Merge pull request #12458 from hmlanigan/identify-charms-deployed
6bd766cf37 Merge pull request #12456 from jameinel/2.8-into-2.9

