### PR TITLE
enable refresh for charmhub resources

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1407,26 +1407,26 @@ func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmU
 }
 
 func makeParamsCharmOrigin(origin *state.CharmOrigin) params.CharmOrigin {
-	var rev *int
-	if origin.Revision != nil {
-		rev = origin.Revision
+	retOrigin := params.CharmOrigin{
+		Source: origin.Source,
+		ID:     origin.ID,
+		Hash:   origin.Hash,
 	}
-	var track *string
-	var risk string
+	if origin.Revision != nil {
+		retOrigin.Revision = origin.Revision
+	}
 	if origin.Channel != nil {
-		risk = origin.Channel.Risk
+		retOrigin.Risk = origin.Channel.Risk
 		if origin.Channel.Track != "" {
-			track = &origin.Channel.Track
+			retOrigin.Track = &origin.Channel.Track
 		}
 	}
-	return params.CharmOrigin{
-		Source:   origin.Source,
-		ID:       origin.ID,
-		Hash:     origin.Hash,
-		Risk:     risk,
-		Revision: rev,
-		Track:    track,
+	if origin.Platform != nil {
+		retOrigin.Architecture = origin.Platform.Architecture
+		retOrigin.OS = origin.Platform.OS
+		retOrigin.Series = origin.Platform.Series
 	}
+	return retOrigin
 }
 
 // Set implements the server side of Application.Set.

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -978,6 +978,11 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 			Track: "latest",
 			Risk:  "stable",
 		},
+		Platform: &state.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Series:       "focal",
+		},
 	}
 	s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
 	result, err := s.applicationAPI.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "wordpress"})
@@ -986,10 +991,13 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 	c.Assert(result.URL, gc.Equals, "local:quantal/wordpress-3")
 	latest := "latest"
 	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
-		Source:   "local",
-		Risk:     "stable",
-		Revision: &rev,
-		Track:    &latest,
+		Source:       "local",
+		Risk:         "stable",
+		Revision:     &rev,
+		Track:        &latest,
+		Architecture: "amd64",
+		OS:           "ubuntu",
+		Series:       "focal",
 	})
 }
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -423,28 +423,24 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	}
 	ctx.Infof("Added %s charm %q, revision %d%s, to the model", oldOrigin.Source, curl.Name, curl.Revision, channel)
 
-	// If it's the charmhub, we don't upgrade any resources as they're currently
-	// not supported. For now we do our best to create a valid charm.ID, but
-	// will most likely fail.
+	// Next, upgrade resources.
+
+	resourceLister, err := c.NewResourceLister(apiRoot)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	charmsClient := c.NewCharmClient(apiRoot)
+	meta, err := utils.GetMetaResources(curl, charmsClient)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	chID := application.CharmID{
 		URL:    curl,
 		Origin: commoncharm.CoreCharmOrigin(charmID.Origin),
 	}
-	resourceIDs := make(map[string]string)
-	if !charm.CharmHub.Matches(curl.Schema) {
-		// Next, upgrade resources.
-		charmsClient := c.NewCharmClient(apiRoot)
-		resourceLister, err := c.NewResourceLister(apiRoot)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		meta, err := utils.GetMetaResources(curl, charmsClient)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if resourceIDs, err = c.upgradeResources(apiRoot, resourceLister, chID, charmID.Macaroon, meta); err != nil {
-			return errors.Trace(err)
-		}
+	resourceIDs, err := c.upgradeResources(apiRoot, resourceLister, chID, charmID.Macaroon, meta)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	var bindingsChangelog []string
@@ -556,7 +552,7 @@ func (c *refreshCommand) checkApplicationFacadeSupport(verQuerier versionQuerier
 
 // upgradeResources pushes metadata up to the server for each resource defined
 // in the new charm's metadata and returns a map of resource names to pending
-// IDs to include in the upgrage-charm call.
+// IDs to include in the refresh call.
 //
 // TODO(axw) apiRoot is passed in here because DeployResources requires it,
 // DeployResources should accept a resource-specific client instead.


### PR DESCRIPTION
Requires PR #12521 for testing, can land without it.

Ensure that GetCharmURL returns a origin which includes the platform.  

Remove the do not refresh resources for CharmHub charms code.  The necessary changes to the resources package for deploying with a CharmHub resource have been made, which are also used by refresh.  

## QA steps

Limited testing is currently possible due to current data available and no way to create it today.

```console
$ juju bootstrap localhost test
$ juju add-model seven --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju deploy postgresql --config aws_region="us-east-1"
Located charm "postgresql" in charm-hub, revision 215
Deploying "postgresql" from charm-hub charm "postgresql", revision 215 in channel latest/stable

# wait for it to settle

$ juju refresh postgresql
Looking up metadata for charm-hub charm "postgresql" from channel stable
ERROR already running latest charm "postgresql"
```

