### PR TITLE
[2.9] Fix panic when serializing Proxier to YAML

### DIFF
--- a/caas/kubernetes/provider/connection.go
+++ b/caas/kubernetes/provider/connection.go
@@ -4,16 +4,27 @@
 package provider
 
 import (
+	"github.com/juju/errors"
+
 	k8sproxy "github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/proxy"
 )
 
 func (k *kubernetesClient) ConnectionProxyInfo() (proxy.Proxier, error) {
-	return k8sproxy.GetControllerProxy(
+	p, err := k8sproxy.GetControllerProxy(
 		getBootstrapResourceName(JujuControllerStackName, proxyResourceName),
 		k.k8sCfgUnlocked.Host,
 		k.client().CoreV1().ConfigMaps(k.GetCurrentNamespace()),
 		k.client().CoreV1().ServiceAccounts(k.GetCurrentNamespace()),
 		k.client().CoreV1().Secrets(k.GetCurrentNamespace()),
 	)
+
+	// If an error occurred return a nil to avoid converting the nil
+	// *Proxier into a typed nil which allows MarshalYAML to be called
+	// against a nil value which effectively causes a nil pointer
+	// dereference.
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return p, nil
 }


### PR DESCRIPTION
The original implementation of ConnectionProxyInfo() for k8s invoked
k8sproxy.GetControllerProxy which returns (*k8sproxy.Proxy, error) and
returned the result back to the caller after coercing the first value
into a proxy.Proxy interface.

As a result, if k8sproxy.GetControllerProxy returns an error, the nil
k8sproxy.GetControllerProxy value gets converted into a typed nil. Given
the way that k8sproxy.GetControllerProxy is implemented, you can
actually invoke MarshalYAML on a (*k8sproxy.Proxy)(nil) and trigger a
panic (null pointer dereference) when the marshal logic attempts to call
yaml.Marshal(&p.config).

## QA steps

```sh
Run assess_caas_deploy_charms.py on gke
```

## Bug reference
Caught by CI: https://jenkins.juju.canonical.com/job/nw-deploy-bionic-gke/1501/console