### PR TITLE
Set AdmissionReviewVersion to v1 for addmission controller;

### DIFF
--- a/worker/caasadmission/admission.go
+++ b/worker/caasadmission/admission.go
@@ -29,6 +29,9 @@ const (
 	// ids. For example using this component "admission" with "juju.io" would
 	// yield admission.juju.io
 	Component = "admission"
+
+	// we still accept v1beta1 AdmissionReview only.
+	reviewVersionV1beta1 = "v1beta1"
 )
 
 var (
@@ -75,9 +78,10 @@ func NewAdmissionCreator(
 					CABundle: caPemBuffer.Bytes(),
 					Service:  service,
 				},
-				FailurePolicy: &failurePolicy,
-				MatchPolicy:   &matchPolicy,
-				Name:          provider.MakeK8sDomain(Component),
+				AdmissionReviewVersions: []string{reviewVersionV1beta1},
+				FailurePolicy:           &failurePolicy,
+				MatchPolicy:             &matchPolicy,
+				Name:                    provider.MakeK8sDomain(Component),
 				NamespaceSelector: &meta.LabelSelector{
 					MatchLabels: provider.LabelsForModel(modelName),
 				},

--- a/worker/caasadmission/admission_test.go
+++ b/worker/caasadmission/admission_test.go
@@ -64,6 +64,7 @@ func (a *AdmissionSuite) TestAdmissionCreatorObject(c *gc.C) {
 			c.Assert(obj.Namespace, gc.Equals, namespace)
 			c.Assert(len(obj.Webhooks), gc.Equals, 1)
 			webhook := obj.Webhooks[0]
+			c.Assert(webhook.AdmissionReviewVersions, gc.DeepEquals, []string{"v1beta1"})
 			c.Assert(webhook.SideEffects, gc.NotNil)
 			c.Assert(*webhook.SideEffects, gc.Equals, admission.SideEffectClassNone)
 			svc := webhook.ClientConfig.Service


### PR DESCRIPTION
*Set AdmissionReviewVersion to v1 for addmission controller because this field is required for API v1;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
$ juju add-model t1 microk8s

$ juju add-model t2 microk8s

$ mkubectl get mutatingWebhookConfigurations -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
{
  "apiVersion": "admissionregistration.k8s.io/v1",
  "name": "juju-model-admission-controller-k1"
}
{
  "apiVersion": "admissionregistration.k8s.io/v1",
  "name": "juju-model-admission-t1"
}
{
  "apiVersion": "admissionregistration.k8s.io/v1",
  "name": "juju-model-admission-t2"
}
```

## Documentation changes

No

## Bug reference

No
