### PR TITLE
Fix typo in action Enqueue() api

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -100,7 +100,6 @@ func (c *Client) Enqueue(actions []Action) ([]ActionResult, error) {
 	arg := params.Actions{Actions: make([]params.Action, len(actions))}
 	for i, a := range actions {
 		arg.Actions[i] = params.Action{
-			Tag:        names.NewActionTag(a.ID).String(),
 			Receiver:   a.Receiver,
 			Name:       a.Name,
 			Parameters: a.Parameters,


### PR DESCRIPTION
The Enqueue() API on the action client api was incorrectly assuming an ID was passed in and trying to use it to make a tag.
CI tests picked up the issue. This api is deprecated and already removed in Juju 3.0 branch.

## QA steps

juju run-action foo/0 some-action

