### PR TITLE
[dev] Use juju ssh to reboot machines in acceptance tests

### DIFF
--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -464,8 +464,13 @@ class AssessNetworkHealth:
                     self.ssh(client, machine,
                              'sudo lxc restart {}'.format(' '.join(cont_ids)))
                 log.info("Restarting machine: {}".format(machine))
-                client.juju('run', ('--machine', machine,
-                                    'sudo shutdown -r now'))
+                try:
+                    client.juju('ssh', (machine, 'sudo shutdown -r now'))
+                except subprocess.CalledProcessError as e:
+                    if e.returncode != 255:
+                        raise e
+                    log.info("Ignoring `juju ssh` exit status after triggering reboot")
+
                 hostname = client.get_status().get_machine_dns_name(machine)
                 wait_for_port(hostname, 22, timeout=240)
 


### PR DESCRIPTION
Prior to this change, some of the acceptance tests would use `juju run`
to reboot machines. However, the develop branch has removed support for
'--machine' from juju run causing these tests to fail. This commit
updates the affected tests to use `juju ssh` instead.

In addition, this commit also updates assess_container_networking to
work with python 3 by changing `x.iteritems()` to `iter(x.items())`.

NOTE: after landing these changes we will need to update the CI jobs to use python 3 for any tests that use `assess_container_networking`.

## QA steps

Run the following tests:
- assess_container_networking
- assess_network_health