### PR TITLE
Add Windows error message version for connection refused

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -127,6 +127,7 @@ func WaitForAgentInitialisation(
 		case errors.Cause(err) == io.EOF,
 			strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
 			strings.HasSuffix(errorMessage, "connection refused"),
+			strings.HasSuffix(errorMessage, "target machine actively refused it."), // Winsock message for connection refused
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
 			strings.HasSuffix(errorMessage, "deadline exceeded"),


### PR DESCRIPTION
There's bound to be some better way to portably test if an error is a
connection refused error, but it's certainly not easy to find if there
is. There's syscall.ECONNREFUSED, but I believe this error would print
as plain "connection refused" if that were the underlying error, so I
think it's not actually ECONNREFUSED.

This should fix the nw-deploy-client-windows failures:
* https://jenkins.juju.canonical.com/job/nw-deploy-client-windows/2433/console
* https://jenkins.juju.canonical.com/job/nw-deploy-client-windows/2434/console
