### PR TITLE
Update json for hash struct elements for resource downloads.

### DIFF
--- a/apiserver/facades/client/resources/repository_test.go
+++ b/apiserver/facades/client/resources/repository_test.go
@@ -169,7 +169,11 @@ func (s *CharmHubClientSuite) expectRefreshWithRevision(rev int) {
 				Name:      "ubuntu",
 				Resources: []transport.ResourceRevision{
 					{
-						Download:    transport.ResourceDownload{HashSHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", HashSHA3384: "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", HashSHA384: "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b", HashSHA512: "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", Size: 0, URL: "https://api.staging.charmhub.io/api/v1/resources/download/charm_jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD.wal-e_0"},
+						Download: transport.Download{
+							HashSHA384: "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+							Size:       0,
+							URL:        "https://api.staging.charmhub.io/api/v1/resources/download/charm_jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD.wal-e_0",
+						},
 						Name:        "wal-e",
 						Revision:    rev,
 						Type:        "file",

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -103,7 +103,7 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 			Entity: transport.RefreshEntity{
 				Resources: []transport.ResourceRevision{
 					{
-						Download: transport.ResourceDownload{
+						Download: transport.Download{
 							HashSHA384: "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f",
 							Size:       5,
 						},
@@ -112,7 +112,7 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 						Type:     "file",
 					},
 					{
-						Download: transport.ResourceDownload{
+						Download: transport.Download{
 							HashSHA384: "03130092073c5ac523ecb21f548b9ad6e1387d1cb05f3cb892fcc26029d01428afbe74025b6c567b6564a3168a47179a",
 							Size:       6,
 						},

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -51,10 +51,7 @@ func (c *ResourcesClient) ListResourceRevisions(ctx context.Context, charm, reso
 }
 
 var resourceFilter = []string{
-	"download.hash-sha256",
-	"download.hash-sha3-384",
-	"download.hash-sha384",
-	"download.hash-sha512",
+	"download.hash-sha-384",
 	"download.size",
 	"download.url",
 	"name",

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -20,8 +20,12 @@ type Platform struct {
 	Series       string `json:"series"`
 }
 
+// Download represents the download structure from CharmHub.
+// Elements not used by juju but not used are: "hash-sha3-384"
+// and "hash-sha-512"
 type Download struct {
 	HashSHA256 string `json:"hash-sha-256"`
+	HashSHA384 string `json:"hash-sha-384"`
 	Size       int    `json:"size"`
 	URL        string `json:"url"`
 }

--- a/charmhub/transport/resources.go
+++ b/charmhub/transport/resources.go
@@ -8,19 +8,10 @@ type ResourcesResponse struct {
 }
 
 type ResourceRevision struct {
-	Download    ResourceDownload `json:"download"`
-	Description string           `json:"description"`
-	Name        string           `json:"name"`
-	Filename    string           `json:"filename"`
-	Revision    int              `json:"revision"`
-	Type        string           `json:"type"`
-}
-
-type ResourceDownload struct {
-	HashSHA256  string `json:"hash-sha256"`
-	HashSHA3384 string `json:"hash-sha3-384"`
-	HashSHA384  string `json:"hash-sha384"`
-	HashSHA512  string `json:"hash-sha512"`
-	Size        int    `json:"size"`
-	URL         string `json:"url"`
+	Download    Download `json:"download"`
+	Description string   `json:"description"`
+	Name        string   `json:"name"`
+	Filename    string   `json:"filename"`
+	Revision    int      `json:"revision"`
+	Type        string   `json:"type"`
 }

--- a/resource/resourceadapters/charmhub_test.go
+++ b/resource/resourceadapters/charmhub_test.go
@@ -85,13 +85,10 @@ func (s *CharmHubSuite) expectRefresh() {
 				Name: "ubuntu",
 				Resources: []transport.ResourceRevision{
 					{
-						Download: transport.ResourceDownload{
-							HashSHA256:  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-							HashSHA3384: "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004",
-							HashSHA384:  "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
-							HashSHA512:  "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-							Size:        0,
-							URL:         "https://api.staging.charmhub.io/api/v1/resources/download/charm_jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD.wal-e_0"},
+						Download: transport.Download{
+							HashSHA384: "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+							Size:       0,
+							URL:        "https://api.staging.charmhub.io/api/v1/resources/download/charm_jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD.wal-e_0"},
 						Name:     "wal-e",
 						Revision: 0,
 						Type:     "file",


### PR DESCRIPTION

ResourceDownload can be replaced with existing Download structure for the CharmHub api now that json naming of elements is consistent between the two.

## QA steps

```console
$ juju bootstrap localhost
$ juju add-model six --config charm-hub-url="https://api.staging.snapcraft.io"

# Deploy a CharmHub charm with resources, set the region to trigger resource_get in the charm.
$ juju deploy postgresql --config aws_region="us-east-1"
# wait for the charm to install and try to get the resource successfully
# there will be a status message about installing the Wal-e snap
$ juju show-status-log postgresql/0
Time                   Type       Status       Message
....
08 Dec 2020 22:27:55Z  juju-unit  executing    running install hook
08 Dec 2020 22:28:52Z  workload   maintenance  Updating apt cache
08 Dec 2020 22:28:54Z  workload   maintenance  Installing wal-e snap
```

