### PR TITLE
[Charmhub] - Normalize channel

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -148,6 +148,7 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	// were passed in.  ResolveWithPreferredChannel is called for both charms to be
 	// deployed, and charms which are being upgraded.  Only charms being upgraded
 	// will have an ID and Hash.  Those values should only ever be updated in
+	// chRepro FindDownloadURL.
 	resOrigin := params.CharmOrigin{
 		Source:       origin.Source,
 		Type:         string(entity.Type),


### PR DESCRIPTION
We should always normalize the channel passed into the refresh config.
This is because "latest" is a special keyword and that it can and will
be omitted when doing matches.

The code just cleans up how we construct the params conversion so that
we do it once. It leads to better readability, but more verbose code. I
think this is fine for now.

There is still work to do around picking the right method for
refreshing, but that can come later.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model two --config charmhub-url="https://api.staging.charmhub.io"
$ juju deploy ubuntu
$ juju deploy charmed-kubernetes
```
