### PR TITLE
Update to klog in Juju and tunnel.

### DIFF
--- a/caas/kubernetes/pod/package_test.go
+++ b/caas/kubernetes/pod/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pod_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/caas/kubernetes/pod/pod.go
+++ b/caas/kubernetes/pod/pod.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pod
+
+import (
+	core "k8s.io/api/core/v1"
+)
+
+// getPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+// These methods come directly from the Kubernetes code base. We can't import
+// them as Kubernetes forbids this. Code can be found here:
+// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/api/pod/util.go
+func GetPodCondition(status *core.PodStatus, conditionType core.PodConditionType) (int, *core.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return GetPodConditionFromList(status.Conditions, conditionType)
+}
+
+// getPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+// These methods come directly from the Kubernetes code base. We can't import
+// them as Kubernetes forbids this. Code can be found here:
+// https://github.com/kubernetes/kubernetes/blob/12d9183da03d86c65f9f17e3e28be3c7c18ed22a/pkg/api/pod/util.go
+func GetPodConditionFromList(conditions []core.PodCondition, conditionType core.PodConditionType) (int, *core.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// IsPodRunning checks all the conditions of a pod to make sure PodReady is true
+func IsPodRunning(pod *core.Pod) bool {
+	_, cond := GetPodCondition(&pod.Status, core.PodReady)
+	if cond == nil {
+		return false
+	}
+	return cond.Status == core.ConditionTrue
+}

--- a/caas/kubernetes/provider/klog.go
+++ b/caas/kubernetes/provider/klog.go
@@ -29,9 +29,9 @@ func (k *klogAdapter) Enabled() bool {
 // Error see https://pkg.go.dev/github.com/go-logr/logr#Logger
 func (k *klogAdapter) Error(err error, msg string, keysAndValues ...interface{}) {
 	if err != nil {
-		k.Logger.Debugf(msg+": "+err.Error(), keysAndValues...)
+		k.Logger.Errorf(msg+": "+err.Error(), keysAndValues...)
 	} else {
-		k.Logger.Debugf(msg, keysAndValues...)
+		k.Logger.Errorf(msg, keysAndValues...)
 	}
 }
 

--- a/caas/kubernetes/provider/proxy/setup.go
+++ b/caas/kubernetes/provider/proxy/setup.go
@@ -60,8 +60,13 @@ func CreateControllerProxy(
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods", "services"},
-				Verbs:     []string{"list", "get"},
+				Resources: []string{"pods"},
+				Verbs:     []string{"list", "get", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get"},
 			},
 			{
 				APIGroups: []string{""},

--- a/caas/kubernetes/provider/proxy/setup_test.go
+++ b/caas/kubernetes/provider/proxy/setup_test.go
@@ -64,10 +64,12 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(role.Name, gc.Equals, config.Name)
-	c.Assert(role.Rules[0].Resources, jc.DeepEquals, []string{"pods", "services"})
-	c.Assert(role.Rules[0].Verbs, jc.DeepEquals, []string{"list", "get"})
-	c.Assert(role.Rules[1].Resources, jc.DeepEquals, []string{"pods/portforward"})
-	c.Assert(role.Rules[1].Verbs, jc.DeepEquals, []string{"create"})
+	c.Assert(role.Rules[0].Resources, jc.DeepEquals, []string{"pods"})
+	c.Assert(role.Rules[0].Verbs, jc.DeepEquals, []string{"list", "get", "watch"})
+	c.Assert(role.Rules[1].Resources, jc.DeepEquals, []string{"services"})
+	c.Assert(role.Rules[1].Verbs, jc.DeepEquals, []string{"get"})
+	c.Assert(role.Rules[2].Resources, jc.DeepEquals, []string{"pods/portforward"})
+	c.Assert(role.Rules[2].Verbs, jc.DeepEquals, []string{"create"})
 
 	sa, err := s.client.CoreV1().ServiceAccounts(testNamespace).Get(
 		context.TODO(),

--- a/cmd/k8sagent/initialize/package_test.go
+++ b/cmd/k8sagent/initialize/package_test.go
@@ -47,6 +47,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"apiserver/params",
 		"cmd/k8sagent/utils",
 		"caas/kubernetes",
+		"caas/kubernetes/pod",
 		"caas/kubernetes/provider/constants",
 		"caas/kubernetes/provider/proxy",
 		"charmhub",


### PR DESCRIPTION
This update respects the level of klog messages and passes them onto
loggo as such.

Also in this update is a change to k8s tunneling behaviour that waits
for the tunnel to pod to become ready before trying to tunnel. This also
adds a timeout for operations as to not fully block Juju.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap to several Kubernetes clusters such as kind and minikube and check for no error messages during bootstrap. Also try other juju commands like deploy and status.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1912348
