### PR TITLE
Merge 2.8 into 2.9

### DIFF
--- a/worker/uniter/runner/jujuc/unit-get.go
+++ b/worker/uniter/runner/jujuc/unit-get.go
@@ -64,7 +64,17 @@ func (c *UnitGetCommand) Run(ctx *cmd.Context) error {
 		if err != nil || len(networkInfos[""].Info) == 0 || len(networkInfos[""].Info[0].Addresses) == 0 {
 			value, err = c.ctx.PrivateAddress()
 		} else {
-			value = networkInfos[""].Info[0].Addresses[0].Address
+			// Here, we preserve behaviour that changed inadvertently in 2.8.7
+			// when we pushed host name resolution from the network-get tool
+			// into the NetworkInfo method on the uniter API.
+			// If addresses were resolved from host names, return the host name
+			// instead of the IP we resolved.
+			addr := networkInfos[""].Info[0].Addresses[0]
+			if addr.Hostname != "" {
+				value = addr.Hostname
+			} else {
+				value = addr.Address
+			}
 		}
 	} else {
 		value, err = c.ctx.PublicAddress()

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -153,6 +153,21 @@ func (s *UnitGetSuite) TestNetworkInfoPrivateAddress(c *gc.C) {
 		},
 	}
 
+	resultsResolvedHost := map[string]params.NetworkInfoResult{
+		"": {
+			Info: []params.NetworkInfo{{
+				MACAddress:    "00:11:22:33:44:0",
+				InterfaceName: "eth0",
+				Addresses: []params.InterfaceAddress{
+					{
+						Address:  "10.20.1.42",
+						Hostname: "host-name.somewhere.invalid",
+					},
+				},
+			}},
+		},
+	}
+
 	launchCommand := func(input map[string]params.NetworkInfoResult, expected string) {
 		hctx := s.GetHookContext(c, -1, "")
 		hctx.info.NetworkInterface.NetworkInfoResults = input
@@ -170,4 +185,5 @@ func (s *UnitGetSuite) TestNetworkInfoPrivateAddress(c *gc.C) {
 	launchCommand(resultsDefaultNoAddress, "192.168.0.99")
 	launchCommand(resultsDefaultAddress, "10.20.1.42")
 	launchCommand(resultsDefaultAddressV6, "fc00::1")
+	launchCommand(resultsResolvedHost, "host-name.somewhere.invalid")
 }


### PR DESCRIPTION
Single patch, no-conflict forward port.

#12528 from manadart/2.8-unit-get-use-host