### PR TITLE
Introduce auto bootstrap to kubeconfig contexts.

### DIFF
--- a/caas/kubernetes/clientconfig/export_test.go
+++ b/caas/kubernetes/clientconfig/export_test.go
@@ -4,12 +4,11 @@
 package clientconfig
 
 var (
-	NewK8sClientSet                               = newK8sClientSet
-	EnsureJujuAdminServiceAccount                 = ensureJujuAdminServiceAccount
-	GetOrCreateClusterRole                        = getOrCreateClusterRole
-	GetOrCreateServiceAccount                     = getOrCreateServiceAccount
-	GetOrCreateClusterRoleBinding                 = getOrCreateClusterRoleBinding
-	GetServiceAccountSecret                       = getServiceAccountSecret
-	ReplaceAuthProviderWithServiceAccountAuthData = replaceAuthProviderWithServiceAccountAuthData
-	RemoveJujuAdminServiceAccount                 = removeJujuAdminServiceAccount
+	NewK8sClientSet               = newK8sClientSet
+	EnsureJujuAdminServiceAccount = ensureJujuAdminServiceAccount
+	GetOrCreateClusterRole        = getOrCreateClusterRole
+	GetOrCreateServiceAccount     = getOrCreateServiceAccount
+	GetOrCreateClusterRoleBinding = getOrCreateClusterRoleBinding
+	GetServiceAccountSecret       = getServiceAccountSecret
+	RemoveJujuAdminServiceAccount = removeJujuAdminServiceAccount
 )

--- a/caas/kubernetes/clientconfig/types.go
+++ b/caas/kubernetes/clientconfig/types.go
@@ -56,7 +56,7 @@ type ClientConfigFunc func(
 func NewClientConfigReader(cloudType string) (ClientConfigFunc, error) {
 	switch cloudType {
 	case "kubernetes":
-		return NewK8sClientConfig, nil
+		return NewK8sClientConfigFromReader, nil
 	default:
 		return nil, errors.Errorf("Cannot read local config: unsupported cloud type '%s'", cloudType)
 	}

--- a/caas/kubernetes/cloud/cloud.go
+++ b/caas/kubernetes/cloud/cloud.go
@@ -1,0 +1,179 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/juju/errors"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/cloud"
+)
+
+// CloudParameters describes basic properties that should be set on a Juju
+// cloud.Cloud object. This struct exists to help form Cloud structs from
+// Kubernetes config structs.
+type CloudParamaters struct {
+	Name            string
+	Description     string
+	HostCloudRegion string
+	Regions         []cloud.Region
+}
+
+// buildCloudFromCluster finishes building a cloud from the provided kube
+// cluster
+func buildCloudFromCluster(c *cloud.Cloud, cluster *clientcmdapi.Cluster) error {
+	c.Endpoint = cluster.Server
+	c.SkipTLSVerify = cluster.InsecureSkipTLSVerify
+	c.AuthTypes = SupportedAuthTypes()
+
+	clusterCAData, err := dataOrFile(cluster.CertificateAuthorityData, cluster.CertificateAuthority)
+	if err != nil {
+		return errors.Annotate(err, "getting cluster CA data")
+	}
+	c.CACertificates = []string{string(clusterCAData)}
+
+	return nil
+}
+
+// ConfigFromReader does the heavy lifting of transforming a reader object into
+// a kubernetes api config
+func ConfigFromReader(reader io.Reader) (*clientcmdapi.Config, error) {
+	confBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, errors.Annotate(err, "reading kubernetes configuration data")
+	}
+
+	conf, err := clientcmd.NewClientConfigFromBytes(confBytes)
+	if err != nil {
+		return nil, errors.Annotate(err, "parsing kubernetes configuration data")
+	}
+
+	apiConf, err := conf.RawConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "fetching kubernetes configuration")
+	}
+	return &apiConf, nil
+}
+
+// CloudsFromKubeConfigContexts generates a list of clouds from the supplied
+// config context slice
+func CloudsFromKubeConfigContexts(config *clientcmdapi.Config) ([]cloud.Cloud, error) {
+	return CloudsFromKubeConfigContextsWithParams(CloudParamaters{}, config)
+}
+
+// CloudsFromKubeConfigContextsWithParams generates a list of clouds from the
+// supplied config context slice. Uses params to help seed values for the
+// resulting clouds. Currently only description is taken from params attribute.
+func CloudsFromKubeConfigContextsWithParams(
+	params CloudParamaters,
+	config *clientcmdapi.Config,
+) ([]cloud.Cloud, error) {
+	clouds := []cloud.Cloud{}
+	for ctxName, _ := range config.Contexts {
+		cloud, err := CloudFromKubeConfigContext(
+			ctxName,
+			config,
+			CloudParamaters{
+				Description: params.Description,
+				Name:        ctxName,
+			},
+		)
+		if err != nil {
+			return clouds, errors.Trace(err)
+		}
+		clouds = append(clouds, cloud)
+	}
+	return clouds, nil
+}
+
+// CloudFromKubeConfigContext generates a juju cloud based on the supplied
+// context and config
+func CloudFromKubeConfigContext(
+	ctxName string,
+	config *clientcmdapi.Config,
+	params CloudParamaters,
+) (cloud.Cloud, error) {
+	newCloud := cloud.Cloud{
+		Name:            params.Name,
+		Type:            constants.CAASProviderType,
+		HostCloudRegion: params.HostCloudRegion,
+		Regions:         params.Regions,
+		Description:     params.Description,
+	}
+
+	context, exists := config.Contexts[ctxName]
+	if !exists {
+		return newCloud, errors.NotFoundf("kubernetes context %q", ctxName)
+	}
+
+	cluster, exists := config.Clusters[context.Cluster]
+	if !exists {
+		return newCloud, errors.NotFoundf("kubernetes cluster %q associated with context %q",
+			context.Cluster, ctxName)
+	}
+	return newCloud, buildCloudFromCluster(&newCloud, cluster)
+}
+
+// CloudFromKubeConfigContextReader constructs a Juju cloud object using the
+// supplied Kubernetes context name and parsing the raw Kubernetes config
+// located in reader.
+func CloudFromKubeConfigContextReader(
+	ctxName string,
+	reader io.Reader,
+	params CloudParamaters,
+) (cloud.Cloud, error) {
+	config, err := ConfigFromReader(reader)
+	if err != nil {
+		return cloud.Cloud{}, err
+	}
+	return CloudFromKubeConfigContext(ctxName, config, params)
+}
+
+// CloudFromKubeConfigCluster attempts to construct a Juju cloud object using
+// the supplied Kubernetes config and the cluster name. This function attempts
+// to find a context that it can leverage that uses the specificed cluster name.
+// The first context using the cluster name is taken and if no options exists
+// results in an error.
+func CloudFromKubeConfigCluster(
+	clusterName string,
+	config *clientcmdapi.Config,
+	params CloudParamaters,
+) (cloud.Cloud, error) {
+	newCloud := cloud.Cloud{
+		Name:            params.Name,
+		Type:            constants.CAASProviderType,
+		HostCloudRegion: params.HostCloudRegion,
+		Regions:         params.Regions,
+		Description:     params.Description,
+	}
+
+	cluster, exists := config.Clusters[clusterName]
+	if !exists {
+		return newCloud, errors.NotFoundf("kubernetes cluster %q not found", clusterName)
+	}
+
+	return newCloud, buildCloudFromCluster(&newCloud, cluster)
+}
+
+// CloudFromKubeConfigClusterReader attempts to construct a Juju cloud object
+// using the supplied raw Kubernetes config in reader and the cluster name. This
+// function attempts to find a context that it can leverage that uses the
+// specificed cluster name. The first context using the cluster name is taken
+// and if no options exists results in an error.
+func CloudFromKubeConfigClusterReader(
+	clusterName string,
+	reader io.Reader,
+	params CloudParamaters,
+) (cloud.Cloud, error) {
+	config, err := ConfigFromReader(reader)
+	if err != nil {
+		return cloud.Cloud{}, err
+	}
+	return CloudFromKubeConfigCluster(clusterName, config, params)
+}

--- a/caas/kubernetes/cloud/cloud_test.go
+++ b/caas/kubernetes/cloud/cloud_test.go
@@ -1,0 +1,439 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/cloud"
+)
+
+type cloudSuite struct {
+}
+
+var _ = gc.Suite(&cloudSuite{})
+
+func (s *cloudSuite) TestConfigFromReader(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: wallyworld
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	_, exists := conf.Contexts["jujukube"]
+	c.Assert(exists, jc.IsTrue)
+	_, exists = conf.Clusters["jujukube"]
+	c.Assert(exists, jc.IsTrue)
+	_, exists = conf.AuthInfos["wallyworld"]
+	c.Assert(exists, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestCloudsFromKubeConfigContexts(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+- cluster:
+    server: https://localhost:8443
+  name: jujukube1
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+- context:
+    cluster: jujukube1
+    namespace: juju-controller
+    user: tlm
+  name: jujukube1
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: wallyworld
+  user:
+    username: wallyworld
+    password: jujurocks
+- name: tlm
+  user:
+    username: tlm
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	clouds, err := k8scloud.CloudsFromKubeConfigContexts(conf)
+	c.Assert(len(clouds), gc.Equals, 2)
+
+	foundCloud1 := false
+	for _, cloud := range clouds {
+		if cloud.Name == "jujukube" {
+			foundCloud1 = true
+		}
+	}
+	c.Assert(foundCloud1, jc.IsTrue)
+	foundCloud2 := false
+	for _, cloud := range clouds {
+		if cloud.Name == "jujukube1" {
+			foundCloud2 = true
+		}
+	}
+	c.Assert(foundCloud2, jc.IsTrue)
+}
+
+func (s *cloudSuite) TestCloudFromKubeConfigContext(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	cl, err := k8scloud.CloudFromKubeConfigContext(
+		"jujukube",
+		conf,
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cl.Name, gc.Equals, "test1")
+	c.Assert(cl.Type, gc.Equals, constants.CAASProviderType)
+	c.Assert(cl.HostCloudRegion, gc.Equals, "jujutest")
+	c.Assert(cl.Description, gc.Equals, "description")
+	c.Assert(cl.Regions, jc.DeepEquals, []cloud.Region{
+		{
+			Name: "juju test",
+		},
+	})
+}
+
+func (s *cloudSuite) TestCloudFromKubeConfigContextReader(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	cl, err := k8scloud.CloudFromKubeConfigContextReader(
+		"jujukube",
+		strings.NewReader(rawConf),
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cl.Name, gc.Equals, "test1")
+	c.Assert(cl.Type, gc.Equals, constants.CAASProviderType)
+	c.Assert(cl.HostCloudRegion, gc.Equals, "jujutest")
+	c.Assert(cl.Description, gc.Equals, "description")
+	c.Assert(cl.Regions, jc.DeepEquals, []cloud.Region{
+		{
+			Name: "juju test",
+		},
+	})
+}
+
+func (s *cloudSuite) CloudFromKubeConfigCluster(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	cl, err := k8scloud.CloudFromKubeConfigCluster(
+		"jujukube",
+		conf,
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cl.Name, gc.Equals, "test1")
+	c.Assert(cl.Type, gc.Equals, constants.CAASProviderType)
+	c.Assert(cl.HostCloudRegion, gc.Equals, "jujutest")
+	c.Assert(cl.Description, gc.Equals, "description")
+	c.Assert(cl.Regions, jc.DeepEquals, []cloud.Region{
+		{
+			Name: "juju test",
+		},
+	})
+}
+
+func (s *cloudSuite) TestCloudFromKubeConfigContextDoesNotExist(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = k8scloud.CloudFromKubeConfigContext(
+		"jujukube-doest-not-exist",
+		conf,
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *cloudSuite) TestCloudFromKubeConfigContextClusterDoesNotExist(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube-does-not-exist
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = k8scloud.CloudFromKubeConfigContext(
+		"jujukube",
+		conf,
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}
+
+func (s *cloudSuite) CloudFromKubeConfigClusterReader(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	cl, err := k8scloud.CloudFromKubeConfigClusterReader(
+		"jujukube",
+		strings.NewReader(rawConf),
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cl.Name, gc.Equals, "test1")
+	c.Assert(cl.Type, gc.Equals, constants.CAASProviderType)
+	c.Assert(cl.HostCloudRegion, gc.Equals, "jujutest")
+	c.Assert(cl.Description, gc.Equals, "description")
+	c.Assert(cl.Regions, jc.DeepEquals, []cloud.Region{
+		{
+			Name: "juju test",
+		},
+	})
+}
+
+func (s *cloudSuite) CloudFromKubeConfigClusterNotExist(c *gc.C) {
+	rawConf := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+  name: jujukube
+contexts:
+- context:
+    cluster: jujukube
+    namespace: juju-controller
+    user: wallyworld
+  name: jujukube
+current-context: jujukube
+kind: Config
+preferences: {}
+users:
+- name: tlm
+  user:
+    username: wallyworld
+    password: jujurocks
+`
+
+	conf, err := k8scloud.ConfigFromReader(strings.NewReader(rawConf))
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = k8scloud.CloudFromKubeConfigCluster(
+		"does-not-exist",
+		conf,
+		k8scloud.CloudParamaters{
+			Name:            "test1",
+			Description:     "description",
+			HostCloudRegion: "jujutest",
+			Regions: []cloud.Region{
+				{
+					Name: "juju test",
+				},
+			},
+		},
+	)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+}

--- a/caas/kubernetes/cloud/credential.go
+++ b/caas/kubernetes/cloud/credential.go
@@ -1,0 +1,177 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"sort"
+
+	"github.com/juju/errors"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/juju/juju/cloud"
+)
+
+const (
+	// CredAttrUsername is the attribute key for username credentials
+	CredAttrUsername = "username"
+	// CredAttrPassword is the attribute key for password credentials
+	CredAttrPassword = "password"
+	// CredAttrClientCertificateData is the attribute key for client certificate credentials
+	CredAttrClientCertificateData = "ClientCertificateData"
+	// CredAttrClientKeyData is the attribute key for client certificate key credentials
+	CredAttrClientKeyData = "ClientKeyData"
+	// CredAttrToken is the attribute key for outh2 token credentials
+	CredAttrToken = "Token"
+	// RBACLabelKeyName key id for rbac credential labels
+	RBACLabelKeyName = "rbac-id"
+)
+
+// SupportedCredentialSchemas holds the schemas that the kubernetes caas provider
+// supports.
+var SupportedCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
+	cloud.UserPassAuthType: {
+		{
+			Name:           CredAttrUsername,
+			CredentialAttr: cloud.CredentialAttr{Description: "The username to authenticate with."},
+		}, {
+			Name: CredAttrPassword,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "The password for the specified username.",
+				Hidden:      true,
+			},
+		},
+	},
+	cloud.OAuth2AuthType: {
+		{
+			Name: CredAttrToken,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "the kubernetes token",
+				Hidden:      true,
+			},
+		},
+	},
+	cloud.CertificateAuthType: {
+		{
+			Name: CredAttrClientCertificateData,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "the kubernetes certificate data",
+			},
+		},
+		{
+			Name: CredAttrClientKeyData,
+			CredentialAttr: cloud.CredentialAttr{
+				Description: "the kubernetes certificate key",
+				Hidden:      true,
+			},
+		},
+		{
+			Name: RBACLabelKeyName,
+			CredentialAttr: cloud.CredentialAttr{
+				Optional:    true,
+				Description: "the unique ID key name of the rbac resources",
+			},
+		},
+	},
+}
+
+// SupportedAuthTypes returns a slice of support auth types that the Kubernetes
+// caas provider supports.
+func SupportedAuthTypes() cloud.AuthTypes {
+	var ats cloud.AuthTypes
+	for k := range SupportedCredentialSchemas {
+		ats = append(ats, k)
+	}
+	sort.Sort(ats)
+	return ats
+}
+
+// CredentialFromAuthInfo will generate a Juju credential based on the supplied
+// Kubernetes AuthInfo
+func CredentialFromAuthInfo(
+	authName string,
+	authInfo *clientcmdapi.AuthInfo,
+) (cloud.Credential, error) {
+	attrs := map[string]string{}
+
+	// TODO(axw) if the certificate/key are specified by path,
+	// then we should just store the path in the credential,
+	// and rely on credential finalization to read it at time
+	// of use.
+
+	clientCertData, err := dataOrFile(authInfo.ClientCertificateData, authInfo.ClientCertificate)
+	if err != nil {
+		return cloud.Credential{},
+			errors.Annotatef(
+				err,
+				"getting authinfo %q client certificate",
+				authName)
+	}
+	hasClientCert := len(clientCertData) > 0
+
+	clientCertKeyData, err := dataOrFile(authInfo.ClientKeyData, authInfo.ClientKey)
+	if err != nil {
+		return cloud.Credential{},
+			errors.Annotatef(
+				err,
+				"getting authinfo %q client certificate key",
+				authName)
+	}
+	hasClientCertKey := len(clientCertKeyData) > 0
+
+	token, err := stringOrFile(authInfo.Token, authInfo.TokenFile)
+	if err != nil {
+		return cloud.Credential{},
+			errors.Annotatef(
+				err,
+				"getting authinfo %q token",
+				authName)
+	}
+	hasToken := len(token) > 0
+
+	var authType cloud.AuthType
+	switch {
+	case hasClientCert && hasClientCertKey:
+		authType = cloud.CertificateAuthType
+		attrs["ClientCertificateData"] = string(clientCertData)
+		attrs["ClientKeyData"] = string(clientCertKeyData)
+	case hasToken:
+		authType = cloud.OAuth2AuthType
+		attrs["Token"] = token
+	case authInfo.Username != "":
+		authType = cloud.UserPassAuthType
+		attrs["username"] = authInfo.Username
+		attrs["password"] = authInfo.Password
+	default:
+		return cloud.Credential{}, errors.NotSupportedf("configuration for %q", authName)
+	}
+
+	return cloud.NewNamedCredential(authName, authType, attrs, false), nil
+}
+
+// CredentialFromKubeConfig generates a Juju credential from the supplied
+// Kubernetes config
+func CredentialFromKubeConfig(
+	authName string,
+	config *clientcmdapi.Config,
+) (cloud.Credential, error) {
+	authInfo, exists := config.AuthInfos[authName]
+	if !exists {
+		return cloud.Credential{}, errors.NotFoundf("kubernetes config authinfo %q", authName)
+	}
+	c, err := CredentialFromAuthInfo(authName, authInfo)
+	return c, err
+}
+
+// CredentialFromKubeConfigContext generate a Juju credential from the supplied
+// Kubernetes config context.
+func CredentialFromKubeConfigContext(
+	ctxName string,
+	config *clientcmdapi.Config,
+) (cloud.Credential, error) {
+	ctx, exists := config.Contexts[ctxName]
+	if !exists {
+		return cloud.Credential{}, errors.NotFoundf("could not find context %s", ctxName)
+	}
+	return CredentialFromKubeConfig(ctx.AuthInfo, config)
+}

--- a/caas/kubernetes/cloud/credential_test.go
+++ b/caas/kubernetes/cloud/credential_test.go
@@ -1,0 +1,140 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud_test
+
+import (
+	"io/ioutil"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
+	"github.com/juju/juju/cloud"
+)
+
+type credentialSuite struct {
+}
+
+var _ = gc.Suite(&credentialSuite{})
+
+func (s *credentialSuite) TestValidCredentials(c *gc.C) {
+	tests := []struct {
+		AuthInfo   *clientcmdapi.AuthInfo
+		AuthType   cloud.AuthType
+		Attributes map[string]string
+		Name       string
+		PreSetup   func(*clientcmdapi.AuthInfo) error
+	}{
+		{
+			AuthInfo: &clientcmdapi.AuthInfo{
+				ClientCertificateData: []byte("cert-data"),
+				ClientKeyData:         []byte("cert-key-data"),
+			},
+			AuthType: cloud.CertificateAuthType,
+			Attributes: map[string]string{
+				"ClientCertificateData": "cert-data",
+				"ClientKeyData":         "cert-key-data",
+			},
+			Name: "client-cert-data",
+		},
+		{
+			AuthInfo: &clientcmdapi.AuthInfo{},
+			AuthType: cloud.CertificateAuthType,
+			Attributes: map[string]string{
+				"ClientCertificateData": "cert-data",
+				"ClientKeyData":         "cert-key-data",
+			},
+			Name: "client-cert-data-from-file",
+			PreSetup: func(a *clientcmdapi.AuthInfo) error {
+				certFile, err := ioutil.TempFile("", "")
+				if err != nil {
+					return err
+				}
+				_, err = certFile.WriteString("cert-data")
+				if err != nil {
+					return err
+				}
+				certKeyFile, err := ioutil.TempFile("", "")
+				if err != nil {
+					return err
+				}
+				_, err = certKeyFile.WriteString("cert-key-data")
+				if err != nil {
+					return err
+				}
+
+				a.ClientCertificate = certFile.Name()
+				a.ClientKey = certKeyFile.Name()
+				certFile.Close()
+				certKeyFile.Close()
+				return nil
+			},
+		},
+		{
+			AuthInfo: &clientcmdapi.AuthInfo{
+				Token: "wef44t34f23",
+			},
+			AuthType: cloud.OAuth2AuthType,
+			Attributes: map[string]string{
+				"Token": "wef44t34f23",
+			},
+			Name: "token",
+		},
+		{
+			AuthInfo: &clientcmdapi.AuthInfo{},
+			AuthType: cloud.OAuth2AuthType,
+			Attributes: map[string]string{
+				"Token": "wef44t34f23",
+			},
+			Name: "token-from-file",
+			PreSetup: func(a *clientcmdapi.AuthInfo) error {
+				tokenFile, err := ioutil.TempFile("", "")
+				if err != nil {
+					return err
+				}
+				_, err = tokenFile.WriteString("wef44t34f23")
+				if err != nil {
+					return err
+				}
+
+				a.TokenFile = tokenFile.Name()
+				tokenFile.Close()
+				return nil
+			},
+		},
+		{
+			AuthInfo: &clientcmdapi.AuthInfo{
+				Username: "tlm",
+				Password: "top-secret",
+			},
+			AuthType: cloud.UserPassAuthType,
+			Attributes: map[string]string{
+				"username": "tlm",
+				"password": "top-secret",
+			},
+			Name: "username-password",
+		},
+	}
+
+	for _, test := range tests {
+		if test.PreSetup != nil {
+			err := test.PreSetup(test.AuthInfo)
+			c.Assert(err, jc.ErrorIsNil)
+		}
+		cred, err := k8scloud.CredentialFromAuthInfo(test.Name, test.AuthInfo)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(cred.AuthType(), gc.Equals, test.AuthType)
+		c.Assert(cred.Attributes(), jc.DeepEquals, test.Attributes)
+	}
+}
+
+func (s *credentialSuite) TestUnsupportedCredentials(c *gc.C) {
+	authInfo := &clientcmdapi.AuthInfo{
+		ClientKeyData: []byte("test"),
+	}
+
+	_, err := k8scloud.CredentialFromAuthInfo("unsupported", authInfo)
+	c.Assert(err.Error(), gc.Equals, "configuration for \"unsupported\" not supported")
+}

--- a/caas/kubernetes/cloud/package_test.go
+++ b/caas/kubernetes/cloud/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/caas/kubernetes/cloud/util.go
+++ b/caas/kubernetes/cloud/util.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"io/ioutil"
+
+	"github.com/juju/errors"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// dataOrFile returns either the contents of data or if that is empty the
+// contents of the fileName. If both are empty then no data is returned with a nil
+// error
+func dataOrFile(data []byte, fileName string) ([]byte, error) {
+	if len(data) != 0 {
+		return data, nil
+	} else if fileName == "" {
+		return []byte{}, nil
+	}
+	return ioutil.ReadFile(fileName)
+}
+
+//PickCOntextByClusterName finds the first available context in the supplied
+// kube config that is using the clusterName. If not context's are found then
+// a not found error is return with an empty context name.
+func PickContextByClusterName(
+	config *clientcmdapi.Config,
+	clusterName string,
+) (string, error) {
+	for contextName, context := range config.Contexts {
+		if clusterName == context.Cluster {
+			return contextName, nil
+		}
+	}
+	return "", errors.NotFoundf("context for cluster name %q", clusterName)
+}
+
+// stringOrFile returns either the contents of data or if that is empty the
+// contents of the fileName. If both are empty then no data is returned with a nil
+// error
+func stringOrFile(data string, fileName string) (string, error) {
+	if len(data) != 0 {
+		return data, nil
+	} else if fileName == "" {
+		return "", nil
+	}
+	d, err := ioutil.ReadFile(fileName)
+	return string(d), err
+}

--- a/caas/kubernetes/cloud/util_test.go
+++ b/caas/kubernetes/cloud/util_test.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloud
+
+import (
+	"io/ioutil"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type utilSuite struct {
+}
+
+var _ = gc.Suite(&utilSuite{})
+
+func (u *utilSuite) TestDataOrFile(c *gc.C) {
+	tests := []struct {
+		dataContents     []byte
+		fileContents     []byte
+		expectedContents []byte
+	}{
+		{
+			dataContents:     []byte("test"),
+			expectedContents: []byte("test"),
+		},
+		{
+			dataContents:     []byte{},
+			fileContents:     []byte("test"),
+			expectedContents: []byte("test"),
+		},
+		{
+			dataContents:     []byte{},
+			fileContents:     []byte{},
+			expectedContents: []byte{},
+		},
+	}
+
+	for _, test := range tests {
+		fileName := ""
+		if len(test.fileContents) > 0 {
+			f, err := ioutil.TempFile("", "")
+			fileName = f.Name()
+			c.Assert(err, jc.ErrorIsNil)
+			n, err := f.Write(test.fileContents)
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(n, gc.Equals, len(test.fileContents))
+		}
+
+		r, err := dataOrFile(test.dataContents, fileName)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(r, jc.DeepEquals, test.expectedContents)
+	}
+}
+
+func (u *utilSuite) TestStringOrFile(c *gc.C) {
+	tests := []struct {
+		dataContents     string
+		fileContents     string
+		expectedContents string
+	}{
+		{
+			dataContents:     "test",
+			expectedContents: "test",
+		},
+		{
+			fileContents:     "test",
+			expectedContents: "test",
+		},
+		{
+			expectedContents: "",
+		},
+	}
+
+	for _, test := range tests {
+		fileName := ""
+		if test.fileContents != "" {
+			f, err := ioutil.TempFile("", "")
+			fileName = f.Name()
+			c.Assert(err, jc.ErrorIsNil)
+			n, err := f.Write([]byte(test.fileContents))
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(n, gc.Equals, len(test.fileContents))
+		}
+
+		r, err := stringOrFile(test.dataContents, fileName)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(r, jc.DeepEquals, test.expectedContents)
+	}
+}

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -139,38 +139,30 @@ func (s *builtinSuite) TestAttemptMicroK8sCloud(c *gc.C) {
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s.config"}).Returns(&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sConfig)}, nil)
 
-	k8sCloud, credential, credentialName, err := provider.AttemptMicroK8sCloud(s.runner, s.kubeCloudParams)
+	k8sCloud, err := provider.AttemptMicroK8sCloud(s.runner)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(k8sCloud, gc.DeepEquals, cloud.Cloud{
-		Name:           caas.K8sCloudMicrok8s,
-		Endpoint:       "http://1.1.1.1:8080",
-		Type:           cloud.CloudTypeCAAS,
-		AuthTypes:      []cloud.AuthType{cloud.CertificateAuthType},
-		CACertificates: []string{"fakecadata1"},
+		Name:     caas.K8sCloudMicrok8s,
+		Endpoint: "http://1.1.1.1:8080",
+		Type:     cloud.CloudTypeCAAS,
+		AuthTypes: []cloud.AuthType{
+			cloud.CertificateAuthType,
+			cloud.OAuth2AuthType,
+			cloud.UserPassAuthType,
+		},
+		CACertificates: []string{""},
 		Description:    cloud.DefaultCloudDescription(cloud.CloudTypeCAAS),
 		Regions: []cloud.Region{{
 			Name: "localhost",
 		}},
 	})
-	c.Assert(credential, gc.DeepEquals, cloud.NewNamedCredential(
-		"microk8s", "certificate",
-		map[string]string{
-			"ClientCertificateData": `
------BEGIN CERTIFICATE-----
-MIIDBDCCAeygAwIBAgIJAPUHbpCysNxyMA0GCSqGSIb3DQEBCwUAMBcxFTATBgNV`[1:],
-			"Token": "xfdfsdfsdsd",
-		}, false,
-	))
-	c.Assert(credentialName, gc.Equals, "microk8s")
 }
 
 func (s *builtinSuite) TestAttemptMicroK8sCloudErrors(c *gc.C) {
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "which microk8s.config"}).Returns(&exec.ExecResponse{Code: 1}, nil)
-	k8sCloud, credential, credentialName, err := provider.AttemptMicroK8sCloud(s.runner, s.kubeCloudParams)
+	k8sCloud, err := provider.AttemptMicroK8sCloud(s.runner)
 	c.Assert(err, gc.ErrorMatches, `microk8s not found`)
 	c.Assert(k8sCloud, gc.DeepEquals, cloud.Cloud{})
-	c.Assert(credential, gc.DeepEquals, cloud.Credential{})
-	c.Assert(credentialName, gc.Equals, "")
 }

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -51,11 +51,6 @@ type KubeCloudStorageParams struct {
 	GetClusterMetadataFunc GetClusterMetadataFunc
 }
 
-// CloudFromKubeConfig attempts to extract a cloud and credential details from the provided Kubeconfig.
-func CloudFromKubeConfig(reader io.Reader, cloudParams KubeCloudParams) (cloud.Cloud, cloud.Credential, error) {
-	return newCloudCredentialFromKubeConfig(reader, cloudParams)
-}
-
 func newCloudCredentialFromKubeConfig(reader io.Reader, cloudParams KubeCloudParams) (cloud.Cloud, cloud.Credential, error) {
 	// Get Cloud (incl. endpoint) and credential details from the kubeconfig details.
 	var credential cloud.Credential
@@ -68,11 +63,8 @@ func newCloudCredentialFromKubeConfig(reader io.Reader, cloudParams KubeCloudPar
 		Type:            cloudParams.CaasType,
 		HostCloudRegion: cloudParams.HostCloudRegion,
 	}
-	clientConfigFunc, err := cloudParams.ClientConfigGetter(cloudParams.CaasType)
-	if err != nil {
-		return fail(errors.Trace(err))
-	}
-	caasConfig, err := clientConfigFunc(
+
+	caasConfig, err := clientconfig.NewK8sClientConfigFromReader(
 		cloudParams.CredentialUID, reader,
 		cloudParams.ContextName, cloudParams.ClusterName,
 		clientconfig.GetJujuAdminServiceAccountResolver(cloudParams.Clock),
@@ -280,29 +272,44 @@ func BaseKubeCloudOpenParams(cloud cloud.Cloud, credential cloud.Credential) (en
 func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudContext, cld cloud.Cloud) (cloud.Cloud, error) {
 	// We special case Microk8s here as we need to query the cluster for the
 	// storage details with no input from the user
-	if cld.Name != caas.K8sCloudMicrok8s {
-		return cld, nil
-	}
-
-	if err := ensureMicroK8sSuitable(p.cmdRunner); err != nil {
-		return cld, errors.Trace(err)
-	}
 
 	// if storage is already defined there is no need to query the cluster
 	if opStorage, ok := cld.Config[k8sconstants.OperatorStorageKey]; ok && opStorage != "" {
 		return cld, nil
 	}
 
-	// Need the credentials, need to query for those details
-	mk8sCloud, credential, _, err := p.builtinCloudGetter(p.cmdRunner)
-	if err != nil {
-		return cloud.Cloud{}, errors.Trace(err)
-	}
-	if mk8sCloud.SkipTLSVerify {
-		logger.Warningf("k8s cloud %v is configured to skip server certificate validity checks", mk8sCloud.Name)
+	var credentials cloud.Credential
+	if cld.Name != caas.K8sCloudMicrok8s {
+		creds, err := p.RegisterCredentials(cld)
+		if err != nil {
+			return cld, err
+		}
+
+		credentials = creds[cld.Name].AuthCredentials[creds[cld.Name].DefaultCredential]
+	} else {
+		if err := ensureMicroK8sSuitable(p.cmdRunner); err != nil {
+			return cld, errors.Trace(err)
+		}
+		// Need the credentials, need to query for those details
+		mk8sCloud, err := p.builtinCloudGetter(p.cmdRunner)
+		if err != nil {
+			return cloud.Cloud{}, errors.Trace(err)
+		}
+		cld = mk8sCloud
+
+		creds, err := p.RegisterCredentials(cld)
+		if err != nil {
+			return cld, err
+		}
+
+		credentials = creds[cld.Name].AuthCredentials[creds[cld.Name].DefaultCredential]
 	}
 
-	openParams, err := BaseKubeCloudOpenParams(mk8sCloud, credential)
+	if cld.SkipTLSVerify {
+		logger.Warningf("k8s cloud %v is configured to skip server certificate validity checks", cld.Name)
+	}
+
+	openParams, err := BaseKubeCloudOpenParams(cld, credentials)
 	if err != nil {
 		return cloud.Cloud{}, errors.Trace(err)
 	}
@@ -320,11 +327,17 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 			return clusterMetadata, nil
 		},
 	}
-	_, err = UpdateKubeCloudWithStorage(&mk8sCloud, storageUpdateParams)
+
+	_, err = UpdateKubeCloudWithStorage(&cld, storageUpdateParams)
 	if err != nil {
 		return cloud.Cloud{}, errors.Trace(err)
 	}
-	return mk8sCloud, nil
+
+	if cld.HostCloudRegion == "" {
+		cld.HostCloudRegion = caas.K8sCloudOther
+	}
+
+	return cld, nil
 }
 
 func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -107,20 +107,6 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 	s.runner = dummyRunner{CallMocker: testing.NewCallMocker(logger)}
 }
 
-func (s *cloudSuite) TestFinalizeCloudNotMicrok8s(c *gc.C) {
-	notK8sCloud := jujucloud.Cloud{}
-	p := provider.NewProviderWithFakes(
-		dummyRunner{},
-		getterFunc(builtinCloudRet{}),
-		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil })
-	cloudFinalizer := p.(environs.CloudFinalizer)
-
-	var ctx mockContext
-	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, notK8sCloud)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cloud, jc.DeepEquals, notK8sCloud)
-}
-
 func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
@@ -192,9 +178,11 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 	s.fakeBroker.Call("GetClusterMetadata").Returns(defaultClusterMetadata, nil)
 	s.fakeBroker.Call("CheckDefaultWorkloadStorage").Returns(nil)
+	ret := builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}
 	return provider.NewProviderWithFakes(
 		s.runner,
-		getterFunc(builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}),
+		credentialGetterFunc(ret),
+		cloudGetterFunc(ret),
 		func(environs.OpenParams) (caas.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
 	)
 }

--- a/caas/kubernetes/provider/credentials.go
+++ b/caas/kubernetes/provider/credentials.go
@@ -4,100 +4,25 @@
 package provider
 
 import (
+	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
 
-const (
-	CredAttrUsername              = "username"
-	CredAttrPassword              = "password"
-	CredAttrClientCertificateData = "ClientCertificateData"
-	CredAttrClientKeyData         = "ClientKeyData"
-	CredAttrToken                 = "Token"
-
-	RBACLabelKeyName = "rbac-id"
-)
-
-var k8sCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
-	cloud.UserPassAuthType: {
-		{
-			Name:           CredAttrUsername,
-			CredentialAttr: cloud.CredentialAttr{Description: "The username to authenticate with."},
-		}, {
-			Name: CredAttrPassword,
-			CredentialAttr: cloud.CredentialAttr{
-				Description: "The password for the specified username.",
-				Hidden:      true,
-			},
-		},
-	},
-	cloud.OAuth2WithCertAuthType: {
-		{
-			Name: CredAttrClientCertificateData,
-			CredentialAttr: cloud.CredentialAttr{
-				Description: "the kubernetes certificate data",
-			},
-		},
-		{
-			Name: CredAttrClientKeyData,
-			CredentialAttr: cloud.CredentialAttr{
-				Description: "the kubernetes private key data",
-				Hidden:      true,
-			},
-		},
-		{
-			Name: CredAttrToken,
-			CredentialAttr: cloud.CredentialAttr{
-				Description: "the kubernetes token",
-				Hidden:      true,
-			},
-		},
-	},
-	cloud.CertificateAuthType: {
-		{
-			Name: CredAttrClientCertificateData,
-			CredentialAttr: cloud.CredentialAttr{
-				Description: "the kubernetes certificate data",
-			},
-		},
-		{
-			Name: CredAttrToken,
-			CredentialAttr: cloud.CredentialAttr{
-				Description: "the kubernetes service account bearer token",
-				Hidden:      true,
-			},
-		},
-		{
-			Name: RBACLabelKeyName,
-			CredentialAttr: cloud.CredentialAttr{
-				Optional:    true,
-				Description: "the unique ID key name of the rbac resources",
-			},
-		},
-	},
-}
-
 type environProviderCredentials struct {
-	cmdRunner          CommandRunner
-	builtinCloudGetter func(CommandRunner) (cloud.Cloud, cloud.Credential, string, error)
+	cmdRunner               CommandRunner
+	builtinCredentialGetter func(CommandRunner) (cloud.Credential, error)
 }
 
 // CredentialSchemas is part of the environs.ProviderCredentials interface.
 func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.CredentialSchema {
-	return k8sCredentialSchemas
-}
-
-func (environProviderCredentials) supportedAuthTypes() cloud.AuthTypes {
-	var ats cloud.AuthTypes
-	for k := range k8sCredentialSchemas {
-		ats = append(ats, k)
-	}
-	return ats
+	return k8scloud.SupportedCredentialSchemas
 }
 
 // DetectCredentials is part of the environs.ProviderCredentials interface.
@@ -132,9 +57,9 @@ func (environProviderCredentials) FinalizeCredential(_ environs.FinalizeCredenti
 func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[string]*cloud.CloudCredential, error) {
 	cloudName := cld.Name
 	if cloudName != caas.K8sCloudMicrok8s {
-		return make(map[string]*cloud.CloudCredential), nil
+		return registerCredentialsKubeConfig(cld)
 	}
-	_, cred, _, err := p.builtinCloudGetter(p.cmdRunner)
+	cred, err := p.builtinCredentialGetter(p.cmdRunner)
 
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -148,4 +73,36 @@ func (p environProviderCredentials) RegisterCredentials(cld cloud.Cloud) (map[st
 			},
 		},
 	}, nil
+}
+
+func registerCredentialsKubeConfig(
+	cld cloud.Cloud,
+) (map[string]*cloud.CloudCredential, error) {
+	k8sConfig, err := clientconfig.GetLocalKubeConfig()
+	if err != nil {
+		return make(map[string]*cloud.CloudCredential), errors.Annotate(err, "reading local kubeconf")
+	}
+
+	context, exists := k8sConfig.Contexts[cld.Name]
+	if !exists {
+		return make(map[string]*cloud.CloudCredential), nil
+	}
+
+	resolver := clientconfig.GetJujuAdminServiceAccountResolver(jujuclock.WallClock)
+	conf, err := resolver(cld.Name, k8sConfig, cld.Name)
+	if err != nil {
+		return make(map[string]*cloud.CloudCredential), errors.Annotatef(
+			err,
+			"registering juju admin service account for cloud %q", cld.Name)
+	}
+
+	cred, err := k8scloud.CredentialFromKubeConfig(context.AuthInfo, conf)
+	return map[string]*cloud.CloudCredential{
+		cld.Name: {
+			DefaultCredential: cld.Name,
+			AuthCredentials: map[string]cloud.Credential{
+				cld.Name: cred,
+			},
+		},
+	}, err
 }

--- a/caas/kubernetes/provider/credentials_test.go
+++ b/caas/kubernetes/provider/credentials_test.go
@@ -34,7 +34,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestCredentialSchemas(c *gc.C) {
-	envtesting.AssertProviderAuthTypes(c, s.provider, "userpass", "certificate", "oauth2withcert")
+	envtesting.AssertProviderAuthTypes(c, s.provider, "userpass", "certificate", "oauth2")
 }
 
 func (s *credentialsSuite) TestCredentialsValid(c *gc.C) {
@@ -46,8 +46,8 @@ func (s *credentialsSuite) TestCredentialsValid(c *gc.C) {
 
 func (s *credentialsSuite) TestHiddenAttributes(c *gc.C) {
 	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "userpass", "password")
-	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "oauth2withcert", "Token", "ClientKeyData")
-	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "certificate", "Token")
+	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "oauth2", "Token")
+	envtesting.AssertProviderCredentialsAttributesHidden(c, s.provider, "certificate", "ClientKeyData")
 }
 
 var singleConfigYAML = `
@@ -92,14 +92,22 @@ func (s *credentialsSuite) TestDetectCredentials(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestRegisterCredentialsNotMicrok8s(c *gc.C) {
-	p := provider.NewProviderCredentials(getterFunc(builtinCloudRet{}))
+	p := provider.NewProviderCredentials(credentialGetterFunc(builtinCloudRet{}))
 	credentials, err := p.RegisterCredentials(cloud.Cloud{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 0)
 }
 
 func (s *credentialsSuite) TestRegisterCredentialsMicrok8s(c *gc.C) {
-	p := provider.NewProviderCredentials(getterFunc(builtinCloudRet{cloud: defaultK8sCloud, credential: getDefaultCredential(), err: nil}))
+	p := provider.NewProviderCredentials(
+		credentialGetterFunc(
+			builtinCloudRet{
+				cloud:      defaultK8sCloud,
+				credential: getDefaultCredential(),
+				err:        nil,
+			},
+		),
+	)
 	credentials, err := p.RegisterCredentials(defaultK8sCloud)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(credentials, gc.HasLen, 1)

--- a/caas/kubernetes/provider/detectcloud.go
+++ b/caas/kubernetes/provider/detectcloud.go
@@ -7,13 +7,22 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/cloud"
 )
 
 // DetectClouds implements environs.CloudDetector.
 func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
 	clouds := []cloud.Cloud{}
-	mk8sCloud, _, _, err := p.builtinCloudGetter(p.cmdRunner)
+
+	localKubeConfigClouds, err := localKubeConfigClouds()
+	if err != nil {
+		return clouds, errors.Annotate(err, "detecing local kube config clouds")
+	}
+	clouds = append(clouds, localKubeConfigClouds...)
+
+	mk8sCloud, err := p.builtinCloudGetter(p.cmdRunner)
 	if err == nil {
 		clouds = append(clouds, mk8sCloud)
 		return clouds, nil
@@ -25,19 +34,40 @@ func (p kubernetesEnvironProvider) DetectClouds() ([]cloud.Cloud, error) {
 	return clouds, nil
 }
 
-// DetectCloud implements environs.CloudDetector.
-func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
-	if name != caas.K8sCloudMicrok8s {
-		return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
+func localKubeConfigClouds() ([]cloud.Cloud, error) {
+	k8sConfig, err := clientconfig.GetLocalKubeConfig()
+	if err != nil {
+		return []cloud.Cloud{}, errors.Annotate(err, "reading local kubeconf")
 	}
 
-	mk8sCloud, _, _, err := p.builtinCloudGetter(p.cmdRunner)
-	if err == nil {
+	return k8scloud.CloudsFromKubeConfigContextsWithParams(
+		k8scloud.CloudParamaters{
+			Description: "A local Kubernetes context",
+		},
+		k8sConfig,
+	)
+}
+
+// DetectCloud implements environs.CloudDetector.
+func (p kubernetesEnvironProvider) DetectCloud(name string) (cloud.Cloud, error) {
+	mk8sCloud, err := p.builtinCloudGetter(p.cmdRunner)
+	if err == nil && name == caas.K8sCloudMicrok8s {
 		return mk8sCloud, nil
 	}
-	if errors.IsNotFound(err) {
-		err = errors.Annotatef(err, "microk8s is not installed")
+	if !errors.IsNotFound(err) && err != nil {
+		return cloud.Cloud{}, errors.Trace(err)
 	}
-	logger.Debugf("failed to query local microk8s: %s", err.Error())
-	return cloud.Cloud{}, err
+
+	localKubeConfigClouds, err := localKubeConfigClouds()
+	if err != nil {
+		return cloud.Cloud{}, errors.Annotatef(err, "detecing local kube config clouds for %s", name)
+	}
+
+	for _, cloud := range localKubeConfigClouds {
+		if cloud.Name == name {
+			return cloud, nil
+		}
+	}
+
+	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
 }

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -27,18 +27,19 @@ import (
 )
 
 var (
-	PrepareWorkloadSpec    = prepareWorkloadSpec
-	OperatorPod            = operatorPod
-	ExtractRegistryURL     = extractRegistryURL
-	CreateDockerConfigJSON = createDockerConfigJSON
-	ControllerCorelation   = controllerCorelation
-	GetLocalMicroK8sConfig = getLocalMicroK8sConfig
-	AttemptMicroK8sCloud   = attemptMicroK8sCloudInternal
-	EnsureMicroK8sSuitable = ensureMicroK8sSuitable
-	NewK8sBroker           = newK8sBroker
-	ToYaml                 = toYaml
-	Indent                 = indent
-	ProcessSecretData      = processSecretData
+	PrepareWorkloadSpec       = prepareWorkloadSpec
+	OperatorPod               = operatorPod
+	ExtractRegistryURL        = extractRegistryURL
+	CreateDockerConfigJSON    = createDockerConfigJSON
+	ControllerCorelation      = controllerCorelation
+	GetLocalMicroK8sConfig    = getLocalMicroK8sConfig
+	AttemptMicroK8sCloud      = attemptMicroK8sCloud
+	AttemptMicroK8sCredential = attemptMicroK8sCredential
+	EnsureMicroK8sSuitable    = ensureMicroK8sSuitable
+	NewK8sBroker              = newK8sBroker
+	ToYaml                    = toYaml
+	Indent                    = indent
+	ProcessSecretData         = processSecretData
 
 	CompileK8sCloudCheckers                    = compileK8sCloudCheckers
 	CompileLifecycleApplicationRemovalSelector = compileLifecycleApplicationRemovalSelector
@@ -107,18 +108,25 @@ func NewProvider() caas.ContainerEnvironProvider {
 
 func NewProviderWithFakes(
 	runner CommandRunner,
-	getter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error),
+	credentialGetter func(CommandRunner) (jujucloud.Credential, error),
+	getter func(CommandRunner) (cloud.Cloud, error),
 	brokerGetter func(environs.OpenParams) (caas.ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{
+		environProviderCredentials: environProviderCredentials{
+			cmdRunner:               runner,
+			builtinCredentialGetter: credentialGetter,
+		},
 		cmdRunner:          runner,
 		builtinCloudGetter: getter,
 		brokerGetter:       brokerGetter,
 	}
 }
 
-func NewProviderCredentials(getter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error)) environProviderCredentials {
+func NewProviderCredentials(
+	getter func(CommandRunner) (jujucloud.Credential, error),
+) environProviderCredentials {
 	return environProviderCredentials{
-		builtinCloudGetter: getter,
+		builtinCredentialGetter: getter,
 	}
 }
 

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -16,11 +16,11 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas"
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8swatcher "github.com/juju/juju/caas/kubernetes/provider/watcher"
 	"github.com/juju/juju/cloud"
-	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -31,15 +31,15 @@ import (
 type kubernetesEnvironProvider struct {
 	environProviderCredentials
 	cmdRunner          CommandRunner
-	builtinCloudGetter func(CommandRunner) (cloud.Cloud, jujucloud.Credential, string, error)
+	builtinCloudGetter func(CommandRunner) (cloud.Cloud, error)
 	brokerGetter       func(environs.OpenParams) (caas.ClusterMetadataChecker, error)
 }
 
 var _ environs.EnvironProvider = (*kubernetesEnvironProvider)(nil)
 var providerInstance = kubernetesEnvironProvider{
 	environProviderCredentials: environProviderCredentials{
-		cmdRunner:          defaultRunner{},
-		builtinCloudGetter: attemptMicroK8sCloud,
+		cmdRunner:               defaultRunner{},
+		builtinCredentialGetter: attemptMicroK8sCredential,
 	},
 	cmdRunner:          defaultRunner{},
 	builtinCloudGetter: attemptMicroK8sCloud,
@@ -112,12 +112,12 @@ func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Conf
 	credentialAttrs := cloudSpec.Credential.Attributes()
 	return &rest.Config{
 		Host:        cloudSpec.Endpoint,
-		Username:    credentialAttrs[CredAttrUsername],
-		Password:    credentialAttrs[CredAttrPassword],
-		BearerToken: credentialAttrs[CredAttrToken],
+		Username:    credentialAttrs[k8scloud.CredAttrUsername],
+		Password:    credentialAttrs[k8scloud.CredAttrPassword],
+		BearerToken: credentialAttrs[k8scloud.CredAttrToken],
 		TLSClientConfig: rest.TLSClientConfig{
-			CertData: []byte(credentialAttrs[CredAttrClientCertificateData]),
-			KeyData:  []byte(credentialAttrs[CredAttrClientKeyData]),
+			CertData: []byte(credentialAttrs[k8scloud.CredAttrClientCertificateData]),
+			KeyData:  []byte(credentialAttrs[k8scloud.CredAttrClientKeyData]),
 			CAData:   CAData,
 			Insecure: cloudSpec.SkipTLSVerify,
 		},
@@ -209,7 +209,8 @@ func (p kubernetesEnvironProvider) validateCloudSpec(spec environscloudspec.Clou
 	if spec.Credential == nil {
 		return errors.NotValidf("missing credential")
 	}
-	if authType := spec.Credential.AuthType(); !p.supportedAuthTypes().Contains(authType) {
+
+	if authType := spec.Credential.AuthType(); !k8scloud.SupportedAuthTypes().Contains(authType) {
 		return errors.NotSupportedf("%q auth-type", authType)
 	}
 	return nil

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -49,17 +49,11 @@ const (
 	// UserPassAuthType is an authentication type using a username and password.
 	UserPassAuthType AuthType = "userpass"
 
-	// UserPassWithCertAuthType is an authentication type using a username and password and a client certificate
-	UserPassWithCertAuthType AuthType = "userpasswithcert"
-
 	// OAuth1AuthType is an authentication type using oauth1.
 	OAuth1AuthType AuthType = "oauth1"
 
 	// OAuth2AuthType is an authentication type using oauth2.
 	OAuth2AuthType AuthType = "oauth2"
-
-	// OAuth2WithCertAuthType is an authentication type using oauth2 and a client certificate
-	OAuth2WithCertAuthType AuthType = "oauth2withcert"
 
 	// JSONFileAuthType is an authentication type that takes a path to
 	// a JSON file.

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
+	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
@@ -22,6 +23,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucaas "github.com/juju/juju/caas"
@@ -56,11 +58,19 @@ clusters:
     server: https://1.1.1.1:8888
     certificate-authority-data: QQ==
   name: the-cluster
+- cluster:
+    server: https://1.1.1.1:8888
+    certificate-authority-data: QQ==
+  name: myk8s
 contexts:
 - context:
     cluster: the-cluster
     user: the-user
   name: the-context
+- context:
+    cluster: myk8s
+    user: test-user
+  name: myk8s-ctx
 current-context: the-context
 preferences: {}
 users:
@@ -68,6 +78,9 @@ users:
   user:
     password: thepassword
     username: theuser
+- name: test-user
+  user:
+    token: xfdfsdfsdsd
 `
 
 var invalidTLSKubeConfigStr = `
@@ -254,6 +267,31 @@ func (s *addCAASSuite) setupBroker(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
+func CreateKubeConfigData(conf string) (string, error) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	_, err = file.WriteString(conf)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	return file.Name(), nil
+}
+
+func SetKubeConfigData(conf string) error {
+	fname, err := CreateKubeConfigData(conf)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return os.Setenv("KUBECONFIG", fname)
+}
+
 func (s *addCAASSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.dir = c.MkDir()
@@ -326,6 +364,11 @@ func (s *addCAASSuite) makeCommand(c *gc.C, cloudTypeExists, emptyClientConfig, 
 		NewMockClientStore(),
 		func() (caas.AddCloudAPI, error) {
 			return s.fakeCloudAPI, nil
+		},
+		func(_ jujuclock.Clock) clientconfig.K8sCredentialResolver {
+			return func(_ string, c *clientcmdapi.Config, _ string) (*clientcmdapi.Config, error) {
+				return c, nil
+			}
 		},
 		func(cloud jujucloud.Cloud, credential jujucloud.Credential) (jujucaas.ClusterMetadataChecker, error) {
 			return s.fakeK8sClusterMetadataChecker, nil
@@ -436,7 +479,7 @@ func (s *addCAASSuite) TestAddExtraArg(c *gc.C) {
 func (s *addCAASSuite) TestEmptyKubeConfigFileWithoutStdin(c *gc.C) {
 	command := s.makeCommand(c, true, true, true)
 	_, err := s.runCommand(c, nil, command, "k8sname", "--client")
-	c.Assert(err, gc.ErrorMatches, `No k8s cluster definitions found in config`)
+	c.Assert(err, gc.ErrorMatches, `kubernetes context "" not found`)
 }
 
 func (s *addCAASSuite) TestPublicCloudAddNameClash(c *gc.C) {
@@ -446,8 +489,10 @@ func (s *addCAASSuite) TestPublicCloudAddNameClash(c *gc.C) {
 }
 
 func (s *addCAASSuite) TestLocalCloudExists(c *gc.C) {
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "mrcloud1", "--controller", "foo", "--client")
+	_, err = s.runCommand(c, nil, command, "mrcloud1", "--controller", "foo", "--client")
 	c.Assert(err, gc.ErrorMatches, "use `update-k8s mrcloud1 --client` to override known local definition: k8s \"mrcloud1\" already exists")
 }
 
@@ -564,6 +609,8 @@ type regionTestCase struct {
 }
 
 func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
 	for i, ts := range []regionTestCase{
 		{
 			title:          "missing cloud --region=/region",
@@ -641,7 +688,7 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 		delete(s.initialCloudMap, "myk8s")
 		command := s.makeCommand(c, true, false, true)
 		args := []string{
-			"myk8s", "-c", "foo", "--cluster-name", "mrcloud2",
+			"myk8s", "-c", "foo", "--cluster-name", "the-cluster",
 		}
 		if ts.region != "" {
 			args = append(args, "--region", ts.region)
@@ -665,8 +712,11 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 }
 
 func (s *addCAASSuite) TestGatherClusterRegionMetaRegionNoMatchesThenIgnored(c *gc.C) {
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--client")
+	_, err = s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudMetadataStore.CheckCall(c, 3, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{
@@ -731,13 +781,10 @@ func (s *addCAASSuite) assertAddCloudResult(
 				AuthCredentials: map[string]jujucloud.Credential{
 					"myk8s": jujucloud.NewNamedCredential(
 						"myk8s",
-						jujucloud.AuthType("certificate"),
+						jujucloud.AuthType("oauth2"),
 						map[string]string{
-							"ClientCertificateData": `
------BEGIN CERTIFICATE-----
-MIIDBDCCAeygAwIBAgIJAPUHbpCysNxyMA0GCSqGSIb3DQEBCwUAMBcxFTATBgNV`[1:],
-							"rbac-id": "9baa5e46",
 							"Token":   "xfdfsdfsdsd",
+							"rbac-id": "9baa5e46",
 						},
 						false,
 					),
@@ -756,16 +803,16 @@ MIIDBDCCAeygAwIBAgIJAPUHbpCysNxyMA0GCSqGSIb3DQEBCwUAMBcxFTATBgNV`[1:],
 		HostCloudRegion:  cloudRegion,
 		Type:             "kubernetes",
 		Description:      "",
-		AuthTypes:        cloud.AuthTypes{"certificate"},
-		Endpoint:         "fakeendpoint2",
+		AuthTypes:        cloud.AuthTypes{"certificate", "oauth2", "userpass"},
+		Endpoint:         "https://1.1.1.1:8888",
 		IdentityEndpoint: "",
 		StorageEndpoint:  "",
 		Config:           map[string]interface{}{"operator-storage": operatorStorage, "workload-storage": workloadStorage},
 		RegionConfig:     cloud.RegionConfig(nil),
-		CACertificates:   []string{"fakecadata2"},
+		CACertificates:   []string{"A"},
 	}
 	if region != "" {
-		expectedCloudToAdd.Regions = []cloud.Region{{Name: region, Endpoint: "fakeendpoint2"}}
+		expectedCloudToAdd.Regions = []cloud.Region{{Name: region, Endpoint: "https://1.1.1.1:8888"}}
 	}
 	if !t.controller {
 		s.fakeCloudAPI.CheckNoCalls(c)
@@ -812,11 +859,14 @@ func (s *addCAASSuite) TestGatherClusterRegionMetaRegionMatchesAndPassThrough(c 
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--client", "-c", "foo")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--client", "-c", "foo")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s".
+		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s".
 You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, cloudRegion, "", "operator-sc", testData{client: true, controller: true})
 }
@@ -825,8 +875,11 @@ func (s *addCAASSuite) TestGatherClusterMetadataError(c *gc.C) {
 	var result *jujucaas.ClusterMetadata
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, errors.New("oops"))
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2")
+	_, err = s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -844,11 +897,14 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRegions(c *gc.C) {
 	var result jujucaas.ClusterMetadata
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&result, nil)
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--client", "-c", "foo")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--client", "-c", "foo")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s"
+		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s"
 with operator storage provisioned by the workload storage class.
 You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, "other", "", "", testData{client: true, controller: true})
@@ -862,8 +918,11 @@ func (s *addCAASSuite) TestGatherClusterMetadataUnknownError(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, nil)
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("foo"))
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "-c", "foo")
+	_, err = s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "-c", "foo")
 	expectedErr := `
 	Juju needs to query the k8s cluster to ensure that the recommended
 	storage defaults are available and to detect the cluster's cloud/region.
@@ -878,8 +937,11 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoStorageError(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, nil)
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("foo"))
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "-c", "foo")
+	_, err = s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "-c", "foo")
 	expectedErr := `
 	Juju needs to know what storage class to use to provision workload storage.
 	Run add-k8s again, using --storage=<name> to specify the storage class to use.
@@ -902,11 +964,14 @@ func (s *addCAASSuite) TestGatherClusterMetadataUserStorage(c *gc.C) {
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--client", "-c", "foo", "--storage", "mystorage")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--client", "-c", "foo", "--storage", "mystorage")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned
+		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with storage provisioned
 by the existing "mystorage" storage class.
 You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, "other", "mystorage", "mystorage", testData{client: true, controller: true})
@@ -916,8 +981,11 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRecommendedStorageError(c *gc.
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(
 		&jujucaas.NonPreferredStorageError{PreferredStorage: jujucaas.PreferredStorage{Name: "disk"}})
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "-c", "foo")
+	_, err = s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "-c", "foo")
 	expectedErr := `
 	No recommended storage configuration is defined on this cluster.
 	Run add-k8s again with --storage=<name> and Juju will use the
@@ -943,13 +1011,16 @@ func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage", "--client")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--storage", "mystorage", "--client")
 		c.Assert(err, jc.ErrorIsNil)
 		result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 		result = strings.Replace(result, "\n", " ", -1)
-		c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+		c.Assert(result, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, cloudRegion, "mystorage", "mystorage", testData{client: true, controller: true})
 
 }
@@ -959,12 +1030,15 @@ func (s *addCAASSuite) TestSkipStorage(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, nil)
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("foo"))
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	command := s.makeCommand(c, true, false, true)
-	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "-c", "foo", "--skip-storage")
+	ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "-c", "foo", "--skip-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	out := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 	out = strings.Replace(out, "\n", " ", -1)
-	c.Assert(out, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with no configured storage provisioning capability on controller foo.`)
+	c.Assert(out, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with no configured storage provisioning capability on controller foo.`)
 }
 
 func (s *addCAASSuite) assertCreateDefaultStorageProvisioner(c *gc.C, expectedMsg string, t testData, additionalArgs ...string) {
@@ -987,9 +1061,12 @@ func (s *addCAASSuite) assertCreateDefaultStorageProvisioner(c *gc.C, expectedMs
 		Provisioner: "kubernetes.io/gce-pd",
 	}).Returns(storageProvisioner, nil)
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		args := []string{"myk8s", "--cluster-name", "mrcloud2", "--storage", "mystorage"}
+		args := []string{"myk8s", "--cluster-name", "myk8s", "--storage", "mystorage"}
 		if t.controller {
 			args = append(args, "-c", "foo")
 		}
@@ -1009,19 +1086,19 @@ func (s *addCAASSuite) assertCreateDefaultStorageProvisioner(c *gc.C, expectedMs
 
 func (s *addCAASSuite) TestCreateDefaultStorageProvisionerBoth(c *gc.C) {
 	s.assertCreateDefaultStorageProvisioner(c,
-		`k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
+		`k8s substrate "myk8s" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
 		testData{client: true, controller: true})
 }
 
 func (s *addCAASSuite) TestCreateDefaultStorageProvisionerClientOnly(c *gc.C) {
 	s.assertCreateDefaultStorageProvisioner(c,
-		`k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
+		`k8s substrate "myk8s" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
 		testData{client: true})
 }
 
 func (s *addCAASSuite) TestCreateDefaultStorageProvisionerControllerOnly(c *gc.C) {
 	s.assertCreateDefaultStorageProvisioner(c,
-		`k8s substrate "mrcloud2" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class on controller foo.`,
+		`k8s substrate "myk8s" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class on controller foo.`,
 		testData{controller: true})
 }
 
@@ -1043,13 +1120,16 @@ func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--storage", "mystorage", "--client")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--storage", "mystorage", "--client")
 		c.Assert(err, jc.ErrorIsNil)
 		result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 		result = strings.Replace(result, "\n", " ", -1)
-		c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the new "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+		c.Assert(result, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with storage provisioned by the new "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, cloudRegion, "mystorage", "mystorage", testData{client: true, controller: true})
 }
 
@@ -1071,13 +1151,16 @@ func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStora
 		Name: "mystorage",
 	}).Returns(storageProvisioner, nil)
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--cloud", "maas", "--client")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--cloud", "maas", "--client")
 		c.Assert(err, jc.ErrorIsNil)
 		result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 		result = strings.Replace(result, "\n", " ", -1)
-		c.Assert(result, gc.Equals, `k8s substrate "mrcloud2" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+		c.Assert(result, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, "maas", "mystorage", "mystorage", testData{client: true, controller: true})
 }
 
@@ -1088,11 +1171,14 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "mrcloud2", "--client")
+		ctx, err := s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "--client")
 		c.Assert(err, jc.ErrorIsNil)
-		expected := `k8s substrate "mrcloud2" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
+		expected := `k8s substrate "myk8s" added as cloud "myk8s".You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`
 		c.Assert(strings.Replace(cmdtesting.Stdout(ctx), "\n", "", -1), gc.Equals, expected)
 	}, cloudRegion, "", "operator-sc", testData{client: true})
 }
@@ -1230,7 +1316,7 @@ func (s *addCAASSuite) assertStoreClouds(c *gc.C, hostCloud string) {
 				Name:             "myk8s",
 				Type:             "kubernetes",
 				Description:      "",
-				AuthTypes:        cloud.AuthTypes{"userpass"},
+				AuthTypes:        cloud.AuthTypes{"certificate", "oauth2", "userpass"},
 				Endpoint:         "https://1.1.1.1:8888",
 				IdentityEndpoint: "",
 				StorageEndpoint:  "",
@@ -1277,9 +1363,11 @@ func (s *addCAASSuite) assertStoreClouds(c *gc.C, hostCloud string) {
 func (s *addCAASSuite) TestCorrectUseCurrentContext(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
-	s.credentialStoreAPI.EXPECT().UpdateCredential("myk8s", gomock.Any()).Times(1).Return(nil)
+	s.credentialStoreAPI.EXPECT().UpdateCredential("the-cluster", gomock.Any()).Times(1).Return(nil)
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "-c", "foo", "myk8s", "--client")
+	_, err = s.runCommand(c, nil, command, "-c", "foo", "the-cluster", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudMetadataStore.CheckCall(c, 3, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{
@@ -1309,19 +1397,19 @@ func (s *addCAASSuite) TestCorrectUseCurrentContext(c *gc.C) {
 				Config:           map[string]interface{}(nil),
 				RegionConfig:     cloud.RegionConfig(nil),
 			},
-			"myk8s": {
-				Name:             "myk8s",
+			"the-cluster": {
+				Name:             "the-cluster",
 				Type:             "kubernetes",
 				Description:      "",
 				HostCloudRegion:  "gce/us-east1",
-				AuthTypes:        cloud.AuthTypes{"certificate"},
-				Endpoint:         "fakeendpoint1",
+				AuthTypes:        cloud.AuthTypes{"certificate", "oauth2", "userpass"},
+				Endpoint:         "https://1.1.1.1:8888",
 				IdentityEndpoint: "",
 				StorageEndpoint:  "",
-				Regions:          []cloud.Region{{Name: "us-east1", Endpoint: "fakeendpoint1"}},
+				Regions:          []cloud.Region{{Name: "us-east1", Endpoint: "https://1.1.1.1:8888"}},
 				Config:           map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": ""},
 				RegionConfig:     cloud.RegionConfig(nil),
-				CACertificates:   []string{"fakecadata1"},
+				CACertificates:   []string{"A"},
 			},
 		},
 	)
@@ -1331,8 +1419,10 @@ func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 	s.credentialStoreAPI.EXPECT().UpdateCredential("myk8s", gomock.Any()).Times(1).Return(nil)
+	err := SetKubeConfigData(kubeConfigStr)
+	c.Assert(err, jc.ErrorIsNil)
 	command := s.makeCommand(c, true, false, true)
-	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "mrcloud2", "--client")
+	_, err = s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "the-cluster", "--client")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudMetadataStore.CheckCall(c, 3, "WritePersonalCloudMetadata",
 		map[string]cloud.Cloud{
@@ -1367,14 +1457,14 @@ func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
 				Type:             "kubernetes",
 				Description:      "",
 				HostCloudRegion:  "gce/us-east1",
-				AuthTypes:        cloud.AuthTypes{"certificate"},
-				Endpoint:         "fakeendpoint2",
+				AuthTypes:        cloud.AuthTypes{"certificate", "oauth2", "userpass"},
+				Endpoint:         "https://1.1.1.1:8888",
 				IdentityEndpoint: "",
 				StorageEndpoint:  "",
-				Regions:          []cloud.Region{{Name: "us-east1", Endpoint: "fakeendpoint2"}},
+				Regions:          []cloud.Region{{Name: "us-east1", Endpoint: "https://1.1.1.1:8888"}},
 				Config:           map[string]interface{}{"operator-storage": "operator-sc", "workload-storage": ""},
 				RegionConfig:     cloud.RegionConfig(nil),
-				CACertificates:   []string{"fakecadata2"},
+				CACertificates:   []string{"A"},
 			},
 		},
 	)

--- a/cmd/juju/caas/credential.go
+++ b/cmd/juju/caas/credential.go
@@ -10,12 +10,13 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	jujucloud "github.com/juju/juju/cloud"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 )
 
-const rbacLabelKeyName = provider.RBACLabelKeyName
+const rbacLabelKeyName = k8scloud.RBACLabelKeyName
 
 func ensureCredentialUID(
 	credentialName, credentialUID string,

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 
+	jujuclock "github.com/juju/clock"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 
@@ -22,20 +23,22 @@ func NewAddCAASCommandForTest(
 	credentialStoreAPI CredentialStoreAPI,
 	store jujuclient.ClientStore,
 	addCloudAPIFunc func() (AddCloudAPI, error),
+	adminServiceAccountResolver func(jujuclock.Clock) clientconfig.K8sCredentialResolver,
 	brokerGetter BrokerGetter,
 	k8sCluster k8sCluster,
 	newClientConfigReaderFunc func(string) (clientconfig.ClientConfigFunc, error),
 	getAllCloudDetails func() (map[string]*jujucmdcloud.CloudDetails, error),
 ) cmd.Command {
 	command := &AddCAASCommand{
-		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
-		cloudMetadataStore:        cloudMetadataStore,
-		credentialStoreAPI:        credentialStoreAPI,
-		addCloudAPIFunc:           addCloudAPIFunc,
-		brokerGetter:              brokerGetter,
-		k8sCluster:                k8sCluster,
-		newClientConfigReader:     newClientConfigReaderFunc,
-		credentialUIDGetter:       func(credentialGetter, string, string) (string, error) { return "9baa5e46", nil },
+		OptionalControllerCommand:   modelcmd.OptionalControllerCommand{Store: store},
+		cloudMetadataStore:          cloudMetadataStore,
+		credentialStoreAPI:          credentialStoreAPI,
+		addCloudAPIFunc:             addCloudAPIFunc,
+		brokerGetter:                brokerGetter,
+		adminServiceAccountResolver: adminServiceAccountResolver,
+		k8sCluster:                  k8sCluster,
+		newClientConfigReader:       newClientConfigReaderFunc,
+		credentialUIDGetter:         func(credentialGetter, string, string) (string, error) { return "9baa5e46", nil },
 		getAllCloudDetails: func(jujuclient.CredentialGetter) (map[string]*jujucmdcloud.CloudDetails, error) {
 			return getAllCloudDetails()
 		},

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1272,7 +1272,6 @@ func (c *bootstrapCommand) credentialsAndRegionName(
 	regionName string,
 	err error,
 ) {
-
 	store := c.ClientStore()
 
 	// When looking for credentials, we should attempt to see if there are any


### PR DESCRIPTION
This change introduces changes to Juju that will allow a user to
bootstrap to a Kubernetes cluster from the kubeconfig file without the
add-k8s step.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

This change allows you to bootstrap directly to Kubernetes context's defined in your local KubeConfig file.

This can be tested by making a Kubeconfig that points to several clusters. 
 - GKE
 - Minikube
 - Kind
 - Azure.

Then run `juju clouds` to make sure the clouds appear.

After this `juju bootstrap <context_name>` can be run.

## Documentation changes

Discourse post incoming

## Bug reference

NA
