### PR TITLE
[2.9-python3-acceptancetests] Even more python3 compat fixes for acceptance tests - part 2

### DIFF
--- a/acceptancetests/assess_network_spaces.py
+++ b/acceptancetests/assess_network_spaces.py
@@ -306,7 +306,8 @@ def get_machine_ip_in_space(client, machine, space):
         yaml.safe_load(
             client.get_juju_output(
                 'list-spaces', '--format=yaml')))
-    subnet = spaces['spaces'][space].keys()[0]
+    target_space = spaces['spaces'][space]
+    subnet = next(iter(target_space.keys()))
     for ip in machines[machine]['ip-addresses']:
         if ip_in_cidr(ip, subnet):
             return ip
@@ -332,8 +333,7 @@ def ip_in_cidr(address, cidr):
     :param address: A valid IPv4 address (string)
     :param cidr: A valid subnet in CIDR notation (string)
     """
-    return (ipaddress.ip_address(address.decode('utf-8'))
-            in ipaddress.ip_network(cidr.decode('utf-8')))
+    return (ipaddress.ip_address(address) in ipaddress.ip_network(cidr))
 
 
 def parse_args(argv):

--- a/acceptancetests/assess_wallet.py
+++ b/acceptancetests/assess_wallet.py
@@ -80,7 +80,10 @@ def _try_creating_wallet(client, name, value):
         log.info('Created new wallet "{}" with value {}'.format(name,
                                                                 value))
     except subprocess.CalledProcessError as e:
-        output = [e.output.decode('utf-8'), getattr(e, 'stderr', '')]
+        output = [
+            e.output.decode('utf-8'),
+            getattr(e, 'stderr', '').decode('utf-8'),
+        ]
         if any('already exists' in message for message in output):
             log.info('Reusing wallet "{}" with value {}'.format(name, value))
             pass  # this will be a failure once lp:1663258 is fixed

--- a/acceptancetests/jujupy/backend.py
+++ b/acceptancetests/jujupy/backend.py
@@ -278,7 +278,7 @@ class JujuBackend:
                         b'307: Temporary Redirect' in sub_error):
                     raise CannotConnectEnv(e)
                 raise e
-        return sub_output
+        return sub_output.decode('utf-8')
 
     def get_active_model(self, juju_data_dir):
         """Determine the active model in a juju data dir."""


### PR DESCRIPTION
This PR adds some extra bytes to string `decode` calls that where unfortunately missed by the changes in #12519 