### PR TITLE
Revert "Add controller charm units to new HA controller machines"

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -334,7 +334,7 @@ func (st *state) Context() context.Context {
 // returned will apply a 30-second write deadline, so WriteJSON should
 // only be called from one goroutine.
 func (st *state) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
-	path, err := apiPath(st.modelTag.Id(), path)
+	path, err := apiPath(st.modelTag, path)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -514,7 +514,7 @@ func (st *state) addCookiesToHeader(h http.Header) error {
 // apiEndpoint returns a URL that refers to the given API slash-prefixed
 // endpoint path and query parameters.
 func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
-	path, err := apiPath(st.modelTag.Id(), path)
+	path, err := apiPath(st.modelTag, path)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -526,42 +526,22 @@ func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
 	}, nil
 }
 
-// ControllerAPIURL returns the URL to use to connect to the controller API.
-func ControllerAPIURL(addr string) string {
-	urlStr, _ := url.QueryUnescape(apiURL(addr, "").String())
-	return urlStr
-}
-
-// ModelAPITemplateURL returns a URL template to use to connect to a model API.
-func ModelAPITemplateURL(addr string) string {
-	urlStr, _ := url.QueryUnescape(apiURL(addr, "${modelUUID}").String())
-	return urlStr
-}
-
-func apiURL(addr, model string) *url.URL {
-	path, _ := apiPath(model, "/api")
-	return &url.URL{
-		Scheme: "wss",
-		Host:   addr,
-		Path:   path,
-	}
-}
-
 // Ping implements api.Connection.
 func (s *state) Ping() error {
 	return s.APICall("Pinger", s.pingerFacadeVersion, "", "Ping", nil, nil)
 }
 
 // apiPath returns the given API endpoint path relative
-// to the given model string.
-func apiPath(model, path string) (string, error) {
+// to the given model tag.
+func apiPath(modelTag names.ModelTag, path string) (string, error) {
 	if !strings.HasPrefix(path, "/") {
 		return "", errors.Errorf("cannot make API path from non-slash-prefixed path %q", path)
 	}
-	if model == "" {
+	modelUUID := modelTag.Id()
+	if modelUUID == "" {
 		return path, nil
 	}
-	return modelRoot + model + path, nil
+	return modelRoot + modelUUID + path, nil
 }
 
 // tagToString returns the value of a tag's String method, or "" if the tag is nil.
@@ -635,7 +615,7 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	if opts.DNSCache == nil {
 		opts.DNSCache = nopDNSCache{}
 	}
-	path, err := apiPath(info.ModelTag.Id(), "/api")
+	path, err := apiPath(info.ModelTag, "/api")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2150,7 +2150,7 @@ func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
 			err:       `--controller-charm ".*" is not a valid charm`,
 		}, {
 			charmPath: "/invalid/path",
-			err:       `problem with --controller-charm: .* /invalid/path: .*`,
+			err:       `problem with --controller-charm: stat /invalid/path: no such file or directory`,
 		},
 	} {
 		var gotArgs bootstrap.BootstrapParams

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
@@ -486,8 +485,7 @@ func addControllerApplication(st *state.State, curl *charm.URL, m *state.Machine
 			addr = pa.Value
 		}
 	}
-	cfg["controller-url"] = api.ControllerAPIURL(addr)
-	cfg["model-url-template"] = api.ModelAPITemplateURL(addr)
+	cfg["controller-url"] = fmt.Sprintf("https://%s", addr)
 	app, err := st.AddApplication(state.AddApplicationArgs{
 		Name:   bootstrap.ControllerApplicationName,
 		Series: curl.Series,

--- a/state/application.go
+++ b/state/application.go
@@ -2080,7 +2080,7 @@ func (a *Application) addUnitOps(
 		if err != nil {
 			return "", nil, errors.Trace(err)
 		}
-		if args.machineID != "" && !strings.HasPrefix(a.doc.CharmURL.Name, "juju-") {
+		if args.machineID != "" {
 			return "", nil, errors.NotSupportedf("non-empty machineID")
 		}
 	}

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/tools"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset"
 	jujutxn "github.com/juju/txn"
@@ -19,10 +21,7 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/mongo"
 	stateerrors "github.com/juju/juju/state/errors"
-	"github.com/juju/juju/tools"
 )
 
 func isController(mdoc *machineDoc) bool {
@@ -171,30 +170,9 @@ func (st *State) enableHAIntentionOps(
 	var ops []txn.Op
 	var change ControllersChanges
 
-	// TODO(wallyworld) - only need until we transition away from enable-ha
-	controllerApp, err := st.Application(bootstrap.ControllerApplicationName)
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, ControllersChanges{}, errors.Trace(err)
-	}
-
 	for _, m := range intent.convert {
 		ops = append(ops, convertControllerOps(m)...)
 		change.Converted = append(change.Converted, m.Id())
-		// Add a controller charm unit to the promoted machine.
-		if controllerApp != nil {
-			unitName, unitOps, err := controllerApp.addUnitOps("", AddUnitParams{machineID: m.Id()}, nil)
-			if err != nil {
-				return nil, ControllersChanges{}, errors.Trace(err)
-			}
-			ops = append(ops, unitOps...)
-			addToMachineOp := txn.Op{
-				C:      machinesC,
-				Id:     m.doc.DocID,
-				Assert: txn.DocExists,
-				Update: bson.D{{"$addToSet", bson.D{{"principals", unitName}}}, {"$set", bson.D{{"clean", false}}}},
-			}
-			ops = append(ops, addToMachineOp)
-		}
 	}
 
 	// Use any placement directives that have been provided when adding new
@@ -222,36 +200,15 @@ func (st *State) enableHAIntentionOps(
 			Constraints: cons,
 			Placement:   placement,
 		}
-		// Set up the new controller to have a controller charm unit.
-		// The unit itself is created below.
-		var controllerUnitName string
-		if controllerApp != nil {
-			controllerUnitName, err = controllerApp.newUnitName()
-			if err != nil {
-				return nil, ControllersChanges{}, errors.Trace(err)
-			}
-			template.Dirty = true
-			template.principals = []string{controllerUnitName}
-		}
 		mdoc, addOps, err := st.addMachineOps(template)
 		if err != nil {
-			return nil, ControllersChanges{}, errors.Trace(err)
+			return nil, ControllersChanges{}, err
 		}
 		if isController(mdoc) {
 			controllerIds = append(controllerIds, mdoc.Id)
 		}
 		ops = append(ops, addOps...)
 		change.Added = append(change.Added, mdoc.Id)
-		if controllerApp != nil {
-			_, unitOps, err := controllerApp.addUnitOps("", AddUnitParams{
-				UnitName:  &controllerUnitName,
-				machineID: mdoc.Id,
-			}, nil)
-			if err != nil {
-				return nil, ControllersChanges{}, errors.Trace(err)
-			}
-			ops = append(ops, unitOps...)
-		}
 	}
 
 	for _, m := range intent.maintain {

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -105,50 +105,6 @@ func (s *EnableHASuite) TestEnableHAAddsNewMachines(c *gc.C) {
 	s.assertControllerInfo(c, ids, ids, nil)
 }
 
-func (s *EnableHASuite) TestEnableHAAddsControllerCharm(c *gc.C) {
-	state.AddTestingApplicationForSeries(c, s.State, "focal", "controller",
-		state.AddTestingCharmMultiSeries(c, s.State, "juju-controller"))
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes.Added, gc.HasLen, 3)
-	for i := 0; i < 3; i++ {
-		unitName := fmt.Sprintf("controller/%d", i)
-		m, err := s.State.Machine(fmt.Sprint(i))
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(m.Principals(), jc.DeepEquals, []string{unitName})
-		u, err := s.State.Unit(unitName)
-		c.Assert(err, jc.ErrorIsNil)
-		mID, err := u.AssignedMachineId()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(mID, gc.Equals, fmt.Sprint(i))
-	}
-}
-
-func (s *EnableHASuite) TestEnableHAAddsControllerCharmToPromoted(c *gc.C) {
-	state.AddTestingApplicationForSeries(c, s.State, "focal", "controller",
-		state.AddTestingCharmMultiSeries(c, s.State, "juju-controller"))
-	m0, err := s.State.AddMachine("bionic", state.JobHostUnits)
-	c.Assert(err, jc.ErrorIsNil)
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", []string{"0"})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes.Added, gc.HasLen, 2)
-	c.Assert(changes.Converted, gc.HasLen, 1)
-	for i := 0; i < 3; i++ {
-		unitName := fmt.Sprintf("controller/%d", i)
-		m, err := s.State.Machine(fmt.Sprint(i))
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(m.Principals(), jc.DeepEquals, []string{unitName})
-		u, err := s.State.Unit(unitName)
-		c.Assert(err, jc.ErrorIsNil)
-		mID, err := u.AssignedMachineId()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(mID, gc.Equals, fmt.Sprint(i))
-	}
-	err = m0.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m0.Principals(), gc.DeepEquals, []string{"controller/0"})
-}
-
 func (s *EnableHASuite) TestEnableHATo(c *gc.C) {
 	ids := make([]string, 3)
 	m0, err := s.State.AddMachine("bionic", state.JobHostUnits, state.JobManageModel)

--- a/state/machine.go
+++ b/state/machine.go
@@ -20,7 +20,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/constraints"
 	corecontainer "github.com/juju/juju/core/container"
@@ -1769,8 +1768,7 @@ func (st *State) maybeUpdateControllerCharm(publicAddr string) error {
 		return errors.Trace(err)
 	}
 	return controllerApp.UpdateCharmConfig(model.GenerationMaster, charm.Settings{
-		"controller-url":     api.ControllerAPIURL(publicAddr),
-		"model-url-template": api.ModelAPITemplateURL(publicAddr),
+		"controller-url": fmt.Sprintf("https://%s", publicAddr),
 	})
 }
 


### PR DESCRIPTION
Reverts juju/juju#12491

This appears to have broken many CI tests. Broken tests:

nw-assess-persistent-storage
nw-deploy-bionic-eks
nw-deploy-bionic-amd64-lxd
nw-deploy-multimodel
nw-deploy-xenial-amd64-lxd
nw-grant-revoke
nw-network-health-aws
nw-network-health-azure
nw-network-health-gce
nw-network-health-maas-2-3
nw-network-spaces-aws