### PR TITLE
Add controller charm units to new HA controller machines

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2150,7 +2150,7 @@ func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
 			err:       `--controller-charm ".*" is not a valid charm`,
 		}, {
 			charmPath: "/invalid/path",
-			err:       `problem with --controller-charm: stat /invalid/path: no such file or directory`,
+			err:       `problem with --controller-charm: .* /invalid/path: .*`,
 		},
 	} {
 		var gotArgs bootstrap.BootstrapParams

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
@@ -485,7 +486,8 @@ func addControllerApplication(st *state.State, curl *charm.URL, m *state.Machine
 			addr = pa.Value
 		}
 	}
-	cfg["controller-url"] = fmt.Sprintf("https://%s", addr)
+	cfg["controller-url"] = api.ControllerAPIURL(addr)
+	cfg["model-url-template"] = api.ModelAPITemplateURL(addr)
 	app, err := st.AddApplication(state.AddApplicationArgs{
 		Name:   bootstrap.ControllerApplicationName,
 		Series: curl.Series,

--- a/state/application.go
+++ b/state/application.go
@@ -2080,7 +2080,7 @@ func (a *Application) addUnitOps(
 		if err != nil {
 			return "", nil, errors.Trace(err)
 		}
-		if args.machineID != "" {
+		if args.machineID != "" && !strings.HasPrefix(a.doc.CharmURL.Name, "juju-") {
 			return "", nil, errors.NotSupportedf("non-empty machineID")
 		}
 	}

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -8,9 +8,6 @@ import (
 	"strconv"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/tools"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset"
 	jujutxn "github.com/juju/txn"
@@ -22,7 +19,10 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/mongo"
 	stateerrors "github.com/juju/juju/state/errors"
+	"github.com/juju/juju/tools"
 )
 
 func isController(mdoc *machineDoc) bool {

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -105,6 +105,50 @@ func (s *EnableHASuite) TestEnableHAAddsNewMachines(c *gc.C) {
 	s.assertControllerInfo(c, ids, ids, nil)
 }
 
+func (s *EnableHASuite) TestEnableHAAddsControllerCharm(c *gc.C) {
+	state.AddTestingApplicationForSeries(c, s.State, "focal", "controller",
+		state.AddTestingCharmMultiSeries(c, s.State, "juju-controller"))
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(changes.Added, gc.HasLen, 3)
+	for i := 0; i < 3; i++ {
+		unitName := fmt.Sprintf("controller/%d", i)
+		m, err := s.State.Machine(fmt.Sprint(i))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.Principals(), jc.DeepEquals, []string{unitName})
+		u, err := s.State.Unit(unitName)
+		c.Assert(err, jc.ErrorIsNil)
+		mID, err := u.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(mID, gc.Equals, fmt.Sprint(i))
+	}
+}
+
+func (s *EnableHASuite) TestEnableHAAddsControllerCharmToPromoted(c *gc.C) {
+	state.AddTestingApplicationForSeries(c, s.State, "focal", "controller",
+		state.AddTestingCharmMultiSeries(c, s.State, "juju-controller"))
+	m0, err := s.State.AddMachine("bionic", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", []string{"0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(changes.Added, gc.HasLen, 2)
+	c.Assert(changes.Converted, gc.HasLen, 1)
+	for i := 0; i < 3; i++ {
+		unitName := fmt.Sprintf("controller/%d", i)
+		m, err := s.State.Machine(fmt.Sprint(i))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.Principals(), jc.DeepEquals, []string{unitName})
+		u, err := s.State.Unit(unitName)
+		c.Assert(err, jc.ErrorIsNil)
+		mID, err := u.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(mID, gc.Equals, fmt.Sprint(i))
+	}
+	err = m0.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m0.Principals(), gc.DeepEquals, []string{"controller/0"})
+}
+
 func (s *EnableHASuite) TestEnableHATo(c *gc.C) {
 	ids := make([]string, 3)
 	m0, err := s.State.AddMachine("bionic", state.JobHostUnits, state.JobManageModel)

--- a/state/machine.go
+++ b/state/machine.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/constraints"
 	corecontainer "github.com/juju/juju/core/container"
@@ -1768,7 +1769,8 @@ func (st *State) maybeUpdateControllerCharm(publicAddr string) error {
 		return errors.Trace(err)
 	}
 	return controllerApp.UpdateCharmConfig(model.GenerationMaster, charm.Settings{
-		"controller-url": fmt.Sprintf("https://%s", publicAddr),
+		"controller-url":     api.ControllerAPIURL(publicAddr),
+		"model-url-template": api.ModelAPITemplateURL(publicAddr),
 	})
 }
 


### PR DESCRIPTION
For new controller machines created by enable-ha, add a controller charm unit to those machines.

Update the controller charm set up to write values for:
- controller-url
- model-url-template
(these will be used by the dashboard charm).

## QA steps

cd charms
git clone https://github.com/juju/juju-controller.git
cd juju-controller
charmcraft build

$ juju bootstrap lxd --controller-charm /path/to/charms/juju-controller/build --no-default-model
$ juju enable-ha
$ juju status

see each machine has a controller charm

$ juju add-machine
$ juju enable-ha -n 5 --to 3
$ juju statuus

see each machine has a controller charm