### PR TITLE
[dev] Apply pending python3 patches to acceptance tests

### DIFF
--- a/acceptancetests/assess_bootstrap.py
+++ b/acceptancetests/assess_bootstrap.py
@@ -75,7 +75,7 @@ def assess_metadata(bs_manager, local_source):
 def get_controller_hostname(client):
     """Get the hostname of the controller for this model."""
     controller_client = client.get_controller_client()
-    name = controller_client.run(['hostname'], machines=['0'], use_json=False)
+    name = controller_client.exec_cmds(['hostname'], machines=['0'], use_json=False)
     return name.strip()
 
 

--- a/acceptancetests/assess_container_networking.py
+++ b/acceptancetests/assess_container_networking.py
@@ -348,21 +348,14 @@ def assess_container_networking(client, types, space):
     try:
         for host in hosts:
             log.info("Restarting hosted machine: {}".format(host))
-            try:
-                client.juju('ssh', (host, 'sudo shutdown -r now'))
-            except subprocess.CalledProcessError as e:
-                if e.returncode != 255:
-                    raise e
-                log.info("Ignoring `juju ssh` exit status after triggering reboot")
-            hostname = client.get_status().get_machine_dns_name(host)
-            wait_for_port(hostname, 22, timeout=240)
+            client.reboot(host)
 
         log.info("Restarting controller machine 0")
         controller_client = client.get_controller_client()
         controller_status = controller_client.get_status()
         controller_host = controller_status.status['machines']['0']['dns-name']
         first_uptime = get_uptime(controller_client, '0')
-        ssh(controller_client, '0', 'sudo shutdown -r +1')
+        controller_client.reboot('0')
         # Ensure the reboots have started.
         time.sleep(70)
     except subprocess.CalledProcessError as e:

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -226,7 +226,10 @@ class AssessNetworkHealth:
                 out = client.action_do(nh_unit, 'unit-info')
                 out = client.action_fetch(out)
                 out = yaml.safe_load(out)
-                interfaces = out['results']['interfaces']
+                # NOTE(achilleasa): in juju 3, 'show-task' gives you the result
+                # directly whereas in previous versions you would get it
+                # wrapped in a "results" block
+                interfaces = out['interfaces']
                 results[machine]['interfaces'][nh_unit] = interfaces
         return results
 

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -247,13 +247,13 @@ class AssessNetworkHealth:
                      "machine: {}".format(unit[0]))
             results[unit[0]] = False
             try:
-                routes = client.run(['ip route show'], machines=[unit[0]])
+                routes = client.exec_cmds(['ip route show'], machines=[unit[0]])
             except subprocess.CalledProcessError:
                 log.error('Could not connect to address for unit: {0}, '
                           'unable to find default route.'.format(unit[0]))
                 continue
             default_route = re.search(r'(default via )+([\d\.]+)\s+',
-                                      json.dumps(routes[0]))
+                                      json.dumps(routes[unit[0]]))
             if default_route:
                 results[unit[0]] = True
             else:
@@ -301,9 +301,9 @@ class AssessNetworkHealth:
                     pattern = r"(pass)"
                     log.info('Attempting to contact {}:{} '
                              'from {}'.format(ip, PORT, unit))
-                    out = client.run(['curl {}:{}'.format(ip, PORT)],
+                    out = client.exec_cmds(['curl {}:{}'.format(ip, PORT)],
                                      units=[unit])
-                    match = re.search(pattern, json.dumps(out[0]))
+                    match = re.search(pattern, json.dumps(out[unit]))
                     if match:
                         log.info('pass')
                         result[app][unit][ip] = True

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -21,7 +21,6 @@ from utility import (
     add_basic_testing_arguments,
     generate_default_clean_dir,
     configure_logging,
-    wait_for_port
     )
 from substrate import (
     maas_account_from_boot_config,
@@ -464,15 +463,7 @@ class AssessNetworkHealth:
                     self.ssh(client, machine,
                              'sudo lxc restart {}'.format(' '.join(cont_ids)))
                 log.info("Restarting machine: {}".format(machine))
-                try:
-                    client.juju('ssh', (machine, 'sudo shutdown -r now'))
-                except subprocess.CalledProcessError as e:
-                    if e.returncode != 255:
-                        raise e
-                    log.info("Ignoring `juju ssh` exit status after triggering reboot")
-
-                hostname = client.get_status().get_machine_dns_name(machine)
-                wait_for_port(hostname, 22, timeout=240)
+                client.reboot(machine)
 
         except subprocess.CalledProcessError as e:
             logging.info(

--- a/acceptancetests/assess_network_spaces.py
+++ b/acceptancetests/assess_network_spaces.py
@@ -190,13 +190,13 @@ class AssessNetworkSpaces:
             log.info("Assessing internet connection for "
                      "machine: {}".format(unit[0]))
             try:
-                routes = client.run(['ip route show'], machines=[unit[0]])
+                routes = client.exec_cmds(['ip route show'], machines=[unit[0]])
             except subprocess.CalledProcessError:
                 raise TestFailure(('Could not connect to address for unit: {0}'
                                    ', unable to find default route.').format(
                                        unit[0]))
             default_route = re.search(r'(default via )+([\d\.]+)\s+',
-                                      json.dumps(routes[0]))
+                                      json.dumps(routes[unit[0]]))
             if not default_route:
                 raise TestFailure('Default route not found for {}'.format(
                     unit[0]))

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -202,7 +202,7 @@ def _get_token(remote, token_path="/var/run/dummy-sink/token"):
         if e.returncode != 1:
             raise
         return ""
-    return token_pattern.match(contents.decode("utf-8")).group(1)
+    return token_pattern.match(contents).group(1)
 
 
 def check_token(client, token, timeout=120):
@@ -445,7 +445,7 @@ def copy_remote_logs(remote, directory):
 # NOTE: Since juju 3, "juju run" has been renamed to "juju exec"
 def assess_juju_exec(client):
     responses = client.exec_cmds(('uname',),
-                           applications=['dummy-source', 'dummy-sink'])
+                                 applications=['dummy-source', 'dummy-sink'])
     for response in responses.values():
         if response.get('results').get('return-code'):
             raise ValueError('juju exec on unit %s returned %d: %s' % (

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+import socket
 import shutil
 import subprocess
 import sys
@@ -62,6 +63,8 @@ from jujupy.utility import (
     _dns_name_for_machine,
     pause,
     qualified_model_name,
+    is_ipv6_address,
+    print_now,
     skip_on_missing_file,
     split_address_port,
     temp_yaml_file,
@@ -1004,7 +1007,7 @@ class ModelClient:
                   credential=None, auto_upgrade=False, metadata_source=None,
                   no_gui=False, agent_version=None, db_snap_path=None,
                   db_snap_asserts_path=None, mongo_memory_profile=None,
-                  caas_image_repo=None, force=False, db_snap_channel=None, 
+                  caas_image_repo=None, force=False, db_snap_channel=None,
                   config_options=None):
         """Bootstrap a controller."""
         self._check_bootstrap()
@@ -1329,6 +1332,17 @@ class ModelClient:
         return self._backend.juju(
             command, args, self.used_feature_flags, self.env.juju_home,
             model, check, timeout, extra_env, suppress_err=suppress_err)
+
+    def reboot(self, machine):
+        """Reboot a machine."""
+        try:
+            self.juju('ssh', (machine, 'sudo shutdown -r now'))
+        except subprocess.CalledProcessError as e:
+            if e.returncode != 255:
+                raise e
+            log.info("Ignoring `juju ssh` exit status after triggering reboot")
+        hostname = self.get_status().get_machine_dns_name(machine)
+        wait_for_port(hostname, 22, timeout=240)
 
     def expect(self, command, args=(), include_e=True,
                timeout=None, extra_env=None):
@@ -1874,6 +1888,14 @@ class ModelClient:
         backup_file_path = os.path.abspath(backup_file_name)
         log.info("State-Server backup at %s", backup_file_path)
         return backup_file_path.decode(getpreferredencoding())
+
+    def restore_backup(self, backup_file):
+        self.juju(
+            'restore-backup',
+            ('--file', backup_file))
+
+    def restore_backup_async(self, backup_file):
+        return self.juju_async('restore-backup', ('--file', backup_file))
 
     def enable_ha(self):
         self.juju(
@@ -2590,3 +2612,58 @@ def client_for_existing(juju_path, juju_data_dir, debug=False,
     return ModelClient(
         config, version, full_path,
         debug=debug, soft_deadline=soft_deadline, _backend=backend)
+
+
+# Equivalent of socket.EAI_NODATA when using windows sockets
+# <https://msdn.microsoft.com/ms740668#WSANO_DATA>
+WSANO_DATA = 11004
+
+
+def wait_for_port(host, port, closed=False, timeout=30):
+    family = socket.AF_INET6 if is_ipv6_address(host) else socket.AF_INET
+    for remaining in until_timeout(timeout):
+        try:
+            addrinfo = socket.getaddrinfo(host, port, family,
+                                          socket.SOCK_STREAM)
+        except socket.error as e:
+            if e.errno not in (socket.EAI_NODATA, WSANO_DATA):
+                raise
+            if closed:
+                return
+            else:
+                continue
+        sockaddr = addrinfo[0][4]
+        # Treat Azure messed-up address lookup as a closed port.
+        if sockaddr[0] == '0.0.0.0':
+            if closed:
+                return
+            else:
+                continue
+        conn = socket.socket(*addrinfo[0][:3])
+        conn.settimeout(max(remaining or 0, 5))
+        try:
+            conn.connect(sockaddr)
+        except socket.timeout:
+            if closed:
+                return
+        except socket.error as e:
+            if e.errno not in (errno.ECONNREFUSED, errno.ENETUNREACH,
+                               errno.ETIMEDOUT, errno.EHOSTUNREACH):
+                raise
+            if closed:
+                return
+        except socket.gaierror as e:
+            print_now(str(e))
+        except Exception as e:
+            print_now('Unexpected {!r}: {}'.format(type(e), e))
+            raise
+        else:
+            conn.close()
+            if not closed:
+                return
+            time.sleep(1)
+    raise PortTimeoutError('Timed out waiting for port.')
+
+
+class PortTimeoutError(Exception):
+    pass

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1910,14 +1910,13 @@ class ModelClient:
         cases where it's available.
         Returns the yaml output of the fetched action.
         """
-        out = self.get_juju_output("show-task", id, "--wait", timeout)
-        status = yaml.safe_load(out)["status"]
-        if status != "completed":
+        try:
+            return self.get_juju_output("show-task", id, "--wait", timeout)
+        except Exception as e:
             action_name = '' if not action else ' "{}"'.format(action)
             raise Exception(
-                'Timed out waiting for action{} to complete during fetch '
-                'with status: {}.'.format(action_name, status))
-        return out
+                'Timed out waiting for action {} to complete during fetch '
+                'caught exception: {}.'.format(action_name, str(e)))
 
     def action_do(self, unit, action, *args):
         """Performs the given action on the given unit.
@@ -1927,7 +1926,7 @@ class ModelClient:
         """
         args = ("--background", unit, action) + args
 
-        output = self.get_juju_output("run", *args)
+        output = self.get_juju_output("run", *args, merge_stderr=True)
         action_id_pattern = re.compile("Check task status with 'juju show-task ([0-9]+)'")
         match = action_id_pattern.search(output)
         if match is None:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1889,14 +1889,6 @@ class ModelClient:
         log.info("State-Server backup at %s", backup_file_path)
         return backup_file_path.decode(getpreferredencoding())
 
-    def restore_backup(self, backup_file):
-        self.juju(
-            'restore-backup',
-            ('--file', backup_file))
-
-    def restore_backup_async(self, backup_file):
-        return self.juju_async('restore-backup', ('--file', backup_file))
-
     def enable_ha(self):
         self.juju(
             'enable-ha', ('-n', '3', '-c', self.env.controller.name),

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -2853,7 +2853,7 @@ class TestModelClient(ClientTest):
         run_output = json.dumps(run_list)
         with patch.object(client._backend, 'get_juju_output',
                           return_value=run_output) as gjo_mock:
-            result = client.run(('wname',), applications=['foo', 'bar'])
+            result = client.exec_cmds(('wname',), applications=['foo', 'bar'])
         self.assertEqual(run_list, result)
         gjo_mock.assert_called_once_with(
             'exec', ('--format', 'json', '--application', 'foo,bar', 'wname'),
@@ -2865,7 +2865,7 @@ class TestModelClient(ClientTest):
         output = json.dumps({"ReturnCode": 255})
         with patch.object(client, 'get_juju_output',
                           return_value=output) as output_mock:
-            client.run(['true'], machines=['0', '1', '2'])
+            client.exec_cmds(['true'], machines=['0', '1', '2'])
         output_mock.assert_called_once_with(
             'exec', '--format', 'json', '--machine', '0,1,2', 'true')
 
@@ -2873,7 +2873,7 @@ class TestModelClient(ClientTest):
         client = fake_juju_client(cls=ModelClient)
         output = json.dumps({"ReturnCode": 255})
         with patch.object(client, 'get_juju_output', return_value=output):
-            result = client.run(['true'], use_json=False)
+            result = client.exec_cmds(['true'], use_json=False)
         self.assertEqual(output, result)
 
     def test_exec_units(self):
@@ -2881,7 +2881,7 @@ class TestModelClient(ClientTest):
         output = json.dumps({"ReturnCode": 255})
         with patch.object(client, 'get_juju_output',
                           return_value=output) as output_mock:
-            client.run(['true'], units=['foo/0', 'foo/1', 'foo/2'])
+            client.exec_cmds(['true'], units=['foo/0', 'foo/1', 'foo/2'])
         output_mock.assert_called_once_with(
             'exec', '--format', 'json', '--unit', 'foo/0,foo/1,foo/2', 'true')
 


### PR DESCRIPTION
When 2.9 was forward ported to develop, some of the python3 upgrades for the acceptance tests were not merged successfully due to the change from `juju run` (which now runs actions) to `juju exec`.

This PR ensures that everything is consistent.