### PR TITLE
[2.9-python3-acceptancetests] More python3 acceptance test fixes

### DIFF
--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -14,6 +14,7 @@ azure-mgmt-redis>=0.30.0rc3
 azure-mgmt-resource>=0.30.0rc3
 azure-mgmt-scheduler>=0.30.0rc3
 azure-mgmt-storage>=0.30.0rc3
+azure-mgmt-containerservice>=0.30.0rc3
 azure-mgmt-web>=0.30.0rc3
 azure-nspkg>=1.0.0
 azure-servicebus>=0.20.1

--- a/caas/kubernetes/provider/connection.go
+++ b/caas/kubernetes/provider/connection.go
@@ -4,16 +4,27 @@
 package provider
 
 import (
+	"github.com/juju/errors"
+
 	k8sproxy "github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/proxy"
 )
 
 func (k *kubernetesClient) ConnectionProxyInfo() (proxy.Proxier, error) {
-	return k8sproxy.GetControllerProxy(
+	p, err := k8sproxy.GetControllerProxy(
 		getBootstrapResourceName(JujuControllerStackName, proxyResourceName),
 		k.k8sCfgUnlocked.Host,
 		k.client().CoreV1().ConfigMaps(k.GetCurrentNamespace()),
 		k.client().CoreV1().ServiceAccounts(k.GetCurrentNamespace()),
 		k.client().CoreV1().Secrets(k.GetCurrentNamespace()),
 	)
+
+	// If an error occurred return a nil to avoid converting the nil
+	// *Proxier into a typed nil which allows MarshalYAML to be called
+	// against a nil value which effectively causes a nil pointer
+	// dereference.
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return p, nil
 }


### PR DESCRIPTION
This is a followup to #12519 (and related PRs) which:

- Brings in the 2.9 fix from #12536 (makes the gke deployment test green)
- Adds a missing dependecy for azure.
- Ensures that the juju RSA keys are included as options when the tests shell out to `ssh` (remote.py).
- Refactors the log collection logic for tests (see extended commit for details)

# QA steps

The log collection logic can be tested for various series as follows:

```
./deploy_job.py --series xenial lxd `which juju` /tmp/art-1 deploy-xenial
./deploy_job.py --series bionic lxd `which juju` /tmp/art-2 deploy-bionic
./deploy_job.py --series focal lxd `which juju` /tmp/art-3 deploy-focal
```