### PR TITLE
[2.9-python3-acceptancetests] Force python3 when running acceptance tests

### DIFF
--- a/acceptancetests/Makefile
+++ b/acceptancetests/Makefile
@@ -24,8 +24,8 @@ test:
 	TMPDIR=/tmp python -m unittest discover . -p "$(p)"
 	TMPDIR=/tmp python3 -W ignore::DeprecationWarning -m unittest discover jujupy -t . -p "$(p)"
 lint:
-	python3 -m flake8 --ignore=$(flake8_ignore) --builtins xrange,basestring $(py3) --exclude=repository $(mkfile_dir)
-	flake8 --ignore=$(flake8_ignore) --builtins xrange,basestring --exclude=$(py3),repository $(mkfile_dir)
+	python3 -m flake8 --ignore=$(flake8_ignore) --builtins xrange $(py3) --exclude=repository $(mkfile_dir)
+	flake8 --ignore=$(flake8_ignore) --builtins xrange --exclude=$(py3),repository $(mkfile_dir)
 cover:
 	python -m coverage run --source="./" --omit "./tests/*" -m unittest discover -vv ./tests
 	python -m coverage report

--- a/acceptancetests/assess
+++ b/acceptancetests/assess
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # create_juju_test_env is a developer-centric tool. It creates an environment for running
 # acceptance tests locally under LXD.

--- a/acceptancetests/assess_add_cloud.py
+++ b/acceptancetests/assess_add_cloud.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import re

--- a/acceptancetests/assess_add_cloud.py
+++ b/acceptancetests/assess_add_cloud.py
@@ -9,6 +9,12 @@ from copy import deepcopy
 
 import yaml
 
+from utility import (
+    add_arg_juju_bin,
+    JujuAssertionError,
+    temp_dir,
+)
+
 from jujupy import (
     ModelClient,
     JujuData,
@@ -18,11 +24,6 @@ from jujupy.exceptions import (
     InvalidEndpoint,
     NameNotAccepted,
     TypeNotAccepted,
-)
-from utility import (
-    add_arg_juju_bin,
-    JujuAssertionError,
-    temp_dir,
 )
 
 # URLs are limited to 2083 bytes in many browsers, anything more is excessive.
@@ -62,9 +63,9 @@ class CloudValidation:
     def __init__(self, version):
         """Initialize with the juju version."""
         self.version = version
-        if re.match('2\.0[^\d]', version):
+        if re.match(r'2\.0[^\d]', version):
             self.support = self.NONE
-        elif re.match('2\.1[^\d]', version):
+        elif re.match(r'2\.1[^\d]', version):
             self.support = self.BASIC
         else:
             # re.match('2\.2[^\d]', version)
@@ -137,7 +138,8 @@ def assess_cloud(client, cloud_name, example_cloud):
     actual_cloud = clouds['clouds'][cloud_name]
     # Accept the creation of a default region even though there's not one in
     # the example cloud.
-    if 'regions' not in example_cloud and actual_cloud.get('regions') == {'default': {}}:
+    using_default_region = actual_cloud.get('regions') == {'default': {}}
+    if 'regions' not in example_cloud and using_default_region:
         del actual_cloud['regions']
 
     if actual_cloud != example_cloud:
@@ -155,27 +157,32 @@ def iter_clouds(clouds, cloud_validation):
     :param clouds: cloud data as defined in $JUJU_DATA/clouds.yaml
     :param cloud_validation: an instance of CloudValidation.
     """
-    yield cloud_spec('bogus-type', 'bogus-type', {'type': 'bogus'}, exception=TypeNotAccepted)
+    yield cloud_spec('bogus-type', 'bogus-type', {'type': 'bogus'},
+                     exception=TypeNotAccepted)
 
     long_text = 'A' * EXCEEDED_LIMIT
     for cloud_name, cloud in clouds.items():
         yield cloud_spec(cloud_name, cloud_name, cloud)
-        yield cloud_spec('slash-in-name-{}'.format(cloud_name), 'invalid/name', cloud, NameNotAccepted, 1641981)
-        yield cloud_spec('numeral-prefix-{}'.format(cloud_name), '99invalid/name', cloud, NameNotAccepted, 1641981)
+        yield cloud_spec('slash-in-name-{}'.format(cloud_name), 'invalid/name',
+                         cloud, NameNotAccepted, 1641981)
+        yield cloud_spec('numeral-prefix-{}'.format(cloud_name),
+                         '99invalid/name', cloud, NameNotAccepted, 1641981)
 
         if cloud['type'] not in ('maas', 'manual', 'vsphere'):
             auth_config = deepcopy(cloud)
             auth_config['auth-types'] = ['asdf']
             variant_name = 'bogus-auth-{}'.format(cloud_name)
-            yield cloud_spec(variant_name, cloud_name, auth_config, AuthNotAccepted, 1641970)
+            yield cloud_spec(variant_name, cloud_name, auth_config,
+                             AuthNotAccepted, 1641970)
 
         if cloud['type'] == 'vsphere':
             continue
 
-        # juju saves for each cloud at least one region, even if the cloud does not support them.
-        # The code below `tests to add invalid regions for each region`
-        # but because juju always at least adds one empty region
-        # it will try to run the code below and test for invalid region endpoints.
+        # juju saves for each cloud at least one region, even if the cloud does
+        # not support them.  The code below `tests to add invalid regions for
+        # each region` but because juju always at least adds one empty region
+        # it will try to run the code below and test for invalid region
+        # endpoints.
         regions = cloud.get('regions', {})
         if regions.get("default") == {}:
             regions = []
@@ -188,16 +195,20 @@ def iter_clouds(clouds, cloud_validation):
         illegal_endpoint_config = deepcopy(cloud)
         illegal_endpoint_config['endpoint'] = long_text
         illegal_endpoint_name = 'long-endpoint-{}'.format(cloud_name)
-        for region_name in regions:
-            illegal_endpoint_config['regions'][region_name]['endpoint'] = long_text
-        yield cloud_spec(illegal_endpoint_name, cloud_name, illegal_endpoint_config, expected_exception, 1641970)
+        for rg_name in regions:
+            illegal_endpoint_config['regions'][rg_name]['endpoint'] = long_text
+        yield cloud_spec(illegal_endpoint_name, cloud_name,
+                         illegal_endpoint_config, expected_exception, 1641970)
 
         for region_name in regions:
-            regional_long_endpoint_name = 'long-endpoint-{}-{}'.format(cloud_name, region_name)
+            regional_long_endpoint_name = 'long-endpoint-{}-{}'.format(
+                cloud_name, region_name)
             regional_long_endpoint_config = deepcopy(cloud)
             # test each region independently of others
-            regional_long_endpoint_config['regions'] = {region_name: {'endpoint': long_text}}
-            yield cloud_spec(regional_long_endpoint_name, cloud_name, regional_long_endpoint_config, expected_exception,
+            regional_long_endpoint_config['regions'] = {
+                region_name: {'endpoint': long_text}}
+            yield cloud_spec(regional_long_endpoint_name, cloud_name,
+                             regional_long_endpoint_config, expected_exception,
                              1641970)
 
 

--- a/acceptancetests/assess_add_credentials.py
+++ b/acceptancetests/assess_add_credentials.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 import argparse
 import logging
 import os
-import pexpect
 import shutil
 import sys
 import yaml
+import pexpect
 
 from deploy_stack import (
     BootstrapManager,
@@ -47,8 +47,9 @@ def assess_add_credentials(args):
     else:
         env = args.env.split('parallel-')[1]
 
-    # If no cloud-city path is given, we grab the credentials from env juju_home.
-    # Else we override the path where we read the credentials yaml for testing purposes.
+    # If no cloud-city path is given, we grab the credentials from env
+    # juju_home.  Else we override the path where we read the credentials yaml
+    # for testing purposes.
     if args.juju_home is not None:
         cred = get_credentials(env, args.juju_home)
     else:

--- a/acceptancetests/assess_add_credentials.py
+++ b/acceptancetests/assess_add_credentials.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess proper functionality of juju add-credential."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_agent_metadata.py
+++ b/acceptancetests/assess_agent_metadata.py
@@ -234,7 +234,7 @@ def get_controller_series_and_alternative_series(client):
     controller_series = machines['0']['series']
     try:
         supported_series.remove(controller_series)
-    except:
+    except Exception:
         raise ValueError("Unknown series {}".format(controller_series))
     return controller_series, supported_series[0]
 
@@ -369,7 +369,7 @@ def make_unique_tool(agent_file, agent_stream):
         os.makedirs(juju_tool_src)
         clone_tgz_file_and_change_shasum(agent_file, os.path.join(
             juju_tool_src, os.path.basename(agent_file)))
-        log.debug("Created agent directory to perform bootstrap".format(
+        log.debug("Created agent directory {} to perform bootstrap".format(
             agent_dir))
         yield agent_dir
 

--- a/acceptancetests/assess_agent_metadata.py
+++ b/acceptancetests/assess_agent_metadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Juju agent-metadata-url validation on passing as an argument during
  juju bootstrap

--- a/acceptancetests/assess_autoload_credentials.py
+++ b/acceptancetests/assess_autoload_credentials.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tests for the autoload-credentials command."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_autoload_credentials.py
+++ b/acceptancetests/assess_autoload_credentials.py
@@ -22,15 +22,15 @@ from textwrap import dedent
 import pexpect
 
 from deploy_stack import BootstrapManager
-from jujupy import (
-    client_from_config,
-    )
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
     ensure_dir,
     scoped_environ,
     temp_dir,
+    )
+from jujupy import (
+    client_from_config,
     )
 
 
@@ -104,17 +104,17 @@ def client_credentials_to_details(client):
     cloud_name = client.env.get_cloud()
     log.info("cloud_name: {}".format(cloud_name))
     credentials = client.env.get_cloud_credentials()
-    if 'ec2' == provider:
+    if provider == 'ec2':
         return {'secret_key': credentials['secret-key'],
                 'access_key': credentials['access-key'],
                 }
-    if 'gce' == provider:
+    if provider == 'gce':
         gce_prepare_for_load()
         return {'client_id': credentials['client-id'],
                 'client_email': credentials['client-email'],
                 'private_key': credentials['private-key'],
                 }
-    if 'openstack' == provider:
+    if provider == 'openstack':
         os_cloud = client.env.clouds['clouds'][cloud_name]
         return {'os_tenant_name': credentials['tenant-name'],
                 'os_password': credentials['password'],
@@ -273,7 +273,7 @@ def run_autoload_credentials(client, envvars, answers):
     selection = 1
     while not process.eof():
         out = process.readline()
-        pattern = '.*(\d). {} \(.*\).*'.format(answers.cloud_listing)
+        pattern = r'.*(\d). {} \(.*\).*'.format(answers.cloud_listing)
         match = re.match(pattern, out)
         if match:
             selection = match.group(1)

--- a/acceptancetests/assess_block.py
+++ b/acceptancetests/assess_block.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess juju blocks prevent users from making changes and models"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_bootstrap.py
+++ b/acceptancetests/assess_bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 from argparse import ArgumentParser

--- a/acceptancetests/assess_cloud.py
+++ b/acceptancetests/assess_cloud.py
@@ -4,6 +4,10 @@ import logging
 from textwrap import dedent
 import yaml
 
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
 from deploy_stack import (
     BootstrapManager,
     )
@@ -15,10 +19,6 @@ from jujupy import (
     )
 from jujupy.wait_condition import (
     ConditionList,
-    )
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
     )
 
 
@@ -103,9 +103,8 @@ def assess_cloud_kill_controller(bs_manager):
         # We expect juju to die with a connection error (because we just
         # stopped its jujud).  This would normally be seen as a bug, so we
         # suppress it.
-        controller_client.juju('run', (
-            '--machine', '0', 'sudo service jujud-machine-0 stop'),
-            check=False, suppress_err=True)
+        cmd = ('--machine', '0', 'sudo service jujud-machine-0 stop')
+        controller_client.juju('run', cmd, check=False, suppress_err=True)
         bs_manager.has_controller = False
 
 

--- a/acceptancetests/assess_cloud.py
+++ b/acceptancetests/assess_cloud.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import logging
 from textwrap import dedent

--- a/acceptancetests/assess_cloud_display.py
+++ b/acceptancetests/assess_cloud_display.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/acceptancetests/assess_cloud_display.py
+++ b/acceptancetests/assess_cloud_display.py
@@ -12,11 +12,11 @@ from pprint import pformat
 import sys
 import yaml
 
-from jujupy import client_from_config
 from utility import (
     add_arg_juju_bin,
     JujuAssertionError,
 )
+from jujupy import client_from_config
 
 
 def remove_display_attributes(cloud):
@@ -39,8 +39,9 @@ def remove_display_attributes(cloud):
     assert_equal(defined, 'local')
     description = cloud.pop('description', "")
 
-    # Delete None values, which are "errors" from parsing the yaml
-    # E.g. output can show values which we show to the customers but should actually not parsed and compared
+    # Delete None values, which are "errors" from parsing the yaml E.g. output
+    # can show values which we show to the customers but should actually not
+    # parsed and compared
     for key in cloud.keys():
         if cloud[key] is None:
             del cloud[key]
@@ -89,7 +90,8 @@ def assess_show_cloud(client, expected):
     """Assess how show-cloud behaves."""
     for cloud_name, expected_cloud in expected.items():
         actual_cloud = yaml.safe_load(client.get_juju_output(
-            'show-cloud', cloud_name, '--format', 'yaml', '--local', include_e=False))
+            'show-cloud', cloud_name, '--format', 'yaml',
+            '--local', include_e=False))
         remove_display_attributes(actual_cloud)
         assert_equal(actual_cloud, expected_cloud)
 
@@ -132,7 +134,8 @@ def main():
         with open(args.clouds_file) as f:
             supplied_clouds = yaml.safe_load(f.read().decode('utf-8'))
         client.env.write_clouds(client.env.juju_home, supplied_clouds)
-        no_region_endpoint = strip_redundant_endpoints(supplied_clouds['clouds'])
+        no_region_endpoint = strip_redundant_endpoints(
+            supplied_clouds['clouds'])
         with testing('assess_clouds'):
             assess_clouds(client, no_region_endpoint)
         with testing('assess_show_cloud'):

--- a/acceptancetests/assess_constraints.py
+++ b/acceptancetests/assess_constraints.py
@@ -54,8 +54,8 @@ def mem_to_int(size):
         val = int(size[0:-1])
         unit = size[-1]
         return val * (1024 ** 'MGTP'.find(unit))
-    else:
-        return int(size)
+
+    return int(size)
 
 
 class Constraints:
@@ -162,13 +162,13 @@ class Constraints:
                 key = 'cpu-cores'
             if key not in actual_data:
                 raise JujuAssertionError('Missing data:', key)
-            elif key in ['mem', 'root-disk']:
+            if key in ['mem', 'root-disk']:
                 if mem_to_int(value) != mem_to_int(actual_data[key]):
                     return False
             elif value != actual_data[key]:
                 return False
-        else:
-            return True
+
+        return True
 
     def meets_all(self, actual_data):
         return (self.meets_root_disk(actual_data.get('root-disk')) and
@@ -337,7 +337,7 @@ def assess_multiple_constraints(client, base_name, **kwargs):
 
     Makes sure the combination of constraints gives us new instance type."""
     finger_prints = []
-    for (part, (constraint, value)) in enumerate(kwargs.iteritems()):
+    for (part, (constraint, value)) in enumerate(iter(kwargs.items())):
         data = prepare_constraint_test(
             client, Constraints(**{constraint: value}),
             '{}-part{}'.format(base_name, part))
@@ -355,9 +355,9 @@ def assess_multiple_constraints(client, base_name, **kwargs):
 def assess_constraints(client, test_kvm=False):
     """Assess deployment with constraints."""
     provider = client.env.provider
-    if 'lxd' == provider:
+    if provider == 'lxd':
         assess_virt_type_constraints(client, test_kvm)
-    elif 'ec2' == provider:
+    elif provider == 'ec2':
         assess_instance_type_constraints(client, provider)
         assess_root_disk_constraints(client, ['16G'])
         assess_cores_constraints(client, ['2'])

--- a/acceptancetests/assess_constraints.py
+++ b/acceptancetests/assess_constraints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This module tests the deployment with constraints."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_container_networking.py
+++ b/acceptancetests/assess_container_networking.py
@@ -15,6 +15,12 @@ import tempfile
 from textwrap import dedent
 import time
 
+from utility import (
+    JujuAssertionError,
+    add_basic_testing_arguments,
+    configure_logging,
+    wait_for_port,
+    )
 from deploy_stack import (
     BootstrapManager,
     get_random_string,
@@ -24,12 +30,6 @@ from jujupy import (
     KVM_MACHINE,
     LXC_MACHINE,
     LXD_MACHINE,
-    )
-from utility import (
-    JujuAssertionError,
-    add_basic_testing_arguments,
-    configure_logging,
-    wait_for_port,
     )
 
 
@@ -59,7 +59,8 @@ def parse_args(argv=None):
         choices=[KVM_MACHINE, LXC_MACHINE, LXD_MACHINE])
     parser.add_argument(
         '--space-constraint',
-        help='The network space to constrain containers to. Default is no space constraints.',
+        help=('The network space to constrain containers to. '
+              'Default is no space constraints.'),
         default=None,
         dest='space')
     args = parser.parse_args(argv)
@@ -124,7 +125,8 @@ def make_machines(client, container_types, space):
 
     for host, containers in required.iteritems():
         for container in containers:
-            client.juju('add-machine', tuple(['{}:{}'.format(container, host)] + sargs))
+            client.juju('add-machine',
+                        tuple(['{}:{}'.format(container, host)] + sargs))
 
     status = client.wait_for_started()
 
@@ -420,7 +422,8 @@ def main(argv=None):
     client = bs_manager.client
     machine_types = _get_container_types(client, args.machine_type)
     with cleaned_bootstrap_context(bs_manager, args):
-        assess_container_networking(bs_manager.client, machine_types, args.space)
+        assess_container_networking(bs_manager.client, machine_types,
+                                    args.space)
     return 0
 
 

--- a/acceptancetests/assess_container_networking.py
+++ b/acceptancetests/assess_container_networking.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from argparse import ArgumentParser
 import contextlib
@@ -121,7 +121,7 @@ def make_machines(client, container_types, space):
     sargs = []
     if space:
         sargs = ['--constraints', 'spaces=' + space]
-         
+
     for host, containers in required.iteritems():
         for container in containers:
             client.juju('add-machine', tuple(['{}:{}'.format(container, host)] + sargs))

--- a/acceptancetests/assess_cross_model_relations.py
+++ b/acceptancetests/assess_cross_model_relations.py
@@ -26,13 +26,19 @@ The above feature tests will be run on:
 """
 
 from __future__ import print_function
+from textwrap import dedent
 
 import argparse
 import logging
 import sys
 import yaml
-from textwrap import dedent
 
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    JujuAssertionError,
+    )
+from jujucharm import local_charm_path
 from deploy_stack import (
     BootstrapManager,
     )
@@ -42,12 +48,6 @@ from jujupy.client import (
     )
 from jujupy.models import (
     temporary_model
-    )
-from jujucharm import local_charm_path
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
-    JujuAssertionError,
     )
 
 
@@ -64,7 +64,8 @@ def assess_cross_model_relations_single_controller(args):
         offer_model = bs_manager.client
         with temporary_model(offer_model, 'consume-model') as consume_model:
             ensure_cmr_offer_management(offer_model)
-            ensure_cmr_offer_consumption_and_relation(offer_model, consume_model)
+            ensure_cmr_offer_consumption_and_relation(offer_model,
+                                                      consume_model)
 
 
 def assess_cross_model_relations_multiple_controllers(args):

--- a/acceptancetests/assess_cross_model_relations.py
+++ b/acceptancetests/assess_cross_model_relations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Functional tests for Cross Model Relation (CMR) functionality.
 
 This test exercises the CMR Juju functionality which allows applications to

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -314,12 +314,11 @@ def main(argv=None):
 
     begin = time.time()
     bs_manager = BootstrapManager.from_args(args)
-    with bs_manager.booted_context(
-        args.upload_tools,
-        db_snap_path=db_snap_path,
-        db_snap_asserts_path=db_snap_asserts_path,
-        mongo_memory_profile=args.mongo_memory_profile,
-    ):
+    with bs_manager.booted_context(args.upload_tools,
+                                   db_snap_path=db_snap_path,
+                                   db_snap_asserts_path=db_snap_asserts_path,
+                                   mongo_memory_profile=args.
+                                   mongo_memory_profile):
         client = bs_manager.client
         mongo_version, mongo_profile = extract_mongo_details(client)
         log.info("MongoVersion used for deployment: {} (profile: {})".format(

--- a/acceptancetests/assess_destroy_model.py
+++ b/acceptancetests/assess_destroy_model.py
@@ -68,7 +68,8 @@ def destroy_model(client, new_client):
             if not_found_error in e.stderr:
                 log.info("Model fully removed")
                 break
-            removed_error = b'model "admin/{}" has been removed from the controller'.format(old_model)
+            removed_error = (b'model "admin/{}" has been removed '
+                             b'from the controller').format(old_model)
             if removed_error not in e.stderr:
                 error = 'unexpected error calling status\n{}'.format(e.stderr)
                 raise JujuAssertionError(error)
@@ -81,7 +82,8 @@ def destroy_model(client, new_client):
         # We didn't break out of the loop, so the model-removed message didn't
         # change to model not found (indicating that the model hasn't been
         # removed from the state pool).
-        raise JujuAssertionError("didn't get not found error - model still in state pool")
+        raise JujuAssertionError(
+            "didn't get not found error - model still in state pool")
 
 
 def switch_model(client, current_model, current_controller):

--- a/acceptancetests/assess_destroy_model.py
+++ b/acceptancetests/assess_destroy_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess if Juju tracks the model when the current model is destroyed."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_endpoint_bindings.py
+++ b/acceptancetests/assess_endpoint_bindings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Validate endpoint bindings functionality on MAAS."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_heterogeneous_control.py
+++ b/acceptancetests/assess_heterogeneous_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from argparse import ArgumentParser
 from contextlib import contextmanager

--- a/acceptancetests/assess_heterogeneous_control.py
+++ b/acceptancetests/assess_heterogeneous_control.py
@@ -7,25 +7,25 @@ from textwrap import dedent
 from subprocess import CalledProcessError
 import sys
 
+from utility import (
+    configure_logging,
+    until_timeout,
+)
+from jujuci import add_credential_args
 from jujucharm import (
     local_charm_path,
 )
-from jujupy import (
-    client_from_config,
-    fake_juju_client,
-    JujuData,
-    )
 from deploy_stack import (
     BootstrapManager,
     check_token,
     get_random_string,
     )
-from jujuci import add_credential_args
-from utility import (
-    configure_logging,
-    until_timeout,
-)
 
+from jujupy import (
+    client_from_config,
+    fake_juju_client,
+    JujuData,
+    )
 
 def prepare_dummy_env(client):
     """Use a client to prepare a dummy environment."""
@@ -47,9 +47,9 @@ def get_clients(initial, other, base_env, debug, agent_url):
         environment = JujuData.from_config(base_env)
         client = fake_juju_client(env=environment)
         return client, client, client
-    else:
-        initial_client = client_from_config(base_env, initial, debug=debug)
-        environment = initial_client.env
+
+    initial_client = client_from_config(base_env, initial, debug=debug)
+    environment = initial_client.env
     if agent_url is None:
         environment.discard_option('tools-metadata-url')
     other_client = initial_client.clone_from_path(other)
@@ -91,7 +91,7 @@ def run_context(bs_manager, other, upload_tools):
         # Test clean shutdown of an environment.
         callback_with_fallback(other, bs_manager.tear_down_client,
                                nice_tear_down)
-    except:
+    except Exception:
         bs_manager.tear_down()
         raise
 
@@ -203,8 +203,8 @@ def wait_until_removed(client, agent_id):
     for ignored in until_timeout(240):
         if not has_agent(client, agent_id):
             return
-    else:
-        raise AssertionError('Machine not destroyed: {}.'.format(agent_id))
+
+    raise AssertionError('Machine not destroyed: {}.'.format(agent_id))
 
 
 def check_series(client, machine='0', series=None):

--- a/acceptancetests/assess_juju_output.py
+++ b/acceptancetests/assess_juju_output.py
@@ -34,6 +34,7 @@ __metaclass__ = type
 
 log = logging.getLogger("assess_juju_output")
 
+
 def verify_juju_status_contains_display_name(client_status):
     fields_to_test = [
         "instance-id",
@@ -45,6 +46,7 @@ def verify_juju_status_contains_display_name(client_status):
         except KeyError:
             err = "juju status excludes {}".format(field)
             raise JujuAssertionError(err)
+
 
 def verify_juju_status_attribute_of_charm(charm_details):
     """Verify the juju-status of the deployed charm
@@ -106,7 +108,6 @@ def assess_juju_status(client, series):
     """
     deploy_charm_with_subordinate_charm(client, series)
     status = client.get_status()
-    verify_juju_status_fields(status)
     charm_details = status.get_applications()['dummy-sink']
     verify_juju_status_attribute_of_charm(charm_details)
     verify_juju_status_attribute_of_subordinate_charm(charm_details)

--- a/acceptancetests/assess_juju_output.py
+++ b/acceptancetests/assess_juju_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Deploy a charm and subordinate charm and verify juju-status attribute of
     the deployed charms.

--- a/acceptancetests/assess_juju_sync_tools.py
+++ b/acceptancetests/assess_juju_sync_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/acceptancetests/assess_log_forward.py
+++ b/acceptancetests/assess_log_forward.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test Juju's log forwarding feature.
 
 Log forwarding allows a controller to forward syslog from all models of a

--- a/acceptancetests/assess_log_forward.py
+++ b/acceptancetests/assess_log_forward.py
@@ -150,12 +150,12 @@ def get_assert_regex(raw_uuid, message=None):
     # Maybe over simplified removing the last 8 characters
     uuid = re.escape(raw_uuid)
     short_uuid = re.escape(raw_uuid[:-8])
-    date_check = '[A-Z][a-z]{,2}\ +[0-9]+\ +[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}'
+    date_check = r'[A-Z][a-z]{,2}\ +[0-9]+\ +[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}'
     machine = 'machine-0.{}'.format(uuid)
     agent = 'jujud-machine-agent-{}'.format(short_uuid)
     message = message or '.*'
 
-    return '"^{datecheck}\ {machine}\ {agent}\ {message}$"'.format(
+    return r'"^{datecheck}\ {machine}\ {agent}\ {message}$"'.format(
         datecheck=date_check,
         machine=machine,
         agent=agent,

--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -8,6 +8,9 @@ import re
 
 import yaml
 
+from utility import (
+    add_basic_testing_arguments,
+)
 from deploy_stack import (
     boot_context,
     update_env,
@@ -18,9 +21,6 @@ from jujucharm import (
 from jujupy import (
     client_from_config,
     juju_home_path,
-)
-from utility import (
-    add_basic_testing_arguments,
 )
 
 
@@ -77,7 +77,8 @@ def assess_machine_rotation(client):
                   "machine={}".format(machine_id))
 
 
-def test_rotation(client, logfile, prefix, fill_action, size_action, log_size, *args):
+def test_rotation(client, logfile, prefix, fill_action, size_action, log_size,
+                  *args):
     """A reusable help for testing log rotation.log
 
     Deploys the fill-logs charm and uses it to fill the machine or unit log and
@@ -94,7 +95,8 @@ def test_rotation(client, logfile, prefix, fill_action, size_action, log_size, *
     def run_fill_log_action():
         """Using fill action to fill logs, returns resulting output."""
         for _ in range(log_size//single_megs):
-            client.action_do_fetch("fill-logs/0", fill_action, FILL_TIMEOUT, *args)
+            client.action_do_fetch("fill-logs/0", fill_action, FILL_TIMEOUT,
+                                   *args)
         # Need to give the disk sometime to actually move files before
         # requesting resulting output.
         sleep(10)
@@ -157,7 +159,7 @@ def check_expected_backup(key, logprefix, action_output):
         raise LogRotateError(
             "Missing backup log '{}' after rotation.".format(key))
 
-    backup_pattern = "/var/log/juju/%s-(.+?)\.log.gz" % logprefix
+    backup_pattern = r"/var/log/juju/%s-(.+?)\.log.gz" % logprefix
 
     log_name = log["name"]
     matches = re.match(backup_pattern, log_name)
@@ -233,8 +235,9 @@ def main():
     client = make_client_from_args(args)
     with boot_context(args.temp_env_name, client,
                       bootstrap_host=args.bootstrap_host,
-                      machines=args.machine, series=args.series, arch=args.arch,
-                      agent_url=args.agent_url, agent_stream=args.agent_stream,
+                      machines=args.machine, series=args.series,
+                      arch=args.arch, agent_url=args.agent_url,
+                      agent_stream=args.agent_stream,
                       log_dir=args.logs, keep_env=args.keep_env,
                       upload_tools=args.upload_tools,
                       region=args.region):

--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 from argparse import ArgumentParser

--- a/acceptancetests/assess_min_version.py
+++ b/acceptancetests/assess_min_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import argparse

--- a/acceptancetests/assess_mixed_images.py
+++ b/acceptancetests/assess_mixed_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess mixed deployment of images from two sets of simplestreams."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_model_config_tree.py
+++ b/acceptancetests/assess_model_config_tree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test Model Tree Config functionality.
 
 Tests that default values can be overwritten and then unset.

--- a/acceptancetests/assess_model_defaults.py
+++ b/acceptancetests/assess_model_defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess the model-defaults command."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_model_defaults.py
+++ b/acceptancetests/assess_model_defaults.py
@@ -23,7 +23,8 @@ __metaclass__ = type
 log = logging.getLogger('assess_model_defaults')
 
 
-def assemble_model_default(model_key, default, controller_value=None, region_values=None):
+def assemble_model_default(model_key, default, controller_value=None,
+                           region_values=None):
     """Create a dict that contains the formatted model-defaults data."""
     # Ordering in the regions argument is lost.
     defaults = {'default': default}
@@ -55,11 +56,12 @@ def get_new_model_config(client, cloud=None, region=None, model_name=None):
     cloud_region = None
     if region is not None:
         new_env.set_region(region)
-        cloud_region = client.get_cloud_region(cloud,region)
+        cloud_region = client.get_cloud_region(cloud, region)
     # Don't use the bootstrap config, we want to check that the default series
     # is inherited from the model defaults correctly and the bootstrap config
     # might override it.
-    new_model = client.add_model(new_env, cloud_region, use_bootstrap_config=False)
+    new_model = client.add_model(new_env, cloud_region,
+                                 use_bootstrap_config=False)
     config_data = new_model.get_model_config()
     new_model.destroy_model()
     return config_data
@@ -120,7 +122,8 @@ def assess_model_defaults(client, other_region):
     if other_region is not None:
         log.info('Checking other region model-defaults.')
         assess_model_defaults_region(
-            client, 'default-series', 'bionic', cloud=cloud, region=other_region)
+            client, 'default-series', 'bionic', cloud=cloud,
+            region=other_region)
 
 
 def parse_args(argv):

--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tests for the Model Migration feature"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -12,6 +12,15 @@ import sys
 from time import sleep
 import yaml
 
+from remote import remote_from_address
+from utility import (
+    JujuAssertionError,
+    add_basic_testing_arguments,
+    configure_logging,
+    qualified_model_name,
+    temp_dir,
+    until_timeout,
+)
 from assess_user_grant_revoke import User
 from deploy_stack import (
     BootstrapManager,
@@ -25,15 +34,6 @@ from jujupy.workloads import (
     assert_deployed_charm_is_responding,
     deploy_dummy_source_to_new_model,
     deploy_simple_server_to_new_model,
-)
-from remote import remote_from_address
-from utility import (
-    JujuAssertionError,
-    add_basic_testing_arguments,
-    configure_logging,
-    qualified_model_name,
-    temp_dir,
-    until_timeout,
 )
 
 
@@ -62,13 +62,16 @@ def assess_model_migration(bs1, bs2, args):
             ensure_model_logs_are_migrated(source_client, dest_client)
             ensure_api_login_redirects(source_client, dest_client)
 
-            # TODO - adding a new user with lxc cloud fails due to missing creds
+            # TODO - adding a new user with lxc cloud fails due to missing
+            # creds
             # TODO - local lxd creds need to be added to controller by running
             # TODO - autoload-credentials and then update-credentials
-            # assess_user_permission_model_migrations(source_client, dest_client)
+            # assess_user_permission_model_migrations(source_client,
+            # dest_client)
 
             # TODO - fix 'migration in progress' error
-            # ensure_migration_rolls_back_on_failure(source_client, dest_client)
+            # ensure_migration_rolls_back_on_failure(source_client,
+            # dest_client)
 
         # Continue test where we ensure that a migrated model continues to
         # work after it's originating controller has been destroyed.
@@ -134,7 +137,7 @@ def wait_until_model_disappears(client, model_name, timeout=600):
             # error and the model is no longer in the output.
             if 'cannot get model details' not in e.stderr:
                 raise
-        else:
+
             # 2.2-rc1 introduced new model listing output name/short-name.
             all_model_names = [
                 m.get('short-name', m['name']) for m in models['models']]
@@ -307,8 +310,8 @@ def ensure_superuser_can_migrate_other_user_models(
         attempt_client.env.user_name)
 
     migration_client = source_client.migrate(
-        user_qualified_model_name, user_qualified_model_name, attempt_client, dest_client,
-        include_e=False)
+        user_qualified_model_name, user_qualified_model_name, attempt_client,
+        dest_client, include_e=False)
 
     wait_for_model(
         migration_client, user_qualified_model_name)
@@ -365,10 +368,10 @@ def get_full_model_name(client, include_user_name):
             client.env.controller.name,
             client.env.user_name,
             client.env.environment)
-    else:
-        return '{}:{}'.format(
-            client.env.controller.name,
-            client.env.environment)
+
+    return '{}:{}'.format(
+        client.env.controller.name,
+        client.env.environment)
 
 
 def ensure_model_is_functional(client, application):
@@ -462,8 +465,8 @@ def ensure_migration_rolls_back_on_failure(source_client, dest_client):
     test_model, application = deploy_simple_server_to_new_model(
         source_client, 'rollmeback')
     test_model.migrate(
-        test_model.env.environment, test_model.env.environment, test_model, dest_client,
-        include_e=False)
+        test_model.env.environment, test_model.env.environment, test_model,
+        dest_client, include_e=False)
     # Once migration has started interrupt it
     wait_for_migrating(test_model)
     log.info('Disrupting target controller to force rollback')
@@ -536,7 +539,8 @@ def ensure_migrating_with_superuser_user_permissions_succeeds(
         user_source_client, 'super-permissions')
     log.info('Attempting migration process')
     migrated_client = migrate_model_to_controller(
-        user_new_model, source_client, user_dest_client, include_user_name=True)
+        user_new_model, source_client, user_dest_client,
+        include_user_name=True)
     log.info('SUCCESS: superuser migrated other user model.')
     migrated_client.destroy_model()
 

--- a/acceptancetests/assess_model_migration_versions.py
+++ b/acceptancetests/assess_model_migration_versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test migrating models between controllers of increasing versions."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_model_migration_versions.py
+++ b/acceptancetests/assess_model_migration_versions.py
@@ -11,6 +11,14 @@ from distutils.version import (
 import logging
 import sys
 
+from deploy_stack import (
+    BootstrapManager,
+    get_random_string,
+    )
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
 from assess_model_migration import (
     _new_log_dir,
     assert_model_migrated_successfully,
@@ -27,14 +35,6 @@ from jujupy.wait_condition import (
 )
 from jujupy.workloads import (
     deploy_simple_server_to_new_model,
-    )
-from deploy_stack import (
-    BootstrapManager,
-    get_random_string,
-    )
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
     )
 
 __metaclass__ = type
@@ -67,7 +67,7 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
                 'version-migration',
                 resource_contents)
             migration_target_client = migrate_model_to_controller(
-                test_stable_model, devel_client)
+                test_stable_model, stable_client, devel_client)
             assert_model_migrated_successfully(
                 migration_target_client, application, resource_contents)
 
@@ -77,6 +77,7 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
                 another_bsm.client.get_controller_client().wait_for(
                     AllMachinesRunning())
                 another_migration_client = migrate_model_to_controller(
+                    test_stable_model,
                     migration_target_client, another_bsm.client)
                 assert_model_migrated_successfully(
                     another_migration_client, application, resource_contents)

--- a/acceptancetests/assess_multi_series_charms.py
+++ b/acceptancetests/assess_multi_series_charms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Charms have the capability to declare that they support more than
 one series. Previously a separate copy of the charm was required for

--- a/acceptancetests/assess_multimodel.py
+++ b/acceptancetests/assess_multimodel.py
@@ -16,13 +16,13 @@ from deploy_stack import (
     get_random_string,
     safe_print_status,
     )
-from jujupy import (
-    client_from_config,
-    )
 from utility import (
     add_basic_testing_arguments,
     ensure_dir,
     print_now,
+    )
+from jujupy import (
+    client_from_config,
     )
 
 
@@ -78,8 +78,7 @@ def multimodel_setup(args):
             args.agent_stream,
             args.logs, args.keep_env,
             upload_tools=False,
-            region=args.region,
-            ):
+            region=args.region):
         yield client, charm_series, base_env
 
 
@@ -93,7 +92,7 @@ def hosted_environment(system_client, log_dir, suffix):
     client = system_client.add_model(env_name)
     try:
         yield client
-    except:
+    except Exception:
         logging.exception(
             'Exception while environment "{}" active'.format(
                 client.env.environment))

--- a/acceptancetests/assess_multimodel.py
+++ b/acceptancetests/assess_multimodel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess multimodel support."""
 
 from argparse import ArgumentParser

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -6,20 +6,14 @@ import argparse
 import logging
 import sys
 import json
-import yaml
 import subprocess
 import re
 import time
 import os
 import socket
+import yaml
 from collections import defaultdict
 
-from jujupy import (
-    client_for_existing
-    )
-from jujupy.wait_condition import (
-    WaitApplicationNotPresent
-    )
 from deploy_stack import (
     BootstrapManager
     )
@@ -31,6 +25,12 @@ from utility import (
     )
 from substrate import (
     maas_account_from_boot_config,
+    )
+from jujupy import (
+    client_for_existing
+    )
+from jujupy.wait_condition import (
+    WaitApplicationNotPresent
     )
 
 __metaclass__ = type
@@ -48,8 +48,7 @@ class AssessNetworkHealth:
         if args.logs:
             self.log_dir = args.logs
         else:
-            self.log_dir = generate_default_clean_dir(
-                            args.temp_env_name)
+            self.log_dir = generate_default_clean_dir(args.temp_env_name)
         self.expose_client = None
         self.existing_series = set([])
         self.expose_test_charms = set([])
@@ -259,7 +258,8 @@ class AssessNetworkHealth:
         return results
 
     def get_nh_unit_info(self, apps, by_unit=False):
-        """Parses juju status information to return deployed network-health units.
+        """Parses juju status information to return deployed network-health
+        units.
 
         :param apps: Dict of apps given by get_status().get_applications()
         :param by_unit: Bool, returns dict of NH units keyed by the unit they
@@ -432,12 +432,12 @@ class AssessNetworkHealth:
         log.info('Parsing final results.')
         error_string = []
         for nh_source, service_result in visibility.items():
-                for service, unit_res in service_result.items():
-                    if False in unit_res.values():
-                        failed = [u for u, r in unit_res.items() if r is False]
-                        error = ('Unit {0} failed to contact '
-                                 'targets(s): {1}'.format(nh_source, failed))
-                        error_string.append(error)
+            for service, unit_res in service_result.items():
+                if False in unit_res.values():
+                    failed = [u for u, r in unit_res.items() if r is False]
+                    error = ('Unit {0} failed to contact '
+                             'targets(s): {1}'.format(nh_source, failed))
+                    error_string.append(error)
         for unit, res in internet.items():
             if not res:
                 error = 'Machine {} failed internet connection.'.format(unit)
@@ -507,7 +507,8 @@ class AssessNetworkHealth:
         return True
 
     def to_json(self, units):
-        """Returns a formatted json string to be passed through juju run-action.
+        """Returns a formatted json string to be passed through juju
+        run-action.
 
         :param units: Dict of units
         :return: A "JSON-like" string that can be passed to Juju without it

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess network health for a given deployment or bundle"""
 from __future__ import print_function
 

--- a/acceptancetests/assess_network_spaces.py
+++ b/acceptancetests/assess_network_spaces.py
@@ -11,15 +11,15 @@ import re
 import ipaddress
 import boto3
 
-from jujupy.exceptions import (
-    ProvisioningError
-    )
 from deploy_stack import (
     BootstrapManager
     )
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
+    )
+from jujupy.exceptions import (
+    ProvisioningError
     )
 
 __metaclass__ = type
@@ -61,8 +61,8 @@ class AssessNetworkSpaces:
             try:
                 test(client)
             except TestFailure as e:
-                fail_messages.append(e.message)
-                log.info('FAILED: ' + e.message + '\n')
+                fail_messages.append(str(e))
+                log.info('FAILED: ' + str(e) + '\n')
 
         log.info('Tests complete.')
         if fail_messages:
@@ -86,8 +86,8 @@ class AssessNetworkSpaces:
         :param client: Juju client object with controller
         """
         log.info('Assigning network spaces on {}.'.format(client.env.provider))
-        subnets = yaml.safe_load(
-                client.get_juju_output('list-subnets', '--format=yaml'))
+        subnets = yaml.safe_load(client.get_juju_output('list-subnets',
+                                                        '--format=yaml'))
         if not subnets:
             raise SubnetsNotReady(
                 'No subnets defined in {}'.format(client.env.provider))
@@ -96,9 +96,8 @@ class AssessNetworkSpaces:
             subnet_count += 1
             client.juju('add-space', ('space{}'.format(subnet_count), subnet))
         if subnet_count < 3:
-            raise SubnetsNotReady(
-                    '3 subnets required for spaces assignment. '
-                    '{} found.'.format(subnet_count))
+            raise SubnetsNotReady('3 subnets required for spaces assignment. '
+                                  '{} found.'.format(subnet_count))
 
     def assert_machines_in_correct_spaces(self, client):
         """Check all the machines to verify they are in the expected spaces
@@ -121,11 +120,10 @@ class AssessNetworkSpaces:
                 expected_space = 'space{}'.format(machine)
             ip = get_machine_ip_in_space(client, machine, expected_space)
             if not ip:
-                raise TestFailure(
-                        'Machine {machine} has NO IPs in '
-                        '{space}'.format(
-                            machine=machine,
-                            space=expected_space))
+                raise TestFailure('Machine {machine} has NO IPs in '
+                                  '{space}'.format(
+                                      machine=machine,
+                                      space=expected_space))
         log.info('PASSED')
 
     def assert_machine_connectivity(self, client):
@@ -168,9 +166,9 @@ class AssessNetworkSpaces:
             machine = client.show_machine('2')['machines'][0]
             container = machine['containers']['2/lxd/0']
             if container['juju-status']['current'] == 'started':
-                raise TestFailure(
-                        'Encountered no conflict when launching a container '
-                        'on a machine with a different spaces constraint.')
+                raise TestFailure(('Encountered no conflict when launching a '
+                                   'container on a machine with a different '
+                                   'spaces constraint.'))
         except ProvisioningError:
             log.info('Container correctly failed to provision.')
         finally:
@@ -194,14 +192,14 @@ class AssessNetworkSpaces:
             try:
                 routes = client.run(['ip route show'], machines=[unit[0]])
             except subprocess.CalledProcessError:
-                raise TestFailure(
-                        'Could not connect to address for unit: {0}, '
-                        'unable to find default route.'.format(unit[0]))
+                raise TestFailure(('Could not connect to address for unit: {0}'
+                                   ', unable to find default route.').format(
+                                       unit[0]))
             default_route = re.search(r'(default via )+([\d\.]+)\s+',
                                       json.dumps(routes[0]))
             if not default_route:
-                raise TestFailure(
-                        'Default route not found for {}'.format(unit[0]))
+                raise TestFailure('Default route not found for {}'.format(
+                    unit[0]))
         log.info('PASSED')
 
     def deploy_spaces_machines(self, client, series=None):
@@ -322,8 +320,8 @@ def machine_can_ping_ip(client, machine, ip):
     :param ip: IP address to ping
     :returns: success of ping
     """
-    rc, _ = client.juju(
-            'ssh', ('--proxy', machine, 'ping -c1 -q ' + ip), check=False)
+    rc, _ = client.juju('ssh', ('--proxy', machine, 'ping -c1 -q ' + ip),
+                        check=False)
     return rc == 0
 
 
@@ -381,11 +379,10 @@ class SpacesAWS(Spaces):
             return False
 
         creds = client.env.get_cloud_credentials()
-        ec2 = boto3.resource(
-                'ec2',
-                region_name=client.env.get_region(),
-                aws_access_key_id=creds['access-key'],
-                aws_secret_access_key=creds['secret-key'])
+        ec2 = boto3.resource('ec2',
+                             region_name=client.env.get_region(),
+                             aws_access_key_id=creds['access-key'],
+                             aws_secret_access_key=creds['secret-key'])
 
         # See if the VPC we want already exists.
         vpc_response = ec2.meta.client.describe_vpcs(Filters=[{
@@ -403,7 +400,8 @@ class SpacesAWS(Spaces):
         log.info('Setting up VPC in AWS region {}'.format(
             client.env.get_region()))
         vpc = ec2.create_vpc(CidrBlock='10.0.0.0/16')
-        vpc.create_tags(Tags=[{'Key': 'Name', 'Value': 'assess-network-spaces'}])
+        vpc.create_tags(Tags=[{'Key': 'Name',
+                               'Value': 'assess-network-spaces'}])
         vpc.wait_until_available()
 
         self.vpcid = vpc.id
@@ -450,12 +448,10 @@ class SpacesAWS(Spaces):
             region=client.env.get_region(),
             vpcid=self.vpcid))
         creds = client.env.get_cloud_credentials()
-        ec2 = boto3.resource(
-                'ec2',
-                region_name=client.env.get_region(),
-                aws_access_key_id=creds['access-key'],
-                aws_secret_access_key=creds['secret-key'])
-        ec2client = ec2.meta.client
+        ec2 = boto3.resource('ec2',
+                             region_name=client.env.get_region(),
+                             aws_access_key_id=creds['access-key'],
+                             aws_secret_access_key=creds['secret-key'])
         vpc = ec2.Vpc(self.vpcid)
         # delete any instances
         for subnet in vpc.subnets.all():

--- a/acceptancetests/assess_network_spaces.py
+++ b/acceptancetests/assess_network_spaces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess network spaces for supported providers (currently only EC2)"""
 
 import argparse

--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Testing Juju's persistent storage feature."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -113,7 +113,7 @@ def assert_storage_count(storage_list, expected):
 
 def assert_single_blk_existence(storage_list, storage_id):
     log.info(
-        'Checking existence of single block device storage.'.format(
+        'Checking existence of single block device storage {}.'.format(
             storage_id))
     if storage_id not in storage_list:
         raise JujuAssertionError(
@@ -124,7 +124,8 @@ def assert_single_blk_existence(storage_list, storage_id):
 
 def assert_single_blk_removal(storage_list, storage_id):
     log.info(
-        'Checking removal of single block device storage.'.format(storage_id))
+        'Checking removal of single block device storage {}.'.format(
+            storage_id))
     if storage_id in storage_list:
         raise JujuAssertionError(
             '{} still exists in storage list.'.format(storage_id))

--- a/acceptancetests/assess_primary_sub_relations.py
+++ b/acceptancetests/assess_primary_sub_relations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test relations between primary and subordinates are cleanedup correctly"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_proxy.py
+++ b/acceptancetests/assess_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess Juju under various proxy network conditions.
 
 This test is dangerous to run on your own host. It will change the host's

--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Backup and restore a stack.
 
 from __future__ import print_function

--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -13,19 +13,17 @@ from subprocess import CalledProcessError
 import yaml
 
 from deploy_stack import (BootstrapManager, deploy_dummy_stack,
-                          get_remote_machines, get_token_from_status,
-                          wait_for_state_server_to_shutdown)
-from jujupy import parse_new_state_server_from_error
-from substrate import convert_to_azure_ids, terminate_instances
+                          get_remote_machines)
 from utility import (JujuAssertionError, LoggedException,
-                     add_basic_testing_arguments, configure_logging,
-                     until_timeout)
+                     add_basic_testing_arguments, configure_logging)
+from jujupy import parse_new_state_server_from_error
 
 __metaclass__ = type
 
-running_instance_pattern = re.compile('\["([^"]+)"\]')
+running_instance_pattern = re.compile(r'\["([^"]+)"\]')
 
 log = logging.getLogger("assess_recovery")
+
 
 def set_token(client, token):
     # unfortunately deploying a stack currently requires a token setting, but
@@ -34,6 +32,7 @@ def set_token(client, token):
     # or before the token is set multiple times.
     client.set_config('dummy-source', {'token': token})
     return client.action_do('dummy-sink/0', 'echo', "value={}".format(token))
+
 
 def check_token(client, id, token):
     result = client.action_fetch(id, 'echo', "300s")
@@ -44,6 +43,7 @@ def check_token(client, id, token):
     raise JujuAssertionError('Token is not {}: {}'.format(
                              token, value))
 
+
 def deploy_stack(client, charm_series):
     """"Deploy a simple stack, state-server and ubuntu."""
     deploy_dummy_stack(client, charm_series)
@@ -51,6 +51,7 @@ def deploy_stack(client, charm_series):
     client.wait_for_workloads()
     check_token(client, id, 'One')
     log.info("%s is ready to testing", client.env.environment)
+
 
 def enable_ha(bs_manager, controller_client):
     """Enable HA and wait for the controllers to be ready."""
@@ -62,19 +63,22 @@ def enable_ha(bs_manager, controller_client):
         controller_client, bs_manager.known_hosts)
     return remote_machines
 
+
 def disable_ha(bs_manager, controller_client):
     """Disable HA and wait for the controllers to be ready."""
     log.info("Disabling HA.")
-    condition = controller_client.remove_machine(["1", "2"], force=True, controller=True)
+    condition = controller_client.remove_machine(["1", "2"], force=True,
+                                                 controller=True)
     controller_client.wait_for(condition)
     show_controller(controller_client)
     remote_machines = get_remote_machines(
         controller_client, None)
     return remote_machines
 
+
 def restore_ha(bs_manager, controller_client):
-    """Restore HA after a backup, as there is a possiblility that the controllers
-    will be in a down state"""
+    """Restore HA after a backup, as there is a possiblility that the
+    controllers will be in a down state"""
     log.info("Restoring HA")
     machines_to_remove = []
     show_controller(controller_client)
@@ -83,24 +87,28 @@ def restore_ha(bs_manager, controller_client):
     # the pause, one will report back.
     controller_client._backend.pause(300)
     status = controller_client.get_status(controller=True)
-    # the order of the machines are normally wrong after a restore, so iterating
-    # through the machines until you find the correct ones to remove works.
+    # the order of the machines are normally wrong after a restore, so
+    # iterating through the machines until you find the correct ones to remove
+    # works.
     for name, machine in status.iter_machines():
         machine_status = machine['juju-status']
         if machine_status["current"] == "down":
             machines_to_remove.append(name)
     if len(machines_to_remove) > 0:
         controller_client.show_status()
-        condition = controller_client.remove_machine(machines_to_remove, force=True, controller=True)
+        condition = controller_client.remove_machine(machines_to_remove,
+                                                     force=True,
+                                                     controller=True)
         controller_client.wait_for(condition)
     return enable_ha(bs_manager, controller_client)
+
 
 def show_controller(client):
     controller_info = client.show_controller(format='yaml')
     log.info('Controller is:\n{}'.format(controller_info))
 
-def restore_backup(bs_manager, client, backup_file,
-                                 check_controller=True):
+
+def restore_backup(bs_manager, client, backup_file, check_controller=True):
     """juju-restore restores the backup file."""
     log.info("Starting restore.")
     try:
@@ -115,6 +123,7 @@ def restore_backup(bs_manager, client, backup_file,
     show_controller(bs_manager.client)
     bs_manager.has_controller = True
 
+
 def assess_backup(client):
     id = set_token(client, 'Two')
     client.wait_for_started()
@@ -123,10 +132,12 @@ def assess_backup(client):
     log.info("%s restored", client.env.environment)
     log.info("PASS")
 
+
 def create_tmp_model(client):
     model_name = 'temp-model'
     new_env = client.env.clone(model_name)
     return client.add_model(new_env)
+
 
 def parse_args(argv=None):
     parser = ArgumentParser(description='Test recovery strategies.')
@@ -142,6 +153,7 @@ def parse_args(argv=None):
         const='ha-backup', help="Test backup of HA.")
     return parser.parse_args(argv)
 
+
 @contextmanager
 def detect_bootstrap_machine(bs_manager):
     try:
@@ -151,6 +163,7 @@ def detect_bootstrap_machine(bs_manager):
         if address is not None:
             bs_manager.known_hosts['0'] = address
         raise
+
 
 def assess_recovery(bs_manager, strategy, charm_series):
     log.info("Setting up test.")
@@ -175,11 +188,12 @@ def assess_recovery(bs_manager, strategy, charm_series):
     # check_controller if NOT in haBackup, as we know that some of the
     # controllers are currently down.
     restore_backup(bs_manager, controller_client, backup_file,
-        check_controller=not haBackup)
+                   check_controller=not haBackup)
     if haBackup:
         bs_manager.known_hosts = restore_ha(bs_manager, controller_client)
     assess_backup(bs_manager.client)
     log.info("Test complete.")
+
 
 def main(argv):
     args = parse_args(argv)

--- a/acceptancetests/assess_resolve.py
+++ b/acceptancetests/assess_resolve.py
@@ -20,16 +20,16 @@ import sys
 from deploy_stack import (
     BootstrapManager,
     )
+from jujucharm import local_charm_path
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
 from jujupy.models import (
     temporary_model,
     )
 from jujupy.wait_condition import (
     UnitInstallCondition,
-    )
-from jujucharm import local_charm_path
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
     )
 
 
@@ -53,17 +53,17 @@ def assess_resolve(client, local_charm='simple-resolve'):
 
 
 def ensure_retry_does_not_rerun_failed_hook(client, resolve_charm):
-        with temporary_model(client, "no-retry") as temp_client:
-            unit_name = 'simple-resolve/0'
-            temp_client.deploy(resolve_charm)
-            temp_client.wait_for(UnitInstallError(unit_name))
-            temp_client.juju('resolve', ('--no-retry', unit_name))
-            # simple-resolve start hook sets a message when active to indicate
-            # it ran and if the install hook ran successfully or not.
-            # Here we make sure it's active and no install hook success.
-            temp_client.wait_for(
-                UnitInstallActive(
-                    unit_name, ResolveCharmMessage.ACTIVE_NO_INSTALL_HOOK))
+    with temporary_model(client, "no-retry") as temp_client:
+        unit_name = 'simple-resolve/0'
+        temp_client.deploy(resolve_charm)
+        temp_client.wait_for(UnitInstallError(unit_name))
+        temp_client.juju('resolve', ('--no-retry', unit_name))
+        # simple-resolve start hook sets a message when active to indicate
+        # it ran and if the install hook ran successfully or not.
+        # Here we make sure it's active and no install hook success.
+        temp_client.wait_for(
+            UnitInstallActive(
+                unit_name, ResolveCharmMessage.ACTIVE_NO_INSTALL_HOOK))
 
 
 class UnitInstallError(UnitInstallCondition):

--- a/acceptancetests/assess_resolve.py
+++ b/acceptancetests/assess_resolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Ensure resolve command resolves hook issues.
 
 This test covers the resolve command (and the option --no-retry)

--- a/acceptancetests/assess_resources.py
+++ b/acceptancetests/assess_resources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/acceptancetests/assess_sla.py
+++ b/acceptancetests/assess_sla.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This test will test the juju sla command. Currently, testing budget or
 supported sla models requires a functioning omnibus. As such, the current
 test merely checks to ensure unsupported models appear as unsupported"""

--- a/acceptancetests/assess_spaces_subnets.py
+++ b/acceptancetests/assess_spaces_subnets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from argparse import ArgumentParser
 import re

--- a/acceptancetests/assess_spaces_subnets.py
+++ b/acceptancetests/assess_spaces_subnets.py
@@ -120,9 +120,9 @@ def _assess_spaces_subnets(client, network_config, charms_to_space):
             cidrs_in_space[name].append(cidr)
 
     units_checked = 0
-    for space, cidrs in cidrs_in_space.iteritems():
+    for space, cidrs in iter(cidrs_in_space.items()):
         for cidr in cidrs:
-            for unit, address in unit_priv_address.iteritems():
+            for unit, address in iter(unit_priv_address.items()):
                 if ipv4_in_cidr(address, cidr):
                     units_checked += 1
                     charm = unit.split('/')[0]

--- a/acceptancetests/assess_ssh_keys.py
+++ b/acceptancetests/assess_ssh_keys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Validate ability of the user to import and remove ssh keys"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess juju charm storage."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -11,11 +11,11 @@ import os
 import sys
 import time
 
-from deploy_stack import BootstrapManager
 from distutils.version import (
     LooseVersion,
     StrictVersion,
 )
+from deploy_stack import BootstrapManager
 from jujucharm import (
     Charm,
     local_charm_path,
@@ -196,7 +196,7 @@ def create_storage_charm(charm_dir, name, summary, storage):
 
 def assess_create_pool(client):
     """Test creating storage pool."""
-    for name, pool in storage_pool_details.iteritems():
+    for name, pool in iter(storage_pool_details.items()):
         client.create_storage_pool(name, pool["provider"],
                                    pool["attrs"]["size"])
 

--- a/acceptancetests/assess_unregister.py
+++ b/acceptancetests/assess_unregister.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tests for the unregister command
 
 Ensure that a users controller can be unregistered.

--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Assess upgrading juju controllers and models.
 
 Bootstrap a previous version of juju and then upgrade the controller and models
@@ -259,7 +259,7 @@ def main(argv=None):
 
     assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client)
 
-    # LP:1742342 Moving from released stream to devel stream doesn't work, 
+    # LP:1742342 Moving from released stream to devel stream doesn't work,
     # because upgrade-juju doesn't honour --agent-stream over the model-config.
     #
     # assess_upgrade_passing_agent_stream(args, devel_client)

--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -21,14 +21,14 @@ import sys
 from collections import (
     namedtuple,
     )
+from textwrap import (
+    dedent,
+)
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
     temp_dir,
     )
-from textwrap import (
-    dedent,
-)
 from deploy_stack import (
     BootstrapManager
 )
@@ -128,11 +128,15 @@ def assert_upgrade_is_successful(
 def upgrade_stable_to_devel_version(client, extra_args):
     devel_version = get_stripped_version_number(client.version)
     client.get_controller_client().juju(
-        'upgrade-juju', ('-m', 'controller', '--debug', '--agent-stream', 'devel', '--agent-version', devel_version,) + extra_args)
+        'upgrade-juju', ('-m', 'controller', '--debug',
+                         '--agent-stream', 'devel',
+                         '--agent-version', devel_version,) + extra_args)
     assert_model_is_version(client.get_controller_client(), devel_version)
     wait_until_model_upgrades(client)
 
-    client.juju('upgrade-juju', ('--debug', '--agent-stream', 'devel', '--agent-version', devel_version,) + extra_args)
+    client.juju('upgrade-juju', ('--debug', '--agent-stream',
+                                 'devel', '--agent-version', devel_version,) +
+                extra_args)
     assert_model_is_version(client, devel_version)
     wait_until_model_upgrades(client)
 
@@ -217,7 +221,7 @@ def increment_patch_version(patch_version):
         return int(patch_version) + 1
     except ValueError:
         # Named patch version (alpha/beta etc.)
-        name, num = re.search('(\D+)(\d+)', patch_version).groups()
+        name, num = re.search(r'(\D+)(\d+)', patch_version).groups()
         return "{name}{num}".format(
             name=name,
             num=int(num) + 1,

--- a/acceptancetests/assess_upgrade_lxd_profile.py
+++ b/acceptancetests/assess_upgrade_lxd_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ Assess upgrading charms with lxd-profiles in different deployment scenarios.
 """

--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess upgrading using the 'upgrade-series' commands."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_user_grant_revoke.py
+++ b/acceptancetests/assess_user_grant_revoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This testsuite is intended to test basic user permissions. Users
    can be granted read or full privileges by model. Revoking those
    privileges should remove them.

--- a/acceptancetests/assess_wallet.py
+++ b/acceptancetests/assess_wallet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This tests the wallet commands utilized for commercial charm billing.
 These commands are linked to a ubuntu sso account, and as such, require the

--- a/acceptancetests/assess_wallet.py
+++ b/acceptancetests/assess_wallet.py
@@ -9,15 +9,15 @@ You can use charm login to do this, or let juju authenticate with a browser.
 from __future__ import print_function
 
 import argparse
-from fixtures import EnvironmentVariable
 import json
 import logging
 import os
-import pexpect
 from random import randint
 import shutil
 import subprocess
 import sys
+import pexpect
+from fixtures import EnvironmentVariable
 
 
 from deploy_stack import (
@@ -123,7 +123,7 @@ def assert_set_wallet(client, name, limit, error_strings):
     try:
         _try_setting_wallet(client, name, limit)
     except JujuAssertionError as e:
-        if error_strings['pass'] not in e.message:
+        if error_strings['pass'] not in str(e):
             raise JujuAssertionError(
                 '{}: {}'.format(error_strings['unknown'], e))
     else:

--- a/acceptancetests/certificates.py
+++ b/acceptancetests/certificates.py
@@ -1,6 +1,6 @@
-from OpenSSL import crypto
 import os
 from textwrap import dedent
+from OpenSSL import crypto
 
 
 def create_certificate(target_dir, ip_address):

--- a/acceptancetests/deploy_job.py
+++ b/acceptancetests/deploy_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from deploy_stack import deploy_job
 if __name__ == '__main__':
     deploy_job()

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 from argparse import ArgumentParser
@@ -874,7 +874,7 @@ class BootstrapManager:
         controller_strategy = ExistingController(client)
         return cls(
             args.temp_env_name, client, client, args.bootstrap_host,
-            args.machine, args.series, args.arch, args.agent_url, 
+            args.machine, args.series, args.arch, args.agent_url,
             args.agent_stream, args.region, args.logs, args.keep_env,
             controller_strategy=controller_strategy,
             existing_controller=existing_controller)

--- a/acceptancetests/jujucharm.py
+++ b/acceptancetests/jujucharm.py
@@ -3,10 +3,9 @@
 from contextlib import contextmanager
 import logging
 import os
-import pexpect
 import re
 import subprocess
-
+import pexpect
 import yaml
 
 from utility import (
@@ -139,13 +138,13 @@ class CharmCommand:
         try:
             command = pexpect.spawn(
                 self.charm_bin, ['login'], env=self._get_env())
-            command.expect('(?i)Login to Ubuntu SSO')
-            command.expect('(?i)Press return to select.*\.')
-            command.expect('(?i)E-Mail:')
+            command.expect(r'(?i)Login to Ubuntu SSO')
+            command.expect(r'(?i)Press return to select.*\.')
+            command.expect(r'(?i)E-Mail:')
             command.sendline(user_email)
-            command.expect('(?i)Password')
+            command.expect(r'(?i)Password')
             command.sendline(password)
-            command.expect('(?i)Two-factor auth')
+            command.expect(r'(?i)Two-factor auth')
             command.sendline()
             command.expect(pexpect.EOF)
             if command.isalive():

--- a/acceptancetests/jujupy/backend.py
+++ b/acceptancetests/jujupy/backend.py
@@ -41,12 +41,6 @@ from jujupy.wait_condition import (
 
 __metaclass__ = type
 
-# Python 2 and 3 compatibility
-try:
-    argtype = basestring
-except NameError:
-    argtype = str
-
 log = logging.getLogger("jujupy.backend")
 
 JUJU_DEV_FEATURE_FLAGS = 'JUJU_DEV_FEATURE_FLAGS'
@@ -189,7 +183,7 @@ class JujuBackend:
 
         # If args is a string, make it a tuple. This makes writing commands
         # with one argument a bit nicer.
-        if isinstance(args, argtype):
+        if isinstance(args, str):
             args = (args,)
         # we split the command here so that the caller can control where the -m
         # model flag goes.  Everything in the command string is put before the

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -563,9 +563,12 @@ def describe_substrate(env):
 def get_stripped_version_number(version_string):
     return get_version_string_parts(version_string)[0]
 
-
 def get_version_string_parts(version_string):
     # strip the series and arch from the built version.
+    # Note:
+    if isinstance(version_string, bytes):
+        version_string = str(version_string, 'utf-8')
+
     version_parts = version_string.split('-')
     if len(version_parts) == 4:
         # Version contains "-<patchname>", reconstruct it after the split.

--- a/acceptancetests/jujupy/fake.py
+++ b/acceptancetests/jujupy/fake.py
@@ -42,12 +42,6 @@ from jujupy.wait_condition import (
 
 __metaclass__ = type
 
-# Python 2 and 3 compatibility
-try:
-    argtype = basestring
-except NameError:
-    argtype = str
-
 
 class ControllerOperation(Exception):
 
@@ -775,9 +769,9 @@ class FakeBackend:
         parser.add_argument('--series')
         parsed = parser.parse_args(args)
         if len(parsed.host_placement) > 0 and parsed.count != 1:
-                raise subprocess.CalledProcessError(
-                    1, 'cannot use -n when specifying a placement directive.'
-                    'See Lp #1384350.')
+            raise subprocess.CalledProcessError(
+                1, 'cannot use -n when specifying a placement directive.'
+                'See Lp #1384350.')
         if len(parsed.host_placement) == 1:
             split = parsed.host_placement[0].split(':')
             if len(split) == 1:
@@ -890,13 +884,12 @@ class FakeBackend:
         full_args.extend(args)
         self.log.log(level, u' '.join(full_args))
 
-    def juju(self, command, args, used_feature_flags,
-             juju_home, model=None, check=True, timeout=None, extra_env=None,
-             suppress_err=False):
+    def juju(self, command, args, used_feature_flags, juju_home, model=None,
+             check=True, timeout=None, extra_env=None, suppress_err=False):
         if 'service' in command:
             raise Exception('Command names must not contain "service".')
 
-        if isinstance(args, argtype):
+        if isinstance(args, str):
             args = (args,)
         self._log_command(command, args, model)
         if model is not None:

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -187,7 +187,7 @@ def agent_tgz_from_juju_binary(
 
     try:
         version_output = subprocess.check_output(
-            [jujud_path, 'version']).rstrip('\n')
+            [jujud_path, 'version']).rstrip(str.encode('\n'))
         version, bin_series, arch = get_version_string_parts(version_output)
         bin_agent_series = _series_lookup(bin_series)
     except subprocess.CalledProcessError as e:
@@ -267,7 +267,7 @@ def _get_series_details(series):
 
 def _get_tgz_file_details(agent_tgz_path):
     file_details = dict(size=os.path.getsize(agent_tgz_path))
-    with open(agent_tgz_path) as f:
+    with open(agent_tgz_path, 'rb') as f:
         content = f.read()
     for hashtype in 'md5', 'sha256':
         hash_obj = hashlib.new(hashtype)

--- a/acceptancetests/jujupy/timeout.py
+++ b/acceptancetests/jujupy/timeout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of JujuPy, a library for driving the Juju CLI.
 # Copyright 2015, 2017 Canonical Ltd.

--- a/acceptancetests/jujupy/workloads.py
+++ b/acceptancetests/jujupy/workloads.py
@@ -107,7 +107,7 @@ def assert_keystone_is_responding(client):
         raise AssertionError('keystone not responding; {}: {}'.format(
             resp.status_code, resp.reason
         ))
-    if '{"versions": {"values":' not in resp.content:
+    if '{"versions": {"values":' not in str(resp.content, 'utf-8'):
         raise AssertionError('Got unexpected keystone page content: {}'.format(resp.content))
 
 
@@ -139,7 +139,7 @@ def deploy_simple_server_to_new_model(
 def deploy_simple_resource_server(
         client, resource_contents=None, series='xenial'):
     application_name = 'simple-resource-http'
-    log.info('Deploying charm: '.format(application_name))
+    log.info('Deploying charm: {}'.format(application_name))
     charm_path = local_charm_path(
         charm=application_name, juju_ver=client.version)
     # Create a temp file which we'll use as the resource.

--- a/acceptancetests/log_check.py
+++ b/acceptancetests/log_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Simple looped check over provided file for regex content."""
 from __future__ import print_function
 

--- a/acceptancetests/remote.py
+++ b/acceptancetests/remote.py
@@ -8,8 +8,8 @@ import zlib
 
 import winrm
 
-import jujupy
 import utility
+import jujupy
 
 
 __metaclass__ = type
@@ -283,7 +283,7 @@ class WinRmRemote(_Remote):
 
     def run_cmd(self, cmd_list):
         """Run cmd and arguments given as a list returning response object."""
-        if isinstance(cmd_list, basestring):
+        if isinstance(cmd_list, (str, bytes)):
             raise ValueError("run_cmd requires a list not a string")
         # pywinrm does not correctly escape arguments, fix up by escaping cmd
         # and giving args as a list of a single pre-escaped string.

--- a/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
+++ b/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
@@ -211,7 +211,7 @@ def get_monitoring_password(haproxy_config_file="/etc/haproxy/haproxy.cfg"):
     haproxy_config = load_haproxy_config(haproxy_config_file)
     if haproxy_config is None:
         return None
-    m = re.search("stats auth\s+(\w+):(\w+)", haproxy_config)
+    m = re.search(r"stats auth\s+(\w+):(\w+)", haproxy_config)
     if m is not None:
         return m.group(2)
     else:
@@ -239,14 +239,14 @@ def get_listen_stanzas(haproxy_config_file="/etc/haproxy/haproxy.cfg"):
     if haproxy_config is None:
         return ()
     listen_stanzas = re.findall(
-        "listen\s+([^\s]+)\s+([^:]+):(.*)",
+        r"listen\s+([^\s]+)\s+([^:]+):(.*)",
         haproxy_config)
     # Match bind stanzas like:
     #
     # bind 1.2.3.5:234
     # bind 1.2.3.4:123 ssl crt /foo/bar
     bind_stanzas = re.findall(
-        "\s+bind\s+([^:]+):(\d+).*\n\s+default_backend\s+([^\s]+)",
+        r"\s+bind\s+([^:]+):(\d+).*\n\s+default_backend\s+([^\s]+)",
         haproxy_config, re.M)
     return (tuple(((service, addr, int(port))
                    for service, addr, port in listen_stanzas)) +
@@ -417,7 +417,7 @@ def _append_backend(service_config, name, options, errorfiles, server_entries):
             server_line = "    server %s %s:%s" % \
                 (server_name, server_ip, server_port)
             if server_options is not None:
-                if isinstance(server_options, basestring):
+                if isinstance(server_options, str):
                     server_line += " " + server_options
                 else:
                     server_line += " " + " ".join(server_options)
@@ -446,7 +446,7 @@ def create_monitoring_stanza(service_name="haproxy_monitoring"):
     monitoring_config.append("http-request deny unless allowed_cidr")
     monitoring_config.append("stats enable")
     monitoring_config.append("stats uri /")
-    monitoring_config.append("stats realm Haproxy\ Statistics")
+    monitoring_config.append(r"stats realm Haproxy\ Statistics")
     monitoring_config.append("stats auth %s:%s" %
                              (config_data['monitoring_username'],
                               monitoring_password))
@@ -487,7 +487,7 @@ def parse_services_yaml(services, yaml_data):
             services[None] = {"service_name": service_name}
 
         if "service_options" in service:
-            if isinstance(service["service_options"], basestring):
+            if isinstance(service["service_options"], str):
                 service["service_options"] = comma_split(
                     service["service_options"])
 
@@ -496,7 +496,7 @@ def parse_services_yaml(services, yaml_data):
                 service["service_options"].append("option forwardfor")
 
         if (("server_options" in service and
-             isinstance(service["server_options"], basestring))):
+             isinstance(service["server_options"], str))):
             service["server_options"] = comma_split(service["server_options"])
 
         services[service_name] = merge_service(
@@ -1236,7 +1236,7 @@ def is_selfsigned_cert_stale(cert_file, key_file):
                 extension.get_data(), asn1Spec=rfc2459.SubjectAltName())[0]
             for name in names:
                 cert_addresses.add(str(name.getComponent()))
-        except:
+        except Exception:
             pass
     if cert_addresses != unit_addresses:
         log('subjAltName: Cert (%s) != Unit (%s), assuming stale' % (
@@ -1351,6 +1351,7 @@ def main(hook_name):
     else:
         print("Unknown hook")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     hook_name = os.path.basename(sys.argv[0])

--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -470,8 +470,9 @@ class AzureARMAccount:
             if m.get('short-name', m['name']) == client.model_name][0]
         resource_group = 'juju-{}-model-{}'.format(
             model.get('short-name', model['name']), model['model-uuid'])
-        resources = winazurearm.list_resources(
-            self.arm_client, glob=resource_group, recursive=True)
+        # NOTE(achilleasa): resources was not used in this func
+        # resources = winazurearm.list_resources(
+        #    self.arm_client, glob=resource_group, recursive=True)
         vm_ids = []
         for machine_name in instance_ids:
             rgd, vm = winazurearm.find_vm_deployment(
@@ -896,11 +897,7 @@ class LXDAccount:
 
 def get_config(boot_config):
     config = boot_config.make_config_copy()
-    if boot_config.provider not in (
-        'lxd',
-        'manual',
-        'kubernetes',
-    ):
+    if boot_config.provider not in ('lxd', 'manual', 'kubernetes'):
         config.update(boot_config.get_cloud_credentials())
     return config
 

--- a/acceptancetests/template_assess.py.tmpl
+++ b/acceptancetests/template_assess.py.tmpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ TODO: Single line description of this assess script purpose.
 
 TODO: add description For:

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -87,7 +87,7 @@ def _clean_dir(maybe_dir):
             # we don't raise this error due to tests abusing /tmp/logs
             logging.warning('Not a directory {}'.format(maybe_dir))
         if e.errno == errno.EEXIST:
-            logging.warnings('Directory {} already exists'.format(maybe_dir))
+            logging.warning('Directory {} already exists'.format(maybe_dir))
     else:
         if contents and contents != ["empty"]:
             logging.warning(
@@ -142,7 +142,7 @@ def wait_for_port(host, port, closed=False, timeout=30):
         except socket.gaierror as e:
             print_now(str(e))
         except Exception as e:
-            print_now('Unexpected {!r}: {}'.format((type(e), e)))
+            print_now('Unexpected {!r}: {}'.format(type(e), e))
             raise
         else:
             conn.close()


### PR DESCRIPTION
This PR applies a few changes to make some of the tests suitable for running using python3. More specifically:
- decode byte slices prior to testing regexes
- specify 'rb' access mode when reading binary files (python3 attempts to decode contents as utf-8 and explodes)

The PR targets a special branch `2.9-python3-acceptancetests` which allows us to land this set of changes, have the CI run all acceptance tests and fix the ones that break due to python2/python3 incompatibilities in a followup PR.

## QA steps

- make install from this branch
- install the latest 2.9 rc snap
- ./assess_upgrade.py lxd `which juju` /tmp/art nw-upgrade-juju-amd64-lxd --stable-juju-bin /snap/juju/current/bin/juju
