### PR TITLE
[Charmhub] - Rename charmhub model config value.

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -143,7 +143,7 @@ LXC_BRIDGE="ignored"`[1:])
 
 	modelAttrs := testing.FakeConfig().Merge(testing.Attrs{
 		"agent-version":  jujuversion.Current.String(),
-		"charmhub-url":  charmhub.CharmHubServerURL,
+		"charmhub-url":   charmhub.CharmHubServerURL,
 		"not-for-hosted": "foo",
 	})
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
@@ -422,7 +422,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	})
 	modelAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
 		"agent-version": jujuversion.Current.String(),
-		"charmhub-url": charmhub.CharmHubServerURL,
+		"charmhub-url":  charmhub.CharmHubServerURL,
 	})
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -143,7 +143,7 @@ LXC_BRIDGE="ignored"`[1:])
 
 	modelAttrs := testing.FakeConfig().Merge(testing.Attrs{
 		"agent-version":  jujuversion.Current.String(),
-		"charm-hub-url":  charmhub.CharmHubServerURL,
+		"charmhub-url":  charmhub.CharmHubServerURL,
 		"not-for-hosted": "foo",
 	})
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
@@ -422,7 +422,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	})
 	modelAttrs := dummy.SampleConfig().Delete("admin-secret").Merge(testing.Attrs{
 		"agent-version": jujuversion.Current.String(),
-		"charm-hub-url": charmhub.CharmHubServerURL,
+		"charmhub-url": charmhub.CharmHubServerURL,
 	})
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -76,7 +76,7 @@ func (s *charmHubAPISuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *charmHubAPISuite) expectModelConfig(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
-		"charm-hub-url": "https://someurl.com",
+		"charmhub-url": "https://someurl.com",
 		"type":          "my-type",
 		"name":          "my-name",
 		"uuid":          testing.ModelTag.Id(),

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -77,9 +77,9 @@ func (s *charmHubAPISuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *charmHubAPISuite) expectModelConfig(c *gc.C) {
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"charmhub-url": "https://someurl.com",
-		"type":          "my-type",
-		"name":          "my-name",
-		"uuid":          testing.ModelTag.Id(),
+		"type":         "my-type",
+		"name":         "my-name",
+		"uuid":         testing.ModelTag.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.EXPECT().ModelConfig().Return(cfg, nil)

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -148,7 +148,7 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 	checkAgentVersion := c.checkAgentVersion()
 
 	// Make sure we don't allow changing of the charmhub-url.
-	checkCharmHubURL := c.checkCharmHubURL()
+	checkCharmhubURL := c.checkCharmhubURL()
 
 	// Only controller admins can set trace level debugging on a model.
 	checkLogTrace := c.checkLogTrace()
@@ -158,7 +158,7 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 
 	// Replace any deprecated attributes with their new values.
 	attrs := config.ProcessDeprecatedAttributes(args.Config)
-	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion, checkLogTrace, checkDefaultSpace, checkCharmHubURL)
+	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion, checkLogTrace, checkDefaultSpace, checkCharmhubURL)
 }
 
 func (c *ModelConfigAPI) checkLogTrace() state.ValidateConfigFunc {
@@ -223,7 +223,7 @@ func (c *ModelConfigAPI) checkDefaultSpace() state.ValidateConfigFunc {
 	}
 }
 
-func (c *ModelConfigAPI) checkCharmHubURL() state.ValidateConfigFunc {
+func (c *ModelConfigAPI) checkCharmhubURL() state.ValidateConfigFunc {
 	return func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
 		if v, found := updateAttrs["charmhub-url"]; found {
 			oldURL, _ := oldConfig.CharmHubURL()

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -147,7 +147,7 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 	// Make sure we don't allow changing agent-version.
 	checkAgentVersion := c.checkAgentVersion()
 
-	// Make sure we don't allow changing of the charm-hub-url.
+	// Make sure we don't allow changing of the charmhub-url.
 	checkCharmHubURL := c.checkCharmHubURL()
 
 	// Only controller admins can set trace level debugging on a model.
@@ -225,10 +225,10 @@ func (c *ModelConfigAPI) checkDefaultSpace() state.ValidateConfigFunc {
 
 func (c *ModelConfigAPI) checkCharmHubURL() state.ValidateConfigFunc {
 	return func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
-		if v, found := updateAttrs["charm-hub-url"]; found {
+		if v, found := updateAttrs["charmhub-url"]; found {
 			oldURL, _ := oldConfig.CharmHubURL()
 			if v != oldURL {
-				return errors.New("charm-hub-url cannot be changed")
+				return errors.New("charmhub-url cannot be changed")
 			}
 		}
 		return nil

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -41,7 +41,7 @@ func (s *modelconfigSuite) SetUpTest(c *gc.C) {
 			"agent-version":   {"1.2.3.4", "model"},
 			"ftp-proxy":       {"http://proxy", "model"},
 			"authorized-keys": {testing.FakeAuthKeys, "model"},
-			"charm-hub-url":   {"http://meshuggah.rocks", "model"},
+			"charmhub-url":   {"http://meshuggah.rocks", "model"},
 		},
 	}
 	var err error
@@ -56,7 +56,7 @@ func (s *modelconfigSuite) TestModelGet(c *gc.C) {
 		"type":          {"dummy", "model"},
 		"ftp-proxy":     {"http://proxy", "model"},
 		"agent-version": {Value: "1.2.3.4", Source: "model"},
-		"charm-hub-url": {"http://meshuggah.rocks", "model"},
+		"charmhub-url": {"http://meshuggah.rocks", "model"},
 	})
 }
 
@@ -130,21 +130,21 @@ func (s *modelconfigSuite) TestModelSetCannotChangeAgentVersion(c *gc.C) {
 
 func (s *modelconfigSuite) TestModelSetCannotChangeCharmHubURL(c *gc.C) {
 	old, err := config.New(config.UseDefaults, dummy.SampleConfig().Merge(testing.Attrs{
-		"charm-hub-url": "http://meshuggah.rocks",
+		"charmhub-url": "http://meshuggah.rocks",
 	}))
 	c.Assert(err, jc.ErrorIsNil)
 	s.backend.old = old
 	args := params.ModelSet{
-		map[string]interface{}{"charm-hub-url": "http://another-url.com"},
+		map[string]interface{}{"charmhub-url": "http://another-url.com"},
 	}
 	err = s.api.ModelSet(args)
-	c.Assert(err, gc.ErrorMatches, "charm-hub-url cannot be changed")
+	c.Assert(err, gc.ErrorMatches, "charmhub-url cannot be changed")
 
-	// It's okay to pass config back with the same charm-hub-url.
+	// It's okay to pass config back with the same charmhub-url.
 	result, err := s.api.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Config["charm-hub-url"], gc.NotNil)
-	args.Config["charm-hub-url"] = result.Config["charm-hub-url"].Value
+	c.Assert(result.Config["charmhub-url"], gc.NotNil)
+	args.Config["charmhub-url"] = result.Config["charmhub-url"].Value
 	err = s.api.ModelSet(args)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -41,7 +41,7 @@ func (s *modelconfigSuite) SetUpTest(c *gc.C) {
 			"agent-version":   {"1.2.3.4", "model"},
 			"ftp-proxy":       {"http://proxy", "model"},
 			"authorized-keys": {testing.FakeAuthKeys, "model"},
-			"charmhub-url":   {"http://meshuggah.rocks", "model"},
+			"charmhub-url":    {"http://meshuggah.rocks", "model"},
 		},
 	}
 	var err error
@@ -56,7 +56,7 @@ func (s *modelconfigSuite) TestModelGet(c *gc.C) {
 		"type":          {"dummy", "model"},
 		"ftp-proxy":     {"http://proxy", "model"},
 		"agent-version": {Value: "1.2.3.4", Source: "model"},
-		"charmhub-url": {"http://meshuggah.rocks", "model"},
+		"charmhub-url":  {"http://meshuggah.rocks", "model"},
 	})
 }
 

--- a/apiserver/facades/controller/charmrevisionupdater/interface_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface_test.go
@@ -66,9 +66,9 @@ func makeModel(c *gc.C, ctrl *gomock.Controller) charmrevisionupdater.Model {
 	uuid := testing.ModelTag.Id()
 	cfg, err := config.New(true, map[string]interface{}{
 		"charmhub-url": "https://api.staging.charmhub.io", // not actually used in tests
-		"name":          "model",
-		"type":          "type",
-		"uuid":          uuid,
+		"name":         "model",
+		"type":         "type",
+		"uuid":         uuid,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	model.EXPECT().Config().Return(cfg, nil).AnyTimes()

--- a/apiserver/facades/controller/charmrevisionupdater/interface_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface_test.go
@@ -65,7 +65,7 @@ func makeModel(c *gc.C, ctrl *gomock.Controller) charmrevisionupdater.Model {
 	model.EXPECT().CloudRegion().Return("juju-land").AnyTimes()
 	uuid := testing.ModelTag.Id()
 	cfg, err := config.New(true, map[string]interface{}{
-		"charm-hub-url": "https://api.staging.charmhub.io", // not actually used in tests
+		"charmhub-url": "https://api.staging.charmhub.io", // not actually used in tests
 		"name":          "model",
 		"type":          "type",
 		"uuid":          uuid,

--- a/caas/kubernetes/provider/proxy/info_test.go
+++ b/caas/kubernetes/provider/proxy/info_test.go
@@ -100,6 +100,7 @@ func (i *infoSuite) TestGetControllerProxier(c *gc.C) {
 		},
 		meta.CreateOptions{},
 	)
+	c.Assert(err, jc.ErrorIsNil)
 
 	sa, err := i.client.CoreV1().ServiceAccounts(testNamespace).Get(
 		context.TODO(),

--- a/caas/kubernetes/provider/proxy/setup_test.go
+++ b/caas/kubernetes/provider/proxy/setup_test.go
@@ -119,6 +119,7 @@ func (s *setupSuite) TestProxyConfigMap(c *gc.C) {
 		config.Name,
 		meta.GetOptions{},
 	)
+	c.Assert(err, jc.ErrorIsNil)
 
 	fetchedConfig := proxy.ControllerProxyConfig{}
 	configJson := cm.Data[proxy.ProxyConfigMapKey]

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -93,7 +93,7 @@ func (c *downloadCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.charmHubCommand.SetFlags(f)
 
 	f.StringVar(&c.channel, "channel", "", "specify a channel to use instead of the default release")
-	f.StringVar(&c.charmHubURL, "charm-hub-url", "", "override the model config by specifying the charmhub url for querying the store")
+	f.StringVar(&c.charmHubURL, "charmhub-url", "", "override the model config by specifying the charmhub url for querying the store")
 	f.StringVar(&c.archivePath, "filepath", "", "filepath location of the charm to download to")
 }
 
@@ -122,7 +122,7 @@ func (c *downloadCommand) Init(args []string) error {
 	if c.charmHubURL != "" {
 		_, err := url.ParseRequestURI(c.charmHubURL)
 		if err != nil {
-			return errors.Annotatef(err, "unexpected charm-hub-url")
+			return errors.Annotatef(err, "unexpected charmhub-url")
 		}
 	}
 

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -93,7 +93,7 @@ func (c *downloadCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.charmHubCommand.SetFlags(f)
 
 	f.StringVar(&c.channel, "channel", "", "specify a channel to use instead of the default release")
-	f.StringVar(&c.charmHubURL, "charmhub-url", "", "override the model config by specifying the charmhub url for querying the store")
+	f.StringVar(&c.charmHubURL, "charmhub-url", "", "override the model config by specifying the Charmhub URL for querying the store")
 	f.StringVar(&c.archivePath, "filepath", "", "filepath location of the charm to download to")
 }
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -121,7 +121,7 @@ func (s *downloadSuite) TestRunWithCustomCharmHubURL(c *gc.C) {
 			return s.downloadCommandAPI, nil
 		},
 	}
-	err := cmdtesting.InitCommand(command, []string{"--charm-hub-url=" + url, "test"})
+	err := cmdtesting.InitCommand(command, []string{"--charmhub-url=" + url, "test"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := commandContextForTest(c)
@@ -140,8 +140,8 @@ func (s *downloadSuite) TestRunWithCustomInvalidCharmHubURL(c *gc.C) {
 			return s.downloadCommandAPI, nil
 		},
 	}
-	err := cmdtesting.InitCommand(command, []string{"--charm-hub-url=" + url, "test"})
-	c.Assert(err, gc.ErrorMatches, `unexpected charm-hub-url: parse "meshuggah": invalid URI for request`)
+	err := cmdtesting.InitCommand(command, []string{"--charmhub-url=" + url, "test"})
+	c.Assert(err, gc.ErrorMatches, `unexpected charmhub-url: parse "meshuggah": invalid URI for request`)
 }
 
 func (s *downloadSuite) TestRunWithInvalidStdout(c *gc.C) {
@@ -188,7 +188,7 @@ func (s *downloadSuite) expectModelGet(charmHubURL string) {
 		"type":          "my-type",
 		"name":          "my-name",
 		"uuid":          "deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		"charm-hub-url": charmHubURL,
+		"charmhub-url": charmHubURL,
 	}, nil)
 }
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -185,9 +185,9 @@ func (s *downloadSuite) setUpMocks(c *gc.C) *gomock.Controller {
 
 func (s *downloadSuite) expectModelGet(charmHubURL string) {
 	s.modelConfigAPI.EXPECT().ModelGet().Return(map[string]interface{}{
-		"type":          "my-type",
-		"name":          "my-name",
-		"uuid":          "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		"type":         "my-type",
+		"name":         "my-name",
+		"uuid":         "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		"charmhub-url": charmHubURL,
 	}, nil)
 }

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -418,7 +418,7 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 			if c.ignoreReadOnlyFields {
 				continue
 			}
-			return errors.Errorf(`"charm-hub-url" must be set via "add-model"`)
+			return errors.Errorf(`"charmhub-url" must be set via "add-model"`)
 		}
 
 		values[k] = v

--- a/cmd/juju/model/config_test.go
+++ b/cmd/juju/model/config_test.go
@@ -221,8 +221,8 @@ func (s *ConfigCommandSuite) TestSetAgentVersion(c *gc.C) {
 }
 
 func (s *ConfigCommandSuite) TestSetCharmhubURL(c *gc.C) {
-	_, err := s.run(c, "charm-hub-url=http://meshuggah.rocks")
-	c.Assert(err, gc.ErrorMatches, `"charm-hub-url" must be set via "add-model"`)
+	_, err := s.run(c, "charmhub-url=http://meshuggah.rocks")
+	c.Assert(err, gc.ErrorMatches, `"charmhub-url" must be set via "add-model"`)
 }
 
 func (s *ConfigCommandSuite) TestSetAndReset(c *gc.C) {

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -254,7 +254,7 @@ const (
 	LXDSnapChannel = "lxd-snap-channel"
 
 	// CharmHubURLKey is the key for the url to use for CharmHub API calls
-	CharmHubURLKey = "charm-hub-url"
+	CharmHubURLKey = "charmhub-url"
 
 	// ModeKey is the key for defining the mode that a given model should be
 	// using.
@@ -797,7 +797,7 @@ func Validate(cfg, old *Config) error {
 		}
 		if _, oldFound := old.CharmHubURL(); oldFound {
 			if _, newFound := cfg.CharmHubURL(); !newFound {
-				return errors.New("cannot clear charm-hub-url")
+				return errors.New("cannot clear charmhub-url")
 			}
 		}
 	}

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -593,20 +593,20 @@ var configTests = []configTest{
 		about:       "Valid charm-hub api url",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"charm-hub-url": "http://test.com",
+			"charmhub-url": "http://test.com",
 		}),
 	}, {
 		about:       "Malformed charm-hub api url",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"charm-hub-url": "http://t est.com",
+			"charmhub-url": "http://t est.com",
 		}),
 		err: `charm-hub url "http://t est.com" not valid`,
 	}, {
 		about:       "Invalid charm-hub api url",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"charm-hub-url": "meshuggah",
+			"charmhub-url": "meshuggah",
 		}),
 		err: `charm-hub url "meshuggah" not valid`,
 	},
@@ -898,10 +898,10 @@ var validationTests = []validationTest{{
 	new:   testing.Attrs{"uuid": "dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4"},
 	err:   "cannot change uuid from \"90168e4c-2f10-4e9c-83c2-1fb55a58e5a9\" to \"dcfbdb4a-bca2-49ad-aa7c-f011424e0fe4\"",
 }, {
-	about: "Can't change the charm-hub-url (global->none)",
-	old:   testing.Attrs{"charm-hub-url": "http://a.com"},
-	new:   testing.Attrs{"charm-hub-url": "http://b.com"},
-	err:   `cannot change charm-hub-url from "http://a.com" to "http://b.com"`,
+	about: "Can't change the charmhub-url (global->none)",
+	old:   testing.Attrs{"charmhub-url": "http://a.com"},
+	new:   testing.Attrs{"charmhub-url": "http://b.com"},
+	err:   `cannot change charmhub-url from "http://a.com" to "http://b.com"`,
 }}
 
 func (s *ConfigSuite) TestValidateChange(c *gc.C) {
@@ -1212,7 +1212,7 @@ func (s *ConfigSuite) TestMode(c *gc.C) {
 func (s *ConfigSuite) TestCharmHubURLSettingValue(c *gc.C) {
 	url := "http://meshuggah-rocks.com/charmhub"
 	config := newTestConfig(c, testing.Attrs{
-		"charm-hub-url": url,
+		"charmhub-url": url,
 	})
 	chURL, ok := config.CharmHubURL()
 	c.Assert(ok, jc.IsTrue)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4511,16 +4511,21 @@ func (s *upgradesSuite) TestAddCharmHubToModelConfig(c *gc.C) {
 	})
 	defer func() { _ = m1.Close() }()
 	// Value set to something other that default
-	m2 := s.makeModel(c, "m3", coretesting.Attrs{
-		"charm-hub-url": "http://meshuggah.rocks",
+	m2 := s.makeModel(c, "m2", coretesting.Attrs{
+		"charmhub-url": "http://meshuggah.rocks",
 	})
 	defer func() { _ = m2.Close() }()
+	// Value set the old way.
+	m3 := s.makeModel(c, "m3", coretesting.Attrs{
+		"charm-hub-url": "http://beyond-creation.rocks",
+	})
+	defer func() { _ = m3.Close() }()
 
 	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
 	defer settingsCloser()
 	// To simulate a 2.9.0 without any setting, delete the record from it.
 	err := settingsColl.UpdateId(m1.ModelUUID()+":e",
-		bson.M{"$unset": bson.M{"settings.charm-hub-url": 1}},
+		bson.M{"$unset": bson.M{"settings.charmhub-url": 1}},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	// And an extra document from somewhere else that we shouldn't touch
@@ -4542,9 +4547,13 @@ func (s *upgradesSuite) TestAddCharmHubToModelConfig(c *gc.C) {
 	expectedSettings := []bson.M{}
 
 	expectedChanges := map[string]bson.M{
-		m1.ModelUUID() + ":e": {"charm-hub-url": charmhub.CharmHubServerURL, "other-setting": "val"},
-		m2.ModelUUID() + ":e": {"charm-hub-url": "http://meshuggah.rocks"},
+		m1.ModelUUID() + ":e": {"charmhub-url": charmhub.CharmHubServerURL, "other-setting": "val"},
+		m2.ModelUUID() + ":e": {"charmhub-url": "http://meshuggah.rocks"},
+		m3.ModelUUID() + ":e": {"charmhub-url": "http://beyond-creation.rocks"},
 		"not-a-model":         {"other-setting": "val"},
+	}
+	expectedRemovals := map[string]string{
+		m3.ModelUUID() + ":e": "charm-hub-url",
 	}
 	for iter.Next(&rawSettings) {
 		expSettings := copyMap(rawSettings, nil)
@@ -4564,6 +4573,11 @@ func (s *upgradesSuite) TestAddCharmHubToModelConfig(c *gc.C) {
 			for k, v := range changes {
 				settings[k] = v
 			}
+		}
+		if removal, ok := expectedRemovals[idStr]; ok {
+			raw, ok := expSettings["settings"]
+			c.Assert(ok, jc.IsTrue)
+			delete(raw.(bson.M), removal)
 		}
 		expectedSettings = append(expectedSettings, expSettings)
 	}

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -102,7 +102,7 @@ func mustUUID() string {
 func CustomModelConfig(c *gc.C, extra Attrs) *config.Config {
 	attrs := FakeConfig().Merge(Attrs{
 		"agent-version": "2.0.0",
-		"charm-hub-url": charmhub.CharmHubServerURL,
+		"charmhub-url": charmhub.CharmHubServerURL,
 	}).Merge(extra).Delete("admin-secret")
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -102,7 +102,7 @@ func mustUUID() string {
 func CustomModelConfig(c *gc.C, extra Attrs) *config.Config {
 	attrs := FakeConfig().Merge(Attrs{
 		"agent-version": "2.0.0",
-		"charmhub-url": charmhub.CharmHubServerURL,
+		"charmhub-url":  charmhub.CharmHubServerURL,
 	}).Merge(extra).Delete("admin-secret")
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)

--- a/tests/includes/colors.sh
+++ b/tests/includes/colors.sh
@@ -1,21 +1,32 @@
-red() {
-    if [ -n "${TERM:-}" ]; then
-        if which tput >/dev/null 2>&1; then
-            tput sgr0
-            echo "$(tput setaf 1)${1}$(tput sgr0)"
+supports_colors() {
+    if [ -z "${TERM}" ] || [ "${TERM}" = "" ] || [ "${TERM}" = "dumb" ]; then
+        echo "NO"
+        return
+    fi
+    if which tput >/dev/null 2>&1; then
+        # shellcheck disable=SC2046
+        if [[ $(tput colors) -gt 1 ]]; then
+            echo "YES"
             return
         fi
+    fi
+    echo "NO"
+}
+
+red() {
+    if [ "$(supports_colors)" = "YES" ]; then
+        tput sgr0
+        echo "$(tput setaf 1)${1}$(tput sgr0)"
+        return
     fi
     echo "${1}"
 }
 
 green() {
-    if [ -n "${TERM:-}" ]; then
-        if which tput >/dev/null 2>&1; then
-            tput sgr0
-            echo "$(tput setaf 2)${1}$(tput sgr0)"
-            return
-        fi
+    if [ "$(supports_colors)" = "YES" ]; then
+        tput sgr0
+        echo "$(tput setaf 2)${1}$(tput sgr0)"
+        return
     fi
     echo "${1}"
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -20,7 +20,7 @@ var serviceDiscovery = service.DiscoverService
 func stateStepsFor29() []Step {
 	return []Step{
 		&upgradeStep{
-			description: "add charm-hub-url to model config",
+			description: "add charmhub-url to model config",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {
 				return context.State().AddCharmHubToModelConfig()

--- a/upgrades/steps_29_test.go
+++ b/upgrades/steps_29_test.go
@@ -38,7 +38,7 @@ func (s *steps29Suite) TestStoreDeployedUnitsInMachineAgentConf(c *gc.C) {
 }
 
 func (s *steps29Suite) TestAddCharmhubToModelConfig(c *gc.C) {
-	step := findStateStep(c, v290, "add charm-hub-url to model config")
+	step := findStateStep(c, v290, "add charmhub-url to model config")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
 


### PR DESCRIPTION
It was decided that charmhub shouldn't be hyphenated. It was originally
like this, but was changed to follow the charm-store standardization.

The code essentially updates the new model-config value (charmhub-url)
from the default server URL or from what was previously set. This is so
we don't break existing model configs that users might have previously
set to a new value.

## QA steps

Test that the old way works firstly:

```sh
$ juju bootstrap lxd test --agent-version=2.9-rc3
$ juju add-model other --config charm-hub-url="https://api.staging.snapcraft.io"
$ juju model-config
$ juju model-config charm-hub-url
```

Test that once upgraded the new way works and the old way doesn't:

```sh
$ juju upgrade-controller --build-agent
$ juju switch default
$ juju model config
$ juju switch other
$ juju model-config
$ juju model-config charmhub-url
$ juju model-config charm-hub-url
ERROR "charm-hub-url" seems to be neither a file nor a key of the currently targeted model: "admin/other"
```
