### PR TITLE
Ha controller charm again

### DIFF
--- a/acceptancetests/repository/bundles-lxc.yaml
+++ b/acceptancetests/repository/bundles-lxc.yaml
@@ -1,5 +1,5 @@
 dense-scaled:
-  services:
+  applications:
     juju-gui:
       charm: "cs:trusty/juju-gui-16"
       num_units: 1

--- a/acceptancetests/repository/bundles-lxd.yaml
+++ b/acceptancetests/repository/bundles-lxd.yaml
@@ -1,5 +1,5 @@
 dense-scaled:
-  services:
+  applications:
     juju-gui:
       charm: "cs:trusty/juju-gui-16"
       num_units: 1

--- a/acceptancetests/repository/landscape-scalable.yaml
+++ b/acceptancetests/repository/landscape-scalable.yaml
@@ -1,6 +1,6 @@
 landscape-scalable:
     series: trusty
-    services:
+    applications:
         rabbitmq-server:
             charm: cs:trusty/rabbitmq-server-7
         postgresql:

--- a/acceptancetests/repository/openstack-baremetal-7-default.yaml
+++ b/acceptancetests/repository/openstack-baremetal-7-default.yaml
@@ -10,7 +10,7 @@
 # http://bazaar.launchpad.net/~ost-maintainers/openstack-charm-testing/trunk/view/head:/bundles/baremetal/7-default.yaml
 #
 openstack-services:
-  services:
+  applications:
     mysql:
       charm: cs:trusty/mysql
       options:
@@ -184,7 +184,7 @@ openstack-singlerabbit:
     - [ "neutron-gateway:amqp", rabbitmq-server ]
 openstack-icehouse:
   inherits: openstack-singlerabbit
-  services:
+  applications:
     neutron-api:
       charm: cs:~openstack-charmers-next/trusty/neutron-api
       options:
@@ -204,7 +204,7 @@ openstack-icehouse:
   - [ neutron-openvswitch, rabbitmq-server ]
 openstack-icehouse-msg-split:
   inherits: openstack-services
-  services:
+  applications:
     neutron-api:
       charm: cs:~openstack-charmers-next/trusty/neutron-api
       options:
@@ -228,7 +228,7 @@ openstack-icehouse-msg-split:
 precise-icehouse:
   inherits: openstack-icehouse
   series: precise
-  services:
+  applications:
     mysql:
       branch: lp:charms/trusty/mysql
   overrides:

--- a/acceptancetests/repository/scale-lxc.yaml
+++ b/acceptancetests/repository/scale-lxc.yaml
@@ -1,5 +1,5 @@
 dense-scaled:
-  services:
+  applications:
     apache2:
       charm: "cs:trusty/apache2-1"
       num_units: 1

--- a/acceptancetests/repository/scale-lxd.yaml
+++ b/acceptancetests/repository/scale-lxd.yaml
@@ -1,5 +1,5 @@
 dense-scaled:
-  services:
+  applications:
     apache2:
       charm: "cs:trusty/apache2-1"
       num_units: 1

--- a/acceptancetests/repository/simple-scale-bundle-lxc.yaml
+++ b/acceptancetests/repository/simple-scale-bundle-lxc.yaml
@@ -1,5 +1,5 @@
 simple-scale:
-  services:
+  applications:
     ubuntu:
       charm: "cs:trusty/ubuntu"
       num_units: 18

--- a/acceptancetests/repository/simple-scale-bundle-lxd.yaml
+++ b/acceptancetests/repository/simple-scale-bundle-lxd.yaml
@@ -1,5 +1,5 @@
 simple-scale:
-  services:
+  applications:
     ubuntu:
       charm: "cs:trusty/ubuntu"
       num_units: 18

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2150,7 +2150,7 @@ func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
 			err:       `--controller-charm ".*" is not a valid charm`,
 		}, {
 			charmPath: "/invalid/path",
-			err:       `problem with --controller-charm: stat /invalid/path: no such file or directory`,
+			err:       `problem with --controller-charm: .* /invalid/path: .*`,
 		},
 	} {
 		var gotArgs bootstrap.BootstrapParams

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
@@ -485,7 +486,8 @@ func addControllerApplication(st *state.State, curl *charm.URL, m *state.Machine
 			addr = pa.Value
 		}
 	}
-	cfg["controller-url"] = fmt.Sprintf("https://%s", addr)
+	cfg["controller-url"] = api.ControllerAPIURL(addr)
+	cfg["model-url-template"] = api.ModelAPITemplateURL(addr)
 	app, err := st.AddApplication(state.AddApplicationArgs{
 		Name:   bootstrap.ControllerApplicationName,
 		Series: curl.Series,

--- a/state/application.go
+++ b/state/application.go
@@ -2080,7 +2080,7 @@ func (a *Application) addUnitOps(
 		if err != nil {
 			return "", nil, errors.Trace(err)
 		}
-		if args.machineID != "" {
+		if args.machineID != "" && !strings.HasPrefix(a.doc.CharmURL.Name, "juju-") {
 			return "", nil, errors.NotSupportedf("non-empty machineID")
 		}
 	}

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/tools"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset"
 	jujutxn "github.com/juju/txn"
@@ -21,7 +19,10 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/mongo"
 	stateerrors "github.com/juju/juju/state/errors"
+	"github.com/juju/juju/tools"
 )
 
 func isController(mdoc *machineDoc) bool {
@@ -170,9 +171,30 @@ func (st *State) enableHAIntentionOps(
 	var ops []txn.Op
 	var change ControllersChanges
 
+	// TODO(wallyworld) - only need until we transition away from enable-ha
+	controllerApp, err := st.Application(bootstrap.ControllerApplicationName)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, ControllersChanges{}, errors.Trace(err)
+	}
+
 	for _, m := range intent.convert {
 		ops = append(ops, convertControllerOps(m)...)
 		change.Converted = append(change.Converted, m.Id())
+		// Add a controller charm unit to the promoted machine.
+		if controllerApp != nil {
+			unitName, unitOps, err := controllerApp.addUnitOps("", AddUnitParams{machineID: m.Id()}, nil)
+			if err != nil {
+				return nil, ControllersChanges{}, errors.Trace(err)
+			}
+			ops = append(ops, unitOps...)
+			addToMachineOp := txn.Op{
+				C:      machinesC,
+				Id:     m.doc.DocID,
+				Assert: txn.DocExists,
+				Update: bson.D{{"$addToSet", bson.D{{"principals", unitName}}}, {"$set", bson.D{{"clean", false}}}},
+			}
+			ops = append(ops, addToMachineOp)
+		}
 	}
 
 	// Use any placement directives that have been provided when adding new
@@ -200,15 +222,36 @@ func (st *State) enableHAIntentionOps(
 			Constraints: cons,
 			Placement:   placement,
 		}
+		// Set up the new controller to have a controller charm unit.
+		// The unit itself is created below.
+		var controllerUnitName string
+		if controllerApp != nil {
+			controllerUnitName, err = controllerApp.newUnitName()
+			if err != nil {
+				return nil, ControllersChanges{}, errors.Trace(err)
+			}
+			template.Dirty = true
+			template.principals = []string{controllerUnitName}
+		}
 		mdoc, addOps, err := st.addMachineOps(template)
 		if err != nil {
-			return nil, ControllersChanges{}, err
+			return nil, ControllersChanges{}, errors.Trace(err)
 		}
 		if isController(mdoc) {
 			controllerIds = append(controllerIds, mdoc.Id)
 		}
 		ops = append(ops, addOps...)
 		change.Added = append(change.Added, mdoc.Id)
+		if controllerApp != nil {
+			_, unitOps, err := controllerApp.addUnitOps("", AddUnitParams{
+				UnitName:  &controllerUnitName,
+				machineID: mdoc.Id,
+			}, nil)
+			if err != nil {
+				return nil, ControllersChanges{}, errors.Trace(err)
+			}
+			ops = append(ops, unitOps...)
+		}
 	}
 
 	for _, m := range intent.maintain {

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -105,6 +105,50 @@ func (s *EnableHASuite) TestEnableHAAddsNewMachines(c *gc.C) {
 	s.assertControllerInfo(c, ids, ids, nil)
 }
 
+func (s *EnableHASuite) TestEnableHAAddsControllerCharm(c *gc.C) {
+	state.AddTestingApplicationForSeries(c, s.State, "focal", "controller",
+		state.AddTestingCharmMultiSeries(c, s.State, "juju-controller"))
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(changes.Added, gc.HasLen, 3)
+	for i := 0; i < 3; i++ {
+		unitName := fmt.Sprintf("controller/%d", i)
+		m, err := s.State.Machine(fmt.Sprint(i))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.Principals(), jc.DeepEquals, []string{unitName})
+		u, err := s.State.Unit(unitName)
+		c.Assert(err, jc.ErrorIsNil)
+		mID, err := u.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(mID, gc.Equals, fmt.Sprint(i))
+	}
+}
+
+func (s *EnableHASuite) TestEnableHAAddsControllerCharmToPromoted(c *gc.C) {
+	state.AddTestingApplicationForSeries(c, s.State, "focal", "controller",
+		state.AddTestingCharmMultiSeries(c, s.State, "juju-controller"))
+	m0, err := s.State.AddMachine("bionic", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", []string{"0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(changes.Added, gc.HasLen, 2)
+	c.Assert(changes.Converted, gc.HasLen, 1)
+	for i := 0; i < 3; i++ {
+		unitName := fmt.Sprintf("controller/%d", i)
+		m, err := s.State.Machine(fmt.Sprint(i))
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(m.Principals(), jc.DeepEquals, []string{unitName})
+		u, err := s.State.Unit(unitName)
+		c.Assert(err, jc.ErrorIsNil)
+		mID, err := u.AssignedMachineId()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(mID, gc.Equals, fmt.Sprint(i))
+	}
+	err = m0.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m0.Principals(), gc.DeepEquals, []string{"controller/0"})
+}
+
 func (s *EnableHASuite) TestEnableHATo(c *gc.C) {
 	ids := make([]string, 3)
 	m0, err := s.State.AddMachine("bionic", state.JobHostUnits, state.JobManageModel)

--- a/state/machine.go
+++ b/state/machine.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/constraints"
 	corecontainer "github.com/juju/juju/core/container"
@@ -1768,7 +1769,8 @@ func (st *State) maybeUpdateControllerCharm(publicAddr string) error {
 		return errors.Trace(err)
 	}
 	return controllerApp.UpdateCharmConfig(model.GenerationMaster, charm.Settings{
-		"controller-url": fmt.Sprintf("https://%s", publicAddr),
+		"controller-url":     api.ControllerAPIURL(publicAddr),
+		"model-url-template": api.ModelAPITemplateURL(publicAddr),
 	})
 }
 


### PR DESCRIPTION
PR #12498 reverted this commit since it seemed a cause of some CI failures.
The issue though lied elsewhere, in that support for legacy bundles using services has been removed.
This PR reinstates the original PR, plus updates some in-tree bundles.
There's still some store bundles t update also.

## QA steps

Just a bootstrap and deploy to check for regressions.

