### PR TITLE
[2.9] Migrate acceptance tests to python3

### DIFF
--- a/acceptancetests/Makefile
+++ b/acceptancetests/Makefile
@@ -24,8 +24,8 @@ test:
 	TMPDIR=/tmp python -m unittest discover . -p "$(p)"
 	TMPDIR=/tmp python3 -W ignore::DeprecationWarning -m unittest discover jujupy -t . -p "$(p)"
 lint:
-	python3 -m flake8 --ignore=$(flake8_ignore) --builtins xrange,basestring $(py3) --exclude=repository $(mkfile_dir)
-	flake8 --ignore=$(flake8_ignore) --builtins xrange,basestring --exclude=$(py3),repository $(mkfile_dir)
+	python3 -m flake8 --ignore=$(flake8_ignore) --builtins xrange $(py3) --exclude=repository $(mkfile_dir)
+	flake8 --ignore=$(flake8_ignore) --builtins xrange --exclude=$(py3),repository $(mkfile_dir)
 cover:
 	python -m coverage run --source="./" --omit "./tests/*" -m unittest discover -vv ./tests
 	python -m coverage report

--- a/acceptancetests/assess
+++ b/acceptancetests/assess
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # create_juju_test_env is a developer-centric tool. It creates an environment for running
 # acceptance tests locally under LXD.

--- a/acceptancetests/assess_add_credentials.py
+++ b/acceptancetests/assess_add_credentials.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess proper functionality of juju add-credential."""
 
 from __future__ import print_function
@@ -6,10 +6,10 @@ from __future__ import print_function
 import argparse
 import logging
 import os
-import pexpect
 import shutil
 import sys
 import yaml
+import pexpect
 
 from deploy_stack import (
     BootstrapManager,
@@ -47,8 +47,9 @@ def assess_add_credentials(args):
     else:
         env = args.env.split('parallel-')[1]
 
-    # If no cloud-city path is given, we grab the credentials from env juju_home.
-    # Else we override the path where we read the credentials yaml for testing purposes.
+    # If no cloud-city path is given, we grab the credentials from env
+    # juju_home.  Else we override the path where we read the credentials yaml
+    # for testing purposes.
     if args.juju_home is not None:
         cred = get_credentials(env, args.juju_home)
     else:

--- a/acceptancetests/assess_agent_metadata.py
+++ b/acceptancetests/assess_agent_metadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Juju agent-metadata-url validation on passing as an argument during
  juju bootstrap
@@ -234,7 +234,7 @@ def get_controller_series_and_alternative_series(client):
     controller_series = machines['0']['series']
     try:
         supported_series.remove(controller_series)
-    except:
+    except Exception:
         raise ValueError("Unknown series {}".format(controller_series))
     return controller_series, supported_series[0]
 
@@ -369,7 +369,7 @@ def make_unique_tool(agent_file, agent_stream):
         os.makedirs(juju_tool_src)
         clone_tgz_file_and_change_shasum(agent_file, os.path.join(
             juju_tool_src, os.path.basename(agent_file)))
-        log.debug("Created agent directory to perform bootstrap".format(
+        log.debug("Created agent directory {} to perform bootstrap".format(
             agent_dir))
         yield agent_dir
 

--- a/acceptancetests/assess_autoload_credentials.py
+++ b/acceptancetests/assess_autoload_credentials.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tests for the autoload-credentials command."""
 
 from __future__ import print_function
@@ -22,15 +22,15 @@ from textwrap import dedent
 import pexpect
 
 from deploy_stack import BootstrapManager
-from jujupy import (
-    client_from_config,
-    )
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
     ensure_dir,
     scoped_environ,
     temp_dir,
+    )
+from jujupy import (
+    client_from_config,
     )
 
 
@@ -104,17 +104,17 @@ def client_credentials_to_details(client):
     cloud_name = client.env.get_cloud()
     log.info("cloud_name: {}".format(cloud_name))
     credentials = client.env.get_cloud_credentials()
-    if 'ec2' == provider:
+    if provider == 'ec2':
         return {'secret_key': credentials['secret-key'],
                 'access_key': credentials['access-key'],
                 }
-    if 'gce' == provider:
+    if provider == 'gce':
         gce_prepare_for_load()
         return {'client_id': credentials['client-id'],
                 'client_email': credentials['client-email'],
                 'private_key': credentials['private-key'],
                 }
-    if 'openstack' == provider:
+    if provider == 'openstack':
         os_cloud = client.env.clouds['clouds'][cloud_name]
         return {'os_tenant_name': credentials['tenant-name'],
                 'os_password': credentials['password'],
@@ -273,7 +273,7 @@ def run_autoload_credentials(client, envvars, answers):
     selection = 1
     while not process.eof():
         out = process.readline()
-        pattern = '.*(\d). {} \(.*\).*'.format(answers.cloud_listing)
+        pattern = r'.*(\d). {} \(.*\).*'.format(answers.cloud_listing)
         match = re.match(pattern, out)
         if match:
             selection = match.group(1)

--- a/acceptancetests/assess_block.py
+++ b/acceptancetests/assess_block.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess juju blocks prevent users from making changes and models"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_bootstrap.py
+++ b/acceptancetests/assess_bootstrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 from argparse import ArgumentParser

--- a/acceptancetests/assess_cloud.py
+++ b/acceptancetests/assess_cloud.py
@@ -1,9 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import logging
 from textwrap import dedent
 import yaml
 
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
 from deploy_stack import (
     BootstrapManager,
     )
@@ -15,10 +19,6 @@ from jujupy import (
     )
 from jujupy.wait_condition import (
     ConditionList,
-    )
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
     )
 
 
@@ -103,9 +103,8 @@ def assess_cloud_kill_controller(bs_manager):
         # We expect juju to die with a connection error (because we just
         # stopped its jujud).  This would normally be seen as a bug, so we
         # suppress it.
-        controller_client.juju('run', (
-            '--machine', '0', 'sudo service jujud-machine-0 stop'),
-            check=False, suppress_err=True)
+        cmd = ('--machine', '0', 'sudo service jujud-machine-0 stop')
+        controller_client.juju('run', cmd, check=False, suppress_err=True)
         bs_manager.has_controller = False
 
 

--- a/acceptancetests/assess_constraints.py
+++ b/acceptancetests/assess_constraints.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This module tests the deployment with constraints."""
 
 from __future__ import print_function
@@ -54,8 +54,8 @@ def mem_to_int(size):
         val = int(size[0:-1])
         unit = size[-1]
         return val * (1024 ** 'MGTP'.find(unit))
-    else:
-        return int(size)
+
+    return int(size)
 
 
 class Constraints:
@@ -156,19 +156,19 @@ class Constraints:
         if self.instance_type is None:
             return True
         instance_data = get_instance_spec(self.instance_type)
-        for (key, value) in instance_data.iteritems():
+        for (key, value) in iter(instance_data.items()):
             # Temperary fix until cpu-cores -> cores switch is finished.
             if key == 'cores' and 'cpu-cores' in actual_data:
                 key = 'cpu-cores'
             if key not in actual_data:
                 raise JujuAssertionError('Missing data:', key)
-            elif key in ['mem', 'root-disk']:
+            if key in ['mem', 'root-disk']:
                 if mem_to_int(value) != mem_to_int(actual_data[key]):
                     return False
             elif value != actual_data[key]:
                 return False
-        else:
-            return True
+
+        return True
 
     def meets_all(self, actual_data):
         return (self.meets_root_disk(actual_data.get('root-disk')) and
@@ -337,7 +337,7 @@ def assess_multiple_constraints(client, base_name, **kwargs):
 
     Makes sure the combination of constraints gives us new instance type."""
     finger_prints = []
-    for (part, (constraint, value)) in enumerate(kwargs.iteritems()):
+    for (part, (constraint, value)) in enumerate(iter(kwargs.items())):
         data = prepare_constraint_test(
             client, Constraints(**{constraint: value}),
             '{}-part{}'.format(base_name, part))
@@ -355,9 +355,9 @@ def assess_multiple_constraints(client, base_name, **kwargs):
 def assess_constraints(client, test_kvm=False):
     """Assess deployment with constraints."""
     provider = client.env.provider
-    if 'lxd' == provider:
+    if provider == 'lxd':
         assess_virt_type_constraints(client, test_kvm)
-    elif 'ec2' == provider:
+    elif provider == 'ec2':
         assess_instance_type_constraints(client, provider)
         assess_root_disk_constraints(client, ['16G'])
         assess_cores_constraints(client, ['2'])

--- a/acceptancetests/assess_cross_model_relations.py
+++ b/acceptancetests/assess_cross_model_relations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Functional tests for Cross Model Relation (CMR) functionality.
 
 This test exercises the CMR Juju functionality which allows applications to
@@ -26,13 +26,19 @@ The above feature tests will be run on:
 """
 
 from __future__ import print_function
+from textwrap import dedent
 
 import argparse
 import logging
 import sys
 import yaml
-from textwrap import dedent
 
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    JujuAssertionError,
+    )
+from jujucharm import local_charm_path
 from deploy_stack import (
     BootstrapManager,
     )
@@ -42,12 +48,6 @@ from jujupy.client import (
     )
 from jujupy.models import (
     temporary_model
-    )
-from jujucharm import local_charm_path
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
-    JujuAssertionError,
     )
 
 
@@ -64,7 +64,8 @@ def assess_cross_model_relations_single_controller(args):
         offer_model = bs_manager.client
         with temporary_model(offer_model, 'consume-model') as consume_model:
             ensure_cmr_offer_management(offer_model)
-            ensure_cmr_offer_consumption_and_relation(offer_model, consume_model)
+            ensure_cmr_offer_consumption_and_relation(offer_model,
+                                                      consume_model)
 
 
 def assess_cross_model_relations_multiple_controllers(args):

--- a/acceptancetests/assess_deploy_webscale.py
+++ b/acceptancetests/assess_deploy_webscale.py
@@ -90,7 +90,7 @@ def extract_module_logs(client, module):
         '--no-tail', '--replay', '-l', 'TRACE',
         '--include-module', module,
     )
-    return deploy_logs.decode('utf-8')
+    return deploy_logs
 
 
 def extract_txn_metrics(logs, module):
@@ -314,12 +314,11 @@ def main(argv=None):
 
     begin = time.time()
     bs_manager = BootstrapManager.from_args(args)
-    with bs_manager.booted_context(
-        args.upload_tools,
-        db_snap_path=db_snap_path,
-        db_snap_asserts_path=db_snap_asserts_path,
-        mongo_memory_profile=args.mongo_memory_profile,
-    ):
+    with bs_manager.booted_context(args.upload_tools,
+                                   db_snap_path=db_snap_path,
+                                   db_snap_asserts_path=db_snap_asserts_path,
+                                   mongo_memory_profile=args.
+                                   mongo_memory_profile):
         client = bs_manager.client
         mongo_version, mongo_profile = extract_mongo_details(client)
         log.info("MongoVersion used for deployment: {} (profile: {})".format(

--- a/acceptancetests/assess_destroy_model.py
+++ b/acceptancetests/assess_destroy_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess if Juju tracks the model when the current model is destroyed."""
 
 from __future__ import print_function
@@ -64,11 +64,13 @@ def destroy_model(client, new_client):
         try:
             client.get_juju_output('status', include_e=False)
         except subprocess.CalledProcessError as e:
-            not_found_error = b'{} not found'.format(old_model)
+            not_found_error = str.encode('{} not found'.format(old_model))
             if not_found_error in e.stderr:
                 log.info("Model fully removed")
                 break
-            removed_error = b'model "admin/{}" has been removed from the controller'.format(old_model)
+            removed_error = str.encode(('model "admin/{}" has been removed '
+                                        'from the controller').format(
+                                            old_model))
             if removed_error not in e.stderr:
                 error = 'unexpected error calling status\n{}'.format(e.stderr)
                 raise JujuAssertionError(error)
@@ -81,7 +83,8 @@ def destroy_model(client, new_client):
         # We didn't break out of the loop, so the model-removed message didn't
         # change to model not found (indicating that the model hasn't been
         # removed from the state pool).
-        raise JujuAssertionError("didn't get not found error - model still in state pool")
+        raise JujuAssertionError(
+            "didn't get not found error - model still in state pool")
 
 
 def switch_model(client, current_model, current_controller):
@@ -107,7 +110,7 @@ def get_current_controller(client):
     :param client: Jujupy ModelClient object
     :return: String name of current controller
     """
-    raw = client.get_juju_output('switch', include_e=False).decode('utf-8')
+    raw = client.get_juju_output('switch', include_e=False)
     raw = raw.split(':')[0]
     return raw
 

--- a/acceptancetests/assess_endpoint_bindings.py
+++ b/acceptancetests/assess_endpoint_bindings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Validate endpoint bindings functionality on MAAS."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_juju_output.py
+++ b/acceptancetests/assess_juju_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Deploy a charm and subordinate charm and verify juju-status attribute of
     the deployed charms.
@@ -34,6 +34,7 @@ __metaclass__ = type
 
 log = logging.getLogger("assess_juju_output")
 
+
 def verify_juju_status_contains_display_name(client_status):
     fields_to_test = [
         "instance-id",
@@ -45,6 +46,7 @@ def verify_juju_status_contains_display_name(client_status):
         except KeyError:
             err = "juju status excludes {}".format(field)
             raise JujuAssertionError(err)
+
 
 def verify_juju_status_attribute_of_charm(charm_details):
     """Verify the juju-status of the deployed charm
@@ -106,7 +108,6 @@ def assess_juju_status(client, series):
     """
     deploy_charm_with_subordinate_charm(client, series)
     status = client.get_status()
-    verify_juju_status_fields(status)
     charm_details = status.get_applications()['dummy-sink']
     verify_juju_status_attribute_of_charm(charm_details)
     verify_juju_status_attribute_of_subordinate_charm(charm_details)

--- a/acceptancetests/assess_juju_sync_tools.py
+++ b/acceptancetests/assess_juju_sync_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/acceptancetests/assess_log_forward.py
+++ b/acceptancetests/assess_log_forward.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test Juju's log forwarding feature.
 
 Log forwarding allows a controller to forward syslog from all models of a
@@ -150,12 +150,12 @@ def get_assert_regex(raw_uuid, message=None):
     # Maybe over simplified removing the last 8 characters
     uuid = re.escape(raw_uuid)
     short_uuid = re.escape(raw_uuid[:-8])
-    date_check = '[A-Z][a-z]{,2}\ +[0-9]+\ +[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}'
+    date_check = r'[A-Z][a-z]{,2}\ +[0-9]+\ +[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}'
     machine = 'machine-0.{}'.format(uuid)
     agent = 'jujud-machine-agent-{}'.format(short_uuid)
     message = message or '.*'
 
-    return '"^{datecheck}\ {machine}\ {agent}\ {message}$"'.format(
+    return r'"^{datecheck}\ {machine}\ {agent}\ {message}$"'.format(
         datecheck=date_check,
         machine=machine,
         agent=agent,

--- a/acceptancetests/assess_log_rotation.py
+++ b/acceptancetests/assess_log_rotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 from argparse import ArgumentParser
@@ -8,6 +8,9 @@ import re
 
 import yaml
 
+from utility import (
+    add_basic_testing_arguments,
+)
 from deploy_stack import (
     boot_context,
     update_env,
@@ -18,9 +21,6 @@ from jujucharm import (
 from jujupy import (
     client_from_config,
     juju_home_path,
-)
-from utility import (
-    add_basic_testing_arguments,
 )
 
 
@@ -77,7 +77,8 @@ def assess_machine_rotation(client):
                   "machine={}".format(machine_id))
 
 
-def test_rotation(client, logfile, prefix, fill_action, size_action, log_size, *args):
+def test_rotation(client, logfile, prefix, fill_action, size_action, log_size,
+                  *args):
     """A reusable help for testing log rotation.log
 
     Deploys the fill-logs charm and uses it to fill the machine or unit log and
@@ -94,7 +95,8 @@ def test_rotation(client, logfile, prefix, fill_action, size_action, log_size, *
     def run_fill_log_action():
         """Using fill action to fill logs, returns resulting output."""
         for _ in range(log_size//single_megs):
-            client.action_do_fetch("fill-logs/0", fill_action, FILL_TIMEOUT, *args)
+            client.action_do_fetch("fill-logs/0", fill_action, FILL_TIMEOUT,
+                                   *args)
         # Need to give the disk sometime to actually move files before
         # requesting resulting output.
         sleep(10)
@@ -157,7 +159,7 @@ def check_expected_backup(key, logprefix, action_output):
         raise LogRotateError(
             "Missing backup log '{}' after rotation.".format(key))
 
-    backup_pattern = "/var/log/juju/%s-(.+?)\.log.gz" % logprefix
+    backup_pattern = r"/var/log/juju/%s-(.+?)\.log.gz" % logprefix
 
     log_name = log["name"]
     matches = re.match(backup_pattern, log_name)
@@ -233,8 +235,9 @@ def main():
     client = make_client_from_args(args)
     with boot_context(args.temp_env_name, client,
                       bootstrap_host=args.bootstrap_host,
-                      machines=args.machine, series=args.series, arch=args.arch,
-                      agent_url=args.agent_url, agent_stream=args.agent_stream,
+                      machines=args.machine, series=args.series,
+                      arch=args.arch, agent_url=args.agent_url,
+                      agent_stream=args.agent_stream,
                       log_dir=args.logs, keep_env=args.keep_env,
                       upload_tools=args.upload_tools,
                       region=args.region):

--- a/acceptancetests/assess_min_version.py
+++ b/acceptancetests/assess_min_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import argparse

--- a/acceptancetests/assess_mixed_images.py
+++ b/acceptancetests/assess_mixed_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess mixed deployment of images from two sets of simplestreams."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_model_config_tree.py
+++ b/acceptancetests/assess_model_config_tree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test Model Tree Config functionality.
 
 Tests that default values can be overwritten and then unset.

--- a/acceptancetests/assess_model_defaults.py
+++ b/acceptancetests/assess_model_defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess the model-defaults command."""
 
 from __future__ import print_function
@@ -23,7 +23,8 @@ __metaclass__ = type
 log = logging.getLogger('assess_model_defaults')
 
 
-def assemble_model_default(model_key, default, controller_value=None, region_values=None):
+def assemble_model_default(model_key, default, controller_value=None,
+                           region_values=None):
     """Create a dict that contains the formatted model-defaults data."""
     # Ordering in the regions argument is lost.
     defaults = {'default': default}
@@ -55,11 +56,12 @@ def get_new_model_config(client, cloud=None, region=None, model_name=None):
     cloud_region = None
     if region is not None:
         new_env.set_region(region)
-        cloud_region = client.get_cloud_region(cloud,region)
+        cloud_region = client.get_cloud_region(cloud, region)
     # Don't use the bootstrap config, we want to check that the default series
     # is inherited from the model defaults correctly and the bootstrap config
     # might override it.
-    new_model = client.add_model(new_env, cloud_region, use_bootstrap_config=False)
+    new_model = client.add_model(new_env, cloud_region,
+                                 use_bootstrap_config=False)
     config_data = new_model.get_model_config()
     new_model.destroy_model()
     return config_data
@@ -120,7 +122,8 @@ def assess_model_defaults(client, other_region):
     if other_region is not None:
         log.info('Checking other region model-defaults.')
         assess_model_defaults_region(
-            client, 'default-series', 'bionic', cloud=cloud, region=other_region)
+            client, 'default-series', 'bionic', cloud=cloud,
+            region=other_region)
 
 
 def parse_args(argv):

--- a/acceptancetests/assess_model_migration_versions.py
+++ b/acceptancetests/assess_model_migration_versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test migrating models between controllers of increasing versions."""
 
 from __future__ import print_function
@@ -11,6 +11,14 @@ from distutils.version import (
 import logging
 import sys
 
+from deploy_stack import (
+    BootstrapManager,
+    get_random_string,
+    )
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
 from assess_model_migration import (
     _new_log_dir,
     assert_model_migrated_successfully,
@@ -27,14 +35,6 @@ from jujupy.wait_condition import (
 )
 from jujupy.workloads import (
     deploy_simple_server_to_new_model,
-    )
-from deploy_stack import (
-    BootstrapManager,
-    get_random_string,
-    )
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
     )
 
 __metaclass__ = type
@@ -67,7 +67,7 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
                 'version-migration',
                 resource_contents)
             migration_target_client = migrate_model_to_controller(
-                test_stable_model, devel_client)
+                test_stable_model, stable_client, devel_client)
             assert_model_migrated_successfully(
                 migration_target_client, application, resource_contents)
 
@@ -77,6 +77,7 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
                 another_bsm.client.get_controller_client().wait_for(
                     AllMachinesRunning())
                 another_migration_client = migrate_model_to_controller(
+                    test_stable_model,
                     migration_target_client, another_bsm.client)
                 assert_model_migrated_successfully(
                     another_migration_client, application, resource_contents)

--- a/acceptancetests/assess_multi_series_charms.py
+++ b/acceptancetests/assess_multi_series_charms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Charms have the capability to declare that they support more than
 one series. Previously a separate copy of the charm was required for

--- a/acceptancetests/assess_multimodel.py
+++ b/acceptancetests/assess_multimodel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess multimodel support."""
 
 from argparse import ArgumentParser
@@ -16,13 +16,13 @@ from deploy_stack import (
     get_random_string,
     safe_print_status,
     )
-from jujupy import (
-    client_from_config,
-    )
 from utility import (
     add_basic_testing_arguments,
     ensure_dir,
     print_now,
+    )
+from jujupy import (
+    client_from_config,
     )
 
 
@@ -78,8 +78,7 @@ def multimodel_setup(args):
             args.agent_stream,
             args.logs, args.keep_env,
             upload_tools=False,
-            region=args.region,
-            ):
+            region=args.region):
         yield client, charm_series, base_env
 
 
@@ -93,7 +92,7 @@ def hosted_environment(system_client, log_dir, suffix):
     client = system_client.add_model(env_name)
     try:
         yield client
-    except:
+    except Exception:
         logging.exception(
             'Exception while environment "{}" active'.format(
                 client.env.environment))

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess network health for a given deployment or bundle"""
 from __future__ import print_function
 
@@ -6,20 +6,14 @@ import argparse
 import logging
 import sys
 import json
-import yaml
 import subprocess
 import re
 import time
 import os
 import socket
+import yaml
 from collections import defaultdict
 
-from jujupy import (
-    client_for_existing
-    )
-from jujupy.wait_condition import (
-    WaitApplicationNotPresent
-    )
 from deploy_stack import (
     BootstrapManager
     )
@@ -31,6 +25,12 @@ from utility import (
     )
 from substrate import (
     maas_account_from_boot_config,
+    )
+from jujupy import (
+    client_for_existing
+    )
+from jujupy.wait_condition import (
+    WaitApplicationNotPresent
     )
 
 __metaclass__ = type
@@ -48,8 +48,7 @@ class AssessNetworkHealth:
         if args.logs:
             self.log_dir = args.logs
         else:
-            self.log_dir = generate_default_clean_dir(
-                            args.temp_env_name)
+            self.log_dir = generate_default_clean_dir(args.temp_env_name)
         self.expose_client = None
         self.existing_series = set([])
         self.expose_test_charms = set([])
@@ -140,9 +139,7 @@ class AssessNetworkHealth:
             self.existing_series.add(info['series'])
         for series in self.existing_series:
             try:
-                # TODO: The latest network-health charm (11 onwards) is broken;
-                # it doesn't properly install charmhelpers.
-                client.deploy('cs:~juju-qa/network-health-10', series=series,
+                client.deploy('cs:~juju-qa/network-health', series=series,
                               alias='network-health-{}'.format(series))
 
             except subprocess.CalledProcessError:
@@ -155,6 +152,10 @@ class AssessNetworkHealth:
         apps = client.get_status().get_applications()
         log.info('Known applications: {}'.format(apps.keys()))
         for app, info in apps.items():
+            # We cannot relate to ourselves!
+            if 'network-health' in app:
+                continue
+
             app_series = info['series']
             try:
                 client.juju('add-relation',
@@ -259,7 +260,8 @@ class AssessNetworkHealth:
         return results
 
     def get_nh_unit_info(self, apps, by_unit=False):
-        """Parses juju status information to return deployed network-health units.
+        """Parses juju status information to return deployed network-health
+        units.
 
         :param apps: Dict of apps given by get_status().get_applications()
         :param by_unit: Bool, returns dict of NH units keyed by the unit they
@@ -342,10 +344,10 @@ class AssessNetworkHealth:
             out = subprocess.check_output(
                 'curl {}:{} -m 5'.format(ip, PORT), shell=True)
         except subprocess.CalledProcessError as e:
-            out = ''
+            out = b''
             log.warning('Curl failed for error:\n{}'.format(e))
         log.info('Got: "{}" from unit at {}:{}'.format(out, ip, PORT))
-        if 'pass' in out:
+        if b'pass' in out:
             return True
         return False
 
@@ -386,9 +388,7 @@ class AssessNetworkHealth:
         for app, info in apps.items():
             if 'network-health' not in app:
                 alias = 'network-health-{}'.format(app)
-                # The latest network-health charm (11 onwards) is broken;
-                # it doesn't properly install charmhelpers.
-                client.deploy('cs:~juju-qa/network-health-10', alias=alias,
+                client.deploy('cs:~juju-qa/network-health', alias=alias,
                               series=info['series'])
                 try:
                     client.juju('add-relation', (app, alias))
@@ -432,12 +432,12 @@ class AssessNetworkHealth:
         log.info('Parsing final results.')
         error_string = []
         for nh_source, service_result in visibility.items():
-                for service, unit_res in service_result.items():
-                    if False in unit_res.values():
-                        failed = [u for u, r in unit_res.items() if r is False]
-                        error = ('Unit {0} failed to contact '
-                                 'targets(s): {1}'.format(nh_source, failed))
-                        error_string.append(error)
+            for service, unit_res in service_result.items():
+                if False in unit_res.values():
+                    failed = [u for u, r in unit_res.items() if r is False]
+                    error = ('Unit {0} failed to contact '
+                             'targets(s): {1}'.format(nh_source, failed))
+                    error_string.append(error)
         for unit, res in internet.items():
             if not res:
                 error = 'Machine {} failed internet connection.'.format(unit)
@@ -507,7 +507,8 @@ class AssessNetworkHealth:
         return True
 
     def to_json(self, units):
-        """Returns a formatted json string to be passed through juju run-action.
+        """Returns a formatted json string to be passed through juju
+        run-action.
 
         :param units: Dict of units
         :return: A "JSON-like" string that can be passed to Juju without it

--- a/acceptancetests/assess_network_spaces.py
+++ b/acceptancetests/assess_network_spaces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess network spaces for supported providers (currently only EC2)"""
 
 import argparse
@@ -11,15 +11,15 @@ import re
 import ipaddress
 import boto3
 
-from jujupy.exceptions import (
-    ProvisioningError
-    )
 from deploy_stack import (
     BootstrapManager
     )
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
+    )
+from jujupy.exceptions import (
+    ProvisioningError
     )
 
 __metaclass__ = type
@@ -61,8 +61,8 @@ class AssessNetworkSpaces:
             try:
                 test(client)
             except TestFailure as e:
-                fail_messages.append(e.message)
-                log.info('FAILED: ' + e.message + '\n')
+                fail_messages.append(str(e))
+                log.info('FAILED: ' + str(e) + '\n')
 
         log.info('Tests complete.')
         if fail_messages:
@@ -86,8 +86,8 @@ class AssessNetworkSpaces:
         :param client: Juju client object with controller
         """
         log.info('Assigning network spaces on {}.'.format(client.env.provider))
-        subnets = yaml.safe_load(
-                client.get_juju_output('list-subnets', '--format=yaml'))
+        subnets = yaml.safe_load(client.get_juju_output('list-subnets',
+                                                        '--format=yaml'))
         if not subnets:
             raise SubnetsNotReady(
                 'No subnets defined in {}'.format(client.env.provider))
@@ -96,9 +96,8 @@ class AssessNetworkSpaces:
             subnet_count += 1
             client.juju('add-space', ('space{}'.format(subnet_count), subnet))
         if subnet_count < 3:
-            raise SubnetsNotReady(
-                    '3 subnets required for spaces assignment. '
-                    '{} found.'.format(subnet_count))
+            raise SubnetsNotReady('3 subnets required for spaces assignment. '
+                                  '{} found.'.format(subnet_count))
 
     def assert_machines_in_correct_spaces(self, client):
         """Check all the machines to verify they are in the expected spaces
@@ -121,11 +120,10 @@ class AssessNetworkSpaces:
                 expected_space = 'space{}'.format(machine)
             ip = get_machine_ip_in_space(client, machine, expected_space)
             if not ip:
-                raise TestFailure(
-                        'Machine {machine} has NO IPs in '
-                        '{space}'.format(
-                            machine=machine,
-                            space=expected_space))
+                raise TestFailure('Machine {machine} has NO IPs in '
+                                  '{space}'.format(
+                                      machine=machine,
+                                      space=expected_space))
         log.info('PASSED')
 
     def assert_machine_connectivity(self, client):
@@ -168,9 +166,9 @@ class AssessNetworkSpaces:
             machine = client.show_machine('2')['machines'][0]
             container = machine['containers']['2/lxd/0']
             if container['juju-status']['current'] == 'started':
-                raise TestFailure(
-                        'Encountered no conflict when launching a container '
-                        'on a machine with a different spaces constraint.')
+                raise TestFailure(('Encountered no conflict when launching a '
+                                   'container on a machine with a different '
+                                   'spaces constraint.'))
         except ProvisioningError:
             log.info('Container correctly failed to provision.')
         finally:
@@ -194,14 +192,14 @@ class AssessNetworkSpaces:
             try:
                 routes = client.run(['ip route show'], machines=[unit[0]])
             except subprocess.CalledProcessError:
-                raise TestFailure(
-                        'Could not connect to address for unit: {0}, '
-                        'unable to find default route.'.format(unit[0]))
+                raise TestFailure(('Could not connect to address for unit: {0}'
+                                   ', unable to find default route.').format(
+                                       unit[0]))
             default_route = re.search(r'(default via )+([\d\.]+)\s+',
                                       json.dumps(routes[0]))
             if not default_route:
-                raise TestFailure(
-                        'Default route not found for {}'.format(unit[0]))
+                raise TestFailure('Default route not found for {}'.format(
+                    unit[0]))
         log.info('PASSED')
 
     def deploy_spaces_machines(self, client, series=None):
@@ -278,14 +276,14 @@ def non_infan_subnets(subnets):
     newsubnets = {}
     if 'subnets' in subnets:
         newsubnets['subnets'] = {}
-        for subnet, details in subnets['subnets'].iteritems():
+        for subnet, details in iter(subnets['subnets'].items()):
             if 'INFAN' not in details['provider-id']:
                 newsubnets['subnets'][subnet] = details
     if 'spaces' in subnets:
         newsubnets['spaces'] = {}
         for details in subnets['spaces']:
             space = details['name']
-            for subnet, subnet_details in details['subnets'].iteritems():
+            for subnet, subnet_details in iter(details['subnets'].items()):
                 if 'INFAN' not in subnet_details['provider-id']:
                     newsubnets['spaces'].setdefault(space, {})
                     newsubnets['spaces'][space][subnet] = subnet_details
@@ -308,7 +306,8 @@ def get_machine_ip_in_space(client, machine, space):
         yaml.safe_load(
             client.get_juju_output(
                 'list-spaces', '--format=yaml')))
-    subnet = spaces['spaces'][space].keys()[0]
+    target_space = spaces['spaces'][space]
+    subnet = next(iter(target_space.keys()))
     for ip in machines[machine]['ip-addresses']:
         if ip_in_cidr(ip, subnet):
             return ip
@@ -322,8 +321,8 @@ def machine_can_ping_ip(client, machine, ip):
     :param ip: IP address to ping
     :returns: success of ping
     """
-    rc, _ = client.juju(
-            'ssh', ('--proxy', machine, 'ping -c1 -q ' + ip), check=False)
+    rc, _ = client.juju('ssh', ('--proxy', machine, 'ping -c1 -q ' + ip),
+                        check=False)
     return rc == 0
 
 
@@ -334,8 +333,7 @@ def ip_in_cidr(address, cidr):
     :param address: A valid IPv4 address (string)
     :param cidr: A valid subnet in CIDR notation (string)
     """
-    return (ipaddress.ip_address(address.decode('utf-8'))
-            in ipaddress.ip_network(cidr.decode('utf-8')))
+    return (ipaddress.ip_address(address) in ipaddress.ip_network(cidr))
 
 
 def parse_args(argv):
@@ -381,11 +379,10 @@ class SpacesAWS(Spaces):
             return False
 
         creds = client.env.get_cloud_credentials()
-        ec2 = boto3.resource(
-                'ec2',
-                region_name=client.env.get_region(),
-                aws_access_key_id=creds['access-key'],
-                aws_secret_access_key=creds['secret-key'])
+        ec2 = boto3.resource('ec2',
+                             region_name=client.env.get_region(),
+                             aws_access_key_id=creds['access-key'],
+                             aws_secret_access_key=creds['secret-key'])
 
         # See if the VPC we want already exists.
         vpc_response = ec2.meta.client.describe_vpcs(Filters=[{
@@ -403,7 +400,8 @@ class SpacesAWS(Spaces):
         log.info('Setting up VPC in AWS region {}'.format(
             client.env.get_region()))
         vpc = ec2.create_vpc(CidrBlock='10.0.0.0/16')
-        vpc.create_tags(Tags=[{'Key': 'Name', 'Value': 'assess-network-spaces'}])
+        vpc.create_tags(Tags=[{'Key': 'Name',
+                               'Value': 'assess-network-spaces'}])
         vpc.wait_until_available()
 
         self.vpcid = vpc.id
@@ -450,12 +448,10 @@ class SpacesAWS(Spaces):
             region=client.env.get_region(),
             vpcid=self.vpcid))
         creds = client.env.get_cloud_credentials()
-        ec2 = boto3.resource(
-                'ec2',
-                region_name=client.env.get_region(),
-                aws_access_key_id=creds['access-key'],
-                aws_secret_access_key=creds['secret-key'])
-        ec2client = ec2.meta.client
+        ec2 = boto3.resource('ec2',
+                             region_name=client.env.get_region(),
+                             aws_access_key_id=creds['access-key'],
+                             aws_secret_access_key=creds['secret-key'])
         vpc = ec2.Vpc(self.vpcid)
         # delete any instances
         for subnet in vpc.subnets.all():

--- a/acceptancetests/assess_persistent_storage.py
+++ b/acceptancetests/assess_persistent_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Testing Juju's persistent storage feature."""
 
 from __future__ import print_function
@@ -113,7 +113,7 @@ def assert_storage_count(storage_list, expected):
 
 def assert_single_blk_existence(storage_list, storage_id):
     log.info(
-        'Checking existence of single block device storage.'.format(
+        'Checking existence of single block device storage {}.'.format(
             storage_id))
     if storage_id not in storage_list:
         raise JujuAssertionError(
@@ -124,7 +124,8 @@ def assert_single_blk_existence(storage_list, storage_id):
 
 def assert_single_blk_removal(storage_list, storage_id):
     log.info(
-        'Checking removal of single block device storage.'.format(storage_id))
+        'Checking removal of single block device storage {}.'.format(
+            storage_id))
     if storage_id in storage_list:
         raise JujuAssertionError(
             '{} still exists in storage list.'.format(storage_id))

--- a/acceptancetests/assess_primary_sub_relations.py
+++ b/acceptancetests/assess_primary_sub_relations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test relations between primary and subordinates are cleanedup correctly"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_proxy.py
+++ b/acceptancetests/assess_proxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess Juju under various proxy network conditions.
 
 This test is dangerous to run on your own host. It will change the host's

--- a/acceptancetests/assess_recovery.py
+++ b/acceptancetests/assess_recovery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Backup and restore a stack.
 
 from __future__ import print_function
@@ -13,19 +13,17 @@ from subprocess import CalledProcessError
 import yaml
 
 from deploy_stack import (BootstrapManager, deploy_dummy_stack,
-                          get_remote_machines, get_token_from_status,
-                          wait_for_state_server_to_shutdown)
-from jujupy import parse_new_state_server_from_error
-from substrate import convert_to_azure_ids, terminate_instances
+                          get_remote_machines)
 from utility import (JujuAssertionError, LoggedException,
-                     add_basic_testing_arguments, configure_logging,
-                     until_timeout)
+                     add_basic_testing_arguments, configure_logging)
+from jujupy import parse_new_state_server_from_error
 
 __metaclass__ = type
 
-running_instance_pattern = re.compile('\["([^"]+)"\]')
+running_instance_pattern = re.compile(r'\["([^"]+)"\]')
 
 log = logging.getLogger("assess_recovery")
+
 
 def set_token(client, token):
     # unfortunately deploying a stack currently requires a token setting, but
@@ -34,6 +32,7 @@ def set_token(client, token):
     # or before the token is set multiple times.
     client.set_config('dummy-source', {'token': token})
     return client.action_do('dummy-sink/0', 'echo', "value={}".format(token))
+
 
 def check_token(client, id, token):
     result = client.action_fetch(id, 'echo', "300s")
@@ -44,6 +43,7 @@ def check_token(client, id, token):
     raise JujuAssertionError('Token is not {}: {}'.format(
                              token, value))
 
+
 def deploy_stack(client, charm_series):
     """"Deploy a simple stack, state-server and ubuntu."""
     deploy_dummy_stack(client, charm_series)
@@ -51,6 +51,7 @@ def deploy_stack(client, charm_series):
     client.wait_for_workloads()
     check_token(client, id, 'One')
     log.info("%s is ready to testing", client.env.environment)
+
 
 def enable_ha(bs_manager, controller_client):
     """Enable HA and wait for the controllers to be ready."""
@@ -62,19 +63,22 @@ def enable_ha(bs_manager, controller_client):
         controller_client, bs_manager.known_hosts)
     return remote_machines
 
+
 def disable_ha(bs_manager, controller_client):
     """Disable HA and wait for the controllers to be ready."""
     log.info("Disabling HA.")
-    condition = controller_client.remove_machine(["1", "2"], force=True, controller=True)
+    condition = controller_client.remove_machine(["1", "2"], force=True,
+                                                 controller=True)
     controller_client.wait_for(condition)
     show_controller(controller_client)
     remote_machines = get_remote_machines(
         controller_client, None)
     return remote_machines
 
+
 def restore_ha(bs_manager, controller_client):
-    """Restore HA after a backup, as there is a possiblility that the controllers
-    will be in a down state"""
+    """Restore HA after a backup, as there is a possiblility that the
+    controllers will be in a down state"""
     log.info("Restoring HA")
     machines_to_remove = []
     show_controller(controller_client)
@@ -83,24 +87,28 @@ def restore_ha(bs_manager, controller_client):
     # the pause, one will report back.
     controller_client._backend.pause(300)
     status = controller_client.get_status(controller=True)
-    # the order of the machines are normally wrong after a restore, so iterating
-    # through the machines until you find the correct ones to remove works.
+    # the order of the machines are normally wrong after a restore, so
+    # iterating through the machines until you find the correct ones to remove
+    # works.
     for name, machine in status.iter_machines():
         machine_status = machine['juju-status']
         if machine_status["current"] == "down":
             machines_to_remove.append(name)
     if len(machines_to_remove) > 0:
         controller_client.show_status()
-        condition = controller_client.remove_machine(machines_to_remove, force=True, controller=True)
+        condition = controller_client.remove_machine(machines_to_remove,
+                                                     force=True,
+                                                     controller=True)
         controller_client.wait_for(condition)
     return enable_ha(bs_manager, controller_client)
+
 
 def show_controller(client):
     controller_info = client.show_controller(format='yaml')
     log.info('Controller is:\n{}'.format(controller_info))
 
-def restore_backup(bs_manager, client, backup_file,
-                                 check_controller=True):
+
+def restore_backup(bs_manager, client, backup_file, check_controller=True):
     """juju-restore restores the backup file."""
     log.info("Starting restore.")
     try:
@@ -115,6 +123,7 @@ def restore_backup(bs_manager, client, backup_file,
     show_controller(bs_manager.client)
     bs_manager.has_controller = True
 
+
 def assess_backup(client):
     id = set_token(client, 'Two')
     client.wait_for_started()
@@ -123,10 +132,12 @@ def assess_backup(client):
     log.info("%s restored", client.env.environment)
     log.info("PASS")
 
+
 def create_tmp_model(client):
     model_name = 'temp-model'
     new_env = client.env.clone(model_name)
     return client.add_model(new_env)
+
 
 def parse_args(argv=None):
     parser = ArgumentParser(description='Test recovery strategies.')
@@ -142,6 +153,7 @@ def parse_args(argv=None):
         const='ha-backup', help="Test backup of HA.")
     return parser.parse_args(argv)
 
+
 @contextmanager
 def detect_bootstrap_machine(bs_manager):
     try:
@@ -151,6 +163,7 @@ def detect_bootstrap_machine(bs_manager):
         if address is not None:
             bs_manager.known_hosts['0'] = address
         raise
+
 
 def assess_recovery(bs_manager, strategy, charm_series):
     log.info("Setting up test.")
@@ -175,11 +188,12 @@ def assess_recovery(bs_manager, strategy, charm_series):
     # check_controller if NOT in haBackup, as we know that some of the
     # controllers are currently down.
     restore_backup(bs_manager, controller_client, backup_file,
-        check_controller=not haBackup)
+                   check_controller=not haBackup)
     if haBackup:
         bs_manager.known_hosts = restore_ha(bs_manager, controller_client)
     assess_backup(bs_manager.client)
     log.info("Test complete.")
+
 
 def main(argv):
     args = parse_args(argv)

--- a/acceptancetests/assess_resolve.py
+++ b/acceptancetests/assess_resolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Ensure resolve command resolves hook issues.
 
 This test covers the resolve command (and the option --no-retry)
@@ -20,16 +20,16 @@ import sys
 from deploy_stack import (
     BootstrapManager,
     )
+from jujucharm import local_charm_path
+from utility import (
+    add_basic_testing_arguments,
+    configure_logging,
+    )
 from jujupy.models import (
     temporary_model,
     )
 from jujupy.wait_condition import (
     UnitInstallCondition,
-    )
-from jujucharm import local_charm_path
-from utility import (
-    add_basic_testing_arguments,
-    configure_logging,
     )
 
 
@@ -53,17 +53,17 @@ def assess_resolve(client, local_charm='simple-resolve'):
 
 
 def ensure_retry_does_not_rerun_failed_hook(client, resolve_charm):
-        with temporary_model(client, "no-retry") as temp_client:
-            unit_name = 'simple-resolve/0'
-            temp_client.deploy(resolve_charm)
-            temp_client.wait_for(UnitInstallError(unit_name))
-            temp_client.juju('resolve', ('--no-retry', unit_name))
-            # simple-resolve start hook sets a message when active to indicate
-            # it ran and if the install hook ran successfully or not.
-            # Here we make sure it's active and no install hook success.
-            temp_client.wait_for(
-                UnitInstallActive(
-                    unit_name, ResolveCharmMessage.ACTIVE_NO_INSTALL_HOOK))
+    with temporary_model(client, "no-retry") as temp_client:
+        unit_name = 'simple-resolve/0'
+        temp_client.deploy(resolve_charm)
+        temp_client.wait_for(UnitInstallError(unit_name))
+        temp_client.juju('resolve', ('--no-retry', unit_name))
+        # simple-resolve start hook sets a message when active to indicate
+        # it ran and if the install hook ran successfully or not.
+        # Here we make sure it's active and no install hook success.
+        temp_client.wait_for(
+            UnitInstallActive(
+                unit_name, ResolveCharmMessage.ACTIVE_NO_INSTALL_HOOK))
 
 
 class UnitInstallError(UnitInstallCondition):

--- a/acceptancetests/assess_resources.py
+++ b/acceptancetests/assess_resources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -87,7 +87,7 @@ def push_resource(client, resource_name, finger_print, size, agent_timeout,
 def fill_dummy_file(file_path, size):
     with open(file_path, "wb") as f:
         f.seek(size - 1)
-        f.write('\0')
+        f.write(b'\0')
 
 
 def large_assess(client, agent_timeout, resource_timeout):

--- a/acceptancetests/assess_sla.py
+++ b/acceptancetests/assess_sla.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This test will test the juju sla command. Currently, testing budget or
 supported sla models requires a functioning omnibus. As such, the current
 test merely checks to ensure unsupported models appear as unsupported"""

--- a/acceptancetests/assess_spaces_subnets.py
+++ b/acceptancetests/assess_spaces_subnets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from argparse import ArgumentParser
 import re
@@ -114,15 +114,15 @@ def _assess_spaces_subnets(client, network_config, charms_to_space):
                     unit_priv_address[unit_name] = addr[1]
 
     cidrs_in_space = {}
-    for name, attrs in spaces['spaces'].iteritems():
+    for name, attrs in iter(spaces['spaces'].items()):
         cidrs_in_space[name] = []
         for cidr in attrs:
             cidrs_in_space[name].append(cidr)
 
     units_checked = 0
-    for space, cidrs in cidrs_in_space.iteritems():
+    for space, cidrs in iter(cidrs_in_space.items()):
         for cidr in cidrs:
-            for unit, address in unit_priv_address.iteritems():
+            for unit, address in iter(unit_priv_address.items()):
                 if ipv4_in_cidr(address, cidr):
                     units_checked += 1
                     charm = unit.split('/')[0]

--- a/acceptancetests/assess_ssh_keys.py
+++ b/acceptancetests/assess_ssh_keys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Validate ability of the user to import and remove ssh keys"""
 
 from __future__ import print_function

--- a/acceptancetests/assess_storage.py
+++ b/acceptancetests/assess_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess juju charm storage."""
 
 from __future__ import print_function
@@ -11,11 +11,11 @@ import os
 import sys
 import time
 
-from deploy_stack import BootstrapManager
 from distutils.version import (
     LooseVersion,
     StrictVersion,
 )
+from deploy_stack import BootstrapManager
 from jujucharm import (
     Charm,
     local_charm_path,
@@ -128,22 +128,18 @@ def wait_for_storage_removal(client, storage_id, interval, timeout):
 
 def make_expected_ls(storage_name, unit_name, kind='filesystem'):
     """Return the expected data from list-storage for filesystem or block."""
-    if kind == 'block':
-        location = ''
-    else:
-        location = '/srv/data'
+    unit_data = {'life': 'alive'}
+    if kind != 'block':
+        unit_data['location'] = '/srv/data'
     data = {
         "storage": {
             storage_name: {
                 "kind": kind,
                 "attachments": {
                     "units": {
-                        unit_name: {
-                            "location": location,
-                            "life": "alive"
-                            }
-                        }
+                        unit_name: unit_data
                     },
+                },
                 "life": "alive"
                 }
             }
@@ -196,7 +192,7 @@ def create_storage_charm(charm_dir, name, summary, storage):
 
 def assess_create_pool(client):
     """Test creating storage pool."""
-    for name, pool in storage_pool_details.iteritems():
+    for name, pool in iter(storage_pool_details.items()):
         client.create_storage_pool(name, pool["provider"],
                                    pool["attrs"]["size"])
 

--- a/acceptancetests/assess_unregister.py
+++ b/acceptancetests/assess_unregister.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tests for the unregister command
 
 Ensure that a users controller can be unregistered.
@@ -88,7 +88,7 @@ def assert_controller_list(client, controller_list):
     output = json.loads(json_output)
 
     try:
-        controller_names = output['controllers'].keys()
+        controller_names = list(output['controllers'].keys())
     except AttributeError:
         # It's possible that there are 0 controllers for this client.
         controller_names = []

--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Assess upgrading juju controllers and models.
 
 Bootstrap a previous version of juju and then upgrade the controller and models
@@ -21,14 +21,14 @@ import sys
 from collections import (
     namedtuple,
     )
+from textwrap import (
+    dedent,
+)
 from utility import (
     add_basic_testing_arguments,
     configure_logging,
     temp_dir,
     )
-from textwrap import (
-    dedent,
-)
 from deploy_stack import (
     BootstrapManager
 )
@@ -128,11 +128,15 @@ def assert_upgrade_is_successful(
 def upgrade_stable_to_devel_version(client, extra_args):
     devel_version = get_stripped_version_number(client.version)
     client.get_controller_client().juju(
-        'upgrade-juju', ('-m', 'controller', '--debug', '--agent-stream', 'devel', '--agent-version', devel_version,) + extra_args)
+        'upgrade-juju', ('-m', 'controller', '--debug',
+                         '--agent-stream', 'devel',
+                         '--agent-version', devel_version,) + extra_args)
     assert_model_is_version(client.get_controller_client(), devel_version)
     wait_until_model_upgrades(client)
 
-    client.juju('upgrade-juju', ('--debug', '--agent-stream', 'devel', '--agent-version', devel_version,) + extra_args)
+    client.juju('upgrade-juju', ('--debug', '--agent-stream',
+                                 'devel', '--agent-version', devel_version,) +
+                extra_args)
     assert_model_is_version(client, devel_version)
     wait_until_model_upgrades(client)
 
@@ -217,7 +221,7 @@ def increment_patch_version(patch_version):
         return int(patch_version) + 1
     except ValueError:
         # Named patch version (alpha/beta etc.)
-        name, num = re.search('(\D+)(\d+)', patch_version).groups()
+        name, num = re.search(r'(\D+)(\d+)', patch_version).groups()
         return "{name}{num}".format(
             name=name,
             num=int(num) + 1,
@@ -259,7 +263,7 @@ def main(argv=None):
 
     assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client)
 
-    # LP:1742342 Moving from released stream to devel stream doesn't work, 
+    # LP:1742342 Moving from released stream to devel stream doesn't work,
     # because upgrade-juju doesn't honour --agent-stream over the model-config.
     #
     # assess_upgrade_passing_agent_stream(args, devel_client)

--- a/acceptancetests/assess_upgrade_lxd_profile.py
+++ b/acceptancetests/assess_upgrade_lxd_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ Assess upgrading charms with lxd-profiles in different deployment scenarios.
 """

--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Assess upgrading using the 'upgrade-series' commands."""
 
 from __future__ import print_function

--- a/acceptancetests/assess_user_grant_revoke.py
+++ b/acceptancetests/assess_user_grant_revoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This testsuite is intended to test basic user permissions. Users
    can be granted read or full privileges by model. Revoking those
    privileges should remove them.
@@ -69,8 +69,6 @@ def _generate_random_string():
 
 
 def assert_equal(found, expected):
-    found = sorted(found)
-    expected = sorted(expected)
     if found != expected:
         raise JujuAssertionError(
             'Found: {}\nExpected: {}'.format(found, expected))
@@ -112,7 +110,7 @@ def list_shares(client):
         client.get_juju_output(
             'show-model', '--format', 'json', include_e=False))
     share_list = model_data[client.model_name]['users']
-    for key, value in share_list.iteritems():
+    for key, value in iter(share_list.items()):
         value.pop("last-connection", None)
     return share_list
 
@@ -196,20 +194,20 @@ def assert_user_permissions(user, user_client, controller_client):
     """Test if users' permissions are within expectations"""
     expect = iter(user.expect)
     permission = user.permissions
-    assert_read_model(user_client, permission, expect.next())
-    assert_write_model(user_client, permission, expect.next())
+    assert_read_model(user_client, permission, next(expect))
+    assert_write_model(user_client, permission, next(expect))
     assert_admin_model(
-        controller_client, user_client, permission, expect.next())
+        controller_client, user_client, permission, next(expect))
 
     log.info("Revoking {} permission from {}".format(
         user.permissions, user.name))
     controller_client.revoke(user.name, permissions=user.permissions)
     log.info('Revoke accepted')
 
-    assert_read_model(user_client, permission, expect.next())
-    assert_write_model(user_client, permission, expect.next())
+    assert_read_model(user_client, permission, next(expect))
+    assert_write_model(user_client, permission, next(expect))
     assert_admin_model(
-        controller_client, user_client, permission, expect.next())
+        controller_client, user_client, permission, next(expect))
 
 
 def assert_change_password(client, user, password):

--- a/acceptancetests/certificates.py
+++ b/acceptancetests/certificates.py
@@ -1,6 +1,6 @@
-from OpenSSL import crypto
 import os
 from textwrap import dedent
+from OpenSSL import crypto
 
 
 def create_certificate(target_dir, ip_address):

--- a/acceptancetests/deploy_job.py
+++ b/acceptancetests/deploy_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from deploy_stack import deploy_job
 if __name__ == '__main__':
     deploy_job()

--- a/acceptancetests/jujucharm.py
+++ b/acceptancetests/jujucharm.py
@@ -3,10 +3,9 @@
 from contextlib import contextmanager
 import logging
 import os
-import pexpect
 import re
 import subprocess
-
+import pexpect
 import yaml
 
 from utility import (
@@ -139,13 +138,13 @@ class CharmCommand:
         try:
             command = pexpect.spawn(
                 self.charm_bin, ['login'], env=self._get_env())
-            command.expect('(?i)Login to Ubuntu SSO')
-            command.expect('(?i)Press return to select.*\.')
-            command.expect('(?i)E-Mail:')
+            command.expect(r'(?i)Login to Ubuntu SSO')
+            command.expect(r'(?i)Press return to select.*\.')
+            command.expect(r'(?i)E-Mail:')
             command.sendline(user_email)
-            command.expect('(?i)Password')
+            command.expect(r'(?i)Password')
             command.sendline(password)
-            command.expect('(?i)Two-factor auth')
+            command.expect(r'(?i)Two-factor auth')
             command.sendline()
             command.expect(pexpect.EOF)
             if command.isalive():

--- a/acceptancetests/jujupy/backend.py
+++ b/acceptancetests/jujupy/backend.py
@@ -41,12 +41,6 @@ from jujupy.wait_condition import (
 
 __metaclass__ = type
 
-# Python 2 and 3 compatibility
-try:
-    argtype = basestring
-except NameError:
-    argtype = str
-
 log = logging.getLogger("jujupy.backend")
 
 JUJU_DEV_FEATURE_FLAGS = 'JUJU_DEV_FEATURE_FLAGS'
@@ -189,7 +183,7 @@ class JujuBackend:
 
         # If args is a string, make it a tuple. This makes writing commands
         # with one argument a bit nicer.
-        if isinstance(args, argtype):
+        if isinstance(args, str):
             args = (args,)
         # we split the command here so that the caller can control where the -m
         # model flag goes.  Everything in the command string is put before the
@@ -218,7 +212,7 @@ class JujuBackend:
         # Mutate os.environ instead of supplying env parameter so Windows can
         # search env['PATH']
         stderr = subprocess.PIPE if suppress_err else None
-        # Keep track of commands and how long the take.
+        # Keep track of commands and how long they take.
         command_time = CommandTime(command, args, env)
         with scoped_environ(env):
             log.debug('Running juju with env: {}'.format(env))
@@ -284,7 +278,7 @@ class JujuBackend:
                         b'307: Temporary Redirect' in sub_error):
                     raise CannotConnectEnv(e)
                 raise e
-        return sub_output
+        return sub_output.decode('utf-8')
 
     def get_active_model(self, juju_data_dir):
         """Determine the active model in a juju data dir."""
@@ -305,7 +299,7 @@ class JujuBackend:
         try:
             current = json.loads(self.get_juju_output(
                 'controllers', ('--format', 'json'), set(),
-                juju_data_dir, model=None).decode('ascii'))
+                juju_data_dir, model=None))
         except subprocess.CalledProcessError:
             raise NoActiveControllers(
                 'No active controller for {}'.format(juju_data_dir))
@@ -320,7 +314,7 @@ class JujuBackend:
         try:
             current = json.loads(self.get_juju_output(
                 'controllers', ('--format', 'json'), set(),
-                juju_data_dir, model=None).decode('ascii'))
+                juju_data_dir, model=None))
         except subprocess.CalledProcessError:
             raise NoActiveControllers(
                 'No active controller for {}'.format(juju_data_dir))

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -563,9 +563,12 @@ def describe_substrate(env):
 def get_stripped_version_number(version_string):
     return get_version_string_parts(version_string)[0]
 
-
 def get_version_string_parts(version_string):
     # strip the series and arch from the built version.
+    # Note:
+    if isinstance(version_string, bytes):
+        version_string = str(version_string, 'utf-8')
+
     version_parts = version_string.split('-')
     if len(version_parts) == 4:
         # Version contains "-<patchname>", reconstruct it after the split.
@@ -1173,7 +1176,7 @@ class ModelClient:
                 return self.status_class.from_text(
                     self.get_juju_output(
                         self._show_status, '--format', 'yaml',
-                        controller=controller).decode('utf-8'))
+                        controller=controller))
             except subprocess.CalledProcessError:
                 pass
         raise StatusTimeout(
@@ -1187,7 +1190,7 @@ class ModelClient:
                     self.get_juju_output(
                         self._show_controller, '--format', 'yaml',
                         include_e=False,
-                    ).decode('utf-8'),
+                    ),
                 )
             except subprocess.CalledProcessError:
                 pass
@@ -1204,7 +1207,7 @@ class ModelClient:
                         '--controller', controller_name,
                         '--format', 'yaml',
                         include_e=False,
-                    ).decode('utf-8'),
+                    ),
                 )
             except subprocess.CalledProcessError:
                 pass
@@ -1253,7 +1256,7 @@ class ModelClient:
     def get_env_option(self, option):
         """Return the value of the environment's configured option."""
         return self.get_juju_output(
-            'model-config', option).decode(getpreferredencoding())
+            'model-config', option)
 
     def set_env_option(self, option, value):
         """Set the value of the option in the environment."""

--- a/acceptancetests/jujupy/fake.py
+++ b/acceptancetests/jujupy/fake.py
@@ -42,12 +42,6 @@ from jujupy.wait_condition import (
 
 __metaclass__ = type
 
-# Python 2 and 3 compatibility
-try:
-    argtype = basestring
-except NameError:
-    argtype = str
-
 
 class ControllerOperation(Exception):
 
@@ -775,9 +769,9 @@ class FakeBackend:
         parser.add_argument('--series')
         parsed = parser.parse_args(args)
         if len(parsed.host_placement) > 0 and parsed.count != 1:
-                raise subprocess.CalledProcessError(
-                    1, 'cannot use -n when specifying a placement directive.'
-                    'See Lp #1384350.')
+            raise subprocess.CalledProcessError(
+                1, 'cannot use -n when specifying a placement directive.'
+                'See Lp #1384350.')
         if len(parsed.host_placement) == 1:
             split = parsed.host_placement[0].split(':')
             if len(split) == 1:
@@ -842,7 +836,7 @@ class FakeBackend:
     def get_users(self):
         share_names = self.controller_state.shares
         permissions = []
-        for key, value in self.controller_state.users.iteritems():
+        for key, value in iter(self.controller_state.users.items()):
             if key in share_names:
                 permissions.append(value['permission'])
         share_list = {}
@@ -890,13 +884,12 @@ class FakeBackend:
         full_args.extend(args)
         self.log.log(level, u' '.join(full_args))
 
-    def juju(self, command, args, used_feature_flags,
-             juju_home, model=None, check=True, timeout=None, extra_env=None,
-             suppress_err=False):
+    def juju(self, command, args, used_feature_flags, juju_home, model=None,
+             check=True, timeout=None, extra_env=None, suppress_err=False):
         if 'service' in command:
             raise Exception('Command names must not contain "service".')
 
-        if isinstance(args, argtype):
+        if isinstance(args, str):
             args = (args,)
         self._log_command(command, args, model)
         if model is not None:

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -187,7 +187,7 @@ def agent_tgz_from_juju_binary(
 
     try:
         version_output = subprocess.check_output(
-            [jujud_path, 'version']).rstrip('\n')
+            [jujud_path, 'version']).rstrip(str.encode('\n'))
         version, bin_series, arch = get_version_string_parts(version_output)
         bin_agent_series = _series_lookup(bin_series)
     except subprocess.CalledProcessError as e:
@@ -267,7 +267,7 @@ def _get_series_details(series):
 
 def _get_tgz_file_details(agent_tgz_path):
     file_details = dict(size=os.path.getsize(agent_tgz_path))
-    with open(agent_tgz_path) as f:
+    with open(agent_tgz_path, 'rb') as f:
         content = f.read()
     for hashtype in 'md5', 'sha256':
         hash_obj = hashlib.new(hashtype)

--- a/acceptancetests/jujupy/timeout.py
+++ b/acceptancetests/jujupy/timeout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of JujuPy, a library for driving the Juju CLI.
 # Copyright 2015, 2017 Canonical Ltd.

--- a/acceptancetests/jujupy/workloads.py
+++ b/acceptancetests/jujupy/workloads.py
@@ -107,7 +107,7 @@ def assert_keystone_is_responding(client):
         raise AssertionError('keystone not responding; {}: {}'.format(
             resp.status_code, resp.reason
         ))
-    if '{"versions": {"values":' not in resp.content:
+    if '{"versions": {"values":' not in str(resp.content, 'utf-8'):
         raise AssertionError('Got unexpected keystone page content: {}'.format(resp.content))
 
 
@@ -139,7 +139,7 @@ def deploy_simple_server_to_new_model(
 def deploy_simple_resource_server(
         client, resource_contents=None, series='xenial'):
     application_name = 'simple-resource-http'
-    log.info('Deploying charm: '.format(application_name))
+    log.info('Deploying charm: {}'.format(application_name))
     charm_path = local_charm_path(
         charm=application_name, juju_ver=client.version)
     # Create a temp file which we'll use as the resource.

--- a/acceptancetests/log_check.py
+++ b/acceptancetests/log_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Simple looped check over provided file for regex content."""
 from __future__ import print_function
 

--- a/acceptancetests/remote.py
+++ b/acceptancetests/remote.py
@@ -8,8 +8,8 @@ import zlib
 
 import winrm
 
-import jujupy
 import utility
+import jujupy
 
 
 __metaclass__ = type
@@ -133,6 +133,9 @@ class SSHRemote(_Remote):
         "-o", "UserKnownHostsFile /dev/null",
         "-o", "StrictHostKeyChecking no",
         "-o", "PasswordAuthentication no",
+        # prevent "permanently added to known hosts" warning from polluting
+        # test log output
+        "-o", "LogLevel ERROR",
     ]
 
     # Limit each operation over SSH to 2 minutes by default
@@ -179,7 +182,7 @@ class SSHRemote(_Remote):
         args.append(self.address)
         args.extend(command_args)
         logging.debug(' '.join(utility.quote(i) for i in args))
-        return self._run_subprocess(args)
+        return self._run_subprocess(args).decode('utf-8')
 
     def copy(self, destination_dir, source_globs):
         """Copy files from the remote machine."""
@@ -198,6 +201,12 @@ class SSHRemote(_Remote):
         Tildes and environment variables in the form $TMP will be expanded.
         """
         return self.run(["cat", filename])
+
+    def use_ssh_key(self, identity_file):
+        if "-i" in self._ssh_opts:
+            return
+        self._ssh_opts.append("-i")
+        self._ssh_opts.append(identity_file)
 
     def _run_subprocess(self, command):
         if self.timeout:
@@ -283,7 +292,7 @@ class WinRmRemote(_Remote):
 
     def run_cmd(self, cmd_list):
         """Run cmd and arguments given as a list returning response object."""
-        if isinstance(cmd_list, basestring):
+        if isinstance(cmd_list, (str, bytes)):
             raise ValueError("run_cmd requires a list not a string")
         # pywinrm does not correctly escape arguments, fix up by escaping cmd
         # and giving args as a list of a single pre-escaped string.

--- a/acceptancetests/repository/charms/network-health/actions/ping.py
+++ b/acceptancetests/repository/charms/network-health/actions/ping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/local/sbin/charm-env python3
 import subprocess
 import os
 import sys

--- a/acceptancetests/repository/charms/network-health/actions/unit-info.py
+++ b/acceptancetests/repository/charms/network-health/actions/unit-info.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python3
+#!/usr/local/sbin/charm-env python3
 import subprocess
+import ipaddress
 import re
 
 from charmhelpers.core.hookenv import (
@@ -13,36 +14,69 @@ def main():
 
 
 def interfaces():
-    raw = subprocess.check_output('ifconfig', shell=True).decode("utf-8")
-    patterns = ['(?P<device>^[a-zA-Z0-9:]+)(.*)Link encap:(.*).*',
-                '(.*)Link encap:(.*)(HWaddr )(?P<ether>[^\s]*).*',
-                '.*(inet addr:)(?P<inet>[^\s]*).*',
-                '.*(inet6 addr: )(?P<inet6>[^\s\/]*/(?P<prefixlen>[\d]*)).*',
-                '.*(P-t-P:)(?P<ptp>[^\s]*).*',
-                '.*(Bcast:)(?P<broadcast>[^\s]*).*',
-                '.*(Mask:)(?P<netmask>[^\s]*).*',
-                '.*(Scope:)(?P<scopeid>[^\s]*).*',
-                '.*(RX bytes:)(?P<rxbytes>\d+).*',
-                '.*(TX bytes:)(?P<txbytes>\d+).*']
-    interfaces = {}
-    cur = None
-    all_keys = []
+    if_matches = re.findall(
+        (r'\d+: (?P<ifname>[^:@]+).*?link/[^\s]+ (?P<hwaddr>[^\s]+)'
+         r'.*?RX:.*?(?P<rx>[\d]+).*?TX:.*?(?P<tx>[\d]+)'),
+        subprocess.check_output('ip -s link', shell=True).decode("utf-8"),
+        re.DOTALL
+    )
 
-    for line in raw.splitlines():
-        for pattern in patterns:
-            match = re.search(pattern, line)
-            if match:
-                groupdict = match.groupdict()
-            if 'device' in groupdict:
-                cur = groupdict['device']
-                if cur not in interfaces:
-                    interfaces[cur] = {}
+    all_ifs = {}
+    for if_match in if_matches:
+        name, hwaddr, rx, tx = if_match
+        iface = {
+            'device': name,
+            'ether': hwaddr,
+            'rxbytes': rx,
+            'txbytes': tx,
+        }
 
-            for key in groupdict:
-                if key not in all_keys:
-                    all_keys.append(key)
-                interfaces[cur][key] = groupdict[key]
-    return interfaces
+        # Grab address details
+        addr_out = subprocess.check_output('ip addr show ' + name,
+                                           shell=True).decode("utf-8")
+
+        inet_patterns = [
+            # address with no broadcast (e.g. if this is a loopback device)
+            r'.*inet (?P<addr>[^\s]+) scope (?P<scope>[^\s]*).*',
+            # address with broadcast
+            (r'.*inet (?P<addr>[^\s]+) brd (?P<broadcast>[^\s]*).*?'
+             r' scope (?P<scope>[^\s]*).*'),
+        ]
+        for pat in inet_patterns:
+            match = re.search(pat, addr_out)
+            if not match:
+                continue
+
+            match_dict = match.groupdict()
+            ipnet = ipaddress.ip_interface(match_dict['addr'])
+            iface['inet_addr'] = format(ipnet.ip)
+            iface['inet_netmask'] = format(ipnet.netmask)
+            iface['scope'] = match_dict['scope']
+            if 'broadcast' in match_dict:
+                iface['inet_broadcast'] = match_dict['broadcast']
+
+        inet6_patterns = [
+            # address with no broadcast (e.g. if this is a loopback device)
+            r'.*inet6 (?P<addr>[^\s]+) scope (?P<scope>[^\s]*).*',
+            # address with broadcast
+            (r'.*inet6 (?P<addr>[^\s]+) brd (?P<broadcast>[^\s]*).*?'
+             r' scope (?P<scope>[^\s]*).*'),
+        ]
+        for pat in inet6_patterns:
+            match = re.search(pat, addr_out)
+            if not match:
+                continue
+
+            match_dict = match.groupdict()
+            ipnet = ipaddress.ip_interface(match_dict['addr'])
+            iface['inet6_addr'] = format(ipnet.ip)
+            iface['inet6_netmask'] = format(ipnet.netmask)
+            iface['scope'] = match_dict['scope']
+            if 'broadcast' in match_dict:
+                iface['inet6_broadcast'] = match_dict['broadcast']
+
+        all_ifs[name] = iface
+    return all_ifs
 
 
 if __name__ == "__main__":

--- a/acceptancetests/repository/network-health-2-machines-bind.yaml
+++ b/acceptancetests/repository/network-health-2-machines-bind.yaml
@@ -1,10 +1,10 @@
 # network-health-2-machines:
 machines:
   '0':
-    series: xenial
+    series: bionic
   '1':
-    series: xenial
-series: xenial
+    series: bionic
+series: bionic
 applications:
   dummy-source-a:
     charm: cs:~juju-qa/dummy-source
@@ -23,7 +23,7 @@ applications:
     to:
     - lxd:0
     bindings:
-      "": space-0
+      "": space1
   dummy-source-c:
     charm: cs:~juju-qa/dummy-source
     num_units: 1
@@ -33,7 +33,7 @@ applications:
     to:
     - lxd:1
     bindings:
-      "": space-0
+      "": space1
   dummy-sink-a:
     charm: cs:~juju-qa/dummy-sink
     num_units: 1
@@ -43,7 +43,7 @@ applications:
     to:
     - lxd:0
     bindings:
-      "": space-0
+      "": space1
   dummy-sink-b:
     charm: cs:~juju-qa/dummy-sink
     num_units: 1
@@ -53,7 +53,7 @@ applications:
     to:
     - '1'
     bindings:
-      "": space-0
+      "": space1
   dummy-sink-c:
     charm: cs:~juju-qa/dummy-sink
     num_units: 1
@@ -63,7 +63,7 @@ applications:
     to:
     - lxd:1
     bindings:
-      "": space-0
+      "": space1
   dummy-subordinate:
     charm: cs:~juju-qa/dummy-subordinate
     expose: false

--- a/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
+++ b/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
@@ -211,7 +211,7 @@ def get_monitoring_password(haproxy_config_file="/etc/haproxy/haproxy.cfg"):
     haproxy_config = load_haproxy_config(haproxy_config_file)
     if haproxy_config is None:
         return None
-    m = re.search("stats auth\s+(\w+):(\w+)", haproxy_config)
+    m = re.search(r"stats auth\s+(\w+):(\w+)", haproxy_config)
     if m is not None:
         return m.group(2)
     else:
@@ -239,14 +239,14 @@ def get_listen_stanzas(haproxy_config_file="/etc/haproxy/haproxy.cfg"):
     if haproxy_config is None:
         return ()
     listen_stanzas = re.findall(
-        "listen\s+([^\s]+)\s+([^:]+):(.*)",
+        r"listen\s+([^\s]+)\s+([^:]+):(.*)",
         haproxy_config)
     # Match bind stanzas like:
     #
     # bind 1.2.3.5:234
     # bind 1.2.3.4:123 ssl crt /foo/bar
     bind_stanzas = re.findall(
-        "\s+bind\s+([^:]+):(\d+).*\n\s+default_backend\s+([^\s]+)",
+        r"\s+bind\s+([^:]+):(\d+).*\n\s+default_backend\s+([^\s]+)",
         haproxy_config, re.M)
     return (tuple(((service, addr, int(port))
                    for service, addr, port in listen_stanzas)) +
@@ -417,7 +417,7 @@ def _append_backend(service_config, name, options, errorfiles, server_entries):
             server_line = "    server %s %s:%s" % \
                 (server_name, server_ip, server_port)
             if server_options is not None:
-                if isinstance(server_options, basestring):
+                if isinstance(server_options, str):
                     server_line += " " + server_options
                 else:
                     server_line += " " + " ".join(server_options)
@@ -446,7 +446,7 @@ def create_monitoring_stanza(service_name="haproxy_monitoring"):
     monitoring_config.append("http-request deny unless allowed_cidr")
     monitoring_config.append("stats enable")
     monitoring_config.append("stats uri /")
-    monitoring_config.append("stats realm Haproxy\ Statistics")
+    monitoring_config.append(r"stats realm Haproxy\ Statistics")
     monitoring_config.append("stats auth %s:%s" %
                              (config_data['monitoring_username'],
                               monitoring_password))
@@ -487,7 +487,7 @@ def parse_services_yaml(services, yaml_data):
             services[None] = {"service_name": service_name}
 
         if "service_options" in service:
-            if isinstance(service["service_options"], basestring):
+            if isinstance(service["service_options"], str):
                 service["service_options"] = comma_split(
                     service["service_options"])
 
@@ -496,7 +496,7 @@ def parse_services_yaml(services, yaml_data):
                 service["service_options"].append("option forwardfor")
 
         if (("server_options" in service and
-             isinstance(service["server_options"], basestring))):
+             isinstance(service["server_options"], str))):
             service["server_options"] = comma_split(service["server_options"])
 
         services[service_name] = merge_service(
@@ -1236,7 +1236,7 @@ def is_selfsigned_cert_stale(cert_file, key_file):
                 extension.get_data(), asn1Spec=rfc2459.SubjectAltName())[0]
             for name in names:
                 cert_addresses.add(str(name.getComponent()))
-        except:
+        except Exception:
             pass
     if cert_addresses != unit_addresses:
         log('subjAltName: Cert (%s) != Unit (%s), assuming stale' % (
@@ -1351,6 +1351,7 @@ def main(hook_name):
     else:
         print("Unknown hook")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     hook_name = os.path.basename(sys.argv[0])

--- a/acceptancetests/requirements.txt
+++ b/acceptancetests/requirements.txt
@@ -14,6 +14,7 @@ azure-mgmt-redis>=0.30.0rc3
 azure-mgmt-resource>=0.30.0rc3
 azure-mgmt-scheduler>=0.30.0rc3
 azure-mgmt-storage>=0.30.0rc3
+azure-mgmt-containerservice>=0.30.0rc3
 azure-mgmt-web>=0.30.0rc3
 azure-nspkg>=1.0.0
 azure-servicebus>=0.20.1

--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -470,8 +470,9 @@ class AzureARMAccount:
             if m.get('short-name', m['name']) == client.model_name][0]
         resource_group = 'juju-{}-model-{}'.format(
             model.get('short-name', model['name']), model['model-uuid'])
-        resources = winazurearm.list_resources(
-            self.arm_client, glob=resource_group, recursive=True)
+        # NOTE(achilleasa): resources was not used in this func
+        # resources = winazurearm.list_resources(
+        #    self.arm_client, glob=resource_group, recursive=True)
         vm_ids = []
         for machine_name in instance_ids:
             rgd, vm = winazurearm.find_vm_deployment(
@@ -896,11 +897,7 @@ class LXDAccount:
 
 def get_config(boot_config):
     config = boot_config.make_config_copy()
-    if boot_config.provider not in (
-        'lxd',
-        'manual',
-        'kubernetes',
-    ):
+    if boot_config.provider not in ('lxd', 'manual', 'kubernetes'):
         config.update(boot_config.get_cloud_credentials())
     return config
 
@@ -943,7 +940,7 @@ def start_libvirt_domain(uri, domain):
     try:
         subprocess.check_output(command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        if 'already active' in e.output:
+        if 'already active' in e.output.decode('utf-8'):
             return '%s is already running; nothing to do.' % domain
         raise Exception('%s failed:\n %s' % (command, e.output))
     sleep(30)
@@ -965,7 +962,7 @@ def stop_libvirt_domain(uri, domain):
     try:
         subprocess.check_output(command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        if 'domain is not running' in e.output:
+        if 'domain is not running' in e.output.decode('utf-8'):
             return ('%s is not running; nothing to do.' % domain)
         raise Exception('%s failed:\n %s' % (command, e.output))
     sleep(30)

--- a/acceptancetests/template_assess.py.tmpl
+++ b/acceptancetests/template_assess.py.tmpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ TODO: Single line description of this assess script purpose.
 
 TODO: add description For:

--- a/acceptancetests/utility.py
+++ b/acceptancetests/utility.py
@@ -87,7 +87,7 @@ def _clean_dir(maybe_dir):
             # we don't raise this error due to tests abusing /tmp/logs
             logging.warning('Not a directory {}'.format(maybe_dir))
         if e.errno == errno.EEXIST:
-            logging.warnings('Directory {} already exists'.format(maybe_dir))
+            logging.warning('Directory {} already exists'.format(maybe_dir))
     else:
         if contents and contents != ["empty"]:
             logging.warning(
@@ -142,7 +142,7 @@ def wait_for_port(host, port, closed=False, timeout=30):
         except socket.gaierror as e:
             print_now(str(e))
         except Exception as e:
-            print_now('Unexpected {!r}: {}'.format((type(e), e)))
+            print_now('Unexpected {!r}: {}'.format(type(e), e))
             raise
         else:
             conn.close()
@@ -268,7 +268,7 @@ def add_basic_testing_arguments(
                         default=None)
     parser.add_argument('temp_env_name', nargs='?',
                         help='A temporary test environment name. By default, '
-                             ' this will generate an enviroment name using the '
+                             ' this will generate an enviroment name using the'
                              ' timestamp and testname. '
                              ' test_name_timestamp_temp_env',
                         default=_generate_default_temp_env_name())
@@ -296,16 +296,20 @@ def add_basic_testing_arguments(
     parser.add_argument('--bootstrap-host',
                         help='The host to use for bootstrap.')
     parser.add_argument('--machine', help='A machine to add or when used with '
-                                          'KVM based MaaS, a KVM image to start.',
+                                          'KVM based MaaS, a KVM image to '
+                                          'start.',
                         action='append', default=[])
     parser.add_argument('--keep-env', action='store_true',
                         help='Keep the Juju environment after the test'
                              ' completes.')
     parser.add_argument('--logging-config',
-                        help="Override logging configuration for a deployment.",
+                        help="Override logging configuration for a "
+                             "deployment.",
                         default="<root>=INFO;unit=INFO")
-    parser.add_argument('--juju-home', help="Directory of juju home. It is not used during integration test runs. "
-                                            "One can override this arg for local runs.", default=None)
+    parser.add_argument('--juju-home', help="Directory of juju home. It is not"
+                                            " used during integration test "
+                                            "runs. One can override this arg "
+                                            "for local runs.", default=None)
 
     if existing:
         parser.add_argument(
@@ -436,10 +440,18 @@ def assert_dict_is_subset(sub_dict, super_dict):
     :raises JujuAssertionError: when sub_dict items are missing.
     :return: True when when sub_dict is a subset of super_dict
     """
-    if not all(item in super_dict.items() for item in sub_dict.items()):
+    if not is_subset(sub_dict, super_dict):
         raise JujuAssertionError(
             'Found: {} \nExpected: {}'.format(super_dict, sub_dict))
     return True
+
+def is_subset(subset, superset):
+    """ Recursively check that subset is indeed a subset of superset """
+    if isinstance(subset, dict):
+        return all(key in superset and is_subset(val, superset[key]) for key, val in iter(subset.items()))
+    if isinstance(subset, list) or isinstance(subset, set):
+        return all(any(is_subset(subitem, superitem) for superitem in superset) for subitem in subset)
+    return subset == superset
 
 
 def add_model(client):
@@ -481,7 +493,7 @@ def list_models(client):
     """
     try:
         raw = client.get_juju_output('list-models', '--format', 'json',
-                                     include_e=False).decode('utf-8')
+                                     include_e=False)
     except subprocess.CalledProcessError as e:
         log.error('Failed to list current models due to error: {}'.format(e))
         raise e
@@ -513,7 +525,8 @@ def subordinate_machines_from_app_info(app_data, apps):
     for sub_name in app_data['subordinate-to']:
         for app_name, prim_app_data in apps.items():
             if sub_name == app_name:
-                machines.extend(application_machines_from_app_info(prim_app_data))
+                machines.extend(application_machines_from_app_info(
+                    prim_app_data))
     return machines
 
 

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -10,11 +10,8 @@ run_network_health() {
     juju deploy ubuntu ubuntu-bionic --series bionic
 
     # Now the testing charm for each series.
-    # TODO (manadart 2020-06-08): This charm needs updating with Focal support.
-    # TODO: The latest network-health charm (11 onwards) is broken;
-    # it doesn't properly install charmhelpers.
-    juju deploy 'cs:~juju-qa/network-health-10' network-health-xenial --series xenial
-    juju deploy 'cs:~juju-qa/network-health-10' network-health-bionic --series bionic
+    juju deploy 'cs:~juju-qa/network-health' network-health-xenial --series xenial
+    juju deploy 'cs:~juju-qa/network-health' network-health-bionic --series bionic
 
     juju expose network-health-xenial
     juju expose network-health-bionic


### PR DESCRIPTION
This PR merges the changes from the `2.9-python3-acceptancetests` branch which migrate all acceptance tests to python3 and also fix some pre-existing issues.

Here is a list of PRs that are included in this changeset:

- b78793637d (upstream/2.9-python3-acceptancetests, origin/2.9-python3-acceptancetests, 2.9-python3-acceptancetests) Merge pull request #12565 from achilleasa/2.9-even-more-test-fixes
- 5e73141899 Merge pull request #12562 from achilleasa/2.9-fix-maas-tests
- c2e9f8195f Merge pull request #12547 from achilleasa/2.9-more-python3-acceptance-test-fixes
- fca6851418 Merge pull request #12531 from achilleasa/2.9-more-python3-compat-fixes-for-acceptance-tests
- 2cf9aa6a8f Merge pull request #12524 from achilleasa/2.9-yet-more-python3-compat-fixes-for-acceptance-tests
- 6def57bc2c Merge pull request #12520 from achilleasa/2.9-even-even-even-more-python3-compat-fixes-for-acceptance-tests
- d9de57cbb3 Merge pull request #12519 from achilleasa/2.9-even-even-more-python3-compat-fixes-for-acceptance-tests
- 54b8dff88c Merge pull request #12516 from achilleasa/2.9-even-more-python3-compat-fixes-for-acceptance-tests
- f2ac34d3be Merge pull request #12510 from achilleasa/2.9-fix-more-python2-to-python3-inconsistencies
- 261be046aa (origin/2.9-convert-acceptance-tests-to-use-python3) Merge pull request #12504 from achilleasa/2.9-convert-acceptance-tests-to-use-python3
