### PR TITLE
Fix list operation args

### DIFF
--- a/api/action/client.go
+++ b/api/action/client.go
@@ -44,8 +44,17 @@ func (c *Client) ListOperations(arg OperationQueryArgs) (Operations, error) {
 	if v := c.BestAPIVersion(); v < 6 {
 		return Operations{}, errors.Errorf("ListOperations not supported by this version (%d) of Juju", v)
 	}
+	args := params.OperationQueryArgs{
+		Applications: arg.Applications,
+		Units:        arg.Units,
+		Machines:     arg.Machines,
+		ActionNames:  arg.ActionNames,
+		Status:       arg.Status,
+		Offset:       arg.Offset,
+		Limit:        arg.Limit,
+	}
 	results := params.OperationResults{}
-	err := c.facade.FacadeCall("ListOperations", arg, &results)
+	err := c.facade.FacadeCall("ListOperations", args, &results)
 	if params.ErrCode(err) == params.CodeNotFound {
 		err = nil
 	}

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -207,7 +207,8 @@ func (s *actionSuite) TestWatchActionProgressNotSupported(c *gc.C) {
 }
 
 func (s *actionSuite) TestListOperations(c *gc.C) {
-	var args action.OperationQueryArgs
+	offset := 100
+	limit := 200
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -216,7 +217,15 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 				a, result interface{},
 			) error {
 				c.Assert(request, gc.Equals, "ListOperations")
-				c.Assert(a, jc.DeepEquals, args)
+				c.Assert(a, jc.DeepEquals, params.OperationQueryArgs{
+					Applications: []string{"app"},
+					Units:        []string{"unit/0"},
+					Machines:     []string{"0"},
+					ActionNames:  []string{"backup"},
+					Status:       []string{"running"},
+					Offset:       &offset,
+					Limit:        &limit,
+				})
 				c.Assert(result, gc.FitsTypeOf, &params.OperationResults{})
 				*(result.(*params.OperationResults)) = params.OperationResults{
 					Results: []params.OperationResult{{
@@ -235,7 +244,15 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 		BestVersion: 6,
 	}
 	client := action.NewClient(apiCaller)
-	result, err := client.ListOperations(args)
+	result, err := client.ListOperations(action.OperationQueryArgs{
+		Applications: []string{"app"},
+		Units:        []string{"unit/0"},
+		Machines:     []string{"0"},
+		ActionNames:  []string{"backup"},
+		Status:       []string{"running"},
+		Offset:       &offset,
+		Limit:        &limit,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, action.Operations{
 		Operations: []action.Operation{{

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -125,7 +125,7 @@ func (a *ActionAPI) ListOperations(arg params.OperationQueryArgs) (params.Operat
 		receiverTags = append(receiverTags, names.NewMachineTag(id))
 	}
 	appNames := arg.Applications
-	if len(appNames) == 0 && len(receiverTags) == 0 {
+	if len(arg.ActionNames) == 0 && len(appNames) == 0 && len(receiverTags) == 0 {
 		apps, err := a.state.AllApplications()
 		if err != nil {
 			return params.OperationResults{}, errors.Trace(err)

--- a/cmd/juju/action/action.go
+++ b/cmd/juju/action/action.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 )
 
-// type APIClient represents the action API functionality.
+// APIClient represents the action API functionality.
 type APIClient interface {
 	io.Closer
 

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/actions"
 )
 
+// NewListOperationsCommand returns a ListOperations command.
 func NewListOperationsCommand() cmd.Command {
 	return modelcmd.Wrap(&listOperationsCommand{})
 }
@@ -45,9 +46,15 @@ const listOperationsDoc = `
 List the operations with the specified query criteria.
 When an application is specified, all units from that application are relevant.
 
+When run without any arguments, operations corresponding to actions for all
+application units are returned.
+To see operations corresponding to juju run tasks, specify an action name
+"juju-run" and/or one or more machines.
+
 Examples:
     juju operations
     juju operations --format yaml
+    juju operations --actions juju-run
     juju operations --actions backup,restore
     juju operations --apps mysql,mediawiki
     juju operations --units mysql/0,mediawiki/1
@@ -61,7 +68,7 @@ See also:
     show-task
 `
 
-// Set up the output.
+// SetFlags implements Command.
 func (c *listOperationsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
 	defaultFormatter := "plain"

--- a/state/operation.go
+++ b/state/operation.go
@@ -342,7 +342,7 @@ func (m *Model) ListOperations(
 	var actions []actionDoc
 	err := actionsCollection.Find(actionsQuery).
 		// For now we'll limit what we return to the caller as action results
-		// can be large and show-task ca be used to get more detail as needed.
+		// can be large and show-task can be used to get more detail as needed.
 		Select(bson.D{
 			{"model-uuid", 0},
 			{"messages", 0},


### PR DESCRIPTION
When invoking the ListOperations API, the input parameters were not being copied to the API call.
Also a couple of drive by clean ups.

## QA steps

Run 2 different actions on a unit
juju operations --actions=foo
juju operations --actions=bar

