### PR TITLE
[2.9] Use positional arguments for azure clients

### DIFF
--- a/acceptancetests/winazurearm.py
+++ b/acceptancetests/winazurearm.py
@@ -73,13 +73,13 @@ class ARMClient:
         self.credentials = ServicePrincipalCredentials(
             client_id=self.client_id, secret=self.secret, tenant=self.tenant)
         self.storage = StorageManagementClient(
-            credential=self.credentials, subscription_id=self.subscription_id)
+            self.credentials, self.subscription_id)
         self.resource = ResourceManagementClient(
-            credential=self.credentials, subscription_id=self.subscription_id)
+            self.credentials, self.subscription_id)
         self.compute = ComputeManagementClient(
-            credential=self.credentials, subscription_id=self.subscription_id)
+            self.credentials, self.subscription_id)
         self.network = NetworkManagementClient(
-            credential=self.credentials, subscription_id=self.subscription_id)
+            self.credentials, self.subscription_id)
 
 
 class ResourceGroupDetails:


### PR DESCRIPTION
The updated azure packages used by acceptance tests have switched their constructors to accept the credential and client_id parameters as positional args (instead of kwargs).

## QA steps

```sh
$ cd acceptance-tests
$ ./assess_network_health.py parallel-azure-arm `which juju` /tmp/art nw-health  --series bionic --bundle cs:~juju/bundle/mediawiki-single --logging-config juju.state.txn=TRACE; echo "EXIT $?"
```