### PR TITLE
Merge 2.9 branch into develop

### DIFF
--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -1452,7 +1452,7 @@ class TestModelClient(ClientTest):
             machines:
               "0":
                 agent-state: started
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:
@@ -1488,7 +1488,7 @@ class TestModelClient(ClientTest):
             machines:
               "0":
                 agent-state: started
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:
@@ -1527,7 +1527,7 @@ class TestModelClient(ClientTest):
             machines:
               "0":
                 agent-state: started
-            services:
+            applications:
               ubuntu:
                 units:
                   ubuntu/0:
@@ -1630,7 +1630,7 @@ class TestModelClient(ClientTest):
 
     def test_wait_for_workload_all_unknown(self):
         status = Status.from_text("""\
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:
@@ -1654,7 +1654,7 @@ class TestModelClient(ClientTest):
 
     def test_wait_for_workload_no_workload_status(self):
         status = Status.from_text("""\
-            services:
+            applications:
               jenkins:
                 units:
                   jenkins/0:

--- a/acceptancetests/repository/basic-openstack-lxd.yaml
+++ b/acceptancetests/repository/basic-openstack-lxd.yaml
@@ -44,7 +44,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: xenial
-services:
+applications:
   glance:
     annotations:
       gui-x: '250'

--- a/acceptancetests/repository/bundles-kubernetes-core-lxd.yaml
+++ b/acceptancetests/repository/bundles-kubernetes-core-lxd.yaml
@@ -7,7 +7,7 @@ machines:
   '1':
     constraints: cores=4 mem=8G root-disk=20G
     series: bionic
-services:
+applications:
   easyrsa:
     annotations:
       gui-x: '450'

--- a/acceptancetests/repository/bundles-trust-checker.yaml
+++ b/acceptancetests/repository/bundles-trust-checker.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     trust-checker:
         charm: cs:~juju-qa/bionic/trust-checker-0
         num_units: 1

--- a/acceptancetests/repository/mediawiki-scalable.yaml
+++ b/acceptancetests/repository/mediawiki-scalable.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
   haproxy:
     charm: cs:trusty/haproxy-13
     num_units: 1

--- a/acceptancetests/repository/network-health-2-machines-bind.yaml
+++ b/acceptancetests/repository/network-health-2-machines-bind.yaml
@@ -5,7 +5,7 @@ machines:
   '1':
     series: xenial
 series: xenial
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/network-health-2-machines-vipl.yaml
+++ b/acceptancetests/repository/network-health-2-machines-vipl.yaml
@@ -7,7 +7,7 @@ machines:
     series: bionic
     constraints: tags=qa-node-1
 series: bionic
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/network-health-2-machines.yaml
+++ b/acceptancetests/repository/network-health-2-machines.yaml
@@ -5,7 +5,7 @@ machines:
   '1':
     series: bionic
 series: bionic
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/network-health-3-machines.yaml
+++ b/acceptancetests/repository/network-health-3-machines.yaml
@@ -7,7 +7,7 @@ machines:
   '2':
     series: bionic
 series: bionic
-services:
+applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
     num_units: 1

--- a/acceptancetests/repository/openstack-base-lxc.yaml
+++ b/acceptancetests/repository/openstack-base-lxc.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: trusty
-services:
+applications:
   ceph:
     annotations:
       gui-x: '750'

--- a/acceptancetests/repository/openstack-base-lxd.yaml
+++ b/acceptancetests/repository/openstack-base-lxd.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: trusty
-services:
+applications:
   ceph:
     annotations:
       gui-x: '750'

--- a/acceptancetests/repository/scale2-lxc.yaml
+++ b/acceptancetests/repository/scale2-lxc.yaml
@@ -3,7 +3,7 @@ machines:
     series: trusty
   "2":
     series: trusty
-services:
+applications:
   apache2:
     charm: "cs:trusty/apache2-19"
     num_units: 1

--- a/acceptancetests/repository/scale2-lxd.yaml
+++ b/acceptancetests/repository/scale2-lxd.yaml
@@ -3,7 +3,7 @@ machines:
     series: trusty
   "2":
     series: trusty
-services:
+applications:
   apache2:
     charm: "cs:trusty/apache2-19"
     num_units: 1

--- a/acceptancetests/repository/scale2lxd.yaml
+++ b/acceptancetests/repository/scale2lxd.yaml
@@ -3,7 +3,7 @@ machines:
     series: trusty
   "2":
     series: trusty
-services:
+applications:
   apache2:
     charm: "cs:trusty/apache2-19"
     num_units: 1

--- a/acceptancetests/repository/webscale-lxd.yaml
+++ b/acceptancetests/repository/webscale-lxd.yaml
@@ -2,7 +2,7 @@ relations:
 - - keystone:shared-db
   - mysql:shared-db
 series: bionic
-services:
+applications:
   keystone:
     annotations:
       gui-x: '500'

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -103,7 +104,7 @@ func (*modelWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContext(cmdtesting.Context(c)),
+		modelcmd.BootstrapContext(context.Background(), cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
@@ -4,6 +4,7 @@
 package fanconfigurer_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -131,7 +132,7 @@ func (s *fanconfigurerSuite) TestFanConfigFetchError(c *gc.C) {
 func testingEnvConfig(c *gc.C) *config.Config {
 	env, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContext(cmdtesting.Context(c)),
+		modelcmd.BootstrapContext(context.Background(), cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: testing.FakeControllerConfig(),

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -637,7 +637,7 @@ func getCharmHubBundleResponse() ([]transport.InfoChannelMap, transport.InfoChan
 
 const entityBundle = `
 series: bionic
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -37,6 +37,7 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/mongo"
 )
 
@@ -316,13 +317,27 @@ func (c *controllerStack) doCleanUp() {
 	}
 }
 
-// Deploy creates all resources for controller stack.
+// Deploy creates all resources for the controller stack.
 func (c *controllerStack) Deploy() (err error) {
 	// creating namespace for controller stack, this namespace will be removed by broker.DestroyController if bootstrap failed.
 	nsName := c.broker.GetCurrentNamespace()
 	c.ctx.Infof("Creating k8s resources for controller %q", nsName)
 	if err = c.broker.createNamespace(nsName); err != nil {
 		return errors.Annotate(err, "creating namespace for controller stack")
+	}
+
+	// Check context manually for cancellation between each step (not ideal,
+	// but it avoids wiring context absolutely everywhere).
+	isDone := func() bool {
+		select {
+		case <-c.ctx.Context().Done():
+			return true
+		default:
+			return false
+		}
+	}
+	if isDone() {
+		return bootstrap.Cancelled()
 	}
 
 	defer func() {
@@ -335,36 +350,58 @@ func (c *controllerStack) Deploy() (err error) {
 	if err = c.createControllerService(); err != nil {
 		return errors.Annotate(err, "creating service for controller")
 	}
+	if isDone() {
+		return bootstrap.Cancelled()
+	}
 
 	// create shared-secret secret for controller pod.
 	if err = c.createControllerSecretSharedSecret(); err != nil {
 		return errors.Annotate(err, "creating shared-secret secret for controller")
+	}
+	if isDone() {
+		return bootstrap.Cancelled()
 	}
 
 	// create server.pem secret for controller pod.
 	if err = c.createControllerSecretServerPem(); err != nil {
 		return errors.Annotate(err, "creating server.pem secret for controller")
 	}
+	if isDone() {
+		return bootstrap.Cancelled()
+	}
 
 	// create mongo admin account secret for controller pod.
 	if err = c.createControllerSecretMongoAdmin(); err != nil {
 		return errors.Annotate(err, "creating mongo admin account secret for controller")
+	}
+	if isDone() {
+		return bootstrap.Cancelled()
 	}
 
 	// create bootstrap-params configmap for controller pod.
 	if err = c.ensureControllerConfigmapBootstrapParams(); err != nil {
 		return errors.Annotate(err, "creating bootstrap-params configmap for controller")
 	}
+	if isDone() {
+		return bootstrap.Cancelled()
+	}
 
 	// Note: create agent config configmap for controller pod lastly because agentConfig has been updated in previous steps.
 	if err = c.ensureControllerConfigmapAgentConf(); err != nil {
 		return errors.Annotate(err, "creating agent config configmap for controller")
+	}
+	if isDone() {
+		return bootstrap.Cancelled()
 	}
 
 	// create statefulset to ensure controller stack.
 	if err = c.createControllerStatefulset(); err != nil {
 		return errors.Annotate(err, "creating statefulset for controller")
 	}
+	if isDone() {
+		return bootstrap.Cancelled()
+	}
+
 	return nil
 }
 

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -365,7 +365,7 @@ Add yourself to that group before trying again:
 		}
 	}
 	if len(requiredAddons) > 0 {
-		return errors.Errorf("required addons not enabled for microk8s, run 'microk8s.enable %s'", strings.Join(requiredAddons, " "))
+		return errors.Errorf("required addons not enabled for microk8s, run 'microk8s enable %s'", strings.Join(requiredAddons, " "))
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -221,7 +221,7 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageDisabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s.enable storage'`)
+	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable storage'`)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
@@ -233,7 +233,7 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s.enable dns'`)
+	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable dns'`)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableNotInGroup(c *gc.C) {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -431,7 +431,7 @@ please choose a different hosted model name then try again.`, hostedModelName),
 		}
 		return errors.Annotate(
 			controllerStack.Deploy(),
-			"creating controller stack for controller",
+			"creating controller stack",
 		)
 	}
 

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -753,7 +753,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(
 	lxdProfilePath := testcharms.RepoWithSeries("bionic").ClonedDirPath(charmsPath, "lxd-profile")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
-        services:
+        applications:
             lxd-profile:
                 charm: %s
                 num_units: 1
@@ -779,7 +779,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfi
 	lxdProfilePath := testcharms.RepoWithSeries("bionic").ClonedDirPath(charmsPath, "lxd-profile-fail")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
-        services:
+        applications:
             lxd-profile-fail:
                 charm: %s
                 num_units: 1
@@ -792,7 +792,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentBadLXDProfi
 	lxdProfilePath := testcharms.RepoWithSeries("bionic").ClonedDirPath(charmsPath, "lxd-profile-fail")
 	err := s.DeployBundleYAML(c, fmt.Sprintf(`
         series: bionic
-        services:
+        applications:
             lxd-profile-fail:
                 charm: %s
                 num_units: 1

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -94,6 +94,9 @@ func (d *deployBundle) deploy(
 		return errors.Annotatef(err, "cannot deploy bundle")
 	}
 	d.bundleDir = d.bundleDataSource.BasePath()
+	if bundleData.UnmarshaledWithServices() {
+		logger.Warningf(`"services" key found in bundle file is deprecated, superseded by "applications" key.`)
+	}
 
 	// Short-circuit trust checks if the operator specifies '--force'
 	if !d.trust {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -120,7 +120,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		panic("tests must call setupAutoUploadTest or otherwise patch envtools.BundleTools")
 	})
 
-	s.PatchValue(&waitForAgentInitialisation, func(*cmd.Context, *modelcmd.ModelCommandBase, bool, string, string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(environs.BootstrapContext, *modelcmd.ModelCommandBase, bool, string) error {
 		return nil
 	})
 
@@ -2146,7 +2146,7 @@ func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {
 
 	// Record the controller name seen by ModelCommandBase at the end of bootstrap.
 	var seenControllerName string
-	s.PatchValue(&waitForAgentInitialisation, func(_ *cmd.Context, base *modelcmd.ModelCommandBase, _ bool, controllerName, _ string) error {
+	s.PatchValue(&waitForAgentInitialisation, func(_ environs.BootstrapContext, base *modelcmd.ModelCommandBase, _ bool, controllerName string) error {
 		seenControllerName = controllerName
 		return nil
 	})

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -9,21 +9,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v2"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/block"
 	"github.com/juju/juju/apiserver/params"
 	caasprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/jujuclient"
 )
 
 var (
@@ -39,7 +39,12 @@ type listBlocksAPI interface {
 
 // getBlockAPI returns a block api for listing blocks.
 func getBlockAPI(c *modelcmd.ModelCommandBase) (listBlocksAPI, error) {
-	root, err := c.NewAPIRoot()
+	// Set a short dial timeout so WaitForAgentInitialisation can check
+	// ctx.Done() in its retry loop.
+	dialOpts := api.DefaultDialOpts()
+	dialOpts.Timeout = 3 * time.Second
+
+	root, err := c.NewAPIRootWithDialOpts(&dialOpts)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -64,11 +69,10 @@ func tryAPI(c *modelcmd.ModelCommandBase) error {
 // command which will fail until the controller is fully initialised.
 // TODO(wallyworld) - add a bespoke command to maybe the admin facade for this purpose.
 func WaitForAgentInitialisation(
-	ctx *cmd.Context,
+	ctx environs.BootstrapContext,
 	c *modelcmd.ModelCommandBase,
 	isCAASController bool,
-	controllerName,
-	hostedModelName string,
+	controllerName string,
 ) (err error) {
 	// TODO(katco): 2016-08-09: lp:1611427
 	attempts := utils.AttemptStrategy{
@@ -101,6 +105,14 @@ func WaitForAgentInitialisation(
 			break
 		}
 
+		// Check whether context is cancelled after each attempt (as context
+		// isn't fully threaded through yet).
+		select {
+		case <-ctx.Context().Done():
+			return errors.Annotatef(err, "contacting controller (cancelled)")
+		default:
+		}
+
 		// As the API server is coming up, it goes through a number of steps.
 		// Initially the upgrade steps run, but the api server allows some
 		// calls to be processed during the upgrade, but not the list blocks.
@@ -114,11 +126,12 @@ func WaitForAgentInitialisation(
 		switch {
 		case errors.Cause(err) == io.EOF,
 			strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
+			strings.HasSuffix(errorMessage, "connection refused"),
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
 			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):
-			ctx.Verbosef("Still waiting for API to become available")
+			ctx.Verbosef("Still waiting for API to become available: %v", err)
 			continue
 		case params.ErrCode(err) == params.CodeUpgradeInProgress:
 			ctx.Verbosef("Still waiting for API to become available: %v", err)

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -97,7 +98,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 		s.mockBlockClient.numRetries = t.numRetries
 		s.mockBlockClient.retryCount = 0
 		runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-			err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+			bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+			err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 			c.Check(errors.Cause(err), gc.DeepEquals, t.err)
 		})
 		expectedRetries := t.numRetries
@@ -116,7 +118,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C
 	s.mockBlockClient.discoveringSpacesError = 2
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
@@ -128,7 +131,8 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C)
 	s.mockBlockClient.loginError = io.EOF
 
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 		c.Check(err, jc.ErrorIsNil)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 1)
@@ -139,10 +143,22 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyStopsRetriesWithOpenErr(c *gc.
 	s.mockBlockClient.retryCount = 0
 	s.mockBlockClient.loginError = errors.NewUnauthorized(nil, "")
 	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		err := WaitForAgentInitialisation(ctx, base, false, "controller", "default")
+		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
 		c.Check(err, jc.Satisfies, errors.IsUnauthorized)
 	})
 	c.Check(s.mockBlockClient.retryCount, gc.Equals, 0)
+}
+
+func (s *controllerSuite) TestWaitForAgentCancelled(c *gc.C) {
+	s.mockBlockClient.numRetries = 2
+	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
+		stdCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		bootstrapCtx := modelcmd.BootstrapContext(stdCtx, ctx)
+		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
+		c.Check(err, gc.ErrorMatches, `contacting controller \(cancelled\): .*`)
+	})
 }
 
 func runInCommand(c *gc.C, run func(ctx *cmd.Context, base *modelcmd.ModelCommandBase)) {

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,7 +43,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
@@ -813,7 +814,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	err = env.PrepareForBootstrap(nullContext(), "controller-1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	callCtx := context.NewCloudCallContext()
+	callCtx := envcontext.NewCloudCallContext()
 	s.AddCleanup(func(c *gc.C) {
 		err := env.DestroyController(callCtx, controllerCfg.ControllerUUID())
 		c.Assert(err, jc.ErrorIsNil)
@@ -861,14 +862,14 @@ func nullContext() environs.BootstrapContext {
 	ctx.Stdin = io.LimitReader(nil, 0)
 	ctx.Stdout = ioutil.Discard
 	ctx.Stderr = ioutil.Discard
-	return modelcmd.BootstrapContext(ctx)
+	return modelcmd.BootstrapContext(context.Background(), ctx)
 }
 
 type mockDummyEnviron struct {
 	environs.Environ
 }
 
-func (m *mockDummyEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+func (m *mockDummyEnviron) Instances(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 	// ensure that callback is used...
 	ctx.InvalidateCredential("considered invalid for the sake of testing")
 	return m.Environ.Instances(ctx, ids)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -210,6 +210,17 @@ func (c *CommandBase) NewAPIRoot(
 	store jujuclient.ClientStore,
 	controllerName, modelName string,
 ) (api.Connection, error) {
+	return c.NewAPIRootWithDialOpts(store, controllerName, modelName, nil)
+}
+
+// NewAPIRootWithDialOpts returns a new connection to the API server for the
+// given model or controller (the default dial options will be overridden if
+// dialOpts is not nil).
+func (c *CommandBase) NewAPIRootWithDialOpts(
+	store jujuclient.ClientStore,
+	controllerName, modelName string,
+	dialOpts *api.DialOpts,
+) (api.Connection, error) {
 	c.assertRunStarted()
 	accountDetails, err := store.AccountDetails(controllerName)
 	if err != nil && !errors.IsNotFound(err) {
@@ -241,6 +252,9 @@ func (c *CommandBase) NewAPIRoot(
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if dialOpts != nil {
+		param.DialOpts = *dialOpts
 	}
 	conn, err := juju.NewAPIConnection(param)
 	if modelName != "" && params.ErrCode(err) == params.CodeModelNotFound {

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -4,6 +4,7 @@
 package modelcmd_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -217,12 +218,12 @@ func (s *ModelCommandSuite) TestModelGeneration(c *gc.C) {
 }
 
 func (s *ModelCommandSuite) TestBootstrapContext(c *gc.C) {
-	ctx := modelcmd.BootstrapContext(&cmd.Context{})
+	ctx := modelcmd.BootstrapContext(context.Background(), &cmd.Context{})
 	c.Assert(ctx.ShouldVerifyCredentials(), jc.IsTrue)
 }
 
 func (s *ModelCommandSuite) TestBootstrapContextNoVerify(c *gc.C) {
-	ctx := modelcmd.BootstrapContextNoVerify(&cmd.Context{})
+	ctx := modelcmd.BootstrapContextNoVerify(context.Background(), &cmd.Context{})
 	c.Assert(ctx.ShouldVerifyCredentials(), jc.IsFalse)
 }
 

--- a/cmd/plugins/juju-metadata/generateagents_test.go
+++ b/cmd/plugins/juju-metadata/generateagents_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,7 +56,7 @@ func (s *GenerateAgentsSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	e, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContextNoVerify(cmdtesting.Context(c)),
+		modelcmd.BootstrapContextNoVerify(context.Background(), cmdtesting.Context(c)),
 		jujuclient.NewMemStore(),
 		bootstrap.PrepareParams{
 			ControllerConfig: coretesting.FakeControllerConfig(),

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -4,6 +4,7 @@
 package environs
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
@@ -146,4 +147,7 @@ type BootstrapContext interface {
 	// ShouldVerifyCredentials indicates whether the caller's cloud
 	// credentials should be verified.
 	ShouldVerifyCredentials() bool
+
+	// Context is the context.Context value for this bootstrap command.
+	Context() context.Context
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -50,6 +50,8 @@ You may want to use the 'agent-metadata-url' configuration setting to specify th
 
 var (
 	logger = loggo.GetLogger("juju.environs.bootstrap")
+
+	errCancelled = errors.New("cancelled")
 )
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
@@ -1147,4 +1149,14 @@ func hashAndSize(path string) (hash string, size int64, err error) {
 		return "", 0, errors.Mask(err)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), size, nil
+}
+
+// Cancelled returns an error that satisfies IsCancelled.
+func Cancelled() error {
+	return errCancelled
+}
+
+// IsCancelled reports whether err is a "bootstrap cancelled" error.
+func IsCancelled(err error) bool {
+	return errors.Cause(err) == errCancelled
 }

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -4,6 +4,7 @@
 package bootstrap_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -34,7 +35,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/dashboard"
 	"github.com/juju/juju/environs/filestorage"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -68,7 +69,7 @@ type bootstrapSuite struct {
 	coretesting.BaseSuite
 	envtesting.ToolsFixture
 
-	callContext context.ProviderCallContext
+	callContext envcontext.ProviderCallContext
 }
 
 var _ = gc.Suite(&bootstrapSuite{})
@@ -90,7 +91,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(bootstrap.DashboardFetchMetadata, func(string, int, int, ...simplestreams.DataSource) ([]*dashboard.Metadata, error) {
 		return nil, nil
 	})
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = envcontext.NewCloudCallContext()
 }
 
 func (s *bootstrapSuite) TearDownTest(c *gc.C) {
@@ -489,7 +490,7 @@ func (s *bootstrapSuite) setupProviderWithSomeSupportedArches(c *gc.C) bootstrap
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
 	// test provider constraints only has amd64 and arm64 as supported architectures
-	consBefore, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	consBefore, err := env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	desiredArch := constraints.MustParse("arch=i386")
 	unsupported, err := consBefore.Validate(desiredArch)
@@ -536,7 +537,7 @@ func (s *bootstrapSuite) setupProviderWithNoSupportedArches(c *gc.C) bootstrapEn
 	}
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
-	consBefore, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	consBefore, err := env.ConstraintsValidator(envcontext.NewCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	// test provider constraints only has amd64 and arm64 as supported architectures
 	desiredArch := constraints.MustParse("arch=i386")
@@ -911,7 +912,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardSuccessRemote(c *gc.C) {
 		"dashboard-stream": "devel",
 	})
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:           coretesting.FakeControllerConfig(),
 			AdminSecret:                "admin-secret",
@@ -935,7 +936,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardSuccessLocal(c *gc.C) {
 	s.PatchEnvironment("JUJU_DASHBOARD", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
@@ -967,7 +968,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardSuccessLocal(c *gc.C) {
 func (s *bootstrapSuite) TestBootstrapDashboardSuccessNoGUI(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
@@ -985,7 +986,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardNoStreams(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:           coretesting.FakeControllerConfig(),
 			AdminSecret:                "admin-secret",
@@ -1004,7 +1005,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardStreamsFailure(c *gc.C) {
 	})
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:           coretesting.FakeControllerConfig(),
 			AdminSecret:                "admin-secret",
@@ -1021,7 +1022,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardErrorNotFound(c *gc.C) {
 	s.PatchEnvironment("JUJU_DASHBOARD", "/no/such/file")
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
@@ -1039,7 +1040,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardErrorInvalidArchive(c *gc.C) {
 	s.PatchEnvironment("JUJU_DASHBOARD", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
@@ -1055,7 +1056,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardErrorInvalidVersion(c *gc.C) {
 	s.PatchEnvironment("JUJU_DASHBOARD", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
@@ -1071,7 +1072,7 @@ func (s *bootstrapSuite) TestBootstrapDashboardErrorUnexpectedArchive(c *gc.C) {
 	s.PatchEnvironment("JUJU_DASHBOARD", path)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
-	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), env,
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
@@ -1620,7 +1621,7 @@ func (s *bootstrapSuite) setDummyStorage(c *gc.C, env *bootstrapEnviron) {
 	s.AddCleanup(func(c *gc.C) { closer.Close() })
 }
 
-func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	e.bootstrapCount++
 	e.args = args
 
@@ -1655,7 +1656,7 @@ func (e *bootstrapEnviron) Storage() storage.Storage {
 	return e.storage
 }
 
-func (e *bootstrapEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+func (e *bootstrapEnviron) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	e.constraintsValidatorCount++
 	v := constraints.NewValidator()
 	v.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64})
@@ -1687,7 +1688,7 @@ type bootstrapEnvironNoExplicitArchitectures struct {
 	*bootstrapEnvironWithRegion
 }
 
-func (e bootstrapEnvironNoExplicitArchitectures) ConstraintsValidator(context.ProviderCallContext) (constraints.Validator, error) {
+func (e bootstrapEnvironNoExplicitArchitectures) ConstraintsValidator(envcontext.ProviderCallContext) (constraints.Validator, error) {
 	e.constraintsValidatorCount++
 	v := constraints.NewValidator()
 	return v, nil

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"context"
+
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -13,8 +15,8 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
-	instances "github.com/juju/juju/environs/instances"
+	envcontext "github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/common"
 )
 
@@ -28,7 +30,7 @@ func DisableFinishBootstrap() func() {
 		environs.BootstrapContext,
 		ssh.Client,
 		environs.Environ,
-		context.ProviderCallContext,
+		envcontext.ProviderCallContext,
 		instances.Instance,
 		*instancecfg.InstanceConfig,
 		environs.BootstrapDialOpts,
@@ -41,5 +43,5 @@ func DisableFinishBootstrap() func() {
 
 // BootstrapContext creates a simple bootstrap execution context.
 func BootstrapContext(c *gc.C) environs.BootstrapContext {
-	return modelcmd.BootstrapContext(cmdtesting.Context(c))
+	return modelcmd.BootstrapContext(context.Background(), cmdtesting.Context(c))
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -44,7 +45,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/filestorage"
 	sstesting "github.com/juju/juju/environs/simplestreams/testing"
 	"github.com/juju/juju/environs/storage"
@@ -130,7 +131,7 @@ type JujuConnSuite struct {
 	oldJujuXDGDataHome  string
 	DummyConfig         testing.Attrs
 	Factory             *factory.Factory
-	ProviderCallContext context.ProviderCallContext
+	ProviderCallContext envcontext.ProviderCallContext
 
 	idleFuncMutex       *sync.Mutex
 	txnSyncNotify       chan struct{}
@@ -536,7 +537,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	cloudSpec := dummy.SampleCloudSpec()
 	bootstrapEnviron, err := bootstrap.PrepareController(
 		false,
-		modelcmd.BootstrapContext(ctx),
+		modelcmd.BootstrapContext(context.Background(), ctx),
 		s.ControllerStore,
 		bootstrap.PrepareParams{
 			ControllerConfig: s.ControllerConfig,
@@ -571,8 +572,8 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	// Dummy provider uses a random port, which is added to cfg used to create environment.
 	apiPort := dummy.APIPort(environ.Provider())
 	s.ControllerConfig["api-port"] = apiPort
-	s.ProviderCallContext = context.NewCloudCallContext()
-	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
+	s.ProviderCallContext = envcontext.NewCloudCallContext()
+	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
 		CloudRegion:      "dummy-region",
 		Cloud: cloud.Cloud{

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -4,6 +4,8 @@
 package lxd_test
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -17,7 +19,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
 	coretesting "github.com/juju/juju/testing"
@@ -28,7 +30,7 @@ var errTestUnAuth = errors.New("not authorized")
 type environSuite struct {
 	lxd.BaseSuite
 
-	callCtx           context.ProviderCallContext
+	callCtx           envcontext.ProviderCallContext
 	invalidCredential bool
 }
 
@@ -36,7 +38,7 @@ var _ = gc.Suite(&environSuite{})
 
 func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = &context.CloudCallContext{
+	s.callCtx = &envcontext.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -92,7 +94,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 		ControllerConfig:         coretesting.FakeControllerConfig(),
 		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
 	}
-	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(ctx), s.callCtx, params)
+	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Arch, gc.Equals, "amd64")
@@ -377,7 +379,7 @@ func (s *environSuite) TestInstanceAvailabilityZoneNamesInvalidCredentials(c *gc
 type environCloudProfileSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 
 	svr          *lxd.MockServer
 	cloudSpecEnv environs.CloudSpecSetter
@@ -440,7 +442,7 @@ func (s *environCloudProfileSuite) expectCreateProfile(name string, err error) {
 type environProfileSuite struct {
 	lxd.EnvironSuite
 
-	callCtx context.ProviderCallContext
+	callCtx envcontext.ProviderCallContext
 
 	svr    *lxd.MockServer
 	lxdEnv environs.LXDProfiler

--- a/provider/rackspace/environ_test.go
+++ b/provider/rackspace/environ_test.go
@@ -4,8 +4,8 @@
 package rackspace_test
 
 import (
+	"context"
 	"io"
-	"os"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
+	envcontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/rackspace"
@@ -36,7 +36,7 @@ type environSuite struct {
 	environ      environs.Environ
 	innerEnviron *fakeEnviron
 
-	callCtx           *context.CloudCallContext
+	callCtx           *envcontext.CloudCallContext
 	invalidCredential bool
 }
 
@@ -46,7 +46,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.innerEnviron = new(fakeEnviron)
 	s.environ = rackspace.NewEnviron(s.innerEnviron)
-	s.callCtx = &context.CloudCallContext{
+	s.callCtx = &envcontext.CloudCallContext{
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -60,7 +60,7 @@ func (s *environSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *environSuite) TestBootstrap(c *gc.C) {
-	s.PatchValue(rackspace.Bootstrap, func(ctx environs.BootstrapContext, env environs.Environ, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	s.PatchValue(rackspace.Bootstrap, func(ctx environs.BootstrapContext, env environs.Environ, callCtx envcontext.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 		return s.innerEnviron.Bootstrap(ctx, callCtx, args)
 	})
 	s.environ.Bootstrap(nil, s.callCtx, environs.BootstrapParams{
@@ -72,12 +72,12 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 func (s *environSuite) TestStartInstance(c *gc.C) {
 	configurator := &fakeConfigurator{}
 	s.PatchValue(rackspace.WaitSSH, func(
+		ctx context.Context,
 		stdErr io.Writer,
-		interrupted <-chan os.Signal,
 		client ssh.Client,
 		checkHostScript string,
 		inst common.InstanceRefresher,
-		callCtx context.ProviderCallContext,
+		callCtx envcontext.ProviderCallContext,
 		timeout environs.BootstrapDialOpts,
 		hostSSHOptions common.HostSSHOptionsFunc,
 	) (addr string, err error) {
@@ -122,12 +122,12 @@ func (s *environSuite) TestStartInstanceInvalidCredential(c *gc.C) {
 		},
 	}
 	s.PatchValue(rackspace.WaitSSH, func(
+		ctx context.Context,
 		stdErr io.Writer,
-		interrupted <-chan os.Signal,
 		client ssh.Client,
 		checkHostScript string,
 		inst common.InstanceRefresher,
-		callCtx context.ProviderCallContext,
+		callCtx envcontext.ProviderCallContext,
 		timeout environs.BootstrapDialOpts,
 		hostSSHOptions common.HostSSHOptionsFunc,
 	) (addr string, err error) {
@@ -191,7 +191,7 @@ func (p *fakeEnviron) Open(cfg *config.Config) (environs.Environ, error) {
 	return nil, nil
 }
 
-func (e *fakeEnviron) Create(callCtx context.ProviderCallContext, args environs.CreateParams) error {
+func (e *fakeEnviron) Create(callCtx envcontext.ProviderCallContext, args environs.CreateParams) error {
 	e.Push("Create", callCtx, args)
 	return nil
 }
@@ -201,29 +201,29 @@ func (e *fakeEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, control
 	return nil
 }
 
-func (e *fakeEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (e *fakeEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.ProviderCallContext, params environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	e.Push("Bootstrap", ctx, callCtx, params)
 	return nil, nil
 }
 
-func (e *fakeEnviron) StartInstance(callCtx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (e *fakeEnviron) StartInstance(callCtx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	e.Push("StartInstance", callCtx, args)
 	return &environs.StartInstanceResult{
 		Instance: &fakeInstance{},
 	}, nil
 }
 
-func (e *fakeEnviron) StopInstances(callCtx context.ProviderCallContext, ids ...instance.Id) error {
+func (e *fakeEnviron) StopInstances(callCtx envcontext.ProviderCallContext, ids ...instance.Id) error {
 	e.Push("StopInstances", callCtx, ids)
 	return nil
 }
 
-func (e *fakeEnviron) AllInstances(callCtx context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *fakeEnviron) AllInstances(callCtx envcontext.ProviderCallContext) ([]instances.Instance, error) {
 	e.Push("AllInstances", callCtx)
 	return nil, nil
 }
 
-func (e *fakeEnviron) AllRunningInstances(callCtx context.ProviderCallContext) ([]instances.Instance, error) {
+func (e *fakeEnviron) AllRunningInstances(callCtx envcontext.ProviderCallContext) ([]instances.Instance, error) {
 	e.Push("AllRunningInstances", callCtx)
 	return nil, nil
 }
@@ -232,7 +232,7 @@ func (e *fakeEnviron) Config() *config.Config {
 	return e.config
 }
 
-func (e *fakeEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
+func (e *fakeEnviron) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	e.Push("ConstraintsValidator", ctx)
 	return nil, nil
 }
@@ -242,42 +242,42 @@ func (e *fakeEnviron) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
-func (e *fakeEnviron) Instances(callCtx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+func (e *fakeEnviron) Instances(callCtx envcontext.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
 	e.Push("Instances", callCtx, ids)
 	return []instances.Instance{&fakeInstance{}}, nil
 }
 
-func (e *fakeEnviron) ControllerInstances(callCtx context.ProviderCallContext, st string) ([]instance.Id, error) {
+func (e *fakeEnviron) ControllerInstances(callCtx envcontext.ProviderCallContext, st string) ([]instance.Id, error) {
 	e.Push("ControllerInstances", callCtx, st)
 	return nil, nil
 }
 
-func (e *fakeEnviron) AdoptResources(callCtx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
+func (e *fakeEnviron) AdoptResources(callCtx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	e.Push("AdoptResources", callCtx, controllerUUID, fromVersion)
 	return nil
 }
 
-func (e *fakeEnviron) Destroy(callCtx context.ProviderCallContext) error {
+func (e *fakeEnviron) Destroy(callCtx envcontext.ProviderCallContext) error {
 	e.Push("Destroy", callCtx)
 	return nil
 }
 
-func (e *fakeEnviron) DestroyController(callCtx context.ProviderCallContext, controllerUUID string) error {
+func (e *fakeEnviron) DestroyController(callCtx envcontext.ProviderCallContext, controllerUUID string) error {
 	e.Push("Destroy", callCtx, controllerUUID)
 	return nil
 }
 
-func (e *fakeEnviron) OpenPorts(callCtx context.ProviderCallContext, rules firewall.IngressRules) error {
+func (e *fakeEnviron) OpenPorts(callCtx envcontext.ProviderCallContext, rules firewall.IngressRules) error {
 	e.Push("OpenPorts", callCtx, rules)
 	return nil
 }
 
-func (e *fakeEnviron) ClosePorts(callCtx context.ProviderCallContext, rules firewall.IngressRules) error {
+func (e *fakeEnviron) ClosePorts(callCtx envcontext.ProviderCallContext, rules firewall.IngressRules) error {
 	e.Push("ClosePorts", callCtx, rules)
 	return nil
 }
 
-func (e *fakeEnviron) IngressRules(callCtx context.ProviderCallContext) (firewall.IngressRules, error) {
+func (e *fakeEnviron) IngressRules(callCtx envcontext.ProviderCallContext) (firewall.IngressRules, error) {
 	e.Push("Ports", callCtx)
 	return nil, nil
 }
@@ -287,7 +287,7 @@ func (e *fakeEnviron) Provider() environs.EnvironProvider {
 	return nil
 }
 
-func (e *fakeEnviron) PrecheckInstance(callCtx context.ProviderCallContext, args environs.PrecheckInstanceParams) error {
+func (e *fakeEnviron) PrecheckInstance(callCtx envcontext.ProviderCallContext, args environs.PrecheckInstanceParams) error {
 	e.Push("PrecheckInstance", callCtx, args)
 	return nil
 }
@@ -302,7 +302,7 @@ func (e *fakeEnviron) StorageProvider(t storage.ProviderType) (storage.Provider,
 	return nil, errors.NotImplementedf("StorageProvider")
 }
 
-func (e *fakeEnviron) InstanceTypes(context.ProviderCallContext, constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (e *fakeEnviron) InstanceTypes(envcontext.ProviderCallContext, constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	return instances.InstanceTypesWithCostMetadata{}, nil
 }
 
@@ -364,7 +364,7 @@ func (e *fakeInstance) Id() instance.Id {
 	return instance.Id("")
 }
 
-func (e *fakeInstance) Status(callCtx context.ProviderCallContext) instance.Status {
+func (e *fakeInstance) Status(callCtx envcontext.ProviderCallContext) instance.Status {
 	e.Push("Status", callCtx)
 	return instance.Status{
 		Status:  status.Provisioning,
@@ -372,12 +372,12 @@ func (e *fakeInstance) Status(callCtx context.ProviderCallContext) instance.Stat
 	}
 }
 
-func (e *fakeInstance) Refresh(callCtx context.ProviderCallContext) error {
+func (e *fakeInstance) Refresh(callCtx envcontext.ProviderCallContext) error {
 	e.Push("Refresh", callCtx)
 	return nil
 }
 
-func (e *fakeInstance) Addresses(callCtx context.ProviderCallContext) (network.ProviderAddresses, error) {
+func (e *fakeInstance) Addresses(callCtx envcontext.ProviderCallContext) (network.ProviderAddresses, error) {
 	e.Push("Addresses", callCtx)
 	return []network.ProviderAddress{{
 		MachineAddress: network.MachineAddress{
@@ -388,17 +388,17 @@ func (e *fakeInstance) Addresses(callCtx context.ProviderCallContext) (network.P
 	}}, nil
 }
 
-func (e *fakeInstance) OpenPorts(callCtx context.ProviderCallContext, machineId string, ports firewall.IngressRules) error {
+func (e *fakeInstance) OpenPorts(callCtx envcontext.ProviderCallContext, machineId string, ports firewall.IngressRules) error {
 	e.Push("OpenPorts", callCtx, machineId, ports)
 	return nil
 }
 
-func (e *fakeInstance) ClosePorts(callCtx context.ProviderCallContext, machineId string, ports firewall.IngressRules) error {
+func (e *fakeInstance) ClosePorts(callCtx envcontext.ProviderCallContext, machineId string, ports firewall.IngressRules) error {
 	e.Push("ClosePorts", callCtx, machineId, ports)
 	return nil
 }
 
-func (e *fakeInstance) IngressRules(callCtx context.ProviderCallContext, machineId string) (firewall.IngressRules, error) {
+func (e *fakeInstance) IngressRules(callCtx envcontext.ProviderCallContext, machineId string) (firewall.IngressRules, error) {
 	e.Push("Ports", callCtx, machineId)
 	return nil, nil
 }

--- a/testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
+++ b/testcharms/charm-hub/bundles/wordpress-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-conf-param/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     aws-integrator:
         charm: cs:~containers/aws-integrator        
         num_units: 1

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-multi/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     aws-integrator:
         charm: cs:~containers/aws-integrator        
         num_units: 1

--- a/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
+++ b/testcharms/charm-repo/bundle/aws-integrator-trust-single/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     aws-integrator:
         charm: cs:~containers/aws-integrator        
         num_units: 1

--- a/testcharms/charm-repo/bundle/bad/bundle.yaml
+++ b/testcharms/charm-repo/bundle/bad/bundle.yaml
@@ -1,6 +1,6 @@
 # This bundle has a bad relation, which will cause it to fail
 # its verification.
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/basic/bundle.yaml
+++ b/testcharms/charm-repo/bundle/basic/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     ubuntu-lite:
         charm: cs:~jameinel/ubuntu-lite-7
         num_units: 1

--- a/testcharms/charm-repo/bundle/bitcoinminer-with-dashboard/bundle.yaml
+++ b/testcharms/charm-repo/bundle/bitcoinminer-with-dashboard/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     dashboard:
         charm: cs:dashboard4miner
         num_units: 1

--- a/testcharms/charm-repo/bundle/gitlab/bundle.yaml
+++ b/testcharms/charm-repo/bundle/gitlab/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     gitlab:
         charm: cs:precise/gitlab-5
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-fail-local/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-fail-local/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile-fail-local:
         charm: ./../../quantal/lxd-profile-fail
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-fail/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-fail/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile-fail:
         charm: cs:~juju-qa/bionic/lxd-profile-fail-0
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-local/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-local/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile-local:
         charm: ./../../quantal/lxd-profile
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile-mixed-fail/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile-mixed-fail/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile:
         charm: cs:~juju-qa/bionic/lxd-profile-0
         num_units: 1

--- a/testcharms/charm-repo/bundle/lxd-profile/bundle.yaml
+++ b/testcharms/charm-repo/bundle/lxd-profile/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     lxd-profile:
         charm: cs:~juju-qa/bionic/lxd-profile-0
         num_units: 1

--- a/testcharms/charm-repo/bundle/openstack/bundle.yaml
+++ b/testcharms/charm-repo/bundle/openstack/bundle.yaml
@@ -1,5 +1,5 @@
 series: precise
-services:
+applications:
   mysql:
     charm: cs:precise/mysql
     constraints: mem=1G

--- a/testcharms/charm-repo/bundle/terms-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/terms-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     terms1:
         charm: cs:terms1
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-endpoint-bindings/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress-extra-bindings:
         charm: cs:wordpress-extra-bindings
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-mysql-storage/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-mysql-storage/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1

--- a/testcharms/charm-repo/bundle/wordpress-with-plans/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-with-plans/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: cs:wordpress
         num_units: 1


### PR DESCRIPTION
Includes the following PRs:

* #12473 - Update MicroK8s hints to reflect current CLI
* #12475 - Handle Ctrl-C during bootstrap (refactored)
* #12478 - Deprecate services in bundles
* #12480 - Merge branch 2.8 into 2.9

Conflicts:

* environs/bootstrap/bootstrap_test.go