### PR TITLE
[2.9] Populate CIDR field when faking NICs in instancepoller

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -380,6 +380,15 @@ func NewScopedProviderAddress(value string, scope Scope) ProviderAddress {
 	return ProviderAddress{MachineAddress: NewScopedMachineAddress(value, scope)}
 }
 
+// NewScopedProviderAddressWithNetwork creates a new ProviderAddress by
+// embedding the result of NewScopedMachineAddress and populating its CIDR
+// value. No space information is populated.
+func NewScopedProviderAddressWithNetwork(value, networkCIDR string, scope Scope) ProviderAddress {
+	addr := NewScopedProviderAddress(value, scope)
+	addr.CIDR = networkCIDR
+	return addr
+}
+
 // NewProviderAddressInSpace creates a new ProviderAddress, deriving its type
 // and scope from the value, and associating it with the given space name.
 func NewProviderAddressInSpace(spaceName string, value string) ProviderAddress {

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -505,6 +505,8 @@ func fakeInterfacesFromInstanceAddrs(addrs []network.ProviderAddress) network.In
 		default:
 			instIfaceList[i].Addresses = append(instIfaceList[i].Addresses, addr)
 		}
+
+		instIfaceList[i].CIDR = addr.CIDR
 	}
 
 	return instIfaceList

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -36,8 +36,8 @@ var (
 	_ = gc.Suite(&workerSuite{})
 
 	testAddrs = network.ProviderAddresses{
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
-		network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
+		network.NewScopedProviderAddressWithNetwork("10.0.0.1", "10.0.0.0/24", network.ScopeCloudLocal),
+		network.NewScopedProviderAddressWithNetwork("1.1.1.42", "1.1.1.0/24", network.ScopePublic),
 	}
 
 	testNetIfs = network.InterfaceInfos{
@@ -47,10 +47,10 @@ var (
 			MACAddress:    "de:ad:be:ef:00:00",
 			CIDR:          "10.0.0.0/24",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+				network.NewScopedProviderAddressWithNetwork("10.0.0.1", "10.0.0.0/24", network.ScopeCloudLocal),
 			},
 			ShadowAddresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
+				network.NewScopedProviderAddressWithNetwork("1.1.1.42", "1.1.1.0/24", network.ScopePublic),
 			},
 		},
 	}
@@ -58,14 +58,16 @@ var (
 	testCoercedNetIfs = network.InterfaceInfos{
 		{
 			DeviceIndex: 0,
+			CIDR:        "10.0.0.0/24",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+				network.NewScopedProviderAddressWithNetwork("10.0.0.1", "10.0.0.0/24", network.ScopeCloudLocal),
 			},
 		},
 		{
 			DeviceIndex: 1,
+			CIDR:        "1.1.1.0/24",
 			ShadowAddresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("1.1.1.42", network.ScopePublic),
+				network.NewScopedProviderAddressWithNetwork("1.1.1.42", "1.1.1.0/24", network.ScopePublic),
 			},
 		},
 	}


### PR DESCRIPTION
When the environment **does not** support the Networking interface, the instancepoller worker iterates the addresses reported as part of the instance info and creates fake NICs based on the discovered addresses.

This commit ensures that the CIDR for the generated NICs gets populated using the network details associated with each instance address to prevent the code in networkingcommon from emitting validation errors when it encounters a blank CIDR value.

Note that from 2.9 onwards, all providers support the Networking interface and can provide a NIC list so this is not an issue anymore (hence the lack of QA steps). I stumbled on this issue while testing the WIP for the Packet provider which has not yet implemented this interface.