### PR TITLE
Improve error messages for kubernetes/IAAS charms

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1291,7 +1291,7 @@ func (s *DeploySuite) TestInvalidSeriesForModel(c *gc.C) {
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	err := s.runDeployForState(c, charmDir.Path, "portlandia", "--series", "kubernetes")
-	c.Assert(err, gc.ErrorMatches, `cannot add application "portlandia": series "kubernetes" in a non container model not valid`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "portlandia": \"portlandia\" is not a IAAS charm`)
 }
 
 func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
@@ -1762,13 +1762,13 @@ func (s *DeploySuite) TestSetMetricCredentialsNotCalledForUnmeteredCharm(c *gc.C
 }
 
 func (s *DeploySuite) TestAddMetricCredentialsNotNeededForOptionalPlan(c *gc.C) {
-	metricsYAML := `		
-plan:		
-required: false		
-metrics:		
-pings:		
-  type: gauge		
-  description: ping pongs		
+	metricsYAML := `
+plan:
+required: false
+metrics:
+pings:
+  type: gauge
+  description: ping pongs
 `
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "metered")
 	metadataPath := filepath.Join(charmDir.Path, "metrics.yaml")
@@ -1812,13 +1812,13 @@ pings:
 }
 
 func (s *DeploySuite) TestSetMetricCredentialsCalledWhenPlanSpecifiedWhenOptional(c *gc.C) {
-	metricsYAML := `		
-plan:		
-required: false		
-metrics:		
-pings:		
-  type: gauge		
-  description: ping pongs		
+	metricsYAML := `
+plan:
+required: false
+metrics:
+pings:
+  type: gauge
+  description: ping pongs
 `
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "metered")
 	metadataPath := filepath.Join(charmDir.Path, "metrics.yaml")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1291,7 +1291,7 @@ func (s *DeploySuite) TestInvalidSeriesForModel(c *gc.C) {
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	err := s.runDeployForState(c, charmDir.Path, "portlandia", "--series", "kubernetes")
-	c.Assert(err, gc.ErrorMatches, `cannot add application "portlandia": \"portlandia\" is not a IAAS charm`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "portlandia": \"portlandia\" is not an IAAS charm`)
 }
 
 func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -70,9 +70,9 @@ func ValidateSeries(args ValidateSeriesArgs) error {
 			return nil
 		case IAAS:
 			return errors.NotValidf("IAAS models don't support systems referencing a resource")
-		default:
-			return nil
 		}
+
+		return nil
 	}
 
 	os, err := series.GetOSFromSeries(args.Series)
@@ -83,16 +83,17 @@ func ValidateSeries(args ValidateSeriesArgs) error {
 	case CAAS:
 		if !caasOS.Contains(os.String()) {
 			return errors.NewNotValid(nil, fmt.Sprintf(
-				`%q is not a Kubernetes charm (look for the charms with "-k8s" suffix in their name)`, args.Name,
+				`%q is not a Containers-as-a-Service (like kubernetes) charm`, args.Name,
 			))
 		}
 	case IAAS:
 		if caasOS.Contains(os.String()) {
 			return errors.NewNotValid(nil, fmt.Sprintf(
-				"%q is not a IAAS charm",
+				"%q is not an IAAS charm",
 				args.Name,
 			))
 		}
 	}
+
 	return nil
 }

--- a/core/model/model_test.go
+++ b/core/model/model_test.go
@@ -21,16 +21,15 @@ var _ = gc.Suite(&ModelSuite{})
 
 func (*ModelSuite) TestValidateSeries(c *gc.C) {
 	for _, t := range []struct {
-		modelType model.ModelType
-		series    string
-		valid     bool
+		args  model.ValidateSeriesArgs
+		valid bool
 	}{
-		{model.IAAS, "bionic", true},
-		{model.IAAS, "kubernetes", false},
-		{model.CAAS, "bionic", false},
-		{model.CAAS, "kubernetes", true},
+		{model.ValidateSeriesArgs{model.IAAS, "test", "bionic", charm.FormatV1}, true},
+		{model.ValidateSeriesArgs{model.IAAS, "test", "kubernetes", charm.FormatV1}, false},
+		{model.ValidateSeriesArgs{model.CAAS, "test", "bionic", charm.FormatV1}, false},
+		{model.ValidateSeriesArgs{model.CAAS, "test", "kubernetes", charm.FormatV1}, true},
 	} {
-		err := model.ValidateSeries(t.modelType, t.series, charm.FormatV1)
+		err := model.ValidateSeries(t.args)
 		if t.valid {
 			c.Check(err, jc.ErrorIsNil)
 		} else {
@@ -41,16 +40,15 @@ func (*ModelSuite) TestValidateSeries(c *gc.C) {
 
 func (*ModelSuite) TestValidateSeriesNewCharm(c *gc.C) {
 	for _, t := range []struct {
-		modelType model.ModelType
-		series    string
-		valid     bool
+		args  model.ValidateSeriesArgs
+		valid bool
 	}{
-		{model.IAAS, "bionic", true},
-		{model.IAAS, "bionic", true},
-		{model.CAAS, "bionic", true},
-		{model.CAAS, "bionic", true},
+		{model.ValidateSeriesArgs{model.IAAS, "test", "bionic", charm.FormatV2}, true},
+		{model.ValidateSeriesArgs{model.IAAS, "test", "bionic", charm.FormatV2}, true},
+		{model.ValidateSeriesArgs{model.CAAS, "test", "bionic", charm.FormatV2}, true},
+		{model.ValidateSeriesArgs{model.CAAS, "test", "bionic", charm.FormatV2}, true},
 	} {
-		err := model.ValidateSeries(t.modelType, t.series, charm.FormatV2)
+		err := model.ValidateSeries(t.args)
 		if t.valid {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -307,7 +307,7 @@ func (s *CAASModelSuite) TestDeployIAASApplication(c *gc.C) {
 		Charm:  ch,
 	}
 	_, err := st.AddApplication(args)
-	c.Assert(err.Error(), gc.Equals, `cannot add application "gitlab": "gitlab" is not a Kubernetes charm (look for the charms with "-k8s" suffix in their name)`)
+	c.Assert(err.Error(), gc.Equals, `cannot add application "gitlab": "gitlab" is not a Containers-as-a-Service (like kubernetes) charm`)
 }
 
 func (s *CAASModelSuite) TestContainers(c *gc.C) {

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -307,7 +307,7 @@ func (s *CAASModelSuite) TestDeployIAASApplication(c *gc.C) {
 		Charm:  ch,
 	}
 	_, err := st.AddApplication(args)
-	c.Assert(err, gc.ErrorMatches, `cannot add application "gitlab": series "bionic" in a kubernetes model not valid`)
+	c.Assert(err.Error(), gc.Equals, `cannot add application "gitlab": "gitlab" is not a Kubernetes charm (look for the charms with "-k8s" suffix in their name)`)
 }
 
 func (s *CAASModelSuite) TestContainers(c *gc.C) {

--- a/state/charm.go
+++ b/state/charm.go
@@ -739,10 +739,10 @@ func validateCharmSeries(modelType ModelType, name, series string, ch hasMeta) e
 	}
 
 	return model.ValidateSeries(model.ValidateSeriesArgs{
-		Model:  model.ModelType(modelType),
-		Name:   name,
-		Series: series,
-		Format: ch.Meta().Format(),
+		ModelType: model.ModelType(modelType),
+		Name:      name,
+		Series:    series,
+		Format:    ch.Meta().Format(),
 	})
 }
 

--- a/state/charm.go
+++ b/state/charm.go
@@ -685,7 +685,7 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := validateCharmSeries(model.Type(), info.ID.Series, info.Charm); err != nil {
+	if err := validateCharmSeries(model.Type(), info.ID.Name, info.ID.Series, info.Charm); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -724,19 +724,26 @@ type hasMeta interface {
 	Meta() *charm.Meta
 }
 
-func validateCharmSeries(modelType ModelType, series string, ch hasMeta) error {
+func validateCharmSeries(modelType ModelType, name, series string, ch hasMeta) error {
 	if series == "" {
 		allSeries := ch.Meta().ComputedSeries()
 		if len(allSeries) > 0 {
 			series = allSeries[0]
 		}
 	}
+
 	// TODO(wallyworld) - update lots-o-tests
 	// Some tests don't set a series.
 	if series == "" {
 		return nil
 	}
-	return model.ValidateSeries(model.ModelType(modelType), series, ch.Meta().Format())
+
+	return model.ValidateSeries(model.ValidateSeriesArgs{
+		Model:  model.ModelType(modelType),
+		Name:   name,
+		Series: series,
+		Format: ch.Meta().Format(),
+	})
 }
 
 // AllCharms returns all charms in state.

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -520,7 +520,7 @@ func (s *ModelSuite) TestDeployCAASApplication(c *gc.C) {
 		Charm:  ch,
 	}
 	_, err := s.State.AddApplication(args)
-	c.Assert(err, gc.ErrorMatches, `cannot add application "gitlab": "gitlab" is not a IAAS charm`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "gitlab": "gitlab" is not an IAAS charm`)
 }
 
 func (s *ModelSuite) TestAllUnits(c *gc.C) {

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -520,7 +520,7 @@ func (s *ModelSuite) TestDeployCAASApplication(c *gc.C) {
 		Charm:  ch,
 	}
 	_, err := s.State.AddApplication(args)
-	c.Assert(err, gc.ErrorMatches, `cannot add application "gitlab": series "kubernetes" in a non container model not valid`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "gitlab": "gitlab" is not a IAAS charm`)
 }
 
 func (s *ModelSuite) TestAllUnits(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1034,7 +1034,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return nil, errors.Trace(err)
 	}
 	// TODO(embedded): handle systems
-	if err := validateCharmSeries(model.Type(), args.Series, args.Charm); err != nil {
+	if err := validateCharmSeries(model.Type(), args.Name, args.Series, args.Charm); err != nil {
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
Full spectre of arguments was not passed to the validatation
function, so I had to change signature of it and related methods too

Fixes https://bugs.launchpad.net/juju/+bug/1828441
Refs https://discourse.charmhub.io/t/error-when-running-k8s-gitlab-charm-from-the-store/2563/2

