### PR TITLE
Run MacOS Tests

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -15,7 +15,7 @@ jobs:
         # other clients.
         # To turn on macOS, just update the os to include it.
         # os: [ubuntu-latest, macOS-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
 
@@ -41,17 +41,6 @@ jobs:
 
         make install-mongo-dependencies
 
-    - name: "Install Mongo Dependencies: macOS-latest"
-      if: (matrix.os == 'macOS-latest')
-      run: |
-        curl -o mongodb-3.6.14.tgz https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.6.14.tgz
-        tar xzvf mongodb-3.6.14.tgz
-        sudo mkdir -p /usr/local/mongodb
-        sudo mv mongodb-osx-x86_64-3.6.14/bin/* /usr/local/mongodb
-        sudo mkdir -p /user/local/bin
-        sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod
-      shell: bash
-
     - name: "Remove Mongo Dependencies: windows-latest"
       if: (matrix.os == 'windows-latest')
       uses: crazy-max/ghaction-chocolatey@v1
@@ -62,10 +51,36 @@ jobs:
       if: (matrix.os == 'windows-latest')
       uses: crazy-max/ghaction-chocolatey@v1
       with:
-        args: install mongodb.install --version=3.6.0 --allow-downgrade
+        args: install mongodb.install --version=4.0.21 --allow-downgrade
 
-    - name: Test client
+    # GitHub runners already have preinstalled version of mongodb, but
+    # we specifically need 4.0.21, otherwise our tests will not pass
+    - name: "Install Mongo Dependencies: macOS-latest"
+      if: (matrix.os == 'macOS-latest')
+      run: |
+        curl -o mongodb-4.0.21.tgz https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.21.tgz
+        tar xzvf mongodb-4.0.21.tgz
+        sudo rm -rf /usr/local/mongodb
+        sudo mkdir -p /usr/local/mongodb
+        sudo mv mongodb-osx-x86_64-4.0.21/bin/* /usr/local/mongodb
+        sudo mkdir -p /usr/local/bin
+        sudo rm /usr/local/bin/mongod
+        sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod
+      shell: bash
+
+    - name: "Test client: macOS-latest"
+      if: (matrix.os == 'macOS-latest')
+      run: |
+        # There is a concurrency issue with macos setup for the "./cmd/juju/..." packages.
+        # So we have to limit amount of used CPUs and therefore parallelization
+        go test -v -p 1 ./cmd/juju/... -check.v
+        go test -v  ./cmd/plugins/... -check.v
+      shell: bash
+
+    - name: "Test client: ubuntu-latest"
+      if: (matrix.os == 'ubuntu-latest')
       run: |
         # Jenkins can perform the full jujud testing.
         go test -v ./cmd/juju/... -check.v
         go test -v ./cmd/plugins/... -check.v
+      shell: bash

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ TEST_TIMEOUT:=$(TEST_TIMEOUT)
 ifeq ($(shell echo "${GOARCH}" | sed -E 's/.*(s390x).*/golang/'), golang)
 	TEST_ARGS := -p 4
 else
-	TEST_ARGS := 
+	TEST_ARGS :=
 endif
 
 # Enable verbose testing for reporting.
@@ -55,11 +55,11 @@ GIT_TREE_STATE = $(if $(shell git -C $(PROJECT_DIR) rev-parse --is-inside-work-t
 
 # Build tags passed to go install/build.
 # Example: BUILD_TAGS="minimal provider_kubernetes"
-BUILD_TAGS ?= 
+BUILD_TAGS ?=
 
 # Build number passed in must be a monotonic int representing
 # the build.
-JUJU_BUILD_NUMBER ?= 
+JUJU_BUILD_NUMBER ?=
 
 # Build flag passed to go -mod
 # CI should set this to vendor
@@ -118,7 +118,7 @@ test: run-tests
 # Can't make the length of the TMP dir too long or it hits socket name length issues.
 run-tests:
 ## run-tests: Run the unit tests
-	$(eval TMP := $(shell mktemp -d jj-XXX --tmpdir))
+	$(eval TMP := $(shell mktemp -d $${TMPDIR:-/tmp}/jj-XXX))
 	$(eval TEST_PACKAGES := $(shell go list $(PROJECT)/... | grep -v $(PROJECT)$$ | grep -v $(PROJECT)/vendor/ | grep -v $(PROJECT)/acceptancetests/ | grep -v $(PROJECT)/generate/ | grep -v mocks))
 	@echo 'go test -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES -check.v'
 	@TMPDIR=$(TMP) go test -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES) -check.v
@@ -268,7 +268,7 @@ local-operator-update: check-k8s-model operator-image
 	$(foreach wm,$(kubeworkers), juju scp -m ${JUJU_K8S_MODEL} ${DOCKER_STAGING_DIR}/jujud-operator-image.tar.gz $(wm):/tmp/jujud-operator-image.tar.gz ; )
 	$(foreach wm,$(kubeworkers), juju ssh -m ${JUJU_K8S_MODEL} $(wm) -- "zcat /tmp/jujud-operator-image.tar.gz | docker load" ; )
 
-STATIC_ANALYSIS_JOB ?= 
+STATIC_ANALYSIS_JOB ?=
 
 static-analysis:
 ## static-analysis: Check the go code using static-analysis

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -37,7 +37,18 @@ func (suite *PluginSuite) SetUpTest(c *gc.C) {
 	}
 	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	suite.oldPath = os.Getenv("PATH")
-	os.Setenv("PATH", "/bin:"+gitjujutesting.HomePath())
+
+	// We have to be careful to leave the default cmds that we need for tests
+	// like "touch" (which its in /usr/bin on mac but in /bin on linux).
+	// We doings this, because we need to add "binaries" from the tmp dir and reduce
+	// tests execution, since we are looking into all paths in $PATH to find juju plugins
+	path := "/bin:%s"
+	if runtime.GOOS == "darwin" {
+		path = "/bin:/usr/bin:%s"
+	}
+
+	os.Setenv("PATH", fmt.Sprintf(path, gitjujutesting.HomePath()))
+
 	jujuclienttesting.SetupMinimalFileStore(c)
 }
 


### PR DESCRIPTION
There was four types of issues for running tests on macos.

## Makefile

On macos syntax of the command `mktemp` is a bit different, it doesn't have
the `--tmpdir` argument on macos it just creates a directory `--tmpdir` in
the source path and bunch of other temporary directories. This complecates the
development and confuses the tests.

> makefile: remove deadspace
> makefile: make creation of temp dir cross os

## Plugin Tests

Plugin code checks every path on the `$PATH` list in order to
find addtional plugins. In tests it reduces the amount of paths
by temporary editing the `$PATH` list leaving  only temp dir and `/bin` folder.
Assuming that the bash commands used inside the tests are present on the target
system. Like `touch` for example, but in newer macos systems, some of the
commands are present inside `/usr/bin` path

> tests: carefully edit `$PATH` variable in tests, so it would be cross OS

## CI Configuration

There was minor issues with macos preparation instructions. Like putting
mongo on incorrect path `/user/...` instead of `/usr/...` and assuming that
GitHub runners are doesn't have mongodb installed.

> ci: correct macos preparation instructions

`go test` Parallization Issues

There is several tests that used mongodb concurrently,
at least "cmd/application" and "juju/commands". Presumably operationg on the
same set of data and/or their structure. It makes the tests execution a little
bit slower on macos environment. Have not invisitigated why this doesn't happen
on ubuntu. Perhaps amount of CPUs already limited or because Go differently
works with parallization on Linux machines

> ci: limit amount of available CPUs to one for macos setup
