### PR TITLE
[Charmhub] - Ensure refresh install actions

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -124,10 +124,12 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 		WithArchitecture(origin.Architecture).
 		WithRevision(revision)
 
+	// Create a resolved origin.  Keep the original values for ID and Hash, if any
+	// were passed in.  ResolveWithPreferredChannel is called for both charms to be
+	// deployed, and charms which are being upgraded.  Only charms being upgraded
+	// will have an ID and Hash.  Those values should only ever be updated in
 	resOrigin := origin
 	resOrigin.Type = string(entity.Type)
-	resOrigin.ID = res.ID
-	resOrigin.Hash = entity.Download.HashSHA256
 	resOrigin.Track = track
 	resOrigin.Risk = string(channel.Risk)
 	resOrigin.Revision = &revision
@@ -169,6 +171,9 @@ func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url
 	}
 
 	resOrigin := origin
+	// We've called Refresh with the install action.  Now update the
+	// charm ID and Hash values saved.  This is the only place where
+	// they should be saved.
 	resOrigin.ID = refreshRes.Entity.ID
 	resOrigin.Hash = refreshRes.Entity.Download.HashSHA256
 

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -27,7 +27,20 @@ type charmHubRepositoriesSuite struct {
 
 var _ = gc.Suite(&charmHubRepositoriesSuite{})
 
-func (s *charmHubRepositoriesSuite) TestResolve(c *gc.C) {
+func (s *charmHubRepositoriesSuite) TestResolveForDeploy(c *gc.C) {
+	// The origin.ID should never be saved to the origin during
+	// ResolveWithPreferredChannel.  That is done during the file
+	// download only.
+	s.testResolve(c, "")
+}
+
+func (s *charmHubRepositoriesSuite) TestResolveForUpgrade(c *gc.C) {
+	// If the origin has an ID, ensure it's kept thru the call
+	// to ResolveWithPreferredChannel.
+	s.testResolve(c, "charmCHARMcharmCHARMcharmCHARM01")
+}
+
+func (s *charmHubRepositoriesSuite) testResolve(c *gc.C, id string) {
 	defer s.setupMocks(c).Finish()
 	s.expectCharmRefresh(c)
 
@@ -45,7 +58,6 @@ func (s *charmHubRepositoriesSuite) TestResolve(c *gc.C) {
 
 	curl.Revision = 16
 
-	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"
@@ -73,7 +85,6 @@ func (s *charmHubRepositoriesSuite) TestResolveWithoutSeries(c *gc.C) {
 
 	curl.Revision = 16
 
-	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"
@@ -99,7 +110,6 @@ func (s *charmHubRepositoriesSuite) TestResolveWithBundles(c *gc.C) {
 
 	curl.Revision = 17
 
-	origin.ID = "bundleBUNDLEbundleBUNDLE01"
 	origin.Type = "bundle"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"
@@ -126,7 +136,6 @@ func (s *charmHubRepositoriesSuite) TestResolveInvalidPlatformError(c *gc.C) {
 
 	curl.Revision = 16
 
-	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"
@@ -167,7 +176,6 @@ func (s *charmHubRepositoriesSuite) TestResolveRevisionNotFoundError(c *gc.C) {
 
 	curl.Revision = 16
 
-	origin.ID = "charmCHARMcharmCHARMcharmCHARM01"
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
 	origin.Risk = "stable"

--- a/core/charm/strategies.go
+++ b/core/charm/strategies.go
@@ -342,7 +342,7 @@ func (StoreCharmStore) Validate(curl *charm.URL) error {
 
 // Download the charm from the charm store.
 func (s StoreCharmStore) Download(curl *charm.URL, file string, origin Origin) (StoreCharm, ChecksumCheckFn, Origin, error) {
-	s.logger.Tracef("Download(%s) %s", curl)
+	s.logger.Tracef("Download(%s)", curl)
 	archive, err := s.repository.DownloadCharm(curl.String(), file)
 	if err != nil {
 		if cause := errors.Cause(err); httpbakery.IsDischargeError(cause) || httpbakery.IsInteractionError(cause) {
@@ -377,7 +377,7 @@ func (StoreCharmHub) Validate(curl *charm.URL) error {
 
 // Download the charm from the charm hub.
 func (s StoreCharmHub) Download(curl *charm.URL, file string, origin Origin) (StoreCharm, ChecksumCheckFn, Origin, error) {
-	s.logger.Tracef("Download(%s) %s", curl)
+	s.logger.Tracef("Download(%s) %s", curl, pretty.Sprint(origin))
 	repositoryURL, downloadOrigin, err := s.repository.FindDownloadURL(curl, origin)
 	if err != nil {
 		return nil, nil, downloadOrigin, errors.Trace(err)


### PR DESCRIPTION

Ensure we use the Install action of Refresh when deploying a charm and the Refresh action of Refresh when upgrading a charm by only saving the charm ID while downloading it for install.

Saving the charm ID is important as a charm from CharmHub can be renamed.

## QA steps

```console
$ juju deploy ubuntu-juju-qa --series bionic
Located charm "ubuntu-juju-qa" in charm-hub, revision 14
Deploying "ubuntu-juju-qa" from charm-hub charm "ubuntu-juju-qa", revision 14 in channel stable
$ juju refresh ubuntu-juju-qa --channel candidate
Looking up metadata for charm-hub charm "ubuntu-juju-qa" from channel edge
Added charm-hub charm "ubuntu-juju-qa", revision 16 in channel candidate, to the model
```

