### PR TITLE
juju-run is now juju-exec

### DIFF
--- a/agent/tools/diskmanager_test.go
+++ b/agent/tools/diskmanager_test.go
@@ -102,8 +102,7 @@ func (s *DiskManagerSuite) assertToolsContents(c *gc.C, t *coretools.Tools, file
 	gotTools, err := s.manager.ReadTools(t.Version)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*gotTools, gc.Equals, *t)
-	// Make sure that the tools directory is readable by the ubuntu user (for
-	// juju-run)
+	// Make sure that the tools directory is readable by the ubuntu user (for juju-exec).
 	info, err := os.Stat(dir)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Mode().Perm(), gc.Equals, agenttools.DirPerm)

--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -122,7 +122,7 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 	}
 
 	// The tempdir is created with 0700, so we need to make it more
-	// accessible for juju-run.
+	// accessible for juju-exec.
 	err = os.Chmod(dir, dirPerm)
 	if err != nil {
 		return err

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -210,7 +210,7 @@ func (s *operationSuite) TestListOperationsMachineFilter(c *gc.C) {
 	// Set up an operation with a pending action.
 	arg := params.Actions{
 		Actions: []params.Action{
-			{Receiver: s.machine0.Tag().String(), Name: "juju-run", Parameters: map[string]interface{}{
+			{Receiver: s.machine0.Tag().String(), Name: "juju-exec", Parameters: map[string]interface{}{
 				"command": "ls",
 				"timeout": 1,
 			}},
@@ -233,7 +233,7 @@ func (s *operationSuite) TestListOperationsMachineFilter(c *gc.C) {
 	}
 	c.Assert(result.Status, gc.Equals, "pending")
 	action := result.Actions[0].Action
-	c.Assert(action.Name, gc.Equals, "juju-run")
+	c.Assert(action.Name, gc.Equals, "juju-exec")
 	c.Assert(action.Receiver, gc.Equals, "machine-0")
 	c.Assert(action.Tag, gc.Equals, "action-7")
 	c.Assert(result.Actions[0].Status, gc.Equals, "pending")

--- a/apiserver/facades/client/action/run.go
+++ b/apiserver/facades/client/action/run.go
@@ -151,8 +151,7 @@ func (a *ActionAPI) createRunActionsParams(
 ) (params.Actions, error) {
 	apiActionParams := params.Actions{Actions: []params.Action{}}
 
-	actionRunnerName := actions.JujuRunActionName
-	if strings.Contains(quotedCommands, actionRunnerName) {
+	if actions.HasJujuExecAction(quotedCommands) {
 		return apiActionParams, errors.NewNotSupported(nil, fmt.Sprintf("cannot use %q as an action command", quotedCommands))
 	}
 
@@ -164,7 +163,7 @@ func (a *ActionAPI) createRunActionsParams(
 	for _, tag := range actionReceiverTags {
 		apiActionParams.Actions = append(apiActionParams.Actions, params.Action{
 			Receiver:       tag.String(),
-			Name:           actionRunnerName,
+			Name:           actions.JujuExecActionName,
 			Parameters:     actionParams,
 			Parallel:       parallel,
 			ExecutionGroup: executionGroup,

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -201,9 +201,9 @@ func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 	executionGroup := "group"
 	arg := params.Actions{
 		Actions: []params.Action{
-			{Receiver: "unit-magic-0", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
-			{Receiver: "unit-magic-1", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
-			{Receiver: "machine-0", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "unit-magic-0", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "unit-magic-1", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "machine-0", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
 		},
 	}
 	s.addMachine(c)
@@ -230,7 +230,7 @@ func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 	for i, r := range op.Actions {
 		c.Assert(r.Action, gc.NotNil)
 		c.Assert(r.Action.Tag, gc.Not(gc.Equals), emptyActionTag)
-		c.Assert(r.Action.Name, gc.Equals, "juju-run")
+		c.Assert(r.Action.Name, gc.Equals, "juju-exec")
 		c.Assert(r.Action.Receiver, gc.Equals, arg.Actions[i].Receiver)
 		c.Assert(r.Action.Parameters, jc.DeepEquals, expectedPayload)
 		c.Assert(r.Action.Parallel, jc.DeepEquals, &parallel)
@@ -250,8 +250,8 @@ func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
 	executionGroup := "group"
 	arg := params.Actions{
 		Actions: []params.Action{
-			{Receiver: "unit-magic-0", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
-			{Receiver: "unit-magic-1", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "unit-magic-0", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "unit-magic-1", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
 		},
 	}
 	s.addMachine(c)
@@ -278,7 +278,7 @@ func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
 	for i, r := range op.Actions {
 		c.Assert(r.Action, gc.NotNil)
 		c.Assert(r.Action.Tag, gc.Not(gc.Equals), emptyActionTag)
-		c.Assert(r.Action.Name, gc.Equals, "juju-run")
+		c.Assert(r.Action.Name, gc.Equals, "juju-exec")
 		c.Assert(r.Action.Receiver, gc.Equals, arg.Actions[i].Receiver)
 		c.Assert(r.Action.Parameters, jc.DeepEquals, expectedPayload)
 		c.Assert(r.Action.Parallel, jc.DeepEquals, &parallel)
@@ -298,9 +298,9 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 	executionGroup := "group"
 	arg := params.Actions{
 		Actions: []params.Action{
-			{Receiver: "machine-0", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
-			{Receiver: "machine-1", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
-			{Receiver: "machine-2", Name: "juju-run", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "machine-0", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "machine-1", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
+			{Receiver: "machine-2", Name: "juju-exec", Parameters: expectedPayload, Parallel: &parallel, ExecutionGroup: &executionGroup},
 		},
 	}
 	// Make three machines.
@@ -323,7 +323,7 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 	for i, r := range op.Actions {
 		c.Assert(r.Action, gc.NotNil)
 		c.Assert(r.Action.Tag, gc.Not(gc.Equals), emptyActionTag)
-		c.Assert(r.Action.Name, gc.Equals, "juju-run")
+		c.Assert(r.Action.Name, gc.Equals, "juju-exec")
 		c.Assert(r.Action.Receiver, gc.Equals, arg.Actions[i].Receiver)
 		c.Assert(r.Action.Parameters, jc.DeepEquals, expectedPayload)
 		c.Assert(r.Action.Parallel, jc.DeepEquals, &parallel)

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -31,8 +31,8 @@ const (
 	// AgentHTTPPathStartup is the path used for startup probes on the agent
 	AgentHTTPPathStartup = "/startup"
 
-	// JujuRunServerSocketPort is the port used by juju run callbacks.
-	JujuRunServerSocketPort = 30666
+	// JujuExecServerSocketPort is the port used by juju run callbacks.
+	JujuExecServerSocketPort = 30666
 
 	// TemplateFileNameAgentConf is the template agent.conf file name.
 	TemplateFileNameAgentConf = "template-" + agent.AgentConfigFilename

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1376,7 +1376,7 @@ func ensureJujuInitContainer(podSpec *core.PodSpec, operatorImagePath string) er
 
 func getJujuInitContainerAndStorageInfo(operatorImagePath string) (container core.Container, vol core.Volume, volMounts []core.VolumeMount, err error) {
 	dataDir := paths.DataDir(paths.OSUnixLike)
-	jujuRun := paths.JujuRun(paths.OSUnixLike)
+	jujuExec := paths.JujuExec(paths.OSUnixLike)
 	jujudCmd := `
 initCmd=$($JUJU_TOOLS_DIR/jujud help commands | grep caas-unit-init)
 if test -n "$initCmd"; then
@@ -1414,7 +1414,7 @@ fi`[1:]
 	}
 	volMounts = []core.VolumeMount{
 		{Name: dataDirVolumeName, MountPath: dataDir},
-		{Name: dataDirVolumeName, MountPath: jujuRun, SubPath: "tools/jujud"},
+		{Name: dataDirVolumeName, MountPath: jujuExec, SubPath: "tools/jujud"},
 	}
 	return container, vol, volMounts, nil
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -7757,7 +7757,7 @@ func dataVolumeMounts() []core.VolumeMount {
 		},
 		{
 			Name:      "juju-data-dir",
-			MountPath: "/usr/bin/juju-run",
+			MountPath: "/usr/bin/juju-exec",
 			SubPath:   "tools/jujud",
 		},
 	}

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -210,8 +210,8 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 			Ports: []core.ServicePort{
 				{
 					Protocol:   core.ProtocolTCP,
-					Port:       caasconstants.JujuRunServerSocketPort,
-					TargetPort: intstr.FromInt(caasconstants.JujuRunServerSocketPort),
+					Port:       caasconstants.JujuExecServerSocketPort,
+					TargetPort: intstr.FromInt(caasconstants.JujuExecServerSocketPort),
 				},
 			},
 		},

--- a/caas/operator.go
+++ b/caas/operator.go
@@ -14,7 +14,7 @@ const (
 	OperatorInfoFile = "operator.yaml"
 
 	// OperatorClientInfoFile is the file containing info about the operator,
-	// copied to the workload pod so the hook tools and juju-run can function.
+	// copied to the workload pod so the hook tools and juju-exec can function.
 	OperatorClientInfoFile = "operator-client.yaml"
 
 	// OperatorClientInfoCacheFile is a cache of OperatorClientInfoFile stored on the operator.

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -340,7 +340,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 	}
 
 	// Make the lock dir and change the ownership of the lock dir itself to
-	// ubuntu:ubuntu from root:root so the juju-run command run as the ubuntu
+	// ubuntu:ubuntu from root:root so the juju-exec command run as the ubuntu
 	// user is able to get access to the hook execution lock (like the uniter
 	// itself does.)
 	lockDir := path.Join(w.icfg.DataDir, "locks")

--- a/cmd/juju/action/exec.go
+++ b/cmd/juju/action/exec.go
@@ -110,7 +110,7 @@ targets.
 
 Since juju exec creates tasks, you can query for the status of commands
 started with juju run by calling 
-"juju operations --machines <id>,... --actions juju-run".
+"juju operations --machines <id>,... --actions juju-exec".
 
 If you need to pass options to the command being run, you must precede the
 command and its arguments with "--", to tell "juju exec" to stop processing

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -53,12 +53,12 @@ When an application is specified, all units from that application are relevant.
 When run without any arguments, operations corresponding to actions for all
 application units are returned.
 To see operations corresponding to juju run tasks, specify an action name
-"juju-run" and/or one or more machines.
+"juju-exec" and/or one or more machines.
 
 Examples:
     juju operations
     juju operations --format yaml
-    juju operations --actions juju-run
+    juju operations --actions juju-exec
     juju operations --actions backup,restore
     juju operations --apps mysql,mediawiki
     juju operations --units mysql/0,mediawiki/1

--- a/cmd/juju/action/listoperations_test.go
+++ b/cmd/juju/action/listoperations_test.go
@@ -141,7 +141,7 @@ var listOperationResults = actionapi.Operations{
 			Action: &actionapi.Action{
 				ID:       "6",
 				Receiver: "machine-1",
-				Name:     "juju-run",
+				Name:     "juju-exec",
 			},
 		}},
 		Summary:   "operation 5",
@@ -331,7 +331,7 @@ func (s *ListOperationsSuite) TestRunYaml(c *gc.C) {
   summary: operation 5
   status: pending
   action:
-    name: juju-run
+    name: juju-exec
     parameters: {}
   timing:
     enqueued: 2013-02-14 06:06:06 +0000 UTC

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -767,7 +767,7 @@ func (s *MachineSuite) TestMachineAgentSymlinks(c *gc.C) {
 	s.waitStopped(c, state.JobManageModel, a, done)
 }
 
-func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
+func (s *MachineSuite) TestMachineAgentSymlinkJujuExecExists(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		// Cannot make symlink to nonexistent file on windows or
 		// create a file point a symlink to it then remove it
@@ -789,7 +789,7 @@ func (s *MachineSuite) TestMachineAgentSymlinkJujuRunExists(c *gc.C) {
 	// Start the agent and wait for it be running.
 	_, done := s.waitForOpenState(c, a)
 
-	// juju-run symlink should have been recreated.
+	// juju-exec symlink should have been recreated.
 	for _, link := range jujudSymlinks {
 		fullLink := utils.EnsureBaseDir(a.rootDir, link)
 		linkTarget, err := symlink.Read(fullLink)

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -332,9 +332,9 @@ func Main(args []string) int {
 	switch commandName {
 	case jujunames.Jujud:
 		code, err = jujuDMain(args, ctx)
-	case jujunames.JujuRun:
+	case jujunames.JujuExec:
 		lock, err := machinelock.New(machinelock.Config{
-			AgentName:   "juju-run",
+			AgentName:   "juju-exec",
 			Clock:       clock.WallClock,
 			Logger:      loggo.GetLogger("juju.machinelock"),
 			LogFilename: filepath.Join(config.LogDir, machinelock.Filename),

--- a/cmd/jujud/run/run_test.go
+++ b/cmd/jujud/run/run_test.go
@@ -208,7 +208,7 @@ func (s *RunTestSuite) TestInsideContext(c *gc.C) {
 	s.PatchEnvironment("JUJU_CONTEXT_ID", "fake-id")
 	runCommand := s.runCommand()
 	err := runCommand.Init([]string{"foo", "bar"})
-	c.Assert(err, gc.ErrorMatches, "juju-run cannot be called from within a hook.*")
+	c.Assert(err, gc.ErrorMatches, "juju-exec cannot be called from within a hook.*")
 }
 
 func (s *RunTestSuite) TestMissingAgentName(c *gc.C) {

--- a/cmd/k8sagent/config/config.go
+++ b/cmd/k8sagent/config/config.go
@@ -8,8 +8,5 @@ import (
 )
 
 var (
-	JujuRun        = paths.JujuRun(paths.CurrentOS())
-	JujuDumpLogs   = paths.JujuDumpLogs(paths.CurrentOS())
-	JujuIntrospect = paths.JujuIntrospect(paths.CurrentOS())
-	LogDir         = paths.LogDir(paths.CurrentOS())
+	LogDir = paths.LogDir(paths.CurrentOS())
 )

--- a/cmd/k8sagent/main_nix.go
+++ b/cmd/k8sagent/main_nix.go
@@ -122,8 +122,8 @@ func mainWrapper(f commandFactotry, args []string) (code int) {
 	switch filepath.Base(args[0]) {
 	case names.K8sAgent:
 		code = f.k8sAgentCmd(ctx, args)
-	case names.JujuRun:
-		code = f.jujuRun(ctx, args)
+	case names.JujuExec:
+		code = f.jujuExec(ctx, args)
 	case names.JujuIntrospect:
 		code = f.jujuIntrospect(ctx, args)
 	default:
@@ -155,16 +155,16 @@ func main() {
 			}
 			return cmd.Main(cmdToRun, ctx, args[1:])
 		},
-		jujuRun: func(ctx *cmd.Context, args []string) int {
+		jujuExec: func(ctx *cmd.Context, args []string) int {
 			lock, err := machinelock.New(machinelock.Config{
-				AgentName: "juju-run",
+				AgentName: "juju-exec",
 				Clock:     clock.WallClock,
 				Logger:    loggo.GetLogger("juju.machinelock"),
 				// TODO(ycliuhw): consider to rename machinelock package to something more generic for k8s pod lock.
 				LogFilename: filepath.Join(config.LogDir, machinelock.Filename),
 			})
 			if err != nil {
-				err = errors.Annotatef(err, "acquiring machine lock for juju-run")
+				err = errors.Annotatef(err, "acquiring machine lock for juju-exec")
 				cmd.WriteError(ctx.Stderr, err)
 				os.Exit(1)
 			}
@@ -181,7 +181,7 @@ type command func(*cmd.Context, []string) int
 
 type commandFactotry struct {
 	k8sAgentCmd    command
-	jujuRun        command
+	jujuExec       command
 	jujuDumpLogs   command
 	jujuIntrospect command
 }

--- a/cmd/k8sagent/main_test.go
+++ b/cmd/k8sagent/main_test.go
@@ -30,7 +30,7 @@ func (s *k8sAgentSuite) TestMainWrapper(c *gc.C) {
 		k8sAgentCmd: func(ctx *cmd.Context, args []string) int {
 			return 11
 		},
-		jujuRun: func(ctx *cmd.Context, args []string) int {
+		jujuExec: func(ctx *cmd.Context, args []string) int {
 			return 12
 		},
 		jujuIntrospect: func(ctx *cmd.Context, args []string) int {
@@ -39,7 +39,7 @@ func (s *k8sAgentSuite) TestMainWrapper(c *gc.C) {
 	}
 	for _, tc := range []mainWrapperTC{
 		{args: []string{"k8sagent"}, code: 11},
-		{args: []string{"juju-run"}, code: 12},
+		{args: []string{"juju-exec"}, code: 12},
 		{args: []string{"juju-introspect"}, code: 14},
 	} {
 		c.Check(mainWrapper(factory, tc.args), gc.DeepEquals, tc.code)

--- a/cmd/k8sagent/unit/agent.go
+++ b/cmd/k8sagent/unit/agent.go
@@ -200,7 +200,7 @@ func (c *k8sUnitAgent) ensureToolSymlinks(srcPath, dataDir string, unitTag names
 
 	for _, link := range []string{
 		jnames.K8sAgent,
-		jnames.JujuRun,
+		jnames.JujuExec,
 		jnames.JujuIntrospect,
 	} {
 		if err = c.fileReaderWriter.Symlink(path.Join(srcPath, jnames.K8sAgent), path.Join(toolsDir, link)); err != nil {

--- a/cmd/k8sagent/unit/agent_test.go
+++ b/cmd/k8sagent/unit/agent_test.go
@@ -102,7 +102,7 @@ func (s *k8sUnitAgentSuite) TestParseSuccess(c *gc.C) {
 		s.environment.EXPECT().Unsetenv("DELETE").Return(nil),
 		s.fileReaderWriter.EXPECT().MkdirAll(toolsDir, os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.K8sAgent)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuRun)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuExec)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuIntrospect)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.Jujuc)).Return(nil),
 	)

--- a/core/actions/actions.go
+++ b/core/actions/actions.go
@@ -5,26 +5,44 @@
 package actions
 
 import (
+	"strings"
+
 	"github.com/juju/charm/v9"
 )
 
-// JujuRunActionName defines the action name used by juju-run.
-const JujuRunActionName = "juju-run"
+// JujuExecActionName defines the action name used by juju-exec.
+const JujuExecActionName = "juju-exec"
+
+// legacyJujuRunActionName will be removed in Juju 4.
+const legacyJujuRunActionName = "juju-run"
+
+// IsJujuExecAction returns true if name is the "juju-exec" action.
+func IsJujuExecAction(name string) bool {
+	// Check for the legacy "juju-run" as well in case an upgrade was
+	// done and actions had been previously queued.
+	return name == JujuExecActionName || name == legacyJujuRunActionName
+}
+
+// HasJujuExecAction returns true if the "juju-exec" binary name appears
+// anywhere in the specified commands.
+func HasJujuExecAction(commands string) bool {
+	return strings.Contains(commands, JujuExecActionName) || strings.Contains(commands, legacyJujuRunActionName)
+}
 
 // PredefinedActionsSpec defines a spec for each predefined action.
 var PredefinedActionsSpec = map[string]charm.ActionSpec{
-	JujuRunActionName: {
-		Description: "predefined juju-run action",
+	JujuExecActionName: {
+		Description: "predefined juju-exec action",
 		Parallel:    true,
 		Params: map[string]interface{}{
 			"type":        "object",
-			"title":       JujuRunActionName,
-			"description": "predefined juju-run action params",
+			"title":       JujuExecActionName,
+			"description": "predefined juju-exec action params",
 			"required":    []interface{}{"command", "timeout"},
 			"properties": map[string]interface{}{
 				"command": map[string]interface{}{
 					"type":        "string",
-					"description": "command to be ran under juju-run",
+					"description": "command to be ran under juju-exec",
 				},
 				"timeout": map[string]interface{}{
 					"type":        "number",

--- a/core/paths/paths.go
+++ b/core/paths/paths.go
@@ -28,7 +28,7 @@ const (
 	dataDir
 	storageDir
 	confDir
-	jujuRun
+	jujuExec
 	certDir
 	metricsSpoolDir
 	uniterStateDir
@@ -59,7 +59,7 @@ var nixVals = map[osVarType]string{
 	transientDataDir:     NixTransientDataDir,
 	storageDir:           "/var/lib/juju/storage",
 	confDir:              "/etc/juju",
-	jujuRun:              "/usr/bin/juju-run",
+	jujuExec:             "/usr/bin/juju-exec",
 	jujuDumpLogs:         "/usr/bin/juju-dumplogs",
 	jujuIntrospect:       "/usr/bin/juju-introspect",
 	certDir:              "/etc/juju/certs.d",
@@ -77,7 +77,7 @@ var winVals = map[osVarType]string{
 	transientDataDir: "C:/Juju/lib/juju-transient",
 	storageDir:       "C:/Juju/lib/juju/storage",
 	confDir:          "C:/Juju/etc",
-	jujuRun:          "C:/Juju/bin/juju-run.exe",
+	jujuExec:         "C:/Juju/bin/juju-exec.exe",
 	jujuDumpLogs:     "C:/Juju/bin/juju-dumplogs.exe",
 	jujuIntrospect:   "C:/Juju/bin/juju-introspect.exe",
 	certDir:          "C:/Juju/certs",
@@ -179,10 +179,10 @@ func ConfDir(os OS) string {
 	return osVal(os, confDir)
 }
 
-// JujuRun returns the absolute path to the juju-run binary for
+// JujuExec returns the absolute path to the juju-exec binary for
 // a particular series.
-func JujuRun(os OS) string {
-	return osVal(os, jujuRun)
+func JujuExec(os OS) string {
+	return osVal(os, jujuExec)
 }
 
 // JujuDumpLogs returns the absolute path to the juju-dumplogs binary

--- a/doc/charms-in-action.txt
+++ b/doc/charms-in-action.txt
@@ -78,19 +78,6 @@ software deployed by the charm in any way; and there is currently no mechanism
 by which deployed software can safely feed information back into the charm
 and/or expect that it will be acted upon in a timely way.
 
-[TODO: this sucks a bit. We have plans for a tool called `juju-run`, which
-would allow an arbitrary script to be invoked as though it were a hook at any
-time (well, it'd block until no other hook were running, but still). Probably
-isn't even that hard but it's still rolling around my brain, might either click
-soon or be overridden by higher priorities and be left for ages. I'm less sure,
-but have a suspicion, that `juju ssh <unit>` should also default to a juju-run
-model: primarily because, without this, in the context of forced upgrades,
-the system cannot offer *any* guarantees about what it might suddenly do to the
-charm directory while the user's doing things with it. The alternative is to
-allow unguarded ssh, but tell people that they have to use something like
-`juju-run --interactive` before they modify the charm dir; this feels somewhat
-user-hostile, though.]
-
 Execution environment
 ---------------------
 

--- a/doc/system-ssh-key.txt
+++ b/doc/system-ssh-key.txt
@@ -5,7 +5,7 @@ potential use-cases.
  * Allows the api server machines to ssh to other machines in the model
    * could be used to set up ssh tunnels through a single public facing IP
      address on the server
-   * allows juju-run commands to be run on remote machiens
+   * allows juju-exec commands to be run on remote machiens
 
 Juju already creates a private key for serving the mongo database. It was an
 option to also use this key, but in the end, having different keys for

--- a/juju/names/names.go
+++ b/juju/names/names.go
@@ -6,12 +6,11 @@
 package names
 
 const (
-	Juju           = "juju"
 	Jujuc          = "jujuc"
 	Jujud          = "jujud"
 	K8sAgent       = "k8sagent"
 	JujudVersions  = "jujud-versions.yaml"
-	JujuRun        = "juju-run"
+	JujuExec       = "juju-exec"
 	JujuDumpLogs   = "juju-dumplogs"
 	JujuIntrospect = "juju-introspect"
 )

--- a/juju/names/names_windows.go
+++ b/juju/names/names_windows.go
@@ -10,7 +10,7 @@ const (
 	Jujud          = "jujud.exe"
 	K8sAgent       = "not-available"
 	JujudVersions  = "jujud-versions.yaml"
-	JujuRun        = "juju-run.exe"
+	JujuExec       = "juju-exec.exe"
 	JujuDumpLogs   = "juju-dumplogs.exe"
 	JujuIntrospect = "juju-introspect.exe"
 )

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2540,11 +2540,11 @@ func (s *MachineSuite) TestMachineValidActions(c *gc.C) {
 		expectedPayload map[string]interface{}
 	}{
 		{
-			actionName: "juju-run",
+			actionName: "juju-exec",
 			errString:  `validation failed: (root) : "command" property is missing and required, given {}; (root) : "timeout" property is missing and required, given {}`,
 		},
 		{
-			actionName:      "juju-run",
+			actionName:      "juju-exec",
 			givenPayload:    map[string]interface{}{"command": "allyourbasearebelongtous", "timeout": 5.0},
 			expectedPayload: map[string]interface{}{"command": "allyourbasearebelongtous", "timeout": 5.0},
 		},

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2490,23 +2490,23 @@ snapshot:
 			expectedPayload: map[string]interface{}{"outfile": "abcd"},
 		},
 		{
-			actionName: "juju-run",
+			actionName: "juju-exec",
 			errString:  `validation failed: \(root\) : "command" property is missing and required, given \{\}; \(root\) : "timeout" property is missing and required, given \{\}`,
 		},
 		{
-			actionName:   "juju-run",
+			actionName:   "juju-exec",
 			givenPayload: map[string]interface{}{"command": "allyourbasearebelongtous"},
 			errString:    `validation failed: \(root\) : "timeout" property is missing and required, given \{"command":"allyourbasearebelongtous"\}`,
 		},
 		{
-			actionName:   "juju-run",
+			actionName:   "juju-exec",
 			givenPayload: map[string]interface{}{"timeout": 5 * time.Second},
 			// Note: in Go 1.8 the representation of large numbers in JSON changed
 			// to use integer rather than exponential notation, hence the pattern.
 			errString: `validation failed: \(root\) : "command" property is missing and required, given \{"timeout":5.*\}`,
 		},
 		{
-			actionName:      "juju-run",
+			actionName:      "juju-exec",
 			givenPayload:    map[string]interface{}{"command": "allyourbasearebelongtous", "timeout": 5.0},
 			expectedPayload: map[string]interface{}{"command": "allyourbasearebelongtous", "timeout": 5.0},
 		},

--- a/worker/caasoperator/paths.go
+++ b/worker/caasoperator/paths.go
@@ -59,9 +59,9 @@ func (paths Paths) ComponentDir(name string) string {
 // RuntimePaths represents the set of paths that are relevant at runtime.
 type RuntimePaths struct {
 
-	// JujuRunSocket listens for juju-run invocations, and is always
+	// JujuExecSocket listens for juju-exec invocations, and is always
 	// active.
-	JujuRunSocket string
+	JujuExecSocket string
 
 	// HookCommandServerSocket listens for hook command invocations, and is only
 	// active when supporting a hook execution context.

--- a/worker/machineactions/handleactions.go
+++ b/worker/machineactions/handleactions.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/core/actions"
 )
 
-// RunAsUser is the user that the machine juju-run action is executed as.
+// RunAsUser is the user that the machine juju-exec action is executed as.
 var RunAsUser = "ubuntu"
 
 // HandleAction receives a name and a map of parameters for a given machine action.
@@ -31,15 +31,14 @@ func HandleAction(name string, params map[string]interface{}) (results map[strin
 		return nil, errors.Errorf("invalid action parameters")
 	}
 
-	switch name {
-	case actions.JujuRunActionName:
-		return handleJujuRunAction(params)
-	default:
+	if actions.IsJujuExecAction(name) {
+		return handleJujuExecAction(params)
+	} else {
 		return nil, errors.Errorf("unexpected action %s", name)
 	}
 }
 
-func handleJujuRunAction(params map[string]interface{}) (results map[string]interface{}, err error) {
+func handleJujuExecAction(params map[string]interface{}) (results map[string]interface{}, err error) {
 	// The spec checks that the parameters are available so we don't need to check again here
 	command, _ := params["command"].(string)
 	logger.Tracef("juju run %q", command)

--- a/worker/machineactions/handleactions_test.go
+++ b/worker/machineactions/handleactions_test.go
@@ -37,7 +37,7 @@ func (s *HandleSuite) TestInvalidAction(c *gc.C) {
 }
 
 func (s *HandleSuite) TestValidActionInvalidParams(c *gc.C) {
-	results, err := machineactions.HandleAction(actions.JujuRunActionName, nil)
+	results, err := machineactions.HandleAction(actions.JujuExecActionName, nil)
 	c.Assert(err, gc.ErrorMatches, "invalid action parameters")
 	c.Assert(results, gc.IsNil)
 }
@@ -48,7 +48,7 @@ func (s *HandleSuite) TestTimeoutRun(c *gc.C) {
 		"timeout": float64(1),
 	}
 
-	results, err := machineactions.HandleAction(actions.JujuRunActionName, params)
+	results, err := machineactions.HandleAction(actions.JujuExecActionName, params)
 	c.Assert(errors.Cause(err), gc.Equals, exec.ErrCancelled)
 	c.Assert(results, gc.IsNil)
 }
@@ -59,7 +59,7 @@ func (s *HandleSuite) TestSuccessfulRun(c *gc.C) {
 		"timeout": float64(0),
 	}
 
-	results, err := machineactions.HandleAction(actions.JujuRunActionName, params)
+	results, err := machineactions.HandleAction(actions.JujuExecActionName, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results["return-code"], gc.Equals, 0)
 	c.Assert(strings.TrimRight(results["stdout"].(string), "\r\n"), gc.Equals, "1")
@@ -72,7 +72,7 @@ func (s *HandleSuite) TestErrorRun(c *gc.C) {
 		"timeout": float64(0),
 	}
 
-	results, err := machineactions.HandleAction(actions.JujuRunActionName, params)
+	results, err := machineactions.HandleAction(actions.JujuExecActionName, params)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results["return-code"], gc.Equals, 42)
 	c.Assert(results["stdout"], gc.Equals, "")

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -89,12 +89,12 @@ type SocketPair struct {
 
 // RuntimePaths represents the set of paths that are relevant at runtime.
 type RuntimePaths struct {
-	// JujuRunSocket listens for juju-run invocations, and is always
+	// LocalJujuExecSocket listens for juju-exec invocations, and is always
 	// active.
-	LocalJujuRunSocket SocketPair
+	LocalJujuExecSocket SocketPair
 
-	// RemoteJujuRunSocket listens for remote juju-run invocations.
-	RemoteJujuRunSocket SocketPair
+	// RemoteJujuExecSocket listens for remote juju-exec invocations.
+	RemoteJujuExecSocket SocketPair
 
 	// JujucServerSocket listens for jujuc invocations, and is only
 	// active when supporting a jujuc execution context.
@@ -159,7 +159,7 @@ func NewWorkerPaths(dataDir string, unitTag names.UnitTag, worker string, socket
 				port = jujucServerSocketPort + unitTag.Number()
 				address = socketConfig.OperatorAddress
 			case "run":
-				port = caasconstants.JujuRunServerSocketPort
+				port = caasconstants.JujuExecServerSocketPort
 				address = socketConfig.ServiceAddress
 			default:
 				return SocketPair{}
@@ -187,9 +187,9 @@ func NewWorkerPaths(dataDir string, unitTag names.UnitTag, worker string, socket
 	return Paths{
 		ToolsDir: filepath.FromSlash(toolsDir),
 		Runtime: RuntimePaths{
-			RemoteJujuRunSocket:     newSocket("run"),
+			RemoteJujuExecSocket:    newSocket("run"),
 			RemoteJujucServerSocket: newSocket("agent"),
-			LocalJujuRunSocket:      newUnixSocket(baseDir, unitTag, worker, "run", false),
+			LocalJujuExecSocket:     newUnixSocket(baseDir, unitTag, worker, "run", false),
 			LocalJujucServerSocket:  newUnixSocket(baseDir, unitTag, worker, "agent", true),
 		},
 		State: StatePaths{

--- a/worker/uniter/paths_test.go
+++ b/worker/uniter/paths_test.go
@@ -44,7 +44,7 @@ func (s *PathsSuite) TestWindows(c *gc.C) {
 	c.Assert(paths, jc.DeepEquals, uniter.Paths{
 		ToolsDir: relData("tools/unit-some-application-323"),
 		Runtime: uniter.RuntimePaths{
-			LocalJujuRunSocket:     uniter.SocketPair{localRunSocket, localRunSocket},
+			LocalJujuExecSocket:    uniter.SocketPair{localRunSocket, localRunSocket},
 			LocalJujucServerSocket: uniter.SocketPair{localJujucSocket, localJujucSocket},
 		},
 		State: uniter.StatePaths{
@@ -73,7 +73,7 @@ func (s *PathsSuite) TestWorkerPathsWindows(c *gc.C) {
 	c.Assert(paths, jc.DeepEquals, uniter.Paths{
 		ToolsDir: relData("tools/unit-some-application-323"),
 		Runtime: uniter.RuntimePaths{
-			LocalJujuRunSocket:     uniter.SocketPair{localRunSocket, localRunSocket},
+			LocalJujuExecSocket:    uniter.SocketPair{localRunSocket, localRunSocket},
 			LocalJujucServerSocket: uniter.SocketPair{localJujucSocket, localJujucSocket},
 		},
 		State: uniter.StatePaths{
@@ -102,7 +102,7 @@ func (s *PathsSuite) TestOther(c *gc.C) {
 	c.Assert(paths, jc.DeepEquals, uniter.Paths{
 		ToolsDir: relData("tools/unit-some-application-323"),
 		Runtime: uniter.RuntimePaths{
-			LocalJujuRunSocket:     uniter.SocketPair{localRunSocket, localRunSocket},
+			LocalJujuExecSocket:    uniter.SocketPair{localRunSocket, localRunSocket},
 			LocalJujucServerSocket: uniter.SocketPair{localJujucSocket, localJujucSocket},
 		},
 		State: uniter.StatePaths{
@@ -140,9 +140,9 @@ func (s *PathsSuite) TestTCPRemote(c *gc.C) {
 	c.Assert(paths, jc.DeepEquals, uniter.Paths{
 		ToolsDir: relData("tools/unit-some-application-323"),
 		Runtime: uniter.RuntimePaths{
-			LocalJujuRunSocket:      uniter.SocketPair{localRunSocket, localRunSocket},
+			LocalJujuExecSocket:     uniter.SocketPair{localRunSocket, localRunSocket},
 			LocalJujucServerSocket:  uniter.SocketPair{localJujucSocket, localJujucSocket},
-			RemoteJujuRunSocket:     uniter.SocketPair{remoteRunServerSocket, remoteRunClientSocket},
+			RemoteJujuExecSocket:    uniter.SocketPair{remoteRunServerSocket, remoteRunClientSocket},
 			RemoteJujucServerSocket: uniter.SocketPair{remoteJujucServerSocket, remoteJujucClientSocket},
 		},
 		State: uniter.StatePaths{
@@ -170,7 +170,7 @@ func (s *PathsSuite) TestWorkerPaths(c *gc.C) {
 	c.Assert(paths, jc.DeepEquals, uniter.Paths{
 		ToolsDir: relData("tools/unit-some-application-323"),
 		Runtime: uniter.RuntimePaths{
-			LocalJujuRunSocket:     uniter.SocketPair{localRunSocket, localRunSocket},
+			LocalJujuExecSocket:    uniter.SocketPair{localRunSocket, localRunSocket},
 			LocalJujucServerSocket: uniter.SocketPair{localJujucSocket, localJujucSocket},
 		},
 		State: uniter.StatePaths{

--- a/worker/uniter/runlistener_test.go
+++ b/worker/uniter/runlistener_test.go
@@ -75,7 +75,7 @@ func (s *ListenerSuite) TestClientCall(c *gc.C) {
 		ForceRemoteUnit: false,
 		UnitName:        "test/0",
 	}
-	err = client.Call(uniter.JujuRunEndpoint, args, &result)
+	err = client.Call(uniter.JujuExecEndpoint, args, &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(result.Stdout), gc.Equals, "some-command stdout")
@@ -99,7 +99,7 @@ func (s *ListenerSuite) TestUnregisterRunner(c *gc.C) {
 		ForceRemoteUnit: false,
 		UnitName:        "test/0",
 	}
-	err = client.Call(uniter.JujuRunEndpoint, args, &result)
+	err = client.Call(uniter.JujuExecEndpoint, args, &result)
 	c.Assert(err, gc.ErrorMatches, ".*no runner is registered for unit test/0")
 }
 
@@ -119,7 +119,7 @@ func (s *ListenerSuite) TestOperatorFlag(c *gc.C) {
 		UnitName:        "test/0",
 		Operator:        true,
 	}
-	err = client.Call(uniter.JujuRunEndpoint, args, &result)
+	err = client.Call(uniter.JujuExecEndpoint, args, &result)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(result.Stdout), gc.Equals, "some-command stdout")

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -241,7 +241,7 @@ type HookContext struct {
 	assignedMachineTag names.MachineTag
 
 	// process is the process of the command that is being run in the local context,
-	// like a juju-run command or a hook
+	// like a juju-exec command or a hook
 	process HookProcess
 
 	// rebootPriority tells us when the hook wants to reboot. If rebootPriority is hooks.RebootNow

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -470,7 +470,7 @@ func (s *InterfaceSuite) TestRequestRebootNowTimeout(c *gc.C) {
 }
 
 func (s *InterfaceSuite) TestRequestRebootNowNoProcess(c *gc.C) {
-	// A normal hook run or a juju-run command will record the *os.Process
+	// A normal hook run or a juju-exec command will record the *os.Process
 	// object of the running command, in HookContext. When requesting a
 	// reboot with the --now flag, the process is killed and only
 	// then will we set the reboot priority. This test basically simulates

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -227,9 +227,9 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 			},
 		},
 		{
-			// juju-run should work as a predefined action even if
+			// juju-exec should work as a predefined action even if
 			// it's not part of the charm
-			actionName: "juju-run",
+			actionName: "juju-exec",
 			payload: map[string]interface{}{
 				"command": "foo",
 				"timeout": 0.0,

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -485,7 +485,7 @@ func (s *RunMockContextSuite) TestRunActionDataFailure(c *gc.C) {
 		actionData:    &context.ActionData{},
 		actionDataErr: expectErr,
 	}
-	_, actualErr := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-run")
+	_, actualErr := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-exec")
 	c.Assert(errors.Cause(actualErr), gc.Equals, expectErr)
 }
 
@@ -501,9 +501,9 @@ func (s *RunMockContextSuite) TestRunActionSuccessful(c *gc.C) {
 		actionParams:  params,
 		actionResults: map[string]interface{}{},
 	}
-	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-run")
+	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-exec")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-exec")
 	c.Assert(ctx.flushFailure, gc.IsNil)
 	c.Assert(ctx.actionResults["return-code"], gc.Equals, 0)
 	c.Assert(strings.TrimRight(ctx.actionResults["stdout"].(string), "\r\n"), gc.Equals, "1")
@@ -522,9 +522,9 @@ func (s *RunMockContextSuite) TestRunActionError(c *gc.C) {
 		actionParams:  params,
 		actionResults: map[string]interface{}{},
 	}
-	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-run")
+	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-exec")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-exec")
 	c.Assert(ctx.flushFailure, gc.IsNil)
 	c.Assert(ctx.actionResults["return-code"], gc.Equals, 3)
 	c.Assert(strings.TrimRight(ctx.actionResults["stdout"].(string), "\r\n"), gc.Equals, "1")
@@ -544,9 +544,9 @@ func (s *RunMockContextSuite) TestRunActionCancelled(c *gc.C) {
 		actionParams:  params,
 		actionResults: map[string]interface{}{},
 	}
-	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-run")
+	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-exec")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-exec")
 	c.Assert(ctx.flushFailure, gc.Equals, exec.ErrCancelled)
 	c.Assert(ctx.actionResults["return-code"], gc.Equals, 0)
 	c.Assert(ctx.actionResults["stdout"], gc.Equals, nil)
@@ -679,10 +679,10 @@ func (s *RunMockContextSuite) TestRunActionCAASSuccess(c *gc.C) {
 		c.Fatal("invalid count")
 		return nil, nil
 	}
-	_, err := runner.NewRunner(ctx, s.paths, execFunc).RunAction("juju-run")
+	_, err := runner.NewRunner(ctx, s.paths, execFunc).RunAction("juju-exec")
 	c.Assert(execCount, gc.Equals, 2)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-exec")
 	c.Assert(ctx.actionResults["return-code"], gc.Equals, 0)
 	c.Assert(strings.TrimRight(ctx.actionResults["stdout"].(string), "\r\n"), gc.Equals, "1")
 	c.Assert(ctx.actionResults["stderr"], gc.Equals, nil)
@@ -729,10 +729,10 @@ export PATH='important-path'
 		c.Fatal("invalid count")
 		return nil, nil
 	}
-	_, err := runner.NewRunner(ctx, s.paths, execFunc).RunAction("juju-run")
+	_, err := runner.NewRunner(ctx, s.paths, execFunc).RunAction("juju-exec")
 	c.Assert(execCount, gc.Equals, 2)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-exec")
 	c.Assert(ctx.actionResults["return-code"], gc.Equals, 0)
 	c.Assert(strings.TrimRight(ctx.actionResults["stdout"].(string), "\r\n"), gc.Equals, "1")
 	c.Assert(ctx.actionResults["stderr"], gc.Equals, nil)
@@ -752,9 +752,9 @@ func (s *RunMockContextSuite) TestRunActionOnWorkloadIgnoredIAAS(c *gc.C) {
 		actionParams:  params,
 		actionResults: map[string]interface{}{},
 	}
-	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-run")
+	_, err := runner.NewRunner(ctx, s.paths, nil).RunAction("juju-exec")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.flushBadge, gc.Equals, "juju-run")
+	c.Assert(ctx.flushBadge, gc.Equals, "juju-exec")
 	c.Assert(ctx.flushFailure, gc.IsNil)
 	c.Assert(ctx.actionResults["return-code"], gc.Equals, 0)
 	c.Assert(strings.TrimRight(ctx.actionResults["stdout"].(string), "\r\n"), gc.Equals, "1")

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -823,8 +823,8 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	if err := os.MkdirAll(u.paths.State.BaseDir, 0755); err != nil {
 		return errors.Trace(err)
 	}
-	socket := u.paths.Runtime.LocalJujuRunSocket.Server
-	u.logger.Debugf("starting local juju-run listener on %v", socket)
+	socket := u.paths.Runtime.LocalJujuExecSocket.Server
+	u.logger.Debugf("starting local juju-exec listener on %v", socket)
 	u.localRunListener, err = NewRunListener(socket, u.logger)
 	if err != nil {
 		return errors.Annotate(err, "creating juju run listener")


### PR DESCRIPTION
This PR updates the "juju-run" infrastructure to match the CLI changes where "juju run" is now "juju exec".

The /usr/bin/juju-run symlink is now /usr/bun/juju-exec, and any legacy /usr/bin/juju-run symlink is removed.

## QA steps

Deploy a unit on 2.9
upgrade to 3 and ensure /usr/bin/juju-run symlink is removed
juju exec --unit foo/0 hostname
juju operations --name juju-exec
juju ssh foo/0 "sudo juju-exec pwd"
juju ssh foo/0 "sudo juju-exec config-get"
juju exec --unit foo/0 "sudo juju-exec  pwd" -> error
