### PR TITLE
Look for "deadline exceeded" error and increase timeout to cover login

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -136,7 +136,8 @@ type DialOpts struct {
 	DialTimeout time.Duration
 
 	// Timeout is the amount of time to wait for the entire
-	// api.Open to succeed. If this is zero, there is no timeout.
+	// api.Open to succeed (including dial and login). If this is
+	// zero, there is no timeout.
 	Timeout time.Duration
 
 	// RetryDelay is the amount of time to wait between

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -42,7 +42,7 @@ func getBlockAPI(c *modelcmd.ModelCommandBase) (listBlocksAPI, error) {
 	// Set a short dial timeout so WaitForAgentInitialisation can check
 	// ctx.Done() in its retry loop.
 	dialOpts := api.DefaultDialOpts()
-	dialOpts.Timeout = 3 * time.Second
+	dialOpts.Timeout = 6 * time.Second
 
 	root, err := c.NewAPIRootWithDialOpts(&dialOpts)
 	if err != nil {
@@ -129,6 +129,7 @@ func WaitForAgentInitialisation(
 			strings.HasSuffix(errorMessage, "connection refused"),
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
+			strings.HasSuffix(errorMessage, "deadline exceeded"),
 			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):
 			ctx.Verbosef("Still waiting for API to become available: %v", err)


### PR DESCRIPTION
As of PR #12475, tryAPI/getBlockAPI set the dial timeout to 3 seconds
(the default is 10 minutes) so we can retry and check context
cancellation (for Ctrl-C handling) in the WaitForAgentInitialisation
loop. However, this timeout includes both the dial and the controller
login, and just after bootstrap it sometimes takes more than 3 seconds.
Because we didn't catch the "deadline exceeded" error, it didn't retry
but instead failed the bootstrap there and then.

This was causing our nw-cross-model-relations CI tests to fail
frequently when bootstrapping on AWS (and is probably an issue in real
life too). 3 out of 5 of the recent failures should be fixed by this.

Alternatively we could add a separate DialOpts.LoginTimeout and use that
if present, but it doesn't seem worth it. 6 seconds is double the
timeout we had, and is still relatively short enough to be responsive
to Ctrl-C during bootstrap.

Example failure log, before this fix was in place
(https://jenkins.juju.canonical.com/job/nw-cross-model-relations/2808/console):

Running machine configuration script...
Bootstrap agent now started
17:27:20 INFO  juju.juju api.go:314 API endpoints changed from [] to [52.53.163.253:17070 172.31.0.153:17070]
Contacting Juju controller at 52.53.163.253 to verify accessibility...
17:27:20 INFO  juju.juju api.go:76 connecting to API addresses: [52.53.163.253:17070 172.31.0.153:17070]
17:27:23 INFO  cmd controller.go:134 Still waiting for API to become available: dial tcp 172.31.0.153:17070: i/o timeout
17:27:23 INFO  juju.juju api.go:76 connecting to API addresses: [52.53.163.253:17070 172.31.0.153:17070]
17:27:26 INFO  juju.api apiclient.go:641 connection established to "wss://52.53.163.253:17070/model/ee0b64bf-f8e8-4e16-88e1-ee382a74acaa/api"
17:27:26 ERROR juju.cmd.juju.commands bootstrap.go:879 unable to contact api server after 2 attempts: cannot log in: context deadline exceeded
