### PR TITLE
[Charmhub] - Migrate download charm to refresh API

### DIFF
--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -127,6 +127,11 @@ type refreshOne struct {
 	instanceKey string
 }
 
+// InstanceKey returns the underlying instance key.
+func (c refreshOne) InstanceKey() string {
+	return c.instanceKey
+}
+
 func (c refreshOne) String() string {
 	return fmt.Sprintf("Refresh one (instanceKey: %s): using ID %s revision %+v, with channel %s and platform %v",
 		c.instanceKey, c.ID, c.Revision, c.Channel, c.Platform.String())
@@ -195,6 +200,11 @@ type executeOne struct {
 	// asynchronous calls.
 	action      Action
 	instanceKey string
+}
+
+// InstanceKey returns the underlying instance key.
+func (c executeOne) InstanceKey() string {
+	return c.instanceKey
 }
 
 // InstallOneFromRevision creates a request config using the revision and not
@@ -342,8 +352,12 @@ func (c executeOne) String() string {
 	} else {
 		using = fmt.Sprintf("Name %s", c.Name)
 	}
-	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using %s with revision: %+v, channel %v and platform %s",
-		c.action, c.instanceKey, using, c.Revision, channel, c.Platform)
+	var revision string
+	if c.Revision != nil {
+		revision = fmt.Sprintf(" with revision: %+v", c.Revision)
+	}
+	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using %s%s channel %v and platform %s",
+		c.action, c.instanceKey, using, revision, channel, c.Platform)
 }
 
 type refreshMany struct {
@@ -449,4 +463,18 @@ func validatePlatform(rp RefreshPlatform) error {
 		return err
 	}
 	return nil
+}
+
+type instanceKey interface {
+	InstanceKey() string
+}
+
+// ExtractConfigInstanceKey is used to get the instance key from a refresh
+// config.
+func ExtractConfigInstanceKey(cfg RefreshConfig) string {
+	key, ok := cfg.(instanceKey)
+	if ok {
+		return key.InstanceKey()
+	}
+	return ""
 }

--- a/cmd/juju/charmhub/interface.go
+++ b/cmd/juju/charmhub/interface.go
@@ -36,6 +36,7 @@ type FindCommandAPI interface {
 // command.
 type DownloadCommandAPI interface {
 	Info(context.Context, string, ...charmhub.InfoOption) (transport.InfoResponse, error)
+	Refresh(context.Context, charmhub.RefreshConfig) ([]transport.RefreshResponse, error)
 	Download(context.Context, *url.URL, string, ...charmhub.DownloadOption) error
 }
 

--- a/cmd/juju/charmhub/mocks/api_mock.go
+++ b/cmd/juju/charmhub/mocks/api_mock.go
@@ -76,6 +76,21 @@ func (mr *MockDownloadCommandAPIMockRecorder) Info(arg0, arg1 interface{}, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockDownloadCommandAPI)(nil).Info), varargs...)
 }
 
+// Refresh mocks base method
+func (m *MockDownloadCommandAPI) Refresh(arg0 context.Context, arg1 charmhub0.RefreshConfig) ([]transport.RefreshResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Refresh", arg0, arg1)
+	ret0, _ := ret[0].([]transport.RefreshResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Refresh indicates an expected call of Refresh
+func (mr *MockDownloadCommandAPIMockRecorder) Refresh(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockDownloadCommandAPI)(nil).Refresh), arg0, arg1)
+}
+
 // MockInfoCommandAPI is a mock of InfoCommandAPI interface
 type MockInfoCommandAPI struct {
 	ctrl     *gomock.Controller
@@ -320,4 +335,19 @@ func (m *MockCharmHubClient) Info(arg0 context.Context, arg1 string) (transport.
 func (mr *MockCharmHubClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockCharmHubClient)(nil).Info), arg0, arg1)
+}
+
+// Refresh mocks base method
+func (m *MockCharmHubClient) Refresh(arg0 context.Context, arg1 charmhub0.RefreshConfig) ([]transport.RefreshResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Refresh", arg0, arg1)
+	ret0, _ := ret[0].([]transport.RefreshResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Refresh indicates an expected call of Refresh
+func (mr *MockCharmHubClientMockRecorder) Refresh(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockCharmHubClient)(nil).Refresh), arg0, arg1)
 }


### PR DESCRIPTION
With the up and coming changes to the info API it is required that we
move to refresh API. The following changes are mainly mechanical, in
such that we're calling a different API but the results end up being the
same.

It should be noted that the request via info API, sole purpose is to check if
the entity is a bundle or a charm. Once the refresh API supports bundles
we can remove this block of code.

## QA steps

#### With controller

```sh
$ juju bootstrap lxd test
$ juju download ubuntu
```

#### Without controller

```sh
$ juju download --charmhub-url=https://api.staging.charmcraft.io ubuntu
```
