### PR TITLE
[2.8] Allow bundle to update existing offers

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -145,7 +145,13 @@ func (api *OffersAPI) Offer(all params.AddApplicationOffers) (params.ErrorResult
 			result[i].Error = common.ServerError(err)
 			continue
 		}
-		_, err = api.GetApplicationOffers(backend).AddOffer(applicationOfferParams)
+
+		offerBackend := api.GetApplicationOffers(backend)
+		if _, err = offerBackend.ApplicationOffer(applicationOfferParams.OfferName); err == nil {
+			_, err = offerBackend.UpdateOffer(applicationOfferParams)
+		} else {
+			_, err = offerBackend.AddOffer(applicationOfferParams)
+		}
 		result[i].Error = common.ServerError(err)
 	}
 	return params.ErrorResults{Results: result}, nil

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	addOffersBackendCall  = "addOffersCall"
-	listOffersBackendCall = "listOffersCall"
+	addOffersBackendCall   = "addOffersCall"
+	updateOfferBackendCall = "updateOfferCall"
+	listOffersBackendCall  = "listOffersCall"
 )
 
 type baseSuite struct {

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -44,8 +44,10 @@ type stubApplicationOffers struct {
 	jtesting.Stub
 	jujucrossmodel.ApplicationOffers
 
-	addOffer   func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error)
-	listOffers func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error)
+	applicationOffer func(name string) (*jujucrossmodel.ApplicationOffer, error)
+	addOffer         func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error)
+	updateOffer      func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error)
+	listOffers       func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error)
 }
 
 func (m *stubApplicationOffers) AddOffer(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
@@ -60,7 +62,7 @@ func (m *stubApplicationOffers) ListOffers(filters ...jujucrossmodel.Application
 
 func (m *stubApplicationOffers) UpdateOffer(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
 	m.AddCall(updateOfferCall)
-	panic("not implemented")
+	return m.updateOffer(offer)
 }
 
 func (m *stubApplicationOffers) Remove(url string, force bool) error {
@@ -70,7 +72,7 @@ func (m *stubApplicationOffers) Remove(url string, force bool) error {
 
 func (m *stubApplicationOffers) ApplicationOffer(name string) (*jujucrossmodel.ApplicationOffer, error) {
 	m.AddCall(offerCall)
-	panic("not implemented")
+	return m.applicationOffer(name)
 }
 
 func (m *stubApplicationOffers) ApplicationOfferForUUID(uuid string) (*jujucrossmodel.ApplicationOffer, error) {

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1380,6 +1380,14 @@ func buildModelRepresentation(
 	for bundleMachine, modelMachine := range bundleMachines {
 		machineMap[bundleMachine] = modelMachine
 	}
+
+	offersByApplication := make(map[string][]string)
+	for _, offer := range status.Offers {
+		appOffers := offersByApplication[offer.ApplicationName]
+		appOffers = append(appOffers, offer.OfferName)
+		offersByApplication[offer.ApplicationName] = appOffers
+	}
+
 	applications := make(map[string]*bundlechanges.Application)
 	for name, appStatus := range status.Applications {
 		app := &bundlechanges.Application{
@@ -1389,6 +1397,7 @@ func buildModelRepresentation(
 			Exposed:       appStatus.Exposed,
 			Series:        appStatus.Series,
 			SubordinateTo: appStatus.SubordinateTo,
+			Offers:        offersByApplication[name],
 		}
 		for unitName, unit := range appStatus.Units {
 			app.Units = append(app.Units, bundlechanges.Unit{

--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1117,10 +1117,7 @@ func (h *bundleHandler) createOffer(change *bundlechanges.CreateOfferChange) err
 	if err == nil && len(result) > 0 && result[0].Error != nil {
 		err = result[0].Error
 	}
-	if err != nil {
-		return errors.Annotatef(err, "cannot create offer %s", p.OfferName)
-	}
-	return nil
+	return err
 }
 
 // consumeOffer consumes an existing offer

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/joyent/gosdc v0.0.0-20140524000815-2f11feadd2d9
 	github.com/joyent/gosign v0.0.0-20140524000734-0da0d5f13420
 	github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf
-	github.com/juju/bundlechanges v1.0.0
+	github.com/juju/bundlechanges v1.0.1-0.20210209114844-acd700ed48fe
 	github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815
 	github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN76APTgBEdHkR/PSbpeY4I8cWeEA=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges v1.0.0 h1:MWHsdeas7iy5uJJlgqKCNmgUCr3aTgV4Vn+Sz5L3UJg=
-github.com/juju/bundlechanges v1.0.0/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
+github.com/juju/bundlechanges v1.0.1-0.20210209114844-acd700ed48fe h1:E9EzcSqUfYZzgLDPDVCvon2Kmy3u4SMuQ/9oO5mrRfU=
+github.com/juju/bundlechanges v1.0.1-0.20210209114844-acd700ed48fe/go.mod h1:nsBnRyayHbdHeduPzHgQVwbYhUz73aiRTjfJl5d86Uc=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596 h1:HxkKL4WZ8j/2q63vngE6poi5p1I6KzsxC0v93bvpDBM=
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596/go.mod h1:/Hb24f6NaHMuxV/XeKR9v1QY8qCc0NanWAXQuv6+Ob0=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85 h1:YgEB2tnlAwVftOnPUKTN4i6NDYZy0ztR5l/HdUuHS2Y=


### PR DESCRIPTION
This PR allows juju users to deploy a bundle containing offers multiple times. With this set of changes, juju will detect when an offer already exists and update its details instead of emitting a "offer already exists" error. In addition, `bundlechanges` has also been updated so that we can show an "update offer" instead of "create offer" for existing offers.

## QA steps

```console
# Create a bundle with these contents:
series: bionic
applications:
  graylog:
    charm: cs:~llama-charmers-next/graylog
    num_units: 1
    options:
      channel: 3/stable
---
applications:
  graylog:
    offers:
      graylog-beats:
        endpoints:
          - beats

# Bootstrap a 2.8 controller (using snap)
$ /snap/bin/juju bootstrap lxd test

# Deploy bundle and check that attempting to re-deploy it results in an error
$ juju deploy ./bundle.yaml
Resolving charm: cs:~llama-charmers-next/graylog
Executing changes:
- upload charm cs:~llama-charmers-next/graylog-11 for series bionic
- deploy application graylog on bionic using cs:~llama-charmers-next/graylog-11
  added resource core
  added resource graylog
- create offer graylog-beats using graylog:beats
- add unit graylog/0 to new machine 0
Deploy of bundle completed.

$ juju deploy ./bundle.yaml
...
cannot add application offer "graylog-beats": application offer already exists

# Upgrade with the code from this PR
$ juju upgrade-controller --build-agent
$ juju upgrade-model

# Try the deploy again and notice the "update offer" entry
$ juju deploy ./bundle.yaml
...
Resolving charm: cs:~llama-charmers-next/graylog
Executing changes:
- update offer graylog-beats using graylog:beats
Deploy of bundle completed.
```

Check that juju prevents you from removing offer endpoints that have active connections when updating an offer

```console
$ juju add-model db
$ juju deploy percona-cluster
$ juju offer percona-cluster:db,db-admin db-offer

$ juju add-model consumer
$ juju deploy wordpress
$ juju consume db.db-offer
$ juju relate wordpress:db db-offer:db

$ juju switch db

# Try to deploy this bundle
$ cat bundle.yaml
series: bionic
applications:
  percona-cluster:
    charm: cs:percona-cluster-293
--- # overlay.yaml
applications:
  percona-cluster:
    offers:
      db-offer:
        endpoints:
        - db-admin
        acl:
          admin: admin

$ juju deploy ./bundle.yaml
Executing changes:
- update offer db-offer using percona-cluster:db-admin
ERROR cannot deploy bundle: cannot update application offer "db-offer": application endpoint "db" has active consumers

# Try this bundle instead (drops db-admin)
$ cat bundle2.yaml
series: bionic
applications:
  percona-cluster:
    charm: cs:percona-cluster-293
--- # overlay.yaml
applications:
  percona-cluster:
    offers:
      db-offer:
        endpoints:
        - db
        acl:
          admin: admin

$ juju deploy ./bundle2.yaml
Executing changes:
- update offer db-offer using percona-cluster:db
- grant user admin admin access to offer db-offer
Deploy of bundle completed.
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1894004