### PR TITLE
Upgrade internal ingress API calls to v1;

### DIFF
--- a/caas/kubernetes/provider/admissionregistration.go
+++ b/caas/kubernetes/provider/admissionregistration.go
@@ -13,7 +13,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
@@ -108,7 +107,7 @@ func (k *kubernetesClient) ensureMutatingWebhookConfigurationV1(cfg *admissionre
 	existingItems, err := api.List(context.TODO(), metav1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(cfg.GetLabels()).String(),
 	})
-	if k8serrors.IsNotFound(err) || len(existingItems.Items) == 0 {
+	if k8serrors.IsNotFound(err) || existingItems == nil || len(existingItems.Items) == 0 {
 		// cfg.Name is already used for an existing MutatingWebhookConfiguration.
 		return cleanUp, errors.AlreadyExistsf("MutatingWebhookConfiguration %q", cfg.GetName())
 	}
@@ -135,74 +134,43 @@ func (k *kubernetesClient) EnsureMutatingWebhookConfiguration(cfg *admissionregi
 // nil.
 func (k *kubernetesClient) ensureMutatingWebhookConfigurationV1beta1(cfg *admissionregistrationv1beta1.MutatingWebhookConfiguration) (func(), error) {
 	cleanUp := func() {}
-	out, err := k.createMutatingWebhookConfiguration(cfg)
+	api := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
+	out, err := api.Create(context.TODO(), cfg, metav1.CreateOptions{})
 	if err == nil {
 		logger.Debugf("MutatingWebhookConfiguration %q created", out.GetName())
-		cleanUp = func() { _ = k.deleteMutatingWebhookConfiguration(out.GetName(), out.GetUID()) }
+		cleanUp = func() {
+			_ = api.Delete(context.TODO(), out.GetName(), utils.NewPreconditionDeleteOptions(out.GetUID()))
+		}
 		return cleanUp, nil
 	}
-	if !errors.IsAlreadyExists(err) {
+	if !k8serrors.IsAlreadyExists(err) {
 		return cleanUp, errors.Trace(err)
 	}
-	_, err = k.listMutatingWebhookConfigurations(utils.LabelsToSelector(cfg.GetLabels()))
+	existingItems, err := api.List(context.TODO(), metav1.ListOptions{
+		LabelSelector: utils.LabelsToSelector(cfg.GetLabels()).String(),
+	})
+	if k8serrors.IsNotFound(err) || existingItems == nil || len(existingItems.Items) == 0 {
+		// cfg.Name is already used for an existing MutatingWebhookConfiguration.
+		return cleanUp, errors.AlreadyExistsf("MutatingWebhookConfiguration %q", cfg.GetName())
+	}
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// cfg.Name is already used for an existing MutatingWebhookConfiguration.
-			return cleanUp, errors.AlreadyExistsf("MutatingWebhookConfiguration %q", cfg.GetName())
-		}
 		return cleanUp, errors.Trace(err)
 	}
-	existingCfg, err := k.getMutatingWebhookConfiguration(cfg.GetName())
+	existingCfg, err := api.Get(context.TODO(), cfg.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return cleanUp, errors.Trace(err)
 	}
 	cfg.SetResourceVersion(existingCfg.GetResourceVersion())
-	err = k.updateMutatingWebhookConfiguration(cfg)
+	_, err = api.Update(context.TODO(), cfg, metav1.UpdateOptions{})
 	logger.Debugf("updating MutatingWebhookConfiguration %q", cfg.GetName())
 	return cleanUp, errors.Trace(err)
 }
 
-func (k *kubernetesClient) createMutatingWebhookConfiguration(cfg *admissionregistrationv1beta1.MutatingWebhookConfiguration) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error) {
-	utils.PurifyResource(cfg)
-	out, err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.TODO(), cfg, metav1.CreateOptions{})
-	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("MutatingWebhookConfiguration %q", cfg.GetName())
-	}
-	return out, errors.Trace(err)
-}
-
-func (k *kubernetesClient) getMutatingWebhookConfiguration(name string) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error) {
-	cfg, err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, errors.NotFoundf("MutatingWebhookConfiguration %q", name)
-		}
-		return nil, errors.Trace(err)
-	}
-	return cfg, nil
-}
-
-func (k *kubernetesClient) updateMutatingWebhookConfiguration(cfg *admissionregistrationv1beta1.MutatingWebhookConfiguration) error {
-	_, err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(context.TODO(), cfg, metav1.UpdateOptions{})
-	if k8serrors.IsNotFound(err) {
-		return errors.NotFoundf("MutatingWebhookConfiguration %q", cfg.GetName())
-	}
-	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) deleteMutatingWebhookConfiguration(name string, uid types.UID) error {
-	err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
-	if k8serrors.IsNotFound(err) {
-		return nil
-	}
-	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) listMutatingWebhookConfigurations(selector k8slabels.Selector) ([]admissionregistrationv1beta1.MutatingWebhookConfiguration, error) {
+func (k *kubernetesClient) listMutatingWebhookConfigurations(selector k8slabels.Selector) ([]admissionregistrationv1.MutatingWebhookConfiguration, error) {
 	listOps := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
-	cfgList, err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.TODO(), listOps)
+	cfgList, err := k.client().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.TODO(), listOps)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -213,7 +181,7 @@ func (k *kubernetesClient) listMutatingWebhookConfigurations(selector k8slabels.
 }
 
 func (k *kubernetesClient) deleteMutatingWebhookConfigurations(selector k8slabels.Selector) error {
-	err := k.client().AdmissionregistrationV1beta1().MutatingWebhookConfigurations().DeleteCollection(context.TODO(), metav1.DeleteOptions{
+	err := k.client().AdmissionregistrationV1().MutatingWebhookConfigurations().DeleteCollection(context.TODO(), metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, metav1.ListOptions{
 		LabelSelector: selector.String(),
@@ -356,47 +324,11 @@ func (k *kubernetesClient) ensureValidatingWebhookConfigurationV1beta1(cfg *admi
 	return cleanUp, errors.Trace(err)
 }
 
-func (k *kubernetesClient) createValidatingWebhookConfiguration(cfg *admissionregistrationv1beta1.ValidatingWebhookConfiguration) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
-	utils.PurifyResource(cfg)
-	out, err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(context.TODO(), cfg, metav1.CreateOptions{})
-	if k8serrors.IsAlreadyExists(err) {
-		return nil, errors.AlreadyExistsf("ValidatingWebhookConfiguration %q", cfg.GetName())
-	}
-	return out, errors.Trace(err)
-}
-
-func (k *kubernetesClient) getValidatingWebhookConfiguration(name string) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
-	cfg, err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, errors.NotFoundf("ValidatingWebhookConfiguration %q", name)
-		}
-		return nil, errors.Trace(err)
-	}
-	return cfg, nil
-}
-
-func (k *kubernetesClient) updateValidatingWebhookConfiguration(cfg *admissionregistrationv1beta1.ValidatingWebhookConfiguration) error {
-	_, err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(context.TODO(), cfg, metav1.UpdateOptions{})
-	if k8serrors.IsNotFound(err) {
-		return errors.NotFoundf("ValidatingWebhookConfiguration %q", cfg.GetName())
-	}
-	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) deleteValidatingWebhookConfiguration(name string, uid types.UID) error {
-	err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
-	if k8serrors.IsNotFound(err) {
-		return nil
-	}
-	return errors.Trace(err)
-}
-
-func (k *kubernetesClient) listValidatingWebhookConfigurations(selector k8slabels.Selector) ([]admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
+func (k *kubernetesClient) listValidatingWebhookConfigurations(selector k8slabels.Selector) ([]admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 	listOps := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
-	cfgList, err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(context.TODO(), listOps)
+	cfgList, err := k.client().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), listOps)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -407,7 +339,7 @@ func (k *kubernetesClient) listValidatingWebhookConfigurations(selector k8slabel
 }
 
 func (k *kubernetesClient) deleteValidatingWebhookConfigurations(selector k8slabels.Selector) error {
-	err := k.client().AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().DeleteCollection(context.TODO(), metav1.DeleteOptions{
+	err := k.client().AdmissionregistrationV1().ValidatingWebhookConfigurations().DeleteCollection(context.TODO(), metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, metav1.ListOptions{
 		LabelSelector: selector.String(),

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -139,14 +139,6 @@ func (k *kubernetesClient) ensureCustomResourceDefinitionV1(
 	return out, cleanUps, errors.Trace(err)
 }
 
-func (k *kubernetesClient) deleteCustomResourceDefinition(name string, uid types.UID) error {
-	err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
-	if k8serrors.IsNotFound(err) {
-		return nil
-	}
-	return errors.Trace(err)
-}
-
 func (k *kubernetesClient) getCustomResourceDefinition(name string) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	crd, err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
@@ -155,11 +147,11 @@ func (k *kubernetesClient) getCustomResourceDefinition(name string) (*apiextensi
 	return crd, errors.Trace(err)
 }
 
-func (k *kubernetesClient) listCustomResourceDefinitions(selector k8slabels.Selector) ([]apiextensionsv1beta1.CustomResourceDefinition, error) {
+func (k *kubernetesClient) listCustomResourceDefinitions(selector k8slabels.Selector) ([]apiextensionsv1.CustomResourceDefinition, error) {
 	listOps := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
-	list, err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), listOps)
+	list, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), listOps)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -178,7 +170,7 @@ func (k *kubernetesClient) deleteCustomResourceDefinitionsForApp(appName string)
 }
 
 func (k *kubernetesClient) deleteCustomResourceDefinitions(selector k8slabels.Selector) error {
-	err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().DeleteCollection(context.TODO(), metav1.DeleteOptions{
+	err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().DeleteCollection(context.TODO(), metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, metav1.ListOptions{
 		LabelSelector: selector.String(),

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -80,6 +80,7 @@ func (k *kubernetesClient) ensureIngressV1beta1(appName string, spec *networking
 	if !k8serrors.IsAlreadyExists(err) {
 		return cleanUp, errors.Trace(err)
 	}
+
 	if !force {
 		existing, err := api.Get(context.TODO(), spec.GetName(), metav1.GetOptions{})
 		if err != nil {
@@ -106,6 +107,7 @@ func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.In
 	if !k8serrors.IsAlreadyExists(err) {
 		return cleanUp, errors.Trace(err)
 	}
+
 	if !force {
 		existing, err := api.Get(context.TODO(), spec.GetName(), metav1.GetOptions{})
 		if err != nil {

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -120,7 +120,7 @@ func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.In
 }
 
 func (k *kubernetesClient) deleteIngress(name string, uid k8stypes.UID) error {
-	err := k.client().NetworkingV1beta1().Ingresses(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
+	err := k.client().NetworkingV1().Ingresses(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -128,7 +128,7 @@ func (k *kubernetesClient) deleteIngress(name string, uid k8stypes.UID) error {
 }
 
 func (k *kubernetesClient) deleteIngressResources(appName string) error {
-	err := k.client().NetworkingV1beta1().Ingresses(k.namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{
+	err := k.client().NetworkingV1().Ingresses(k.namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, metav1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(k.getIngressLabels(appName)).String(),

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -7520,7 +7520,7 @@ func (s *K8sBrokerSuite) TestExposeServiceIngressClassProvided(c *gc.C) {
 			},
 		},
 	}
-
+	pathType := networkingv1.PathTypePrefix
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "gitlab",
@@ -7539,7 +7539,8 @@ func (s *K8sBrokerSuite) TestExposeServiceIngressClassProvided(c *gc.C) {
 				IngressRuleValue: networkingv1.IngressRuleValue{
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{
-							Path: "/",
+							Path:     "/",
+							PathType: &pathType,
 							Backend: networkingv1.IngressBackend{
 								Service: &networkingv1.IngressServiceBackend{
 									Name: "gitlab",
@@ -7593,6 +7594,7 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClassFromResource(c *
 		},
 	}
 
+	pathType := networkingv1.PathTypeImplementationSpecific
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "gitlab",
@@ -7611,7 +7613,8 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClassFromResource(c *
 				IngressRuleValue: networkingv1.IngressRuleValue{
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{
-							Path: "/",
+							Path:     "/",
+							PathType: &pathType,
 							Backend: networkingv1.IngressBackend{
 								Service: &networkingv1.IngressServiceBackend{
 									Name: "gitlab",
@@ -7675,6 +7678,7 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClass(c *gc.C) {
 		},
 	}
 
+	pathType := networkingv1.PathTypePrefix
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "gitlab",
@@ -7693,7 +7697,8 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClass(c *gc.C) {
 				IngressRuleValue: networkingv1.IngressRuleValue{
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{{
-							Path: "/",
+							Path:     "/",
+							PathType: &pathType,
 							Backend: networkingv1.IngressBackend{
 								Service: &networkingv1.IngressServiceBackend{
 									Name: "gitlab",

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/juju/version"
 	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1647,32 +1648,32 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 	)
 
 	// timer +1.
-	s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{
+	s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{
 		LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test",
 	}).AnyTimes().
-		Return(&apiextensionsv1beta1.CustomResourceDefinitionList{}, nil).
+		Return(&apiextensionsv1.CustomResourceDefinitionList{}, nil).
 		After(
-			s.mockCustomResourceDefinitionV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+			s.mockCustomResourceDefinitionV1.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
 				v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockMutatingWebhookConfigurationV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
-		Return(&admissionregistrationv1beta1.MutatingWebhookConfigurationList{}, nil).
+	s.mockMutatingWebhookConfigurationV1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
+		Return(&admissionregistrationv1.MutatingWebhookConfigurationList{}, nil).
 		After(
-			s.mockMutatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+			s.mockMutatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
 				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockValidatingWebhookConfigurationV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
-		Return(&admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}, nil).
+	s.mockValidatingWebhookConfigurationV1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
+		Return(&admissionregistrationv1.ValidatingWebhookConfigurationList{}, nil).
 		After(
-			s.mockValidatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+			s.mockValidatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
 				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
@@ -1985,19 +1986,19 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 		).Return(nil),
 
 		// delete all custom resource definitions.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+		s.mockCustomResourceDefinitionV1.EXPECT().DeleteCollection(gomock.Any(),
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
 			v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=test,juju-resource-lifecycle notin (model,persistent),model.juju.is/name=test"},
 		).Return(nil),
 
 		// delete all mutating webhook configurations.
-		s.mockMutatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+		s.mockMutatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
 			v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=test,model.juju.is/name=test"},
 		).Return(nil),
 
 		// delete all validating webhook configurations.
-		s.mockValidatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+		s.mockValidatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 			s.deleteOptions(v1.DeletePropagationForeground, ""),
 			v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=test,model.juju.is/name=test"},
 		).Return(nil),

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -13,10 +13,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -225,30 +226,30 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	)
 
 	// timer +1.
-	s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"}).AnyTimes().
-		Return(&apiextensionsv1beta1.CustomResourceDefinitionList{}, nil).
+	s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"}).AnyTimes().
+		Return(&apiextensionsv1.CustomResourceDefinitionList{}, nil).
 		After(
-			s.mockCustomResourceDefinitionV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+			s.mockCustomResourceDefinitionV1.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
 				v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockMutatingWebhookConfigurationV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
-		Return(&admissionregistrationv1beta1.MutatingWebhookConfigurationList{}, nil).
+	s.mockMutatingWebhookConfigurationV1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
+		Return(&admissionregistrationv1.MutatingWebhookConfigurationList{}, nil).
 		After(
-			s.mockMutatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+			s.mockMutatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
 				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
 		)
 
 	// timer +1.
-	s.mockValidatingWebhookConfigurationV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
-		Return(&admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}, nil).
+	s.mockValidatingWebhookConfigurationV1.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=test"}).
+		Return(&admissionregistrationv1.ValidatingWebhookConfigurationList{}, nil).
 		After(
-			s.mockValidatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+			s.mockValidatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 				s.deleteOptions(v1.DeletePropagationForeground, ""),
 				v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 			).Return(s.k8sNotFoundError()),
@@ -447,17 +448,17 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
 	)
 
-	s.mockCustomResourceDefinitionV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+	s.mockCustomResourceDefinitionV1.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
 		v1.ListOptions{LabelSelector: "juju-resource-lifecycle notin (persistent),model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
-	s.mockMutatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+	s.mockMutatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
 		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())
 
-	s.mockValidatingWebhookConfigurationV1Beta1.EXPECT().DeleteCollection(gomock.Any(),
+	s.mockValidatingWebhookConfigurationV1.EXPECT().DeleteCollection(gomock.Any(),
 		s.deleteOptions(v1.DeletePropagationForeground, ""),
 		v1.ListOptions{LabelSelector: "model.juju.is/name=test"},
 	).Return(s.k8sNotFoundError())


### PR DESCRIPTION
*Upgrade internal ingress API calls to v1;*

Driveby fix: 
- Upgrade internal CRD and webhooks API calls to v1;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju deploy cs:~juju/mariadb-k8s-3
$ juju deploy cs:~juju/mediawiki-k8s-4 --config juju-external-hostname=172.16.104.2.xip.io
$ juju relate mediawiki-k8s:db mariadb-k8s:server
$ juju expose mediawiki-k8s
$ mkubectl get ing -nt1 mediawiki-k8s -o yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    ingress.kubernetes.io/rewrite-target: ""
    ingress.kubernetes.io/ssl-passthrough: "false"
    ingress.kubernetes.io/ssl-redirect: "false"
    kubernetes.io/ingress.allow-http: "false"
  creationTimestamp: "2021-01-28T04:03:06Z"
  generation: 1
  labels:
    app.kubernetes.io/managed-by: juju
    app.kubernetes.io/name: mediawiki-k8s
    juju-controller-uuid: 9b96268b-2f5f-4a0b-8b5b-64f381846e15
    juju-model-uuid: 0520eed6-ba7d-4646-8d45-e780c4682a01
  name: mediawiki-k8s
  namespace: t1
  resourceVersion: "2180057"
  selfLink: /apis/networking.k8s.io/v1/namespaces/t1/ingresses/mediawiki-k8s
  uid: 9b021114-7656-47d8-a6ba-198e6a66402b
spec:
  ingressClassName: public
  rules:
  - host: 172.16.104.2.xip.io
    http:
      paths:
      - backend:
          service:
            name: mediawiki-k8s
            port:
              number: 80
        path: /
        pathType: ImplementationSpecific
status:
  loadBalancer:
    ingress:
    - ip: 127.0.0.1

$ juju remove-application mariadb-k8s -m k1:t1 --destroy-storage --force
$ juju remove-application mediawiki-k8s -m k1:t1 --destroy-storage --force
$ mkubectl get ing -nt1
No resources found in t1 namespace.
```

## Documentation changes

No

## Bug reference

No
