### PR TITLE
Remove unused CodeRetry

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1204,12 +1204,6 @@ func (s *state) APICall(facade string, vers int, id, method string, args, respon
 			return nil
 		}
 		code := params.ErrCode(err)
-		if code == params.CodeRetry {
-			if !a.More() {
-				return errors.Annotatef(err, "too many retries")
-			}
-			continue
-		}
 		if code != params.CodeIncompatibleClient {
 			return errors.Trace(err)
 		}

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -238,8 +238,6 @@ func ServerErrorAndStatus(err error) (*params.Error, int) {
 		status = http.StatusForbidden
 	case params.CodeDischargeRequired:
 		status = http.StatusUnauthorized
-	case params.CodeRetry:
-		status = http.StatusServiceUnavailable
 	case params.CodeRedirect:
 		status = http.StatusMovedPermanently
 	}

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -296,7 +296,6 @@ func (s *errorsSuite) TestErrorTransform(c *gc.C) {
 			params.CodeMachineHasAttachedStorage,
 			params.CodeDischargeRequired,
 			params.CodeModelNotFound,
-			params.CodeRetry,
 			params.CodeRedirect,
 			params.CodeIncompatibleClient:
 			continue

--- a/apiserver/params/apierror.go
+++ b/apiserver/params/apierror.go
@@ -208,7 +208,6 @@ const (
 	CodeForbidden                 = "forbidden"
 	CodeDischargeRequired         = "macaroon discharge required"
 	CodeRedirect                  = "redirection required"
-	CodeRetry                     = "retry"
 	CodeIncompatibleSeries        = "incompatible series"
 	CodeCloudRegionRequired       = "cloud region required"
 	CodeIncompatibleClouds        = "incompatible clouds"


### PR DESCRIPTION
The API client `APICall` method has handling for `CodeRetry`, but we never actually emit this code and don't appear to have from at least version 2.0.

This patch removes the code and associated logic/tests.

## QA steps

Bootstrap to AWS, deploy a few things and ensure that there are no errors. Charmed-k8s quiesced fine for me.

## Documentation changes

None.

## Bug reference

N/A