### PR TITLE
[Charmhub] - No charmhub charm by revision

### DIFF
--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -92,33 +92,12 @@ func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMapWithChannel
 }
 
 func (s *charmHubRepositoriesSuite) TestResolveWithRevision(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-	s.expectCharmInfo(nil)
-
 	curl := charm.MustParseURL("ch:wordpress-13")
 	origin := params.CharmOrigin{Source: "charm-hub", Architecture: arch.DefaultArchitecture}
 
 	resolver := &chRepo{client: s.client}
-	obtainedCurl, obtainedOrigin, obtainedSeries, err := resolver.ResolveWithPreferredChannel(curl, origin)
-	c.Assert(err, jc.ErrorIsNil)
-
-	track := "second"
-	curl.Revision = 13
-
-	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
-	origin.Type = "charm"
-	origin.Revision = &curl.Revision
-	origin.Risk = "stable"
-	origin.Track = &track
-	origin.Architecture = arch.DefaultArchitecture
-	origin.OS = "ubuntu"
-	origin.Series = "bionic"
-
-	expected := s.expectedCURL(curl, 13, arch.DefaultArchitecture, "bionic")
-
-	c.Assert(obtainedCurl, jc.DeepEquals, expected)
-	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
-	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "xenial"})
+	_, _, _, err := resolver.ResolveWithPreferredChannel(curl, origin)
+	c.Assert(err, gc.NotNil)
 }
 
 func (s *charmHubRepositoriesSuite) TestCharmResolveDefaultChannelMapWithFallbackSeries(c *gc.C) {
@@ -209,18 +188,6 @@ func (s *charmHubRepositoriesSuite) TestBundleResolveDefaultChannelMapWithFallba
 	c.Assert(obtainedCurl, jc.DeepEquals, expected)
 	c.Assert(obtainedOrigin, jc.DeepEquals, origin)
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic"})
-}
-
-func (s *charmHubRepositoriesSuite) TestResolveWithRevisionNotFound(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-	s.expectCharmInfo(nil)
-
-	curl := charm.MustParseURL("ch:wordpress-42")
-	origin := params.CharmOrigin{Source: "charm-hub", Architecture: arch.DefaultArchitecture}
-
-	resolver := &chRepo{client: s.client}
-	_, _, _, err := resolver.ResolveWithPreferredChannel(curl, origin)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -232,13 +232,13 @@ func (d *localBundle) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, 
 	return d.deploy(ctx, deployAPI, resolver, macaroonGetter)
 }
 
-type charmstoreBundle struct {
+type repositoryBundle struct {
 	deployBundle
 }
 
 // String returns a string description of the deployer.
-func (d *charmstoreBundle) String() string {
-	str := fmt.Sprintf("deploy charm store bundle: %s", d.bundleURL.String())
+func (d *repositoryBundle) String() string {
+	str := fmt.Sprintf("deploy bundle: %s", d.bundleURL.String())
 	if isEmptyOrigin(d.origin, commoncharm.OriginCharmStore) {
 		return str
 	}
@@ -250,7 +250,7 @@ func (d *charmstoreBundle) String() string {
 }
 
 // PrepareAndDeploy deploys a local bundle, no further preparation is needed.
-func (d *charmstoreBundle) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
+func (d *repositoryBundle) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
 	var revision string
 	if d.bundleURL.Revision != -1 {
 		revision = fmt.Sprintf(", revision %d", d.bundleURL.Revision)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -327,7 +327,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			continue
 		}
 
-		ch, err := resolveCharmURL(spec.Charm)
+		ch, err := resolveAndValidateCharmURL(spec.Charm)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -543,7 +543,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	}
 
 	// Not a local charm, so grab from the store.
-	ch, err := resolveCharmURL(chParams.Charm)
+	ch, err := resolveAndValidateCharmURL(chParams.Charm)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1047,7 +1047,7 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 	}
 
 	p := change.Params
-	cURL, err := resolveCharmURL(resolve(p.Charm, h.results))
+	cURL, err := resolveAndValidateCharmURL(resolve(p.Charm, h.results))
 	if err != nil {
 		return errors.Trace(err)
 	} else if cURL == nil {

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -34,7 +34,7 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-type BundleDeployCharmStoreSuite struct {
+type BundleDeployRepositorySuite struct {
 	allWatcher     *mocks.MockAllWatch
 	bundleResolver *mocks.MockResolver
 	deployerAPI    *mocks.MockDeployerAPI
@@ -45,15 +45,15 @@ type BundleDeployCharmStoreSuite struct {
 	output     *bytes.Buffer
 }
 
-var _ = gc.Suite(&BundleDeployCharmStoreSuite{})
+var _ = gc.Suite(&BundleDeployRepositorySuite{})
 
-func (s *BundleDeployCharmStoreSuite) SetUpTest(c *gc.C) {
+func (s *BundleDeployRepositorySuite) SetUpTest(c *gc.C) {
 	s.deployArgs = make(map[string]application.DeployArgs)
 	s.output = bytes.NewBuffer([]byte{})
 	//logger.SetLogLevel(loggo.TRACE)
 }
 
-func (s *BundleDeployCharmStoreSuite) TearDownTest(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TearDownTest(c *gc.C) {
 	s.output.Reset()
 }
 
@@ -62,7 +62,7 @@ func (s *BundleDeployCharmStoreSuite) TearDownTest(c *gc.C) {
 // target in testing/base.go:SetupSuite we'll need to also update the entries
 // herein.
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleNotFoundCharmStore(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleNotFoundCharmStore(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 
@@ -82,7 +82,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNotFoundCharmStore(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `cannot resolve charm or bundle "no-such": bundle not found`)
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleSuccess(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -158,7 +158,7 @@ relations:
   - mysql:db
 `
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithInvalidSeries(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeries(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -185,7 +185,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithInvalidSeries(c *gc.C)
 	c.Assert(err, gc.ErrorMatches, "mysql is not available on the following series: precise not supported")
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleWithInvalidSeriesWithForce(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeriesWithForce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -264,7 +264,7 @@ relations:
   - mysql:db
 `
 
-func (s *BundleDeployCharmStoreSuite) TestDeployKubernetesBundleSuccess(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -330,7 +330,7 @@ relations:
     - mariadb:server
 `
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleStorage(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleStorage(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -405,7 +405,7 @@ relations:
   - mysql:db
 `
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleDevices(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleDevices(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -477,7 +477,7 @@ relations:
     - ["dashboard4miner:miner", "bitcoin-miner:miner"]
 `
 
-func (s *BundleDeployCharmStoreSuite) TestDryRunExistingModel(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDryRunExistingModel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -544,7 +544,7 @@ func (s *BundleDeployCharmStoreSuite) TestDryRunExistingModel(c *gc.C) {
 	c.Check(s.output.String(), gc.Equals, expectedOutput)
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidMachineContainerType(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleInvalidMachineContainerType(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -581,7 +581,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleInvalidMachineContainerTyp
 	c.Assert(err, gc.ErrorMatches, `cannot create machine for holding wp unit: invalid container type "bad"`)
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedToMachines(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -659,7 +659,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleUnitPlacedToMachines(c *gc
 		"Deploy of bundle completed.\n")
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleExpose(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -698,7 +698,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleExpose(c *gc.C) {
 		"Deploy of bundle completed.\n")
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleMultipleRelations(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -786,7 +786,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMultipleRelations(c *gc.C)
 		"Deploy of bundle completed.\n")
 }
 
-func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
+func (s *BundleDeployRepositorySuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
@@ -849,7 +849,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	c.Check(s.output.String(), gc.Equals, fmt.Sprintf(expectedOutput, mysqlPath, wordpressPath))
 }
 
-func (s *BundleDeployCharmStoreSuite) bundleDeploySpec() bundleDeploySpec {
+func (s *BundleDeployRepositorySuite) bundleDeploySpec() bundleDeploySpec {
 	deployResourcesFunc := func(_ string,
 		_ client.CharmID,
 		_ *macaroon.Macaroon,
@@ -872,20 +872,20 @@ func (s *BundleDeployCharmStoreSuite) bundleDeploySpec() bundleDeploySpec {
 	}
 }
 
-func (s *BundleDeployCharmStoreSuite) assertDeployArgs(c *gc.C, curl, appName, series string) {
+func (s *BundleDeployRepositorySuite) assertDeployArgs(c *gc.C, curl, appName, series string) {
 	arg, found := s.deployArgs[appName]
 	c.Assert(found, jc.IsTrue, gc.Commentf("Application %q not found in deploy args", appName))
 	c.Assert(arg.CharmID.URL.String(), gc.Equals, curl)
 	c.Assert(arg.Series, gc.Equals, series)
 }
 
-func (s *BundleDeployCharmStoreSuite) assertDeployArgsStorage(c *gc.C, appName string, storage map[string]storage.Constraints) {
+func (s *BundleDeployRepositorySuite) assertDeployArgsStorage(c *gc.C, appName string, storage map[string]storage.Constraints) {
 	arg, found := s.deployArgs[appName]
 	c.Assert(found, jc.IsTrue, gc.Commentf("Application %q not found in deploy args", appName))
 	c.Assert(arg.Storage, gc.DeepEquals, storage)
 }
 
-func (s *BundleDeployCharmStoreSuite) assertDeployArgsDevices(c *gc.C, appName string, devices map[string]devices.Constraints) {
+func (s *BundleDeployRepositorySuite) assertDeployArgsDevices(c *gc.C, appName string, devices map[string]devices.Constraints) {
 	arg, found := s.deployArgs[appName]
 	c.Assert(found, jc.IsTrue, gc.Commentf("Application %q not found in deploy args", appName))
 	c.Assert(arg.Devices, gc.DeepEquals, devices)
@@ -899,7 +899,7 @@ type charmUnit struct {
 	machineSeries   string
 }
 
-func (s *BundleDeployCharmStoreSuite) setupCharmUnits(charmUnits []charmUnit) {
+func (s *BundleDeployRepositorySuite) setupCharmUnits(charmUnits []charmUnit) {
 	for _, chUnit := range charmUnits {
 		switch chUnit.curl.Schema {
 		case "cs":
@@ -924,7 +924,7 @@ func (s *BundleDeployCharmStoreSuite) setupCharmUnits(charmUnits []charmUnit) {
 	}
 }
 
-func (s *BundleDeployCharmStoreSuite) setupMocks(c *gc.C) *gomock.Controller {
+func (s *BundleDeployRepositorySuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.deployerAPI = mocks.NewMockDeployerAPI(ctrl)
 	s.bundleResolver = mocks.NewMockResolver(ctrl)
@@ -941,7 +941,7 @@ func (s *BundleDeployCharmStoreSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *BundleDeployCharmStoreSuite) expectEmptyModelToStart(c *gc.C) {
+func (s *BundleDeployRepositorySuite) expectEmptyModelToStart(c *gc.C) {
 	// setup for empty current model
 	// bundleHandler.makeModel()
 	s.expectDeployerAPIEmptyStatus()
@@ -949,7 +949,7 @@ func (s *BundleDeployCharmStoreSuite) expectEmptyModelToStart(c *gc.C) {
 	s.expectDeployerAPIModelGet(c)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectEmptyModelRepresentation() {
+func (s *BundleDeployRepositorySuite) expectEmptyModelRepresentation() {
 	// BuildModelRepresentation is tested in bundle pkg.
 	// Setup as if an empty model
 	s.deployerAPI.EXPECT().GetAnnotations(gomock.Any()).Return(nil, nil)
@@ -958,17 +958,17 @@ func (s *BundleDeployCharmStoreSuite) expectEmptyModelRepresentation() {
 	s.deployerAPI.EXPECT().Sequences().Return(nil, errors.NotSupportedf("sequences for test"))
 }
 
-func (s *BundleDeployCharmStoreSuite) expectWatchAll() {
+func (s *BundleDeployRepositorySuite) expectWatchAll() {
 	s.deployerAPI.EXPECT().WatchAll().Return(s.allWatcher, nil)
 	s.allWatcher.EXPECT().Stop().Return(nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectDeployerAPIEmptyStatus() {
+func (s *BundleDeployRepositorySuite) expectDeployerAPIEmptyStatus() {
 	status := &params.FullStatus{}
 	s.deployerAPI.EXPECT().Status(gomock.Any()).Return(status, nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectDeployerAPIStatusWordpressBundle() {
+func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 	status := &params.FullStatus{
 		Model: params.ModelStatusInfo{},
 		Machines: map[string]params.MachineStatus{
@@ -1009,7 +1009,7 @@ func (s *BundleDeployCharmStoreSuite) expectDeployerAPIStatusWordpressBundle() {
 	s.deployerAPI.EXPECT().Status(gomock.Any()).Return(status, nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectDeployerAPIModelGet(c *gc.C) {
+func (s *BundleDeployRepositorySuite) expectDeployerAPIModelGet(c *gc.C) {
 	minimal := map[string]interface{}{
 		"name":            "test",
 		"type":            "manual",
@@ -1026,7 +1026,7 @@ func (s *BundleDeployCharmStoreSuite) expectDeployerAPIModelGet(c *gc.C) {
 	s.deployerAPI.EXPECT().ModelGet().Return(cfg.AllAttrs(), nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectResolveCharm(err error, times int) {
+func (s *BundleDeployRepositorySuite) expectResolveCharm(err error, times int) {
 	s.bundleResolver.EXPECT().ResolveCharm(
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
@@ -1037,11 +1037,11 @@ func (s *BundleDeployCharmStoreSuite) expectResolveCharm(err error, times int) {
 		}).Times(times)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectBestFacadeVersion() {
+func (s *BundleDeployRepositorySuite) expectBestFacadeVersion() {
 	s.deployerAPI.EXPECT().BestFacadeVersion("Application").Return(6)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectAddCharm(force bool) {
+func (s *BundleDeployRepositorySuite) expectAddCharm(force bool) {
 	s.deployerAPI.EXPECT().AddCharm(
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
@@ -1052,7 +1052,7 @@ func (s *BundleDeployCharmStoreSuite) expectAddCharm(force bool) {
 		})
 }
 
-func (s *BundleDeployCharmStoreSuite) expectAddLocalCharm(curl *charm.URL, force bool) {
+func (s *BundleDeployRepositorySuite) expectAddLocalCharm(curl *charm.URL, force bool) {
 	s.deployerAPI.EXPECT().AddLocalCharm(gomock.AssignableToTypeOf(&charm.URL{}), charmInterfaceMatcher{}, force).Return(curl, nil)
 }
 
@@ -1068,11 +1068,11 @@ func (m charmInterfaceMatcher) String() string {
 	return fmt.Sprintf("Require charm.Charm as arg")
 }
 
-func (s *BundleDeployCharmStoreSuite) expectCharmInfo(name string, info *apicharms.CharmInfo) {
+func (s *BundleDeployRepositorySuite) expectCharmInfo(name string, info *apicharms.CharmInfo) {
 	s.deployerAPI.EXPECT().CharmInfo(name).Return(info, nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectDeploy() {
+func (s *BundleDeployRepositorySuite) expectDeploy() {
 	s.deployerAPI.EXPECT().Deploy(gomock.AssignableToTypeOf(application.DeployArgs{})).DoAndReturn(
 		func(args application.DeployArgs) error {
 			// Save the args to do a verification of later.
@@ -1083,18 +1083,18 @@ func (s *BundleDeployCharmStoreSuite) expectDeploy() {
 		})
 }
 
-func (s *BundleDeployCharmStoreSuite) expectExpose(app string) {
+func (s *BundleDeployRepositorySuite) expectExpose(app string) {
 	s.deployerAPI.EXPECT().Expose(app, gomock.Any()).Return(nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectAddMachine(machine, series string) {
+func (s *BundleDeployRepositorySuite) expectAddMachine(machine, series string) {
 	if machine == "" {
 		return
 	}
 	s.expectAddContainer("", machine, series, "")
 }
 
-func (s *BundleDeployCharmStoreSuite) expectAddContainer(parent, machine, series, container string) {
+func (s *BundleDeployRepositorySuite) expectAddContainer(parent, machine, series, container string) {
 	args := []params.AddMachineParams{
 		{
 			ContainerType: instance.ContainerType(container),
@@ -1109,11 +1109,11 @@ func (s *BundleDeployCharmStoreSuite) expectAddContainer(parent, machine, series
 	s.deployerAPI.EXPECT().AddMachines(args).Return(results, nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectAddRelation(endpoints []string) {
+func (s *BundleDeployRepositorySuite) expectAddRelation(endpoints []string) {
 	s.deployerAPI.EXPECT().AddRelation(endpoints, nil).Return(nil, nil)
 }
 
-func (s *BundleDeployCharmStoreSuite) expectAddOneUnit(name, directive, unit string) {
+func (s *BundleDeployRepositorySuite) expectAddOneUnit(name, directive, unit string) {
 	var placement []*instance.Placement
 	if directive != "" {
 		placement = []*instance.Placement{{

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -420,7 +420,7 @@ func (c *charmStoreCharm) String() string {
 func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
 	userRequestedURL := c.userRequestedURL
 	location := "hub"
-	if userRequestedURL.Schema == "cs" {
+	if charm.CharmStore.Matches(userRequestedURL.Schema) {
 		location = "store"
 	}
 	ctx.Verbosef("Preparing to deploy %q from the charm-%s", userRequestedURL.Name, location)

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -396,15 +396,15 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 	return l.deploy(ctx, deployAPI)
 }
 
-type charmStoreCharm struct {
+type repositoryCharm struct {
 	deployCharm
 	userRequestedURL *charm.URL
 	clock            jujuclock.Clock
 }
 
 // String returns a string description of the deployer.
-func (c *charmStoreCharm) String() string {
-	str := fmt.Sprintf("deploy charm store charm: %s", c.userRequestedURL.String())
+func (c *repositoryCharm) String() string {
+	str := fmt.Sprintf("deploy charm: %s", c.userRequestedURL.String())
 	if isEmptyOrigin(c.origin, commoncharm.OriginCharmStore) {
 		return str
 	}
@@ -417,7 +417,7 @@ func (c *charmStoreCharm) String() string {
 
 // PrepareAndDeploy finishes preparing to deploy a charm store charm,
 // then deploys it.
-func (c *charmStoreCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
+func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
 	userRequestedURL := c.userRequestedURL
 	location := "hub"
 	if charm.CharmStore.Matches(userRequestedURL.Schema) {

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -61,8 +61,8 @@ func (d *factory) GetDeployer(cfg DeployerConfig, getter ModelConfigGetter, reso
 		d.maybeReadLocalBundle,
 		func() (Deployer, error) { return d.maybeReadLocalCharm(getter) },
 		d.maybePredeployedLocalCharm,
-		func() (Deployer, error) { return d.maybeReadCharmstoreBundle(resolver) },
-		d.charmStoreCharm, // This always returns a Deployer
+		func() (Deployer, error) { return d.maybeReadRepositoryBundle(resolver) },
+		d.respositoryCharm, // This always returns a Deployer
 	}
 	for _, d := range maybeDeployers {
 		if deploy, err := d(); err != nil {
@@ -389,7 +389,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	}, err
 }
 
-func (d *factory) maybeReadCharmstoreBundle(resolver Resolver) (Deployer, error) {
+func (d *factory) maybeReadRepositoryBundle(resolver Resolver) (Deployer, error) {
 	curl, err := resolveAndValidateCharmURL(d.charmOrBundle)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -445,10 +445,10 @@ func (d *factory) maybeReadCharmstoreBundle(resolver Resolver) (Deployer, error)
 	db.bundleURL = bundleURL
 	db.bundleOverlayFile = d.bundleOverlayFile
 	db.origin = bundleOrigin
-	return &charmstoreBundle{deployBundle: db}, nil
+	return &repositoryBundle{deployBundle: db}, nil
 }
 
-func (d *factory) charmStoreCharm() (Deployer, error) {
+func (d *factory) respositoryCharm() (Deployer, error) {
 	// Validate we have a charm store change
 	userRequestedURL, err := resolveAndValidateCharmURL(d.charmOrBundle)
 	if err != nil {
@@ -465,7 +465,7 @@ func (d *factory) charmStoreCharm() (Deployer, error) {
 
 	deployCharm := d.newDeployCharm()
 	deployCharm.origin = origin
-	return &charmStoreCharm{
+	return &repositoryCharm{
 		deployCharm:      deployCharm,
 		userRequestedURL: userRequestedURL,
 		clock:            d.clock,

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -227,8 +227,8 @@ func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
 		path: "wordpress",
 		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
 	}, {
-		path: "ch:wordpress-42",
-		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: 42},
+		path: "ch:wordpress",
+		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
 	}, {
 		path: "cs:wordpress",
 		url:  &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
@@ -242,6 +242,37 @@ func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("%d %s", i, test.path)
 		url, err := resolveCharmURL(test.path)
+		if test.err != nil {
+			c.Assert(err, gc.ErrorMatches, test.err.Error())
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(url, gc.DeepEquals, test.url)
+		}
+	}
+}
+
+func (s *deployerSuite) TestResolveAndValidateCharmURL(c *gc.C) {
+	tests := []struct {
+		path string
+		url  *charm.URL
+		err  error
+	}{{
+		path: "ch:wordpress-42",
+		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: 42},
+		err:  errors.Errorf("specifying a revision for wordpress is not supported, please use a channel."),
+	}, {
+		path: "ch:wordpress",
+		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
+	}, {
+		path: "cs:wordpress-42",
+		url:  &charm.URL{Schema: "cs", Name: "wordpress", Revision: 42},
+	}, {
+		path: "local:wordpress",
+		url:  &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
+	}}
+	for i, test := range tests {
+		c.Logf("%d %s", i, test.path)
+		url, err := resolveAndValidateCharmURL(test.path)
 		if test.err != nil {
 			c.Assert(err, gc.ErrorMatches, test.err.Error())
 		} else {

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -108,7 +108,7 @@ func (s *deployerSuite) TestGetDeployerLocalCharmError(c *gc.C) {
 func (s *deployerSuite) TestGetDeployerCharmStoreCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectFilesystem()
-	// NotValid ensures that maybeReadCharmstoreBundle won't find
+	// NotValid ensures that maybeReadRepositoryBundle won't find
 	// charmOrBundle is a bundle.
 	s.expectResolveBundleURL(errors.NotValidf("not a bundle"), 1)
 
@@ -120,7 +120,7 @@ func (s *deployerSuite) TestGetDeployerCharmStoreCharm(c *gc.C) {
 	factory := s.newDeployerFactory()
 	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store charm: %s", ch.String()))
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm: %s", ch.String()))
 }
 
 func (s *deployerSuite) TestCharmStoreSeriesOverride(c *gc.C) {
@@ -137,9 +137,9 @@ func (s *deployerSuite) TestCharmStoreSeriesOverride(c *gc.C) {
 	factory := s.newDeployerFactory()
 	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store charm: %s", ch.String()))
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm: %s", ch.String()))
 
-	charmStoreDeployer := deployer.(*charmStoreCharm)
+	charmStoreDeployer := deployer.(*repositoryCharm)
 	c.Assert(charmStoreDeployer.series, gc.Equals, "bionic")
 }
 
@@ -193,7 +193,7 @@ func (s *deployerSuite) TestGetDeployerCharmStoreBundle(c *gc.C) {
 	factory := s.newDeployerFactory()
 	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store bundle: %s", bundle.String()))
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s", bundle.String()))
 }
 
 func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
@@ -215,7 +215,7 @@ func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
 	factory := s.newDeployerFactory()
 	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy charm store bundle: %s from channel edge", bundle.String()))
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s from channel edge", bundle.String()))
 }
 
 func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -341,6 +341,10 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	if c.isCharmHubWithRevision(oldOrigin.Source) {
+		return errors.Errorf("specifying a revision is not supported, please use a channel.")
+	}
+
 	if c.BindToSpaces != "" {
 		if err := c.checkApplicationFacadeSupport(apiRoot, "specifying bindings", 11); err != nil {
 			return err
@@ -491,6 +495,25 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	}
 
 	return nil
+}
+
+func (c *refreshCommand) isCharmHubWithRevision(source commoncharm.OriginSource) bool {
+	if source == commoncharm.OriginCharmHub && c.Revision > -1 {
+		return true
+	}
+	// EnsureSchema will error if input is an empty string.
+	path, err := charm.EnsureSchema(c.SwitchURL)
+	if err != nil {
+		return false
+	}
+	curl, err := charm.ParseURL(path)
+	if err != nil {
+		return false
+	}
+	if charm.CharmHub.Matches(curl.Schema) && curl.Revision > -1 {
+		return true
+	}
+	return false
 }
 
 func (c *refreshCommand) validateEndpointNames(newCharmEndpoints set.Strings, oldEndpointsMap, userBindings map[string]string) error {

--- a/cmd/juju/application/store/charmadapter_test.go
+++ b/cmd/juju/application/store/charmadapter_test.go
@@ -247,7 +247,7 @@ func (s *resolveSuite) TestCharmStoreGetBundle(c *gc.C) {
 func (s *resolveSuite) TestCharmHubGetBundle(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl, err := charm.ParseURL("ch:testme-1")
+	curl, err := charm.ParseURL("ch:testme")
 	c.Assert(err, jc.ErrorIsNil)
 
 	origin := commoncharm.Origin{


### PR DESCRIPTION
CharmHub are meant to act more like snaps, following the channel model.  Therefore deployment should not include specifying a revision.  Either use the latest or a specific channel from which to deploy.  Refresh will happen by checking for updates to the deployment channel, or specifying a new channel, not by revision.

To help with pylibjuju, also have ResolveWithPreferredChannel make the same check.

## QA steps

```console
# Testing charm deploy
$ juju deploy ubuntu-17
ERROR specifying a revision for ubuntu is not supported, please use a channel.
$ juju deploy cs:ubuntu-16
Located charm "ubuntu" in charm-store, revision 16
Deploying "ubuntu" from charm-store charm "ubuntu", revision 16 in channel stable

# Testing bundle deploy
$ cat bundle.yaml
series: focal
applications:
  ubuntu:
    charm: ch:ubuntu-17
    num_units: 1
$ juju deploy ./bundle.yaml
ERROR cannot deploy bundle: specifying a revision for ubuntu is not supported, please use a channel.

# Testing refresh, both revision and switch
$ juju add-model one --config charm-hub-url="https://api.staging.charmhub.io"
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 17
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 17 in channel latest/stable
$ juju refresh ubuntu --revision 18
ERROR specifying a revision for ubuntu is not supported, please use a channel.
$ juju refresh ubuntu --switch ubuntu-18
ERROR specifying a revision for ubuntu is not supported, please use a channel.

```

