### PR TITLE
[2.9] Do not attempt to set proxy settings for windows/centos workloads

### DIFF
--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -23,6 +23,9 @@ import (
 	"github.com/juju/juju/core/watcher"
 )
 
+// Overridden by tests
+var getHostOS = os.HostOS
+
 type Config struct {
 	SupportLegacyValues bool
 	RegistryPath        string
@@ -151,7 +154,7 @@ func (w *proxyWorker) saveProxySettingsToRegistry() error {
 }
 
 func (w *proxyWorker) saveProxySettings() error {
-	switch os.HostOS() {
+	switch getHostOS() {
 	case os.Windows:
 		return w.saveProxySettingsToRegistry()
 	default:
@@ -208,8 +211,8 @@ func getPackageCommander() (commands.PackageCommander, error) {
 }
 
 func (w *proxyWorker) handleSnapProxyValues(proxy proxy.Settings, storeID, storeAssertions, storeProxyURL string) {
-	if os.HostOS() == os.Windows {
-		w.config.Logger.Tracef("no snap proxies on windows")
+	if hostOS := getHostOS(); hostOS == os.Windows || hostOS == os.CentOS {
+		w.config.Logger.Tracef("no snap proxies on %s", hostOS)
 		return
 	}
 	if w.config.RunFunc == nil {
@@ -284,6 +287,11 @@ func (w *proxyWorker) handleSnapProxyValues(proxy proxy.Settings, storeID, store
 }
 
 func (w *proxyWorker) handleAptProxyValues(aptSettings proxy.Settings) error {
+	if hostOS := getHostOS(); hostOS == os.Windows || hostOS == os.CentOS {
+		w.config.Logger.Tracef("no apt proxies on %s", hostOS)
+		return nil
+	}
+
 	if aptSettings != w.aptProxy || w.first {
 		w.config.Logger.Debugf("new apt proxy settings %#v", aptSettings)
 		paccmder, err := getPackageCommander()


### PR DESCRIPTION
This PR ensures that the proxy-updater worker does not attempt to set apt proxy settings on series that do not support apt.

## QA steps

Try this on maas after ensuring that you have pulled the centos7 image 

```console
$ make install
$ juju bootstrap maas test --no-gui

# Add a centos and a bionic machine and wait for them to come up.
$ juju add-machine --series=centos7
$ juju add-machine --series=bionic

# Dial up the logging and change the proxy settings
$ juju model-config logging-config='<root>=DEBUG;juju.worker.proxyupdater=TRACE'
$ juju model-config http-proxy=http://bogus:1337

# Tail the logs for both machines and check that the centos proxy-updater worker shows the 
# following lines:
 juju.worker.proxyupdater no snap proxies on CentOS
 juju.worker.proxyupdater no apt proxies on CentOS

Ensure that /etc/apt/apt.conf.d/95-juju-proxy-settings on the bionic host has been updated as expected
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1901069