### PR TITLE
cs for percona-cluster not required, available in charmhub now

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -44,7 +44,7 @@ manual_deploy() {
 
     juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
 
-    juju deploy cs:percona-cluster
+    juju deploy percona-cluster
 
     wait_for "percona-cluster" "$(idle_condition "percona-cluster" 0 0)"
 


### PR DESCRIPTION

persona-cluster is now available in charmhub production area, no need to specify charmstore to deploy