### PR TITLE
Adds log message to bootstrap  for k8s cluster

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -961,10 +961,14 @@ See `[1:] + "`juju kill-controller`" + `.`)
 		}
 	}
 
-	if cloud.Type == k8sconstants.CAASProviderType &&
-		cloud.HostCloudRegion == caas.K8sCloudOther &&
-		bootstrapParams.ControllerServiceType == "" {
-		logger.Warningf("bootstrapping to an unknown kubernetes cluster should be used with option --config controller-service-type. See juju help bootstrap")
+	if cloud.Type == k8sconstants.CAASProviderType {
+		if cloud.HostCloudRegion == caas.K8sCloudOther {
+			ctx.Infof("Unable to identify bootstrapped Kubernetes cluster")
+		} else {
+			ctx.Infof("Bootstrap to Kubernetes cluster identified as %s",
+				cloud.HostCloudRegion)
+		}
+
 	}
 
 	bootstrapFuncs := getBootstrapFuncs()


### PR DESCRIPTION
This update introduces a new message to bootstrap for Kubernetes that
identifies the Kubernetes cluster being bootstrapped to.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Boot strap to several k8s clusters to make sure Juju correctly identifies the ones it knows about.
