### PR TITLE
[CharmHub] - Resolve the series and arch when deploying a bundle.

### DIFF
--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -48,6 +48,13 @@ type Origin struct {
 	Series string
 }
 
+// WithSeries allows to update the series of an origin.
+func (o Origin) WithSeries(series string) Origin {
+	other := o
+	other.Series = series
+	return other
+}
+
 // CoreChannel returns the core charm channel.
 func (o Origin) CoreChannel() corecharm.Channel {
 	var track string

--- a/apiserver/common/charms/common_test.go
+++ b/apiserver/common/charms/common_test.go
@@ -303,7 +303,7 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 			about: "invalid URL",
 			charm: "wordpress",
 			url:   "not-valid!",
-			err:   `cannot parse URL "not-valid!": name "not-valid!" not valid`,
+			err:   `cannot parse name and/or revision in URL "not-valid!": name "not-valid!" not valid`,
 		},
 		{
 			about: "invalid schema",

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -86,7 +86,7 @@ func (s *bundleSuite) TestGetChangesBundleVerificationErrors(c *gc.C) {
 	c.Assert(r.Errors, jc.SameContents, []string{
 		`placement "1" refers to a machine not defined in this bundle`,
 		`too many units specified in unit placement for application "django"`,
-		`invalid charm URL in application "haproxy": cannot parse URL "42": name "42" not valid`,
+		`invalid charm URL in application "haproxy": cannot parse name and/or revision in URL "42": name "42" not valid`,
 		`negative number of units specified on application "haproxy"`,
 	})
 }
@@ -421,7 +421,7 @@ func (s *bundleSuite) TestGetChangesMapArgsBundleVerificationErrors(c *gc.C) {
 	c.Assert(r.Errors, jc.SameContents, []string{
 		`placement "1" refers to a machine not defined in this bundle`,
 		`too many units specified in unit placement for application "django"`,
-		`invalid charm URL in application "haproxy": cannot parse URL "42": name "42" not valid`,
+		`invalid charm URL in application "haproxy": cannot parse name and/or revision in URL "42": name "42" not valid`,
 		`negative number of units specified on application "haproxy"`,
 	})
 }

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -33,7 +33,7 @@ type chRepo struct {
 // ResolveWithPreferredChannel call the CharmHub version of
 // ResolveWithPreferredChannel.
 func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.CharmOrigin) (*charm.URL, params.CharmOrigin, []string, error) {
-	logger.Tracef("Resolving CharmHub charm %q", curl)
+	logger.Debugf("Resolving CharmHub charm %q", curl)
 
 	channel, err := makeChannel(origin)
 	if err != nil {
@@ -61,7 +61,11 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	// If no revision nor channel specified, use the default release.
 	if curl.Revision == -1 && channel.String() == "" {
 		logger.Debugf("Resolving charm with default release")
-		resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, info.DefaultRelease, true)
+		override := platformOverrides{
+			Arch:   true,
+			Series: false,
+		}
+		resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, info.DefaultRelease, override)
 		if err != nil {
 			return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 		}
@@ -81,11 +85,11 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 		Channel:  channel,
 		Platform: platform,
 	}
-	channelMap, overrideArch, err := findChannelMap(curl.Revision, preferred, info.ChannelMap)
+	channelMap, override, err := findChannelMap(curl.Revision, preferred, info.ChannelMap)
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
-	resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap, overrideArch)
+	resURL, resOrigin, series, err := c.resolveViaChannelMap(info.Type, curl, origin, channelMap, override)
 	if err != nil {
 		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
 	}
@@ -102,7 +106,7 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 // provided archive path.
 // A charm archive is returned.
 func (c *chRepo) DownloadCharm(resourceURL string, archivePath string) (*charm.CharmArchive, error) {
-	logger.Debugf("DownloadCharm from CharmHub %q", resourceURL)
+	logger.Tracef("DownloadCharm from CharmHub %q", resourceURL)
 	curl, err := url.Parse(resourceURL)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -169,7 +173,11 @@ func (c *chRepo) findBundleDownloadURL(curl *charm.URL, origin corecharm.Origin)
 	return selector.Locate(info, origin)
 }
 
-func (c *chRepo) resolveViaChannelMap(t transport.Type, curl *charm.URL, origin params.CharmOrigin, channelMap transport.InfoChannelMap, overrideArch bool) (*charm.URL, params.CharmOrigin, []string, error) {
+func (c *chRepo) resolveViaChannelMap(t transport.Type,
+	curl *charm.URL, origin params.CharmOrigin,
+	channelMap transport.InfoChannelMap,
+	override platformOverrides,
+) (*charm.URL, params.CharmOrigin, []string, error) {
 	mapChannel := channelMap.Channel
 	mapRevision := channelMap.Revision
 
@@ -185,11 +193,13 @@ func (c *chRepo) resolveViaChannelMap(t transport.Type, curl *charm.URL, origin 
 	// even though we know the exact same revision will work with everything.
 	// This is a limited work around until the charmhub API will correctly
 	// explode the channel map architecture.
-	if !overrideArch {
+	if !override.Arch {
 		origin.Architecture = mapChannel.Platform.Architecture
 	}
-	origin.OS = mapChannel.Platform.OS
-	origin.Series = mapChannel.Platform.Series
+	if !override.Series {
+		origin.OS = mapChannel.Platform.OS
+		origin.Series = mapChannel.Platform.Series
+	}
 
 	// Ensure that we force the revision, architecture and series on to the
 	// returning charm URL. This way we can store a unique charm per
@@ -238,14 +248,19 @@ type channelPlatform struct {
 	Platform corecharm.Platform
 }
 
+type platformOverrides struct {
+	Arch   bool
+	Series bool
+}
+
 // Match attempts to match the channel platform to a given channel and
 // architecture.
-func (cp channelPlatform) Match(other transport.InfoChannelMap) (bool, bool) {
+func (cp channelPlatform) Match(other transport.InfoChannelMap) (platformOverrides, bool) {
 	if !cp.MatchChannel(other) {
-		return false, false
+		return platformOverrides{}, false
 	}
 
-	return cp.MatchArch(other)
+	return cp.MatchPlatform(other)
 }
 
 // MatchChannel attempts to match only the channel of a channel map.
@@ -259,7 +274,7 @@ func (cp channelPlatform) MatchChannel(other transport.InfoChannelMap) bool {
 	return track == other.Channel.Track && string(c.Risk) == other.Channel.Risk
 }
 
-// MatchArch attempts to match the architecture for a given channel map, by
+// MatchPlatform attempts to match the architecture for a given channel map, by
 // looking in the following places:
 //
 //  1. Channel Platform
@@ -267,12 +282,31 @@ func (cp channelPlatform) MatchChannel(other transport.InfoChannelMap) bool {
 //
 // If "all" is found instead of the intended arch then we can use that, but
 // report that we found the override as well as the arch.
-func (cp channelPlatform) MatchArch(other transport.InfoChannelMap) (override bool, found bool) {
-	if other.Channel.Platform.Architecture == "all" {
+func (cp channelPlatform) MatchPlatform(other transport.InfoChannelMap) (platformOverrides, bool) {
+	archOverride, archFound := cp.matchArch(other)
+	if !archFound {
+		return platformOverrides{}, false
+	}
+
+	seriesOverride, seriesFound := cp.matchSeries(other)
+	if !seriesFound {
+		return platformOverrides{}, false
+	}
+
+	return platformOverrides{
+		Arch:   archOverride,
+		Series: seriesOverride,
+	}, true
+}
+
+func (cp channelPlatform) matchArch(other transport.InfoChannelMap) (override bool, found bool) {
+	oPlatform := other.Channel.Platform
+	if oPlatform.Architecture == "all" {
 		return true, true
 	}
+
 	norm := cp.Platform.Normalize()
-	if norm.Architecture == other.Channel.Platform.Architecture {
+	if norm.Architecture == oPlatform.Architecture {
 		return false, true
 	}
 
@@ -281,6 +315,28 @@ func (cp channelPlatform) MatchArch(other transport.InfoChannelMap) (override bo
 			return true, true
 		}
 		if platform.Architecture == norm.Architecture {
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func (cp channelPlatform) matchSeries(other transport.InfoChannelMap) (override bool, found bool) {
+	oPlatform := other.Channel.Platform
+	if oPlatform.Series == "all" {
+		return true, true
+	}
+
+	norm := cp.Platform.Normalize()
+	if norm.Series == "" || norm.Series == oPlatform.Series {
+		return false, true
+	}
+
+	for _, platform := range other.Revision.Platforms {
+		if platform.Series == "all" {
+			return true, true
+		}
+		if platform.Series == norm.Series {
 			return false, true
 		}
 	}
@@ -357,9 +413,9 @@ func makePlatform(origin params.CharmOrigin) (corecharm.Platform, error) {
 	return p.Normalize(), nil
 }
 
-func findChannelMap(rev int, preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, bool, error) {
+func findChannelMap(rev int, preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, platformOverrides, error) {
 	if len(channelMaps) == 0 {
-		return transport.InfoChannelMap{}, false, errors.NotValidf("no channels provided by CharmHub")
+		return transport.InfoChannelMap{}, platformOverrides{}, errors.NotValidf("no channels provided by CharmHub")
 	}
 	switch {
 	case preferred.Channel.String() != "" && rev != -1:
@@ -371,35 +427,37 @@ func findChannelMap(rev int, preferred channelPlatform, channelMaps []transport.
 	}
 }
 
-func findByRevision(rev int, preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, bool, error) {
+func findByRevision(rev int, preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, platformOverrides, error) {
 	for _, cMap := range channelMaps {
 		if cMap.Revision.Revision == rev {
-			if overrideArch, ok := preferred.MatchArch(cMap); ok {
+			if override, ok := preferred.MatchPlatform(cMap); ok {
 				// Channel map is in order of most newest/stable channel,
 				// return the first of the requested revision.
-				return cMap, overrideArch, nil
+				return cMap, override, nil
 			}
 		}
 	}
-	return transport.InfoChannelMap{}, false, errors.NotFoundf("charm revision %d", rev)
+	return transport.InfoChannelMap{}, platformOverrides{}, errors.NotFoundf("charm revision %d", rev)
 }
 
-func findByChannel(preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, bool, error) {
+func findByChannel(preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, platformOverrides, error) {
 	for _, cMap := range channelMaps {
-		if overrideArch, ok := preferred.Match(cMap); ok {
-			return cMap, overrideArch, nil
+		if override, ok := preferred.Match(cMap); ok {
+			return cMap, override, nil
 		}
 	}
-	return transport.InfoChannelMap{}, false, errors.NotFoundf("channel %q with arch %q", preferred.Channel.String(), preferred.Platform.Architecture)
+	arch, series := preferred.Platform.Architecture, preferred.Platform.Series
+	return transport.InfoChannelMap{}, platformOverrides{}, errors.NotFoundf("channel %q with arch %q and series %q", preferred.Channel.String(), arch, series)
 }
 
-func findByRevisionAndChannel(rev int, preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, bool, error) {
+func findByRevisionAndChannel(rev int, preferred channelPlatform, channelMaps []transport.InfoChannelMap) (transport.InfoChannelMap, platformOverrides, error) {
 	for _, cMap := range channelMaps {
 		if cMap.Revision.Revision == rev {
-			if overrideArch, ok := preferred.Match(cMap); ok {
-				return cMap, overrideArch, nil
+			if override, ok := preferred.Match(cMap); ok {
+				return cMap, override, nil
 			}
 		}
 	}
-	return transport.InfoChannelMap{}, false, errors.NotFoundf("charm revision %d for channel %q with arch %q", rev, preferred.Channel.String(), preferred.Platform.Architecture)
+	arch, series := preferred.Platform.Architecture, preferred.Platform.Series
+	return transport.InfoChannelMap{}, platformOverrides{}, errors.NotFoundf("charm revision %d for channel %q with arch %q and series %q", rev, preferred.Channel.String(), arch, series)
 }

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -333,11 +333,10 @@ func (cp channelPlatform) matchSeries(other transport.InfoChannelMap) (override 
 	}
 
 	for _, platform := range other.Revision.Platforms {
-		if platform.Series == "all" {
+		// As we found the matching series in the platforms, we want to then
+		// override what they asked for when outputting the origin.
+		if platform.Series == "all" || platform.Series == norm.Series {
 			return true, true
-		}
-		if platform.Series == norm.Series {
-			return false, true
 		}
 	}
 	return false, false

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -65,14 +65,15 @@ func (s channelPlatformSuite) TestMatchArchAMD64(c *gc.C) {
 		Platform: corecharm.MustParsePlatform("amd64"),
 	}
 
-	override, matched := cp.MatchArch(transport.InfoChannelMap{
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
 		Channel: transport.Channel{
 			Platform: transport.Platform{
 				Architecture: "amd64",
 			},
 		},
 	})
-	c.Assert(override, jc.IsFalse)
+	c.Assert(override.Arch, jc.IsFalse)
+	c.Assert(override.Series, jc.IsFalse)
 	c.Assert(matched, jc.IsTrue)
 }
 
@@ -81,14 +82,15 @@ func (s channelPlatformSuite) TestMatchArchAll(c *gc.C) {
 		Platform: corecharm.MustParsePlatform("amd64"),
 	}
 
-	override, matched := cp.MatchArch(transport.InfoChannelMap{
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
 		Channel: transport.Channel{
 			Platform: transport.Platform{
 				Architecture: "all",
 			},
 		},
 	})
-	c.Assert(override, jc.IsTrue)
+	c.Assert(override.Arch, jc.IsTrue)
+	c.Assert(override.Series, jc.IsFalse)
 	c.Assert(matched, jc.IsTrue)
 }
 
@@ -97,7 +99,7 @@ func (s channelPlatformSuite) TestMatchArchAMD64Revision(c *gc.C) {
 		Platform: corecharm.MustParsePlatform("amd64"),
 	}
 
-	override, matched := cp.MatchArch(transport.InfoChannelMap{
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
 		Revision: transport.InfoRevision{
 			Platforms: []transport.Platform{{
 				Architecture: "amd64",
@@ -106,7 +108,8 @@ func (s channelPlatformSuite) TestMatchArchAMD64Revision(c *gc.C) {
 			}},
 		},
 	})
-	c.Assert(override, jc.IsFalse)
+	c.Assert(override.Arch, jc.IsFalse)
+	c.Assert(override.Series, jc.IsFalse)
 	c.Assert(matched, jc.IsTrue)
 }
 
@@ -115,14 +118,14 @@ func (s channelPlatformSuite) TestMatchArchAllRevision(c *gc.C) {
 		Platform: corecharm.MustParsePlatform("amd64"),
 	}
 
-	override, matched := cp.MatchArch(transport.InfoChannelMap{
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
 		Revision: transport.InfoRevision{
 			Platforms: []transport.Platform{{
 				Architecture: "all",
 			}},
 		},
 	})
-	c.Assert(override, jc.IsTrue)
+	c.Assert(override.Arch, jc.IsTrue)
 	c.Assert(matched, jc.IsTrue)
 }
 
@@ -131,11 +134,50 @@ func (s channelPlatformSuite) TestMatchNoRevisions(c *gc.C) {
 		Platform: corecharm.MustParsePlatform("amd64"),
 	}
 
-	override, matched := cp.MatchArch(transport.InfoChannelMap{
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
 		Revision: transport.InfoRevision{
 			Platforms: []transport.Platform{},
 		},
 	})
-	c.Assert(override, jc.IsFalse)
+	c.Assert(override.Arch, jc.IsFalse)
+	c.Assert(override.Series, jc.IsFalse)
 	c.Assert(matched, jc.IsFalse)
+}
+
+func (s channelPlatformSuite) TestMatchSeries(c *gc.C) {
+	cp := channelPlatform{
+		Platform: corecharm.MustParsePlatform("amd64/ubuntu/focal"),
+	}
+
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
+		Channel: transport.Channel{
+			Platform: transport.Platform{
+				Architecture: "amd64",
+				OS:           "ubuntu",
+				Series:       "focal",
+			},
+		},
+	})
+	c.Assert(override.Arch, jc.IsFalse)
+	c.Assert(override.Series, jc.IsFalse)
+	c.Assert(matched, jc.IsTrue)
+}
+
+func (s channelPlatformSuite) TestMatchSeriesAll(c *gc.C) {
+	cp := channelPlatform{
+		Platform: corecharm.MustParsePlatform("amd64/ubuntu/focal"),
+	}
+
+	override, matched := cp.MatchPlatform(transport.InfoChannelMap{
+		Channel: transport.Channel{
+			Platform: transport.Platform{
+				Architecture: "amd64",
+				OS:           "ubuntu",
+				Series:       "all",
+			},
+		},
+	})
+	c.Assert(override.Arch, jc.IsFalse)
+	c.Assert(override.Series, jc.IsTrue)
+	c.Assert(matched, jc.IsTrue)
 }

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -48,7 +48,9 @@ func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMap(c *gc.C) {
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 16, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
 }
@@ -82,7 +84,9 @@ func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMapWithChannel
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 18, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
 }
@@ -110,7 +114,9 @@ func (s *charmHubRepositoriesSuite) TestResolveWithRevision(c *gc.C) {
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 13, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
 }
@@ -138,7 +144,9 @@ func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMapWithFallbac
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 17, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
 }
@@ -166,7 +174,9 @@ func (s *charmHubRepositoriesSuite) TestBundleResolveDefaultChannelMap(c *gc.C) 
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 16, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
 }
@@ -194,7 +204,9 @@ func (s *charmHubRepositoriesSuite) TestBundleResolveDefaultChannelMapWithFallba
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 17, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
 }
@@ -237,7 +249,9 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 13, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
 }
@@ -283,7 +297,9 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannelRiskOnly(c *gc.C) {
 	origin.OS = "ubuntu"
 	origin.Series = "bionic"
 
-	c.Assert(obtainedCurl, jc.DeepEquals, curl)
+	expected := s.expectedCURL(curl, 19, arch.DefaultArchitecture, "bionic")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
 }
@@ -326,6 +342,10 @@ func (s *charmHubRepositoriesSuite) expectBundleInfo(err error) {
 
 func (s *charmHubRepositoriesSuite) expectAlternativeBundleInfo(err error) {
 	s.client.EXPECT().Info(gomock.Any(), "wordpress", gomock.Any()).Return(getAlternativeCharmHubBundleInfoResponse(), err)
+}
+
+func (s *charmHubRepositoriesSuite) expectedCURL(curl *charm.URL, revision int, arch string, series string) *charm.URL {
+	return curl.WithRevision(revision).WithArchitecture(arch).WithSeries(series)
 }
 
 type charmStoreResolversSuite struct {

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -578,7 +578,7 @@ charm path in application "mysql" does not exist: .*mysql`,
                 charm: cs:xenial/rails-42
                 num_units: 1
     `,
-	err: `cannot resolve URL "cs:xenial/rails-42": .* charm or bundle not found`,
+	err: `cannot resolve charm or bundle "rails": .* charm or bundle not found`,
 }, {
 	about:   "invalid bundle content",
 	content: "!",
@@ -624,7 +624,7 @@ negative number of units specified on application "mysql"`,
                 charm: local:wordpress
                 num_units: 1
     `,
-	err: `cannot resolve URL "local:wordpress": unknown schema for charm URL "local:wordpress"`,
+	err: `cannot resolve charm or bundle "wordpress": unknown schema for charm URL "local:wordpress"`,
 }}
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleErrors(c *gc.C) {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -319,7 +319,7 @@ func (s *DeploySuite) TestBlockDeploy(c *gc.C) {
 
 func (s *DeploySuite) TestInvalidPath(c *gc.C) {
 	err := s.runDeploy(c, "/home/nowhere")
-	c.Assert(err, gc.ErrorMatches, `no charm was found at \"/home/nowhere\"`)
+	c.Assert(err, gc.ErrorMatches, `cannot resolve charm or bundle "nowhere": charm or bundle not found`)
 }
 
 func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {
@@ -2595,7 +2595,7 @@ func (f *fakeDeployAPI) ResolveCharm(url *charm.URL, preferredChannel commonchar
 	if results == nil {
 		if url.Schema == "cs" || url.Schema == "ch" {
 			return nil, commoncharm.Origin{}, nil, errors.Errorf(
-				"cannot resolve URL %q: charm or bundle not found", url)
+				"cannot resolve charm or bundle %q: charm or bundle not found", url.Name)
 		}
 		return nil, commoncharm.Origin{}, nil, errors.Errorf(
 			"unknown schema for charm URL %q", url)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -354,13 +354,6 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
 		}
 
-		// CharmHub returns the series and architecture when resolving a charm,
-		// which prevents the bundle detection logic. We will deduce the series
-		// again at a later stage to correct this when uploading the charm.
-		if charm.CharmHub.Matches(url.Schema) {
-			url = url.WithSeries("")
-			origin = origin.WithSeries("")
-		}
 		h.ctx.Infof(formatLocatedText(ch, origin))
 		if url.Series == "bundle" {
 			return errors.Errorf("expected charm, got bundle %q", ch.Name)
@@ -589,6 +582,8 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	if url.Series == "bundle" || resolvedOrigin.Type == "bundle" {
 		return errors.Errorf("expected charm, got bundle %q %v", ch.Name, resolvedOrigin)
 	}
+
+	fmt.Println(">>>", url, resolvedOrigin, origin, series)
 
 	var macaroon *macaroon.Macaroon
 	var charmOrigin commoncharm.Origin

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -353,6 +353,10 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
 		}
+		if charm.CharmHub.Matches(url.Schema) {
+			url = url.WithSeries("")
+			origin = origin.WithSeries("")
+		}
 
 		h.ctx.Infof(formatLocatedText(ch, origin))
 		if url.Series == "bundle" {
@@ -582,8 +586,6 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	if url.Series == "bundle" || resolvedOrigin.Type == "bundle" {
 		return errors.Errorf("expected charm, got bundle %q %v", ch.Name, resolvedOrigin)
 	}
-
-	fmt.Println(">>>", url, resolvedOrigin, origin, series)
 
 	var macaroon *macaroon.Macaroon
 	var charmOrigin commoncharm.Origin

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -79,7 +79,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNotFoundCharmStore(c *gc.C
 	}
 
 	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
-	c.Assert(err, gc.ErrorMatches, `cannot resolve URL "cs:bundle/no-such": bundle not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot resolve charm or bundle "no-such": bundle not found`)
 }
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {

--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,8 @@ require (
 	github.com/hpidcock/juju-fake-init v0.0.0-20201026041434-e95018795575
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v4 v4.0.0-20210112143859-665b333bbd0c
-	github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9
+	github.com/juju/bundlechanges/v4 v4.0.0-20210115143546-96f535924f72
+	github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -394,12 +394,12 @@ github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN7
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v4 v4.0.0-20210112143859-665b333bbd0c h1:btsvFLOVCz5AG5+tj3GH1ZyyHcYqlAanMhBUhWh80B0=
-github.com/juju/bundlechanges/v4 v4.0.0-20210112143859-665b333bbd0c/go.mod h1:rGro4ym8B/S2wOyg4zrrtB1Kl9Yij4+zvsglsXEU1tE=
+github.com/juju/bundlechanges/v4 v4.0.0-20210115143546-96f535924f72 h1:/yhDBWjMcrRmeyFKAH6bCs2rDtPdbZD/7fJF81cPxaw=
+github.com/juju/bundlechanges/v4 v4.0.0-20210115143546-96f535924f72/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0 h1:BuNV5BMVyKI1XUupcAuC/Y2bW/izfV7Tn+uI7jMYjNk=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
-github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9 h1:e6OkRhyixqkgcycaD+aACZQMPwpJSxfbTfNc4qwOBnE=
-github.com/juju/charm/v8 v8.0.0-20201119121237-bd48f89b02b9/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
+github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
+github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f h1:esltimJsCcUSaC9ahxBpC70Gumqnnmgm0Ah+BLVQBTY=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=

--- a/testcharms/charm-hub/bundles/amalgam/bundle.yaml
+++ b/testcharms/charm-hub/bundles/amalgam/bundle.yaml
@@ -1,0 +1,9 @@
+series: focal
+applications:
+  ubuntux:
+    charm: ubuntu
+    num_units: 1
+  ubuntu-s390x:
+    charm: ubuntu
+    num_units: 1
+    constraints: arch=s390x

--- a/testcharms/charm-hub/bundles/charm-reuse/bundle.yaml
+++ b/testcharms/charm-hub/bundles/charm-reuse/bundle.yaml
@@ -1,0 +1,8 @@
+series: bionic
+applications:
+    ubuntu-amd:
+        charm: ubuntu
+        constraints: "arch=amd64"
+    ubuntu-s390x:
+        charm: ubuntu
+        constraints: "arch=s390x"


### PR DESCRIPTION
Pathalogical bundles where we use the same charm with a different series
and architecture now correctly install. There is a slight annoyance in
the fact that when attempting to resolve a charm we end up with a series
and architecture from the resolution that we don't want till later. In
that case, we empty the series, architecture will always be correct and
then refill it in again at a later stage when we're adding the charm.

## QA steps

```sh
$ juju bootstrap aws test
$ juju add-model one --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy ./testcharms/charm-hub/bundles/amalgam/.
```
