### PR TITLE
Small error message change in deploy, reference CharmHub, not the store

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -359,7 +359,7 @@ func (s *DeploySuite) TestDeployFromPathRelativeDir(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, ""+
 		"The charm or bundle \"multi-series\" is ambiguous.\n"+
 		"To deploy a local charm or bundle, run `juju deploy ./multi-series`.\n"+
-		"To deploy a charm or bundle from the store, run `juju deploy cs:multi-series`.")
+		"To deploy a charm or bundle from CharmHub, run `juju deploy ch:multi-series`.")
 }
 
 func (s *DeploySuite) TestDeployFromPathOldCharm(c *gc.C) {

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -242,7 +242,7 @@ func (d *factory) maybeReadLocalBundle() (Deployer, error) {
 		return nil, errors.Errorf(""+
 			"The charm or bundle %q is ambiguous.\n"+
 			"To deploy a local charm or bundle, run `juju deploy ./%[1]s`.\n"+
-			"To deploy a charm or bundle from the store, run `juju deploy cs:%[1]s`.",
+			"To deploy a charm or bundle from CharmHub, run `juju deploy ch:%[1]s`.",
 			bundleFile,
 		)
 	}


### PR DESCRIPTION
Suggestions from juju deploy should reference CharmHub now, not the old charm store.

## QA steps

```sh
$ mkdir charmed-kubernetes
$ juju deploy charmed-kubernetes
ERROR The charm or bundle "charmed-kubernetes" is ambiguous.
To deploy a local charm or bundle, run `juju deploy ./charmed-kubernetes`.
To deploy a charm or bundle from CharmHub, run `juju deploy ch:charmed-kubernetes`.
```

