### PR TITLE
[Charmhub] - Pass architecture for charmstore charms, allowing migration.

### DIFF
--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -977,7 +977,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationDefaultArchCons
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstraints(c *gc.C) {
 	wpch := s.setupCharm(c, "cs:xenial/wordpress-42", "wordpress", "bionic")
-	dch := s.setupCharm(c, "cs:bionic/dummy-0", "dummy", "bionic")
+	dch := s.setupCharmWithArch(c, "cs:bionic/dummy-0", "dummy", "bionic", "i386")
 
 	err := s.DeployBundleYAML(c, `
         applications:

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -242,8 +243,9 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				Source: "charm-store",
-				Risk:   "stable",
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "stable",
 			},
 		},
 		StorageConstraints: map[string]storage.Constraints{
@@ -295,8 +297,9 @@ func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				Source: "charm-store",
-				Risk:   "stable",
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "stable",
 			},
 		},
 		ConfigSettingsYAML: "foo:{}",
@@ -351,8 +354,9 @@ func (s *RefreshSuite) testUpgradeWithBind(c *gc.C, expectedBindings map[string]
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				Source: "charm-store",
-				Risk:   "stable",
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "stable",
 			},
 		},
 		EndpointBindings: expectedBindings,
@@ -570,7 +574,9 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{})
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{
+		Architecture: arch.DefaultArchitecture,
+	})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -578,8 +584,9 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				Source: "charm-store",
-				Risk:   "beta",
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "beta",
 			},
 		},
 	})
@@ -599,8 +606,9 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				Source: "charm-store",
-				Risk:   "beta",
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "beta",
 			},
 		},
 	})
@@ -621,8 +629,9 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: s.resolvedCharmURL,
 			Origin: commoncharm.Origin{
-				Source: "charm-store",
-				Risk:   "stable",
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "stable",
 			},
 		},
 	})

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	commoncharm "github.com/juju/juju/api/common/charm"
+	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/juju/osenv"
 )
@@ -240,7 +241,8 @@ func (s *charmStoreCharmRefresherSuite) TestRefresh(c *gc.C) {
 	curl := charm.MustParseURL(ref)
 	newCurl := charm.MustParseURL(fmt.Sprintf("%s-1", ref))
 	origin := commoncharm.Origin{
-		Source: commoncharm.OriginCharmStore,
+		Source:       commoncharm.OriginCharmStore,
+		Architecture: arch.DefaultArchitecture,
 	}
 
 	authorizer := NewMockMacaroonGetter(ctrl)
@@ -272,7 +274,8 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithNoUpdates(c *gc.C) {
 	ref := "cs:meshuggah"
 	curl := charm.MustParseURL(ref)
 	origin := commoncharm.Origin{
-		Source: commoncharm.OriginCharmStore,
+		Source:       commoncharm.OriginCharmStore,
+		Architecture: arch.DefaultArchitecture,
 	}
 
 	authorizer := NewMockMacaroonGetter(ctrl)
@@ -298,7 +301,8 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
 	ref := "cs:meshuggah-1"
 	curl := charm.MustParseURL(ref)
 	origin := commoncharm.Origin{
-		Source: commoncharm.OriginCharmStore,
+		Source:       commoncharm.OriginCharmStore,
+		Architecture: arch.DefaultArchitecture,
 	}
 
 	authorizer := NewMockMacaroonGetter(ctrl)

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -38,9 +38,10 @@ func DeduceOrigin(url *charm.URL, channel corecharm.Channel, platform corecharm.
 	switch url.Schema {
 	case "cs":
 		return commoncharm.Origin{
-			Source: commoncharm.OriginCharmStore,
-			Risk:   string(channel.Risk),
-			Series: platform.Series,
+			Source:       commoncharm.OriginCharmStore,
+			Risk:         string(channel.Risk),
+			Architecture: architecture,
+			Series:       platform.Series,
 		}, nil
 	case "local":
 		return commoncharm.Origin{

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -509,7 +509,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 
 	origin := exported.CharmOrigin()
 	c.Assert(origin.Channel(), gc.Equals, "beta")
-	c.Assert(origin.Platform(), gc.Equals, "amd64/focal")
+	c.Assert(origin.Platform(), gc.Equals, "amd64/ubuntu/focal")
 
 	c.Assert(exported.CharmConfig(), jc.DeepEquals, map[string]interface{}{
 		"foo": "bar",

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1455,6 +1455,10 @@ func (i *importer) getApplicationPlatform(a description.Application, url *charm.
 			return platform
 		}
 
+		// Attempting to find the right architecture is quite difficult,
+		// especially if we're in a heterogenous deployment. In that case we'll
+		// most likely guess wrong, so we now use the fact that just select
+		// the first available as that's what they most probably started with.
 		var arch string
 		for _, hw := range hardwareCharacteristics {
 			if hw.Arch == nil {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/juju/charm/v8"
+	"github.com/juju/collections/set"
 	"github.com/juju/description/v2"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -1240,12 +1241,14 @@ func (i *importer) importUnitPayloads(unit *Unit, payloads []description.Payload
 }
 
 func (i *importer) makeApplicationDoc(a description.Application) (*applicationDoc, error) {
+	units := a.Units()
+
 	charmURL, err := charm.ParseURL(a.CharmURL())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	origin, err := makeCharmOrigin(a, charmURL)
+	origin, err := i.makeCharmOrigin(a, charmURL, units)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1272,7 +1275,7 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 		ForceCharm:           a.ForceCharm(),
 		PasswordHash:         a.PasswordHash(),
 		Life:                 Alive,
-		UnitCount:            len(a.Units()),
+		UnitCount:            len(units),
 		RelationCount:        i.relationCount(a.Name()),
 		Exposed:              a.Exposed(),
 		ExposedEndpoints:     exposedEndpoints,
@@ -1285,10 +1288,45 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 	}, nil
 }
 
-func makeCharmOrigin(a description.Application, curl *charm.URL) (*CharmOrigin, error) {
+func (i *importer) loadInstanceHardwareFromUnits(units []description.Unit) ([]instance.HardwareCharacteristics, error) {
+	machinesCollection, closer := i.st.db().GetCollection(machinesC)
+	defer closer()
+
+	machineIds := set.NewStrings()
+	for _, unit := range units {
+		tag := unit.Machine()
+		machineIds.Add(tag.Id())
+	}
+
+	docs := []machineDoc{}
+	err := machinesCollection.Find(bson.M{
+		"_id": bson.M{
+			"$in": machineIds.SortedValues(),
+		},
+	}).All(&docs)
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get unit machines")
+	}
+
+	var hwChars []instance.HardwareCharacteristics
+	for _, doc := range docs {
+		machine := newMachine(i.st, &doc)
+		hw, err := machine.HardwareCharacteristics()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if hw == nil {
+			continue
+		}
+		hwChars = append(hwChars, *hw)
+	}
+	return hwChars, nil
+}
+
+func (i *importer) makeCharmOrigin(a description.Application, curl *charm.URL, units []description.Unit) (*CharmOrigin, error) {
 	co := a.CharmOrigin()
 	if co == nil {
-		return deduceCharmOrigin(curl)
+		return i.deduceCharmOrigin(a, curl, units)
 	}
 	rev := co.Revision()
 
@@ -1303,7 +1341,11 @@ func makeCharmOrigin(a description.Application, curl *charm.URL) (*CharmOrigin, 
 			Risk:   string(c.Risk),
 			Branch: c.Branch,
 		}
+	} else {
+		// Attempt to fallback to get the channel if it's missing.
+		_, channel = getApplicationSourceChannel(a, curl)
 	}
+
 	var platform *Platform
 	if serialized := co.Platform(); serialized != "" {
 		p, err := corecharm.ParsePlatformNormalize(serialized)
@@ -1315,6 +1357,10 @@ func makeCharmOrigin(a description.Application, curl *charm.URL) (*CharmOrigin, 
 			OS:           p.OS,
 			Series:       p.Series,
 		}
+	} else {
+		// Attempt to fallback to the application charm URL and then the
+		// application constraints.
+		platform = i.getApplicationPlatform(a, curl, units)
 	}
 
 	// We can hardcode type to charm as we never store bundles in state.
@@ -1329,10 +1375,7 @@ func makeCharmOrigin(a description.Application, curl *charm.URL) (*CharmOrigin, 
 	}, nil
 }
 
-// TODO (hml) 2020-08-04
-// Investigate adding channel from application, appears to be
-// set for cs charms.
-func deduceCharmOrigin(url *charm.URL) (*CharmOrigin, error) {
+func (i *importer) deduceCharmOrigin(a description.Application, url *charm.URL, units []description.Unit) (*CharmOrigin, error) {
 	if url == nil {
 		return &CharmOrigin{}, errors.NotValidf("charm url")
 	}
@@ -1345,20 +1388,99 @@ func deduceCharmOrigin(url *charm.URL) (*CharmOrigin, error) {
 		t = "charm"
 	}
 
-	origin := &CharmOrigin{
+	source, channel := getApplicationSourceChannel(a, url)
+	return &CharmOrigin{
 		Type:     t,
+		Source:   source.String(),
 		Revision: &url.Revision,
-	}
+		Channel:  channel,
+		Platform: i.getApplicationPlatform(a, url, units),
+	}, nil
+}
 
+// Attempt to get as much information from the appChannel where possible.
+func getApplicationSourceChannel(a description.Application, url *charm.URL) (corecharm.Source, *Channel) {
+	var source corecharm.Source
 	switch url.Schema {
 	case "cs":
-		origin.Source = corecharm.CharmStore.String()
+		source = corecharm.CharmStore
 	case "local":
-		origin.Source = corecharm.Local.String()
+		source = corecharm.Local
 	default:
-		origin.Source = corecharm.CharmHub.String()
+		source = corecharm.CharmHub
 	}
-	return origin, nil
+
+	c := a.Channel()
+	if c == "" {
+		return source, nil
+	}
+
+	if source == corecharm.CharmStore || source == corecharm.Local {
+		return source, &Channel{Risk: a.Channel()}
+	}
+
+	norm, err := corecharm.ParseChannelNormalize(a.Channel())
+	if err != nil {
+		return source, nil
+	}
+
+	return source, &Channel{
+		Track:  norm.Track,
+		Risk:   string(norm.Risk),
+		Branch: norm.Branch,
+	}
+}
+
+// Attempt to locate the architecture, if it's found in the URL then use
+// that, otherwise fallback to the arch constraint.
+func (i *importer) getApplicationPlatform(a description.Application, url *charm.URL, units []description.Unit) *Platform {
+	var platform *Platform
+	if url != nil && url.Architecture != "" {
+		platform = &Platform{
+			Architecture: url.Architecture,
+			Series:       url.Series,
+		}
+	} else if arc := getApplicationArchConstraint(a); arc != "" {
+		platform = &Platform{
+			Architecture: arc,
+		}
+	}
+
+	if platform == nil || platform.Architecture == "" {
+		// If we can't find an instance hardware based on the units, then just
+		// return the platform.
+		hardwareCharacteristics, err := i.loadInstanceHardwareFromUnits(units)
+		if err != nil {
+			return platform
+		}
+
+		var arch string
+		for _, hw := range hardwareCharacteristics {
+			if hw.Arch == nil {
+				continue
+			}
+			arch = *hw.Arch
+			continue
+		}
+
+		if platform == nil {
+			platform = &Platform{}
+		}
+		platform.Architecture = arch
+	}
+
+	return platform
+}
+
+func getApplicationArchConstraint(a description.Application) string {
+	cons := a.Constraints()
+	if cons == nil {
+		return ""
+	}
+	if arch := cons.Architecture(); arch != "" {
+		return arch
+	}
+	return ""
 }
 
 func (i *importer) relationCount(application string) int {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1443,6 +1443,7 @@ func (i *importer) getApplicationPlatform(a description.Application, url *charm.
 	} else if arc := getApplicationArchConstraint(a); arc != "" {
 		platform = &Platform{
 			Architecture: arc,
+			Series:       a.Series(),
 		}
 	}
 
@@ -1467,6 +1468,7 @@ func (i *importer) getApplicationPlatform(a description.Application, url *charm.
 			platform = &Platform{}
 		}
 		platform.Architecture = arch
+		platform.Series = a.Series()
 	}
 
 	return platform

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -662,7 +662,10 @@ func (s *MigrationImportSuite) TestApplicationsWithMissingPlatform(c *gc.C) {
 	imported := importedApplications[0]
 
 	expectedOrigin := exported.CharmOrigin()
-	expectedOrigin.Platform = &state.Platform{Architecture: corearch.DefaultArchitecture}
+	expectedOrigin.Platform = &state.Platform{
+		Architecture: corearch.DefaultArchitecture,
+		Series:       "quantal",
+	}
 
 	c.Assert(imported.CharmOrigin(), jc.DeepEquals, expectedOrigin)
 }
@@ -692,7 +695,10 @@ func (s *MigrationImportSuite) TestApplicationsWithMissingPlatformWithoutConstra
 	imported := importedApplications[0]
 
 	expectedOrigin := exported.CharmOrigin()
-	expectedOrigin.Platform = &state.Platform{Architecture: corearch.DefaultArchitecture}
+	expectedOrigin.Platform = &state.Platform{
+		Architecture: corearch.DefaultArchitecture,
+		Series:       "quantal",
+	}
 
 	c.Assert(imported.CharmOrigin(), jc.DeepEquals, expectedOrigin)
 }


### PR DESCRIPTION
The following ensures that we at least attempt to handle missing
architectual origins in charm-store charms. This is not mandatory and
shouldn't reflect what actually is installed 100%, instead should be an
indicator or what was used at install time.


## QA steps

bundle.yaml:

```yaml
series: focal
applications:
  csubuntu:
    charm: cs:ubuntu-16
    num_units: 1
```

```
$ juju bootstrap localhost dst
$ juju bootstrap localhost src
$ juju add-model move
$ juju deploy bundle.yaml
# once it's settled
$ juju migrate move dst
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1911800
