### PR TITLE
Add golangci-lint config file, equivalent to the lint_go.sh configuration

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,8 @@
+[linters]
+disable-all = true
+enable = [
+    "govet", "goimports", "misspell", "unconvert", "ineffassign", "gofmt"
+]
+
+[issues]
+exclude = [ "composite" ]


### PR DESCRIPTION
This is to prevent IDEs configured to run golangci-lint on save, from
spewing hundreds of lint failures that the juju project doesn't care about.

This makes no functional changes to the linting done in CI; it only affects the running of `golangci-lint` locally, as is commonly configured in Go IDEs, such as VSCode, GoLand, etc.

## Bug reference

Relates to, but does not complete https://bugs.launchpad.net/juju/+bug/1912759