### PR TITLE
Slight change to k8s bootstrap wording in log

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -963,7 +963,7 @@ See `[1:] + "`juju kill-controller`" + `.`)
 
 	if cloud.Type == k8sconstants.CAASProviderType {
 		if cloud.HostCloudRegion == caas.K8sCloudOther {
-			ctx.Infof("Unable to identify bootstrapped Kubernetes cluster")
+			ctx.Infof("Bootstrap to generic Kubernetes cluster")
 		} else {
 			ctx.Infof("Bootstrap to Kubernetes cluster identified as %s",
 				cloud.HostCloudRegion)


### PR DESCRIPTION
Based on feedback we are changing the generic case of bootstrap messages.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap Juju to a minikube cluster
