### PR TITLE
Bug 1904619 -

### DIFF
--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -250,7 +250,6 @@ func (m MutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 	// Do not bother for the default or model profile.  We're not interested in non
 	// charm profiles.
 	if wrench.IsActive("instance-mutater", "disable-apply-lxdprofile") && len(expectedProfiles) > 1 {
-
 		m.logger.Warningf("waiting 3 minutes to apply lxd profiles %q due to wrench in the works", strings.Join(expectedProfiles, ", "))
 		select {
 		case <-clock.WallClock.After(3 * time.Minute):
@@ -290,7 +289,9 @@ func (m MutaterMachine) gatherProfileData(info *instancemutater.UnitProfileInfo)
 		add := lxdprofile.ProfilePost{Name: name}
 		// should not happen, but you never know.
 		if !pu.Profile.Empty() {
-			add.Profile = &pu.Profile
+			// We make a copy since the loop var keeps the same pointer.
+			p := pu.Profile
+			add.Profile = &p
 		}
 		result = append(result, add)
 	}

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -156,6 +156,14 @@ func (s *mutaterSuite) info(profiles []string, rev int, add bool) *apiinstancemu
 			{ApplicationName: "lxd-profile",
 				Revision: rev,
 			},
+			// app-no-profile tests the fix for lp:1904619,
+			// use a pointer to a copy of data in for loop,
+			// rather than a pointer to the data as the data
+			// will change in subsequent loop iterations, but
+			// the pointer's address will not.
+			{ApplicationName: "app-no-profile",
+				Revision: rev,
+			},
 		},
 	}
 	if add {


### PR DESCRIPTION

Fix programming error by getting a pointer to a copy of the data in the for loop rather than the data, as the pointer will be contents overwritten, potentially by empty data, in subsequent trip through the loop.

## QA steps

```console
$ cat bundle.yaml
series: bionic
applications:
  containerd:
    charm: cs:~containers/containerd-100
  flannel:
    charm: cs:~containers/flannel-514
  kubernetes-master:
    charm: cs:~containers/kubernetes-master-865
    num_units: 1
    to:
    - "0"
machines:
  "0": {}
relations:
- - flannel:cni
  - kubernetes-master:cni
- - kubernetes-master:container-runtime
  - containerd:containerd

$ juju bootstrap localhost testme
$ juju deploy ./bundle.yaml
# wait for the subordinates to be installed on the machine, this bundle will not turn green and that's okay for purposes of this test.
$ juju upgrade-charm kubernetes-master
Looking up metadata for charm cs:~containers/kubernetes-master (channel: stable)
Added charm "cs:~containers/kubernetes-master-926" to the model.
Adding endpoint "dns-provider" to default space "alpha"
Leaving endpoints in "alpha": aws, aws-iam, azure, ceph-client, ceph-storage, certificates, cluster-dns, cni, container-runtime, coordinator, etcd, gcp, grafana, ha, keystone-credentials, kube-api-endpoint, kube-control, kube-masters, loadbalancer, nrpe-external-master, openstack, prometheus, vault-kv, vsphere

# version that this profile has config and device contents.
$ lxc profile show juju-default-kubernetes-master-926

```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1904619
