### PR TITLE
Allow upgrades to 3 from 2.9-rc

### DIFF
--- a/upgrades/model.go
+++ b/upgrades/model.go
@@ -28,5 +28,7 @@ func UpgradeAllowed(from, to version.Number) (bool, version.Number, error) {
 	if !ok {
 		return false, version.Number{}, errors.Errorf("unknown version %q", to)
 	}
+	// Allow upgrades from rc etc.
+	from.Tag = ""
 	return from.Compare(minVer) >= 0, minVer, nil
 }

--- a/upgrades/model_test.go
+++ b/upgrades/model_test.go
@@ -1,0 +1,69 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+type ModelSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&ModelSuite{})
+
+func (s *ModelSuite) TestUpgradeAllowed(c *gc.C) {
+	for _, t := range []struct {
+		from    string
+		to      string
+		allowed bool
+		minVers string
+		err     string
+	}{
+		{
+			from:    "2.8.0",
+			to:      "3.0.0",
+			allowed: false,
+			minVers: "2.9.0",
+		}, {
+			from:    "2.9-rc1",
+			to:      "3.0.0",
+			allowed: true,
+			minVers: "2.9.0",
+		}, {
+			from:    "2.9.0",
+			to:      "3.0.0",
+			allowed: true,
+			minVers: "2.9.0",
+		}, {
+			from:    "2.9.1",
+			to:      "3.0.0",
+			allowed: true,
+			minVers: "2.9.0",
+		}, {
+			from:    "2.9.0",
+			to:      "4.0.0",
+			allowed: false,
+			minVers: "0.0.0",
+			err:     `unknown version "4.0.0"`,
+		},
+	} {
+		from := version.MustParse(t.from)
+		to := version.MustParse(t.to)
+		minVers := version.MustParse(t.minVers)
+		allowed, vers, err := upgrades.UpgradeAllowed(from, to)
+		c.Assert(allowed, gc.Equals, t.allowed)
+		c.Assert(vers, gc.DeepEquals, minVers)
+		if t.err == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		}
+	}
+}


### PR DESCRIPTION
Tweak the upgrade check to allow upgrading to Juju 3.0 from a 2.9 RC

## QA steps

bootstrap 2.9-rc5
juju upgrade-controller --build-agent

