### PR TITLE
Shut down agent when unit is not found

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -73,6 +73,11 @@ func (u *Unit) Refresh() error {
 	}
 	result := results.Results[0]
 	if result.Error != nil {
+		// We should be able to use apiserver.common.RestoreError here,
+		// but because of poor design, it causes import errors.
+		if params.IsCodeNotFound(result.Error) {
+			return errors.NewNotFound(result.Error, "")
+		}
 		return errors.Trace(result.Error)
 	}
 

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -178,7 +178,8 @@ func (u *Upgrader) loop() error {
 		logger.Debugf("%s requested for %v from %v to %v", direction, u.tag, jujuversion.Current, wantVersion)
 		err = u.operatorUpgrader.Upgrade(u.tag.String(), wantVersion)
 		if err != nil {
-			return errors.Annotatef(err, "requesting upgrade for %v from %v to %v", u.tag, jujuversion.Current, wantVersion)
+			return errors.Annotatef(
+				err, "requesting upgrade for %v from %v to %v", u.tag.String(), jujuversion.Current, wantVersion)
 		}
 	}
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -673,6 +673,11 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return errors.Errorf("unknown model type %q", u.modelType)
 	}
 
+	// If we started up already dead, we should not progress further.
+	// If we become Dead immediately after starting up, we may well
+	// complete any operations in progress before detecting it,
+	// but that race is fundamental and inescapable,
+	// whereas this one is not.
 	u.unit, err = u.st.Unit(unitTag)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -681,11 +686,6 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 		return errors.Trace(err)
 	}
 	if u.unit.Life() == life.Dead {
-		// If we started up already dead, we should not progress further.
-		// If we become Dead immediately after starting up, we may well
-		// complete any operations in progress before detecting it,
-		// but that race is fundamental and inescapable,
-		// whereas this one is not.
 		return u.stopUnitError()
 	}
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -672,21 +672,27 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	default:
 		return errors.Errorf("unknown model type %q", u.modelType)
 	}
+
 	u.unit, err = u.st.Unit(unitTag)
 	if err != nil {
-		return err
+		if errors.IsNotFound(err) {
+			return u.stopUnitError()
+		}
+		return errors.Trace(err)
 	}
 	if u.unit.Life() == life.Dead {
-		// If we started up already dead, we should not progress further. If we
-		// become Dead immediately after starting up, we may well complete any
-		// operations in progress before detecting it; but that race is fundamental
-		// and inescapable, whereas this one is not.
+		// If we started up already dead, we should not progress further.
+		// If we become Dead immediately after starting up, we may well
+		// complete any operations in progress before detecting it,
+		// but that race is fundamental and inescapable,
+		// whereas this one is not.
 		return u.stopUnitError()
 	}
+
 	// If initialising for the first time after deploying, update the status.
 	currentStatus, err := u.unit.UnitStatus()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	// TODO(fwereade/wallyworld): we should have an explicit place in the model
 	// to tell us when we've hit this point, instead of piggybacking on top of

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
@@ -136,6 +137,15 @@ func (s *UniterSuite) TestUniterStartup(c *gc.C) {
 			createApplicationAndUnit{applicationName: "w"},
 			startUniter{unitTag: "unit-u-0"},
 			waitUniterDead{err: `failed to initialize uniter for "unit-u-0": permission denied`},
+		),
+		ut(
+			"unit not found",
+			createCharm{},
+			createApplicationAndUnit{},
+			// Remove the unit after the API login.
+			deleteUnit{},
+			startUniter{},
+			waitUniterDead{err: worker.ErrTerminateAgent.Error()},
 		),
 	})
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -404,6 +404,12 @@ func (csau createApplicationAndUnit) step(c *gc.C, ctx *context) {
 	ctx.apiLogin(c)
 }
 
+type deleteUnit struct{}
+
+func (d deleteUnit) step(c *gc.C, ctx *context) {
+	ctx.unit.DestroyWithForce(true, time.Duration(0))
+}
+
 type createUniter struct {
 	minion               bool
 	executorFunc         uniter.NewOperationExecutorFunc
@@ -556,6 +562,7 @@ type waitUniterDead struct {
 func (s waitUniterDead) step(c *gc.C, ctx *context) {
 	if s.err != "" {
 		err := s.waitDead(c, ctx)
+		c.Log(errors.ErrorStack(err))
 		c.Assert(err, gc.ErrorMatches, s.err)
 		return
 	}


### PR DESCRIPTION
This patch expedites the termination of the unit agent, when its unit is removed from state.

Previously, this condition was not surfaced as an error telling the agent to terminate, so there was potentially a restart before the condition was assessed resulting in shutdown.

The uniter now returns the same error as when the unit's `Life` indicates that it is `dead`.

## QA steps

- Deploy a unit, add a unit, remove a unit. 
- We should quiesce quite quickly without errors.

## Documentation changes

None.

## Bug reference

N/A
