### PR TITLE
[dev] Implement identity discovery for ECS tasks

### DIFF
--- a/cmd/k8sagent/initialize/command.go
+++ b/cmd/k8sagent/initialize/command.go
@@ -95,7 +95,10 @@ func (c *initCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = applicationAPI.Close() }()
 
-	identity := c.identity()
+	identity, err := c.identity()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	unitConfig, err := applicationAPI.UnitIntroduction(identity.PodName, identity.PodUUID)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/k8sagent/initialize/config_test.go
+++ b/cmd/k8sagent/initialize/config_test.go
@@ -6,6 +6,11 @@
 package initialize_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -39,8 +44,35 @@ func (s *initCommandSuit) TestConfigFromEnv(c *gc.C) {
 
 }
 
-func (s *initCommandSuit) TestDefaultIdentity(c *gc.C) {
-	ID := initialize.DefaultIdentity()
+func (s *initCommandSuit) TestDefaultIdentityOnK8S(c *gc.C) {
+	ID, err := initialize.DefaultIdentity()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ID.PodName, gc.DeepEquals, `gitlab-0`)
 	c.Assert(ID.PodUUID, gc.DeepEquals, `gitlab-uuid`)
+}
+
+func (s *initCommandSuit) TestDefaultIdentityOnECS(c *gc.C) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/task", func(w http.ResponseWriter, req *http.Request) {
+		_, err := fmt.Fprintf(w, `
+                        {
+                            "Cluster": "sagittarius",
+                            "TaskARN": "arn:aws:ecs:us-west-2:111122223333:task/default/d3adb33f",
+                            "Family": "nginx"
+                        }
+                `)
+		c.Assert(err, jc.ErrorIsNil)
+	})
+	srv := httptest.NewServer(mux)
+
+	c.Assert(os.Setenv("ECS_CONTAINER_METADATA_URI_V4", srv.URL), jc.ErrorIsNil)
+	defer func() {
+		srv.Close()
+		c.Assert(os.Setenv("ECS_CONTAINER_METADATA_URI_V4", ""), jc.ErrorIsNil)
+	}()
+
+	ID, err := initialize.DefaultIdentity()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ID.PodName, gc.DeepEquals, `arn:aws:ecs:us-west-2:111122223333:task/default/d3adb33f`)
+	c.Assert(ID.PodUUID, gc.DeepEquals, `d3adb33f`)
 }


### PR DESCRIPTION
This PR adds support for ECS task identity discovery within the context of a k8sagent instance running inside an ECS task.

ECS injects the URI to the ECS metadata service in the environment of each task. The PR modifies k8sagent to first scan the environment variables for the presence of the ECS metadata URI. If found, the agent queries it and populates the appropriate identity details for the task instance that the k8sagent is executing under.

Note that the agent will not be able to properly introduce itself as the relevant API assumes that all applications follow the k8s stateful deployment semantics (pods named 'xxx-ordinal') and will return an error when it tries to parse the identity value sent in by the agent.
