### PR TITLE
Default source of LXD root disk to the default storage pool

### DIFF
--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -237,10 +237,7 @@ func (m *containerManager) getContainerSpec(
 		Profiles: instanceConfig.Profiles,
 		Devices:  nics,
 	}
-	err = spec.ApplyConstraints(m.server.serverVersion, cons)
-	if err != nil {
-		return ContainerSpec{}, errors.Trace(err)
-	}
+	spec.ApplyConstraints(m.server.serverVersion, cons)
 
 	return spec, nil
 }

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -180,10 +180,7 @@ func (env *environ) getContainerSpec(
 		Image:    image,
 		Config:   make(map[string]string),
 	}
-	err = cSpec.ApplyConstraints(serverVersion, args.Constraints)
-	if err != nil {
-		return cSpec, errors.Trace(err)
-	}
+	cSpec.ApplyConstraints(serverVersion, args.Constraints)
 
 	cloudCfg, err := cloudinit.New(args.InstanceConfig.Series)
 	if err != nil {


### PR DESCRIPTION
#12383 introduced an error return to the LXD `ContainerSpec.ApplyConstraints` method, which was populated when attempting to apply a root disk constraint without a root disk source constraint being present.

This turns out to break some bundles, notably charmed-kubernetes.

This patch removes the error return, restoring the old signature, and instead ops to use the default storage pool when a root disk constraint is supplied without a source.

## QA steps

Bootstrap to LXD and deploy charmed-kubernets.

## Documentation changes

None.

## Bug reference

N/A