### PR TITLE
Add ingress v1 and v1beta1 support for podspec v3

### DIFF
--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -298,6 +298,7 @@ func (s *BaseSuite) setupK8sRestClient(
 	s.mockNetworkingV1beta1.EXPECT().Ingresses(namespace).AnyTimes().Return(s.mockIngressV1Beta1)
 	s.k8sClient.EXPECT().NetworkingV1beta1().AnyTimes().Return(s.mockNetworkingV1beta1)
 	s.mockIngressClasses = mocks.NewMockIngressClassInterface(ctrl)
+
 	s.mockIngressV1 = mocks.NewMockIngressV1Interface(ctrl)
 	s.mockNetworkingV1 = mocks.NewMockNetworkingV1Interface(ctrl)
 	s.mockNetworkingV1.EXPECT().Ingresses(namespace).AnyTimes().Return(s.mockIngressV1)

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -119,51 +119,12 @@ func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.In
 	return cleanUp, errors.Trace(err)
 }
 
-func (k *kubernetesClient) createIngress(ingress *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
-	utils.PurifyResource(ingress)
-	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Create(context.TODO(), ingress, metav1.CreateOptions{})
-	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("ingress resource %q", ingress.GetName())
-	}
-	return out, errors.Trace(err)
-}
-
-func (k *kubernetesClient) getIngress(name string) (*networkingv1beta1.Ingress, error) {
-	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if k8serrors.IsNotFound(err) {
-		return nil, errors.NotFoundf("ingress resource %q", name)
-	}
-	return out, errors.Trace(err)
-}
-
-func (k *kubernetesClient) updateIngress(ingress *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
-	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
-	if k8serrors.IsNotFound(err) {
-		return nil, errors.NotFoundf("ingress resource %q", ingress.GetName())
-	}
-	return out, errors.Trace(err)
-}
-
 func (k *kubernetesClient) deleteIngress(name string, uid k8stypes.UID) error {
 	err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) listIngressResources(labels map[string]string) ([]networkingv1beta1.Ingress, error) {
-	listOps := metav1.ListOptions{
-		LabelSelector: utils.LabelsToSelector(labels).String(),
-	}
-	ingList, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).List(context.TODO(), listOps)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(ingList.Items) == 0 {
-		return nil, errors.NotFoundf("ingress with labels %v", labels)
-	}
-	return ingList.Items, nil
 }
 
 func (k *kubernetesClient) deleteIngressResources(appName string) error {

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -72,7 +72,7 @@ func (k *kubernetesClient) ensureIngressV1beta1(appName string, spec *networking
 	api := k.client().NetworkingV1beta1().Ingresses(k.namespace)
 	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
-		cleanUp = func() { _ = k.deleteIngress(out.GetName(), out.GetUID()) }
+		cleanUp = func() { _ = api.Delete(context.TODO(), out.GetName(), newPreconditionDeleteOptions(out.GetUID())) }
 		return cleanUp, nil
 	}
 	if !k8serrors.IsAlreadyExists(err) {
@@ -96,7 +96,7 @@ func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.In
 	api := k.client().NetworkingV1().Ingresses(k.namespace)
 	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
-		cleanUp = func() { _ = k.deleteIngress(out.GetName(), out.GetUID()) }
+		cleanUp = func() { _ = api.Delete(context.TODO(), out.GetName(), newPreconditionDeleteOptions(out.GetUID())) }
 		return cleanUp, nil
 	}
 	if !k8serrors.IsAlreadyExists(err) {

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -11,7 +11,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -28,41 +28,58 @@ func (k *kubernetesClient) getIngressLabels(appName string) map[string]string {
 // TODO(caas): should we overwrite the existing `juju expose` created ingress if user runs upgrade-charm with new ingress podspec v2.
 // https://bugs.launchpad.net/juju/+bug/1854123
 func (k *kubernetesClient) ensureIngressResources(
-	appName string, annotations k8sannotations.Annotation, ingSpecs []k8sspecs.K8sIngressSpec,
+	appName string, annotations k8sannotations.Annotation, ingSpecs []k8sspecs.K8sIngress,
 ) (cleanUps []func(), err error) {
 	for _, v := range ingSpecs {
 		if v.Name == appName {
 			return cleanUps, errors.NotValidf("ingress name %q is reserved for juju expose", appName)
 		}
-		ing := &networkingv1beta1.Ingress{
-			ObjectMeta: v1.ObjectMeta{
-				Name:        v.Name,
-				Labels:      k8slabels.Merge(v.Labels, k.getIngressLabels(appName)),
-				Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
-			},
-			Spec: v.Spec,
+
+		obj := metav1.ObjectMeta{
+			Name:        v.Name,
+			Labels:      k8slabels.Merge(v.Labels, k.getIngressLabels(appName)),
+			Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
 		}
-		cleanUp, err := k.ensureIngress(appName, ing, false)
+
+		logger.Infof("ensuring ingress %q with version %q", obj.GetName(), v.Spec.Version)
+		var cleanUp func()
+		switch v.Spec.Version {
+		case k8sspecs.K8sIngressV1:
+			cleanUp, err = k.ensureIngressV1(appName, &networkingv1.Ingress{
+				ObjectMeta: obj,
+				Spec:       v.Spec.SpecV1,
+			}, false)
+		case k8sspecs.K8sIngressV1Beta1:
+			cleanUp, err = k.ensureIngressV1beta1(appName, &networkingv1beta1.Ingress{
+				ObjectMeta: obj,
+				Spec:       v.Spec.SpecV1Beta1,
+			}, false)
+		default:
+			// This should never happen.
+			return cleanUps, errors.NotSupportedf("ingress version %q", v.Spec.Version)
+		}
+
 		cleanUps = append(cleanUps, cleanUp)
 		if err != nil {
-			return cleanUps, errors.Trace(err)
+			return cleanUps, errors.Annotatef(err, "ensuring ingress %q with version %q", obj.GetName(), v.Spec.Version)
 		}
 	}
 	return cleanUps, nil
 }
 
-func (k *kubernetesClient) ensureIngress(appName string, spec *networkingv1beta1.Ingress, force bool) (func(), error) {
+func (k *kubernetesClient) ensureIngressV1beta1(appName string, spec *networkingv1beta1.Ingress, force bool) (func(), error) {
 	cleanUp := func() {}
-	out, err := k.createIngress(spec)
+	api := k.client().NetworkingV1beta1().Ingresses(k.namespace)
+	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
 		cleanUp = func() { _ = k.deleteIngress(out.GetName(), out.GetUID()) }
 		return cleanUp, nil
 	}
-	if !errors.IsAlreadyExists(err) {
+	if !k8serrors.IsAlreadyExists(err) {
 		return cleanUp, errors.Trace(err)
 	}
 	if !force {
-		existing, err := k.getIngress(spec.GetName())
+		existing, err := api.Get(context.TODO(), spec.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return cleanUp, errors.Trace(err)
 		}
@@ -70,13 +87,37 @@ func (k *kubernetesClient) ensureIngress(appName string, spec *networkingv1beta1
 			return cleanUp, errors.NewAlreadyExists(nil, fmt.Sprintf("existing ingress %q found which does not belong to %q", spec.GetName(), appName))
 		}
 	}
-	_, err = k.updateIngress(spec)
+	_, err = api.Update(context.TODO(), spec, metav1.UpdateOptions{})
+	return cleanUp, errors.Trace(err)
+}
+
+func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.Ingress, force bool) (func(), error) {
+	cleanUp := func() {}
+	api := k.client().NetworkingV1().Ingresses(k.namespace)
+	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
+	if err == nil {
+		cleanUp = func() { _ = k.deleteIngress(out.GetName(), out.GetUID()) }
+		return cleanUp, nil
+	}
+	if !k8serrors.IsAlreadyExists(err) {
+		return cleanUp, errors.Trace(err)
+	}
+	if !force {
+		existing, err := api.Get(context.TODO(), spec.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return cleanUp, errors.Trace(err)
+		}
+		if len(existing.GetLabels()) == 0 || !k8slabels.AreLabelsInWhiteList(k.getIngressLabels(appName), existing.GetLabels()) {
+			return cleanUp, errors.NewAlreadyExists(nil, fmt.Sprintf("existing ingress %q found which does not belong to %q", spec.GetName(), appName))
+		}
+	}
+	_, err = api.Update(context.TODO(), spec, metav1.UpdateOptions{})
 	return cleanUp, errors.Trace(err)
 }
 
 func (k *kubernetesClient) createIngress(ingress *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
 	utils.PurifyResource(ingress)
-	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Create(context.TODO(), ingress, v1.CreateOptions{})
+	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Create(context.TODO(), ingress, metav1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("ingress resource %q", ingress.GetName())
 	}
@@ -84,7 +125,7 @@ func (k *kubernetesClient) createIngress(ingress *networkingv1beta1.Ingress) (*n
 }
 
 func (k *kubernetesClient) getIngress(name string) (*networkingv1beta1.Ingress, error) {
-	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
+	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("ingress resource %q", name)
 	}
@@ -92,7 +133,7 @@ func (k *kubernetesClient) getIngress(name string) (*networkingv1beta1.Ingress, 
 }
 
 func (k *kubernetesClient) updateIngress(ingress *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
-	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Update(context.TODO(), ingress, v1.UpdateOptions{})
+	out, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("ingress resource %q", ingress.GetName())
 	}
@@ -108,7 +149,7 @@ func (k *kubernetesClient) deleteIngress(name string, uid k8stypes.UID) error {
 }
 
 func (k *kubernetesClient) listIngressResources(labels map[string]string) ([]networkingv1beta1.Ingress, error) {
-	listOps := v1.ListOptions{
+	listOps := metav1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(labels).String(),
 	}
 	ingList, err := k.client().NetworkingV1beta1().Ingresses(k.namespace).List(context.TODO(), listOps)
@@ -122,9 +163,9 @@ func (k *kubernetesClient) listIngressResources(labels map[string]string) ([]net
 }
 
 func (k *kubernetesClient) deleteIngressResources(appName string) error {
-	err := k.client().NetworkingV1beta1().Ingresses(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
+	err := k.client().NetworkingV1beta1().Ingresses(k.namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
-	}, v1.ListOptions{
+	}, metav1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(k.getIngressLabels(appName)).String(),
 	})
 	if k8serrors.IsNotFound(err) {
@@ -134,7 +175,7 @@ func (k *kubernetesClient) deleteIngressResources(appName string) error {
 }
 
 func (k *kubernetesClient) listIngressClasses(labels map[string]string) ([]networkingv1.IngressClass, error) {
-	listOps := v1.ListOptions{
+	listOps := metav1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(labels).String(),
 	}
 	ingCList, err := k.client().NetworkingV1().IngressClasses().List(context.TODO(), listOps)

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -72,7 +72,9 @@ func (k *kubernetesClient) ensureIngressV1beta1(appName string, spec *networking
 	api := k.client().NetworkingV1beta1().Ingresses(k.namespace)
 	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
-		cleanUp = func() { _ = api.Delete(context.TODO(), out.GetName(), newPreconditionDeleteOptions(out.GetUID())) }
+		cleanUp = func() {
+			_ = api.Delete(context.TODO(), out.GetName(), utils.NewPreconditionDeleteOptions(out.GetUID()))
+		}
 		return cleanUp, nil
 	}
 	if !k8serrors.IsAlreadyExists(err) {
@@ -96,7 +98,9 @@ func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.In
 	api := k.client().NetworkingV1().Ingresses(k.namespace)
 	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
-		cleanUp = func() { _ = api.Delete(context.TODO(), out.GetName(), newPreconditionDeleteOptions(out.GetUID())) }
+		cleanUp = func() {
+			_ = api.Delete(context.TODO(), out.GetName(), utils.NewPreconditionDeleteOptions(out.GetUID()))
+		}
 		return cleanUp, nil
 	}
 	if !k8serrors.IsAlreadyExists(err) {

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -353,12 +353,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreateV1(c *gc.C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-ingress",
 			Labels: map[string]string{
-				"foo":      "bar",
-				"juju-app": "app-name",
+				"foo":                          "bar",
+				"app.kubernetes.io/name":       "app-name",
+				"app.kubernetes.io/managed-by": "juju",
 			},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				"controller.juju.is/id":                      "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 			},
 		},
 		Spec: networkingv1.IngressSpec{
@@ -416,12 +417,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateV1(c *gc.C) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-ingress",
 			Labels: map[string]string{
-				"foo":      "bar",
-				"juju-app": "app-name",
+				"foo":                          "bar",
+				"app.kubernetes.io/name":       "app-name",
+				"app.kubernetes.io/managed-by": "juju",
 			},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				"controller.juju.is/id":                      "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 			},
 		},
 		Spec: networkingv1.IngressSpec{
@@ -484,12 +486,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-ingress",
 				Labels: map[string]string{
-					"foo":      "bar",
-					"juju-app": "app-name",
+					"foo":                          "bar",
+					"app.kubernetes.io/name":       "app-name",
+					"app.kubernetes.io/managed-by": "juju",
 				},
 				Annotations: map[string]string{
 					"nginx.ingress.kubernetes.io/rewrite-target": "/",
-					"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+					"controller.juju.is/id":                      "deadbeef-1bad-500d-9000-4b1d0d06f00d",
 				},
 			},
 			Spec: networkingv1.IngressSpec{

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -10,8 +10,9 @@ import (
 	apps "k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/juju/juju/caas"
@@ -22,7 +23,7 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8sspecs.K8sIngressSpec, expectedErrString string, assertCalls ...*gomock.Call) {
+func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8sspecs.K8sIngress, expectedErrString string, assertCalls ...*gomock.Call) {
 	basicPodSpec := getBasicPodspec()
 	basicPodSpec.ProviderPod = &k8sspecs.K8sPodSpec{
 		KubernetesResources: &k8sspecs.KubernetesResources{
@@ -35,7 +36,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 
 	numUnits := int32(2)
 	statefulSetArg := &appsv1.StatefulSet{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   "app-name",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"},
 			Annotations: map[string]string{
@@ -46,12 +47,12 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &numUnits,
-			Selector: &v1.LabelSelector{
+			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
 			RevisionHistoryLimit: int32Ptr(0),
 			Template: core.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
 					Annotations: map[string]string{
 						"apparmor.security.beta.kubernetes.io/pod": "runtime/default",
@@ -72,7 +73,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 
 	assertCalls = append(
 		[]*gomock.Call{
-			s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
+			s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", metav1.GetOptions{}).
 				Return(nil, s.k8sNotFoundError()),
 		},
 		assertCalls...,
@@ -82,23 +83,23 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 	if expectedErrString == "" {
 		// no error expected, so continue to check following assertions.
 		assertCalls = append(assertCalls, []*gomock.Call{
-			s.mockSecrets.EXPECT().Create(gomock.Any(), ociImageSecret, v1.CreateOptions{}).
+			s.mockSecrets.EXPECT().Create(gomock.Any(), ociImageSecret, metav1.CreateOptions{}).
 				Return(ociImageSecret, nil),
-			s.mockServices.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
+			s.mockServices.EXPECT().Get(gomock.Any(), "app-name", metav1.GetOptions{}).
 				Return(nil, s.k8sNotFoundError()),
-			s.mockServices.EXPECT().Update(gomock.Any(), &serviceArg, v1.UpdateOptions{}).
+			s.mockServices.EXPECT().Update(gomock.Any(), &serviceArg, metav1.UpdateOptions{}).
 				Return(nil, s.k8sNotFoundError()),
-			s.mockServices.EXPECT().Create(gomock.Any(), &serviceArg, v1.CreateOptions{}).
+			s.mockServices.EXPECT().Create(gomock.Any(), &serviceArg, metav1.CreateOptions{}).
 				Return(nil, nil),
-			s.mockServices.EXPECT().Get(gomock.Any(), "app-name-endpoints", v1.GetOptions{}).
+			s.mockServices.EXPECT().Get(gomock.Any(), "app-name-endpoints", metav1.GetOptions{}).
 				Return(nil, s.k8sNotFoundError()),
-			s.mockServices.EXPECT().Update(gomock.Any(), basicHeadlessServiceArg, v1.UpdateOptions{}).
+			s.mockServices.EXPECT().Update(gomock.Any(), basicHeadlessServiceArg, metav1.UpdateOptions{}).
 				Return(nil, s.k8sNotFoundError()),
-			s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, v1.CreateOptions{}).
+			s.mockServices.EXPECT().Create(gomock.Any(), basicHeadlessServiceArg, metav1.CreateOptions{}).
 				Return(nil, nil),
-			s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
+			s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", metav1.GetOptions{}).
 				Return(statefulSetArg, nil),
-			s.mockStatefulSets.EXPECT().Create(gomock.Any(), statefulSetArg, v1.CreateOptions{}).
+			s.mockStatefulSets.EXPECT().Create(gomock.Any(), statefulSetArg, metav1.CreateOptions{}).
 				Return(nil, nil),
 		}...)
 	}
@@ -126,7 +127,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 	}
 }
 
-func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
+func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreateV1Beta1(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
@@ -145,22 +146,27 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
 			},
 		},
 	}
-	ingress1 := k8sspecs.K8sIngressSpec{
-		Name: "test-ingress",
-		Labels: map[string]string{
-			"foo": "bar",
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
 		},
-		Annotations: map[string]string{
-			"nginx.ingress.kubernetes.io/rewrite-target": "/",
-		},
-		Spec: networkingv1beta1.IngressSpec{
-			Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1Beta1,
+			SpecV1Beta1: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+			},
 		},
 	}
 
-	IngressResources := []k8sspecs.K8sIngressSpec{ingress1}
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
 	ingress := &networkingv1beta1.Ingress{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-ingress",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
@@ -174,11 +180,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreate(c *gc.C) {
 	}
 	s.assertIngressResources(
 		c, IngressResources, "",
-		s.mockIngressV1Beta1.EXPECT().Create(gomock.Any(), ingress, v1.CreateOptions{}).Return(ingress, nil),
+		s.mockIngressV1Beta1.EXPECT().Create(gomock.Any(), ingress, metav1.CreateOptions{}).Return(ingress, nil),
 	)
 }
 
-func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
+func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateV1Beta1(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
@@ -197,22 +203,27 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
 			},
 		},
 	}
-	ingress1 := k8sspecs.K8sIngressSpec{
-		Name: "test-ingress",
-		Labels: map[string]string{
-			"foo": "bar",
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
 		},
-		Annotations: map[string]string{
-			"nginx.ingress.kubernetes.io/rewrite-target": "/",
-		},
-		Spec: networkingv1beta1.IngressSpec{
-			Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1Beta1,
+			SpecV1Beta1: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+			},
 		},
 	}
 
-	IngressResources := []k8sspecs.K8sIngressSpec{ingress1}
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
 	ingress := &networkingv1beta1.Ingress{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-ingress",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 			Annotations: map[string]string{
@@ -226,13 +237,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdate(c *gc.C) {
 	}
 	s.assertIngressResources(
 		c, IngressResources, "",
-		s.mockIngressV1Beta1.EXPECT().Create(gomock.Any(), ingress, v1.CreateOptions{}).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockIngressV1Beta1.EXPECT().Get(gomock.Any(), "test-ingress", v1.GetOptions{}).Return(ingress, nil),
-		s.mockIngressV1Beta1.EXPECT().Update(gomock.Any(), ingress, v1.UpdateOptions{}).Return(ingress, nil),
+		s.mockIngressV1Beta1.EXPECT().Create(gomock.Any(), ingress, metav1.CreateOptions{}).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockIngressV1Beta1.EXPECT().Get(gomock.Any(), "test-ingress", metav1.GetOptions{}).Return(ingress, nil),
+		s.mockIngressV1Beta1.EXPECT().Update(gomock.Any(), ingress, metav1.UpdateOptions{}).Return(ingress, nil),
 	)
 }
 
-func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExistingNonJujuManagedIngress(c *gc.C) {
+func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExistingNonJujuManagedIngressV1Beta1(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
@@ -251,24 +262,30 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 			},
 		},
 	}
-	ingress1 := k8sspecs.K8sIngressSpec{
-		Name: "test-ingress",
-		Labels: map[string]string{
-			"foo": "bar",
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
 		},
-		Annotations: map[string]string{
-			"nginx.ingress.kubernetes.io/rewrite-target": "/",
-		},
-		Spec: networkingv1beta1.IngressSpec{
-			Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1Beta1,
+			SpecV1Beta1: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+			},
 		},
 	}
 
-	IngressResources := []k8sspecs.K8sIngressSpec{ingress1}
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
 
 	getIngress := func() *networkingv1beta1.Ingress {
 		return &networkingv1beta1.Ingress{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:   "test-ingress",
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "foo": "bar"},
 				Annotations: map[string]string{
@@ -285,9 +302,208 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 	existingNonJujuManagedIngress := getIngress()
 	existingNonJujuManagedIngress.SetLabels(map[string]string{})
 	s.assertIngressResources(
-		c, IngressResources, `creating or updating ingress resources: existing ingress "test-ingress" found which does not belong to "app-name"`,
-		s.mockIngressV1Beta1.EXPECT().Create(gomock.Any(), ingress, v1.CreateOptions{}).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockIngressV1Beta1.EXPECT().Get(gomock.Any(), "test-ingress", v1.GetOptions{}).Return(existingNonJujuManagedIngress, nil),
+		c, IngressResources, `creating or updating ingress resources: ensuring ingress "test-ingress" with version "v1beta1": existing ingress "test-ingress" found which does not belong to "app-name"`,
+		s.mockIngressV1Beta1.EXPECT().Create(gomock.Any(), ingress, gomock.Any()).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockIngressV1Beta1.EXPECT().Get(gomock.Any(), "test-ingress", metav1.GetOptions{}).Return(existingNonJujuManagedIngress, nil),
+	)
+}
+
+func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreateV1(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	ingress1Rule1 := networkingv1.IngressRule{
+		IngressRuleValue: networkingv1.IngressRuleValue{
+			HTTP: &networkingv1.HTTPIngressRuleValue{
+				Paths: []networkingv1.HTTPIngressPath{
+					{
+						Path: "/testpath",
+						Backend: networkingv1.IngressBackend{
+							Resource: &core.TypedLocalObjectReference{
+								APIGroup: strPtr("k8s.example.com"),
+								Kind:     "StorageBucket",
+								Name:     "icon-assets",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
+		},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1,
+			SpecV1: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{ingress1Rule1},
+			},
+		},
+	}
+
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo":      "bar",
+				"juju-app": "app-name",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{ingress1Rule1},
+		},
+	}
+	s.assertIngressResources(
+		c, IngressResources, "",
+		s.mockIngressV1.EXPECT().Create(gomock.Any(), ingress, gomock.Any()).Return(ingress, nil),
+	)
+}
+
+func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateV1(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	ingress1Rule1 := networkingv1.IngressRule{
+		IngressRuleValue: networkingv1.IngressRuleValue{
+			HTTP: &networkingv1.HTTPIngressRuleValue{
+				Paths: []networkingv1.HTTPIngressPath{
+					{
+						Path: "/testpath",
+						Backend: networkingv1.IngressBackend{
+							Resource: &core.TypedLocalObjectReference{
+								APIGroup: strPtr("k8s.example.com"),
+								Kind:     "StorageBucket",
+								Name:     "icon-assets",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
+		},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1,
+			SpecV1: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{ingress1Rule1},
+			},
+		},
+	}
+
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo":      "bar",
+				"juju-app": "app-name",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{ingress1Rule1},
+		},
+	}
+	s.assertIngressResources(
+		c, IngressResources, "",
+		s.mockIngressV1.EXPECT().Create(gomock.Any(), ingress, gomock.Any()).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockIngressV1.EXPECT().Get(gomock.Any(), "test-ingress", metav1.GetOptions{}).Return(ingress, nil),
+		s.mockIngressV1.EXPECT().Update(gomock.Any(), ingress, gomock.Any()).Return(ingress, nil),
+	)
+}
+
+func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExistingNonJujuManagedIngressV1(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	ingress1Rule1 := networkingv1.IngressRule{
+		IngressRuleValue: networkingv1.IngressRuleValue{
+			HTTP: &networkingv1.HTTPIngressRuleValue{
+				Paths: []networkingv1.HTTPIngressPath{
+					{
+						Path: "/testpath",
+						Backend: networkingv1.IngressBackend{
+							Resource: &core.TypedLocalObjectReference{
+								APIGroup: strPtr("k8s.example.com"),
+								Kind:     "StorageBucket",
+								Name:     "icon-assets",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
+		},
+
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1,
+			SpecV1: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{ingress1Rule1},
+			},
+		},
+	}
+
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
+
+	getIngress := func() *networkingv1.Ingress {
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ingress",
+				Labels: map[string]string{
+					"foo":      "bar",
+					"juju-app": "app-name",
+				},
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/rewrite-target": "/",
+					"juju.io/controller":                         "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{ingress1Rule1},
+			},
+		}
+	}
+	ingress := getIngress()
+	existingNonJujuManagedIngress := getIngress()
+	existingNonJujuManagedIngress.SetLabels(map[string]string{})
+	s.assertIngressResources(
+		c, IngressResources, `creating or updating ingress resources: ensuring ingress "test-ingress" with version "v1": existing ingress "test-ingress" found which does not belong to "app-name"`,
+		s.mockIngressV1.EXPECT().Create(gomock.Any(), ingress, gomock.Any()).Return(nil, s.k8sAlreadyExistsError()),
+		s.mockIngressV1.EXPECT().Get(gomock.Any(), "test-ingress", metav1.GetOptions{}).Return(existingNonJujuManagedIngress, nil),
 	)
 }
 
@@ -310,20 +526,25 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithIngr
 			},
 		},
 	}
-	ingress1 := k8sspecs.K8sIngressSpec{
-		Name: "app-name",
-		Labels: map[string]string{
-			"foo": "bar",
+	ingress1 := k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "app-name",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
 		},
-		Annotations: map[string]string{
-			"nginx.ingress.kubernetes.io/rewrite-target": "/",
-		},
-		Spec: networkingv1beta1.IngressSpec{
-			Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1Beta1,
+			SpecV1Beta1: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+			},
 		},
 	}
 
-	IngressResources := []k8sspecs.K8sIngressSpec{ingress1}
+	IngressResources := []k8sspecs.K8sIngress{ingress1}
 	s.assertIngressResources(
 		c, IngressResources, `creating or updating ingress resources: ingress name "app-name" is reserved for juju expose not valid`,
 	)

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1920,7 +1920,7 @@ func (k *kubernetesClient) ExposeService(appName string, resourceTags map[string
 
 	// TODO(caas): refactor juju expose to solve potential conflict with ingress definition in podspec.
 	// https://bugs.launchpad.net/juju/+bug/1854123
-	_, err = k.ensureIngress(appName, spec, true)
+	_, err = k.ensureIngressV1beta1(appName, spec, true)
 	return errors.Trace(err)
 }
 
@@ -2317,7 +2317,7 @@ type workloadSpec struct {
 	CustomResources                 map[string][]unstructured.Unstructured
 	MutatingWebhookConfigurations   []k8sspecs.K8sMutatingWebhook
 	ValidatingWebhookConfigurations []k8sspecs.K8sValidatingWebhook
-	IngressResources                []k8sspecs.K8sIngressSpec
+	IngressResources                []k8sspecs.K8sIngress
 }
 
 func processContainers(deploymentName string, podSpec *specs.PodSpec, spec *core.PodSpec) error {

--- a/caas/kubernetes/provider/specs/customresourcedefinition.go
+++ b/caas/kubernetes/provider/specs/customresourcedefinition.go
@@ -91,9 +91,5 @@ func (crd K8sCustomResourceDefinition) Validate() error {
 	if err := crd.Spec.Validate(crd.Name); err != nil {
 		return errors.Trace(err)
 	}
-
-	if err := validateLabels(crd.Labels); err != nil {
-		return errors.Trace(err)
-	}
 	return nil
 }

--- a/caas/kubernetes/provider/specs/ingress.go
+++ b/caas/kubernetes/provider/specs/ingress.go
@@ -29,7 +29,6 @@ type K8sIngressSpec struct {
 // UnmarshalJSON implements the json.Unmarshaller interface.
 func (ing *K8sIngressSpec) UnmarshalJSON(value []byte) (err error) {
 	err = unmarshalJSONStrict(value, &ing.SpecV1)
-	logger.Criticalf("K8sIngressSpec.UnmarshalJSON err %#v", err)
 	if err == nil {
 		ing.Version = K8sIngressV1
 		return nil

--- a/caas/kubernetes/provider/specs/ingress.go
+++ b/caas/kubernetes/provider/specs/ingress.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs
+
+import (
+	"encoding/json"
+
+	"github.com/juju/errors"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+)
+
+const (
+	// K8sIngressV1Beta1 defines the v1beta1 API version for ingress.
+	K8sIngressV1Beta1 APIVersion = "v1beta1"
+
+	// K8sIngressV1 defines the v1 API version for ingress.
+	K8sIngressV1 APIVersion = "v1"
+)
+
+// K8sIngressSpec defines the spec details of the Ingress with the API version.
+type K8sIngressSpec struct {
+	Version     APIVersion
+	SpecV1Beta1 networkingv1beta1.IngressSpec
+	SpecV1      networkingv1.IngressSpec
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (ing *K8sIngressSpec) UnmarshalJSON(value []byte) (err error) {
+	err = unmarshalJSONStrict(value, &ing.SpecV1)
+	logger.Criticalf("K8sIngressSpec.UnmarshalJSON err %#v", err)
+	if err == nil {
+		ing.Version = K8sIngressV1
+		return nil
+	}
+	if err2 := unmarshalJSONStrict(value, &ing.SpecV1Beta1); err2 == nil {
+		ing.Version = K8sIngressV1Beta1
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (ing K8sIngressSpec) MarshalJSON() ([]byte, error) {
+	switch ing.Version {
+	case K8sIngressV1Beta1:
+		return json.Marshal(ing.SpecV1Beta1)
+	case K8sIngressV1:
+		return json.Marshal(ing.SpecV1)
+	default:
+		return []byte{}, errors.NotSupportedf("ingress version %q", ing.Version)
+	}
+}
+
+// K8sIngress defines spec for creating or updating an ingress resource.
+type K8sIngress struct {
+	Meta `json:",inline" yaml:",inline"`
+	Spec K8sIngressSpec `json:"spec" yaml:"spec"`
+}
+
+// Validate returns an error if the spec is not valid.
+func (ing K8sIngress) Validate() error {
+	if err := ing.Meta.Validate(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/caas/kubernetes/provider/specs/ingress_test.go
+++ b/caas/kubernetes/provider/specs/ingress_test.go
@@ -1,0 +1,143 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package specs_test
+
+import (
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
+	"github.com/juju/juju/testing"
+)
+
+type ingressSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ingressSuite{})
+
+func (s *crdSuite) TestK8sIngressV1Beta1(c *gc.C) {
+	specV1Beta1 := `
+name: test-ingress
+labels:
+  foo: bar
+annotations:
+  nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /testpath
+            backend:
+              serviceName: test
+              servicePort: 80
+`
+	var obj k8sspecs.K8sIngress
+	err := k8sspecs.NewStrictYAMLOrJSONDecoder(strings.NewReader(specV1Beta1), len(specV1Beta1)).Decode(&obj)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obj, gc.DeepEquals, k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "test-ingress",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			},
+		},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1Beta1,
+			SpecV1Beta1: networkingv1beta1.IngressSpec{
+				Rules: []networkingv1beta1.IngressRule{
+					networkingv1beta1.IngressRule{
+						IngressRuleValue: networkingv1beta1.IngressRuleValue{
+							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+								Paths: []networkingv1beta1.HTTPIngressPath{
+									{
+										Path: "/testpath",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "test",
+											ServicePort: intstr.IntOrString{IntVal: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *crdSuite) TestK8sIngressV1(c *gc.C) {
+	specV1Beta1 := `
+name: ingress-resource-backend
+spec:
+  defaultBackend:
+    resource:
+      apiGroup: k8s.example.com
+      kind: StorageBucket
+      name: static-assets
+  rules:
+    - http:
+        paths:
+          - path: /icons
+            pathType: ImplementationSpecific
+            backend:
+              resource:
+                apiGroup: k8s.example.com
+                kind: StorageBucket
+                name: icon-assets
+`
+	var obj k8sspecs.K8sIngress
+	err := k8sspecs.NewStrictYAMLOrJSONDecoder(strings.NewReader(specV1Beta1), len(specV1Beta1)).Decode(&obj)
+	c.Assert(err, jc.ErrorIsNil)
+
+	pathType := networkingv1.PathTypeImplementationSpecific
+	c.Assert(obj, gc.DeepEquals, k8sspecs.K8sIngress{
+		Meta: k8sspecs.Meta{
+			Name: "ingress-resource-backend",
+		},
+		Spec: k8sspecs.K8sIngressSpec{
+			Version: k8sspecs.K8sIngressV1,
+			SpecV1: networkingv1.IngressSpec{
+				DefaultBackend: &networkingv1.IngressBackend{
+					Resource: &core.TypedLocalObjectReference{
+						APIGroup: strPtr("k8s.example.com"),
+						Kind:     "StorageBucket",
+						Name:     "static-assets",
+					},
+				},
+				Rules: []networkingv1.IngressRule{
+					networkingv1.IngressRule{
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/icons",
+										PathType: &pathType,
+										Backend: networkingv1.IngressBackend{
+											Resource: &core.TypedLocalObjectReference{
+												APIGroup: strPtr("k8s.example.com"),
+												Kind:     "StorageBucket",
+												Name:     "icon-assets",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/caas/kubernetes/provider/specs/ingress_test.go
+++ b/caas/kubernetes/provider/specs/ingress_test.go
@@ -23,7 +23,7 @@ type ingressSuite struct {
 
 var _ = gc.Suite(&ingressSuite{})
 
-func (s *crdSuite) TestK8sIngressV1Beta1(c *gc.C) {
+func (s *ingressSuite) TestK8sIngressV1Beta1(c *gc.C) {
 	specV1Beta1 := `
 name: test-ingress
 labels:
@@ -56,7 +56,7 @@ spec:
 			Version: k8sspecs.K8sIngressV1Beta1,
 			SpecV1Beta1: networkingv1beta1.IngressSpec{
 				Rules: []networkingv1beta1.IngressRule{
-					networkingv1beta1.IngressRule{
+					{
 						IngressRuleValue: networkingv1beta1.IngressRuleValue{
 							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
 								Paths: []networkingv1beta1.HTTPIngressPath{
@@ -77,7 +77,7 @@ spec:
 	})
 }
 
-func (s *crdSuite) TestK8sIngressV1(c *gc.C) {
+func (s *ingressSuite) TestK8sIngressV1(c *gc.C) {
 	specV1Beta1 := `
 name: ingress-resource-backend
 spec:
@@ -117,7 +117,7 @@ spec:
 					},
 				},
 				Rules: []networkingv1.IngressRule{
-					networkingv1.IngressRule{
+					{
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/errors"
 	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -181,25 +180,6 @@ func (ksa K8sServiceAccountSpecV2) Validate() error {
 	return errors.Trace(ksa.ServiceAccountSpecV2.Validate())
 }
 
-// K8sIngressSpec defines spec for creating or updating an ingress resource.
-type K8sIngressSpec struct {
-	Name        string                        `json:"name" yaml:"name"`
-	Labels      map[string]string             `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string             `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Spec        networkingv1beta1.IngressSpec `json:"spec" yaml:"spec"`
-}
-
-// Validate returns an error if the spec is not valid.
-func (ing K8sIngressSpec) Validate() error {
-	if ing.Name == "" {
-		return errors.New("ingress name is missing")
-	}
-	if err := validateLabels(ing.Labels); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
 // KubernetesResourcesV2 is the k8s related resources for version 2.
 type KubernetesResourcesV2 struct {
 	Pod *PodSpec `json:"pod,omitempty" yaml:"pod,omitempty"`
@@ -212,7 +192,7 @@ type KubernetesResourcesV2 struct {
 	ValidatingWebhookConfigurations map[string][]admissionregistration.ValidatingWebhook `json:"validatingWebhookConfigurations,omitempty" yaml:"validatingWebhookConfigurations,omitempty"`
 
 	ServiceAccounts  []K8sServiceAccountSpecV2 `json:"serviceAccounts,omitempty" yaml:"serviceAccounts,omitempty"`
-	IngressResources []K8sIngressSpec          `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
+	IngressResources []K8sIngress          `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
 }
 
 func validateCustomResourceDefinitionV2(name string, crd apiextensionsv1beta1.CustomResourceDefinitionSpec) error {

--- a/caas/kubernetes/provider/specs/v2.go
+++ b/caas/kubernetes/provider/specs/v2.go
@@ -192,7 +192,7 @@ type KubernetesResourcesV2 struct {
 	ValidatingWebhookConfigurations map[string][]admissionregistration.ValidatingWebhook `json:"validatingWebhookConfigurations,omitempty" yaml:"validatingWebhookConfigurations,omitempty"`
 
 	ServiceAccounts  []K8sServiceAccountSpecV2 `json:"serviceAccounts,omitempty" yaml:"serviceAccounts,omitempty"`
-	IngressResources []K8sIngress          `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
+	IngressResources []K8sIngress              `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
 }
 
 func validateCustomResourceDefinitionV2(name string, crd apiextensionsv1beta1.CustomResourceDefinitionSpec) error {

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -541,16 +541,21 @@ echo "do some stuff here for gitlab-init container"
 				},
 			},
 		}
-		ingress1 := k8sspecs.K8sIngressSpec{
-			Name: "test-ingress",
-			Labels: map[string]string{
-				"foo": "bar",
+		ingress1 := k8sspecs.K8sIngress{
+			Meta: k8sspecs.Meta{
+				Name: "test-ingress",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				},
 			},
-			Annotations: map[string]string{
-				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+			Spec: k8sspecs.K8sIngressSpec{
+				Version: k8sspecs.K8sIngressV1Beta1,
+				SpecV1Beta1: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+				},
 			},
 		}
 
@@ -776,7 +781,7 @@ password: shhhh`[1:],
 						},
 					},
 				},
-				IngressResources: []k8sspecs.K8sIngressSpec{ingress1},
+				IngressResources: []k8sspecs.K8sIngress{ingress1},
 				MutatingWebhookConfigurations: []k8sspecs.K8sMutatingWebhook{
 					{
 						Meta: k8sspecs.Meta{Name: "example-mutatingwebhookconfiguration"},
@@ -996,7 +1001,7 @@ kubernetesResources:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `ingress name is missing`)
+	c.Assert(err, gc.ErrorMatches, `name is missing`)
 
 	specStr = version3Header + `
 containers:

--- a/caas/kubernetes/provider/specs/v3.go
+++ b/caas/kubernetes/provider/specs/v3.go
@@ -218,6 +218,9 @@ func (m Meta) Validate() error {
 	if len(m.Name) == 0 {
 		return errors.New("name is missing")
 	}
+	if err := validateLabels(m.Labels); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 
@@ -228,6 +231,7 @@ type K8sService struct {
 	Spec core.ServiceSpec `json:"spec" yaml:"spec"`
 }
 
+// Validate validates the spec.
 func (s K8sService) Validate() error {
 	if err := s.Meta.Validate(); err != nil {
 		return errors.Trace(err)
@@ -249,7 +253,7 @@ type KubernetesResources struct {
 
 	K8sRBACResources `json:",inline" yaml:",inline"`
 
-	IngressResources []K8sIngressSpec `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
+	IngressResources []K8sIngress `json:"ingressResources,omitempty" yaml:"ingressResources,omitempty"`
 }
 
 // Validate is defined on ProviderPod.

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -744,7 +744,7 @@ echo "do some stuff here for gitlab-init container"
 				Version: k8sspecs.K8sIngressV1Beta1,
 				SpecV1Beta1: networkingv1beta1.IngressSpec{
 					Rules: []networkingv1beta1.IngressRule{
-						networkingv1beta1.IngressRule{
+						{
 							IngressRuleValue: networkingv1beta1.IngressRuleValue{
 								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
 									Paths: []networkingv1beta1.HTTPIngressPath{
@@ -779,7 +779,7 @@ echo "do some stuff here for gitlab-init container"
 						},
 					},
 					Rules: []networkingv1.IngressRule{
-						networkingv1.IngressRule{
+						{
 							IngressRuleValue: networkingv1.IngressRuleValue{
 								HTTP: &networkingv1.HTTPIngressRuleValue{
 									Paths: []networkingv1.HTTPIngressPath{

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	core "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -389,6 +390,23 @@ kubernetesResources:
                   backend:
                     serviceName: test
                     servicePort: 80
+    - name: ingress-resource-backend
+      spec:
+        defaultBackend:
+          resource:
+            apiGroup: k8s.example.com
+            kind: StorageBucket
+            name: static-assets
+        rules:
+          - http:
+              paths:
+                - path: /icons
+                  pathType: ImplementationSpecific
+                  backend:
+                    resource:
+                      apiGroup: k8s.example.com
+                      kind: StorageBucket
+                      name: icon-assets
   mutatingWebhookConfigurations:
     - name: example-mutatingwebhookconfiguration
       labels:
@@ -712,31 +730,76 @@ echo "do some stuff here for gitlab-init container"
 			},
 		}
 
-		ingress1Rule1 := networkingv1beta1.IngressRule{
-			IngressRuleValue: networkingv1beta1.IngressRuleValue{
-				HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-					Paths: []networkingv1beta1.HTTPIngressPath{
-						{
-							Path: "/testpath",
-							Backend: networkingv1beta1.IngressBackend{
-								ServiceName: "test",
-								ServicePort: intstr.IntOrString{IntVal: 80},
+		ingressv1beta1 := k8sspecs.K8sIngress{
+			Meta: k8sspecs.Meta{
+				Name: "test-ingress",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				},
+			},
+			Spec: k8sspecs.K8sIngressSpec{
+				Version: k8sspecs.K8sIngressV1Beta1,
+				SpecV1Beta1: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
+						networkingv1beta1.IngressRule{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
+										{
+											Path: "/testpath",
+											Backend: networkingv1beta1.IngressBackend{
+												ServiceName: "test",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+									},
+								},
 							},
 						},
 					},
 				},
 			},
 		}
-		ingress1 := k8sspecs.K8sIngressSpec{
-			Name: "test-ingress",
-			Labels: map[string]string{
-				"foo": "bar",
+		pathType1 := networkingv1.PathTypeImplementationSpecific
+		ingressv1 := k8sspecs.K8sIngress{
+			Meta: k8sspecs.Meta{
+				Name: "ingress-resource-backend",
 			},
-			Annotations: map[string]string{
-				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-			},
-			Spec: networkingv1beta1.IngressSpec{
-				Rules: []networkingv1beta1.IngressRule{ingress1Rule1},
+			Spec: k8sspecs.K8sIngressSpec{
+				Version: k8sspecs.K8sIngressV1,
+				SpecV1: networkingv1.IngressSpec{
+					DefaultBackend: &networkingv1.IngressBackend{
+						Resource: &core.TypedLocalObjectReference{
+							APIGroup: strPtr("k8s.example.com"),
+							Kind:     "StorageBucket",
+							Name:     "static-assets",
+						},
+					},
+					Rules: []networkingv1.IngressRule{
+						networkingv1.IngressRule{
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											Path:     "/icons",
+											PathType: &pathType1,
+											Backend: networkingv1.IngressBackend{
+												Resource: &core.TypedLocalObjectReference{
+													APIGroup: strPtr("k8s.example.com"),
+													Kind:     "StorageBucket",
+													Name:     "icon-assets",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		}
 
@@ -1064,7 +1127,9 @@ password: shhhh`[1:],
 						},
 					},
 				},
-				IngressResources: []k8sspecs.K8sIngressSpec{ingress1},
+				IngressResources: []k8sspecs.K8sIngress{
+					ingressv1beta1, ingressv1,
+				},
 				MutatingWebhookConfigurations: []k8sspecs.K8sMutatingWebhook{
 					{
 						Meta: k8sspecs.Meta{
@@ -1370,7 +1435,7 @@ kubernetesResources:
 `[1:]
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
-	c.Assert(err, gc.ErrorMatches, `ingress name is missing`)
+	c.Assert(err, gc.ErrorMatches, `name is missing`)
 
 	specStr = version3Header + `
 containers:


### PR DESCRIPTION
Changes made:

- Add ingress v1 and v1beta1 support for podspec v3;



## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq .kubernetesResources.ingressResources
[
  {
    "annotations": {
      "kubernetes.io/ingress.class": "nginx",
      "kubernetes.io/ingress.allow-http": "true",
      "ingress.kubernetes.io/rewrite-target": ""
    },
    "labels": {
      "foo": "bar"
    },
    "spec": {
      "rules": [
        {
          "http": {
            "paths": [
              {
                "path": "/test1",
                "backend": {
                  "serviceName": "test",
                  "servicePort": 80
                }
              }
            ]
          }
        }
      ]
    },
    "name": "test-ingress"  # v1beta1
  },
  {
    "name": "ingress-resource-backend",  # v1
    "spec": {
      "rules": [
        {
          "http": {
            "paths": [
              {
                "path": "/icons",
                "pathType": "ImplementationSpecific",
                "backend": {
                  "resource": {
                    "apiGroup": "k8s.example.com",
                    "kind": "StorageBucket",
                    "name": "icon-assets"
                  }
                }
              }
            ]
          }
        }
      ],
      "defaultBackend": {
        "resource": {
          "apiGroup": "k8s.example.com",
          "kind": "StorageBucket",
          "name": "static-assets"
        }
      }
    }
  },
  {
    "annotations": {
      "kubernetes.io/ingress.class": "nginx",
      "kubernetes.io/ingress.allow-http": "true",
      "ingress.kubernetes.io/rewrite-target": ""
    },
    "labels": {
      "foo": "bar"
    },
    "spec": {
      "rules": [
        {
          "host": "blog.launchpad.net",
          "http": {
            "paths": [
              {
                "path": "/",
                "backend": {
                  "serviceName": "wordpress-k8s",
                  "servicePort": 80
                }
              }
            ]
          }
        }
      ],
      "tls": [
        {
          "hosts": [
            "blog.launchpad.net"
          ],
          "secretName": "blog-launchpad-net-tls"
        }
      ]
    },
    "name": "wordpress-k8s"  # v1beta1
  }
]

$ mkubectl get ingress -n t1 -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
{
  "apiVersion": "networking.k8s.io/v1",
  "name": "test-ingress"
}
{
  "apiVersion": "networking.k8s.io/v1",
  "name": "wordpress-k8s"
}
{
  "apiVersion": "networking.k8s.io/v1",
  "name": "ingress-resource-backend"
}

```

```log
controller-0: 16:47:02 INFO juju.kubernetes.provider ensuring ingress "test-ingress" with version "v1beta1"
controller-0: 16:47:02 INFO juju.kubernetes.provider ensuring ingress "ingress-resource-backend" with version "v1"
controller-0: 16:47:02 INFO juju.kubernetes.provider ensuring ingress "wordpress-k8s" with version "v1beta1"
```

## Documentation changes

No

## Bug reference

No