### PR TITLE
Merge 2.9

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1903,13 +1903,13 @@ class ModelClient:
         Action params should be given as args in the form foo=bar.
         Returns the id of the queued action.
         """
-        args = (unit, action) + args
+        args = ("--background", unit, action) + args
 
         output = self.get_juju_output("run", *args)
-        action_id_pattern = re.compile('Action queued with id: "([0-9]+)"')
+        action_id_pattern = re.compile("Check task status with 'juju show-task ([0-9]+)'")
         match = action_id_pattern.search(output)
         if match is None:
-            raise Exception("Action id not found in output: {}".format(output))
+            raise Exception("Task id not found in output: {}".format(output))
         return match.group(1)
 
     def action_do_fetch(self, unit, action, timeout="1m", *args):

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -2802,7 +2802,7 @@ class TestModelClient(ClientTest):
         with patch.object(ModelClient, 'get_juju_output') as mock:
             mock.return_value = "some bad text"
             with self.assertRaisesRegexp(Exception,
-                                         "Action id not found in output"):
+                                         "Task id not found in output"):
                 client.action_do("foo/0", "myaction", "param=5")
 
     def test_action_fetch(self):

--- a/api/action/client.go
+++ b/api/action/client.go
@@ -41,8 +41,17 @@ func (c *Client) Actions(actionIDs []string) ([]ActionResult, error) {
 
 // ListOperations fetches the operation summaries for specified apps/units.
 func (c *Client) ListOperations(arg OperationQueryArgs) (Operations, error) {
+	args := params.OperationQueryArgs{
+		Applications: arg.Applications,
+		Units:        arg.Units,
+		Machines:     arg.Machines,
+		ActionNames:  arg.ActionNames,
+		Status:       arg.Status,
+		Offset:       arg.Offset,
+		Limit:        arg.Limit,
+	}
 	results := params.OperationResults{}
-	err := c.facade.FacadeCall("ListOperations", arg, &results)
+	err := c.facade.FacadeCall("ListOperations", args, &results)
 	if params.ErrCode(err) == params.CodeNotFound {
 		err = nil
 	}

--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -189,7 +189,8 @@ func (s *actionSuite) TestWatchActionProgressArity(c *gc.C) {
 }
 
 func (s *actionSuite) TestListOperations(c *gc.C) {
-	var args action.OperationQueryArgs
+	offset := 100
+	limit := 200
 	apiCaller := basetesting.BestVersionCaller{
 		APICallerFunc: basetesting.APICallerFunc(
 			func(objType string,
@@ -198,7 +199,15 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 				a, result interface{},
 			) error {
 				c.Assert(request, gc.Equals, "ListOperations")
-				c.Assert(a, jc.DeepEquals, args)
+				c.Assert(a, jc.DeepEquals, params.OperationQueryArgs{
+					Applications: []string{"app"},
+					Units:        []string{"unit/0"},
+					Machines:     []string{"0"},
+					ActionNames:  []string{"backup"},
+					Status:       []string{"running"},
+					Offset:       &offset,
+					Limit:        &limit,
+				})
 				c.Assert(result, gc.FitsTypeOf, &params.OperationResults{})
 				*(result.(*params.OperationResults)) = params.OperationResults{
 					Results: []params.OperationResult{{
@@ -217,7 +226,15 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 		BestVersion: 6,
 	}
 	client := action.NewClient(apiCaller)
-	result, err := client.ListOperations(args)
+	result, err := client.ListOperations(action.OperationQueryArgs{
+		Applications: []string{"app"},
+		Units:        []string{"unit/0"},
+		Machines:     []string{"0"},
+		ActionNames:  []string{"backup"},
+		Status:       []string{"running"},
+		Offset:       &offset,
+		Limit:        &limit,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, action.Operations{
 		Operations: []action.Operation{{

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -116,7 +116,7 @@ func (a *ActionAPI) ListOperations(arg params.OperationQueryArgs) (params.Operat
 		receiverTags = append(receiverTags, names.NewMachineTag(id))
 	}
 	appNames := arg.Applications
-	if len(appNames) == 0 && len(receiverTags) == 0 {
+	if len(arg.ActionNames) == 0 && len(appNames) == 0 && len(receiverTags) == 0 {
 		apps, err := a.state.AllApplications()
 		if err != nil {
 			return params.OperationResults{}, errors.Trace(err)

--- a/state/operation.go
+++ b/state/operation.go
@@ -309,7 +309,7 @@ func (m *Model) AllOperations() ([]Operation, error) {
 
 // defaultMaxOperationsLimit is the default maximum number of operations to
 // return when performing an operations query.
-const defaultMaxOperationsLimit = 500
+const defaultMaxOperationsLimit = 50
 
 // OperationInfo encapsulates an operation and summary
 // information about some of its actions.
@@ -342,7 +342,7 @@ func (m *Model) ListOperations(
 	var actions []actionDoc
 	err := actionsCollection.Find(actionsQuery).
 		// For now we'll limit what we return to the caller as action results
-		// can be large and show-task ca be used to get more detail as needed.
+		// can be large and show-task can be used to get more detail as needed.
 		Select(bson.D{
 			{"model-uuid", 0},
 			{"messages", 0},
@@ -377,11 +377,7 @@ func (m *Model) ListOperations(
 	defer closer()
 
 	var docs []operationDoc
-	query := operationCollection.Find(operationsQuery)
-	nominalCount, err := query.Count()
-	if err != nil {
-		return nil, false, errors.Trace(err)
-	}
+	query := operationCollection.Find(operationsQuery).Sort("$natural")
 	if offset != 0 {
 		query = query.Skip(offset)
 	}
@@ -390,11 +386,16 @@ func (m *Model) ListOperations(
 		limit = defaultMaxOperationsLimit
 	}
 	query = query.Limit(limit)
-	err = query.Sort("_id").All(&docs)
+	err = query.All(&docs)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
-	truncated := nominalCount > len(docs)
+	query = query.Skip(offset + limit).Limit(1)
+	nextCount, err := query.Count()
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
+	truncated := nextCount != 0
 
 	result := make([]OperationInfo, len(docs))
 	for i, doc := range docs {

--- a/state/operation_test.go
+++ b/state/operation_test.go
@@ -233,7 +233,7 @@ func (s *OperationSuite) TestListOperationsSubset(c *gc.C) {
 	for i := 0; i < 20; i++ {
 		operationID, err := s.Model.EnqueueOperation(fmt.Sprintf("operation %d", i))
 		c.Assert(err, jc.ErrorIsNil)
-		anAction, err := s.Model.EnqueueAction(operationID, names.NewUnitTag("dummy/0"), "backup", nil)
+		anAction, err := s.Model.EnqueueAction(operationID, names.NewUnitTag("dummy/0"), "backup", nil, false, "")
 		c.Assert(err, jc.ErrorIsNil)
 		_, err = anAction.Begin()
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/operation_test.go
+++ b/state/operation_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -229,11 +230,19 @@ func (s *OperationSuite) TestListOperationsByReceiver(c *gc.C) {
 
 func (s *OperationSuite) TestListOperationsSubset(c *gc.C) {
 	s.setupOperations(c)
-	operations, truncated, err := s.Model.ListOperations(nil, nil, nil, 1, 1)
+	for i := 0; i < 20; i++ {
+		operationID, err := s.Model.EnqueueOperation(fmt.Sprintf("operation %d", i))
+		c.Assert(err, jc.ErrorIsNil)
+		anAction, err := s.Model.EnqueueAction(operationID, names.NewUnitTag("dummy/0"), "backup", nil)
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = anAction.Begin()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	operations, truncated, err := s.Model.ListOperations(nil, nil, nil, 14, 1)
 	c.Assert(truncated, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(operations, gc.HasLen, 1)
-	c.Assert(operations[0].Operation.Summary(), gc.Equals, "another operation")
+	c.Assert(operations[0].Operation.Summary(), gc.Equals, "operation 11")
 	c.Assert(operations[0].Actions, gc.HasLen, 1)
 	s.assertActions(c, operations)
 }


### PR DESCRIPTION
Merge 2.9 plus do a fix for action related acceptance tests to cater for new run behaviour.

#12574 [Charmhub] - Allow resolution for bundles.
#12579 Fix typo in action Enqueue() api
#12582 Fix list operation args
#12583 Add offset/limit handling to list-operations api

## QA steps

See PRs