### PR TITLE
Do not resolve ingress address host names in "unit-get"

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -874,12 +874,15 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 }
 
 // NetworkInfo returns network interfaces/addresses for specified bindings.
-func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error) {
+func (u *Unit) NetworkInfo(
+	bindings []string, relationId *int, preserveIngressHostNames bool,
+) (map[string]params.NetworkInfoResult, error) {
 	var results params.NetworkInfoResults
 	args := params.NetworkInfoParams{
-		Unit:       u.tag.String(),
-		Endpoints:  bindings,
-		RelationId: relationId,
+		Unit:                     u.tag.String(),
+		Endpoints:                bindings,
+		RelationId:               relationId,
+		PreserveIngressHostNames: preserveIngressHostNames,
 	}
 
 	err := u.st.facade.FacadeCall("NetworkInfo", args, &results)

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -875,14 +875,14 @@ func (u *Unit) AddStorage(constraints map[string][]params.StorageConstraints) er
 
 // NetworkInfo returns network interfaces/addresses for specified bindings.
 func (u *Unit) NetworkInfo(
-	bindings []string, relationId *int, preserveIngressHostNames bool,
+	bindings []string, relationId *int, preserveHostNames bool,
 ) (map[string]params.NetworkInfoResult, error) {
 	var results params.NetworkInfoResults
 	args := params.NetworkInfoParams{
-		Unit:                     u.tag.String(),
-		Endpoints:                bindings,
-		RelationId:               relationId,
-		PreserveIngressHostNames: preserveIngressHostNames,
+		Unit:              u.tag.String(),
+		Endpoints:         bindings,
+		RelationId:        relationId,
+		PreserveHostNames: preserveHostNames,
 	}
 
 	err := u.st.facade.FacadeCall("NetworkInfo", args, &results)

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -546,7 +546,7 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	result, err := unit.NetworkInfo([]string{"server"}, &relId)
+	result, err := unit.NetworkInfo([]string{"server"}, &relId, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result["db"].Error, gc.ErrorMatches, "FAIL")
 }

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -226,46 +226,40 @@ func (n *NetworkInfoBase) getEgressForRelation(
 	return subnetsForAddresses(ingress.Values()), nil
 }
 
-func (n *NetworkInfoBase) resolveResultHostNames(netInfoResult params.NetworkInfoResult) params.NetworkInfoResult {
-	// Maintain a cache of host-name -> address resolutions.
-	resolved := make(map[string]string)
-	addressForHost := func(hostName string) string {
-		resolvedAddr, ok := resolved[hostName]
-		if !ok {
-			resolvedAddr = n.resolveHostAddress(hostName)
-			resolved[hostName] = resolvedAddr
-		}
-		return resolvedAddr
-	}
-
-	// Resolve addresses in Info.
-	for i, info := range netInfoResult.Info {
+// resolveResultInfoHostNames returns a new NetworkInfoResult with host names
+// in the `Info` member resolved to IP addresses where possible.
+func (n *NetworkInfoBase) resolveResultInfoHostNames(netInfo params.NetworkInfoResult) params.NetworkInfoResult {
+	for i, info := range netInfo.Info {
 		for j, addr := range info.Addresses {
 			if ip := net.ParseIP(addr.Address); ip == nil {
 				// If the address is not an IP, we assume it is a host name.
 				addr.Hostname = addr.Address
-				addr.Address = addressForHost(addr.Hostname)
-				netInfoResult.Info[i].Addresses[j] = addr
+				addr.Address = n.resolveHostAddress(addr.Hostname)
+				netInfo.Info[i].Addresses[j] = addr
 			}
 		}
 	}
+	return netInfo
+}
 
-	// Resolve addresses in IngressAddresses.
-	// This is slightly different to the addresses above in that we do not
-	// include anything that does not resolve to a usable address.
+// resolveResultIngressHostNames returns a new NetworkInfoResult with host names
+// in the `IngressAddresses` member resolved to IP addresses where possible.
+// This is slightly different to the `Info` addresses above in that we do not
+// include anything that does not resolve to a usable address.
+func (n *NetworkInfoBase) resolveResultIngressHostNames(netInfo params.NetworkInfoResult) params.NetworkInfoResult {
 	var newIngress []string
-	for _, addr := range netInfoResult.IngressAddresses {
+	for _, addr := range netInfo.IngressAddresses {
 		if ip := net.ParseIP(addr); ip != nil {
 			newIngress = append(newIngress, addr)
 			continue
 		}
-		if ipAddr := addressForHost(addr); ipAddr != "" {
+		if ipAddr := n.resolveHostAddress(addr); ipAddr != "" {
 			newIngress = append(newIngress, ipAddr)
 		}
 	}
-	netInfoResult.IngressAddresses = newIngress
+	netInfo.IngressAddresses = newIngress
 
-	return netInfoResult
+	return netInfo
 }
 
 func (n *NetworkInfoBase) resolveHostAddress(hostName string) string {

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -211,7 +211,7 @@ func (s *networkInfoSuite) TestAPIRequestForRelationHostNameNoEgress(c *gc.C) {
 	c.Check(addrs[0].Address, gc.Equals, ip)
 
 	// Run the same request, turning off ingress FQDN resolution.
-	arg.PreserveIngressHostNames = true
+	arg.PreserveHostNames = true
 	result, err = netInfo.ProcessAPIRequest(arg)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -88,7 +88,11 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		result.Results[endpoint] = n.resolveResultHostNames(info)
+		info = n.resolveResultInfoHostNames(info)
+		if !args.PreserveIngressHostNames {
+			info = n.resolveResultIngressHostNames(info)
+		}
+		result.Results[endpoint] = info
 	}
 
 	return result, nil

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -88,9 +88,8 @@ func (n *NetworkInfoCAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		info = n.resolveResultInfoHostNames(info)
-		if !args.PreserveIngressHostNames {
-			info = n.resolveResultIngressHostNames(info)
+		if !args.PreserveHostNames {
+			info = n.resolveResultIngressHostNames(n.resolveResultInfoHostNames(info))
 		}
 		result.Results[endpoint] = info
 	}

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -85,9 +85,8 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		info = n.resolveResultInfoHostNames(info)
-		if !args.PreserveIngressHostNames {
-			info = n.resolveResultIngressHostNames(info)
+		if !args.PreserveHostNames {
+			info = n.resolveResultIngressHostNames(n.resolveResultInfoHostNames(info))
 		}
 		result.Results[endpoint] = info
 	}

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -85,7 +85,11 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 			info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)
 		}
 
-		result.Results[endpoint] = n.resolveResultHostNames(info)
+		info = n.resolveResultInfoHostNames(info)
+		if !args.PreserveIngressHostNames {
+			info = n.resolveResultIngressHostNames(info)
+		}
+		result.Results[endpoint] = info
 	}
 
 	return result, nil

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40139,6 +40139,9 @@
                                 "type": "string"
                             }
                         },
+                        "keep-ingress-fqdn": {
+                            "type": "boolean"
+                        },
                         "relation-id": {
                             "type": "integer"
                         },
@@ -40149,7 +40152,8 @@
                     "additionalProperties": false,
                     "required": [
                         "unit",
-                        "bindings"
+                        "bindings",
+                        "keep-ingress-fqdn"
                     ]
                 },
                 "NetworkInfoResult": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40139,7 +40139,7 @@
                                 "type": "string"
                             }
                         },
-                        "keep-ingress-fqdn": {
+                        "keep-host-fqdn": {
                             "type": "boolean"
                         },
                         "relation-id": {
@@ -40153,7 +40153,7 @@
                     "required": [
                         "unit",
                         "bindings",
-                        "keep-ingress-fqdn"
+                        "keep-host-fqdn"
                     ]
                 },
                 "NetworkInfoResult": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -1159,8 +1159,8 @@ type NetworkInfoParams struct {
 	// purpose.
 	Endpoints []string `json:"bindings"`
 
-	// PreserveIngressHostNames indicates whether we want to preserve any FQDNs
-	// for ingress addresses in the results, instead of resolving their IPs.
+	// PreserveHostNames indicates whether we want to preserve any FQDNs
+	// in the results, instead of resolving their IPs.
 	// TODO (manadart 2021-01-14): This is intended as a stop-gap for
 	// preserving functionality from <= 2.8.6 up until we can make some
 	// breaking changes in 3.0.
@@ -1172,7 +1172,7 @@ type NetworkInfoParams struct {
 	// - Supplying richer information in the output of network-get.
 	//   We currently return the first element of lists,
 	//   and single struct members.
-	PreserveIngressHostNames bool `json:"keep-ingress-fqdn"`
+	PreserveHostNames bool `json:"keep-host-fqdn"`
 }
 
 // FanConfigEntry holds configuration for a single fan.

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -1172,7 +1172,7 @@ type NetworkInfoParams struct {
 	// - Supplying richer information in the output of network-get.
 	//   We currently return the first element of lists,
 	//   and single struct members.
-	PreserveIngressHostNames bool `json:keep-ingress-fqdn`
+	PreserveIngressHostNames bool `json:"keep-ingress-fqdn"`
 }
 
 // FanConfigEntry holds configuration for a single fan.

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -1147,7 +1147,8 @@ type NetworkInfoResultsV6 struct {
 	Results map[string]NetworkInfoResultV6 `json:"results"`
 }
 
-// NetworkInfoParams holds a name of the unit and list of bindings for which we want to get NetworkInfos.
+// NetworkInfoParams holds a name of the unit and list of bindings
+// for which we want to get NetworkInfos.
 type NetworkInfoParams struct {
 	Unit       string `json:"unit"`
 	RelationId *int   `json:"relation-id,omitempty"`
@@ -1157,6 +1158,21 @@ type NetworkInfoParams struct {
 	// Change it to "endpoints" if bumping the facade version for another
 	// purpose.
 	Endpoints []string `json:"bindings"`
+
+	// PreserveIngressHostNames indicates whether we want to preserve any FQDNs
+	// for ingress addresses in the results, instead of resolving their IPs.
+	// TODO (manadart 2021-01-14): This is intended as a stop-gap for
+	// preserving functionality from <= 2.8.6 up until we can make some
+	// breaking changes in 3.0.
+	// For 3.0, we should attend to the following:
+	// - Removal of the unit-get hook tool (relying on this argument).
+	// - Not resolving ingress FQDNs at all for ingress addresses.
+	// - Properly determining the address set for private-address in the uniter
+	//   call to EnterScope.
+	// - Supplying richer information in the output of network-get.
+	//   We currently return the first element of lists,
+	//   and single struct members.
+	PreserveIngressHostNames bool `json:keep-ingress-fqdn`
 }
 
 // FanConfigEntry holds configuration for a single fan.

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -130,7 +130,7 @@ type HookUnit interface {
 	LogActionMessage(names.ActionTag, string) error
 	Name() string
 	NetworkInfo(
-		bindings []string, relationId *int, preserveIngressHostNames bool,
+		bindings []string, relationId *int, preserveHostNames bool,
 	) (map[string]params.NetworkInfoResult, error)
 	OpenPorts(protocol string, fromPort, toPort int) error
 	RequestReboot() error
@@ -1316,11 +1316,11 @@ func (ctx *HookContext) SetUnitWorkloadVersion(version string) error {
 // NetworkInfo returns the network info for the given bindings on the given relation.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
 func (ctx *HookContext) NetworkInfo(
-	bindingNames []string, relationId int, preserveIngressHostNames bool,
+	bindingNames []string, relationId int, preserveHostNames bool,
 ) (map[string]params.NetworkInfoResult, error) {
 	var relId *int
 	if relationId != -1 {
 		relId = &relationId
 	}
-	return ctx.unit.NetworkInfo(bindingNames, relId, preserveIngressHostNames)
+	return ctx.unit.NetworkInfo(bindingNames, relId, preserveHostNames)
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -129,7 +129,9 @@ type HookUnit interface {
 	ConfigSettings() (charm.Settings, error)
 	LogActionMessage(names.ActionTag, string) error
 	Name() string
-	NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error)
+	NetworkInfo(
+		bindings []string, relationId *int, preserveIngressHostNames bool,
+	) (map[string]params.NetworkInfoResult, error)
 	OpenPorts(protocol string, fromPort, toPort int) error
 	RequestReboot() error
 	SetUnitStatus(unitStatus status.Status, info string, data map[string]interface{}) error
@@ -1313,10 +1315,12 @@ func (ctx *HookContext) SetUnitWorkloadVersion(version string) error {
 
 // NetworkInfo returns the network info for the given bindings on the given relation.
 // Implements jujuc.HookContext.ContextNetworking, part of runner.Context.
-func (ctx *HookContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+func (ctx *HookContext) NetworkInfo(
+	bindingNames []string, relationId int, preserveIngressHostNames bool,
+) (map[string]params.NetworkInfoResult, error) {
 	var relId *int
 	if relationId != -1 {
 		relId = &relationId
 	}
-	return ctx.unit.NetworkInfo(bindingNames, relId)
+	return ctx.unit.NetworkInfo(bindingNames, relId, preserveIngressHostNames)
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -113,7 +113,7 @@ func (s *InterfaceSuite) TestUnitNetworkInfo(c *gc.C) {
 	// of the cases are tested separately for network-get, api/uniter, and
 	// apiserver/uniter, respectively.
 	ctx := s.GetContext(c, -1, "")
-	netInfo, err := ctx.NetworkInfo([]string{"unknown"}, -1)
+	netInfo, err := ctx.NetworkInfo([]string{"unknown"}, -1, false)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(netInfo, gc.DeepEquals, map[string]params.NetworkInfoResult{
 		"unknown": {

--- a/worker/uniter/runner/context/mocks/hookunit_mock.go
+++ b/worker/uniter/runner/context/mocks/hookunit_mock.go
@@ -138,18 +138,18 @@ func (mr *MockHookUnitMockRecorder) Name() *gomock.Call {
 }
 
 // NetworkInfo mocks base method
-func (m *MockHookUnit) NetworkInfo(arg0 []string, arg1 *int) (map[string]params.NetworkInfoResult, error) {
+func (m *MockHookUnit) NetworkInfo(arg0 []string, arg1 *int, arg2 bool) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]params.NetworkInfoResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NetworkInfo indicates an expected call of NetworkInfo
-func (mr *MockHookUnitMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockHookUnitMockRecorder) NetworkInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).NetworkInfo), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).NetworkInfo), arg0, arg1, arg2)
 }
 
 // OpenPorts mocks base method

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -198,7 +198,9 @@ type ContextNetworking interface {
 	OpenedPorts() []network.PortRange
 
 	// NetworkInfo returns the network info for the given bindings on the given relation.
-	NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)
+	NetworkInfo(
+		bindingNames []string, relationId int, preserveIngressHostNames bool,
+	) (map[string]params.NetworkInfoResult, error)
 }
 
 // ContextLeadership is the part of a hook context related to the

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -199,7 +199,7 @@ type ContextNetworking interface {
 
 	// NetworkInfo returns the network info for the given bindings on the given relation.
 	NetworkInfo(
-		bindingNames []string, relationId int, preserveIngressHostNames bool,
+		bindingNames []string, relationId int, preserveHostNames bool,
 	) (map[string]params.NetworkInfoResult, error)
 }
 

--- a/worker/uniter/runner/jujuc/jujuctesting/networking.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/networking.go
@@ -104,8 +104,10 @@ func (c *ContextNetworking) OpenedPorts() []network.PortRange {
 }
 
 // NetworkInfo implements jujuc.ContextNetworking.
-func (c *ContextNetworking) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
-	c.stub.AddCall("NetworkInfo", bindingNames, relationId)
+func (c *ContextNetworking) NetworkInfo(
+	bindingNames []string, relationId int, preserveIngressHostNames bool,
+) (map[string]params.NetworkInfoResult, error) {
+	c.stub.AddCall("NetworkInfo", bindingNames, relationId, preserveIngressHostNames)
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/jujuctesting/networking.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/networking.go
@@ -105,9 +105,9 @@ func (c *ContextNetworking) OpenedPorts() []network.PortRange {
 
 // NetworkInfo implements jujuc.ContextNetworking.
 func (c *ContextNetworking) NetworkInfo(
-	bindingNames []string, relationId int, preserveIngressHostNames bool,
+	bindingNames []string, relationId int, preserveHostNames bool,
 ) (map[string]params.NetworkInfoResult, error) {
-	c.stub.AddCall("NetworkInfo", bindingNames, relationId, preserveIngressHostNames)
+	c.stub.AddCall("NetworkInfo", bindingNames, relationId, preserveHostNames)
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -349,18 +349,18 @@ func (mr *MockContextMockRecorder) LogActionMessage(arg0 interface{}) *gomock.Ca
 }
 
 // NetworkInfo mocks base method
-func (m *MockContext) NetworkInfo(arg0 []string, arg1 int) (map[string]params.NetworkInfoResult, error) {
+func (m *MockContext) NetworkInfo(arg0 []string, arg1 int, arg2 bool) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]params.NetworkInfoResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NetworkInfo indicates an expected call of NetworkInfo
-func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1, arg2)
 }
 
 // OpenPorts mocks base method

--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -107,7 +107,7 @@ func (c *NetworkGetCommand) Init(args []string) error {
 }
 
 func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
-	netInfo, err := c.ctx.NetworkInfo([]string{c.bindingName}, c.RelationId)
+	netInfo, err := c.ctx.NetworkInfo([]string{c.bindingName}, c.RelationId, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -122,7 +122,9 @@ func (*RestrictedContext) ClosePorts(protocol string, fromPort, toPort int) erro
 func (*RestrictedContext) OpenedPorts() []network.PortRange { return nil }
 
 // NetworkInfo implements hooks.Context.
-func (*RestrictedContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+func (*RestrictedContext) NetworkInfo(
+	bindingNames []string, relationId int, _ bool,
+) (map[string]params.NetworkInfoResult, error) {
 	return map[string]params.NetworkInfoResult{}, ErrRestrictedContext
 }
 

--- a/worker/uniter/runner/jujuc/unit-get.go
+++ b/worker/uniter/runner/jujuc/unit-get.go
@@ -54,7 +54,7 @@ func (c *UnitGetCommand) Run(ctx *cmd.Context) error {
 	var err error
 	if c.Key == "private-address" {
 		var networkInfos map[string]params.NetworkInfoResult
-		networkInfos, err = c.ctx.NetworkInfo([]string{""}, -1)
+		networkInfos, err = c.ctx.NetworkInfo([]string{""}, -1, true)
 		if err == nil {
 			if networkInfos[""].Error != nil {
 				err = errors.Trace(networkInfos[""].Error)


### PR DESCRIPTION
Host name resolution was pushed from the `network-get` hook tool into the uniter API method `NetworkInfo` in https://github.com/juju/juju/pull/12343. This was so that host-name resolution could be applied selectively based on the IAAS/CAAS case.

What was missed is that the `unit-get` tool calls `NetworkInfo` when asked for a `private-address`. This means behaviour changed in that tool; host names now being returned as IP addresses where the server can resolve them.

Here, we add an argument to the `NetworkInfo` parameters so that host-name resolution can be toggled. This restores prior behaviour. The facade schema is regenerated without incrementing the facade version, as the addition of a false-by-default boolean argument would not break compatibility.

The hope is that for Juju 3.0, we can take the argument back out, unify the CAAS/IAAS host name resolution policy, and potentially remove the deprecated `unit-get` method.

## QA steps

TBC

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/content-cache-charm/+bug/1910974
