### PR TITLE
Rename snapcraft to charmhub in CharmHub urls.

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/interface_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface_test.go
@@ -65,7 +65,7 @@ func makeModel(c *gc.C, ctrl *gomock.Controller) charmrevisionupdater.Model {
 	model.EXPECT().CloudRegion().Return("juju-land").AnyTimes()
 	uuid := testing.ModelTag.Id()
 	cfg, err := config.New(true, map[string]interface{}{
-		"charm-hub-url": "https://api.staging.snapcraft.io", // not actually used in tests
+		"charm-hub-url": "https://api.staging.charmhub.io", // not actually used in tests
 		"name":          "model",
 		"type":          "type",
 		"uuid":          uuid,

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -38,7 +38,7 @@ import (
 // An alternate location can be configured by changing the URL
 // field in the Params struct.
 const (
-	CharmHubServerURL     = "https://api.snapcraft.io"
+	CharmHubServerURL     = "https://api.charmhub.io"
 	CharmHubServerVersion = "v2"
 	CharmHubServerEntity  = "charms"
 
@@ -67,7 +67,7 @@ type Logger interface {
 type Config struct {
 	// URL holds the base endpoint URL of the charmHub,
 	// with no trailing slash, not including the version.
-	// For example https://api.snapcraft.io/v2/charms/
+	// For example https://api.charmhub.io/v2/charms/
 	URL string
 
 	// Version holds the version attribute of the charmHub we're requesting.
@@ -115,7 +115,7 @@ func newOptions() *options {
 }
 
 // CharmHubConfig defines a charmHub client configuration for targeting the
-// snapcraft API.
+// charmhub API.
 func CharmHubConfig(logger Logger, options ...Option) (Config, error) {
 	opts := newOptions()
 	for _, option := range options {

--- a/charmhub/info_integration_test.go
+++ b/charmhub/info_integration_test.go
@@ -46,7 +46,7 @@ func (s *InfoClientSuite) TestLiveInfoRequestWithChannelOption(c *gc.C) {
 
 	logger := &charmhub.FakeLogger{}
 
-	config, err := charmhub.CharmHubConfigFromURL("https://api.staging.snapcraft.io", logger)
+	config, err := charmhub.CharmHubConfigFromURL("https://api.staging.charmhub.io", logger)
 	c.Assert(err, jc.ErrorIsNil)
 	basePath, err := config.BasePath()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
They are techically the same, however it looks better where seen by
users.  The download urls will stay as snapcraft, but that is naming
coming from CharmHub.

## QA steps

```console
$ juju bootstrap localhost test
$ juju deploy ubuntu

$ juju model-config charm-hub-url
https://api.charmhub.io
```

