### PR TITLE
[2.9-python3-acceptancetests] Remove redundant decode() call in python3 acceptance tests

### DIFF
--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -342,10 +342,10 @@ class AssessNetworkHealth:
             out = subprocess.check_output(
                 'curl {}:{} -m 5'.format(ip, PORT), shell=True)
         except subprocess.CalledProcessError as e:
-            out = ''
+            out = b''
             log.warning('Curl failed for error:\n{}'.format(e))
         log.info('Got: "{}" from unit at {}:{}'.format(out, ip, PORT))
-        if 'pass' in out:
+        if b'pass' in out:
             return True
         return False
 

--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -128,22 +128,18 @@ def wait_for_storage_removal(client, storage_id, interval, timeout):
 
 def make_expected_ls(storage_name, unit_name, kind='filesystem'):
     """Return the expected data from list-storage for filesystem or block."""
-    if kind == 'block':
-        location = '/dev/loop3'
-    else:
-        location = '/srv/data'
+    unit_data = {'life': 'alive'}
+    if kind != 'block':
+        unit_data['location'] = '/srv/data'
     data = {
         "storage": {
             storage_name: {
                 "kind": kind,
                 "attachments": {
                     "units": {
-                        unit_name: {
-                            "location": location,
-                            "life": "alive"
-                            }
-                        }
+                        unit_name: unit_data
                     },
+                },
                 "life": "alive"
                 }
             }

--- a/acceptancetests/assess_wallet.py
+++ b/acceptancetests/assess_wallet.py
@@ -70,7 +70,7 @@ def _try_setting_wallet(client, name, value):
         output = [e.output.decode('utf-8'), getattr(e, 'stderr', '')]
         raise JujuAssertionError('Could not set wallet {}'.format(output))
 
-    if b'wallet limit updated' not in output:
+    if 'wallet limit updated' not in output:
         raise JujuAssertionError('Error calling set-wallet {}'.format(output))
 
 

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -202,7 +202,7 @@ def _get_token(remote, token_path="/var/run/dummy-sink/token"):
         if e.returncode != 1:
             raise
         return ""
-    return token_pattern.match(contents.decode('utf-8')).group(1)
+    return token_pattern.match(contents).group(1)
 
 
 def check_token(client, token, timeout=120):


### PR DESCRIPTION
This PR continues the work from #12516 (and previous PRs) by fixing a redundant call to `decode()` in the deploy_stack.py file. In addition, the PR also addresses some compat issues in the assess_wallet and assess_storage tests which should allow most of the gating tests to pass. 