### PR TITLE
charmhub != CharmHub for BestAPIVersion

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -268,7 +268,7 @@ func (c *downloadCommand) getCharmHubURL() (string, error) {
 	}
 	defer func() { _ = apiRoot.Close() }()
 
-	if apiRoot.BestFacadeVersion("charmhub") < 1 {
+	if apiRoot.BestFacadeVersion("CharmHub") < 1 {
 		return "", errors.NotImplementedf("charmhub")
 	}
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -57,7 +57,7 @@ func (s *downloadSuite) TestInitSuccess(c *gc.C) {
 
 func (s *downloadSuite) TestRun(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
-	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
+	s.apiRoot.EXPECT().BestFacadeVersion("CharmHub").Return(1)
 
 	url := "http://example.org/"
 
@@ -83,7 +83,7 @@ func (s *downloadSuite) TestRun(c *gc.C) {
 
 func (s *downloadSuite) TestRunWithStdout(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
-	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
+	s.apiRoot.EXPECT().BestFacadeVersion("CharmHub").Return(1)
 
 	url := "http://example.org/"
 

--- a/cmd/juju/charmhub/find.go
+++ b/cmd/juju/charmhub/find.go
@@ -132,8 +132,7 @@ func (c *findCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	defer func() { _ = apiRoot.Close() }()
-
-	if apiRoot.BestFacadeVersion("charmhub") < 1 {
+	if apiRoot.BestFacadeVersion("CharmHub") < 1 {
 		ctx.Warningf("juju find not supported with controllers < 2.9")
 		return nil
 	}

--- a/cmd/juju/charmhub/find_test.go
+++ b/cmd/juju/charmhub/find_test.go
@@ -185,7 +185,7 @@ func (s *findSuite) setUpMocks(c *gc.C) *gomock.Controller {
 
 	s.apiRoot = basemocks.NewMockAPICallCloser(ctrl)
 	s.apiRoot.EXPECT().Close().AnyTimes()
-	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
+	s.apiRoot.EXPECT().BestFacadeVersion("CharmHub").Return(1)
 
 	return ctrl
 }

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -141,7 +141,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = apiRoot.Close() }()
 
-	if apiRoot.BestFacadeVersion("charmhub") < 1 {
+	if apiRoot.BestFacadeVersion("CharmHub") < 1 {
 		ctx.Warningf("juju info not supported with controllers < 2.9")
 		return nil
 	}

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -312,7 +312,7 @@ func (s *infoSuite) setUpMocks(c *gc.C) *gomock.Controller {
 
 	s.apiRoot = basemocks.NewMockAPICallCloser(ctrl)
 	s.apiRoot.EXPECT().Close().AnyTimes()
-	s.apiRoot.EXPECT().BestFacadeVersion("charmhub").Return(1)
+	s.apiRoot.EXPECT().BestFacadeVersion("CharmHub").Return(1)
 
 	return ctrl
 }


### PR DESCRIPTION
Using charmhub causes failures on 2.9 also, not just 2.9 <.

## QA steps

```console
$ juju find wordpress
Name       Bundle  Version  Publisher           Summary
wordpress  -       21       wordpress-charmers  WordPress is open source software you can
                                                use to create a beautiful website, blog,
                                                or app.


```

