### PR TITLE
Fix RemoveOfferOperation for server-side transactions

### DIFF
--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -262,13 +262,6 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 				return nil, err
 			}
 
-			logger.Debugf("forcing cleanup of remote application %v", remoteApp.Name())
-			remoteAppOps, err := remoteApp.DestroyOperation(op.Force).Build(attempt)
-			if err != nil && err != jujutxn.ErrNoOperations {
-				op.AddError(err)
-			}
-			ops = append(ops, remoteAppOps...)
-
 			// Force any remote units to leave scope so the offer
 			// can be cleaned up.
 			logger.Debugf("forcing cleanup of units for %v", remoteApp.Name())
@@ -295,6 +288,13 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 				return nil, errors.Trace(err)
 			}
 			ops = append(ops, relOps...)
+
+			logger.Debugf("forcing cleanup of remote application %v", remoteApp.Name())
+			remoteAppOps, err := remoteApp.DestroyOperation(op.Force).Build(attempt)
+			if err != nil && err != jujutxn.ErrNoOperations {
+				op.AddError(err)
+			}
+			ops = append(ops, remoteAppOps...)
 		} else {
 			ops = append(ops, txn.Op{
 				C:      relationsC,


### PR DESCRIPTION
The model operation for removing application offers currently accrues transaction operations for removing the remote application *before* those for pushing relation units out of scope and removing relations.

It means that the following operations against the _remoteApplications_ collection are accumulated (in listed order):
```
(txn.Op) {
  C: (string) (len=18) "remoteApplications",
  Id: (string) (len=46) "2e156330-ca09-406e-8668-e9e6bfc32290:wordpress",
  Assert: (bson.D) (len=2 cap=2) {
   (bson.DocElem) {
    Name: (string) (len=4) "life",
    Value: (state.Life) alive
   },
   (bson.DocElem) {
    Name: (string) (len=13) "relationcount",
    Value: (int) 1
   }
  },
  Insert: (interface {}) <nil>,
  Update: (interface {}) <nil>,
  Remove: (bool) true
 },

(txn.Op) {
  C: (string) (len=18) "remoteApplications",
  Id: (string) (len=46) "2e156330-ca09-406e-8668-e9e6bfc32290:wordpress",
  Assert: (bson.D) (len=2 cap=2) {
   (bson.DocElem) {
    Name: (string) (len=13) "relationcount",
    Value: (bson.D) (len=1 cap=1) {
     (bson.DocElem) {
      Name: (string) (len=3) "$gt",
      Value: (int) 0
     }
    }
   },
   (bson.DocElem) {
    Name: (string) (len=4) "life",
    Value: (state.Life) alive
   }
  },
  Insert: (interface {}) <nil>,
  Update: (bson.D) (len=1 cap=1) {
   (bson.DocElem) {
    Name: (string) (len=4) "$inc",
    Value: (bson.D) (len=1 cap=1) {
     (bson.DocElem) {
      Name: (string) (len=13) "relationcount",
      Value: (int) -1
     }
    }
   }
  },
  Remove: (bool) false
 },
}
```

This is a deletion and subsequent update of the same document, which is forgiven by the client-side transaction implementation, but not by the server-side one.

This patch rearranges the composition so that the update occurs before the deletion.

## QA steps

The exact same operations are generated as before, just in a different order.
- Apply this patch:
```diff
diff --git a/state/open.go b/state/open.go
index e1e6284012..930a7da75e 100644
--- a/state/open.go
+++ b/state/open.go
@@ -136,7 +136,7 @@ func newState(
        // plus txn.Op slices that are wrong, eg insert dup or missing asserts.
        // Related test failures here:
        // https://jenkins.juju.canonical.com/job/github-make-check-juju/9317/testReport/
-       sstxn = false
+       sstxn = true

        if sstxn {
                logger.Infof("using server-side transactions")
```
- Run the _applicationOffersSuite.TestRemoveOffersWithConnectionsForce_ unit test in the state package.

## Documentation changes

None.

## Bug reference

N/A
