### PR TITLE
Standardize a number of error messages and help text

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -589,24 +589,24 @@ func caasPrecheck(
 	if ch.Meta().Deployment != nil && ch.Meta().Deployment.DeploymentMode == charm.ModeOperator {
 		if !controllerCfg.Features().Contains(feature.K8sOperators) {
 			return errors.Errorf(
-				"feature flag %q is required for deploying k8s operator charms", feature.K8sOperators,
+				"feature flag %q is required for deploying container operator charms", feature.K8sOperators,
 			)
 		}
 	}
 	if len(args.AttachStorage) > 0 {
 		return errors.Errorf(
-			"AttachStorage may not be specified for k8s models",
+			"AttachStorage may not be specified for container models",
 		)
 	}
 	if len(args.Placement) > 1 {
 		return errors.Errorf(
-			"only 1 placement directive is supported for k8s models, got %d",
+			"only 1 placement directive is supported for container models, got %d",
 			len(args.Placement),
 		)
 	}
 	for _, s := range ch.Meta().Storage {
 		if s.Type == charm.StorageBlock {
-			return errors.Errorf("block storage %q is not supported for k8s charms", s.Name)
+			return errors.Errorf("block storage %q is not supported for container charms", s.Name)
 		}
 	}
 
@@ -1195,19 +1195,19 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 
 var (
 	deploymentInfoUpgradeMessage = `
-Juju on k8s does not support updating deployment info for services.
+Juju on containers does not support updating deployment info for services.
 The new charm's metadata contains updated deployment info.
 You'll need to deploy a new charm rather than upgrading if you need this change.
 `[1:]
 
 	storageUpgradeMessage = `
-k8s does not support updating storage on a statefulset.
+Juju on containers does not support updating storage on a statefulset.
 The new charm's metadata contains updated storage declarations.
 You'll need to deploy a new charm rather than upgrading if you need this change.
 `[1:]
 
 	devicesUpgradeMessage = `
-k8s does not support updating node selectors (configured from charm devices).
+Juju on containers does not support updating node selectors (configured from charm devices).
 The new charm's metadata contains updated device declarations.
 You'll need to deploy a new charm rather than upgrading if you need this change.
 `[1:]
@@ -1523,7 +1523,7 @@ func (api *APIBase) Expose(args params.ApplicationExpose) error {
 		}
 		if appConfig.GetString(caas.JujuExternalHostNameKey, "") == "" {
 			return errors.Errorf(
-				"cannot expose a k8s application without a %q value set, run\n"+
+				"cannot expose a container application without a %q value set, run\n"+
 					"juju config %s %s=<value>", caas.JujuExternalHostNameKey, args.ApplicationName, caas.JujuExternalHostNameKey)
 		}
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -340,7 +340,7 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 	})
 	c.Assert(err, gc.NotNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
-	c.Assert(msg, gc.Matches, "Juju on k8s does not support updating deployment info.*")
+	c.Assert(msg, gc.Matches, "Juju on containers does not support updating deployment info.*")
 }
 
 func (s *ApplicationSuite) TestDeployCAASOperatorProtectedByFlag(c *gc.C) {
@@ -366,7 +366,7 @@ func (s *ApplicationSuite) TestDeployCAASOperatorProtectedByFlag(c *gc.C) {
 	err = result.OneError()
 	c.Assert(err, gc.NotNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
-	c.Assert(msg, gc.Matches, `feature flag "k8s-operators" is required for deploying k8s operator charms`)
+	c.Assert(msg, gc.Matches, `feature flag "k8s-operators" is required for deploying container operator charms`)
 }
 
 func (s *ApplicationSuite) TestUpdateCAASApplicationSettings(c *gc.C) {
@@ -1019,8 +1019,8 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 	c.Assert(results.Results, gc.HasLen, 4)
 	c.Assert(results.Results[0].Error, gc.IsNil)
 	c.Assert(results.Results[1].Error, gc.IsNil)
-	c.Assert(results.Results[2].Error, gc.ErrorMatches, "AttachStorage may not be specified for k8s models")
-	c.Assert(results.Results[3].Error, gc.ErrorMatches, "only 1 placement directive is supported for k8s models, got 2")
+	c.Assert(results.Results[2].Error, gc.ErrorMatches, "AttachStorage may not be specified for container models")
+	c.Assert(results.Results[3].Error, gc.ErrorMatches, "only 1 placement directive is supported for container models, got 2")
 
 	c.Assert(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "NodeIP")
 	// Check parsing of k8s service annotations.
@@ -1049,7 +1049,7 @@ func (s *ApplicationSuite) TestDeployCAASBlockStorageRejected(c *gc.C) {
 	result, err := s.api.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.OneError(), gc.ErrorMatches, `block storage "block" is not supported for k8s charms`)
+	c.Assert(result.OneError(), gc.ErrorMatches, `block storage "block" is not supported for container charms`)
 }
 
 func (s *ApplicationSuite) TestDeployCAASModelNoOperatorStorage(c *gc.C) {
@@ -2079,7 +2079,7 @@ func (s *ApplicationSuite) TestCAASExposeWithoutHostname(c *gc.C) {
 		ApplicationName: "postgresql",
 	})
 	c.Assert(err, gc.ErrorMatches,
-		`cannot expose a k8s application without a "juju-external-hostname" value set, run\n`+
+		`cannot expose a container application without a "juju-external-hostname" value set, run\n`+
 			`juju config postgresql juju-external-hostname=<value>`)
 }
 

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -87,7 +87,7 @@ var caasModelFacadeNames = set.NewStrings(
 
 func caasModelFacadesOnly(facadeName, _ string) error {
 	if !isCAASModelFacade(facadeName) {
-		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported for a CAAS model API connection", facadeName))
+		return errors.NewNotSupported(nil, fmt.Sprintf("facade %q not supported on container models", facadeName))
 	}
 	return nil
 }

--- a/apiserver/restrict_caasmodel_test.go
+++ b/apiserver/restrict_caasmodel_test.go
@@ -32,7 +32,7 @@ func (s *RestrictCAASModelSuite) TestAllowed(c *gc.C) {
 
 func (s *RestrictCAASModelSuite) TestNotAllowed(c *gc.C) {
 	caller, err := s.root.FindMethod("Firewaller", 1, "WatchOpenedPorts")
-	c.Assert(err, gc.ErrorMatches, `facade "Firewaller" not supported for a CAAS model API connection`)
+	c.Assert(err, gc.ErrorMatches, `facade "Firewaller" not supported on container models`)
 	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
 	c.Assert(caller, gc.IsNil)
 }

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -179,5 +179,5 @@ func ValidateIaasController(c modelcmd.CommandBase, cmdName, controllerName stri
 	if details.ModelType == model.IAAS {
 		return nil
 	}
-	return errors.Errorf("Juju command %q not supported on k8s controllers", cmdName)
+	return errors.Errorf("Juju command %q not supported on container controllers", cmdName)
 }

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -584,7 +584,7 @@ func (w *modelCommandWrapper) validateCommandForModelType(runStarted bool) error
 		return nil
 	}
 	if modelType == model.CAAS && iaasOnly {
-		err = errors.Errorf("Juju command %q not supported on kubernetes models", w.Info().Name)
+		err = errors.Errorf("Juju command %q not supported on container models", w.Info().Name)
 	}
 	if modelType == model.IAAS && caasOnly {
 		err = errors.Errorf("Juju command %q not supported on non-container models", w.Info().Name)

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -328,7 +328,7 @@ func (s *ModelCommandSuite) TestIAASOnlyCommandCAASModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = runTestCommand(c, s.store)
-	c.Assert(err, gc.ErrorMatches, `Juju command "test-command" not supported on kubernetes models`)
+	c.Assert(err, gc.ErrorMatches, `Juju command "test-command" not supported on container models`)
 }
 
 func (s *ModelCommandSuite) TestCAASOnlyCommandIAASModel(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1057,7 +1057,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 				count = arg.Count
 			}
 			if charmStorage.CountMin > 0 || count > 0 {
-				return nil, errors.NotSupportedf("block storage on a Kubernetes model")
+				return nil, errors.NotSupportedf("block storage on a container model")
 			}
 		}
 	}

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -453,7 +453,7 @@ func (s *StorageStateSuite) TestBlockStorageNotSupportedOnCAAS(c *gc.C) {
 	ch := state.AddTestingCharmForSeries(c, st, "kubernetes", "storage-block")
 	_, err := st.AddApplication(state.AddApplicationArgs{
 		Name: "storage-block", Series: "kubernetes", Charm: ch})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "storage-block": block storage on a Kubernetes model not supported`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "storage-block": block storage on a container model not supported`)
 }
 
 func (s *StorageStateSuite) TestAddApplicationStorageConstraintsDefault(c *gc.C) {
@@ -737,7 +737,7 @@ func (s *StorageStateSuite) TestAllStorageInstancesEmpty(c *gc.C) {
 
 func (s *StorageStateSuite) TestUnitEnsureDead(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	s.provisionStorageVolume(c, u, storageTag)
@@ -767,7 +767,7 @@ func (s *StorageStateSuite) TestUnitEnsureDead(c *gc.C) {
 
 func (s *StorageStateSuite) TestUnitStorageProvisionerError(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	s.provisionStorageVolume(c, u, storageTag)
@@ -804,7 +804,7 @@ func (s *StorageStateSuite) TestUnitStorageProvisionerError(c *gc.C) {
 
 func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesDyingInstance(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
@@ -827,7 +827,7 @@ func (s *StorageStateSuite) TestRemoveStorageAttachmentsRemovesDyingInstance(c *
 
 func (s *StorageStateSuite) TestRemoveStorageAttachmentsDisownsUnitOwnedInstance(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "persistent-block")
 
@@ -1103,7 +1103,7 @@ func (s *StorageStateSuite) TestAddUnitAttachStorage(c *gc.C) {
 
 func (s *StorageStateSuite) TestConcurrentDestroyStorageInstanceRemoveStorageAttachmentsRemovesInstance(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := u.Destroy()
@@ -1126,7 +1126,7 @@ func (s *StorageStateSuite) TestConcurrentDestroyStorageInstanceRemoveStorageAtt
 
 func (s *StorageStateSuite) TestConcurrentRemoveStorageAttachment(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	s.provisionStorageVolume(c, u, storageTag)
@@ -1154,7 +1154,7 @@ func (s *StorageStateSuite) TestConcurrentRemoveStorageAttachment(c *gc.C) {
 
 func (s *StorageStateSuite) TestRemoveAliveStorageAttachmentError(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
@@ -1169,7 +1169,7 @@ func (s *StorageStateSuite) TestRemoveAliveStorageAttachmentError(c *gc.C) {
 
 func (s *StorageStateSuite) TestConcurrentDestroyInstanceRemoveStorageAttachmentsRemovesInstance(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := u.Destroy()
@@ -1194,7 +1194,7 @@ func (s *StorageStateSuite) TestConcurrentDestroyInstanceRemoveStorageAttachment
 
 func (s *StorageStateSuite) TestConcurrentDestroyStorageInstance(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	err := u.Destroy()
@@ -1221,7 +1221,7 @@ func (s *StorageStateSuite) TestDestroyStorageInstanceNotFound(c *gc.C) {
 
 func (s *StorageStateSuite) TestDestroyStorageInstanceAttachedError(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, _, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 
@@ -1256,7 +1256,7 @@ func (s *StorageStateSuite) TestWatchStorageAttachments(c *gc.C) {
 
 func (s *StorageStateSuite) TestWatchStorageAttachment(c *gc.C) {
 	if s.series == "kubernetes" {
-		c.Skip("volumes on kubernetes not supported")
+		c.Skip("volumes on containers not supported")
 	}
 	_, u, storageTag := s.setupSingleStorage(c, "block", "loop-pool")
 	// Assign the unit to a machine, and provision the attachment. This


### PR DESCRIPTION
This replaces the "too specific" k8s/kubernetes terminology, and potentially
cryptic "CAAS" term, with the more colloquial term "container".

## QA steps

On a k8s controller/model:

```sh
juju backups
juju machines
juju payloads
```
should each return an error message refering to "containers", not k8s/kubernetes/CAAS.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913065