### PR TITLE
EC2 fix panic

### DIFF
--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -23,7 +23,7 @@ type ZonedEnviron interface {
 	// InstanceAvailabilityZoneNames returns the names of the availability
 	// zones for the specified instances. The error returned follows the same
 	// rules as Environ.Instances.
-	InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error)
+	InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error)
 
 	// DeriveAvailabilityZones attempts to derive availability zones from
 	// the specified StartInstanceParams.
@@ -114,8 +114,8 @@ func AvailabilityZoneAllocations(
 		return nil, nil
 	}
 
-	for i, id := range group {
-		zone := instanceZones[i]
+	for _, id := range group {
+		zone := instanceZones[id]
 		if zone == "" {
 			continue
 		}

--- a/provider/common/availabilityzones_test.go
+++ b/provider/common/availabilityzones_test.go
@@ -53,10 +53,14 @@ func (s *AvailabilityZoneSuite) SetUpSuite(c *gc.C) {
 
 func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllRunningInstances(c *gc.C) {
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
 		called++
-		return []string{"az0", "az1", "az2"}, nil
+		return map[instance.Id]string{
+			"inst0": "az0",
+			"inst1": "az1",
+			"inst2": "az2",
+		}, nil
 	})
 	zoneInstances, err := common.AvailabilityZoneAllocations(&s.env, s.callCtx, nil)
 	c.Assert(called, gc.Equals, 1)
@@ -84,10 +88,10 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsAllRunningInstanc
 
 func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsPartialInstances(c *gc.C) {
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"nichts", "inst1", "null", "inst2"})
 		called++
-		return []string{"", "az1", "", "az1"}, environs.ErrPartialInstances
+		return map[instance.Id]string{"inst1": "az1", "inst2": "az1"}, environs.ErrPartialInstances
 	})
 	zoneInstances, err := common.AvailabilityZoneAllocations(&s.env, s.callCtx, []instance.Id{"nichts", "inst1", "null", "inst2"})
 	c.Assert(called, gc.Equals, 1)
@@ -104,7 +108,7 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsPartialInstances(
 func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsInstanceAvailabilityZonesErrors(c *gc.C) {
 	returnErr := fmt.Errorf("whatever")
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 		called++
 		return nil, returnErr
 	})
@@ -116,7 +120,7 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsInstanceAvailabil
 
 func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsInstanceAvailabilityZonesNoInstances(c *gc.C) {
 	var called int
-	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 		called++
 		return nil, environs.ErrNoInstances
 	})
@@ -128,10 +132,10 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsInstanceAvailabil
 
 func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsNoZones(c *gc.C) {
 	var calls []string
-	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
 		calls = append(calls, "InstanceAvailabilityZoneNames")
-		return []string{"", "", ""}, nil
+		return make(map[instance.Id]string, 3), nil
 	})
 	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) (network.AvailabilityZones, error) {
 		calls = append(calls, "AvailabilityZones")
@@ -145,10 +149,10 @@ func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsNoZones(c *gc.C) 
 
 func (s *AvailabilityZoneSuite) TestAvailabilityZoneAllocationsErrors(c *gc.C) {
 	var calls []string
-	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+	s.PatchValue(&s.env.instanceAvailabilityZoneNames, func(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 		c.Assert(ids, gc.DeepEquals, []instance.Id{"inst0", "inst1", "inst2"})
 		calls = append(calls, "InstanceAvailabilityZoneNames")
-		return []string{"", "", ""}, nil
+		return make(map[instance.Id]string, 3), nil
 	})
 	resultErr := fmt.Errorf("u can haz no az")
 	s.PatchValue(&s.env.availabilityZones, func(context.ProviderCallContext) (network.AvailabilityZones, error) {

--- a/provider/common/mock_test.go
+++ b/provider/common/mock_test.go
@@ -98,7 +98,7 @@ func (env *mockEnviron) StorageProvider(t jujustorage.ProviderType) (jujustorage
 }
 
 type availabilityZonesFunc func(context.ProviderCallContext) (network.AvailabilityZones, error)
-type instanceAvailabilityZoneNamesFunc func(context.ProviderCallContext, []instance.Id) ([]string, error)
+type instanceAvailabilityZoneNamesFunc func(context.ProviderCallContext, []instance.Id) (map[instance.Id]string, error)
 type deriveAvailabilityZonesFunc func(context.ProviderCallContext, environs.StartInstanceParams) ([]string, error)
 
 type mockZonedEnviron struct {
@@ -112,7 +112,7 @@ func (env *mockZonedEnviron) AvailabilityZones(ctx context.ProviderCallContext) 
 	return env.availabilityZones(ctx)
 }
 
-func (env *mockZonedEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+func (env *mockZonedEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 	return env.instanceAvailabilityZoneNames(ctx, ids)
 }
 

--- a/provider/common/mocks/zoned_environ.go
+++ b/provider/common/mocks/zoned_environ.go
@@ -217,10 +217,10 @@ func (mr *MockZonedEnvironMockRecorder) DestroyController(arg0, arg1 interface{}
 }
 
 // InstanceAvailabilityZoneNames mocks base method
-func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]string, error) {
+func (m *MockZonedEnviron) InstanceAvailabilityZoneNames(arg0 context.ProviderCallContext, arg1 []instance.Id) (map[instance.Id]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceAvailabilityZoneNames", arg0, arg1)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(map[instance.Id]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1520,7 +1520,7 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (corenetw
 }
 
 // InstanceAvailabilityZoneNames implements environs.ZonedEnviron.
-func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 	if err := env.checkBroken("InstanceAvailabilityZoneNames"); err != nil {
 		return nil, errors.NotSupportedf("instance availability zones")
 	}
@@ -1530,17 +1530,17 @@ func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContex
 	}
 	azMaxIndex := len(availabilityZones) - 1
 	azIndex := 0
-	returnValue := make([]string, len(ids))
-	for i := range ids {
+	returnValue := make(map[instance.Id]string, 0)
+	for _, id := range ids {
 		if availabilityZones[azIndex].Available() {
-			returnValue[i] = availabilityZones[azIndex].Name()
+			returnValue[id] = availabilityZones[azIndex].Name()
 		} else {
 			// Based on knowledge of how the AZs are setup above
 			// in AvailabilityZones()
-			azIndex += 1
-			returnValue[i] = availabilityZones[azIndex].Name()
+			azIndex++
+			returnValue[id] = availabilityZones[azIndex].Name()
 		}
-		azIndex += 1
+		azIndex++
 		if azIndex == azMaxIndex {
 			azIndex = 0
 		}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -289,7 +289,7 @@ func gatherAvailabilityZones(instances []instances.Instance) []string {
 				zones = append(zones, *t.i.Placement.AvailabilityZone)
 			}
 		default:
-			logger.Tracef("unexpected instance type %T when getting availability zones", inst)
+			logger.Errorf("unexpected instance type %T when getting availability zones", inst)
 		}
 	}
 	return zones

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/environs"
@@ -425,19 +426,29 @@ func (*Suite) TestGatherAZ(c *gc.C) {
 	instances := []instances.Instance{
 		&amzInstance{
 			Instance: &amzec2.Instance{
-				AvailZone: "aaa",
+				InstanceId: "id1",
+				AvailZone:  "aaa",
 			},
 		},
 		&sdkInstance{
 			i: &ec2.Instance{
+				InstanceId: ptrString("id2"),
 				Placement: &ec2.Placement{
 					AvailabilityZone: ptrString("bbb"),
 				},
 			},
 		},
+		&sdkInstance{
+			i: &ec2.Instance{
+				InstanceId: ptrString("id3"),
+			},
+		},
 	}
 	az := gatherAvailabilityZones(instances)
-	c.Assert(az, gc.DeepEquals, []string{"aaa", "bbb"})
+	c.Assert(az, gc.DeepEquals, map[instance.Id]string{
+		"id1": "aaa",
+		"id2": "bbb",
+	})
 }
 
 func ptrString(s string) *string {

--- a/provider/ec2/instance.go
+++ b/provider/ec2/instance.go
@@ -37,6 +37,14 @@ func (inst *amzInstance) Id() instance.Id {
 	return instance.Id(inst.InstanceId)
 }
 
+// AvailabilityZone returns the underlying az for an instance.
+func (inst *amzInstance) AvailabilityZone() (string, bool) {
+	if inst.Instance == nil {
+		return "", false
+	}
+	return inst.Instance.AvailZone, true
+}
+
 // Status returns the status of this EC2 instance.
 func (inst *amzInstance) Status(ctx context.ProviderCallContext) instance.Status {
 	// pending | running | shutting-down | terminated | stopping | stopped
@@ -143,6 +151,15 @@ func (inst *sdkInstance) String() string {
 // Id returns the EC2 identifier for the Instance.
 func (inst *sdkInstance) Id() instance.Id {
 	return instance.Id(*inst.i.InstanceId)
+}
+
+// AvailabilityZone returns the underlying az for an instance.
+func (inst *sdkInstance) AvailabilityZone() (string, bool) {
+	if inst.i == nil || inst.i.Placement == nil ||
+		inst.i.Placement.AvailabilityZone == nil {
+		return "", false
+	}
+	return *inst.i.Placement.AvailabilityZone, true
 }
 
 // Status returns the status of this EC2 instance.

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -37,7 +37,7 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (network.
 // InstanceAvailabilityZoneNames returns the names of the availability
 // zones for the specified instances. The error returned follows the same
 // rules as Environ.Instances.
-func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 	instances, err := env.Instances(ctx, ids)
 	if err != nil && err != environs.ErrPartialInstances && err != environs.ErrNoInstances {
 		return nil, errors.Trace(err)
@@ -46,14 +46,14 @@ func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContex
 	// not use errors.Trace in that case since callers may not call
 	// errors.Cause.
 
-	results := make([]string, len(ids))
-	for i, inst := range instances {
-		if eInst := inst.(*environInstance); eInst != nil {
-			results[i] = eInst.base.ZoneName
+	results := make(map[instance.Id]string, len(ids))
+	for _, inst := range instances {
+		if eInst, ok := inst.(*environInstance); ok && eInst != nil {
+			results[inst.Id()] = eInst.base.ZoneName
 		}
 	}
 
-	return results, err
+	return results, nil
 }
 
 // DeriveAvailabilityZones is part of the common.ZonedEnviron interface.

--- a/provider/gce/environ_availzones_test.go
+++ b/provider/gce/environ_availzones_test.go
@@ -64,11 +64,14 @@ func (s *environAZSuite) TestAvailabilityZonesAPI(c *gc.C) {
 func (s *environAZSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 	s.FakeEnviron.Insts = []instances.Instance{s.Instance}
 
-	ids := []instance.Id{instance.Id("spam")}
+	id := instance.Id("spam")
+	ids := []instance.Id{id}
 	zones, err := s.Env.InstanceAvailabilityZoneNames(s.CallCtx, ids)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(zones, jc.DeepEquals, []string{"home-zone"})
+	c.Check(zones, jc.DeepEquals, map[instance.Id]string{
+		id: "home-zone",
+	})
 }
 
 func (s *environAZSuite) TestInstanceAvailabilityZoneNamesAPIs(c *gc.C) {

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -301,7 +301,7 @@ func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (network.
 // For containers, this means the LXD server node names where they reside.
 func (env *environ) InstanceAvailabilityZoneNames(
 	ctx context.ProviderCallContext, ids []instance.Id,
-) ([]string, error) {
+) (map[instance.Id]string, error) {
 	instances, err := env.Instances(ctx, ids)
 	if err != nil && err != environs.ErrPartialInstances {
 		return nil, err
@@ -311,18 +311,18 @@ func (env *environ) InstanceAvailabilityZoneNames(
 	// represented by the single server.
 	server := env.server()
 	if !server.IsClustered() {
-		zones := make([]string, len(ids))
+		zones := make(map[instance.Id]string, len(ids))
 		n := server.Name()
-		for i := range zones {
-			zones[i] = n
+		for _, id := range ids {
+			zones[id] = n
 		}
 		return zones, nil
 	}
 
-	zones := make([]string, len(instances))
-	for i, ins := range instances {
+	zones := make(map[instance.Id]string, len(instances))
+	for _, ins := range instances {
 		if ei, ok := ins.(*environInstance); ok {
-			zones[i] = ei.container.Location
+			zones[ins.Id()] = ei.container.Location
 		}
 	}
 	return zones, nil

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -582,22 +582,26 @@ func (env *maasEnviron) availabilityZones2(ctx context.ProviderCallContext) (cor
 
 // InstanceAvailabilityZoneNames returns the availability zone names for each
 // of the specified instances.
-func (env *maasEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+func (env *maasEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 	instances, err := env.Instances(ctx, ids)
 	if err != nil && err != environs.ErrPartialInstances {
 		return nil, err
 	}
-	zones := make([]string, len(instances))
-	for i, inst := range instances {
+	zones := make(map[instance.Id]string, 0)
+	for _, inst := range instances {
 		if inst == nil {
 			continue
 		}
-		z, err := inst.(maasInstance).zone()
+		mInst, ok := inst.(maasInstance)
+		if !ok {
+			continue
+		}
+		z, err := mInst.zone()
 		if err != nil {
 			logger.Errorf("could not get availability zone %v", err)
 			continue
 		}
-		zones[i] = z
+		zones[inst.Id()] = z
 	}
 	return zones, nil
 }

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -307,13 +307,14 @@ func (e *environSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 		context.Background(), e.listInstancesRequest).Return(
 		e.listInstancesResponse, nil).Times(2)
 
+	id := instance.Id("fakeInstance1")
 	req := []instance.Id{
-		instance.Id("fakeInstance1"),
+		id,
 	}
 	zones, err := e.env.InstanceAvailabilityZoneNames(nil, req)
 	c.Assert(err, gc.IsNil)
 	c.Check(len(zones), gc.Equals, 1)
-	c.Assert(zones[0], gc.Equals, "fakeZone1")
+	c.Assert(zones[id], gc.Equals, "fakeZone1")
 
 	req = []instance.Id{
 		instance.Id("fakeInstance1"),

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -332,7 +332,10 @@ func (s *cinderVolumeSource) availabilityZoneForVolume(
 		return "", nil
 	}
 	// Only choose an AZ from the instance if there's a matching volume AZ.
-	az := aZones[0]
+	var az string
+	for _, az = range aZones {
+		break
+	}
 	if vZones.Contains(az) {
 		logger.Debugf("using availability zone %q to create cinder volume %q", az, volName)
 		return az, nil

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -1018,7 +1018,7 @@ func (s *cinderVolumeSourceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.env = mocks.NewMockZonedEnviron(ctrl)
 	s.env.EXPECT().InstanceAvailabilityZoneNames(
 		s.callCtx, []instance.Id{mockServerId},
-	).Return([]string{"zone-1"}, nil).AnyTimes()
+	).Return(map[instance.Id]string{mockServerId: "zone-1"}, nil).AnyTimes()
 
 	return ctrl
 }

--- a/provider/vsphere/environ_availzones_test.go
+++ b/provider/vsphere/environ_availzones_test.go
@@ -125,7 +125,11 @@ func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNames(c *gc.C) {
 	zonedEnviron := s.env.(common.ZonedEnviron)
 	zones, err := zonedEnviron.InstanceAvailabilityZoneNames(s.callCtx, ids)
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
-	c.Assert(zones, jc.DeepEquals, []string{"z2", "z1", "", "z3/child", ""})
+	c.Assert(zones, jc.DeepEquals, map[instance.Id]string{
+		"inst-0": "z2",
+		"inst-1": "z1",
+		"inst-3": "z3/child",
+	})
 }
 
 func (s *environAvailzonesSuite) TestInstanceAvailabilityZoneNamesNoInstances(c *gc.C) {

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -596,7 +596,7 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller) *mocks
 	broker := mocks.NewMockZonedEnviron(ctrl)
 	exp := broker.EXPECT()
 	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil)
-	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return([]string{}, nil)
+	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return(map[instance.Id]string{}, nil)
 	exp.AvailabilityZones(s.callCtx).Return(zones, nil)
 	return broker
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1964,7 +1964,7 @@ func (b *mockBroker) AvailabilityZones(ctx context.ProviderCallContext) (corenet
 	return b.Environ.(providercommon.ZonedEnviron).AvailabilityZones(ctx)
 }
 
-func (b *mockBroker) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) ([]string, error) {
+func (b *mockBroker) InstanceAvailabilityZoneNames(ctx context.ProviderCallContext, ids []instance.Id) (map[instance.Id]string, error) {
 	return b.Environ.(providercommon.ZonedEnviron).InstanceAvailabilityZoneNames(ctx, ids)
 }
 


### PR DESCRIPTION
This was a fun one to locate. There are two issues here:

 1. Using a slice with holes always leads to bad expectations
 2. Expecting an interface to be backed by one instance seems bad

The following PR ensures that we collect the zones from both `amzInstance`
and `sdkInstance`. As we seem to be transitioning between libraries we
need to ensure that we correctly handle those locations.

There aren't any unit tests in here so I did add some to at least cover
us for those scenarios.

----

I wish there were a better lint guard around this as it's bad
practice to just convert the type without checking.

## QA steps

It expects that you have setup the acceptance tests from the README.

```sh
$ ./assess_model_migration.py aws $GOPATH/bin/juju /tmp/artifacts
```

