### PR TITLE
Add initial support for controller charms (local only for now)

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -295,7 +295,7 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 
 	// Now we need to repackage it with the reserved URL, upload it to
 	// provider storage and update the state.
-	err = h.repackageAndUploadCharm(st, archive, curl)
+	err = RepackageAndUploadCharm(st, archive, curl)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -389,10 +389,10 @@ func (d byDepth) Len() int           { return len(d) }
 func (d byDepth) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
 func (d byDepth) Less(i, j int) bool { return depth(d[i]) < depth(d[j]) }
 
-// repackageAndUploadCharm expands the given charm archive to a
+// RepackageAndUploadCharm expands the given charm archive to a
 // temporary directory, repackages it with the given curl's revision,
 // then uploads it to storage, and finally updates the state.
-func (h *charmsHandler) repackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl *charm.URL) error {
+func RepackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl *charm.URL) error {
 	// Create a temp dir to contain the extracted charm dir.
 	tempDir, err := ioutil.TempDir("", "charm-download")
 	if err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1646,7 +1646,7 @@ func (api *APIBase) AddUnits(args params.AddApplicationUnits) (params.AddApplica
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)
 	}
 	if ch.Meta().Name == bootstrap.ControllerCharmName {
-		return params.AddApplicationUnitsResults{}, errors.NotSupportedf("add units to the controller application")
+		return params.AddApplicationUnitsResults{}, errors.NotSupportedf("adding units to the controller application")
 	}
 
 	if err := api.checkCanWrite(); err != nil {
@@ -1813,7 +1813,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 			appCharms[appName] = ch
 		}
 		if ch.Meta().Name == bootstrap.ControllerCharmName {
-			return nil, errors.NotSupportedf("remove units from the controller application")
+			return nil, errors.NotSupportedf("removing units from the controller application")
 		}
 
 		var info params.DestroyUnitInfo

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2877,6 +2877,13 @@ func (s *applicationSuite) TestBlockApplicationDestroy(c *gc.C) {
 	}
 }
 
+func (s *applicationSuite) TestDestroyControllerApplicationNotAllowed(c *gc.C) {
+	s.AddTestingApplication(c, "controller-application", s.AddTestingCharm(c, "juju-controller"))
+
+	err := s.applicationAPI.Destroy(params.ApplicationDestroy{"controller-application"})
+	c.Assert(err, gc.ErrorMatches, "removing the controller application not supported")
+}
+
 func (s *applicationSuite) TestDestroyPrincipalUnits(c *gc.C) {
 	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
 	units := make([]*state.Unit, 5)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -851,13 +851,13 @@ func (s *ApplicationSuite) assertDestroyUnit(c *gc.C, force bool, maxWait *time.
 
 	s.backend.CheckCallNames(c,
 		"Unit",
+		"Application",
 		"UnitStorageAttachments",
 		"StorageInstance",
 		"StorageInstance",
 		"StorageInstanceFilesystem",
 		"StorageInstanceFilesystem",
 		"ApplyOperation",
-
 		"Unit",
 		"UnitStorageAttachments",
 		"ApplyOperation",
@@ -866,8 +866,8 @@ func (s *ApplicationSuite) assertDestroyUnit(c *gc.C, force bool, maxWait *time.
 	if force {
 		expectedOp.MaxWait = common.MaxWait(maxWait)
 	}
-	s.backend.CheckCall(c, 6, "ApplyOperation", expectedOp)
-	s.backend.CheckCall(c, 9, "ApplyOperation", &state.DestroyUnitOperation{
+	s.backend.CheckCall(c, 7, "ApplyOperation", expectedOp)
+	s.backend.CheckCall(c, 10, "ApplyOperation", &state.DestroyUnitOperation{
 		DestroyStorage: true,
 	})
 }
@@ -1178,7 +1178,7 @@ func (s *ApplicationSuite) TestAddUnits(c *gc.C) {
 		Units: []string{"postgresql/99"},
 	})
 	app := s.backend.applications["postgresql"]
-	app.CheckCall(c, 0, "AddUnit", state.AddUnitParams{})
+	app.CheckCall(c, 1, "AddUnit", state.AddUnitParams{})
 	app.addedUnit.CheckCall(c, 0, "AssignWithPolicy", state.AssignCleanEmpty)
 }
 
@@ -1356,23 +1356,23 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	app := s.backend.applications["postgresql"]
-	app.CheckCall(c, 0, "AddUnit", state.AddUnitParams{
+	app.CheckCall(c, 1, "AddUnit", state.AddUnitParams{
 		AttachStorage: []names.StorageTag{names.NewStorageTag("pgdata/0")},
 	})
 }
 
 func (s *ApplicationSuite) TestAddUnitsAttachStorageMultipleUnits(c *gc.C) {
 	_, err := s.api.AddUnits(params.AddApplicationUnits{
-		ApplicationName: "foo",
+		ApplicationName: "postgresql",
 		NumUnits:        2,
-		AttachStorage:   []string{"storage-foo-0"},
+		AttachStorage:   []string{"storage-postgresql-0"},
 	})
 	c.Assert(err, gc.ErrorMatches, "AttachStorage is non-empty, but NumUnits is 2")
 }
 
 func (s *ApplicationSuite) TestAddUnitsAttachStorageInvalidStorageTag(c *gc.C) {
 	_, err := s.api.AddUnits(params.AddApplicationUnits{
-		ApplicationName: "foo",
+		ApplicationName: "postgresql",
 		NumUnits:        1,
 		AttachStorage:   []string{"volume-0"},
 	})

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 )
@@ -56,6 +57,9 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Ap
 	charmConfig, err := args.Charm.Config().ValidateSettings(args.CharmConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	if args.Charm.Meta().Name == bootstrap.ControllerCharmName {
+		return nil, errors.NotSupportedf("manual deploy of the controller charm")
 	}
 	if args.Charm.Meta().Subordinate {
 		if args.NumUnits != 0 {

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -47,6 +47,16 @@ func (s *DeployLocalSuite) SetUpTest(c *gc.C) {
 	s.charm = charm
 }
 
+func (s *DeployLocalSuite) TestDeployControllerNotAllowed(c *gc.C) {
+	ch := s.AddTestingCharm(c, "juju-controller")
+	_, err := application.DeployApplication(stateDeployer{s.State},
+		application.DeployApplicationParams{
+			ApplicationName: "my-controller",
+			Charm:           ch,
+		})
+	c.Assert(err, gc.ErrorMatches, "manual deploy of the controller charm not supported")
+}
+
 func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -111,3 +111,10 @@ func (*instancecfgSuite) TestDashboardDir(c *gc.C) {
 	}
 	c.Assert(icfg.DashboardDir(), gc.Equals, "/path/to/datadir/dashboard")
 }
+
+func (*instancecfgSuite) TestCharmDir(c *gc.C) {
+	icfg := &instancecfg.InstanceConfig{
+		DataDir: "/path/to/datadir/",
+	}
+	c.Assert(icfg.CharmDir(), gc.Equals, "/path/to/datadir/charms")
+}

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -9,12 +9,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -37,6 +39,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/testcharms"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 )
@@ -172,6 +175,11 @@ func (cfg *testInstanceConfig) setDashboard(url string) *testInstanceConfig {
 		Size:    42,
 		SHA256:  "1234",
 	}
+	return cfg
+}
+
+func (cfg *testInstanceConfig) setControllerCharm(path string) *testInstanceConfig {
+	cfg.Bootstrap.ControllerCharm = path
 	return cfg
 }
 
@@ -715,7 +723,7 @@ printf %%s %s | base64 -d > '/var/lib/juju/dashboard/dashboard.tar.bz2'
 [ -f $dashboard/jujudashboard.sha256 ] && (grep '1234' $dashboard/jujudashboard.sha256 && printf %%s '%s' > $dashboard/downloaded-dashboard.txt || echo Juju Dashboard checksum mismatch)
 rm -f $dashboard/dashboard.tar.bz2 $dashboard/jujudashboard.sha256 $dashboard/downloaded-dashboard.txt
 `, base64Content, dashboardJson))
-	checkCloudInitWithDashboard(c, cfg, expectedScripts, "")
+	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
 
 func (*cloudinitSuite) TestCloudInitWithRemoteDashboard(c *gc.C) {
@@ -729,22 +737,22 @@ curl -sSf -o $dashboard/dashboard.tar.bz2 --retry 10 'https://1.2.3.4/dashboard.
 [ -f $dashboard/jujudashboard.sha256 ] && (grep '1234' $dashboard/jujudashboard.sha256 && printf %%s '%s' > $dashboard/downloaded-dashboard.txt || echo Juju Dashboard checksum mismatch)
 rm -f $dashboard/dashboard.tar.bz2 $dashboard/jujudashboard.sha256 $dashboard/downloaded-dashboard.txt
 `, dashboardJson))
-	checkCloudInitWithDashboard(c, cfg, expectedScripts, "")
+	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
 
 func (*cloudinitSuite) TestCloudInitWithDashboardReadError(c *gc.C) {
 	cfg := makeBootstrapConfig("precise", 0).setDashboard("file:///no/such/dashboard.tar.bz2")
 	expectedError := "cannot set up Juju Dashboard: cannot read Juju Dashboard archive: .*"
-	checkCloudInitWithDashboard(c, cfg, "", expectedError)
+	checkCloudInitWithContent(c, cfg, "", expectedError)
 }
 
 func (*cloudinitSuite) TestCloudInitWithDashboardURLError(c *gc.C) {
 	cfg := makeBootstrapConfig("precise", 0).setDashboard(":")
 	expectedError := "cannot set up Juju Dashboard: cannot parse Juju Dashboard URL: .*"
-	checkCloudInitWithDashboard(c, cfg, "", expectedError)
+	checkCloudInitWithContent(c, cfg, "", expectedError)
 }
 
-func checkCloudInitWithDashboard(c *gc.C, cfg *testInstanceConfig, expectedScripts string, expectedError string) {
+func checkCloudInitWithContent(c *gc.C, cfg *testInstanceConfig, expectedScripts string, expectedError string) {
 	envConfig := minimalModelConfig(c)
 	testConfig := cfg.maybeSetModelConfig(envConfig).render()
 	ci, err := cloudinit.New(testConfig.Series)
@@ -767,6 +775,30 @@ func checkCloudInitWithDashboard(c *gc.C, cfg *testInstanceConfig, expectedScrip
 
 	scripts := getScripts(configKeyValues)
 	assertScriptMatch(c, scripts, expectedScripts, false)
+}
+
+func (*cloudinitSuite) TestCloudInitWithLocalControllerCharm(c *gc.C) {
+	ch := testcharms.RepoForSeries("quantal").CharmDir("juju-controller")
+	dir, err := charm.ReadCharmDir(ch.Path)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerCharmPath := filepath.Join(c.MkDir(), "controller.charm")
+	f, err := os.Create(controllerCharmPath)
+	c.Assert(err, jc.ErrorIsNil)
+	err = dir.ArchiveTo(f)
+	_ = f.Close()
+	c.Assert(err, jc.ErrorIsNil)
+
+	content, err := ioutil.ReadFile(controllerCharmPath)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg := makeBootstrapConfig("precise", 0).setControllerCharm(controllerCharmPath)
+	base64Content := base64.StdEncoding.EncodeToString(content)
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
+install -D -m 644 /dev/null '/var/lib/juju/charms/controller.charm'
+printf %%s %s | base64 -d > '/var/lib/juju/charms/controller.charm'
+`, base64Content))
+	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
 
 func (*cloudinitSuite) TestCloudInitConfigure(c *gc.C) {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -328,7 +328,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")
 	f.BoolVar(&c.Force, "force", false, "Allow the bypassing of checks such as supported series")
 	f.BoolVar(&c.noHostedModel, "no-default-model", false, "Do not create a default model")
-	f.StringVar(&c.ControllerCharmPath, "controller-charm", "", "Path to a locally built controller.charm")
+	f.StringVar(&c.ControllerCharmPath, "controller-charm", "", "Path to a locally built controller charm")
 }
 
 func (c *bootstrapCommand) Init(args []string) (err error) {
@@ -361,6 +361,13 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		_, err := c.Filesystem().Stat(c.ControllerCharmPath)
 		if err != nil {
 			return errors.Annotatef(err, "problem with --controller-charm")
+		}
+		ch, err := charm.ReadCharm(c.ControllerCharmPath)
+		if err != nil {
+			return errors.Errorf("--controller-charm %q is not a valid charm", c.ControllerCharmPath)
+		}
+		if ch.Meta().Name != bootstrap.ControllerCharmName {
+			return errors.Errorf("--controller-charm %q is not a %q charm", c.ControllerCharmPath, bootstrap.ControllerCharmName)
 		}
 	}
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -247,6 +247,8 @@ type bootstrapCommand struct {
 	hostedModelName string
 	noHostedModel   bool
 
+	ControllerCharmPath string
+
 	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 }
@@ -326,6 +328,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")
 	f.BoolVar(&c.Force, "force", false, "Allow the bypassing of checks such as supported series")
 	f.BoolVar(&c.noHostedModel, "no-default-model", false, "Do not create a default model")
+	f.StringVar(&c.ControllerCharmPath, "controller-charm", "", "Path to a locally built controller.charm")
 }
 
 func (c *bootstrapCommand) Init(args []string) (err error) {
@@ -352,6 +355,13 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 
 	if c.JujuDbSnapAssertionsPath != "" && c.JujuDbSnapPath == "" {
 		return errors.New("--db-snap-asserts requires --db-snap")
+	}
+
+	if c.ControllerCharmPath != "" {
+		_, err := c.Filesystem().Stat(c.ControllerCharmPath)
+		if err != nil {
+			return errors.Annotatef(err, "problem with --controller-charm")
+		}
 	}
 
 	if c.showClouds && c.showRegionsForCloud != "" {
@@ -829,6 +839,7 @@ to create a new model to deploy %sworkloads.
 		JujuDbSnapPath:            c.JujuDbSnapPath,
 		JujuDbSnapAssertionsPath:  c.JujuDbSnapAssertionsPath,
 		StoragePools:              bootstrapCfg.storagePools,
+		ControllerCharmPath:       c.ControllerCharmPath,
 		DialOpts: environs.BootstrapDialOpts{
 			Timeout:        bootstrapCfg.bootstrap.BootstrapTimeout,
 			RetryDelay:     bootstrapCfg.bootstrap.BootstrapRetryDelay,

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -175,6 +175,9 @@ type BootstrapParams struct {
 	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 
+	// ControllerCharmPath is a local controller charm archive.
+	ControllerCharmPath string
+
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
 }
@@ -597,6 +600,10 @@ func bootstrapIAAS(
 		return errors.Trace(err)
 	}
 
+	if err := instanceConfig.SetControllerCharm(args.ControllerCharmPath); err != nil {
+		return errors.Trace(err)
+	}
+
 	var environVersion int
 	if e, ok := environ.(environs.Environ); ok {
 		environVersion = e.Provider().Version()
@@ -721,6 +728,7 @@ func finalizeInstanceBootstrapConfig(
 	})
 	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
 	icfg.Bootstrap.JujuDbSnapAssertionsPath = args.JujuDbSnapAssertionsPath
+	icfg.Bootstrap.ControllerCharm = args.ControllerCharmPath
 	return nil
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/juju/juju/juju/keys"
 	"github.com/juju/juju/provider/dummy"
 	corestorage "github.com/juju/juju/storage"
+	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -1096,6 +1097,22 @@ func makeDashboardArchive(c *gc.C, vers string) string {
 	err := exec.Command("tar", "cjf", target, "-C", source, ".").Run()
 	c.Assert(err, jc.ErrorIsNil)
 	return target
+}
+
+func (s *bootstrapSuite) TestBootstrapControllerCharmLocal(c *gc.C) {
+	path := testcharms.RepoForSeries("quantal").CharmDir("juju-controller").Path
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:         coretesting.FakeControllerConfig(),
+			AdminSecret:              "admin-secret",
+			CAPrivateKey:             coretesting.CAKey,
+			SupportedBootstrapSeries: supportedJujuSeries,
+			ControllerCharmPath:      path,
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.instanceConfig.Bootstrap.ControllerCharm, gc.Equals, path)
 }
 
 // createImageMetadata creates some image metadata in a local directory.

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -19,8 +19,19 @@ import (
 	"github.com/juju/juju/jujuclient"
 )
 
-// ControllerModelName is the name of the admin model in each controller.
-const ControllerModelName = "controller"
+const (
+	// ControllerModelName is the name of the admin model in each controller.
+	ControllerModelName = "controller"
+
+	// ControllerCharmName is the name of the controller charm.
+	ControllerCharmName = "juju-controller"
+
+	// ControllerApplicationName is the name of the controller application.
+	ControllerApplicationName = "controller"
+
+	// ControllerCharmArchive is the name of the controller charm archive.
+	ControllerCharmArchive = "controller.charm"
+)
 
 // PrepareParams contains the parameters for preparing a controller Environ
 // for bootstrapping.

--- a/go.mod
+++ b/go.mod
@@ -40,8 +40,8 @@ require (
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/bundlechanges/v5 v5.0.0-20210105101225-fc10c61af1f3
-	github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611
-	github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de
+	github.com/juju/charm/v9 v9.0.0-20210107011734-a80982922c69
+	github.com/juju/charmrepo/v7 v7.0.0-20210107021745-6d3b0475f2e4
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,12 @@ github.com/juju/bundlechanges/v5 v5.0.0-20210105101225-fc10c61af1f3 h1:0bDD/ukLO
 github.com/juju/bundlechanges/v5 v5.0.0-20210105101225-fc10c61af1f3/go.mod h1:0Us8R+t7wi4ZORNGznWWB07hkDOQFGVznTHOwY2XXfQ=
 github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611 h1:LQEQJvPHjeFNNAMgQpjthtF0SRzNz2+H/YCK0HmJxs4=
 github.com/juju/charm/v9 v9.0.0-20210105084816-5204c3802611/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
+github.com/juju/charm/v9 v9.0.0-20210107011734-a80982922c69 h1:VzRv22mb6gJNoAEgkZWQRW1EfUAt8Krw68C1Jw8n3sQ=
+github.com/juju/charm/v9 v9.0.0-20210107011734-a80982922c69/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
 github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de h1:95Or6HY8Lfpv007aWUNMKzw2AnDXPOyqQjlO/N3UfjU=
 github.com/juju/charmrepo/v7 v7.0.0-20210105092546-af3d6b52f7de/go.mod h1:hnCmP2zszIv2WqLZpHyM+4/bkEvDZi5MLHRsvi58Lhs=
+github.com/juju/charmrepo/v7 v7.0.0-20210107021745-6d3b0475f2e4 h1:s51mNG4ES7lUzMMLzDU8Vb7r0+/LIv4FUSMPwVHMBsQ=
+github.com/juju/charmrepo/v7 v7.0.0-20210107021745-6d3b0475f2e4/go.mod h1:dZDpX+a046U+tWpVqv9dUK62PQKyVjuR8lEhJVLvRpg=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -777,7 +777,7 @@ actions:
 `
 
 func (s *CharmTestHelperSuite) TestActionsCharm(c *gc.C) {
-	actions, err := charm.ReadActionsYaml(bytes.NewBuffer([]byte(actionsYaml)))
+	actions, err := charm.ReadActionsYaml("somecharm", bytes.NewBuffer([]byte(actionsYaml)))
 	c.Assert(err, jc.ErrorIsNil)
 
 	forEachStandardCharm(c, func(name string) {

--- a/testcharms/charm-repo/quantal/juju-controller/hooks/install
+++ b/testcharms/charm-repo/quantal/juju-controller/hooks/install
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Done!"

--- a/testcharms/charm-repo/quantal/juju-controller/metadata.yaml
+++ b/testcharms/charm-repo/quantal/juju-controller/metadata.yaml
@@ -1,0 +1,4 @@
+name: juju-controller
+summary: "The Juju Controller"
+description: |
+    The Juju controller.


### PR DESCRIPTION
Introduce initial support for using a controller charm. The charm will be used to relate to a new dashboard charm.
This initial PR wires up support for specifying a local controller charm at bootstrap to enable development to occur.

Restrictions on the controller charm are:
- it must be called "juju-controller"
- it cannot be deployed manually
- it cannot be removed or have units added/removed

Eventually add/remove unit will replace enable-ha, but there's a lot to do to get there.

## QA steps

Create a local charm called "juju-controller"

```
juju bootstrap lxd --controller-charm /path/to/charm --no-default-model
juju status
```
status shows that there's a controller app with one unit

juju add-unit controller -> error
juju remove-unit controller/0 -> error
juju remove-application controller -> error

