### PR TITLE
Handle Ctrl-C during bootstrap (refactored)

### DIFF
--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -103,7 +104,7 @@ func (*modelWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContext(cmdtesting.Context(c)),
+		modelcmd.BootstrapContext(context.Background(), cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
@@ -4,6 +4,7 @@
 package fanconfigurer_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -131,7 +132,7 @@ func (s *fanconfigurerSuite) TestFanConfigFetchError(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContext(cmdtesting.Context(c)),
+		modelcmd.BootstrapContext(context.Background(), cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -33,6 +33,7 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/mongo"
 )
 
@@ -327,7 +328,7 @@ func (c *controllerStack) Deploy() (err error) {
 		}
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	defer func() {
@@ -341,7 +342,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating service for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	// create shared-secret secret for controller pod.
@@ -349,7 +350,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating shared-secret secret for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	// create server.pem secret for controller pod.
@@ -357,7 +358,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating server.pem secret for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	// create mongo admin account secret for controller pod.
@@ -365,7 +366,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating mongo admin account secret for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	// create bootstrap-params configmap for controller pod.
@@ -373,7 +374,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating bootstrap-params configmap for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	// Note: create agent config configmap for controller pod lastly because agentConfig has been updated in previous steps.
@@ -381,7 +382,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating agent config configmap for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	// create statefulset to ensure controller stack.
@@ -389,7 +390,7 @@ func (c *controllerStack) Deploy() (err error) {
 		return errors.Annotate(err, "creating statefulset for controller")
 	}
 	if isDone() {
-		return errors.New("cancelled")
+		return bootstrap.Cancelled()
 	}
 
 	return nil

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -476,7 +476,7 @@ please choose a different hosted model name then try again.`, hostedModelName),
 		}
 		return errors.Annotate(
 			controllerStack.Deploy(),
-			"creating controller stack for controller",
+			"creating controller stack",
 		)
 	}
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -41,7 +42,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/sync"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju"
@@ -416,7 +417,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 // BootstrapInterface provides bootstrap functionality that Run calls to support cleaner testing.
 type BootstrapInterface interface {
 	// Bootstrap bootstraps a controller.
-	Bootstrap(ctx environs.BootstrapContext, environ environs.BootstrapEnviron, callCtx context.ProviderCallContext, args bootstrap.BootstrapParams) error
+	Bootstrap(ctx environs.BootstrapContext, environ environs.BootstrapEnviron, callCtx envcontext.ProviderCallContext, args bootstrap.BootstrapParams) error
 
 	// CloudDetector returns a CloudDetector for the given provider,
 	// if the provider supports it.
@@ -433,7 +434,7 @@ type BootstrapInterface interface {
 
 type bootstrapFuncs struct{}
 
-func (b bootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.BootstrapEnviron, callCtx context.ProviderCallContext, args bootstrap.BootstrapParams) error {
+func (b bootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.BootstrapEnviron, callCtx envcontext.ProviderCallContext, args bootstrap.BootstrapParams) error {
 	return bootstrap.Bootstrap(ctx, env, callCtx, args)
 }
 
@@ -652,7 +653,7 @@ to create a new model to deploy %sworkloads.
 		return errors.Trace(err)
 	}
 
-	cloudCallCtx := context.NewCloudCallContext()
+	cloudCallCtx := envcontext.NewCloudCallContext()
 	// At this stage, the credential we intend to use is not yet stored
 	// server-side. So, if the credential is not accepted by the provider,
 	// we cannot mark it as invalid, just log it as an informative message.
@@ -736,7 +737,29 @@ to create a new model to deploy %sworkloads.
 
 	bootstrapCfg.controller[controller.ControllerName] = c.controllerName
 
-	bootstrapCtx := modelcmd.BootstrapContext(ctx)
+	// Handle Ctrl-C during bootstrap by asking the bootstrap process to stop
+	// early (and the above will then clean up resources).
+	interrupted := make(chan os.Signal, 1)
+	defer close(interrupted)
+	ctx.InterruptNotify(interrupted)
+	defer ctx.StopInterruptNotify(interrupted)
+	stdCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		for range interrupted {
+			// Newline prefix is intentional, so output appears as
+			// "^C\nCtrl-C pressed" instead of "^CCtrl-C pressed".
+			_, _ = fmt.Fprintln(ctx.GetStderr(), "\nCtrl-C pressed, stopping bootstrap and cleaning up resources")
+			select {
+			case <-stdCtx.Done():
+				// Ctrl-C already pressed
+				return
+			default:
+				cancel()
+			}
+		}
+	}()
+
+	bootstrapCtx := modelcmd.BootstrapContext(stdCtx, ctx)
 	bootstrapPrepareParams := bootstrap.PrepareParams{
 		ModelConfig:      bootstrapCfg.bootstrapModel,
 		ControllerConfig: bootstrapCfg.controller,
@@ -843,18 +866,6 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		}
 	}()
 
-	// Block interruption during bootstrap. Providers may also
-	// register for interrupt notification so they can exit early.
-	interrupted := make(chan os.Signal, 1)
-	defer close(interrupted)
-	ctx.InterruptNotify(interrupted)
-	defer ctx.StopInterruptNotify(interrupted)
-	go func() {
-		for range interrupted {
-			ctx.Infof("Interrupt signalled: waiting for bootstrap to exit")
-		}
-	}()
-
 	// If --metadata-source is specified, override the default tools metadata source so
 	// SyncTools can use it, and also upload any image metadata.
 	if c.MetadataSource != "" {
@@ -924,7 +935,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 
 	bootstrapFuncs := getBootstrapFuncs()
 	if err = bootstrapFuncs.Bootstrap(
-		modelcmd.BootstrapContext(ctx),
+		bootstrapCtx,
 		environ,
 		cloudCallCtx,
 		bootstrapParams,
@@ -938,7 +949,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 	}
 
 	controllerDataRefresher := func() error {
-		// this function allows polling address info later during retring.
+		// this function allows polling address info later during retrying.
 		// for example, the Load Balancer needs time to be provisioned.
 		var addrs []network.ProviderAddress
 		if env, ok := environ.(environs.InstanceBroker); ok {
@@ -1005,11 +1016,10 @@ See `[1:] + "`juju kill-controller`" + `.`)
 	// for the controller's machine agent to be ready to accept commands
 	// before exiting this bootstrap command.
 	return waitForAgentInitialisation(
-		ctx,
+		bootstrapCtx,
 		&c.ModelCommandBase,
 		isCAASController,
 		c.controllerName,
-		c.hostedModelName,
 	)
 }
 
@@ -1508,7 +1518,9 @@ func handleBootstrapError(ctx *cmd.Context, cleanup func() error) {
 	defer close(ch)
 	go func() {
 		for range ch {
-			_, _ = fmt.Fprintln(ctx.GetStderr(), "Cleaning up failed bootstrap")
+			// Newline prefix is intentional, so output appears as
+			// "^C\nCtrl-C pressed" instead of "^CCtrl-C pressed".
+			_, _ = fmt.Fprintln(ctx.GetStderr(), "\nCtrl-C pressed, cleaning up failed bootstrap")
 		}
 	}()
 	logger.Debugf("cleaning up after failed bootstrap")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -746,14 +746,14 @@ to create a new model to deploy %sworkloads.
 	stdCtx, cancel := context.WithCancel(context.Background())
 	go func() {
 		for range interrupted {
-			// Newline prefix is intentional, so output appears as
-			// "^C\nCtrl-C pressed" instead of "^CCtrl-C pressed".
-			_, _ = fmt.Fprintln(ctx.GetStderr(), "\nCtrl-C pressed, stopping bootstrap and cleaning up resources")
 			select {
 			case <-stdCtx.Done():
 				// Ctrl-C already pressed
 				return
 			default:
+				// Newline prefix is intentional, so output appears as
+				// "^C\nCtrl-C pressed" instead of "^CCtrl-C pressed".
+				_, _ = fmt.Fprintln(ctx.GetStderr(), "\nCtrl-C pressed, stopping bootstrap and cleaning up resources")
 				cancel()
 			}
 		}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -118,7 +118,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		panic("tests must call setupAutoUploadTest or otherwise patch envtools.BundleTools")
 	})
 
-	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, bool, string, string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(environs.BootstrapContext, *modelcmd.ModelCommandBase, bool, string) error {
 		return nil
 	})
 
@@ -2091,7 +2091,7 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 
 	// Record the controller name seen by ModelCommandBase at the end of bootstrap.
 	var seenControllerName string
-	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _ bool, controllerName, _ string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(_ environs.BootstrapContext, base *modelcmd.ModelCommandBase, _ bool, controllerName string) error {
 		seenControllerName = controllerName
 		return nil
 	})

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -109,7 +109,7 @@ func WaitForAgentInitialisation(
 		// isn't fully threaded through yet).
 		select {
 		case <-ctx.Context().Done():
-			return errors.Annotatef(err, "cancelled waiting for controller")
+			return errors.Annotatef(err, "contacting controller (cancelled)")
 		default:
 		}
 

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -126,11 +126,12 @@ func WaitForAgentInitialisation(
 		switch {
 		case errors.Cause(err) == io.EOF,
 			strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
+			strings.HasSuffix(errorMessage, "connection refused"),
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
 			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):
-			ctx.Verbosef("Still waiting for API to become available")
+			ctx.Verbosef("Still waiting for API to become available: %v", err)
 			continue
 		case params.ErrCode(err) == params.CodeUpgradeInProgress:
 			ctx.Verbosef("Still waiting for API to become available: %v", err)

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -150,6 +150,17 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)
 }
 
+func (s *controllerSuite) TestWaitForAgentCancelled(c *gc.C) {
+	s.mockBlockClient.numRetries = 2
+	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
+		stdCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		bootstrapCtx := modelcmd.BootstrapContext(stdCtx, ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
+		c.Check(err, gc.ErrorMatches, `contacting controller \(cancelled\): .*`)
+	})
+}
+
 func runInCommand(c *gc.C, run func(ctx *cmd.Context, base *modelcmd.ModelCommandBase)) {
 	cmd := &testCommand{
 		run: run,

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -97,7 +98,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
 		runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-			err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+			bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+			err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 			c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		})
 		expectedRetries := t.numRetries
@@ -116,7 +118,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C
 	s.mockBlockClient.discoveringSpacesError = 2
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
@@ -128,7 +131,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C)
 	s.mockBlockClient.loginError = io.EOF
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
@@ -139,7 +143,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 		c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,7 +43,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
@@ -814,7 +815,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	err = env.PrepareForBootstrap(nullContext(), "controller-1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	callCtx := context.NewCloudCallContext()
+	callCtx := envcontext.NewCloudCallContext()
 	s.AddCleanup(func(c *gc.C) {
 		err := env.DestroyController(callCtx, controllerCfg.ControllerUUID())
 		c.Assert(err, jc.ErrorIsNil)
@@ -862,14 +863,14 @@ func nullContext() environs.BootstrapContext {
 	ctx.Stdin = io.LimitReader(nil, 0)
 	ctx.Stdout = ioutil.Discard
 	ctx.Stderr = ioutil.Discard
-	return modelcmd.BootstrapContext(ctx)
+	return modelcmd.BootstrapContext(context.Background(), ctx)
 }
 
 type mockDummyEnviron struct {
 	environs.Environ
 }
 
-func (m *mockDummyEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+func (m *mockDummyEnviron) Instances(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 	// ensure that callback is used...
 	ctx.InvalidateCredential("considered invalid for the sake of testing")
 	return m.Environ.Instances(ctx, ids)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -189,6 +189,17 @@ func (c *CommandBase) NewAPIRoot(
 	store jujuclient.ClientStore,
 	controllerName, modelName string,
 ) (api.Connection, error) {
+	return c.NewAPIRootWithDialOpts(store, controllerName, modelName, nil)
+}
+
+// NewAPIRootWithDialOpts returns a new connection to the API server for the
+// given model or controller (the default dial options will be overridden if
+// dialOpts is not nil).
+func (c *CommandBase) NewAPIRootWithDialOpts(
+	store jujuclient.ClientStore,
+	controllerName, modelName string,
+	dialOpts *api.DialOpts,
+) (api.Connection, error) {
 	c.assertRunStarted()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
@@ -210,6 +221,9 @@ func (c *CommandBase) NewAPIRoot(
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if dialOpts != nil {
+		param.DialOpts = *dialOpts
 	}
 	conn, err := juju.NewAPIConnection(param)
 	if modelName != "" && params.ErrCode(err) == params.CodeModelNotFound {

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -4,6 +4,7 @@
 package modelcmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -401,7 +402,21 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := c.newAPIRoot(modelName)
+	conn, err := c.newAPIRoot(modelName, nil)
+	return conn, errors.Trace(err)
+}
+
+// NewAPIRootWithDialOpts returns a new connection to the API server for the
+// environment directed to the model specified on the command line (and with
+// the given dial options if non-nil).
+func (c *ModelCommandBase) NewAPIRootWithDialOpts(dialOpts *api.DialOpts) (api.Connection, error) {
+	// We need to call ModelDetails() here and not just ModelName() to force
+	// a refresh of the internal model details if those are not yet stored locally.
+	modelName, _, err := c.ModelDetails()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	conn, err := c.newAPIRoot(modelName, dialOpts)
 	return conn, errors.Trace(err)
 }
 
@@ -410,17 +425,17 @@ func (c *ModelCommandBase) NewAPIRoot() (api.Connection, error) {
 // This is for the use of model-centered commands that still want
 // to talk to controller-only APIs.
 func (c *ModelCommandBase) NewControllerAPIRoot() (api.Connection, error) {
-	return c.newAPIRoot("")
+	return c.newAPIRoot("", nil)
 }
 
 // newAPIRoot is the internal implementation of NewAPIRoot and NewControllerAPIRoot;
 // if modelName is empty, it makes a controller-only connection.
-func (c *ModelCommandBase) newAPIRoot(modelName string) (api.Connection, error) {
+func (c *ModelCommandBase) newAPIRoot(modelName string, dialOpts *api.DialOpts) (api.Connection, error) {
 	controllerName, err := c.ControllerName()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conn, err := c.CommandBase.NewAPIRoot(c.store, controllerName, modelName)
+	conn, err := c.CommandBase.NewAPIRootWithDialOpts(c.store, controllerName, modelName, dialOpts)
 	return conn, errors.Trace(err)
 }
 
@@ -622,30 +637,41 @@ func (w *modelCommandWrapper) SetFlags(f *gnuflag.FlagSet) {
 	w.ModelCommand.SetFlags(f)
 }
 
+// Define a type alias so we can embed *cmd.Context and have a Context() method.
+type cmdContext = cmd.Context
+
 type bootstrapContext struct {
-	*cmd.Context
+	*cmdContext
 	verifyCredentials bool
+	ctx               context.Context
 }
 
 // ShouldVerifyCredentials implements BootstrapContext.ShouldVerifyCredentials
-func (ctx *bootstrapContext) ShouldVerifyCredentials() bool {
-	return ctx.verifyCredentials
+func (c *bootstrapContext) ShouldVerifyCredentials() bool {
+	return c.verifyCredentials
+}
+
+// Context returns this bootstrap's context.Context value.
+func (c *bootstrapContext) Context() context.Context {
+	return c.ctx
 }
 
 // BootstrapContext returns a new BootstrapContext constructed from a command Context.
-func BootstrapContext(cmdContext *cmd.Context) environs.BootstrapContext {
+func BootstrapContext(ctx context.Context, cmdContext *cmd.Context) environs.BootstrapContext {
 	return &bootstrapContext{
-		Context:           cmdContext,
+		cmdContext:        cmdContext,
 		verifyCredentials: true,
+		ctx:               ctx,
 	}
 }
 
 // BootstrapContextNoVerify returns a new BootstrapContext constructed from a command Context
 // where the validation of credentials is false.
-func BootstrapContextNoVerify(cmdContext *cmd.Context) environs.BootstrapContext {
+func BootstrapContextNoVerify(ctx context.Context, cmdContext *cmd.Context) environs.BootstrapContext {
 	return &bootstrapContext{
-		Context:           cmdContext,
+		cmdContext:        cmdContext,
 		verifyCredentials: false,
+		ctx:               ctx,
 	}
 }
 

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -4,6 +4,7 @@
 package modelcmd_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -217,12 +218,12 @@ func (s *ModelCommandSuite) TestModelGeneration(c *gc.C) {
 }
 
 func (s *ModelCommandSuite) TestBootstrapContext(c *gc.C) {
-	ctx := modelcmd.BootstrapContext(&cmd.Context{})
+	ctx := modelcmd.BootstrapContext(context.Background(), &cmd.Context{})
 	c.Assert(ctx.ShouldVerifyCredentials(), jc.IsTrue)
 }
 
 func (s *ModelCommandSuite) TestBootstrapContextNoVerify(c *gc.C) {
-	ctx := modelcmd.BootstrapContextNoVerify(&cmd.Context{})
+	ctx := modelcmd.BootstrapContextNoVerify(context.Background(), &cmd.Context{})
 	c.Assert(ctx.ShouldVerifyCredentials(), jc.IsFalse)
 }
 

--- a/cmd/plugins/juju-metadata/toolsmetadata_test.go
+++ b/cmd/plugins/juju-metadata/toolsmetadata_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,7 +56,7 @@ func (s *ToolsMetadataSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	e, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContextNoVerify(cmdtesting.Context(c)),
+		modelcmd.BootstrapContextNoVerify(context.Background(), cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -4,6 +4,7 @@
 package environs
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
@@ -141,4 +142,7 @@ type BootstrapContext interface {
 	// ShouldVerifyCredentials indicates whether the caller's cloud
 	// credentials should be verified.
 	ShouldVerifyCredentials() bool
+
+	// Context is the context.Context value for this bootstrap command.
+	Context() context.Context
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -50,6 +50,8 @@ You may want to use the 'agent-metadata-url' configuration setting to specify th
 
 var (
 	logger = loggo.GetLogger("juju.environs.bootstrap")
+
+	errCancelled = errors.New("cancelled")
 )
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
@@ -1143,4 +1145,14 @@ func hashAndSize(path string) (hash string, size int64, err error) {
 		return "", 0, errors.Mask(err)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), size, nil
+}
+
+// Cancelled returns an error that satisfies IsCancelled.
+func Cancelled() error {
+	return errCancelled
+}
+
+// IsCancelled reports whether err is a "bootstrap cancelled" error.
+func IsCancelled(err error) bool {
+	return errors.Cause(err) == errCancelled
 }

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"context"
+
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -13,8 +15,8 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
-	instances "github.com/juju/juju/environs/instances"
+	envcontext "github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/common"
 )
 
@@ -28,7 +30,7 @@ func DisableFinishBootstrap() func() {
 		environs.BootstrapContext,
 		ssh.Client,
 		environs.Environ,
-		context.ProviderCallContext,
+		envcontext.ProviderCallContext,
 		instances.Instance,
 		*instancecfg.InstanceConfig,
 		environs.BootstrapDialOpts,
@@ -41,5 +43,5 @@ func DisableFinishBootstrap() func() {
 
 // BootstrapContext creates a simple bootstrap execution context.
 func BootstrapContext(c *gc.C) environs.BootstrapContext {
-	return modelcmd.BootstrapContext(cmdtesting.Context(c))
+	return modelcmd.BootstrapContext(context.Background(), cmdtesting.Context(c))
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -42,7 +43,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
@@ -128,7 +129,7 @@ type JujuConnSuite struct {
 	oldJujuXDGDataHome  string
 	DummyConfig         testing.Attrs
 	Factory             *factory.Factory
-	ProviderCallContext context.ProviderCallContext
+	ProviderCallContext envcontext.ProviderCallContext
 
 	idleFuncMutex       *sync.Mutex
 	txnSyncNotify       chan struct{}
@@ -534,7 +535,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	cloudSpec := dummy.SampleCloudSpec()
 	bootstrapEnviron, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContext(ctx),
+		modelcmd.BootstrapContext(context.Background(), ctx),
 		s.ControllerStore,
 		bootstrap.PrepareParams{
 			ControllerConfig: s.ControllerConfig,
@@ -569,8 +570,8 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	// Dummy provider uses a random port, which is added to cfg used to create environment.
 	apiPort := dummy.APIPort(environ.Provider())
 	s.ControllerConfig["api-port"] = apiPort
-	s.ProviderCallContext = context.NewCloudCallContext()
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
+	s.ProviderCallContext = envcontext.NewCloudCallContext()
+	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
 		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -96,7 +96,7 @@ func BootstrapInstance(
 		}
 		return nil, "", nil, errors.Annotatef(err, "use --force to override")
 	}
-	// The series we're attemptting to bootstrap is empty, show a friendly
+	// The series we're attempting to bootstrap is empty, show a friendly
 	// error message, rather than the more cryptic error messages that follow
 	// onwards.
 	if selectedSeries == "" {

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -249,14 +249,15 @@ func BootstrapInstance(
 		if err == nil {
 			break
 		}
-		if zone == "" || environs.IsAvailabilityZoneIndependent(err) {
-			return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")
-		}
 
 		select {
 		case <-ctx.Context().Done():
 			return nil, "", nil, errors.Annotatef(err, "starting controller (cancelled)")
 		default:
+		}
+
+		if zone == "" || environs.IsAvailabilityZoneIndependent(err) {
+			return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")
 		}
 
 		if i < len(zones)-1 {

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -34,6 +34,7 @@ import (
 	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -774,7 +775,7 @@ func WaitSSH(
 			}
 			return "", fmt.Errorf(format, args...)
 		case <-ctx.Done():
-			return "", fmt.Errorf("cancelled")
+			return "", bootstrap.Cancelled()
 		case <-checker.Dead():
 			result, err := checker.Result()
 			if err != nil {

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -34,7 +35,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
@@ -49,7 +50,7 @@ var logger = loggo.GetLogger("juju.provider.common")
 func Bootstrap(
 	ctx environs.BootstrapContext,
 	env environs.Environ,
-	callCtx context.ProviderCallContext,
+	callCtx envcontext.ProviderCallContext,
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
 	result, series, finalizer, err := BootstrapInstance(ctx, env, callCtx, args)
@@ -75,7 +76,7 @@ func Bootstrap(
 func BootstrapInstance(
 	ctx environs.BootstrapContext,
 	env environs.Environ,
-	callCtx context.ProviderCallContext,
+	callCtx envcontext.ProviderCallContext,
 	args environs.BootstrapParams,
 ) (_ *environs.StartInstanceResult, selectedSeries string, _ environs.CloudBootstrapFinalizer, err error) {
 	// TODO make safe in the case of racing Bootstraps
@@ -250,6 +251,13 @@ func BootstrapInstance(
 		if zone == "" || environs.IsAvailabilityZoneIndependent(err) {
 			return nil, "", nil, errors.Annotate(err, "cannot start bootstrap instance")
 		}
+
+		select {
+		case <-ctx.Context().Done():
+			return nil, "", nil, errors.Annotatef(err, "starting controller (cancelled)")
+		default:
+		}
+
 		if i < len(zones)-1 {
 			// Try the next zone.
 			logger.Debugf("failed to start instance in availability zone %q: %s", zone, err)
@@ -294,7 +302,7 @@ func BootstrapInstance(
 	return result, selectedSeries, finalizer, nil
 }
 
-func startInstanceZones(env environs.Environ, ctx context.ProviderCallContext, args environs.StartInstanceParams) ([]string, error) {
+func startInstanceZones(env environs.Environ, ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) ([]string, error) {
 	zonedEnviron, ok := env.(ZonedEnviron)
 	if !ok {
 		return nil, errors.NotImplementedf("ZonedEnviron")
@@ -358,7 +366,7 @@ var FinishBootstrap = func(
 	ctx environs.BootstrapContext,
 	client ssh.Client,
 	env environs.Environ,
-	callCtx context.ProviderCallContext,
+	callCtx envcontext.ProviderCallContext,
 	inst instances.Instance,
 	instanceConfig *instancecfg.InstanceConfig,
 	opts environs.BootstrapDialOpts,
@@ -369,8 +377,8 @@ var FinishBootstrap = func(
 
 	hostSSHOptions := bootstrapSSHOptionsFunc(instanceConfig)
 	addr, err := WaitSSH(
+		ctx.Context(),
 		ctx.GetStderr(),
-		interrupted,
 		client,
 		GetCheckNonceCommand(instanceConfig),
 		&RefreshableInstance{inst, env},
@@ -452,6 +460,7 @@ func ConfigureMachine(
 	}
 	script := shell.DumpFileOnErrorScript(instanceConfig.CloudInitOutputLog) + configScript
 	ctx.Infof("Running machine configuration script...")
+	// TODO(benhoyt) - plumb context through juju/utils/ssh?
 	return sshinit.RunConfigureScript(script, sshinit.ConfigureParams{
 		Host:           "ubuntu@" + host,
 		Client:         client,
@@ -534,16 +543,16 @@ func hostBootstrapSSHOptions(
 // for waiting for SSH access to become available.
 type InstanceRefresher interface {
 	// Refresh refreshes the addresses for the instance.
-	Refresh(ctx context.ProviderCallContext) error
+	Refresh(ctx envcontext.ProviderCallContext) error
 
 	// Addresses returns the addresses for the instance.
 	// To ensure that the results are up to date, call
 	// Refresh first.
-	Addresses(ctx context.ProviderCallContext) (network.ProviderAddresses, error)
+	Addresses(ctx envcontext.ProviderCallContext) (network.ProviderAddresses, error)
 
 	// Status returns the provider-specific status for the
 	// instance.
-	Status(ctx context.ProviderCallContext) instance.Status
+	Status(ctx envcontext.ProviderCallContext) instance.Status
 }
 
 type RefreshableInstance struct {
@@ -552,7 +561,7 @@ type RefreshableInstance struct {
 }
 
 // Refresh refreshes the addresses for the instance.
-func (i *RefreshableInstance) Refresh(ctx context.ProviderCallContext) error {
+func (i *RefreshableInstance) Refresh(ctx envcontext.ProviderCallContext) error {
 	instances, err := i.Env.Instances(ctx, []instance.Id{i.Id()})
 	if err != nil {
 		return errors.Trace(err)
@@ -702,12 +711,12 @@ var connectSSH = func(client ssh.Client, host, checkHostScript string, options *
 // machine's nonce. The "checkHostScript" is a bash script
 // that performs this file check.
 func WaitSSH(
+	ctx context.Context,
 	stdErr io.Writer,
-	interrupted <-chan os.Signal,
 	client ssh.Client,
 	checkHostScript string,
 	inst InstanceRefresher,
-	ctx context.ProviderCallContext,
+	callCtx envcontext.ProviderCallContext,
 	opts environs.BootstrapDialOpts,
 	hostSSHOptions HostSSHOptionsFunc,
 ) (addr string, err error) {
@@ -734,17 +743,17 @@ func WaitSSH(
 		select {
 		case <-pollAddresses.C:
 			pollAddresses.Reset(opts.AddressesDelay)
-			if err := inst.Refresh(ctx); err != nil {
+			if err := inst.Refresh(callCtx); err != nil {
 				return "", fmt.Errorf("refreshing addresses: %v", err)
 			}
-			instanceStatus := inst.Status(ctx)
+			instanceStatus := inst.Status(callCtx)
 			if instanceStatus.Status == status.ProvisioningError {
 				if instanceStatus.Message != "" {
 					return "", errors.Errorf("instance provisioning failed (%v)", instanceStatus.Message)
 				}
 				return "", errors.Errorf("instance provisioning failed")
 			}
-			addresses, err := inst.Addresses(ctx)
+			addresses, err := inst.Addresses(callCtx)
 			if err != nil {
 				return "", fmt.Errorf("getting addresses: %v", err)
 			}
@@ -764,8 +773,8 @@ func WaitSSH(
 				args = append(args, lastErr)
 			}
 			return "", fmt.Errorf(format, args...)
-		case <-interrupted:
-			return "", fmt.Errorf("interrupted")
+		case <-ctx.Done():
+			return "", fmt.Errorf("cancelled")
 		case <-checker.Dead():
 			result, err := checker.Result()
 			if err != nil {

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
@@ -32,7 +33,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/storage"
 	envtesting "github.com/juju/juju/environs/testing"
@@ -46,7 +47,7 @@ type BootstrapSuite struct {
 	coretesting.FakeJujuXDGDataHomeSuite
 	envtesting.ToolsFixture
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 }
 
 var _ = gc.Suite(&BootstrapSuite{})
@@ -63,7 +64,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		return fmt.Errorf("mock connection failure to %s", host)
 	})
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = envcontext.NewCloudCallContext()
 }
 
 func (s *BootstrapSuite) TearDownTest(c *gc.C) {
@@ -113,7 +114,7 @@ func (s *BootstrapSuite) TestCannotStartInstance(c *gc.C) {
 		config:  configGetter(c),
 	}
 
-	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	startInstance := func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -282,12 +283,12 @@ func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return []string{"derived-zone"}, nil
 		},
 	}
 
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -315,10 +316,10 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", false}
 			z2 := &mockAvailabilityZone{"z2", true}
@@ -327,7 +328,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptAllZones(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -356,10 +357,10 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			z2 := &mockAvailabilityZone{"z2", true}
@@ -369,7 +370,7 @@ func (s *BootstrapSuite) TestStartInstanceAttemptZoneConstrained(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -401,10 +402,10 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			z2 := &mockAvailabilityZone{"z2", true}
@@ -414,7 +415,7 @@ func (s *BootstrapSuite) TestStartInstanceNoMatchingConstraintZones(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -446,10 +447,10 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", true}
 			z1 := &mockAvailabilityZone{"z1", true}
 			return []common.AvailabilityZone{z0, z1}, nil
@@ -457,7 +458,7 @@ func (s *BootstrapSuite) TestStartInstanceStopOnZoneIndependentError(c *gc.C) {
 	}
 
 	var callZones []string
-	env.startInstance = func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	env.startInstance = func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -484,10 +485,10 @@ func (s *BootstrapSuite) TestStartInstanceNoUsableZones(c *gc.C) {
 			storage: newStorage(s, c),
 			config:  configGetter(c),
 		},
-		deriveAvailabilityZones: func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
+		deriveAvailabilityZones: func(envcontext.ProviderCallContext, environs.StartInstanceParams) ([]string, error) {
 			return nil, nil
 		},
-		availabilityZones: func(ctx context.ProviderCallContext) ([]common.AvailabilityZone, error) {
+		availabilityZones: func(ctx envcontext.ProviderCallContext) ([]common.AvailabilityZone, error) {
 			z0 := &mockAvailabilityZone{"z0", false}
 			return []common.AvailabilityZone{z0}, nil
 		},
@@ -513,7 +514,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 		id:        checkInstanceId,
 		addresses: corenetwork.NewProviderAddresses("testing.invalid"),
 	}
-	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	startInstance := func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -547,14 +548,14 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 		startInstance: startInstance,
 		config:        getConfig,
 		setConfig:     setConfig,
-		instances: func(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+		instances: func(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 			instancesMu.Lock()
 			defer instancesMu.Unlock()
 			return []instances.Instance{inst}, nil
 		},
 	}
 	inner := cmdtesting.Context(c)
-	ctx := modelcmd.BootstrapContext(inner)
+	ctx := modelcmd.BootstrapContext(context.Background(), inner)
 	result, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		AvailableTools:           fakeAvailableTools(),
@@ -620,7 +621,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 		id:        "i-success",
 		addresses: corenetwork.NewProviderAddresses("testing.invalid"),
 	}
-	startInstance := func(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+	startInstance := func(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 		instances.Instance,
 		*instance.HardwareCharacteristics,
 		corenetwork.InterfaceInfos,
@@ -635,7 +636,7 @@ func (s *BootstrapSuite) TestBootstrapFinalizeCloudInitUserData(c *gc.C) {
 	env := &mockEnviron{
 		startInstance: startInstance,
 		config:        configGetter(c),
-		instances: func(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+		instances: func(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 			instancesMu.Lock()
 			defer instancesMu.Unlock()
 			return []instances.Instance{inst}, nil
@@ -681,11 +682,11 @@ package_upgrade: false
 type neverRefreshes struct {
 }
 
-func (neverRefreshes) Refresh(ctx context.ProviderCallContext) error {
+func (neverRefreshes) Refresh(ctx envcontext.ProviderCallContext) error {
 	return nil
 }
 
-func (neverRefreshes) Status(ctx context.ProviderCallContext) instance.Status {
+func (neverRefreshes) Status(ctx envcontext.ProviderCallContext) instance.Status {
 	return instance.Status{}
 }
 
@@ -693,7 +694,7 @@ type neverAddresses struct {
 	neverRefreshes
 }
 
-func (neverAddresses) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (neverAddresses) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return nil, nil
 }
 
@@ -702,7 +703,7 @@ type failsProvisioning struct {
 	message string
 }
 
-func (f failsProvisioning) Status(ctx context.ProviderCallContext) instance.Status {
+func (f failsProvisioning) Status(ctx envcontext.ProviderCallContext) instance.Status {
 	return instance.Status{
 		Status:  status.ProvisioningError,
 		Message: f.message,
@@ -755,7 +756,7 @@ type brokenAddresses struct {
 	neverRefreshes
 }
 
-func (brokenAddresses) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (brokenAddresses) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return nil, errors.Errorf("Addresses will never work")
 }
 
@@ -774,7 +775,7 @@ type neverOpensPort struct {
 	addr string
 }
 
-func (n *neverOpensPort) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (n *neverOpensPort) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return corenetwork.NewProviderAddresses(n.addr), nil
 }
 
@@ -799,7 +800,7 @@ type interruptOnDial struct {
 	returned    bool
 }
 
-func (i *interruptOnDial) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (i *interruptOnDial) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	// kill the tomb the second time Addresses is called
 	if !i.returned {
 		i.returned = true
@@ -832,18 +833,18 @@ type addressesChange struct {
 	addrs [][]string
 }
 
-func (ac *addressesChange) Refresh(ctx context.ProviderCallContext) error {
+func (ac *addressesChange) Refresh(ctx envcontext.ProviderCallContext) error {
 	if len(ac.addrs) > 1 {
 		ac.addrs = ac.addrs[1:]
 	}
 	return nil
 }
 
-func (ac *addressesChange) Status(ctx context.ProviderCallContext) instance.Status {
+func (ac *addressesChange) Status(ctx envcontext.ProviderCallContext) instance.Status {
 	return instance.Status{}
 }
 
-func (ac *addressesChange) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (ac *addressesChange) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	return corenetwork.NewProviderAddresses(ac.addrs[0]...), nil
 }
 
@@ -934,7 +935,7 @@ func fakeAvailableTools() tools.List {
 	}
 }
 
-func fakeStartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (
+func fakeStartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (
 	instances.Instance,
 	*instance.HardwareCharacteristics,
 	corenetwork.InterfaceInfos,

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -719,7 +718,7 @@ var testSSHTimeout = environs.BootstrapDialOpts{
 func (s *BootstrapSuite) TestWaitSSHTimesOutWaitingForAddresses(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	_, err := common.WaitSSH(
-		ctx.Stderr, nil, ssh.DefaultClient, "/bin/true", neverAddresses{}, s.callCtx, testSSHTimeout,
+		context.Background(), ctx.Stderr, ssh.DefaultClient, "/bin/true", neverAddresses{}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
 	)
 	c.Check(err, gc.ErrorMatches, `waited for `+testSSHTimeout.Timeout.String()+` without getting any addresses`)
@@ -727,26 +726,26 @@ func (s *BootstrapSuite) TestWaitSSHTimesOutWaitingForAddresses(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestWaitSSHKilledWaitingForAddresses(c *gc.C) {
-	ctx := cmdtesting.Context(c)
-	interrupted := make(chan os.Signal)
-	close(interrupted)
+	cmdCtx := cmdtesting.Context(c)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 	_, err := common.WaitSSH(
-		ctx.Stderr, interrupted, ssh.DefaultClient, "/bin/true", neverAddresses{}, s.callCtx, testSSHTimeout,
+		ctx, cmdCtx.Stderr, ssh.DefaultClient, "/bin/true", neverAddresses{}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
 	)
-	c.Check(err, gc.ErrorMatches, "interrupted")
-	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Waiting for address\n")
+	c.Check(err, gc.ErrorMatches, "cancelled")
+	c.Check(cmdtesting.Stderr(cmdCtx), gc.Matches, "Waiting for address\n")
 }
 
 func (s *BootstrapSuite) TestWaitSSHNoticesProvisioningFailures(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	_, err := common.WaitSSH(
-		ctx.Stderr, nil, ssh.DefaultClient, "/bin/true", failsProvisioning{}, s.callCtx, testSSHTimeout,
+		context.Background(), ctx.Stderr, ssh.DefaultClient, "/bin/true", failsProvisioning{}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
 	)
 	c.Check(err, gc.ErrorMatches, `instance provisioning failed`)
 	_, err = common.WaitSSH(
-		ctx.Stderr, nil, ssh.DefaultClient, "/bin/true", failsProvisioning{message: "blargh"}, s.callCtx, testSSHTimeout,
+		context.Background(), ctx.Stderr, ssh.DefaultClient, "/bin/true", failsProvisioning{message: "blargh"}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
 	)
 	c.Check(err, gc.ErrorMatches, `instance provisioning failed \(blargh\)`)
@@ -763,7 +762,7 @@ func (brokenAddresses) Addresses(ctx envcontext.ProviderCallContext) (corenetwor
 func (s *BootstrapSuite) TestWaitSSHStopsOnBadError(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	_, err := common.WaitSSH(
-		ctx.Stderr, nil, ssh.DefaultClient, "/bin/true", brokenAddresses{}, s.callCtx, testSSHTimeout,
+		context.Background(), ctx.Stderr, ssh.DefaultClient, "/bin/true", brokenAddresses{}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
 	)
 	c.Check(err, gc.ErrorMatches, "getting addresses: Addresses will never work")
@@ -783,7 +782,7 @@ func (s *BootstrapSuite) TestWaitSSHTimesOutWaitingForDial(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	// 0.x.y.z addresses are always invalid
 	_, err := common.WaitSSH(
-		ctx.Stderr, nil, ssh.DefaultClient, "/bin/true", &neverOpensPort{addr: "0.1.2.3"}, s.callCtx, testSSHTimeout,
+		context.Background(), ctx.Stderr, ssh.DefaultClient, "/bin/true", &neverOpensPort{addr: "0.1.2.3"}, s.callCtx, testSSHTimeout,
 		common.DefaultHostSSHOptions,
 	)
 	c.Check(err, gc.ErrorMatches,
@@ -793,38 +792,38 @@ func (s *BootstrapSuite) TestWaitSSHTimesOutWaitingForDial(c *gc.C) {
 			"(Attempting to connect to 0.1.2.3:22\n)+")
 }
 
-type interruptOnDial struct {
+type cancelOnDial struct {
 	neverRefreshes
-	name        string
-	interrupted chan os.Signal
-	returned    bool
+	name     string
+	cancel   context.CancelFunc
+	returned bool
 }
 
-func (i *interruptOnDial) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+func (c *cancelOnDial) Addresses(ctx envcontext.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
 	// kill the tomb the second time Addresses is called
-	if !i.returned {
-		i.returned = true
+	if !c.returned {
+		c.returned = true
 	} else {
-		if i.interrupted != nil {
-			close(i.interrupted)
-			i.interrupted = nil
+		if c.cancel != nil {
+			c.cancel()
+			c.cancel = nil
 		}
 	}
-	return corenetwork.NewProviderAddresses(i.name), nil
+	return corenetwork.NewProviderAddresses(c.name), nil
 }
 
 func (s *BootstrapSuite) TestWaitSSHKilledWaitingForDial(c *gc.C) {
-	ctx := cmdtesting.Context(c)
+	cmdCtx := cmdtesting.Context(c)
 	timeout := testSSHTimeout
 	timeout.Timeout = 1 * time.Minute
-	interrupted := make(chan os.Signal)
+	ctx, cancel := context.WithCancel(context.Background())
 	_, err := common.WaitSSH(
-		ctx.Stderr, interrupted, ssh.DefaultClient, "", &interruptOnDial{name: "0.1.2.3", interrupted: interrupted}, s.callCtx, timeout,
+		ctx, cmdCtx.Stderr, ssh.DefaultClient, "", &cancelOnDial{name: "0.1.2.3", cancel: cancel}, s.callCtx, timeout,
 		common.DefaultHostSSHOptions,
 	)
-	c.Check(err, gc.ErrorMatches, "interrupted")
+	c.Check(err, gc.ErrorMatches, "cancelled")
 	// Exact timing is imprecise but it should have tried a few times before being killed
-	c.Check(cmdtesting.Stderr(ctx), gc.Matches,
+	c.Check(cmdtesting.Stderr(cmdCtx), gc.Matches,
 		"Waiting for address\n"+
 			"(Attempting to connect to 0.1.2.3:22\n)+")
 }
@@ -850,7 +849,7 @@ func (ac *addressesChange) Addresses(ctx envcontext.ProviderCallContext) (corene
 
 func (s *BootstrapSuite) TestWaitSSHRefreshAddresses(c *gc.C) {
 	ctx := cmdtesting.Context(c)
-	_, err := common.WaitSSH(ctx.Stderr, nil, ssh.DefaultClient, "", &addressesChange{addrs: [][]string{
+	_, err := common.WaitSSH(context.Background(), ctx.Stderr, ssh.DefaultClient, "", &addressesChange{addrs: [][]string{
 		nil,
 		nil,
 		{"0.1.2.3"},

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -4,6 +4,8 @@
 package lxd_test
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v7"
 	"github.com/juju/cmd/cmdtesting"
@@ -18,7 +20,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
 	coretesting "github.com/juju/juju/testing"
@@ -29,7 +31,7 @@ var errTestUnAuth = errors.New("not authorized")
 type environSuite struct {
 	lxd.BaseSuite
 
-	callCtx           context.ProviderCallContext
+	callCtx           envcontext.ProviderCallContext
 	invalidCredential bool
 }
 
@@ -37,7 +39,7 @@ var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = &context.CloudCallContext{
+	s.callCtx = &envcontext.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -93,7 +95,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 	}
-	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(ctx), s.callCtx, params)
+	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Arch, gc.Equals, "amd64")
@@ -378,7 +380,7 @@ func (s *environSuite) TestInstanceAvailabilityZoneNamesInvalidCredentials(c *gc
 type environCloudProfileSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 
 	svr          *lxd.MockServer
 	cloudSpecEnv environs.CloudSpecSetter
@@ -441,7 +443,7 @@ func (s *environCloudProfileSuite) expectCreateProfile(name string, err error) {
 type environProfileSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 
 	svr    *lxd.MockServer
 	lxdEnv environs.LXDProfiler


### PR DESCRIPTION
*NOTE: this is a refactored version of #12462: this version adds a `Context()` method to the existing `environs.BootstrapContext` interface so we're only passing a single "context" around, and to reduce churn.*

Bootstrap is a bit of a pain to stop/cancel half way through, even if it's obviously failing it keeps retrying stuff for a long time (eg: waitForAgentInitialization would take 10 hours before it gave up). Need to handle Ctrl-C and terminate/cleanup.

This PR adds a `context.Context` to the existing `BootstrapContext` interface, and checks `ctx.Done()` in retry loops and at various points (except in WaitSSH, where we can actually select on `ctx.Done()` properly). We're doing it in this relatively hacky way for now to avoid wiring context up through *everything*, e.g., providers, the old AWS library, etc.

In any case, Ctrl-C is now handled in several parts of the bootstrap:

* BootstrapInstance
* WaitSSH
* waitForAgentInitialization
* K8s Deploy() step

I've tested both a working bootstrap and a `^C`-interrupted bootstrap on lxd, k8s (minikube), and AWS clouds.

Sample output of interrupting `waitForAgentInitialization`:

```
# set up minikube as per https://discourse.charmhub.io/t/using-juju-with-minikube/3975/3
$ juju bootstrap kubernetes k8s
Creating Juju controller "k8s" on kubernetes
WARNING bootstrapping to an unknown kubernetes cluster should be used with option --config controller-service-type. See juju help bootstrap
Fetching Juju Dashboard 0.3.0
Creating k8s resources for controller "controller-k8s"
Downloading images
Starting controller pod
Bootstrap agent now started
Contacting Juju controller at 10.97.223.174 to verify accessibility...
    # hangs due to load balancer error
^C
Ctrl-C pressed, stopping bootstrap and cleaning up resources
    # max 3 second delay here
ERROR contacting controller (cancelled): dial tcp 10.97.223.174:17070: i/o timeout
    # during cleanup, I pressed Ctrl-C a couple more times just for kicks
^C
Ctrl-C pressed, stopping bootstrap and cleaning up resources

Ctrl-C pressed, cleaning up failed bootstrap
^C
Ctrl-C pressed, cleaning up failed bootstrap
```

For reference, https://github.com/juju/juju/commit/c946eff768c2b5f536da1fc71321b68a273db727 is the commit where Ctrl-C "handling" was introduced (basically to ignore it).