### PR TITLE
Use k8s in-cluster creds when inside same cluster as controller.

### DIFF
--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -81,15 +81,16 @@ func (api *CloudSpecAPI) MakeCloudSpec(pSpec *params.CloudSpec) (environscloudsp
 		credential = &credentialValue
 	}
 	spec := environscloudspec.CloudSpec{
-		Type:             pSpec.Type,
-		Name:             pSpec.Name,
-		Region:           pSpec.Region,
-		Endpoint:         pSpec.Endpoint,
-		IdentityEndpoint: pSpec.IdentityEndpoint,
-		StorageEndpoint:  pSpec.StorageEndpoint,
-		CACertificates:   pSpec.CACertificates,
-		SkipTLSVerify:    pSpec.SkipTLSVerify,
-		Credential:       credential,
+		Type:              pSpec.Type,
+		Name:              pSpec.Name,
+		Region:            pSpec.Region,
+		Endpoint:          pSpec.Endpoint,
+		IdentityEndpoint:  pSpec.IdentityEndpoint,
+		StorageEndpoint:   pSpec.StorageEndpoint,
+		CACertificates:    pSpec.CACertificates,
+		SkipTLSVerify:     pSpec.SkipTLSVerify,
+		Credential:        credential,
+		IsControllerCloud: pSpec.IsControllerCloud,
 	}
 	if err := spec.Validate(); err != nil {
 		return environscloudspec.CloudSpec{}, errors.Annotate(err, "validating CloudSpec")

--- a/apiserver/common/cloud.go
+++ b/apiserver/common/cloud.go
@@ -30,17 +30,18 @@ func CloudToParams(cloud jujucloud.Cloud) params.Cloud {
 		regionConfig[r] = attr
 	}
 	return params.Cloud{
-		Type:             cloud.Type,
-		HostCloudRegion:  cloud.HostCloudRegion,
-		AuthTypes:        authTypes,
-		Endpoint:         cloud.Endpoint,
-		IdentityEndpoint: cloud.IdentityEndpoint,
-		StorageEndpoint:  cloud.StorageEndpoint,
-		Regions:          regions,
-		CACertificates:   cloud.CACertificates,
-		SkipTLSVerify:    cloud.SkipTLSVerify,
-		Config:           cloud.Config,
-		RegionConfig:     regionConfig,
+		Type:              cloud.Type,
+		HostCloudRegion:   cloud.HostCloudRegion,
+		AuthTypes:         authTypes,
+		Endpoint:          cloud.Endpoint,
+		IdentityEndpoint:  cloud.IdentityEndpoint,
+		StorageEndpoint:   cloud.StorageEndpoint,
+		Regions:           regions,
+		CACertificates:    cloud.CACertificates,
+		SkipTLSVerify:     cloud.SkipTLSVerify,
+		Config:            cloud.Config,
+		RegionConfig:      regionConfig,
+		IsControllerCloud: cloud.IsControllerCloud,
 	}
 }
 
@@ -66,16 +67,17 @@ func CloudFromParams(cloudName string, p params.Cloud) jujucloud.Cloud {
 		regionConfig[r] = attr
 	}
 	return jujucloud.Cloud{
-		Name:             cloudName,
-		Type:             p.Type,
-		AuthTypes:        authTypes,
-		Endpoint:         p.Endpoint,
-		IdentityEndpoint: p.IdentityEndpoint,
-		StorageEndpoint:  p.StorageEndpoint,
-		Regions:          regions,
-		CACertificates:   p.CACertificates,
-		SkipTLSVerify:    p.SkipTLSVerify,
-		Config:           p.Config,
-		RegionConfig:     regionConfig,
+		Name:              cloudName,
+		Type:              p.Type,
+		AuthTypes:         authTypes,
+		Endpoint:          p.Endpoint,
+		IdentityEndpoint:  p.IdentityEndpoint,
+		StorageEndpoint:   p.StorageEndpoint,
+		Regions:           regions,
+		CACertificates:    p.CACertificates,
+		SkipTLSVerify:     p.SkipTLSVerify,
+		Config:            p.Config,
+		RegionConfig:      regionConfig,
+		IsControllerCloud: p.IsControllerCloud,
 	}
 }

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -96,15 +96,16 @@ func (s cloudSpecAPI) GetCloudSpec(tag names.ModelTag) params.CloudSpecResult {
 		}
 	}
 	result.Result = &params.CloudSpec{
-		Type:             spec.Type,
-		Name:             spec.Name,
-		Region:           spec.Region,
-		Endpoint:         spec.Endpoint,
-		IdentityEndpoint: spec.IdentityEndpoint,
-		StorageEndpoint:  spec.StorageEndpoint,
-		Credential:       paramsCloudCredential,
-		CACertificates:   spec.CACertificates,
-		SkipTLSVerify:    spec.SkipTLSVerify,
+		Type:              spec.Type,
+		Name:              spec.Name,
+		Region:            spec.Region,
+		Endpoint:          spec.Endpoint,
+		IdentityEndpoint:  spec.IdentityEndpoint,
+		StorageEndpoint:   spec.StorageEndpoint,
+		Credential:        paramsCloudCredential,
+		CACertificates:    spec.CACertificates,
+		SkipTLSVerify:     spec.SkipTLSVerify,
+		IsControllerCloud: spec.IsControllerCloud,
 	}
 	return result
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1355,6 +1355,9 @@
                         "identity-endpoint": {
                             "type": "string"
                         },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
                         "name": {
                             "type": "string"
                         },
@@ -6266,6 +6269,9 @@
                         },
                         "identity-endpoint": {
                             "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
                         },
                         "name": {
                             "type": "string"
@@ -16580,6 +16586,9 @@
                         "identity-endpoint": {
                             "type": "string"
                         },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
                         "region-config": {
                             "type": "object",
                             "patternProperties": {
@@ -17778,6 +17787,9 @@
                         },
                         "identity-endpoint": {
                             "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
                         },
                         "name": {
                             "type": "string"
@@ -21446,6 +21458,9 @@
                         },
                         "identity-endpoint": {
                             "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
                         },
                         "name": {
                             "type": "string"
@@ -43277,6 +43292,9 @@
                         },
                         "identity-endpoint": {
                             "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
                         },
                         "name": {
                             "type": "string"

--- a/apiserver/params/cloud.go
+++ b/apiserver/params/cloud.go
@@ -5,17 +5,18 @@ package params
 
 // Cloud holds information about a cloud.
 type Cloud struct {
-	Type             string                            `json:"type"`
-	HostCloudRegion  string                            `json:"host-cloud-region,omitempty"`
-	AuthTypes        []string                          `json:"auth-types,omitempty"`
-	Endpoint         string                            `json:"endpoint,omitempty"`
-	IdentityEndpoint string                            `json:"identity-endpoint,omitempty"`
-	StorageEndpoint  string                            `json:"storage-endpoint,omitempty"`
-	Regions          []CloudRegion                     `json:"regions,omitempty"`
-	CACertificates   []string                          `json:"ca-certificates,omitempty"`
-	SkipTLSVerify    bool                              `json:"skip-tls-verify,omitempty"`
-	Config           map[string]interface{}            `json:"config,omitempty"`
-	RegionConfig     map[string]map[string]interface{} `json:"region-config,omitempty"`
+	Type              string                            `json:"type"`
+	HostCloudRegion   string                            `json:"host-cloud-region,omitempty"`
+	AuthTypes         []string                          `json:"auth-types,omitempty"`
+	Endpoint          string                            `json:"endpoint,omitempty"`
+	IdentityEndpoint  string                            `json:"identity-endpoint,omitempty"`
+	StorageEndpoint   string                            `json:"storage-endpoint,omitempty"`
+	Regions           []CloudRegion                     `json:"regions,omitempty"`
+	CACertificates    []string                          `json:"ca-certificates,omitempty"`
+	SkipTLSVerify     bool                              `json:"skip-tls-verify,omitempty"`
+	Config            map[string]interface{}            `json:"config,omitempty"`
+	RegionConfig      map[string]map[string]interface{} `json:"region-config,omitempty"`
+	IsControllerCloud bool                              `json:"is-controller-cloud,omitempty"`
 }
 
 // CloudRegion holds information about a cloud region.
@@ -191,15 +192,16 @@ type TaggedCredential struct {
 
 // CloudSpec holds a cloud specification.
 type CloudSpec struct {
-	Type             string           `json:"type"`
-	Name             string           `json:"name"`
-	Region           string           `json:"region,omitempty"`
-	Endpoint         string           `json:"endpoint,omitempty"`
-	IdentityEndpoint string           `json:"identity-endpoint,omitempty"`
-	StorageEndpoint  string           `json:"storage-endpoint,omitempty"`
-	Credential       *CloudCredential `json:"credential,omitempty"`
-	CACertificates   []string         `json:"cacertificates,omitempty"`
-	SkipTLSVerify    bool             `json:"skip-tls-verify,omitempty"`
+	Type              string           `json:"type"`
+	Name              string           `json:"name"`
+	Region            string           `json:"region,omitempty"`
+	Endpoint          string           `json:"endpoint,omitempty"`
+	IdentityEndpoint  string           `json:"identity-endpoint,omitempty"`
+	StorageEndpoint   string           `json:"storage-endpoint,omitempty"`
+	Credential        *CloudCredential `json:"credential,omitempty"`
+	CACertificates    []string         `json:"cacertificates,omitempty"`
+	SkipTLSVerify     bool             `json:"skip-tls-verify,omitempty"`
+	IsControllerCloud bool             `json:"is-controller-cloud,omitempty"`
 }
 
 // CloudSpecResult contains a CloudSpec or an error.

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8sstorage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -489,7 +490,9 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 				},
 				Spec: core.PodSpec{
-					RestartPolicy: core.RestartPolicyAlways,
+					RestartPolicy:                core.RestartPolicyAlways,
+					ServiceAccountName:           "controller",
+					AutomountServiceAccountToken: boolPtr(true),
 					Volumes: []core.Volume{
 						{
 							Name: "juju-controller-test-server-pem",
@@ -716,6 +719,42 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 		},
 	}
 
+	controllerServiceAccount := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "controller",
+			Namespace: "controller-1",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by":  "juju",
+				"app.kubernetes.io/name":        "juju-controller-test",
+				"model.juju.is/disable-webhook": "true",
+			},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
+		},
+		AutomountServiceAccountToken: boolPtr(true),
+	}
+
+	controllerServiceCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "controller-1",
+			Labels: map[string]string{
+				"model.juju.is/name": "controller",
+			},
+			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "controller",
+				Namespace: "controller-1",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	}
+
 	eventsPartial := &core.EventList{
 		Items: []core.Event{
 			{
@@ -860,6 +899,13 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			Return(&core.ConfigMapList{Items: []core.ConfigMap{*configMapWithBootstrapParamsAdded}}, nil),
 		s.mockConfigMaps.EXPECT().Update(gomock.Any(), configMapWithAgentConfAdded, v1.UpdateOptions{}).AnyTimes().
 			Return(configMapWithAgentConfAdded, nil),
+
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), controllerServiceAccount, v1.CreateOptions{}).
+			Return(controllerServiceAccount, nil),
+		s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=controller"}).
+			Return(&rbacv1.ClusterRoleBindingList{}, nil),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), controllerServiceCRB, v1.CreateOptions{}).
+			Return(controllerServiceCRB, nil),
 
 		// Check the operator storage exists.
 		// first check if <namespace>-<storage-class> exist or not.

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -89,6 +89,17 @@ var NewK8sClients = func(c *rest.Config) (
 
 // CloudSpecToK8sRestConfig translates cloudspec to k8s rest config.
 func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Config, error) {
+	if cloudSpec.IsControllerCloud {
+		rc, err := rest.InClusterConfig()
+		if err != nil && err != rest.ErrNotInCluster {
+			return nil, errors.Trace(err)
+		}
+		if rc != nil {
+			logger.Infof("using in-cluster config")
+			return rc, nil
+		}
+	}
+
 	if cloudSpec.Credential == nil {
 		return nil, errors.Errorf("cloud %v has no credential", cloudSpec.Name)
 	}

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -25,6 +25,7 @@ func (k *kubernetesClient) deleteClusterScopeResourcesModelTeardown(ctx context.
 		labelSetToRequirements(labels)...,
 	)
 
+	// TODO(caas): Fix to only delete cluster wide resources created by this controller.
 	tasks := []teardownResources{
 		k.deleteClusterRoleBindingsModelTeardown,
 		k.deleteClusterRolesModelTeardown,

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -170,6 +170,9 @@ type Cloud struct {
 	// validate certificates. It is not recommended for production clouds.
 	// It is secure (false) by default.
 	SkipTLSVerify bool
+
+	// IsControllerCloud is true when this is the cloud used by the controller.
+	IsControllerCloud bool
 }
 
 // SplitHostCloudRegion splits host cloud region to cloudType and region.
@@ -226,19 +229,20 @@ type cloudSet struct {
 
 // cloud is equivalent to Cloud, for marshalling and unmarshalling.
 type cloud struct {
-	Name             string                 `yaml:"name,omitempty"`
-	Type             string                 `yaml:"type"`
-	HostCloudRegion  string                 `yaml:"host-cloud-region,omitempty"`
-	Description      string                 `yaml:"description,omitempty"`
-	AuthTypes        []AuthType             `yaml:"auth-types,omitempty,flow"`
-	Endpoint         string                 `yaml:"endpoint,omitempty"`
-	IdentityEndpoint string                 `yaml:"identity-endpoint,omitempty"`
-	StorageEndpoint  string                 `yaml:"storage-endpoint,omitempty"`
-	Regions          regions                `yaml:"regions,omitempty"`
-	Config           map[string]interface{} `yaml:"config,omitempty"`
-	RegionConfig     RegionConfig           `yaml:"region-config,omitempty"`
-	CACertificates   []string               `yaml:"ca-certificates,omitempty"`
-	SkipTLSVerify    bool                   `yaml:"skip-tls-verify,omitempty"`
+	Name              string                 `yaml:"name,omitempty"`
+	Type              string                 `yaml:"type"`
+	HostCloudRegion   string                 `yaml:"host-cloud-region,omitempty"`
+	Description       string                 `yaml:"description,omitempty"`
+	AuthTypes         []AuthType             `yaml:"auth-types,omitempty,flow"`
+	Endpoint          string                 `yaml:"endpoint,omitempty"`
+	IdentityEndpoint  string                 `yaml:"identity-endpoint,omitempty"`
+	StorageEndpoint   string                 `yaml:"storage-endpoint,omitempty"`
+	Regions           regions                `yaml:"regions,omitempty"`
+	Config            map[string]interface{} `yaml:"config,omitempty"`
+	RegionConfig      RegionConfig           `yaml:"region-config,omitempty"`
+	CACertificates    []string               `yaml:"ca-certificates,omitempty"`
+	SkipTLSVerify     bool                   `yaml:"skip-tls-verify,omitempty"`
+	IsControllerCloud bool                   `yaml:"is-controller-cloud,omitempty"`
 }
 
 // regions is a collection of regions, either as a map and/or
@@ -487,18 +491,19 @@ func cloudToInternal(in Cloud, withName bool) *cloud {
 		name = ""
 	}
 	return &cloud{
-		Name:             name,
-		Type:             in.Type,
-		HostCloudRegion:  in.HostCloudRegion,
-		AuthTypes:        in.AuthTypes,
-		Endpoint:         in.Endpoint,
-		IdentityEndpoint: in.IdentityEndpoint,
-		StorageEndpoint:  in.StorageEndpoint,
-		Regions:          regions,
-		Config:           in.Config,
-		RegionConfig:     in.RegionConfig,
-		CACertificates:   in.CACertificates,
-		SkipTLSVerify:    in.SkipTLSVerify,
+		Name:              name,
+		Type:              in.Type,
+		HostCloudRegion:   in.HostCloudRegion,
+		AuthTypes:         in.AuthTypes,
+		Endpoint:          in.Endpoint,
+		IdentityEndpoint:  in.IdentityEndpoint,
+		StorageEndpoint:   in.StorageEndpoint,
+		Regions:           regions,
+		Config:            in.Config,
+		RegionConfig:      in.RegionConfig,
+		CACertificates:    in.CACertificates,
+		SkipTLSVerify:     in.SkipTLSVerify,
+		IsControllerCloud: in.IsControllerCloud,
 	}
 }
 
@@ -523,19 +528,20 @@ func cloudFromInternal(in *cloud) Cloud {
 		}
 	}
 	meta := Cloud{
-		Name:             in.Name,
-		Type:             in.Type,
-		HostCloudRegion:  in.HostCloudRegion,
-		AuthTypes:        in.AuthTypes,
-		Endpoint:         in.Endpoint,
-		IdentityEndpoint: in.IdentityEndpoint,
-		StorageEndpoint:  in.StorageEndpoint,
-		Regions:          regions,
-		Config:           in.Config,
-		RegionConfig:     in.RegionConfig,
-		Description:      in.Description,
-		CACertificates:   in.CACertificates,
-		SkipTLSVerify:    in.SkipTLSVerify,
+		Name:              in.Name,
+		Type:              in.Type,
+		HostCloudRegion:   in.HostCloudRegion,
+		AuthTypes:         in.AuthTypes,
+		Endpoint:          in.Endpoint,
+		IdentityEndpoint:  in.IdentityEndpoint,
+		StorageEndpoint:   in.StorageEndpoint,
+		Regions:           regions,
+		Config:            in.Config,
+		RegionConfig:      in.RegionConfig,
+		Description:       in.Description,
+		CACertificates:    in.CACertificates,
+		SkipTLSVerify:     in.SkipTLSVerify,
+		IsControllerCloud: in.IsControllerCloud,
 	}
 	meta.denormaliseMetadata()
 	return meta

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -688,15 +688,16 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 	}
 	return bootstrapConfig, &environs.PrepareConfigParams{
 		Cloud: environscloudspec.CloudSpec{
-			Type:             bootstrapConfig.CloudType,
-			Name:             bootstrapConfig.Cloud,
-			Region:           bootstrapConfig.CloudRegion,
-			Endpoint:         bootstrapConfig.CloudEndpoint,
-			IdentityEndpoint: bootstrapConfig.CloudIdentityEndpoint,
-			StorageEndpoint:  bootstrapConfig.CloudStorageEndpoint,
-			Credential:       credential,
-			CACertificates:   bootstrapConfig.CloudCACertificates,
-			SkipTLSVerify:    bootstrapConfig.SkipTLSVerify,
+			Type:              bootstrapConfig.CloudType,
+			Name:              bootstrapConfig.Cloud,
+			Region:            bootstrapConfig.CloudRegion,
+			Endpoint:          bootstrapConfig.CloudEndpoint,
+			IdentityEndpoint:  bootstrapConfig.CloudIdentityEndpoint,
+			StorageEndpoint:   bootstrapConfig.CloudStorageEndpoint,
+			Credential:        credential,
+			CACertificates:    bootstrapConfig.CloudCACertificates,
+			SkipTLSVerify:     bootstrapConfig.SkipTLSVerify,
+			IsControllerCloud: bootstrapConfig.Cloud == controllerDetails.Cloud,
 		},
 		Config: cfg,
 	}, nil

--- a/environs/cloudspec/cloudspec.go
+++ b/environs/cloudspec/cloudspec.go
@@ -47,6 +47,9 @@ type CloudSpec struct {
 	// validate certificates. It is not recommended for production clouds.
 	// It is secure (false) by default.
 	SkipTLSVerify bool
+
+	// IsControllerCloud is true when this is the cloud used by the controller.
+	IsControllerCloud bool
 }
 
 // Validate validates that the CloudSpec is well-formed. It does
@@ -65,15 +68,16 @@ func (cs CloudSpec) Validate() error {
 // Cloud, cloud and region names, and credential.
 func MakeCloudSpec(cloud jujucloud.Cloud, cloudRegionName string, credential *jujucloud.Credential) (CloudSpec, error) {
 	cloudSpec := CloudSpec{
-		Type:             cloud.Type,
-		Name:             cloud.Name,
-		Region:           cloudRegionName,
-		Endpoint:         cloud.Endpoint,
-		IdentityEndpoint: cloud.IdentityEndpoint,
-		StorageEndpoint:  cloud.StorageEndpoint,
-		CACertificates:   cloud.CACertificates,
-		SkipTLSVerify:    cloud.SkipTLSVerify,
-		Credential:       credential,
+		Type:              cloud.Type,
+		Name:              cloud.Name,
+		Region:            cloudRegionName,
+		Endpoint:          cloud.Endpoint,
+		IdentityEndpoint:  cloud.IdentityEndpoint,
+		StorageEndpoint:   cloud.StorageEndpoint,
+		CACertificates:    cloud.CACertificates,
+		SkipTLSVerify:     cloud.SkipTLSVerify,
+		Credential:        credential,
+		IsControllerCloud: cloud.IsControllerCloud,
 	}
 	if cloudRegionName != "" {
 		cloudRegion, err := jujucloud.RegionByName(cloud.Regions, cloudRegionName)

--- a/featuretests/api_cloud_test.go
+++ b/featuretests/api_cloud_test.go
@@ -50,9 +50,10 @@ func (s *CloudAPISuite) TestCloudAPI(c *gc.C) {
 				StorageEndpoint:  "dummy-storage-endpoint",
 			},
 		},
-		Endpoint:         "dummy-endpoint",
-		IdentityEndpoint: "dummy-identity-endpoint",
-		StorageEndpoint:  "dummy-storage-endpoint",
+		Endpoint:          "dummy-endpoint",
+		IdentityEndpoint:  "dummy-identity-endpoint",
+		StorageEndpoint:   "dummy-storage-endpoint",
+		IsControllerCloud: true,
 	})
 }
 

--- a/state/clouduser.go
+++ b/state/clouduser.go
@@ -110,6 +110,11 @@ type CloudInfo struct {
 // CloudsForUser returns details including access level of clouds which can
 // be seen by the specified user, or all users if the caller is a superuser.
 func (st *State) CloudsForUser(user names.UserTag, all bool) ([]CloudInfo, error) {
+	ci, err := st.ControllerInfo()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// We only treat the user as a superuser if they pass --all
 	isControllerSuperuser := false
 	if all {
@@ -145,7 +150,7 @@ func (st *State) CloudsForUser(user names.UserTag, all bool) ([]CloudInfo, error
 	result := make([]CloudInfo, len(cloudDocs))
 	for i, c := range cloudDocs {
 		result[i] = CloudInfo{
-			Cloud: c.toCloud(),
+			Cloud: c.toCloud(ci.CloudName),
 		}
 	}
 	if err := st.fillInCloudUserAccess(user, result); err != nil {

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -63,13 +63,14 @@ func (s *environSuite) TestCloudSpec(c *gc.C) {
 	cloudSpec, err := stateenvirons.EnvironConfigGetter{Model: m}.CloudSpec()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environscloudspec.CloudSpec{
-		Type:             "dummy",
-		Name:             "dummy",
-		Region:           "dummy-region",
-		Endpoint:         "dummy-endpoint",
-		IdentityEndpoint: "dummy-identity-endpoint",
-		StorageEndpoint:  "dummy-storage-endpoint",
-		Credential:       &emptyCredential,
+		Type:              "dummy",
+		Name:              "dummy",
+		Region:            "dummy-region",
+		Endpoint:          "dummy-endpoint",
+		IdentityEndpoint:  "dummy-identity-endpoint",
+		StorageEndpoint:   "dummy-storage-endpoint",
+		Credential:        &emptyCredential,
+		IsControllerCloud: true,
 	})
 }
 
@@ -95,13 +96,14 @@ func (s *environSuite) TestCloudSpecForModel(c *gc.C) {
 	cloudSpec, err := stateenvirons.CloudSpecForModel(m)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudSpec, jc.DeepEquals, environscloudspec.CloudSpec{
-		Type:             "dummy",
-		Name:             "dummy",
-		Region:           "dummy-region",
-		Endpoint:         "dummy-endpoint",
-		IdentityEndpoint: "dummy-identity-endpoint",
-		StorageEndpoint:  "dummy-storage-endpoint",
-		Credential:       &emptyCredential,
+		Type:              "dummy",
+		Name:              "dummy",
+		Region:            "dummy-region",
+		Endpoint:          "dummy-endpoint",
+		IdentityEndpoint:  "dummy-identity-endpoint",
+		StorageEndpoint:   "dummy-storage-endpoint",
+		Credential:        &emptyCredential,
+		IsControllerCloud: true,
 	})
 }
 


### PR DESCRIPTION
If a model is inside the same Kubernetes cluster/cloud as the controller, the controller will use in-cluster credentials to connect to the k8s cluster.

This creates a ServiceAccount for the controller and uses a ClusterRoleBinding to give it the cluster-admin built-in role.

## QA steps

Bootstrap microk8s, GKE, AKS etc.
Add model with external k8s cluster (different cluster to the controller).
Add model with same k8s cluster (as the controller).

## Documentation changes

N/A

## Bug reference

N/A
