### PR TITLE
2.9 - Remove legacy check for ongoing space discovery at login

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -130,8 +130,7 @@ func WaitForAgentInitialisation(
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
 			strings.HasSuffix(errorMessage, "deadline exceeded"),
-			strings.HasSuffix(errorMessage, "no api connection available"),
-			strings.Contains(errorMessage, "spaces are still being discovered"):
+			strings.HasSuffix(errorMessage, "no api connection available"):
 			ctx.Verbosef("Still waiting for API to become available: %v", err)
 			continue
 		case params.ErrCode(err) == params.CodeUpgradeInProgress:

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -39,19 +39,14 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 			s.mockBlockClient.loginError = nil
 			return nil, err
 		}
-		if s.mockBlockClient.discoveringSpacesError > 0 {
-			s.mockBlockClient.discoveringSpacesError -= 1
-			return nil, errors.New("spaces are still being discovered")
-		}
 		return s.mockBlockClient, nil
 	})
 }
 
 type mockBlockClient struct {
-	retryCount             int
-	numRetries             int
-	discoveringSpacesError int
-	loginError             error
+	retryCount int
+	numRetries int
+	loginError error
 }
 
 var errOther = errors.New("other error")
@@ -112,17 +107,6 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *gc.C) {
 		}
 		c.Check(s.mockBlockClient.retryCount, gc.Equals, expectedRetries)
 	}
-}
-
-func (s *controllerSuite) TestWaitForAgentAPIReadyWaitsForSpaceDiscovery(c *gc.C) {
-	s.mockBlockClient.discoveringSpacesError = 2
-
-	runInCommand(c, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
-		bootstrapCtx := modelcmd.BootstrapContext(context.Background(), ctx)
-		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
-		c.Check(err, jc.ErrorIsNil)
-	})
-	c.Assert(s.mockBlockClient.discoveringSpacesError, gc.Equals, 0)
 }
 
 func (s *controllerSuite) TestWaitForAgentAPIReadyRetriesWithOpenEOFErr(c *gc.C) {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -7,7 +7,6 @@
 package featuretests
 
 import (
-	"strings"
 	"time"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -301,21 +300,10 @@ func canLoginToAPIAsMachine(c *gc.C, fromConf, toConf agent.Config) bool {
 	toInfo, ok := toConf.APIInfo()
 	c.Assert(ok, jc.IsTrue)
 	fromInfo.Addrs = toInfo.Addrs
-	var err error
-	var apiState api.Connection
-	for a := ShortAttempt.Start(); a.Next(); {
-		apiState, err = api.Open(fromInfo, upgradeTestDialOpts)
-		// If space discovery is still in progress we retry.
-		if err != nil && strings.Contains(err.Error(), "spaces are still being discovered") {
-			if !a.HasNext() {
-				return false
-			}
-			continue
-		}
-		if apiState != nil {
-			apiState.Close()
-		}
-		break
+
+	apiState, err := api.Open(fromInfo, upgradeTestDialOpts)
+	if apiState != nil {
+		func() { _ = apiState.Close() }()
 	}
 	return apiState != nil && err == nil
 }


### PR DESCRIPTION
The post bootstrap login tests returned errors for a set of sub-strings, including "spaces are still being discovered". 

This check appears to date from the 2.0 betas (or earlier) and is redundant. Space discovery is done synchronously for each new model, and Juju does not emit this message.

The check for this sub-string is removed, as are tests associated with it.

## QA steps

Bootstrap to MAAS as a regression test. _guimaas_ is not working at the time of writing, but _finfolk_ works.

## Documentation changes

None.

## Bug reference

N/A
