### PR TITLE
Charmhub expose extras

### DIFF
--- a/charmhub/transport/error.go
+++ b/charmhub/transport/error.go
@@ -11,8 +11,9 @@ import (
 
 // APIError represents the error from the CharmHub API.
 type APIError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    string        `json:"code"`
+	Message string        `json:"message"`
+	Extra   APIErrorExtra `json:"extra"`
 }
 
 // APIErrors represents a slice of APIError's
@@ -30,4 +31,11 @@ func (a APIErrors) Combine() error {
 		return errors.Errorf(strings.Join(combined, "\n"))
 	}
 	return nil
+}
+
+// APIErrorExtra defines additional extra payloads from a given error. Think
+// of this object as a series of suggestions to perform against the errorred
+// API request, in the chance of the new request being successful.
+type APIErrorExtra struct {
+	DefaultPlatforms []Platform `json:"default-platforms"`
 }

--- a/charmhub/transport/error_test.go
+++ b/charmhub/transport/error_test.go
@@ -4,6 +4,8 @@
 package transport
 
 import (
+	"encoding/json"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -43,4 +45,22 @@ func (ErrorSuite) TestWithMultipleErrors(c *gc.C) {
 	err := errors.Combine()
 	c.Assert(err, gc.ErrorMatches, `one
 two`)
+}
+
+func (ErrorSuite) TestExtras(c *gc.C) {
+	expected := APIError{
+		Extra: APIErrorExtra{
+			DefaultPlatforms: []Platform{
+				{Architecture: "amd64", OS: "ubuntu", Series: "focal "},
+			},
+		},
+	}
+	bytes, err := json.Marshal(expected)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var result APIError
+	err = json.Unmarshal(bytes, &result)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(result, gc.DeepEquals, expected)
 }


### PR DESCRIPTION
The following allows for partial refresh requests. This PR is laying out
the groundwork for changes to come for how we resolve charms from
the charmhub API.

The refresh requests will be supported by the charmhub API in that if 
you have a partial platform for OS and Series, passing NA for those will
return an error with suggestions about what is available. We can pass
those to the user when resolving the charm, but for now we won't expose
them in this PR.

The idea with the code is that we don't expose the NA to outside the
library, instead of a series or OS is empty, we then swap it out. This
ensures the purity of the client API.

## QA steps

Tests pass, nothing has changed for Juju internally.