### PR TITLE
Fix oplog TestStops on arm64 by inserting row before starting tailer

### DIFF
--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -114,10 +114,10 @@ func (s *oplogSuite) TestStops(c *gc.C) {
 	_, session := s.startMongo(c)
 
 	oplog := s.makeFakeOplog(c, session)
+	s.insertDoc(c, session, oplog, &mongo.OplogDoc{Timestamp: 1})
+
 	tailer := mongo.NewOplogTailer(mongo.NewOplogSession(oplog, nil), time.Time{})
 	defer tailer.Stop()
-
-	s.insertDoc(c, session, oplog, &mongo.OplogDoc{Timestamp: 1})
 	s.getNextOplog(c, tailer)
 
 	err := tailer.Stop()
@@ -271,6 +271,10 @@ func (s *oplogSuite) makeFakeOplog(c *gc.C, session *mgo.Session) *mgo.Collectio
 		MaxBytes: 1024 * 1024,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		err := oplog.DropCollection()
+		c.Assert(err, jc.ErrorIsNil)
+	})
 	return oplog
 }
 


### PR DESCRIPTION
TestStops was intermittently failing on arm64. I was able to fire up an
arm64 EC2 instance and repro it there, every 50 runs or so. I'm still
not sure why this fixes it, but with this change I can't reproduce it
over thousands of runs. Plus, inserting the row before starting the
tailer is consistent with what TestHonoursInitialTs does.

I also added a cleanup task to drop the fake oplog collection at the
end of the test. This doesn't actually seem to do anything, but I added
it because initially I thought the failure was related to
TestHonoursInitialTs not cleaning up after itself, and TestStops failing
as a result of some interaction. So the AddCleanup here doesn't actually
fix anything, but still seems like the right thing to do.

## QA steps

Create arm64 EC2 instance, clone github.com/juju/juju, install deps, get it building. Run test over and over to get it to fail, for example:

```sh
go test ./mongo -check.f TestStops -test.v -check.v -test.count=100
```

A failure (happens before the fix) will look like this:

```
----------------------------------------------------------------------
FAIL: oplog_test.go:103: oplogSuite.TestStops

[LOG] 0:00.000 DEBUG juju.testing starting mongo in /tmp/test-mgo138077763
[LOG] 0:00.000 DEBUG juju.testing using mongod at: "/usr/bin/mongod" (version=3.6.8)
[LOG] 0:00.087 DEBUG juju.testing started mongod pid 53913 in /tmp/test-mgo138077763 on port 39687
oplog_test.go:114:
    s.getNextOplog(c, tailer)
oplog_test.go:289:
    c.Fatal("timed out waiting for oplog doc")
... Error: timed out waiting for oplog doc

[LOG] 0:12.110 DEBUG juju.testing killing mongod pid 53913 in /tmp/test-mgo138077763 on port 39687 with killed
OOPS: 0 passed, 1 FAILED
--- FAIL: Test (12.12s)
```