### PR TITLE
Merge 2.9

### DIFF
--- a/acceptancetests/assess_cloud.py
+++ b/acceptancetests/assess_cloud.py
@@ -104,7 +104,7 @@ def assess_cloud_kill_controller(bs_manager):
         # stopped its jujud).  This would normally be seen as a bug, so we
         # suppress it.
         cmd = ('--machine', '0', 'sudo service jujud-machine-0 stop')
-        controller_client.juju('run', cmd, check=False, suppress_err=True)
+        controller_client.juju('exec', cmd, check=False, suppress_err=True)
         bs_manager.has_controller = False
 
 

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -512,8 +512,7 @@ class AssessNetworkHealth:
         return True
 
     def to_json(self, units):
-        """Returns a formatted json string to be passed through juju
-        run-action.
+        """Returns a formatted json string to be passed through juju run.
 
         :param units: Dict of units
         :return: A "JSON-like" string that can be passed to Juju without it

--- a/acceptancetests/assess_primary_sub_relations.py
+++ b/acceptancetests/assess_primary_sub_relations.py
@@ -181,7 +181,7 @@ def assert_subordinate_unit_operational(client, primary_app_name):
     primary_unit = '{}/0'.format(primary_app_name)
     try:
         client.juju(
-            'run',
+            'exec',
             (
                 '--unit', primary_unit,
                 'sudo', 'service', sub_unit_name, 'status'))

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1905,7 +1905,7 @@ class ModelClient:
         """
         args = (unit, action) + args
 
-        output = self.get_juju_output("run-action", *args)
+        output = self.get_juju_output("run", *args)
         action_id_pattern = re.compile('Action queued with id: "([0-9]+)"')
         match = action_id_pattern.search(output)
         if match is None:

--- a/acceptancetests/jujupy/fake.py
+++ b/acceptancetests/jujupy/fake.py
@@ -1072,7 +1072,7 @@ class FakeBackend:
                 return model_state.remove_ssh_key(args)
             if command == 'import-ssh-key':
                 return model_state.import_ssh_key(args)
-            if command == 'run-action':
+            if command == 'run':
                 unit_id = args[0]
                 action = args[1]
                 return self.run_action(unit_id, action)

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -2793,7 +2793,7 @@ class TestModelClient(ClientTest):
             id = client.action_do("foo/0", "myaction", "param=5")
             self.assertEqual(id, "666")
         mock.assert_called_once_with(
-            'run-action', 'foo/0', 'myaction', "param=5"
+            'run', 'foo/0', 'myaction', "param=5"
         )
 
     def test_action_do_error(self):

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -2843,7 +2843,7 @@ class TestModelClient(ClientTest):
             out = client.action_do_fetch("foo/0", "myaction", "param=5")
             self.assertEqual(out, ret)
 
-    def test_run(self):
+    def test_exec(self):
         client = fake_juju_client(cls=ModelClient)
         run_list = [
             {"machine": "1",
@@ -2856,34 +2856,34 @@ class TestModelClient(ClientTest):
             result = client.run(('wname',), applications=['foo', 'bar'])
         self.assertEqual(run_list, result)
         gjo_mock.assert_called_once_with(
-            'run', ('--format', 'json', '--application', 'foo,bar', 'wname'),
+            'exec', ('--format', 'json', '--application', 'foo,bar', 'wname'),
             frozenset(['migration']), 'foo',
             'name:name', user_name=None)
 
-    def test_run_machines(self):
+    def test_exec_machines(self):
         client = fake_juju_client(cls=ModelClient)
         output = json.dumps({"ReturnCode": 255})
         with patch.object(client, 'get_juju_output',
                           return_value=output) as output_mock:
             client.run(['true'], machines=['0', '1', '2'])
         output_mock.assert_called_once_with(
-            'run', '--format', 'json', '--machine', '0,1,2', 'true')
+            'exec', '--format', 'json', '--machine', '0,1,2', 'true')
 
-    def test_run_use_json_false(self):
+    def test_exec_use_json_false(self):
         client = fake_juju_client(cls=ModelClient)
         output = json.dumps({"ReturnCode": 255})
         with patch.object(client, 'get_juju_output', return_value=output):
             result = client.run(['true'], use_json=False)
         self.assertEqual(output, result)
 
-    def test_run_units(self):
+    def test_exec_units(self):
         client = fake_juju_client(cls=ModelClient)
         output = json.dumps({"ReturnCode": 255})
         with patch.object(client, 'get_juju_output',
                           return_value=output) as output_mock:
             client.run(['true'], units=['foo/0', 'foo/1', 'foo/2'])
         output_mock.assert_called_once_with(
-            'run', '--format', 'json', '--unit', 'foo/0,foo/1,foo/2', 'true')
+            'exec', '--format', 'json', '--unit', 'foo/0,foo/1,foo/2', 'true')
 
     def test_list_space(self):
         client = ModelClient(JujuData(None, {'type': 'lxd'}),

--- a/acceptancetests/jujupy/workloads.py
+++ b/acceptancetests/jujupy/workloads.py
@@ -45,7 +45,7 @@ def deploy_mediawiki_with_db(client):
     client.deploy('cs:percona-cluster')
     client.wait_for_started()
     client.wait_for_workloads()
-    client.juju('run', ('--unit', 'percona-cluster/0', 'leader-get'))
+    client.juju('exec', ('--unit', 'percona-cluster/0', 'leader-get'))
 
     # Using local mediawiki charm due to db connect bug.
     # Once that's fixed we can use from the charmstore.
@@ -82,7 +82,7 @@ def deploy_keystone_with_db(client):
     client.deploy('cs:percona-cluster')
     client.wait_for_started()
     client.wait_for_workloads()
-    client.juju('run', ('--unit', 'percona-cluster/0', 'leader-get'))
+    client.juju('exec', ('--unit', 'percona-cluster/0', 'leader-get'))
 
     # use a charm which is under development by
     # canonical to try to avoid rot.

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -16,7 +16,7 @@ import (
 
 func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 	ir := params.InfoResponse{
-		Type:        info.Type,
+		Type:        string(info.Type),
 		ID:          info.ID,
 		Name:        info.Name,
 		Description: info.Entity.Description,
@@ -59,7 +59,7 @@ func convertCharmFindResults(responses []transport.FindResponse) []params.FindRe
 
 func convertCharmFindResult(resp transport.FindResponse) params.FindResponse {
 	result := params.FindResponse{
-		Type:      resp.Type,
+		Type:      string(resp.Type),
 		ID:        resp.ID,
 		Name:      resp.Name,
 		Publisher: publisher(resp.Entity),

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -271,9 +271,6 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 		channel         string
 		nonEmptyChannel = origin.Channel != nil && !origin.Channel.Empty()
 	)
-	if method == MethodRevision && nonEmptyChannel {
-		return nil, errors.NotValidf("supplying both revision and channel")
-	}
 
 	// Select the appropriate channel based on the supplied origin.
 	if nonEmptyChannel {

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -382,21 +382,6 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 	})
 }
 
-func (refreshConfigSuite) TestRefreshByRevisionAndChannel(c *gc.C) {
-	revision := 1
-	curl := charm.MustParseURL("ch:wordpress")
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
-	channel := corecharm.MustParseChannel("latest/stable").Normalize()
-	origin := corecharm.Origin{
-		Platform: platform,
-		Channel:  &channel,
-		Revision: &revision,
-	}
-
-	_, err := refreshConfig(curl, origin)
-	c.Assert(err, gc.ErrorMatches, `supplying both revision and channel not valid`)
-}
-
 func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	id := "aaabbbccc"
 	revision := 1

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -416,9 +416,9 @@ func (c refreshMany) String() string {
 
 // constructRefreshPlatform creates a refresh request platform that allows for
 // partial platform queries.
-func constructRefreshPlatform(platform RefreshPlatform) (transport.RefreshRequestPlatform, error) {
+func constructRefreshPlatform(platform RefreshPlatform) (transport.Platform, error) {
 	if platform.Architecture == "" {
-		return transport.RefreshRequestPlatform{}, errors.NotValidf("refresh arch")
+		return transport.Platform{}, errors.NotValidf("refresh arch")
 	}
 	os := platform.OS
 	if os == "" {
@@ -429,7 +429,7 @@ func constructRefreshPlatform(platform RefreshPlatform) (transport.RefreshReques
 		series = NotAvailable
 	}
 
-	return transport.RefreshRequestPlatform{
+	return transport.Platform{
 		Architecture: platform.Architecture,
 		OS:           os,
 		Series:       series,

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -39,7 +39,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          id,
 			Revision:    1,
-			Platform: transport.RefreshRequestPlatform{
+			Platform: transport.Platform{
 				OS:           "ubuntu",
 				Series:       "focal",
 				Architecture: arch.DefaultArchitecture,
@@ -274,7 +274,7 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          "foo",
 			Revision:    1,
-			Platform: transport.RefreshRequestPlatform{
+			Platform: transport.Platform{
 				OS:           "ubuntu",
 				Series:       "focal",
 				Architecture: arch.DefaultArchitecture,
@@ -327,7 +327,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Revision:    &revision,
-			Platform: &transport.RefreshRequestPlatform{
+			Platform: &transport.Platform{
 				OS:           "ubuntu",
 				Series:       "focal",
 				Architecture: arch.DefaultArchitecture,
@@ -358,7 +358,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Channel:     &channel,
-			Platform: &transport.RefreshRequestPlatform{
+			Platform: &transport.Platform{
 				OS:           "ubuntu",
 				Series:       "focal",
 				Architecture: arch.DefaultArchitecture,
@@ -387,7 +387,7 @@ func (s *RefreshConfigSuite) TestInstallOneWithPartialPlatform(c *gc.C) {
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Channel:     &channel,
-			Platform: &transport.RefreshRequestPlatform{
+			Platform: &transport.Platform{
 				OS:           NotAvailable,
 				Series:       NotAvailable,
 				Architecture: arch.DefaultArchitecture,
@@ -478,7 +478,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          &id,
 			Channel:     &channel,
-			Platform: &transport.RefreshRequestPlatform{
+			Platform: &transport.Platform{
 				OS:           "ubuntu",
 				Series:       "focal",
 				Architecture: arch.DefaultArchitecture,
@@ -543,7 +543,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          "foo",
 			Revision:    1,
-			Platform: transport.RefreshRequestPlatform{
+			Platform: transport.Platform{
 				OS:           "ubuntu",
 				Series:       "focal",
 				Architecture: arch.DefaultArchitecture,
@@ -553,7 +553,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			InstanceKey: "foo-baz",
 			ID:          "bar",
 			Revision:    2,
-			Platform: transport.RefreshRequestPlatform{
+			Platform: transport.Platform{
 				OS:           "ubuntu",
 				Series:       "trusty",
 				Architecture: arch.DefaultArchitecture,
@@ -572,7 +572,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			Action:      "install",
 			InstanceKey: "foo-taz",
 			Name:        &name3,
-			Platform: &transport.RefreshRequestPlatform{
+			Platform: &transport.Platform{
 				OS:           "ubuntu",
 				Series:       "disco",
 				Architecture: arch.DefaultArchitecture,

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -6,6 +6,9 @@ package transport
 // The following contains all the common DTOs for a gathering information from
 // a given store.
 
+// Channel defines a unique permutation that corresponds to the track, risk
+// and platform. There can be multiple channels of the same track and risk, but
+// with different platforms.
 type Channel struct {
 	Name       string   `json:"name"`
 	Platform   Platform `json:"platform"`
@@ -14,6 +17,8 @@ type Channel struct {
 	Track      string   `json:"track"`
 }
 
+// Platform is a typed tuple for identifying charms or bundles with a matching
+// architecture, os and series.
 type Platform struct {
 	Architecture string `json:"architecture"`
 	OS           string `json:"os"`
@@ -30,6 +35,8 @@ type Download struct {
 	URL        string `json:"url"`
 }
 
+// Entity holds the information about the charm or bundle, either contains the
+// information about the charm or bundle or whom owns it.
 type Entity struct {
 	Categories  []Category        `json:"categories"`
 	Charms      []Charm           `json:"contains-charms"`
@@ -41,11 +48,13 @@ type Entity struct {
 	StoreURL    string            `json:"store-url"`
 }
 
+// Category defines the category of a given charm or bundle. Akin to a tag.
 type Category struct {
 	Featured bool   `json:"featured"`
 	Name     string `json:"name"`
 }
 
+// Charm is used to identify charms within a bundle.
 type Charm struct {
 	Name      string `json:"name"`
 	PackageID string `json:"package-id"`

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -9,7 +9,7 @@ type FindResponses struct {
 }
 
 type FindResponse struct {
-	Type           string         `json:"type"`
+	Type           Type           `json:"type"`
 	ID             string         `json:"id"`
 	Name           string         `json:"name"`
 	Entity         Entity         `json:"result,omitempty"`

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -3,8 +3,17 @@
 
 package transport
 
-type Type = string
+// Type represents the type of payload is expected from the API
+type Type string
 
+const (
+	// CharmType represents the charm payload.
+	CharmType Type = "charm"
+	// BundleType represents the bundle payload.
+	BundleType Type = "bundle"
+)
+
+// InfoResponse is the result from an information query.
 type InfoResponse struct {
 	Type           Type             `json:"type"`
 	ID             string           `json:"id"`
@@ -15,6 +24,8 @@ type InfoResponse struct {
 	ErrorList      APIErrors        `json:"error-list,omitempty"`
 }
 
+// InfoChannelMap returns the information channel map. This defines a unique
+// revision for a given channel from an info response.
 type InfoChannelMap struct {
 	Channel   Channel            `json:"channel,omitempty"`
 	Resources []ResourceRevision `json:"resources,omitempty"`

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -5,6 +5,9 @@ package transport
 
 import "time"
 
+// RefreshRequest defines a typed request for making refresh queries, containing
+// both a series of context and actions, this powerful setup should allow for
+// making batch queries where possible.
 type RefreshRequest struct {
 	// Context can be empty (for install and download for example), but has to
 	// be always present and hence the no omitempty.
@@ -12,39 +15,43 @@ type RefreshRequest struct {
 	Actions []RefreshRequestAction  `json:"actions"`
 }
 
+// RefreshRequestContext can request a given context for making multiple
+// requests to one given entity.
 type RefreshRequestContext struct {
 	InstanceKey string `json:"instance-key"`
 	ID          string `json:"id"`
 
-	Revision        int                    `json:"revision"`
-	Platform        RefreshRequestPlatform `json:"platform,omitempty"`
-	TrackingChannel string                 `json:"tracking-channel,omitempty"`
-	RefreshedDate   *time.Time             `json:"refresh-date,omitempty"`
+	Revision        int        `json:"revision"`
+	Platform        Platform   `json:"platform,omitempty"`
+	TrackingChannel string     `json:"tracking-channel,omitempty"`
+	RefreshedDate   *time.Time `json:"refresh-date,omitempty"`
 }
 
-type RefreshRequestPlatform struct {
-	OS           string `json:"os"`
-	Series       string `json:"series"`
-	Architecture string `json:"architecture"`
-}
-
+// RefreshRequestAction defines a action to perform against the Refresh API.
 type RefreshRequestAction struct {
-	Action      string                  `json:"action"`
-	InstanceKey string                  `json:"instance-key"`
-	ID          *string                 `json:"id,omitempty"`
-	Name        *string                 `json:"name,omitempty"`
-	Channel     *string                 `json:"channel,omitempty"`
-	Revision    *int                    `json:"revision,omitempty"`
-	Platform    *RefreshRequestPlatform `json:"platform,omitempty"`
+	// Action can be install, download or refresh.
+	Action string `json:"action"`
+	// InstanceKey should be unique for every action, as results may not be
+	// ordered in the same way, so it is expected to use this to ensure
+	// completeness and ordering.
+	InstanceKey string    `json:"instance-key"`
+	ID          *string   `json:"id,omitempty"`
+	Name        *string   `json:"name,omitempty"`
+	Channel     *string   `json:"channel,omitempty"`
+	Revision    *int      `json:"revision,omitempty"`
+	Platform    *Platform `json:"platform,omitempty"`
 }
 
+// RefreshResponses holds a series of typed RefreshResponse or a series of
+// errors if the query performed failed for some reason.
 type RefreshResponses struct {
 	Results   []RefreshResponse `json:"results,omitempty"`
 	ErrorList APIErrors         `json:"error-list,omitempty"`
 }
 
+// RefreshResponse defines a typed response for the refresh query.
 type RefreshResponse struct {
-	Entity           RefreshEntity `json:"charm"`
+	Entity           RefreshEntity `json:"charm"` // TODO: Pick up new naming of this.
 	EffectiveChannel string        `json:"effective-channel"`
 	Error            *APIError     `json:"error,omitempty"`
 	ID               string        `json:"id"`
@@ -57,8 +64,11 @@ type RefreshResponse struct {
 	ReleasedAt time.Time `json:"released-at"`
 }
 
+// RefreshEntity is a typed refresh entity.
+// This can either be a charm or a bundle, the type of the refresh entity
+// doesn't actually matter in this circumstance.
 type RefreshEntity struct {
-	CreatedAt time.Time          `json:"created-at"`
+	Type      Type               `json:"type"`
 	Download  Download           `json:"download"`
 	ID        string             `json:"id"`
 	License   string             `json:"license"`
@@ -68,4 +78,5 @@ type RefreshEntity struct {
 	Revision  int                `json:"revision"`
 	Summary   string             `json:"summary"`
 	Version   string             `json:"version"`
+	CreatedAt time.Time          `json:"created-at"`
 }

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -63,7 +63,6 @@ func (s *downloadSuite) TestRun(c *gc.C) {
 	url := "http://example.org/"
 
 	s.expectModelGet(url)
-	s.expectInfo(url)
 	s.expectRefresh(c, url)
 	s.expectDownload(c, url)
 
@@ -90,7 +89,6 @@ func (s *downloadSuite) TestRunWithStdout(c *gc.C) {
 	url := "http://example.org/"
 
 	s.expectModelGet(url)
-	s.expectInfo(url)
 	s.expectRefresh(c, url)
 	s.expectDownload(c, url)
 
@@ -115,7 +113,6 @@ func (s *downloadSuite) TestRunWithCustomCharmHubURL(c *gc.C) {
 
 	url := "http://example.org/"
 
-	s.expectInfo(url)
 	s.expectRefresh(c, url)
 	s.expectDownload(c, url)
 
@@ -196,29 +193,6 @@ func (s *downloadSuite) expectModelGet(charmHubURL string) {
 	}, nil)
 }
 
-func (s *downloadSuite) expectInfo(charmHubURL string) {
-	s.downloadCommandAPI.EXPECT().Info(gomock.Any(), "test").Return(transport.InfoResponse{
-		Type: "charm",
-		Name: "test",
-		ChannelMap: []transport.InfoChannelMap{{
-			Channel: transport.Channel{
-				Name:  "a",
-				Track: "latest",
-				Risk:  "stable",
-				Platform: transport.Platform{
-					Series: "xenial",
-				},
-			},
-			Revision: transport.InfoRevision{
-				Revision: 1,
-				Download: transport.Download{
-					URL: charmHubURL,
-				},
-			},
-		}},
-	}, nil)
-}
-
 func (s *downloadSuite) expectRefresh(c *gc.C, charmHubURL string) {
 	s.downloadCommandAPI.EXPECT().Refresh(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, cfg charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
 		instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
@@ -226,6 +200,7 @@ func (s *downloadSuite) expectRefresh(c *gc.C, charmHubURL string) {
 		return []transport.RefreshResponse{{
 			InstanceKey: instanceKey,
 			Entity: transport.RefreshEntity{
+				Type: "charm",
 				Name: "test",
 				Download: transport.Download{
 					HashSHA256: "",

--- a/cmd/juju/charmhub/mocks/api_mock.go
+++ b/cmd/juju/charmhub/mocks/api_mock.go
@@ -6,12 +6,13 @@ package mocks
 
 import (
 	context "context"
+	url "net/url"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charmhub "github.com/juju/juju/api/charmhub"
 	charmhub0 "github.com/juju/juju/charmhub"
 	transport "github.com/juju/juju/charmhub/transport"
-	url "net/url"
-	reflect "reflect"
 )
 
 // MockDownloadCommandAPI is a mock of DownloadCommandAPI interface

--- a/cmd/juju/charmhub/mocks/api_mock.go
+++ b/cmd/juju/charmhub/mocks/api_mock.go
@@ -322,21 +322,6 @@ func (mr *MockCharmHubClientMockRecorder) Download(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockCharmHubClient)(nil).Download), arg0, arg1, arg2)
 }
 
-// Info mocks base method
-func (m *MockCharmHubClient) Info(arg0 context.Context, arg1 string) (transport.InfoResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Info", arg0, arg1)
-	ret0, _ := ret[0].(transport.InfoResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Info indicates an expected call of Info
-func (mr *MockCharmHubClientMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockCharmHubClient)(nil).Info), arg0, arg1)
-}
-
 // Refresh mocks base method
 func (m *MockCharmHubClient) Refresh(arg0 context.Context, arg1 charmhub0.RefreshConfig) ([]transport.RefreshResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Merge 2.9 into develop and as a drive by, update the CI tests to use "run" and "exec".

## QA steps

Actions CI tests should pass

