### PR TITLE
Merge 2.8 into 2.9

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -127,6 +127,7 @@ func WaitForAgentInitialisation(
 		case errors.Cause(err) == io.EOF,
 			strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
 			strings.HasSuffix(errorMessage, "connection refused"),
+			strings.HasSuffix(errorMessage, "target machine actively refused it."), // Winsock message for connection refused
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
 			strings.HasSuffix(errorMessage, "deadline exceeded"),

--- a/migration/dialopts.go
+++ b/migration/dialopts.go
@@ -11,14 +11,14 @@ import (
 
 // ControllerDialOpts returns dial parameters suitable for connecting
 // from the source controller to the target controller during model
-// migrations. The total attempt time can't be too long because the
-// areas of the code which make these connections need to be
-// interruptable but a number of retries is useful to deal with short
-// lived issues.
+// migrations.
+// Except for the inclusion of RetryDelay the options mirror what is used
+// by the APICaller for logins.
 func ControllerDialOpts() api.DialOpts {
 	return api.DialOpts{
-		DialAddressInterval: 50 * time.Millisecond,
-		Timeout:             1 * time.Second,
+		DialTimeout:         3 * time.Second,
+		DialAddressInterval: 200 * time.Millisecond,
+		Timeout:             time.Minute,
 		RetryDelay:          100 * time.Millisecond,
 	}
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -319,7 +319,13 @@ func allCollections() CollectionSchema {
 
 		// These collections hold information associated with machines.
 		containerRefsC: {},
-		instanceDataC:  {},
+		instanceDataC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "machineid"},
+			}, {
+				Key: []string{"model-uuid", "instanceid"},
+			}},
+		},
 		machinesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machineid"},

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -28,11 +28,11 @@ const (
 
 	// initialRetryDelay is the starting delay - this will be
 	// increased exponentially up maxRetries.
-	initialRetryDelay = 50 * time.Millisecond
+	initialRetryDelay = 100 * time.Millisecond
 
 	// retryBackoffFactor is how much longer we wait after a failing
-	// retry.  Retrying 10 times starting at 50ms and backing off 1.6x
-	// gives us a total delay time of about 9s.
+	// retry. Retrying 10 times starting at 100ms and backing off 1.6x
+	// gives us a total delay time of about 45s.
 	retryBackoffFactor = 1.6
 )
 

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -70,7 +70,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	}
 }
 
-func (s *Suite) apiOpen(info *api.Info, dialOpts api.DialOpts) (api.Connection, error) {
+func (s *Suite) apiOpen(info *api.Info, _ api.DialOpts) (api.Connection, error) {
 	s.stub.AddCall("API open", info)
 	return &stubConnection{stub: s.stub}, nil
 }
@@ -211,7 +211,7 @@ func (s *Suite) TestVALIDATIONCantConnect(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 
 	// Advance time enough for all of the retries to be exhausted.
-	sleepTime := 50 * time.Millisecond
+	sleepTime := 100 * time.Millisecond
 	for i := 0; i < 9; i++ {
 		err := s.clock.WaitAdvance(sleepTime, coretesting.ShortWait, 1)
 		c.Assert(err, jc.ErrorIsNil)
@@ -250,7 +250,7 @@ func (s *Suite) TestVALIDATIONFail(c *gc.C) {
 	defer workertest.CleanKill(c, w)
 
 	// Advance time enough for all of the retries to be exhausted.
-	sleepTime := 50 * time.Millisecond
+	sleepTime := 100 * time.Millisecond
 	for i := 0; i < 9; i++ {
 		err := s.clock.WaitAdvance(sleepTime, coretesting.ShortWait, 1)
 		c.Assert(err, jc.ErrorIsNil)
@@ -284,12 +284,12 @@ func (s *Suite) TestVALIDATIONRetrySucceed(c *gc.C) {
 
 	waitForStubCalls(c, &stub, "ValidateMigration")
 
-	err = s.clock.WaitAdvance(50*time.Millisecond, coretesting.LongWait, 1)
+	err = s.clock.WaitAdvance(100*time.Millisecond, coretesting.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitForStubCalls(c, &stub, "ValidateMigration", "ValidateMigration")
 
-	err = s.clock.WaitAdvance(100*time.Millisecond, coretesting.LongWait, 1)
+	err = s.clock.WaitAdvance(160*time.Millisecond, coretesting.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.waitForStubCalls(c, []string{


### PR DESCRIPTION
Zero-conflict merge to bring forward the following patches:
- #12503 from manadart/2.8-migration-minion-connection
- #12495 from manadart/2.8-instance-data-index
- #12492 from benhoyt/win-connection-refused