### PR TITLE
Increase log level to find expected logs, test fails otherwise.

### DIFF
--- a/tests/suites/relations/relation_departing_unit.sh
+++ b/tests/suites/relations/relation_departing_unit.sh
@@ -6,6 +6,10 @@ run_relation_departing_unit() {
 
     ensure "${model_name}" "${file}"
 
+    # the log messages the test looks for do not appear if root
+    # log level is INFO.
+    juju model-config -m "${model_name}" logging-config="<root>=DEBUG"
+
     # Deploy 2 departer instances
     juju deploy ./tests/suites/relations/charms/departer -n 2
     wait_for "departer" "$(idle_condition "departer" 0 0)"


### PR DESCRIPTION
Increase log level to find expected logs, test fails otherwise.
## QA steps

```console
# test should not fail with "expected departer/0 to be notified that departer/1 went away"
$ (cd tests; ./main.sh relations test_relation_departing_unit)
```

