### PR TITLE
Add indexes to instanceData collection

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -319,7 +319,11 @@ func allCollections() CollectionSchema {
 
 		// These collections hold information associated with machines.
 		containerRefsC: {},
-		instanceDataC:  {},
+		instanceDataC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machineid"},
+			}},
+		},
 		machinesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machineid"},

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -322,6 +322,8 @@ func allCollections() CollectionSchema {
 		instanceDataC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machineid"},
+			}, {
+				Key: []string{"model-uuid", "instanceid"},
 			}},
 		},
 		machinesC: {


### PR DESCRIPTION
Some logging output captured by @wallyworld shows full scans on the `instanceData` collection.
```
Jan 07 04:54:05 juju-4da59b22-9710-4e69-840a-be49ee864a97-machine-2 mongod.37017[24139]: [conn24411] command juju.settings command: find { find: "settings", filter: { model-uuid: "399d2e29-7731-49c6-89db-1c6cfaea2615" }, skip: 0 } planSummary: COLLSCAN keysExamined:0 docsExamined:58153 cursorExhausted:1 keyUpdates:0 writeConflicts:0 numYields:454 nreturned:1 reslen:2331 locks:{ Global: { acquireCount: { r: 910 } }, Database: { acquireCount: { r: 455 } }, Collection: { acquireCount: { r: 455 } } 
Jan 07 04:54:05 juju-4da59b22-9710-4e69-840a-be49ee864a97-machine-2 mongod.37017[24139]: [conn24678] command juju.instanceData command: find { find: "instanceData", filter: { model-uuid: "c176930a-26e8-4de6-8460-2054d5c0904f" }, skip: 0 } planSummary: COLLSCAN keysExamined:0 docsExamined:103992 cursorExhausted:1 keyUpdates:0 writeConflicts:0 numYields:812 nreturned:0 reslen:123 locks:{ Global: { acquireCount: { r: 1626 } }, Database: { acquireCount: { r: 813 } }, Collection: { acquireCount: ...
```
This patch adds indexes that will accommodate the majority (if not all) access patterns:
- model UUID + machine ID
- model UUID + instance ID

## QA steps

- Bootstrap and add some machines.
- Connect to Mongo and run a query, retrieving stats.
```
db.instanceData.find({"model-uuid": "<id>"}).explain("executionStats")
```
- Return should indicate that the index was used.

## Documentation changes

None.

## Bug reference

N/A
