### PR TITLE
Make `coreos/go-systemd' buildable on windows

### DIFF
--- a/service/systemd/service.go
+++ b/service/systemd/service.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/dbus"
-	"github.com/coreos/go-systemd/v22/util"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v2/shell"
@@ -30,11 +29,6 @@ var (
 	renderer = shell.BashRenderer{}
 	cmds     = commands{renderer, executable}
 )
-
-// IsRunning returns whether or not systemd is the local init system.
-func IsRunning() bool {
-	return util.IsRunningSystemd()
-}
 
 // ListServices returns the list of installed service names.
 func ListServices() ([]string, error) {

--- a/service/systemd/service_unix.go
+++ b/service/systemd/service_unix.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package systemd
+
+import (
+	"github.com/coreos/go-systemd/v22/util"
+)
+
+// IsRunning returns whether or not systemd is the local init system.
+func IsRunning() bool {
+	return util.IsRunningSystemd()
+}

--- a/service/systemd/service_windows.go
+++ b/service/systemd/service_windows.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package systemd
+
+func IsRunning() bool {
+	return false
+}


### PR DESCRIPTION
Fixes https://discourse.charmhub.io/t/building-juju-2-5-0-on-windows/549

## `coreos/go-systemd'
Not all of the parts of systemd is buildable on windows, there is currently
a PR open for it - https://github.com/coreos/go-systemd/pull/352. But even
with these changes our tests couldn't build the test suits. Since we are using
`github.com/coreos/go-systemd/v22/util` which tries to include some os specific binary files.

Solution is to exclude problematic modules on window build via comment tags

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

