### PR TITLE
Add an extra permission to role for the charm operator

### DIFF
--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -84,10 +84,11 @@ func (k *kubernetesClient) ensureOperatorRBACResources(operatorName string, labe
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
+				Resources: []string{"pods", "services"},
 				Verbs: []string{
 					"get",
 					"list",
+					"patch",
 				},
 			},
 			{

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -297,8 +297,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfig(c *gc.C) {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "patch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -406,8 +406,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorCreate(c *gc.C) {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "patch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -521,8 +521,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorUpdate(c *gc.C) {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "patch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -660,8 +660,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoStorageExistingPVC(c *gc.C) {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "patch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -792,8 +792,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoStorage(c *gc.C) {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "patch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -896,8 +896,8 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfigMissingConfigMap(c *gc.C
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "patch"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
The postgresql charm needs to list services and patch pods.
These permissions need to be added to the role used for the charm operator service account.

## QA steps

Deploy a k8s charm
$ kubectl get -o yaml roles/app-operator

See that the role rules are:

```
rules:
- apiGroups:
  - ""
  resources:
  - pods
  - services
  verbs:
  - get
  - list
  - patch
- apiGroups:
  - ""
  resources:
  - pods/exec
  verbs:
  - create
```

## Bug reference

https://bugs.launchpad.net/charm-k8s-postgresql/+bug/1908288