### PR TITLE
Remove arch/os from deploy suggestions on Refresh failure.

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -195,7 +195,7 @@ func (s *charmHubRepositoriesSuite) TestResolveRevisionNotFoundErrorWithNoSeries
 
 	resolver := &chRepo{client: s.client}
 	_, _, _, err := resolver.ResolveWithPreferredChannel(curl, origin)
-	c.Assert(err, gc.ErrorMatches, `refresh: no charm or bundle matching channel or platform; suggestions: stable with amd64/ubuntu/focal`)
+	c.Assert(err, gc.ErrorMatches, `refresh: no charm or bundle matching channel or platform; suggestions: stable with focal`)
 }
 
 func (s *charmHubRepositoriesSuite) TestResolveRevisionNotFoundError(c *gc.C) {
@@ -498,7 +498,7 @@ func (composeSuggestionsSuite) TestSuggestion(c *gc.C) {
 		Architecture: "arch",
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		"stable with arch/os/series",
+		"stable with series",
 	})
 }
 
@@ -507,6 +507,13 @@ func (composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 		Platform: transport.Platform{
 			OS:           "a",
 			Series:       "b",
+			Architecture: "c",
+		},
+		Channel: "stable",
+	}, {
+		Platform: transport.Platform{
+			OS:           "a",
+			Series:       "d",
 			Architecture: "c",
 		},
 		Channel: "stable",
@@ -528,8 +535,8 @@ func (composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 		Architecture: "c",
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		"stable with c/a/b",
-		"2.0/stable with c/e/f",
+		"stable with b, d",
+		"2.0/stable with f",
 	})
 }
 

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/charm"
 )
 
 // Note:
@@ -51,8 +52,6 @@ func (iw infoWriter) print(info interface{}) error {
 	return encoder.Encode(info)
 }
 
-var channelRisks = []string{"stable", "candidate", "beta", "edge"}
-
 func (iw infoWriter) channels() string {
 	if len(iw.in.Channels) == 0 {
 		return ""
@@ -64,7 +63,7 @@ func (iw infoWriter) channels() string {
 	w := InfoUnicodeWriter(ow, iw.unicodeMode)
 	for _, track := range iw.in.Tracks {
 		trackHasOpenChannel := false
-		for _, risk := range channelRisks {
+		for _, risk := range charm.Risks {
 			chName := fmt.Sprintf("%s/%s", track, risk)
 			ch, ok := iw.in.Channels[chName]
 			if ok {

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -34,7 +34,8 @@ const (
 	Edge      Risk = "edge"
 )
 
-var risks = []Risk{
+// Risks is a list of the available channel risks.
+var Risks = []Risk{
 	Stable,
 	Candidate,
 	Beta,
@@ -42,7 +43,7 @@ var risks = []Risk{
 }
 
 func isRisk(potential string) bool {
-	for _, risk := range risks {
+	for _, risk := range Risks {
 		if potential == string(risk) {
 			return true
 		}


### PR DESCRIPTION
Reword suggestions for what can be deployed when juju receives a ErrorCodeRevisionNotFound as part of Resolving a CharmHub charm.

Drive by to make the list of Risks public, for use in other places.  Rather than copying over.

## QA steps

QA via the unit tests.  The API responses have changed, so not as easy to reproduce the case where this suggestion is displayed.
