### PR TITLE
Fix/lp1911653

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -598,6 +598,7 @@ func (op *caasOperator) loop() (err error) {
 				params.UniterFacade = op.config.UniterFacadeFunc(unitTag)
 				params.LeadershipTrackerFunc = op.config.LeadershipTrackerFunc
 				params.ApplicationChannel = aliveUnits[unitID]
+				params.Logger = params.Logger.Child(unitID)
 				if op.deploymentMode != caas.ModeOperator {
 					params.IsRemoteUnit = true
 					params.ContainerRunningStatusChannel = unitRunningChannels[unitID]

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -199,6 +199,10 @@ func (config Config) Validate() error {
 	if config.ExecClientGetter == nil {
 		return errors.NotValidf("missing ExecClientGetter")
 	}
+
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
 	return nil
 }
 

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -103,7 +103,9 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.client.containerWatcher = watchertest.NewMockStringsWatcher(s.containerChanges)
 	s.client.watcher = watchertest.NewMockNotifyWatcher(s.appChanges)
 	s.charmDownloader.ResetCalls()
-	s.uniterParams = &uniter.UniterParams{}
+	s.uniterParams = &uniter.UniterParams{
+		Logger: loggo.GetLogger("uniter"),
+	}
 	s.leadershipTrackerFunc = func(unitTag names.UnitTag) leadership.TrackerWorker {
 		return &runnertesting.FakeTracker{}
 	}
@@ -135,7 +137,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		RunListenerSocketFunc: s.runListenerSocketFunc,
 		StartUniterFunc:       func(runner *worker.Runner, params *uniter.UniterParams) error { return nil },
 		ExecClientGetter:      func() (exec.Executor, error) { return s.mockExecutor, nil },
-		Logger:                loggo.GetLogger("test"),
+		Logger:                loggo.GetLogger("operator"),
 	}
 
 	agentBinaryDir := agenttools.ToolsDir(s.config.DataDir, "application-gitlab")
@@ -201,6 +203,10 @@ func (s *WorkerSuite) TestValidateConfig(c *gc.C) {
 	s.testValidateConfig(c, func(config *caasoperator.Config) {
 		config.VersionSetter = nil
 	}, `missing VersionSetter not valid`)
+
+	s.testValidateConfig(c, func(config *caasoperator.Config) {
+		config.Logger = nil
+	}, `missing Logger not valid`)
 
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1280,6 +1280,14 @@ func (s writeFile) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+type removeCharmDir struct{}
+
+func (s removeCharmDir) step(c *gc.C, ctx *context) {
+	path := filepath.Join(ctx.path, "charm")
+	err := os.RemoveAll(path)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 type custom struct {
 	f func(*gc.C, *context)
 }


### PR DESCRIPTION

*Download charm if charm dir was empty after uniter init;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
$ yml2json /tmp/charm-builds/mariadb-k8s/metadata.yaml | jq '.["min-juju-version"]'
"2.8.0"

$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ mkubectl delete -nt1 pod/mariadb-k8s-operator-0

$ mkubectl exec pod/mariadb-k8s-operator-0 -n t1 -it -- ls -al /var/lib/juju/agents/unit-mariadb-k8s-0
total 20
drwxr-xr-x  5 root root 4096 Feb  1 04:01 .
drwxr-xr-x  4 root root 4096 Feb  1 04:01 ..
drwxr-xr-x 10 root root 4096 Feb  1 04:01 charm
drwxr-xr-x  3 root root 4096 Feb  1 04:01 resources
srwx------  1 root root    0 Feb  1 04:01 run.socket
drwxr-xr-x  4 root root 4096 Feb  1 04:01 state

```

## Documentation changes

No


## Bug reference

https://bugs.launchpad.net/juju/+bug/1911653
