### PR TITLE
[Charmhub] - `Juju info` updates based on upcoming api changes.

### DIFF
--- a/api/charmhub/data.go
+++ b/api/charmhub/data.go
@@ -106,7 +106,6 @@ func convertChannels(in map[string]params.Channel) map[string]Channel {
 			Size:       v.Size,
 			Version:    v.Version,
 			Platforms:  convertPlatforms(v.Platforms),
-			Resources:  convertResources(v.Resources),
 		}
 	}
 	return out
@@ -116,14 +115,6 @@ func convertPlatforms(in []params.Platform) []Platform {
 	out := make([]Platform, len(in))
 	for i, v := range in {
 		out[i] = Platform(v)
-	}
-	return out
-}
-
-func convertResources(in []params.CharmHubInfoResource) []Resource {
-	out := make([]Resource, len(in))
-	for i, v := range in {
-		out[i] = Resource(v)
 	}
 	return out
 }

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -25,12 +25,12 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 		Tags:        categories(info.Entity.Categories),
 		StoreURL:    info.Entity.StoreURL,
 	}
-	switch ir.Type {
-	case "bundle":
+	switch transport.Type(ir.Type) {
+	case transport.BundleType:
 		ir.Bundle = convertBundle(info.Entity.Charms)
 		// TODO (stickupkid): Get the Bundle.Series and set it to the
 		// InfoResponse at a high level.
-	case "charm":
+	case transport.CharmType:
 		ir.Charm, ir.Series = convertCharm(info)
 	}
 

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -132,7 +132,6 @@ func transformInfoChannelMap(channelMap []transport.InfoChannelMap) ([]string, m
 			Size:       cm.Revision.Download.Size,
 			Version:    cm.Revision.Version,
 			Platforms:  convertPlatforms(cm.Revision.Platforms),
-			Resources:  convertResources(cm.Resources),
 		}
 		if !seen.Contains(ch.Track) {
 			seen.Add(ch.Track)
@@ -150,20 +149,6 @@ func convertPlatforms(in []transport.Platform) []params.Platform {
 			Architecture: v.Architecture,
 			OS:           v.OS,
 			Series:       v.Series,
-		}
-	}
-	return out
-}
-
-func convertResources(in []transport.ResourceRevision) []params.CharmHubInfoResource {
-	out := make([]params.CharmHubInfoResource, len(in))
-	for i, v := range in {
-		out[i] = params.CharmHubInfoResource{
-			Name:     v.Name,
-			Revision: v.Revision,
-			Size:     v.Download.Size,
-			Type:     v.Type,
-			URL:      v.Download.URL,
 		}
 	}
 	return out

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -350,7 +350,7 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 		method = MethodChannel
 	}
 	// Bundles can not use method IDs, which in turn forces a refresh.
-	if method == MethodRevision && !matchesType(origin.Type, transport.BundleType) && origin.ID != "" {
+	if method == MethodRevision && !transport.BundleType.Matches(origin.Type) && origin.ID != "" {
 		method = MethodID
 	}
 
@@ -383,10 +383,6 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 		return nil, errors.NotValidf("origin %v", origin)
 	}
 	return cfg, err
-}
-
-func matchesType(originType string, expected transport.Type) bool {
-	return string(expected) == originType
 }
 
 func composeSuggestions(releases []transport.Release, origin params.CharmOrigin) []string {

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -238,7 +238,7 @@ func (s *charmHubRepositoriesSuite) expectCharmRefresh(c *gc.C) {
 			ID:          "charmCHARMcharmCHARMcharmCHARM01",
 			InstanceKey: id,
 			Entity: transport.RefreshEntity{
-				Type:     "charm",
+				Type:     transport.CharmType,
 				ID:       "charmCHARMcharmCHARMcharmCHARM01",
 				Name:     "wordpress",
 				Revision: 16,
@@ -260,7 +260,7 @@ func (s *charmHubRepositoriesSuite) expectBundleRefresh(c *gc.C) {
 			ID:          "bundleBUNDLEbundleBUNDLE01",
 			InstanceKey: id,
 			Entity: transport.RefreshEntity{
-				Type:     "bundle",
+				Type:     transport.BundleType,
 				ID:       "bundleBUNDLEbundleBUNDLE01",
 				Name:     "core-kubernetes",
 				Revision: 17,

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -26,52 +26,6 @@ func (s *charmStoreResolversSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func getCharmHubCharmInfoResponse() transport.InfoResponse {
-	channelMap, defaultRelease := getCharmHubCharmResponse()
-	return transport.InfoResponse{
-		Name:           "wordpress",
-		Type:           "charm",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		DefaultRelease: defaultRelease,
-	}
-}
-
-func getAlternativeCharmHubCharmInfoResponse() transport.InfoResponse {
-	channelMap, _ := getCharmHubCharmResponse()
-	defaultRelease := alternativeDefaultChannelMap()
-	return transport.InfoResponse{
-		Name:           "wordpress",
-		Type:           "charm",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		DefaultRelease: defaultRelease,
-	}
-}
-
-func getCharmHubBundleInfoResponse() transport.InfoResponse {
-	channelMap, defaultRelease := getCharmHubBundleResponse()
-	return transport.InfoResponse{
-		Name:           "wordpress",
-		Type:           "bundle",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		DefaultRelease: defaultRelease,
-	}
-}
-
-func getAlternativeCharmHubBundleInfoResponse() transport.InfoResponse {
-	channelMap, _ := getCharmHubBundleResponse()
-	defaultRelease := alternativeDefaultChannelMap()
-	return transport.InfoResponse{
-		Name:           "wordpress",
-		Type:           "bundle",
-		ID:             "charmCHARMcharmCHARMcharmCHARM01",
-		ChannelMap:     channelMap,
-		DefaultRelease: defaultRelease,
-	}
-}
-
 func getCharmHubCharmResponse() ([]transport.InfoChannelMap, transport.InfoChannelMap) {
 	return []transport.InfoChannelMap{{
 			Channel: transport.Channel{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12361,12 +12361,6 @@
                         "released-at": {
                             "type": "string"
                         },
-                        "resources": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmHubInfoResource"
-                            }
-                        },
                         "revision": {
                             "type": "integer"
                         },
@@ -12391,8 +12385,7 @@
                         "revision",
                         "size",
                         "version",
-                        "platforms",
-                        "resources"
+                        "platforms"
                     ]
                 },
                 "CharmHubBundle": {
@@ -12501,34 +12494,6 @@
                     "required": [
                         "code",
                         "message"
-                    ]
-                },
-                "CharmHubInfoResource": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "revision": {
-                            "type": "integer"
-                        },
-                        "size": {
-                            "type": "integer"
-                        },
-                        "type": {
-                            "type": "string"
-                        },
-                        "url": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "name",
-                        "revision",
-                        "type",
-                        "size",
-                        "url"
                     ]
                 },
                 "CharmOption": {

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -55,28 +55,19 @@ type FindResponse struct {
 }
 
 type Channel struct {
-	ReleasedAt string                 `json:"released-at"`
-	Track      string                 `json:"track"`
-	Risk       string                 `json:"risk"`
-	Revision   int                    `json:"revision"`
-	Size       int                    `json:"size"`
-	Version    string                 `json:"version"`
-	Platforms  []Platform             `json:"platforms"`
-	Resources  []CharmHubInfoResource `json:"resources"`
+	ReleasedAt string     `json:"released-at"`
+	Track      string     `json:"track"`
+	Risk       string     `json:"risk"`
+	Revision   int        `json:"revision"`
+	Size       int        `json:"size"`
+	Version    string     `json:"version"`
+	Platforms  []Platform `json:"platforms"`
 }
 
 type Platform struct {
 	Architecture string `json:"architecture"`
 	OS           string `json:"os"`
 	Series       string `json:"series"`
-}
-
-type CharmHubInfoResource struct {
-	Name     string `json:"name"`
-	Revision int    `json:"revision"`
-	Type     string `json:"type"`
-	Size     int    `json:"size"`
-	URL      string `json:"url"`
 }
 
 type CharmHubCharm struct {

--- a/charmhub/filter.go
+++ b/charmhub/filter.go
@@ -26,7 +26,6 @@ var defaultChannelFilter = []string{
 }
 
 var defaultResultFilter = []string{
-	"result.bugs-url",
 	"result.categories.featured",
 	"result.categories.name",
 	"result.contains-charms.name",
@@ -37,8 +36,6 @@ var defaultResultFilter = []string{
 	"result.publisher.display-name",
 	"result.store-url",
 	"result.summary",
-	"result.used-by",
-	"result.website",
 }
 
 var defaultDownloadFilter = []string{

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -89,7 +89,7 @@ func (c *InfoClient) Info(ctx context.Context, name string, options ...InfoOptio
 	}
 
 	switch resp.Type {
-	case "charm", "bundle":
+	case transport.CharmType, transport.BundleType:
 	default:
 		return resp, errors.Errorf("unexpected response type %q, expected charm or bundle", resp.Type)
 	}

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -103,20 +103,17 @@ func (c *InfoClient) Info(ctx context.Context, name string, options ...InfoOptio
 // receive the Name, ID and Type.
 func defaultInfoFilter() string {
 	filter := defaultResultFilter
-	filter = append(filter, appendFilterList("default-release.revision", defaultDownloadFilter)...)
+	filter = append(filter, "default-release.revision.download.size")
 	filter = append(filter, appendFilterList("default-release", infoDefaultRevisionFilter)...)
 	filter = append(filter, appendFilterList("default-release", defaultChannelFilter)...)
-	filter = append(filter, appendFilterList("channel-map.revision", defaultDownloadFilter)...)
+	filter = append(filter, "channel-map.revision.download.size")
 	filter = append(filter, appendFilterList("channel-map", infoChannelMapRevisionFilter)...)
 	filter = append(filter, appendFilterList("channel-map", defaultChannelFilter)...)
-	filter = append(filter, appendFilterList("default-release.resources", resourceFilter)...)
-	filter = append(filter, appendFilterList("channel-map.resources", resourceFilter)...)
 	return strings.Join(filter, ",")
 }
 
 var infoDefaultRevisionFilter = []string{
 	"revision.config-yaml",
-	"revision.created-at",
 	"revision.metadata-yaml",
 	"revision.bundle-yaml",
 	"revision.platforms.architecture",

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -6,6 +6,25 @@ package transport
 // The following contains all the common DTOs for a gathering information from
 // a given store.
 
+// Type represents the type of payload is expected from the API
+type Type string
+
+// Matches attempts to match a string to a given source.
+func (t Type) Matches(o string) bool {
+	return string(t) == o
+}
+
+func (t Type) String() string {
+	return string(t)
+}
+
+const (
+	// CharmType represents the charm payload.
+	CharmType Type = "charm"
+	// BundleType represents the bundle payload.
+	BundleType Type = "bundle"
+)
+
 // Channel defines a unique permutation that corresponds to the track, risk
 // and platform. There can be multiple channels of the same track and risk, but
 // with different platforms.

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -6,6 +6,15 @@ package transport
 // Type represents the type of payload is expected from the API
 type Type string
 
+// Matches attempts to match a string to a given source.
+func (t Type) Matches(o string) bool {
+	return string(t) == o
+}
+
+func (t Type) String() string {
+	return string(t)
+}
+
 const (
 	// CharmType represents the charm payload.
 	CharmType Type = "charm"

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -36,16 +36,22 @@ type InfoResponse struct {
 // InfoChannelMap returns the information channel map. This defines a unique
 // revision for a given channel from an info response.
 type InfoChannelMap struct {
-	Channel   Channel            `json:"channel,omitempty"`
-	Resources []ResourceRevision `json:"resources,omitempty"`
-	Revision  InfoRevision       `json:"revision,omitempty"`
+	Channel  Channel      `json:"channel,omitempty"`
+	Revision InfoRevision `json:"revision,omitempty"`
 }
 
 // InfoRevision is different from FindRevision.  It has additional
 // fields of ConfigYAML and MetadataYAML.
+// NOTE: InfoRevision will be filled in with the CharmHub api response
+// differently within the InfoResponse.ChannelMap and the
+// InfoResponse.DefaultRelease.  The DefaultRelease InfoRevision will
+// include ConfigYAML, MetadataYAML and BundleYAML
+// NOTE 2: actions-yaml is a possible response for the DefaultRelease
+// InfoRevision, but not implemented.
 type InfoRevision struct {
-	ConfigYAML   string     `json:"config-yaml"`
-	CreatedAt    string     `json:"created-at"`
+	ConfigYAML string `json:"config-yaml"`
+	CreatedAt  string `json:"created-at"`
+	// Via filters, only Download.Size will be available.
 	Download     Download   `json:"download"`
 	MetadataYAML string     `json:"metadata-yaml"`
 	BundleYAML   string     `json:"bundle-yaml"`

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -3,25 +3,6 @@
 
 package transport
 
-// Type represents the type of payload is expected from the API
-type Type string
-
-// Matches attempts to match a string to a given source.
-func (t Type) Matches(o string) bool {
-	return string(t) == o
-}
-
-func (t Type) String() string {
-	return string(t)
-}
-
-const (
-	// CharmType represents the charm payload.
-	CharmType Type = "charm"
-	// BundleType represents the bundle payload.
-	BundleType Type = "bundle"
-)
-
 // InfoResponse is the result from an information query.
 type InfoResponse struct {
 	Type           Type             `json:"type"`

--- a/cmd/juju/application/store/charmadapter.go
+++ b/cmd/juju/application/store/charmadapter.go
@@ -14,6 +14,7 @@ import (
 	apicharm "github.com/juju/juju/api/charms"
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/charmhub"
+	"github.com/juju/juju/charmhub/transport"
 )
 
 // CharmStoreRepoFunc lazily creates a charm store repo.
@@ -114,7 +115,7 @@ func (c *CharmAdaptor) ResolveBundleURL(maybeBundle *charm.URL, preferredOrigin 
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}
 	// We're a bundle so return out before handling the invalid flow.
-	if origin.Type == "bundle" || storeCharmOrBundleURL.Series == "bundle" {
+	if transport.BundleType.Matches(origin.Type) || storeCharmOrBundleURL.Series == "bundle" {
 		return storeCharmOrBundleURL, origin, nil
 	}
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -200,7 +200,7 @@ func (s *downloadSuite) expectRefresh(c *gc.C, charmHubURL string) {
 		return []transport.RefreshResponse{{
 			InstanceKey: instanceKey,
 			Entity: transport.RefreshEntity{
-				Type: "charm",
+				Type: transport.CharmType,
 				Name: "test",
 				Download: transport.Download{
 					HashSHA256: "",


### PR DESCRIPTION
The CharmHub Info api endpoint will shortly change what data is available and will be returned.  Make changes to juju info so that they do not create cause failures.  Data previously requested by juju will no longer available to the InfoResponse: Resources in the InfoChannelMap, and download hashes and url.

Also contained are some drive by fixes found while working on the rest:  deleting unused code,using a type more instead of the strings for charmhub response data.

## QA steps

There should be no difference or errors seen in 'juju info' output
