### PR TITLE
Deprecate services in bundles

### DIFF
--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -1452,7 +1452,7 @@ class TestModelClient(ClientTest):
             machines:
               "0":
                 agent-state: started
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:
@@ -1488,7 +1488,7 @@ class TestModelClient(ClientTest):
             machines:
               "0":
                 agent-state: started
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:
@@ -1527,7 +1527,7 @@ class TestModelClient(ClientTest):
             machines:
               "0":
                 agent-state: started
-            services:
+            applications:
               ubuntu:
                 units:
                   ubuntu/0:
@@ -1630,7 +1630,7 @@ class TestModelClient(ClientTest):
 
     def test_wait_for_workload_all_unknown(self):
         status = Status.from_text("""\
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:
@@ -1654,7 +1654,7 @@ class TestModelClient(ClientTest):
 
     def test_wait_for_workload_no_workload_status(self):
         status = Status.from_text("""\
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:

--- a/acceptancetests/repository/basic-openstack-lxd.yaml
+++ b/acceptancetests/repository/basic-openstack-lxd.yaml
@@ -44,7 +44,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: xenial
-services:
+applications:
   glance:
     annotations:
       gui-x: '250'

--- a/acceptancetests/repository/bundles-kubernetes-core-lxd.yaml
+++ b/acceptancetests/repository/bundles-kubernetes-core-lxd.yaml
@@ -7,7 +7,7 @@ machines:
   '1':
     constraints: cores=4 mem=8G root-disk=20G
     series: bionic
-services:
+applications:
   easyrsa:
     annotations:
       gui-x: '450'

--- a/acceptancetests/repository/bundles-trust-checker.yaml
+++ b/acceptancetests/repository/bundles-trust-checker.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     trust-checker:
         charm: cs:~juju-qa/bionic/trust-checker-0
         num_units: 1

--- a/acceptancetests/repository/mediawiki-scalable.yaml
+++ b/acceptancetests/repository/mediawiki-scalable.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
   haproxy:
     charm: cs:trusty/haproxy-13
     num_units: 1

--- a/acceptancetests/repository/network-health-2-machines-bind.yaml
+++ b/acceptancetests/repository/network-health-2-machines-bind.yaml
@@ -5,7 +5,7 @@ machines:
   '1':
     series: xenial
 series: xenial
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/network-health-2-machines-vipl.yaml
+++ b/acceptancetests/repository/network-health-2-machines-vipl.yaml
@@ -7,7 +7,7 @@ machines:
     series: bionic
     constraints: tags=qa-node-1
 series: bionic
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/network-health-2-machines.yaml
+++ b/acceptancetests/repository/network-health-2-machines.yaml
@@ -5,7 +5,7 @@ machines:
   '1':
     series: bionic
 series: bionic
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/network-health-3-machines.yaml
+++ b/acceptancetests/repository/network-health-3-machines.yaml
@@ -7,7 +7,7 @@ machines:
   '2':
     series: bionic
 series: bionic
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/openstack-base-lxc.yaml
+++ b/acceptancetests/repository/openstack-base-lxc.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: trusty
-services:
+applications:
   ceph:
     annotations:
       gui-x: '750'

--- a/acceptancetests/repository/openstack-base-lxd.yaml
+++ b/acceptancetests/repository/openstack-base-lxd.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: trusty
-services:
+applications:
   ceph:
     annotations:
       gui-x: '750'

--- a/acceptancetests/repository/scale2-lxc.yaml
+++ b/acceptancetests/repository/scale2-lxc.yaml
@@ -3,7 +3,7 @@ machines:
     series: trusty
   "2":
     series: trusty
-services:
+applications:
   apache2:
     charm: "cs:trusty/apache2-19"
     num_units: 1

--- a/acceptancetests/repository/scale2-lxd.yaml
+++ b/acceptancetests/repository/scale2-lxd.yaml
@@ -3,7 +3,7 @@ machines:
     series: trusty
   "2":
     series: trusty
-services:
+applications:
   apache2:
     charm: "cs:trusty/apache2-19"
     num_units: 1

--- a/acceptancetests/repository/scale2lxd.yaml
+++ b/acceptancetests/repository/scale2lxd.yaml
@@ -3,7 +3,7 @@ machines:
     series: trusty
   "2":
     series: trusty
-services:
+applications:
   apache2:
     charm: "cs:trusty/apache2-19"
     num_units: 1

--- a/acceptancetests/repository/webscale-lxd.yaml
+++ b/acceptancetests/repository/webscale-lxd.yaml
@@ -2,7 +2,7 @@ relations:
 - - keystone:shared-db
   - mysql:shared-db
 series: bionic
-services:
+applications:
   keystone:
     annotations:
       gui-x: '500'

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -637,7 +637,7 @@ func getCharmHubBundleResponse() ([]transport.InfoChannelMap, transport.InfoChan
 
 const entityBundle = `
 series: bionic
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -753,7 +753,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(
 	lxdProfilePath := testcharms.RepoWithSeries("bionic").ClonedDirPath(charmsPath, "lxd-profile")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
-        services:
+        applications:
             lxd-profile:
                 charm: %s
                 num_units: 1
@@ -779,7 +779,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfi
 	lxdProfilePath := testcharms.RepoWithSeries("bionic").ClonedDirPath(charmsPath, "lxd-profile-fail")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
-        services:
+        applications:
             lxd-profile-fail:
                 charm: %s
                 num_units: 1
@@ -792,7 +792,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfi
 	lxdProfilePath := testcharms.RepoWithSeries("bionic").ClonedDirPath(charmsPath, "lxd-profile-fail")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
-        services:
+        applications:
             lxd-profile-fail:
                 charm: %s
                 num_units: 1

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -94,6 +94,9 @@ func (d *deployBundle) deploy(
 		return errors.Annotatef(err, "cannot deploy bundle")
 	}
 	d.bundleDir = d.bundleDataSource.BasePath()
+	if bundleData.UnmarshaledWithServices() {
+		logger.Warningf(`"services" key found in bundle file is deprecated, superseded by "applications" key.`)
+	}
 
 	// Short-circuit trust checks if the operator specifies '--force'
 	if !d.trust {

--- a/testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
+++ b/testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     aws-integrator:
         charm: cs:~containers/aws-integrator        
         num_units: 1

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     aws-integrator:
         charm: cs:~containers/aws-integrator        
         num_units: 1

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     aws-integrator:
         charm: cs:~containers/aws-integrator        
         num_units: 1

--- a/testcharms/charm-repo/bundle/bad/bundle.yaml
+++ b/testcharms/charm-repo/bundle/bad/bundle.yaml
@@ -1,6 +1,6 @@
 # This bundle has a bad relation, which will cause it to fail
 # its verification.
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/basic/bundle.yaml
+++ b/testcharms/charm-repo/bundle/basic/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     ubuntu-lite:
         charm: cs:~jameinel/ubuntu-lite-7
         num_units: 1

--- a/testcharms/charm-repo/bundle/bitcoinminer-with-dashboard/bundle.yaml
+++ b/testcharms/charm-repo/bundle/bitcoinminer-with-dashboard/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     dashboard:
         charm: cs:dashboard4miner
         num_units: 1

--- a/testcharms/charm-repo/bundle/gitlab/bundle.yaml
+++ b/testcharms/charm-repo/bundle/gitlab/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     gitlab:
         charm: cs:precise/gitlab-5
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-fail-local/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-fail-local/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile-fail-local:
         charm: ./../../quantal/lxd-profile-fail
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-fail/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-fail/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile-fail:
         charm: cs:~juju-qa/bionic/lxd-profile-fail-0
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-local/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-local/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile-local:
         charm: ./../../quantal/lxd-profile
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-mixed-fail/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-mixed-fail/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile:
         charm: cs:~juju-qa/bionic/lxd-profile-0
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile:
         charm: cs:~juju-qa/bionic/lxd-profile-0
         num_units: 1

--- a/testcharms/charm-repo/bundle/openstack/bundle.yaml
+++ b/testcharms/charm-repo/bundle/openstack/bundle.yaml
@@ -1,5 +1,5 @@
 series: precise
-services:
+applications:
   mysql:
     charm: cs:precise/mysql
     constraints: mem=1G

--- a/testcharms/charm-repo/bundle/terms-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/terms-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     terms1:
         charm: cs:terms1
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress-extra-bindings:
         charm: cs:wordpress-extra-bindings
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-mysql-storage/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-mysql-storage/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-plans/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-plans/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1


### PR DESCRIPTION
Applications have been wildly used as a replacement for services since
1.x timeframe. The following displays a warning that services have been
deprecated and superseded by applications.

Version 3 of Juju will remove services completely allowing for a much
more cleaner code path for handling bundles.

As we don't actually store bundles within the database, we can do this
without a migration step.

Most of the bundle yaml within Juju codebase has now correctly been
converted to prevent the warning from being emitted, paving the way for
Juju 3.

## QA steps

Save the following bundle:

```yaml
services:
    ubuntu-lite:
        charm: cs:~jameinel/ubuntu-lite-7
        num_units: 1
```

## Bootstrap

```sh
$ juju bootstrap lxd test
```

### Local bundle.yaml

```sh
$ juju deploy ./bundle.yaml
WARNING "services" key found in bundle file is deprecated, superseded by "applications" key.
Located charm "ubuntu-lite" in charm-store, revision 7
Executing changes:
- upload charm ubuntu-lite from charm-store
- deploy application ubuntu-lite from charm-store
- add unit ubuntu-lite/0 to new machine 0
Deploy of bundle completed.
```

### Store bundle

```sh
juju deploy cs:~juju-qa/bundle/basic-0
Located bundle "basic" in charm-store, revision 0
WARNING "services" key found in bundle file is deprecated, superseded by "applications" key.
Located charm "ubuntu" in charm-store, revision 12
Executing changes:
- upload charm ubuntu from charm-store for series bionic
- deploy application ubuntu from charm-store on bionic
- set annotations for ubuntu
- set constraints for ubuntu-lite to ""
- set annotations for ubuntu-lite
- add unit ubuntu/0 to new machine 1
Deploy of bundle completed.
```