### PR TITLE
Minor improvements to scripts/generate-password

### DIFF
--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	gnuflag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [modeluuid agent|--user <username>]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s <modeluuid> <agent> [<password>] | --user <username>\n", os.Args[0])
 		gnuflag.PrintDefaults()
 	}
 	user := gnuflag.String("user", "", "supply a username to generate a password instead of modeluuid and agent")
@@ -23,6 +23,7 @@ func main() {
 	args := gnuflag.Args()
 	var modelUUID string
 	var agent string
+	var passwd string
 	if *user == "" {
 		if len(args) < 2 {
 			gnuflag.Usage()
@@ -30,10 +31,15 @@ func main() {
 		}
 		modelUUID = args[0]
 		agent = args[1]
-	}
-	passwd, err := utils.RandomPassword()
-	if err != nil {
-		log.Fatal(err)
+		if len(args) > 2 {
+			passwd = args[2]
+		} else {
+			var err error
+			passwd, err = utils.RandomPassword()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
 	}
 	if *user != "" {
 		salt, err := utils.RandomSalt()
@@ -47,7 +53,7 @@ func main() {
 			*user, salt, hash)
 	} else {
 		hash := utils.AgentPasswordHash(passwd)
-		fmt.Printf("oldpassword: %s\n", passwd)
+		fmt.Printf("apipassword: %s\n", passwd)
 		var collection string
 		if strings.Index(agent, "/") < 0 {
 			// must be a machine

--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -53,7 +53,7 @@ func main() {
 			*user, salt, hash)
 	} else {
 		hash := utils.AgentPasswordHash(passwd)
-		fmt.Printf("apipassword: %s\n", passwd)
+		fmt.Printf("oldpassword: %s\n", passwd)
 		var collection string
 		if strings.Index(agent, "/") < 0 {
 			// must be a machine


### PR DESCRIPTION
scripts/generate-password: Allow the operator to optionally hash a given `oldpassword` instead of generating a random one.

## QA steps

Break a deployed unit by modifying its `apipassword` and `oldpassword` fields in the on-disk `agent-conf` and restarting the agent process.

You'll observe that the agent becomes lost, and the on-disk log notes something like:

```
2021-01-13 02:58:55 ERROR juju.worker.apicaller connect.go:204 Failed to connect to controller: invalid entity name or password (unauthorized access)
```

Next, use this script to either:

1. Generate a new password and hash (the original behaviour):

```
$ go run main.go aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee postgresql/0
oldpassword: kYOOLc2IDyOQn9MMt8N1TN/5
db.units.update({"_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:postgresql/0"}, {$set: {"passwordhash": "IGCgVJSwt8xYTaM0VEq/XtwR"}})
```

or

2. (now available with this change), Just create a new hash for the existing, modified on-disk `oldpassword`:
```
$ go run main.go aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee postgresql/0 examplepassword
oldpassword: examplepassword
db.units.update({"_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:postgresql/0"}, {$set: {"passwordhash": "A4Fha2Ctuq2iGPikTVPQBSPd"}})
```
Doing either of the above and then restarting the agent process again should see the unit recover.