### PR TITLE
Switch environ/ec2 "Instances" methods from amz package to aws-sdk-go 

### DIFF
--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -38,6 +38,7 @@ type Tests struct {
 	CloudEndpoint  string
 	CloudRegion    string
 	ControllerUUID string
+	Env            environs.Environ
 	envtesting.ToolsFixture
 	sstesting.TestDataSuite
 
@@ -93,7 +94,8 @@ func (t *Tests) PrepareParams(c *gc.C) bootstrap.PrepareParams {
 
 // Prepare prepares an instance of the testing environment.
 func (t *Tests) Prepare(c *gc.C) environs.Environ {
-	return t.PrepareWithParams(c, t.PrepareParams(c))
+	t.Env = t.PrepareWithParams(c, t.PrepareParams(c))
+	return t.Env
 }
 
 // PrepareWithParams prepares an instance of the testing environment.
@@ -101,7 +103,8 @@ func (t *Tests) PrepareWithParams(c *gc.C, params bootstrap.PrepareParams) envir
 	e, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(c), t.ControllerStore, params)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", params.ModelConfig))
 	c.Assert(e, gc.NotNil)
-	return e.(environs.Environ)
+	t.Env = e.(environs.Environ)
+	return t.Env
 }
 
 func (t *Tests) AssertPrepareFailsWithConfig(c *gc.C, badConfig coretesting.Attrs, errorMatches string) error {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -13,6 +13,8 @@ import (
 	jujustorage "github.com/juju/juju/storage"
 )
 
+type EC2Client = ec2Client
+
 func StorageEC2(vs jujustorage.VolumeSource) *ec2.EC2 {
 	return vs.(*ebsVolumeSource).env.ec2
 }
@@ -34,7 +36,7 @@ func InstanceEC2(inst instances.Instance) *ec2.Instance {
 }
 
 func TerminatedInstances(e environs.Environ) ([]instances.Instance, error) {
-	return e.(*environ).AllInstancesByState(context.NewCloudCallContext(), "shutting-down", "terminated")
+	return e.(*environ).allInstancesByState(context.NewCloudCallContext(), "shutting-down", "terminated")
 }
 
 func InstanceSecurityGroups(e environs.Environ, ctx context.ProviderCallContext, ids []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -4,8 +4,8 @@
 package ec2
 
 import (
-	sdkec2 "github.com/aws/aws-sdk-go/service/ec2"
-	"gopkg.in/amz.v3/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	amzec2 "gopkg.in/amz.v3/ec2"
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
@@ -16,7 +16,7 @@ import (
 
 type EC2Client = ec2Client
 
-func StorageEC2(vs jujustorage.VolumeSource) *ec2.EC2 {
+func StorageEC2(vs jujustorage.VolumeSource) *amzec2.EC2 {
 	return vs.(*ebsVolumeSource).env.ec2
 }
 
@@ -28,23 +28,23 @@ func MachineGroupName(e environs.Environ, machineId string) string {
 	return e.(*environ).machineGroupName(machineId)
 }
 
-func EnvironEC2(e environs.Environ) *ec2.EC2 {
+func EnvironEC2(e environs.Environ) *amzec2.EC2 {
 	return e.(*environ).ec2
 }
 
-func InstanceEC2(inst instances.Instance) *ec2.Instance {
-	return inst.(*ec2Instance).Instance
+func InstanceEC2(inst instances.Instance) *amzec2.Instance {
+	return inst.(*amzInstance).Instance
 }
 
-func InstanceSDKEC2(inst instances.Instance) *sdkec2.Instance {
-	return inst.(*sdkEC2Instance).i
+func InstanceSDKEC2(inst instances.Instance) *ec2.Instance {
+	return inst.(*sdkInstance).i
 }
 
 func TerminatedInstances(e environs.Environ) ([]instances.Instance, error) {
 	return e.(*environ).allInstancesByState(context.NewCloudCallContext(), "shutting-down", "terminated")
 }
 
-func InstanceSecurityGroups(e environs.Environ, ctx context.ProviderCallContext, ids []instance.Id, states ...string) ([]ec2.SecurityGroup, error) {
+func InstanceSecurityGroups(e environs.Environ, ctx context.ProviderCallContext, ids []instance.Id, states ...string) ([]amzec2.SecurityGroup, error) {
 	return e.(*environ).instanceSecurityGroups(ctx, ids, states...)
 }
 

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	sdkec2 "github.com/aws/aws-sdk-go/service/ec2"
 	"gopkg.in/amz.v3/ec2"
 
 	"github.com/juju/juju/core/instance"
@@ -33,6 +34,10 @@ func EnvironEC2(e environs.Environ) *ec2.EC2 {
 
 func InstanceEC2(inst instances.Instance) *ec2.Instance {
 	return inst.(*ec2Instance).Instance
+}
+
+func InstanceSDKEC2(inst instances.Instance) *sdkec2.Instance {
+	return inst.(*sdkEC2Instance).i
 }
 
 func TerminatedInstances(e environs.Environ) ([]instances.Instance, error) {

--- a/provider/ec2/instance.go
+++ b/provider/ec2/instance.go
@@ -6,6 +6,7 @@ package ec2
 import (
 	"fmt"
 
+	sdkec2 "github.com/aws/aws-sdk-go/service/ec2"
 	"gopkg.in/amz.v3/ec2"
 
 	"github.com/juju/juju/core/instance"
@@ -50,7 +51,6 @@ func (inst *ec2Instance) Status(ctx context.ProviderCallContext) instance.Status
 		Status:  jujuStatus,
 		Message: inst.State.Name,
 	}
-
 }
 
 // Addresses implements network.Addresses() returning generic address
@@ -108,6 +108,112 @@ func (inst *ec2Instance) ClosePorts(ctx context.ProviderCallContext, machineId s
 }
 
 func (inst *ec2Instance) IngressRules(ctx context.ProviderCallContext, machineId string) (firewall.IngressRules, error) {
+	if inst.e.Config().FirewallMode() != config.FwInstance {
+		return nil, fmt.Errorf("invalid firewall mode %q for retrieving ingress rules from instance",
+			inst.e.Config().FirewallMode())
+	}
+	name := inst.e.machineGroupName(machineId)
+	ranges, err := inst.e.ingressRulesInGroup(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return ranges, nil
+}
+
+// AWK SDK version of ec2Instance.
+//
+// TODO(benhoyt) - get rid of ec2Instance and rename this to ec2Instance when
+// everything is converted to the AWS SDK.
+type sdkEC2Instance struct {
+	e *environ
+	i *sdkec2.Instance
+}
+
+func (inst *sdkEC2Instance) String() string {
+	return string(inst.Id())
+}
+
+var _ instances.Instance = (*sdkEC2Instance)(nil)
+
+func (inst *sdkEC2Instance) Id() instance.Id {
+	return instance.Id(*inst.i.InstanceId)
+}
+
+func (inst *sdkEC2Instance) Status(ctx context.ProviderCallContext) instance.Status {
+	if inst.i.State == nil || inst.i.State.Name == nil {
+		return instance.Status{Status: status.Empty}
+	}
+
+	// pending | running | shutting-down | terminated | stopping | stopped
+	var jujuStatus status.Status
+	switch *inst.i.State.Name {
+	case "pending":
+		jujuStatus = status.Pending
+	case "running":
+		jujuStatus = status.Running
+	case "shutting-down", "terminated", "stopping", "stopped":
+		jujuStatus = status.Empty
+	default:
+		jujuStatus = status.Empty
+	}
+	return instance.Status{
+		Status:  jujuStatus,
+		Message: *inst.i.State.Name,
+	}
+}
+
+// Addresses implements network.Addresses() returning generic address
+// details for the instance, and requerying the ec2 api if required.
+func (inst *sdkEC2Instance) Addresses(ctx context.ProviderCallContext) (corenetwork.ProviderAddresses, error) {
+	var addresses []corenetwork.ProviderAddress
+	if inst.i.PublicIpAddress != nil {
+		addresses = append(addresses, corenetwork.ProviderAddress{
+			MachineAddress: corenetwork.MachineAddress{
+				Value: *inst.i.PublicIpAddress,
+				Type:  corenetwork.IPv4Address,
+				Scope: corenetwork.ScopePublic,
+			},
+		})
+	}
+	if inst.i.PrivateIpAddress != nil {
+		addresses = append(addresses, corenetwork.ProviderAddress{
+			MachineAddress: corenetwork.MachineAddress{
+				Value: *inst.i.PrivateIpAddress,
+				Type:  corenetwork.IPv4Address,
+				Scope: corenetwork.ScopeCloudLocal,
+			},
+		})
+	}
+	return addresses, nil
+}
+
+func (inst *sdkEC2Instance) OpenPorts(ctx context.ProviderCallContext, machineId string, rules firewall.IngressRules) error {
+	if inst.e.Config().FirewallMode() != config.FwInstance {
+		return fmt.Errorf("invalid firewall mode %q for opening ports on instance",
+			inst.e.Config().FirewallMode())
+	}
+	name := inst.e.machineGroupName(machineId)
+	if err := inst.e.openPortsInGroup(ctx, name, rules); err != nil {
+		return err
+	}
+	logger.Infof("opened ports in security group %s: %v", name, rules)
+	return nil
+}
+
+func (inst *sdkEC2Instance) ClosePorts(ctx context.ProviderCallContext, machineId string, ports firewall.IngressRules) error {
+	if inst.e.Config().FirewallMode() != config.FwInstance {
+		return fmt.Errorf("invalid firewall mode %q for closing ports on instance",
+			inst.e.Config().FirewallMode())
+	}
+	name := inst.e.machineGroupName(machineId)
+	if err := inst.e.closePortsInGroup(ctx, name, ports); err != nil {
+		return err
+	}
+	logger.Infof("closed ports in security group %s: %v", name, ports)
+	return nil
+}
+
+func (inst *sdkEC2Instance) IngressRules(ctx context.ProviderCallContext, machineId string) (firewall.IngressRules, error) {
 	if inst.e.Config().FirewallMode() != config.FwInstance {
 		return nil, fmt.Errorf("invalid firewall mode %q for retrieving ingress rules from instance",
 			inst.e.Config().FirewallMode())

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -92,7 +92,11 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 			c.Assert(region, gc.Equals, "test")
 			c.Assert(accessKey, gc.Equals, "x")
 			c.Assert(secretKey, gc.Equals, "x")
-			return mockEC2Session{}
+			return &mockEC2Session{
+				newInstancesClient: func() *amzec2.EC2 {
+					return ec2.EnvironEC2(t.Env)
+				},
+			}
 		})
 	}
 }
@@ -135,9 +139,9 @@ func (t *LiveTests) TestInstanceAttributes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(insts), gc.Equals, 1)
 
-	ec2inst := ec2.InstanceEC2(insts[0])
-	c.Assert(ec2inst.IPAddress, gc.Equals, addresses[0].Value)
-	c.Assert(ec2inst.InstanceType, gc.Equals, "t3a.micro")
+	ec2inst := ec2.InstanceSDKEC2(insts[0])
+	c.Assert(*ec2inst.PublicIpAddress, gc.Equals, addresses[0].Value)
+	c.Assert(*ec2inst.InstanceType, gc.Equals, "t3a.micro")
 }
 
 func (t *LiveTests) TestStartInstanceConstraints(c *gc.C) {

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/arch"
@@ -89,7 +88,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	// Use the real ec2 session if we are running with real creds.
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	if accessKey == "" {
-		t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2iface.EC2API {
+		t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2.EC2Client {
 			c.Assert(region, gc.Equals, "test")
 			c.Assert(accessKey, gc.Equals, "x")
 			c.Assert(secretKey, gc.Equals, "x")

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -242,7 +241,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return jujuversion.DefaultSupportedLTS(), nil })
 	t.BaseSuite.PatchValue(ec2.DeleteSecurityGroupInsistently, deleteSecurityGroupForTestFunc)
-	t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2iface.EC2API {
+	t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2.EC2Client {
 		c.Assert(region, gc.Equals, "test")
 		c.Assert(accessKey, gc.Equals, "x")
 		c.Assert(secretKey, gc.Equals, "x")
@@ -594,7 +593,7 @@ func (t *localServerSuite) TestGetTerminatedInstances(c *gc.C) {
 	c.Assert(terminated[0].Id(), jc.DeepEquals, inst1.Id())
 }
 
-func (t *localServerSuite) TestInstanceSecurityGroupsWitheInstanceStatusFilter(c *gc.C) {
+func (t *localServerSuite) TestInstanceSecurityGroupsWithInstanceStatusFilter(c *gc.C) {
 	env := t.prepareAndBootstrap(c)
 
 	insts, err := env.AllRunningInstances(t.callCtx)

--- a/provider/ec2/mock_test.go
+++ b/provider/ec2/mock_test.go
@@ -6,11 +6,14 @@ package ec2_test
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	amzec2 "gopkg.in/amz.v3/ec2"
 )
 
-type mockEC2Session struct{}
+type mockEC2Session struct {
+	newInstancesClient func() *amzec2.EC2
+}
 
-func (mockEC2Session) DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
+func (*mockEC2Session) DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	return &ec2.DescribeAvailabilityZonesOutput{
 		AvailabilityZones: []*ec2.AvailabilityZone{{
 			ZoneName: aws.String("test-available"),
@@ -18,27 +21,67 @@ func (mockEC2Session) DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesIn
 	}, nil
 }
 
-func (mockEC2Session) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	// TODO(benhoyt) - mock properly
-	return &ec2.DescribeInstancesOutput{
-		Reservations: []*ec2.Reservation{
-			{
-				Instances: []*ec2.Instance{
-					{
-						InstanceId:       aws.String("1234"),
-						PrivateIpAddress: aws.String("1.2.3.4"),
-						PublicIpAddress:  aws.String("10.0.0.1"),
-						State: &ec2.InstanceState{
-							Name: aws.String("running"),
-						},
-					},
+func (s *mockEC2Session) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	// Proxy the DescribeInstances request through to the equivalent amz
+	// package's Instances() method, as amz is still used to start the
+	// instances.
+	var ids []string
+	for _, id := range input.InstanceIds {
+		if id == nil {
+			continue
+		}
+		ids = append(ids, *id)
+	}
+
+	filter := amzec2.NewFilter()
+	for _, f := range input.Filters {
+		if f.Name == nil {
+			continue
+		}
+		var values []string
+		for _, v := range f.Values {
+			if v != nil {
+				values = append(values, *v)
+			}
+		}
+		filter.Add(*f.Name, values...)
+	}
+
+	client := s.newInstancesClient()
+	resp, err := client.Instances(ids, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &ec2.DescribeInstancesOutput{}
+	for _, r := range resp.Reservations {
+		res := &ec2.Reservation{}
+		for _, i := range r.Instances {
+			inst := &ec2.Instance{
+				InstanceId:   &i.InstanceId,
+				InstanceType: &i.InstanceType,
+				State: &ec2.InstanceState{
+					Name: &i.State.Name,
 				},
-			},
-		},
-	}, nil
+			}
+			if i.PrivateIPAddress != "" {
+				inst.PrivateIpAddress = &i.PrivateIPAddress
+			}
+			if i.IPAddress != "" {
+				inst.PublicIpAddress = &i.IPAddress
+			}
+			for _, t := range i.Tags {
+				t := t // make a copy so the address is new each loop
+				inst.Tags = append(inst.Tags, &ec2.Tag{Key: &t.Key, Value: &t.Value})
+			}
+			res.Instances = append(res.Instances, inst)
+		}
+		output.Reservations = append(output.Reservations, res)
+	}
+	return output, nil
 }
 
-func (mockEC2Session) DescribeInstanceTypeOfferings(*ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
+func (*mockEC2Session) DescribeInstanceTypeOfferings(*ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	return &ec2.DescribeInstanceTypeOfferingsOutput{
 		InstanceTypeOfferings: []*ec2.InstanceTypeOffering{{
 			InstanceType: aws.String("t3a.micro"),
@@ -60,7 +103,7 @@ func (mockEC2Session) DescribeInstanceTypeOfferings(*ec2.DescribeInstanceTypeOff
 	}, nil
 }
 
-func (mockEC2Session) DescribeInstanceTypes(*ec2.DescribeInstanceTypesInput) (*ec2.DescribeInstanceTypesOutput, error) {
+func (*mockEC2Session) DescribeInstanceTypes(*ec2.DescribeInstanceTypesInput) (*ec2.DescribeInstanceTypesOutput, error) {
 	return &ec2.DescribeInstanceTypesOutput{
 		InstanceTypes: []*ec2.InstanceTypeInfo{{
 			InstanceType: aws.String("t3a.micro"),
@@ -98,7 +141,7 @@ func (mockEC2Session) DescribeInstanceTypes(*ec2.DescribeInstanceTypesInput) (*e
 	}, nil
 }
 
-func (mockEC2Session) DescribeSpotPriceHistory(*ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
+func (*mockEC2Session) DescribeSpotPriceHistory(*ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
 	return &ec2.DescribeSpotPriceHistoryOutput{
 		SpotPriceHistory: nil,
 	}, nil

--- a/provider/ec2/mock_test.go
+++ b/provider/ec2/mock_test.go
@@ -6,18 +6,35 @@ package ec2_test
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
-type mockEC2Session struct {
-	ec2iface.EC2API
-}
+type mockEC2Session struct{}
 
 func (mockEC2Session) DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	return &ec2.DescribeAvailabilityZonesOutput{
 		AvailabilityZones: []*ec2.AvailabilityZone{{
 			ZoneName: aws.String("test-available"),
 		}},
+	}, nil
+}
+
+func (mockEC2Session) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	// TODO(benhoyt) - mock properly
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						InstanceId:       aws.String("1234"),
+						PrivateIpAddress: aws.String("1.2.3.4"),
+						PublicIpAddress:  aws.String("10.0.0.1"),
+						State: &ec2.InstanceState{
+							Name: aws.String("running"),
+						},
+					},
+				},
+			},
+		},
 	}, nil
 }
 

--- a/provider/ec2/series_test.go
+++ b/provider/ec2/series_test.go
@@ -30,8 +30,8 @@ func UseTestImageData(c *gc.C, files map[string]string) {
 // FabricateInstance creates a new fictitious instance
 // given an existing instance and a new id.
 func FabricateInstance(inst instances.Instance, newId string) instances.Instance {
-	oldi := inst.(*ec2Instance)
-	newi := &ec2Instance{
+	oldi := inst.(*amzInstance)
+	newi := &amzInstance{
 		e:        oldi.e,
 		Instance: &awsec2.Instance{},
 	}


### PR DESCRIPTION
This switches the various Environ methods that call EC2's `DescribeInstances` API from the legacy amz package to the aws-sdk-go package. The rationale is that aws-sdk-go has better (more forgiving) retry support, whereas amz only retries on rate-limit responses.

We want to switch to aws-sdk-go for all API calls, but that's too big a chunk of work to bite off for now, so this is my attempt to do it piecemeal, starting for now with instances.

It does mean the mock for `DescribeInstances` is a bit weird. We currently use the amz `ec2test` sub-package to create instances, and the tests rely on those instances being started, so for the `DescribeInstances` mock function to work, we proxy it through to the `Instances` amz call, and convert the request/response types.

## QA steps

To exercise some of the code paths (run `juju debug-log` in another terminal window), first bootstrap with `juju bootstrap aws aws` and check that deploy and open/close ports works. With `firewall-mode=global`:

```
# test on a model with firewall-mode=global
juju add-model fwglobal --config firewall-mode=global
juju model-config firewall-mode  # prints 'global'
juju deploy mediawiki
juju deploy mysql
juju relate mysql mediawiki:db

juju expose mediawiki
# check in AWS console that port 80 is allowed in instance's security group
# also check that http://{ip_address}/ is accessible
# debug log says: opened port ranges [80/tcp from 0.0.0.0/0,::/0] in environment

juju unexpose mediawiki
# port 80 now not allowed in AWS console
# also check that http://{ip_address}/ is not accessible
# debug log says: closed port ranges [80/tcp from 0.0.0.0/0,::/0] in environment

juju destroy-model fwglobal
```

With `firewall-mode=instance` (the default):

```
# test on a model with firewall-mode=instance (the default)
juju add-model fwinstance
juju model-config firewall-mode  # prints 'instance'
juju deploy mediawiki
juju deploy mysql
juju relate mysql mediawiki:db

juju expose mediawiki
# check in AWS console that port 80 is allowed in instance's security group
# also check that http://{ip_address}/ is accessible
# debug log says: opened port ranges [80/tcp from 0.0.0.0/0,::/0] on "machine-0"

juju unexpose mediawiki
# port 80 now not allowed in AWS console
# also check that http://{ip_address}/ is not accessible
# debug log says: closed port ranges [80/tcp from 0.0.0.0/0,::/0] on "machine-0"

juju destroy-model fwinstance
```

Another test I did is to test the auth error handling. I did this by attempting to update the AWS credential on the controller. This calls `checkIAASModelCredential()` which ends up calling `environ.Instances()`, which has the aws-sdk-go error handling. It seems to be handled correctly as a credentials error:

```
$ juju update-credential aws --controller aws
Credential invalid for:
  controller:
    
The provided credentials could not be validated and 
may not be authorized to carry out the request.
Ensure that your account is authorized to use the Amazon EC2 service and 
that you are using the correct access keys. 
These keys are obtained via the "Security Credentials"
page in the AWS console.
: AWS was not able to validate the provided access credentials (AuthFailure)
  default:
    
The provided credentials could not be validated and 
may not be authorized to carry out the request.
Ensure that your account is authorized to use the Amazon EC2 service and 
that you are using the correct access keys. 
These keys are obtained via the "Security Credentials"
page in the AWS console.
: AWS was not able to validate the provided access credentials (AuthFailure)
Failed models may require a different credential.
Use ‘juju set-credential’ to change credential for these models before repeating this update.
```

I also did some local hacking to convince myself that `maybeConvertCredentialError` works the same for both `*ec2.Error` and `awserr.Error`. Tested it by manually calling `env.Instances()`, which calls `groupByName()` using amzec2, then commenting out that so it calls `DescribeInstances` using sdkec2. Both work fine and handle code=AuthFailure correctly.