### PR TITLE
Return host name from "unit-get private-address"

### DIFF
--- a/worker/uniter/runner/jujuc/unit-get.go
+++ b/worker/uniter/runner/jujuc/unit-get.go
@@ -64,7 +64,17 @@ func (c *UnitGetCommand) Run(ctx *cmd.Context) error {
 		if err != nil || len(networkInfos[""].Info) == 0 || len(networkInfos[""].Info[0].Addresses) == 0 {
 			value, err = c.ctx.PrivateAddress()
 		} else {
-			value = networkInfos[""].Info[0].Addresses[0].Address
+			// Here, we preserve behaviour that changed inadvertently in 2.8.7
+			// when we pushed host name resolution from the network-get tool
+			// into the NetworkInfo method on the uniter API.
+			// If addresses were resolved from host names, return the host name
+			// instead of the IP we resolved.
+			addr := networkInfos[""].Info[0].Addresses[0]
+			if addr.Hostname != "" {
+				value = addr.Hostname
+			} else {
+				value = addr.Address
+			}
 		}
 	} else {
 		value, err = c.ctx.PublicAddress()

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -153,6 +153,21 @@ func (s *UnitGetSuite) TestNetworkInfoPrivateAddress(c *gc.C) {
 		},
 	}
 
+	resultsResolvedHost := map[string]params.NetworkInfoResult{
+		"": {
+			Info: []params.NetworkInfo{{
+				MACAddress:    "00:11:22:33:44:0",
+				InterfaceName: "eth0",
+				Addresses: []params.InterfaceAddress{
+					{
+						Address:  "10.20.1.42",
+						Hostname: "host-name.somewhere.invalid",
+					},
+				},
+			}},
+		},
+	}
+
 	launchCommand := func(input map[string]params.NetworkInfoResult, expected string) {
 		hctx := s.GetHookContext(c, -1, "")
 		hctx.info.NetworkInterface.NetworkInfoResults = input
@@ -170,4 +185,5 @@ func (s *UnitGetSuite) TestNetworkInfoPrivateAddress(c *gc.C) {
 	launchCommand(resultsDefaultNoAddress, "192.168.0.99")
 	launchCommand(resultsDefaultAddress, "10.20.1.42")
 	launchCommand(resultsDefaultAddressV6, "fc00::1")
+	launchCommand(resultsResolvedHost, "host-name.somewhere.invalid")
 }


### PR DESCRIPTION
Host name resolution was pushed from the `network-get` hook tool into the uniter API method `NetworkInfo` in https://github.com/juju/juju/pull/12343. This was so that host-name resolution could be applied selectively based on the IAAS/CAAS case.

What was missed is that the `unit-get` tool calls `NetworkInfo` when asked for a `private-address`. This means behaviour changed in that tool; host names now being returned as IP addresses where the server can resolve them.

This patch reverts us to the prior behaviour, returning host name instead of the resolved IP address

## QA steps

- Bootstrap LXD
- Create a juju-manual profile, using the key from .local/share/juju/ssh/juju_id_rsa.pub
```
config:
  user.user-data: |
    #cloud-config
    ssh_authorized_keys:
      - {key file contents}
description: For seeding containers as manual Juju machines
devices:
  eth0:
    nictype: bridged
    parent: lxdbr0
    type: nic
  root:
    path: /
    pool: default
    type: disk
name: juju-manual
```
- Create a container with the new profile: `lxc launch --profile juju-manual ubuntu:bionic m1`
- Add a host file entry on both your machine and the controller: `{container IP} m1`
- Provision the machine: `juju add-machine ssh:ubuntu@m1`
- `juju deploy percona-cluster --to 0`
- Check that the host-name would otherwise be resolved to an IP: `juju run --unit percona-cluster/0 "network-get cluster --bind-address"`
- But `juju run --unit percona-cluster "unit-get private-address"` should return `m1`.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/content-cache-charm/+bug/1910974
