### PR TITLE
Migration minion connection strategy to fix validation step

### DIFF
--- a/migration/dialopts.go
+++ b/migration/dialopts.go
@@ -11,14 +11,14 @@ import (
 
 // ControllerDialOpts returns dial parameters suitable for connecting
 // from the source controller to the target controller during model
-// migrations. The total attempt time can't be too long because the
-// areas of the code which make these connections need to be
-// interruptable but a number of retries is useful to deal with short
-// lived issues.
+// migrations.
+// Except for the inclusion of RetryDelay the options mirror what is used
+// by the APICaller for logins.
 func ControllerDialOpts() api.DialOpts {
 	return api.DialOpts{
-		DialAddressInterval: 50 * time.Millisecond,
-		Timeout:             1 * time.Second,
+		DialTimeout:         3 * time.Second,
+		DialAddressInterval: 200 * time.Millisecond,
+		Timeout:             time.Minute,
 		RetryDelay:          100 * time.Millisecond,
 	}
 }

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -28,11 +28,11 @@ const (
 
 	// initialRetryDelay is the starting delay - this will be
 	// increased exponentially up maxRetries.
-	initialRetryDelay = 50 * time.Millisecond
+	initialRetryDelay = 100 * time.Millisecond
 
 	// retryBackoffFactor is how much longer we wait after a failing
-	// retry.  Retrying 10 times starting at 50ms and backing off 1.6x
-	// gives us a total delay time of about 9s.
+	// retry. Retrying 10 times starting at 100ms and backing off 1.6x
+	// gives us a total delay time of about 45s.
 	retryBackoffFactor = 1.6
 )
 

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -70,7 +70,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *Suite) apiOpen(info *api.Info, dialOpts api.DialOpts) (api.Connection, error) {
+func (s *Suite) apiOpen(info *api.Info, _ api.DialOpts) (api.Connection, error) {
 	s.stub.AddCall("API open", info)
 	return &stubConnection{stub: s.stub}, nil
 }
@@ -211,7 +211,7 @@ func (s *Suite) TestVALIDATIONCantConnect(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 
 	// Advance time enough for all of the retries to be exhausted.
-	sleepTime := 50 * time.Millisecond
+	sleepTime := 100 * time.Millisecond
 	for i := 0; i < 9; i++ {
 		err := s.clock.WaitAdvance(sleepTime, coretesting.ShortWait, 1)
 		c.Assert(err, jc.ErrorIsNil)
@@ -250,7 +250,7 @@ func (s *Suite) TestVALIDATIONFail(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 
 	// Advance time enough for all of the retries to be exhausted.
-	sleepTime := 50 * time.Millisecond
+	sleepTime := 100 * time.Millisecond
 	for i := 0; i < 9; i++ {
 		err := s.clock.WaitAdvance(sleepTime, coretesting.ShortWait, 1)
 		c.Assert(err, jc.ErrorIsNil)
@@ -284,12 +284,12 @@ func (s *Suite) TestVALIDATIONRetrySucceed(c *gc.C) {
 
 	waitForStubCalls(c, &stub, "ValidateMigration")
 
-	err = s.clock.WaitAdvance(50*time.Millisecond, coretesting.LongWait, 1)
+	err = s.clock.WaitAdvance(100*time.Millisecond, coretesting.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForStubCalls(c, &stub, "ValidateMigration", "ValidateMigration")
 
-	err = s.clock.WaitAdvance(100*time.Millisecond, coretesting.LongWait, 1)
+	err = s.clock.WaitAdvance(160*time.Millisecond, coretesting.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.waitForStubCalls(c, []string{


### PR DESCRIPTION
Models of decent size are consistently failing to migrate on multiple substrates.

Errors logged by the migration minion workers include lines like this:
```
unit-kubernetes-worker-0: 11:17:10 DEBUG juju.worker.migrationminion validation failed (retrying): failed to open API to target controller: try again (try again)
```
These are repeated in quick succession (initially sub-second) up to the 10 retry limit at which time the validation fails.

This patch doubles the initial retry delay from 50 to 100 milliseconds, which gives us more retries in the sweet spot for overcoming controller rate-limiting.

In addition we align the dial options for the migration minion connection with those used by the API-caller worker.

## QA steps

Deploy charmed-kubernetes, wait for quiescence and migrate the model to another controller. This is a simple red/green test - fails consistently before, passes after.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1910595
