### PR TITLE
Improve error message with controller older than 2.9.

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -170,6 +170,10 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 
 		charmHubURL, err = c.getCharmHubURL()
 		if err != nil {
+			if errors.IsNotImplemented(err) {
+				cmdContext.Warningf("juju download not supported with controllers < 2.9")
+				return nil
+			}
 			return errors.Trace(err)
 		}
 	}
@@ -263,6 +267,10 @@ func (c *downloadCommand) getCharmHubURL() (string, error) {
 		return "", errors.Trace(err)
 	}
 	defer func() { _ = apiRoot.Close() }()
+
+	if apiRoot.BestFacadeVersion("charmhub") < 1 {
+		return "", errors.NotImplementedf("charmhub")
+	}
 
 	modelConfigClient := c.ModelConfigClientFunc(apiRoot)
 	defer func() { _ = modelConfigClient.Close() }()

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -57,6 +57,7 @@ func (s *downloadSuite) TestInitSuccess(c *gc.C) {
 
 func (s *downloadSuite) TestRun(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
+	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
 
 	url := "http://example.org/"
 
@@ -82,6 +83,7 @@ func (s *downloadSuite) TestRun(c *gc.C) {
 
 func (s *downloadSuite) TestRunWithStdout(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
+	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
 
 	url := "http://example.org/"
 

--- a/cmd/juju/charmhub/find.go
+++ b/cmd/juju/charmhub/find.go
@@ -133,6 +133,11 @@ func (c *findCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = apiRoot.Close() }()
 
+	if apiRoot.BestFacadeVersion("charmhub") < 1 {
+		ctx.Warningf("juju find not supported with controllers < 2.9")
+		return nil
+	}
+
 	charmHubClient := c.CharmHubClientFunc(apiRoot)
 
 	results, err := charmHubClient.Find(c.query)

--- a/cmd/juju/charmhub/find_test.go
+++ b/cmd/juju/charmhub/find_test.go
@@ -185,6 +185,7 @@ func (s *findSuite) setUpMocks(c *gc.C) *gomock.Controller {
 
 	s.apiRoot = basemocks.NewMockAPICallCloser(ctrl)
 	s.apiRoot.EXPECT().Close().AnyTimes()
+	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
 
 	return ctrl
 }

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -141,6 +141,11 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = apiRoot.Close() }()
 
+	if apiRoot.BestFacadeVersion("charmhub") < 1 {
+		ctx.Warningf("juju info not supported with controllers < 2.9")
+		return nil
+	}
+
 	charmHubClient := c.CharmHubClientFunc(apiRoot)
 
 	channel := c.channel

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -312,6 +312,7 @@ func (s *infoSuite) setUpMocks(c *gc.C) *gomock.Controller {
 
 	s.apiRoot = basemocks.NewMockAPICallCloser(ctrl)
 	s.apiRoot.EXPECT().Close().AnyTimes()
+	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
 
 	return ctrl
 }


### PR DESCRIPTION
Download, Find and Info will not work if the controller is not 2.9+.
Improve the error message using a 2.9+ client against a 2.8.x controller
or earlier.


## QA steps

With a 2.8/stable controller and a juju client from this PR run:
```sh
$ juju download ubuntu
WARNING juju download not supported with controllers < 2.9
$ juju find
WARNING juju find not supported with controllers < 2.9
$ juju info ubuntu
WARNING juju info not supported with controllers < 2.9
```

