### PR TITLE
Ensure azure bootstrap to byo vnet with existing subnets

### DIFF
--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -221,7 +221,7 @@ func (env *azureEnviron) networkInfoForInstance(
 		// When bootstrapping the network doesn't exist yet so just
 		// return the relevant subnet ID and it is created as part of
 		// the bootstrap process.
-		if bootstrapping {
+		if bootstrapping && env.config.virtualNetworkName == "" {
 			return vnetID, []network.Id{env.defaultControllerSubnet()}, nil
 		}
 


### PR DESCRIPTION
When bootstrapping to Azure and specifying an existing vnet, juju should have used any of the existing subnets.
Instead, it complained about a missing subnet called "juju-controller-subnet". 

## QA steps

Using the Azure portal:
Create a resource group and add a vnet with at least one subnet.
Create a network security group and allow ingress for 22 and 17070 and assign to the subnet.

Ensure Azure bootstrap works:
juju bootstrap azure --config network=some-resource-group/some-vnet

## Bug reference

https://bugs.launchpad.net/juju/+bug/1909396
