### PR TITLE
[dev] Use 'juju exec' instead of 'juju run' for acceptance tests

### DIFF
--- a/acceptancetests/assess_heterogeneous_control.py
+++ b/acceptancetests/assess_heterogeneous_control.py
@@ -107,7 +107,7 @@ def test_control_heterogeneous(bs_manager, other, upload_tools):
             # Currently, juju ssh is not working on Windows.
             check_token(initial, token)
             check_series(other)
-            other.juju('run', ('--all', 'uname -a'))
+            other.juju('exec', ('--all', 'uname -a'))
         other.get_config('dummy-source')
         other.get_model_config()
         other.juju('remove-relation', ('dummy-source', 'dummy-sink'))

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -201,7 +201,7 @@ def _get_token(remote, token_path="/var/run/dummy-sink/token"):
         if e.returncode != 1:
             raise
         return ""
-    return token_pattern.match(contents).group(1)
+    return token_pattern.match(contents.decode("utf-8")).group(1)
 
 
 def check_token(client, token, timeout=120):

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1918,7 +1918,7 @@ class ModelClient:
         id = self.action_do(unit, action, *args)
         return self.action_fetch(id, action, timeout)
 
-    def run(self, commands, applications=None, machines=None, units=None,
+    def exec_cmds(self, commands, applications=None, machines=None, units=None,
             use_json=True):
         args = []
         if use_json:
@@ -1930,7 +1930,7 @@ class ModelClient:
         if units is not None:
             args.extend(['--unit', ','.join(units)])
         args.extend(commands)
-        responses = self.get_juju_output('run', *args)
+        responses = self.get_juju_output('exec', *args)
         if use_json:
             return json.loads(responses)
         else:


### PR DESCRIPTION
The "juju run" command on the develop branch is now used to execute
actions. The previous functionality is now provided by the "juju exec"
command instead. This commit updates the acceptance tests to use the new
command.

## QA steps

~You will need a **python 2** virtual env for this~. The tests have been updated to work with python3

```sh
make install
cd acceptancetests
./deploy_job.py lxd `which juju` ./tmp/art nw-deploy-lxd
```