### PR TITLE
Improve error reporting for invalid metrics arguments

### DIFF
--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -163,7 +163,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 	resultChannel := make(chan string, len(runResults))
 	for _, result := range runResults {
 		r := result
-		if r.Error != nil {
+		if err := r.Error; err != nil {
 			fmt.Fprintf(ctx.Stdout, "failed to collect metrics: %v\n", err)
 			resultChannel <- "invalid id"
 			continue


### PR DESCRIPTION
When the `collect-metrics` runner returns an error, it's not properly reported. This should fix that.

## QA steps

```sh
juju collect-metrics foo/234
```
The output should be:

```
failed to collect metrics: unit-foo-234 not found
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913063