### PR TITLE
Errcheck linter fixes

### DIFF
--- a/.github/golangci-lint.config.experimental.yaml
+++ b/.github/golangci-lint.config.experimental.yaml
@@ -1,0 +1,12 @@
+linters-settings:
+  errcheck:
+    check-type-assertions: false
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+run:
+  timeout: 20m
+  tests: false
+skip-dirs:
+  - acceptancetests

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tests/tmp.*
 *.out
 *.charm
 *.bundle
+*.log

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1032,7 +1032,7 @@ func lookupIPAddr(ctx context.Context, host string, resolver IPAddrResolver) ([]
 // logic even for errors that happen before we start a try.
 func recordTryError(try *parallel.Try, err error) {
 	logger.Infof("%v", err)
-	try.Start(func(_ <-chan struct{}) (io.Closer, error) {
+	_ = try.Start(func(_ <-chan struct{}) (io.Closer, error) {
 		return nil, errors.Trace(err)
 	})
 }

--- a/api/controller/gui.go
+++ b/api/controller/gui.go
@@ -69,7 +69,7 @@ func (c *Client) SelectGUIVersion(vers version.Number) error {
 		Version: vers,
 	})
 	if err != nil {
-		errors.Annotate(err, "cannot marshal request body")
+		return errors.Annotate(err, "cannot marshal request body")
 	}
 	req, err := http.NewRequest("PUT", guiVersionPath, bytes.NewReader(content))
 	if err != nil {

--- a/api/resources/http.go
+++ b/api/resources/http.go
@@ -95,5 +95,8 @@ func SendHTTPStatusAndJSON(w http.ResponseWriter, statusCode int, response inter
 	w.Header().Set("Content-Type", params.ContentTypeJSON)
 	w.Header().Set("Content-Length", fmt.Sprint(len(body)))
 	w.WriteHeader(statusCode)
-	w.Write(body)
+	_, err = w.Write(body)
+	if err != nil {
+		logger.Errorf("%v", err)
+	}
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -510,10 +510,10 @@ func (srv *Server) loop(ready chan struct{}) error {
 	// registered, first match wins. So more specific ones have to be
 	// registered first.
 	for _, ep := range srv.endpoints() {
-		srv.mux.AddHandler(ep.Method, ep.Pattern, ep.Handler)
+		_ = srv.mux.AddHandler(ep.Method, ep.Pattern, ep.Handler)
 		defer srv.mux.RemoveHandler(ep.Method, ep.Pattern)
 		if ep.Method == "GET" {
-			srv.mux.AddHandler("HEAD", ep.Pattern, ep.Handler)
+			_ = srv.mux.AddHandler("HEAD", ep.Pattern, ep.Handler)
 			defer srv.mux.RemoveHandler("HEAD", ep.Pattern)
 		}
 	}

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -186,7 +186,7 @@ func (h *charmsHandler) archiveEntrySender(filePath string, serveIcon bool) bund
 		}
 		w.Header().Set("Content-Length", strconv.Itoa(len(contents)))
 		w.WriteHeader(http.StatusOK)
-		io.Copy(w, bytes.NewReader(contents))
+		_, _ = io.Copy(w, bytes.NewReader(contents))
 		return nil
 	}
 }

--- a/apiserver/common/watch.go
+++ b/apiserver/common/watch.go
@@ -111,7 +111,7 @@ func NewMultiNotifyWatcher(w ...state.NotifyWatcher) *MultiNotifyWatcher {
 		<-w.Changes()
 		go func(wCopy state.NotifyWatcher) {
 			defer wg.Done()
-			wCopy.Wait()
+			_ = wCopy.Wait()
 		}(w)
 		// Copy events from the watcher to the staging channel.
 		go copyEvents(staging, w.Changes(), &m.tomb)

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -36,7 +36,7 @@ func handleDebugLogDBRequest(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer tailer.Stop()
+	defer func() { _ = tailer.Stop() }()
 
 	// Indicate that all is well.
 	socket.sendOk()

--- a/apiserver/embeddedcli.go
+++ b/apiserver/embeddedcli.go
@@ -59,9 +59,9 @@ func (h *embeddedCLIHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		// Here we configure the ping/pong handling for the websocket so
 		// the server can notice when the client goes away.
 		// See the long note in logsink.go for the rationale.
-		socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
+		_ = socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
 		socket.SetPongHandler(func(string) error {
-			socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
+			_ = socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
 			return nil
 		})
 		ticker := time.NewTicker(websocket.PingPeriod)

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -194,7 +194,7 @@ func singletonCode(err error) (string, bool) {
 	// that by catching the panic if we try to look up
 	// a non-hashable type.
 	defer func() {
-		recover()
+		_ = recover()
 	}()
 	code, ok := singletonErrorCodes[err]
 	return code, ok

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -116,7 +116,7 @@ func getAllUnits(st *state.State, tag names.Tag) ([]string, error) {
 	}
 	// Start a watcher on machine's units, read the initial event and stop it.
 	watch := machine.WatchUnits()
-	defer watch.Stop()
+	defer func() { _ = watch.Stop() }()
 	if units, ok := <-watch.Changes(); ok {
 		return units, nil
 	}

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -430,7 +430,7 @@ func (s *StorageProvisionerAPIv3) WatchVolumeAttachmentPlans(args params.Entitie
 		if stringChanges, ok := <-w.Changes(); ok {
 			changes, err := storagecommon.ParseVolumeAttachmentIds(stringChanges)
 			if err != nil {
-				w.Stop()
+				_ = w.Stop()
 				return "", nil, err
 			}
 			return s.resources.Register(w), changes, nil
@@ -514,7 +514,7 @@ func (s *StorageProvisionerAPIv3) watchAttachments(
 		if stringChanges, ok := <-w.Changes(); ok {
 			changes, err := parseAttachmentIds(stringChanges)
 			if err != nil {
-				w.Stop()
+				_ = w.Stop()
 				return "", nil, err
 			}
 			return s.resources.Register(w), changes, nil

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -231,7 +231,7 @@ func openCSClient(args OpenCSRepoParams) (*csclient.Client, error) {
 		// as a cookie in the HTTP client.
 		// TODO(cmars) discharge any third party caveats in the macaroon.
 		ms := []*macaroon.Macaroon{args.CharmStoreMacaroon}
-		httpbakery.SetCookie(csParams.BakeryClient.Jar, csURL, charmstore.MacaroonNamespace, ms)
+		_ = httpbakery.SetCookie(csParams.BakeryClient.Jar, csURL, charmstore.MacaroonNamespace, ms)
 	}
 	csClient := csclient.New(csParams)
 	channel := csparams.Channel(args.Channel)

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -202,6 +202,6 @@ func MetadataFromResult(result params.BackupsMetadataResult) *backups.Metadata {
 		MachineInstanceID: result.ControllerMachineInstanceID,
 		HANodes:           result.HANodes,
 	}
-	meta.SetFileInfo(result.Size, result.Checksum, result.ChecksumFormat)
+	_ = meta.SetFileInfo(result.Size, result.Checksum, result.ChecksumFormat)
 	return meta
 }

--- a/apiserver/facades/client/backups/restore.go
+++ b/apiserver/facades/client/backups/restore.go
@@ -51,7 +51,7 @@ func (a *API) Restore(p params.RestoreArgs) error {
 	}
 	// Any abnormal termination of this function will mark restore as failed,
 	// successful termination will call Exit and never run this.
-	defer info.SetStatus(state.RestoreFailed)
+	defer func() { _ = info.SetStatus(state.RestoreFailed) }()
 
 	instanceId, err := machine.InstanceId()
 	if err != nil {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -516,7 +516,7 @@ func (api *CrossModelRelationsAPI) WatchRelationsSuspendedStatus(
 			if err != nil {
 				results.Results[i].Error = apiservererrors.ServerError(err)
 				changesParams = nil
-				w.Stop()
+				_ = w.Stop()
 				break
 			}
 			changesParams[j] = *change
@@ -593,7 +593,7 @@ func (api *CrossModelRelationsAPI) WatchOfferStatus(
 		change, err := commoncrossmodel.GetOfferStatusChange(api.model, api.st, arg.OfferUUID, w.OfferName())
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
-			w.Stop()
+			_ = w.Stop()
 			break
 		}
 		results.Results[i].Changes = []params.OfferStatusChange{*change}

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -38,8 +38,8 @@ func addOfferAuthHandlers(offerAuthCtxt *crossmodel.AuthContext, mux *apiserverh
 		})
 	discharger.AddMuxHandlers(appOfferDischargeMux, localOfferAccessLocationPath)
 
-	mux.AddHandler("POST", localOfferAccessLocationPath+"/discharge", appOfferDischargeMux)
-	mux.AddHandler("GET", localOfferAccessLocationPath+"/publickey", appOfferDischargeMux)
+	_ = mux.AddHandler("POST", localOfferAccessLocationPath+"/discharge", appOfferDischargeMux)
+	_ = mux.AddHandler("GET", localOfferAccessLocationPath+"/publickey", appOfferDischargeMux)
 }
 
 func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error) {

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -209,17 +209,17 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// respond to ping control messages, so don't try.
 		var tickChannel <-chan time.Time
 		if endpointVersion > 0 {
-			socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
+			_ = socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
 			socket.SetPongHandler(func(string) error {
 				logger.Tracef("pong logsink %p", socket)
-				socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
+				_ = socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
 				return nil
 			})
 			ticker := time.NewTicker(websocket.PingPeriod)
 			defer ticker.Stop()
 			tickChannel = ticker.C
 		} else {
-			socket.SetReadDeadline(time.Now().Add(vZeroDelay))
+			_ = socket.SetReadDeadline(time.Now().Add(vZeroDelay))
 		}
 
 		stopReceiving, closer := h.newStopChannel()
@@ -323,7 +323,7 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 				// care that much.
 				h.mu.Lock()
 				defer h.mu.Unlock()
-				socket.WriteMessage(gorillaws.CloseMessage, []byte{})
+				_ = socket.WriteMessage(gorillaws.CloseMessage, []byte{})
 				return
 			}
 

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -352,7 +352,7 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 				// If the remote end does not support ping/pong, we bump
 				// the read deadline everytime a message is received.
 				if endpointVersion == 0 {
-					socket.SetReadDeadline(time.Now().Add(vZeroDelay))
+					_ = socket.SetReadDeadline(time.Now().Add(vZeroDelay))
 				}
 			}
 		}

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -214,7 +214,7 @@ func (h *logStreamRequestHandler) serveWebsocket(stop <-chan struct{}) {
 }
 
 func (h *logStreamRequestHandler) close() {
-	h.tailer.Stop()
+	_ = h.tailer.Stop()
 	h.poolHelper.Release()
 }
 

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -95,7 +95,7 @@ func (n *RequestObserver) Login(entity names.Tag, model names.ModelTag, fromCont
 		if !n.state.fromController {
 			n.connLogger.Infof("agent login: %s for %s", n.state.tag, n.state.model)
 		}
-		n.hub.Publish(apiserver.ConnectTopic, apiserver.APIConnection{
+		_, _ = n.hub.Publish(apiserver.ConnectTopic, apiserver.APIConnection{
 			AgentTag:        n.state.tag,
 			ControllerAgent: fromController,
 			ModelUUID:       model.Id(),
@@ -124,7 +124,7 @@ func (n *RequestObserver) Leave() {
 		if !n.state.fromController {
 			n.connLogger.Infof("agent disconnected: %s for %s", n.state.tag, n.state.model)
 		}
-		n.hub.Publish(apiserver.DisconnectTopic, apiserver.APIConnection{
+		_, _ = n.hub.Publish(apiserver.DisconnectTopic, apiserver.APIConnection{
 			AgentTag:        n.state.tag,
 			ControllerAgent: n.state.fromController,
 			ModelUUID:       n.state.model,

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -51,9 +51,9 @@ func (h *pubsubHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Here we configure the ping/pong handling for the websocket so
 		// the server can notice when the client goes away.
 		// See the long note in logsink.go for the rationale.
-		socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
+		_ = socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
 		socket.SetPongHandler(func(string) error {
-			socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
+			_ = socket.SetReadDeadline(time.Now().Add(websocket.PongDelay))
 			return nil
 		})
 		ticker := time.NewTicker(websocket.PingPeriod)

--- a/apiserver/rest.go
+++ b/apiserver/rest.go
@@ -143,6 +143,6 @@ func (h *modelRestHandler) byteSender(w http.ResponseWriter, ext string, content
 	}
 	w.Header().Set("Content-Length", strconv.Itoa(len(contents)))
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, bytes.NewReader(contents))
+	_, _ = io.Copy(w, bytes.NewReader(contents))
 	return nil
 }

--- a/apiserver/stateauthenticator/legacy.go
+++ b/apiserver/stateauthenticator/legacy.go
@@ -42,9 +42,9 @@ func (h *localLoginHandlers) AddLegacyHandlers(mux *apiserverhttp.Mux, discharge
 		localUserIdentityLocationPath+"/wait",
 		makeHandler(h.serveWait),
 	)
-	mux.AddHandler("GET", localUserIdentityLocationPath+"/wait", dischargeMux)
-	mux.AddHandler("GET", localUserIdentityLocationPath+"/login", dischargeMux)
-	mux.AddHandler("POST", localUserIdentityLocationPath+"/login", dischargeMux)
+	_ = mux.AddHandler("GET", localUserIdentityLocationPath+"/wait", dischargeMux)
+	_ = mux.AddHandler("GET", localUserIdentityLocationPath+"/login", dischargeMux)
+	_ = mux.AddHandler("POST", localUserIdentityLocationPath+"/login", dischargeMux)
 }
 
 func (h *localLoginHandlers) serveLogin(response http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/apiserver/stateauthenticator/locallogin.go
+++ b/apiserver/stateauthenticator/locallogin.go
@@ -50,10 +50,10 @@ func (h *localLoginHandlers) AddHandlers(mux *apiserverhttp.Mux) {
 		localUserIdentityLocationPath+formURL,
 		http.HandlerFunc(h.formHandler),
 	)
-	mux.AddHandler("POST", localUserIdentityLocationPath+"/discharge", dischargeMux)
-	mux.AddHandler("GET", localUserIdentityLocationPath+"/publickey", dischargeMux)
-	mux.AddHandler("GET", localUserIdentityLocationPath+"/form", dischargeMux)
-	mux.AddHandler("POST", localUserIdentityLocationPath+"/form", dischargeMux)
+	_ = mux.AddHandler("POST", localUserIdentityLocationPath+"/discharge", dischargeMux)
+	_ = mux.AddHandler("GET", localUserIdentityLocationPath+"/publickey", dischargeMux)
+	_ = mux.AddHandler("GET", localUserIdentityLocationPath+"/form", dischargeMux)
+	_ = mux.AddHandler("POST", localUserIdentityLocationPath+"/form", dischargeMux)
 
 	h.AddLegacyHandlers(mux, dischargeMux)
 }

--- a/apiserver/stateauthenticator/locallogin.go
+++ b/apiserver/stateauthenticator/locallogin.go
@@ -93,7 +93,7 @@ func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Reques
 			return
 		}
 
-		token, err := newId()
+		token, err := newID()
 		if err != nil {
 			h.bakeryError(w, errors.Annotate(err, "cannot generate token"))
 			return
@@ -106,13 +106,13 @@ func (h *localLoginHandlers) formHandler(w http.ResponseWriter, req *http.Reques
 				Value: []byte(token),
 			},
 		}
-		httprequest.WriteJSON(w, http.StatusOK, loginResponse)
+		_ = httprequest.WriteJSON(w, http.StatusOK, loginResponse)
 	default:
 		http.Error(w, fmt.Sprintf("%s method not allowed", req.Method), http.StatusMethodNotAllowed)
 	}
 }
 
-func newId() (string, error) {
+func newID() (string, error) {
 	var id [12]byte
 	if _, err := rand.Read(id[:]); err != nil {
 		return "", fmt.Errorf("cannot read random id: %v", err)
@@ -133,15 +133,15 @@ func (h *localLoginHandlers) checkThirdPartyCaveat(stdCtx context.Context, req *
 		err2.SetInteraction("juju_userpass", form.InteractionInfo{URL: localUserIdentityLocationPath + formURL})
 
 		// TODO(juju3) - remove legacy client support
-		waitId, err := h.authCtxt.localUserInteractions.Start(
+		waitID, err := h.authCtxt.localUserInteractions.Start(
 			cavInfo.Caveat,
 			h.authCtxt.clock.Now().Add(authentication.LocalLoginInteractionTimeout),
 		)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		visitURL := localUserIdentityLocationPath + "/login?waitid=" + waitId
-		waitURL := localUserIdentityLocationPath + "/wait?waitid=" + waitId
+		visitURL := localUserIdentityLocationPath + "/login?waitid=" + waitID
+		waitURL := localUserIdentityLocationPath + "/wait?waitid=" + waitID
 		httpbakery.SetLegacyInteraction(err2, visitURL, waitURL)
 		return nil, err2
 	}

--- a/apiserver/websocket/websocket.go
+++ b/apiserver/websocket/websocket.go
@@ -69,8 +69,7 @@ func (conn *Conn) SendInitialErrorV0(err error) error {
 
 	body, err := json.Marshal(wrapped)
 	if err != nil {
-		errors.Annotatef(err, "cannot marshal error %#v", wrapped)
-		return err
+		return errors.Annotatef(err, "cannot marshal error %#v", wrapped)
 	}
 	body = append(body, '\n')
 
@@ -83,7 +82,7 @@ func (conn *Conn) SendInitialErrorV0(err error) error {
 
 	if wrapped.Error != nil {
 		// Tell the other end we are closing.
-		conn.WriteMessage(websocket.CloseMessage, []byte{})
+		_ = conn.WriteMessage(websocket.CloseMessage, []byte{})
 	}
 
 	return errors.Trace(err)

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -546,7 +546,7 @@ func (c *controllerStack) createControllerService() error {
 
 	c.addCleanUp(func() {
 		logger.Debugf("deleting %q", svcName)
-		c.broker.deleteService(svcName)
+		_ = c.broker.deleteService(svcName)
 	})
 
 	publicAddressPoller := func() error {
@@ -598,7 +598,7 @@ func (c *controllerStack) createControllerSecretSharedSecret() error {
 	logger.Debugf("ensuring shared secret: \n%+v", secret)
 	c.addCleanUp(func() {
 		logger.Debugf("deleting %q shared-secret", secret.Name)
-		c.broker.deleteSecret(secret.GetName(), secret.GetUID())
+		_ = c.broker.deleteSecret(secret.GetName(), secret.GetUID())
 	})
 	return c.broker.updateSecret(secret)
 }
@@ -619,7 +619,7 @@ func (c *controllerStack) createControllerSecretServerPem() error {
 	logger.Debugf("ensuring server.pem secret: \n%+v", secret)
 	c.addCleanUp(func() {
 		logger.Debugf("deleting %q server.pem", secret.Name)
-		c.broker.deleteSecret(secret.GetName(), secret.GetUID())
+		_ = c.broker.deleteSecret(secret.GetName(), secret.GetUID())
 	})
 	return c.broker.updateSecret(secret)
 }
@@ -778,7 +778,7 @@ func (c *controllerStack) createControllerStatefulset() error {
 	logger.Debugf("creating controller statefulset: \n%+v", spec)
 	c.addCleanUp(func() {
 		logger.Debugf("deleting %q statefulset", spec.Name)
-		c.broker.deleteStatefulSet(spec.Name)
+		_ = c.broker.deleteStatefulSet(spec.Name)
 	})
 	w, err := c.broker.WatchUnits(c.resourceNameStatefulSet, caas.ModeWorkload)
 	if err != nil {
@@ -901,11 +901,11 @@ func (c *controllerStack) waitForPod(podWatcher watcher.NotifyWatcher, podName s
 		return false, nil
 	}
 
-	printPodEvents()
+	_ = printPodEvents()
 	for {
 		select {
 		case <-podWatcher.Changes():
-			printPodEvents()
+			_ = printPodEvents()
 			pod, err := c.broker.getPod(podName)
 			if errors.IsNotFound(err) {
 				logger.Debugf("pod %q is not provisioned yet", podName)
@@ -923,7 +923,7 @@ func (c *controllerStack) waitForPod(podWatcher watcher.NotifyWatcher, podName s
 				return nil
 			}
 		case <-podEventWatcher.Changes():
-			printPodEvents()
+			_ = printPodEvents()
 		case <-timeout.Chan():
 			err := pendingReason()
 			if err != nil {

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -309,7 +309,7 @@ func ensureCustomResource(api dynamic.ResourceInterface, cr *unstructured.Unstru
 	logger.Debugf("creating custom resource %q", cr.GetName())
 	if out, err = api.Create(context.TODO(), cr, metav1.CreateOptions{}); err == nil {
 		cleanUps = append(cleanUps, func() {
-			deleteCustomResourceDefinition(api, out.GetName(), out.GetUID())
+			_ = deleteCustomResourceDefinition(api, out.GetName(), out.GetUID())
 		})
 		return out, cleanUps, nil
 	}

--- a/caas/kubernetes/provider/specs/builder.go
+++ b/caas/kubernetes/provider/specs/builder.go
@@ -83,7 +83,7 @@ func (ri *resourceInfo) withNamespace(namespace string) *resourceInfo {
 		logger.Debugf("namespace is force set from %q to %q", ri.namespace, namespace)
 	}
 	ri.namespace = namespace
-	metadataAccessor.SetNamespace(ri.content.Object, ri.namespace)
+	_ = metadataAccessor.SetNamespace(ri.content.Object, ri.namespace)
 	return ri
 }
 

--- a/charmstore/client.go
+++ b/charmstore/client.go
@@ -203,7 +203,7 @@ func (c Client) GetResource(req ResourceRequest) (data ResourceData, err error) 
 	if err := c.jar.Activate(req.Charm); err != nil {
 		return ResourceData{}, errors.Trace(err)
 	}
-	defer c.jar.Deactivate()
+	defer func() { _ = c.jar.Deactivate() }()
 	meta, err := c.csWrapper.ResourceMeta(req.Channel, req.Charm, req.Name, req.Revision)
 
 	if err != nil {
@@ -238,7 +238,7 @@ func (c Client) ResourceInfo(req ResourceRequest) (resource.Resource, error) {
 	if err := c.jar.Activate(req.Charm); err != nil {
 		return resource.Resource{}, errors.Trace(err)
 	}
-	defer c.jar.Deactivate()
+	defer func() { _ = c.jar.Deactivate() }()
 	meta, err := c.csWrapper.ResourceMeta(req.Channel, req.Charm, req.Name, req.Revision)
 	if err != nil {
 		return resource.Resource{}, errors.Trace(err)
@@ -272,7 +272,7 @@ func (c Client) listResources(ch CharmID) ([]resource.Resource, error) {
 	if err := c.jar.Activate(ch.URL); err != nil {
 		return nil, errors.Trace(err)
 	}
-	defer c.jar.Deactivate()
+	defer func() { _ = c.jar.Deactivate() }()
 	resources, err := c.csWrapper.ListResources(ch.Channel, ch.URL)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/charmstore/jar.go
+++ b/charmstore/jar.go
@@ -76,7 +76,7 @@ func (j *macaroonJar) Activate(cURL *charm.URL) error {
 		return errors.Trace(err)
 	}
 	if m != nil {
-		httpbakery.SetCookie(j.underlying, j.serverURL, MacaroonNamespace, m)
+		_ = httpbakery.SetCookie(j.underlying, j.serverURL, MacaroonNamespace, m)
 	}
 	return nil
 }

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -203,7 +203,7 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("juju run action not supported on this version of Juju")
 	}
 
-	operationId, results, err := c.enqueueActions(ctx)
+	operationID, results, err := c.enqueueActions(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -213,7 +213,7 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 		if numTasks > 1 {
 			plural = "s"
 		}
-		ctx.Infof("Running operation %s with %d task%s", operationId, numTasks, plural)
+		ctx.Infof("Running operation %s with %d task%s", operationID, numTasks, plural)
 	}
 
 	var actionID string
@@ -237,13 +237,13 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	ctx.Infof("")
 	if c.background {
 		if numTasks == 1 {
-			ctx.Infof("Scheduled operation %s with task %s", operationId, actionID)
-			ctx.Infof("Check operation status with 'juju show-operation %s'", operationId)
+			ctx.Infof("Scheduled operation %s with task %s", operationID, actionID)
+			ctx.Infof("Check operation status with 'juju show-operation %s'", operationID)
 			ctx.Infof("Check task status with 'juju show-task %s'", actionID)
 		} else {
-			ctx.Infof("Scheduled operation %s with %d tasks", operationId, numTasks)
-			cmd.FormatYaml(ctx.Stdout, info)
-			ctx.Infof("Check operation status with 'juju show-operation %s'", operationId)
+			ctx.Infof("Scheduled operation %s with %d tasks", operationID, numTasks)
+			_ = cmd.FormatYaml(ctx.Stdout, info)
+			ctx.Infof("Check operation status with 'juju show-operation %s'", operationID)
 			ctx.Infof("Check task status with 'juju show-task <id>'")
 		}
 		return nil
@@ -279,7 +279,7 @@ func (c *runCommand) waitForTasks(ctx *cmd.Context, tasks []enqueuedAction, info
 	waitForWatcher := func() {
 		close(actionDone)
 		if logsWatcher != nil {
-			logsWatcher.Wait()
+			_ = logsWatcher.Wait()
 		}
 	}
 

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -76,9 +76,6 @@ func (c *CommandBase) SetFlags(f *gnuflag.FlagSet) {
 
 // Init implements Command.SetFlags.
 func (c *CommandBase) Init(args []string) error {
-	if err := c.ModelCommandBase.Init(args); err != nil {
-		return errors.Trace(err)
-	}
 	c.fs.Visit(func(flag *gnuflag.Flag) {
 		if flag.Name == "verbose" {
 			c.verbose = true

--- a/cmd/juju/backups/backups.go
+++ b/cmd/juju/backups/backups.go
@@ -63,7 +63,7 @@ func (c *CommandBase) NewAPIClient() (APIClient, error) {
 	return newAPIClient(c)
 }
 
-// NewAPIClient returns a client for the backups api endpoint.
+// NewGetAPI returns a client for the backups api endpoint.
 func (c *CommandBase) NewGetAPI() (APIClient, int, error) {
 	return getAPI(c)
 }
@@ -76,7 +76,9 @@ func (c *CommandBase) SetFlags(f *gnuflag.FlagSet) {
 
 // Init implements Command.SetFlags.
 func (c *CommandBase) Init(args []string) error {
-	c.ModelCommandBase.Init(args)
+	if err := c.ModelCommandBase.Init(args); err != nil {
+		return errors.Trace(err)
+	}
 	c.fs.Visit(func(flag *gnuflag.Flag) {
 		if flag.Name == "verbose" {
 			c.verbose = true
@@ -185,7 +187,7 @@ func (c *CommandBase) metadata(result *params.BackupsMetadataResult) string {
 	}
 	t := template.Must(template.New("template").Parse(backupMetadataTemplate))
 	content := bytes.Buffer{}
-	t.Execute(&content, m)
+	_ = t.Execute(&content, m)
 	return content.String()
 }
 

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -99,10 +99,10 @@ func (iw infoWriter) writeOpenChanneltoBuffer(w *UnicodeWriter, channel Channel)
 func (iw infoWriter) writeClosedChannelToBuffer(w *UnicodeWriter, name string, hasOpenChannel bool) {
 	w.Printf("%s:", name)
 	if hasOpenChannel {
-		w.PrintlnUnicode(UnicodeUpArrow)
+		_, _ = w.PrintlnUnicode(UnicodeUpArrow)
 		return
 	}
-	w.PrintlnUnicode(UnicodeDash)
+	_, _ = w.PrintlnUnicode(UnicodeDash)
 }
 
 type bundleInfoOutput struct {

--- a/cmd/juju/cloud/detectcredentials.go
+++ b/cmd/juju/cloud/detectcredentials.go
@@ -528,7 +528,7 @@ func (c *detectCredentialsCommand) printCredentialOptions(ctxt *cmd.Context, dis
 
 func (c *detectCredentialsCommand) promptCredentialNumber(out io.Writer, in io.Reader) (string, error) {
 	fmt.Fprint(out, "Select a credential to save by number, or type Q to quit: ")
-	defer out.Write([]byte{'\n'})
+	defer func() { _, _ = out.Write([]byte{'\n'}) }()
 	input, err := readLine(in)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -539,7 +539,7 @@ func (c *detectCredentialsCommand) promptCredentialNumber(out io.Writer, in io.R
 func (c *detectCredentialsCommand) promptCloudName(out io.Writer, in io.Reader, defaultCloudName string) (string, error) {
 	text := fmt.Sprintf(`Select the cloud it belongs to, or type Q to quit [%s]: `, defaultCloudName)
 	fmt.Fprint(out, text)
-	defer out.Write([]byte{'\n'})
+	defer func() { _, _ = out.Write([]byte{'\n'}) }()
 	input, err := readLine(in)
 	if err != nil {
 		return "", errors.Trace(err)

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -410,8 +410,8 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 		if c.compat {
 			codeKey = "ReturnCode"
 		}
-		ctx.Stdout.Write(formatOutput(result, stdoutKey, c.compat))
-		ctx.Stderr.Write(formatOutput(result, stderrKey, c.compat))
+		_, _ = ctx.Stdout.Write(formatOutput(result, stdoutKey, c.compat))
+		_, _ = ctx.Stderr.Write(formatOutput(result, stderrKey, c.compat))
 		if code, ok := result[codeKey].(int); ok && code != 0 {
 			return cmd.NewRcPassthroughError(code)
 		}
@@ -421,7 +421,7 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 			messageKey = "Message"
 		}
 		if res, ok := result[messageKey].(string); ok && res != "" {
-			ctx.Stderr.Write([]byte(res))
+			_, _ = ctx.Stderr.Write([]byte(res))
 		}
 
 		return nil

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -145,7 +145,7 @@ func (c *helpToolCommand) Run(ctx *cmd.Context) error {
 		info := c.Info()
 		f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, cmd.FlagAlias(c, "option"))
 		c.SetFlags(f)
-		ctx.Stdout.Write(info.Help(f))
+		_, _ = ctx.Stdout.Write(info.Help(f))
 	}
 	return nil
 }

--- a/cmd/juju/commands/ssh_machine.go
+++ b/cmd/juju/commands/ssh_machine.go
@@ -315,7 +315,7 @@ func (c *sshMachine) generateKnownHosts(targets []*resolvedTarget) (string, erro
 	}
 	defer f.Close()
 	c.knownHostsPath = f.Name() // Record for later deletion
-	if knownHosts.write(f); err != nil {
+	if err := knownHosts.write(f); err != nil {
 		return "", errors.Trace(err)
 	}
 	return c.knownHostsPath, nil

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -124,8 +124,8 @@ func (c *syncToolsCommand) Run(ctx *cmd.Context) (resultErr error) {
 	writer := loggo.NewMinimumLevelWriter(
 		cmd.NewCommandLogWriter("juju.environs.sync", ctx.Stdout, ctx.Stderr),
 		loggo.INFO)
-	loggo.RegisterWriter("syncagentbinaries", writer)
-	defer loggo.RemoveWriter("syncagentbinaries")
+	_ = loggo.RegisterWriter("syncagentbinaries", writer)
+	defer func() { _, _ = loggo.RemoveWriter("syncagentbinaries") }()
 
 	sctx := &sync.SyncContext{
 		AllVersions:  c.allVersions,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -100,7 +100,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	}
 
 	if fs.Storage != nil {
-		storage.FormatStorageListForStatusTabular(tw, *fs.Storage)
+		_ = storage.FormatStorageListForStatusTabular(tw, *fs.Storage)
 	}
 
 	endSection(tw)
@@ -108,7 +108,7 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 }
 
 func startSection(tw *ansiterm.TabWriter, top bool, headers ...interface{}) output.Wrapper {
-	w := output.Wrapper{tw}
+	w := output.Wrapper{TabWriter: tw}
 	if !top {
 		w.Println()
 	}

--- a/cmd/jujud/agent/addons/addons.go
+++ b/cmd/jujud/agent/addons/addons.go
@@ -80,10 +80,10 @@ func StartIntrospection(cfg IntrospectionConfig) error {
 		return errors.Trace(err)
 	}
 	go func() {
-		cfg.Engine.Wait()
+		_ = cfg.Engine.Wait()
 		logger.Debugf("engine stopped, stopping introspection")
 		w.Kill()
-		w.Wait()
+		_ = w.Wait()
 		logger.Debugf("introspection stopped")
 	}()
 

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -206,7 +206,7 @@ func (op *CaasOperatorAgent) Run(ctx *cmd.Context) (err error) {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
 
-	op.runner.StartWorker("api", op.Workers)
+	_ = op.runner.StartWorker("api", op.Workers)
 	return cmdutil.AgentDone(logger, op.runner.Wait())
 }
 
@@ -221,7 +221,7 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 
 	agentConfig := op.AgentConf.CurrentConfig()
 	manifoldConfig := caasoperator.ManifoldsConfig{
-		Agent:                agent.APIHostPortsSetter{op},
+		Agent:                agent.APIHostPortsSetter{Agent: op},
 		AgentConfigChanged:   op.configChangedVal,
 		Clock:                clock.WallClock,
 		LogSource:            op.bufferedLogger.Logs(),

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -205,7 +205,7 @@ func (a *machineAgentCmd) Init(args []string) error {
 	// models that have been upgraded, we need to explicitly remove the
 	// file writer if one has been added, otherwise we will get duplicate
 	// lines of all logging in the log file.
-	loggo.RemoveWriter("logfile")
+	_, _ = loggo.RemoveWriter("logfile")
 
 	if a.machineId != "" {
 		a.agentTag = names.NewMachineTag(a.machineId)
@@ -507,7 +507,7 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {
 		return err
 	}
-	a.runner.StartWorker("engine", createEngine)
+	_ = a.runner.StartWorker("engine", createEngine)
 
 	// At this point, all workers will have been configured to start
 	close(a.workersStarted)
@@ -730,7 +730,7 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 		}
 	}
 	if !isController {
-		runner.StartWorker("stateconverter", func() (worker.Worker, error) {
+		_ = runner.StartWorker("stateconverter", func() (worker.Worker, error) {
 			// TODO(fwereade): this worker needs its own facade.
 			facade := apimachiner.NewState(apiConn)
 			handler := conv2state.New(facade, a)

--- a/cmd/jujud/agent/model.go
+++ b/cmd/jujud/agent/model.go
@@ -116,7 +116,7 @@ func (m *ModelCommand) Run(ctx *cmd.Context) error {
 
 	m.upgradeComplete = upgradesteps.NewLock(m.CurrentConfig())
 
-	m.runner.StartWorker("modeloperator", m.Workers)
+	_ = m.runner.StartWorker("modeloperator", m.Workers)
 	return cmdutil.AgentDone(logger, m.runner.Wait())
 }
 

--- a/cmd/jujud/agent/unit.go
+++ b/cmd/jujud/agent/unit.go
@@ -167,7 +167,7 @@ func (a *UnitAgent) Run(ctx *cmd.Context) (err error) {
 	}
 	agentconf.SetupAgentLogging(loggo.DefaultContext(), a.CurrentConfig())
 
-	a.runner.StartWorker("api", a.APIWorkers)
+	_ = a.runner.StartWorker("api", a.APIWorkers)
 	err = cmdutil.AgentDone(logger, a.runner.Wait())
 	return err
 }
@@ -196,7 +196,7 @@ func (a *UnitAgent) APIWorkers() (worker.Worker, error) {
 	}
 
 	manifolds := unitManifolds(unit.ManifoldsConfig{
-		Agent:                agent.APIHostPortsSetter{a},
+		Agent:                agent.APIHostPortsSetter{Agent: a},
 		LogSource:            a.bufferedLogger.Logs(),
 		LeadershipGuarantee:  30 * time.Second,
 		AgentConfigChanged:   a.configChangedVal,

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -197,7 +197,7 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.Stat
 		if !ok {
 			break
 		}
-		writer.WriteString(c.format(
+		_, _ = writer.WriteString(c.format(
 			rec.Time,
 			rec.Level,
 			rec.Entity,

--- a/cmd/jujud/introspect/introspect.go
+++ b/cmd/jujud/introspect/introspect.go
@@ -163,7 +163,7 @@ func (c *IntrospectCommand) Run(ctx *cmd.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(ctx.Stderr, resp.Body)
+		_, _ = io.Copy(ctx.Stderr, resp.Body)
 		return errors.Errorf(
 			"response returned %d (%s)",
 			resp.StatusCode,

--- a/cmd/jujud/run/run.go
+++ b/cmd/jujud/run/run.go
@@ -227,8 +227,8 @@ func (c *RunCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	ctx.Stdout.Write(result.Stdout)
-	ctx.Stderr.Write(result.Stderr)
+	_, _ = ctx.Stdout.Write(result.Stdout)
+	_, _ = ctx.Stderr.Write(result.Stderr)
 	return cmd.NewRcPassthroughError(result.Code)
 }
 

--- a/cmd/k8sagent/unit/agent.go
+++ b/cmd/k8sagent/unit/agent.go
@@ -325,7 +325,7 @@ func (c *k8sUnitAgent) Run(ctx *cmd.Context) (err error) {
 		ctx.Warningf("developer feature flags enabled: %s", flags)
 	}
 
-	c.runner.StartWorker("unit", c.workers)
+	_ = c.runner.StartWorker("unit", c.workers)
 	return AgentDone(logger, c.runner.Wait())
 }
 

--- a/cmd/plugins/juju-metadata/generateagents.go
+++ b/cmd/plugins/juju-metadata/generateagents.go
@@ -110,8 +110,8 @@ func (c *generateAgentsCommand) Run(context *cmd.Context) error {
 	writer := loggo.NewMinimumLevelWriter(
 		cmd.NewCommandLogWriter("juju.environs.tools", context.Stdout, context.Stderr),
 		loggo.INFO)
-	loggo.RegisterWriter("toolsmetadata", writer)
-	defer loggo.RemoveWriter("toolsmetadata")
+	_ = loggo.RegisterWriter("toolsmetadata", writer)
+	defer func() { _, _ = loggo.RemoveWriter("toolsmetadata") }()
 	if c.metadataDir == "" {
 		c.metadataDir = osenv.JujuXDGDataHomeDir()
 	} else {

--- a/cmd/plugins/juju-metadata/signmetadata.go
+++ b/cmd/plugins/juju-metadata/signmetadata.go
@@ -68,8 +68,8 @@ func (c *signMetadataCommand) Run(context *cmd.Context) error {
 	writer := loggo.NewMinimumLevelWriter(
 		cmd.NewCommandLogWriter("juju.plugins.metadata", context.Stdout, context.Stderr),
 		loggo.INFO)
-	loggo.RegisterWriter("signmetadata", writer)
-	defer loggo.RemoveWriter("signmetadata")
+	_ = loggo.RegisterWriter("signmetadata", writer)
+	defer func() { _, _ = loggo.RemoveWriter("signmetadata") }()
 	keyData, err := ioutil.ReadFile(c.keyFile)
 	if err != nil {
 		return err

--- a/cmd/plugins/juju-metadata/validateagentsmetadata.go
+++ b/cmd/plugins/juju-metadata/validateagentsmetadata.go
@@ -242,7 +242,7 @@ func (c *validateAgentsMetadataCommand) Run(context *cmd.Context) error {
 			"Matching Tools Versions": versions,
 			"Resolve Metadata":        *resolveInfo,
 		}
-		c.out.Write(context, metadata)
+		_ = c.out.Write(context, metadata)
 	} else {
 		var sources []string
 		for _, s := range params.Sources {

--- a/cmd/plugins/juju-metadata/validateimagemetadata.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata.go
@@ -142,7 +142,7 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 		return err
 	}
 
-	image_ids, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
+	images, resolveInfo, err := imagemetadata.ValidateImageMetadata(params)
 	if err != nil {
 		if resolveInfo != nil {
 			metadata := map[string]interface{}{
@@ -155,13 +155,13 @@ func (c *validateImageMetadataCommand) Run(context *cmd.Context) error {
 		}
 		return err
 	}
-	if len(image_ids) > 0 {
+	if len(images) > 0 {
 		metadata := map[string]interface{}{
-			"ImageIds":         image_ids,
+			"ImageIds":         images,
 			"Region":           params.Region,
 			"Resolve Metadata": *resolveInfo,
 		}
-		c.out.Write(context, metadata)
+		_ = c.out.Write(context, metadata)
 	} else {
 		var sources []string
 		for _, s := range params.Sources {

--- a/component/all/payload.go
+++ b/component/all/payload.go
@@ -71,7 +71,7 @@ func (c payloads) registerHookContext() {
 		return
 	}
 
-	unitercontext.RegisterComponentFunc(payload.ComponentName,
+	_ = unitercontext.RegisterComponentFunc(payload.ComponentName,
 		func(config unitercontext.ComponentConfig) (jujuc.ContextComponent, error) {
 			hctxClient := c.newUnitFacadeClient(config.APICaller)
 			// TODO(ericsnow) Pass the unit's tag through to the component?

--- a/component/all/resource.go
+++ b/component/all/resource.go
@@ -57,7 +57,7 @@ func (r resources) registerHookContext() {
 		return
 	}
 
-	unitercontext.RegisterComponentFunc(
+	_ = unitercontext.RegisterComponentFunc(
 		resource.ComponentName,
 		func(config unitercontext.ComponentConfig) (jujuc.ContextComponent, error) {
 			unitID := names.NewUnitTag(config.UnitName).String()

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -109,20 +109,20 @@ func (m *containerManager) CreateContainer(
 	storageConfig *container.StorageConfig,
 	callback environs.StatusCallbackFunc,
 ) (instances.Instance, *instance.HardwareCharacteristics, error) {
-	callback(status.Provisioning, "Creating container spec", nil)
+	_ = callback(status.Provisioning, "Creating container spec", nil)
 	spec, err := m.getContainerSpec(instanceConfig, cons, series, networkConfig, storageConfig, callback)
 	if err != nil {
-		callback(status.ProvisioningError, fmt.Sprintf("Creating container spec: %v", err), nil)
+		_ = callback(status.ProvisioningError, fmt.Sprintf("Creating container spec: %v", err), nil)
 		return nil, nil, errors.Trace(err)
 	}
 
-	callback(status.Provisioning, "Creating container", nil)
+	_ = callback(status.Provisioning, "Creating container", nil)
 	c, err := m.server.CreateContainerFromSpec(spec)
 	if err != nil {
-		callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+		_ = callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
 		return nil, nil, errors.Trace(err)
 	}
-	callback(status.Running, "Container started", nil)
+	_ = callback(status.Running, "Container started", nil)
 
 	return &lxdInstance{c.Name, m.server.ContainerServer},
 		&instance.HardwareCharacteristics{AvailabilityZone: &m.availabilityZone}, nil

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -314,7 +314,7 @@ func (t *LiveTests) TestPorts(c *gc.C) {
 
 	inst1, _ := jujutesting.AssertStartInstance(c, t.Env, t.ProviderCallContext, t.ControllerUUID, "1")
 	c.Assert(inst1, gc.NotNil)
-	defer t.Env.StopInstances(t.ProviderCallContext, inst1.Id())
+	defer func() { _ = t.Env.StopInstances(t.ProviderCallContext, inst1.Id()) }()
 	fwInst1, ok := inst1.(instances.InstanceFirewaller)
 	c.Assert(ok, gc.Equals, true)
 
@@ -329,7 +329,7 @@ func (t *LiveTests) TestPorts(c *gc.C) {
 	rules, err = fwInst2.IngressRules(t.ProviderCallContext, "2")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rules, gc.HasLen, 0)
-	defer t.Env.StopInstances(t.ProviderCallContext, inst2.Id())
+	defer func() { _ = t.Env.StopInstances(t.ProviderCallContext, inst2.Id()) }()
 
 	// Open some ports and check they're there.
 	err = fwInst1.OpenPorts(t.ProviderCallContext,
@@ -508,7 +508,7 @@ func (t *LiveTests) TestGlobalPorts(c *gc.C) {
 
 	// Create instances and check open ports on both instances.
 	inst1, _ := jujutesting.AssertStartInstance(c, t.Env, t.ProviderCallContext, t.ControllerUUID, "1")
-	defer t.Env.StopInstances(t.ProviderCallContext, inst1.Id())
+	defer func() { _ = t.Env.StopInstances(t.ProviderCallContext, inst1.Id()) }()
 
 	fwEnv, ok := t.Env.(environs.Firewaller)
 	c.Assert(ok, gc.Equals, true)
@@ -521,7 +521,7 @@ func (t *LiveTests) TestGlobalPorts(c *gc.C) {
 	rules, err = fwEnv.IngressRules(t.ProviderCallContext)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rules, gc.HasLen, 0)
-	defer t.Env.StopInstances(t.ProviderCallContext, inst2.Id())
+	defer func() { _ = t.Env.StopInstances(t.ProviderCallContext, inst2.Id()) }()
 
 	err = fwEnv.OpenPorts(t.ProviderCallContext,
 		firewall.IngressRules{
@@ -669,7 +669,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	c.Assert(status.Machines["0"].InstanceId, gc.Equals, string(instId0))
 
 	mw0 := newMachineToolWaiter(m0)
-	defer mw0.Stop()
+	defer func() { _ = mw0.Stop() }()
 
 	// If the series has not been specified, we expect the most recent Ubuntu LTS release to be used.
 	expectedVersion := version.Binary{
@@ -699,7 +699,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	m1, err := st.Machine(mid1)
 	c.Assert(err, jc.ErrorIsNil)
 	mw1 := newMachineToolWaiter(m1)
-	defer mw1.Stop()
+	defer func() { _ = mw1.Stop() }()
 	waitAgentTools(c, mw1, mtools0.Version)
 
 	err = m1.Refresh()
@@ -707,7 +707,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 	instId1, err := m1.InstanceId()
 	c.Assert(err, jc.ErrorIsNil)
 	uw := newUnitToolWaiter(unit)
-	defer uw.Stop()
+	defer func() { _ = uw.Stop() }()
 	utools := waitAgentTools(c, uw, expectedVersion)
 
 	// Check that we can upgrade the environment.
@@ -732,7 +732,7 @@ func (t *LiveTests) TestBootstrapAndDeploy(c *gc.C) {
 
 	// Wait until unit is dead
 	uwatch := unit.Watch()
-	defer uwatch.Stop()
+	defer func() { _ = uwatch.Stop() }()
 	for unit.Life() != state.Dead {
 		c.Logf("waiting for unit change")
 		<-uwatch.Changes()
@@ -963,7 +963,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		args,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	defer e.(environs.Environ).Destroy(t.ProviderCallContext)
+	defer func() { _ = e.(environs.Environ).Destroy(t.ProviderCallContext) }()
 
 	t.Destroy(c)
 
@@ -976,7 +976,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		t.ControllerStore,
 		args)
 	c.Assert(err, jc.ErrorIsNil)
-	defer environs.Destroy("livetests", env, t.ProviderCallContext, t.ControllerStore)
+	defer func() { _ = environs.Destroy("livetests", env, t.ProviderCallContext, t.ControllerStore) }()
 
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), env, t.ProviderCallContext, t.bootstrapParams())
 	c.Assert(err, jc.ErrorIsNil)
@@ -987,7 +987,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	m0, err := st.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
 	mw0 := newMachineToolWaiter(m0)
-	defer mw0.Stop()
+	defer func() { _ = mw0.Stop() }()
 
 	waitAgentTools(c, mw0, other)
 }
@@ -997,7 +997,7 @@ func (t *LiveTests) TestIngressRulesWithPartiallyMatchingCIDRs(c *gc.C) {
 
 	inst1, _ := jujutesting.AssertStartInstance(c, t.Env, t.ProviderCallContext, t.ControllerUUID, "1")
 	c.Assert(inst1, gc.NotNil)
-	defer t.Env.StopInstances(t.ProviderCallContext, inst1.Id())
+	defer func() { _ = t.Env.StopInstances(t.ProviderCallContext, inst1.Id()) }()
 	fwInst1, ok := inst1.(instances.InstanceFirewaller)
 	c.Assert(ok, gc.Equals, true)
 

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -63,7 +63,7 @@ func GetMockBuildTools(c *gc.C) sync.BuildAgentTarballFunc {
 		toolsDir, err := ioutil.TempDir("", "juju-tools-"+stream)
 		c.Assert(err, jc.ErrorIsNil)
 		name := "name"
-		ioutil.WriteFile(filepath.Join(toolsDir, name), tgz, 0777)
+		_ = ioutil.WriteFile(filepath.Join(toolsDir, name), tgz, 0777)
 
 		return &sync.BuiltAgent{
 			Dir:         toolsDir,

--- a/generate/filetoconst/filetoconst.go
+++ b/generate/filetoconst/filetoconst.go
@@ -50,7 +50,7 @@ func main() {
 	contextData := fmt.Sprintf("%s", string(data))
 	// Quote any ` in the data.
 	contextData = strings.Replace(contextData, "`", "`+\"`\"+`", -1)
-	t.Execute(&buf, content{
+	_ = t.Execute(&buf, content{
 		ConstName:     os.Args[1],
 		Content:       fmt.Sprintf("`%s`", contextData),
 		CopyrightYear: os.Args[4],

--- a/generate/winuserdata/winuserdata.go
+++ b/generate/winuserdata/winuserdata.go
@@ -114,7 +114,7 @@ func main() {
 	addJujuUser = strings.Replace(addJujuUser, "`", "` + \"`\" + `", -1)
 	winpowershell = strings.Replace(winpowershell, "`", "` + \"`\" + `", -1)
 
-	t.Execute(&buf, content{
+	_ = t.Execute(&buf, content{
 		AddJujuUser:             fmt.Sprintf("`%s`", addJujuUser),
 		WindowsPowershellHelper: fmt.Sprintf("`%s`", winpowershell),
 		Pkgname:                 os.Args[3],

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -156,7 +156,7 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
 	if s.InitialLoggingConfig != "" {
-		loggo.ConfigureLoggers(s.InitialLoggingConfig)
+		_ = loggo.ConfigureLoggers(s.InitialLoggingConfig)
 	}
 
 	// This needs to be a pointer as there are other Mixin structures
@@ -654,7 +654,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 		APIPort:      s.ControllerConfig.APIPort(),
 		StatePort:    s.ControllerConfig.StatePort(),
 	}
-	s.State.SetStateServingInfo(servingInfo)
+	_ = s.State.SetStateServingInfo(servingInfo)
 }
 
 // AddToolsToState adds tools to tools storage.

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -60,7 +60,7 @@ type store struct {
 // contention in tests.
 func generateStoreLockName() string {
 	h := sha256.New()
-	h.Write([]byte(JujuControllersPath()))
+	_, _ = h.Write([]byte(JujuControllersPath()))
 	fullHash := fmt.Sprintf("%x", h.Sum(nil))
 	return fmt.Sprintf("store-lock-%x", fullHash[:8])
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -219,7 +219,10 @@ func streamThroughTempFile(r io.Reader) (_ io.ReadSeeker, cleanup func(), err er
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	tempFile.Seek(0, 0)
+	_, err = tempFile.Seek(0, 0)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "potentially corrupt binary")
+	}
 	rmTempFile := func() {
 		filename := tempFile.Name()
 		tempFile.Close()

--- a/network/ssh/testing/sshserver.go
+++ b/network/ssh/testing/sshserver.go
@@ -66,7 +66,7 @@ func CreateTCPServer(c *gc.C, callback func(net.Conn)) (string, chan struct{}) {
 			}
 			// Don't get hung on Accept, set a deadline
 			if tcpListener, ok := listener.(*net.TCPListener); ok {
-				tcpListener.SetDeadline(time.Now().Add(1 * time.Second))
+				_ = tcpListener.SetDeadline(time.Now().Add(1 * time.Second))
 			}
 			tcpConn, err := listener.Accept()
 			if err != nil {

--- a/provider/azure/disk.go
+++ b/provider/azure/disk.go
@@ -295,7 +295,7 @@ func (env *azureEnviron) deleteVault(stdCtx stdcontext.Context, ctx context.Prov
 	}
 	result, err := vaultClient.Delete(stdCtx, env.resourceGroup, vaultName)
 	if err != nil {
-		errorutils.HandleCredentialError(err, ctx)
+		err = errorutils.HandleCredentialError(err, ctx)
 		if !isNotFoundResult(result) {
 			return errors.Annotatef(err, "deleting vault key %q", vaultName)
 		}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1815,7 +1815,7 @@ func (env *azureEnviron) deleteResourceGroup(ctx context.ProviderCallContext, sd
 	client := resources.GroupsClient{env.resources}
 	future, err := client.Delete(sdkCtx, resourceGroup)
 	if err != nil {
-		errorutils.HandleCredentialError(err, ctx)
+		err = errorutils.HandleCredentialError(err, ctx)
 		if !isNotFoundResponse(future.Response()) {
 			return errors.Annotatef(err, "deleting resource group %q", resourceGroup)
 		}

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -387,7 +387,7 @@ func (v *azureVolumeSource) listBlobs(ctx context.ProviderCallContext) ([]intern
 	//           longest common prefix to pass in the parameters
 	blobs, err := vhdContainer.Blobs()
 	if err != nil {
-		errorutils.HandleCredentialError(err, ctx)
+		err = errorutils.HandleCredentialError(err, ctx)
 		if err, ok := err.(azurestorage.AzureStorageServiceError); ok {
 			switch err.Code {
 			case "ContainerNotFound":

--- a/provider/cloudsigma/client.go
+++ b/provider/cloudsigma/client.go
@@ -164,9 +164,9 @@ func (c *environClient) newInstance(
 			return
 		}
 		if srv != nil {
-			srv.Remove(gosigma.RecurseAllDrives)
+			_ = srv.Remove(gosigma.RecurseAllDrives)
 		} else if drv != nil {
-			drv.Remove()
+			_ = drv.Remove()
 		}
 		srv = nil
 		drv = nil

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -658,7 +658,7 @@ type parallelHostChecker struct {
 	stderr         io.Writer
 	wg             sync.WaitGroup
 
-	// active is a map of adresses to channels for addresses actively
+	// active is a map of addresses to channels for addresses actively
 	// being tested. The goroutine testing the address will continue
 	// to attempt connecting to the address until it succeeds, the Try
 	// is killed, or the corresponding channel in this map is closed.
@@ -690,7 +690,7 @@ func (p *parallelHostChecker) UpdateAddresses(addrs []network.ProviderAddress) {
 		}
 		p.wg.Add(1)
 		p.active[addr] = closed
-		p.Start(hc.loop)
+		_ = p.Start(hc.loop)
 	}
 }
 

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -437,7 +437,7 @@ func (state *environState) destroyLocked() {
 
 	if mongoAlive() {
 		logger.Debugf("resetting MgoServer")
-		gitjujutesting.MgoServer.Reset()
+		_ = gitjujutesting.MgoServer.Reset()
 	}
 }
 
@@ -934,7 +934,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			// a dummy provider for anything other than testing, so logging the password
 			// here is fine.
 			logger.Debugf("setting password for %q to %q", owner.Name(), icfg.APIInfo.Password)
-			owner.SetPassword(icfg.APIInfo.Password)
+			_ = owner.SetPassword(icfg.APIInfo.Password)
 			statePool := controller.StatePool()
 			stateAuthenticator, err := stateauthenticator.NewAuthenticator(statePool, clock.WallClock)
 			if err != nil {
@@ -1035,7 +1035,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			go stateAuthenticator.Maintain(abort)
 			go func(apiServer *apiserver.Server) {
 				defer close(abort)
-				apiServer.Wait()
+				_ = apiServer.Wait()
 			}(estate.apiServer)
 		}
 		estate.ops <- OpFinalizeBootstrap{Context: ctx, Env: e.name, InstanceConfig: icfg}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -987,8 +987,8 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			estate.modelCacheWorker = modelCache
 			err = modelcache.ExtractCacheController(modelCache, &estate.controller)
 			if err != nil {
-				worker.Stop(modelCache)
-				worker.Stop(multiWatcherWorker)
+				_ = worker.Stop(modelCache)
+				_ = worker.Stop(multiWatcherWorker)
 				return errors.Trace(err)
 			}
 

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -443,7 +443,7 @@ func (e *environ) StartInstance(
 			return
 		}
 		if err := e.StopInstances(ctx, inst.Id()); err != nil {
-			callback(status.Error, fmt.Sprintf("error stopping failed instance: %v", err), nil)
+			_ = callback(status.Error, fmt.Sprintf("error stopping failed instance: %v", err), nil)
 			logger.Errorf("error stopping failed instance: %v", err)
 		}
 	}()
@@ -1015,10 +1015,10 @@ var runInstances = _runInstances
 // runInstances calls ec2.RunInstances for a fixed number of attempts until
 // RunInstances returns an error code that does not indicate an error that
 // may be caused by eventual consistency.
-func _runInstances(e *amzec2.EC2, ctx context.ProviderCallContext, ri *amzec2.RunInstances, c environs.StatusCallbackFunc) (resp *amzec2.RunInstancesResp, err error) {
+func _runInstances(e *amzec2.EC2, ctx context.ProviderCallContext, ri *amzec2.RunInstances, callback environs.StatusCallbackFunc) (resp *amzec2.RunInstancesResp, err error) {
 	try := 1
 	for a := shortAttempt.Start(); a.Next(); {
-		c(status.Allocating, fmt.Sprintf("Start instance attempt %d", try), nil)
+		_ = callback(status.Allocating, fmt.Sprintf("Start instance attempt %d", try), nil)
 		resp, err = e.RunInstances(ri)
 		if err == nil || !isNotFoundError(err) {
 			break

--- a/provider/gce/google/ruleset.go
+++ b/provider/gce/google/ruleset.go
@@ -153,7 +153,7 @@ type sourcecidrs []string
 func (s sourcecidrs) key() string {
 	src := strings.Join(s.sorted(), ",")
 	hash := sha256.New()
-	hash.Write([]byte(src))
+	_, _ = hash.Write([]byte(src))
 	hashStr := fmt.Sprintf("%x", hash.Sum(nil))
 	return hashStr[:10]
 }

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -40,7 +40,7 @@ func (env *environ) StartInstance(
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		if args.StatusCallback != nil {
-			args.StatusCallback(status.ProvisioningError, err.Error(), nil)
+			_ = args.StatusCallback(status.ProvisioningError, err.Error(), nil)
 		}
 		return nil, errors.Trace(err)
 	}
@@ -96,7 +96,7 @@ func (env *environ) newContainer(
 	longestMsg := 0
 	statusCallback := func(currentStatus status.Status, msg string, data map[string]interface{}) error {
 		if args.StatusCallback != nil {
-			args.StatusCallback(currentStatus, msg, nil)
+			_ = args.StatusCallback(currentStatus, msg, nil)
 		}
 		if len(msg) > longestMsg {
 			longestMsg = len(msg)
@@ -105,7 +105,7 @@ func (env *environ) newContainer(
 	}
 	cleanupCallback := func() {
 		if args.CleanupCallback != nil {
-			args.CleanupCallback(strings.Repeat(" ", longestMsg))
+			_ = args.CleanupCallback(strings.Repeat(" ", longestMsg))
 		}
 	}
 	defer cleanupCallback()
@@ -126,12 +126,12 @@ func (env *environ) newContainer(
 		return nil, errors.Trace(err)
 	}
 
-	statusCallback(status.Allocating, "Creating container", nil)
+	_ = statusCallback(status.Allocating, "Creating container", nil)
 	container, err := target.CreateContainerFromSpec(cSpec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	statusCallback(status.Running, "Container started", nil)
+	_ = statusCallback(status.Running, "Container started", nil)
 	return container, nil
 }
 

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -625,6 +625,6 @@ func (env *maasEnviron) checkForExistingDevice(params deviceCreatorParams) (goma
 	}
 	logger.Debugf("found existing MAAS device for container %q but interfaces did not match, removing device", params.Name)
 	// We found a device, but it doesn't match what we need. remove it and we'll create again.
-	device.Delete()
+	_ = device.Delete()
 	return nil, nil
 }

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -362,22 +362,22 @@ func (env *maasEnviron) createAndPopulateDevice(params deviceCreatorParams) (gom
 	}
 	defer func() {
 		if err != nil {
-			device.Delete()
+			_ = device.Delete()
 		}
 	}()
-	interface_set := device.InterfaceSet()
-	if len(interface_set) != 1 {
+	interfaces := device.InterfaceSet()
+	if len(interfaces) != 1 {
 		// Shouldn't be possible as machine.CreateDevice always
 		// returns a device with one interface.
-		names := make([]string, len(interface_set))
-		for i, iface := range interface_set {
+		names := make([]string, len(interfaces))
+		for i, iface := range interfaces {
 			names[i] = iface.Name()
 		}
 		err = errors.Errorf("unexpected number of interfaces "+
 			"in response from creating device: %v", names)
 		return nil, err
 	}
-	primaryNIC := interface_set[0]
+	primaryNIC := interfaces[0]
 	primaryNICVLAN := primaryNIC.VLAN()
 
 	interfaceCreated := false
@@ -425,9 +425,8 @@ func (env *maasEnviron) createAndPopulateDevice(params deviceCreatorParams) (gom
 
 		if err := createdNIC.LinkSubnet(linkArgs); err != nil {
 			return nil, errors.Annotatef(err, "linking NIC %v to subnet %v", nic.InterfaceName, subnet.CIDR())
-		} else {
-			logger.Debugf("linked device interface to subnet: %+v", createdNIC)
 		}
+		logger.Debugf("linked device interface to subnet: %+v", createdNIC)
 	}
 	// If we have created any secondary interfaces we need to reload device from maas
 	// so that the changes are reflected in structure.

--- a/provider/maas/storage.go
+++ b/provider/maas/storage.go
@@ -191,7 +191,7 @@ func (stor *maas1Storage) Remove(name string) error {
 	// The only thing that can go wrong here, really, is that the file
 	// does not exist.  But deletion is idempotent: deleting a file that
 	// is no longer there anyway is success, not failure.
-	stor.maasClient.GetSubObject(name).Delete()
+	_ = stor.maasClient.GetSubObject(name).Delete()
 	return nil
 }
 

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -82,7 +82,7 @@ func (env *sessionEnviron) StartInstance(ctx context.ProviderCallContext, args e
 
 	vm, hw, err := env.newRawInstance(ctx, args, img)
 	if err != nil {
-		args.StatusCallback(status.ProvisioningError, fmt.Sprint(err), nil)
+		_ = args.StatusCallback(status.ProvisioningError, fmt.Sprint(err), nil)
 		return nil, errors.Trace(err)
 	}
 
@@ -203,7 +203,7 @@ func (env *sessionEnviron) newRawInstance(
 		updateProgressInterval = bootstrapUpdateProgressInterval
 	}
 	updateProgress := func(message string) {
-		args.StatusCallback(status.Provisioning, message, nil)
+		_ = args.StatusCallback(status.Provisioning, message, nil)
 	}
 
 	readOVA := func() (string, io.ReadCloser, error) {

--- a/provider/vsphere/internal/ovatest/ova.go
+++ b/provider/vsphere/internal/ovatest/ova.go
@@ -42,8 +42,8 @@ func init() {
 			Name: file.Name,
 			Size: int64(len(file.Body)),
 		}
-		tw.WriteHeader(hdr)
-		tw.Write([]byte(file.Body))
+		_ = tw.WriteHeader(hdr)
+		_, _ = tw.Write([]byte(file.Body))
 	}
 	tw.Close()
 	fakeOva = buf.Bytes()

--- a/rpc/jsoncodec/conn.go
+++ b/rpc/jsoncodec/conn.go
@@ -59,7 +59,7 @@ func (conn *wsJSONConn) Receive(msg interface{}) error {
 func (conn *wsJSONConn) Close() error {
 	// Tell the other end we are closing.
 	conn.writeMutex.Lock()
-	conn.conn.WriteMessage(websocket.CloseMessage, []byte{})
+	_ = conn.conn.WriteMessage(websocket.CloseMessage, []byte{})
 	conn.writeMutex.Unlock()
 	return conn.conn.Close()
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -556,7 +556,7 @@ func (conn *Conn) runRequest(
 		if panicResult := recover(); panicResult != nil {
 			logger.Criticalf(
 				"panic running request %+v with arg %+v: %v\n%v", req, arg, panicResult, string(debug.Stack()))
-			conn.writeErrorResponse(&req.hdr, errors.Errorf("%v", panicResult), recorder)
+			_ = conn.writeErrorResponse(&req.hdr, errors.Errorf("%v", panicResult), recorder)
 		}
 	}()
 	defer conn.srvPending.Done()

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -451,7 +451,7 @@ func (b *BlobstoreCleaner) cleanupFiles() {
 	for _, path := range b.unreferencedFiles {
 		logger.Debugf("removing blobstore file: %q", path)
 		tick()
-		gridfs.Remove(path)
+		_ = gridfs.Remove(path)
 	}
 	tickDone()
 }

--- a/scripts/juju-force-upgrade/main.go
+++ b/scripts/juju-force-upgrade/main.go
@@ -117,7 +117,7 @@ func main() {
 	checkErr("open model", err)
 	defer func() {
 		modelSt.Release()
-		statePool.Remove(modelUUID)
+		_, _ = statePool.Remove(modelUUID)
 	}()
 
 	checkErr("set model agent version", modelSt.SetModelAgentVersion(agentVersion, true))

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -572,9 +572,9 @@ func (st *State) insertNewMachineOps(mdoc *machineDoc, template MachineTemplate)
 	// history entry. This is risky, and may lead to extra entries, but that's
 	// an intrinsic problem with mixing txn and non-txn ops -- we can't sync
 	// them cleanly.
-	probablyUpdateStatusHistory(st.db(), machineGlobalKey(mdoc.Id), machineStatusDoc)
-	probablyUpdateStatusHistory(st.db(), machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
-	probablyUpdateStatusHistory(st.db(), machineGlobalModificationKey(mdoc.Id), modificationStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), machineGlobalKey(mdoc.Id), machineStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), machineGlobalInstanceKey(mdoc.Id), instanceStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), machineGlobalModificationKey(mdoc.Id), modificationStatusDoc)
 	return prereqOps, machineOp, nil
 }
 

--- a/state/backups/testing/metadata.go
+++ b/state/backups/testing/metadata.go
@@ -40,7 +40,7 @@ func NewMetadataStarted() *backups.Metadata {
 func FinishMetadata(meta *backups.Metadata) {
 	var size int64 = 10
 	checksum := "787b8915389d921fa23fb40e16ae81ea979758bf"
-	meta.MarkComplete(size, checksum)
+	_ = meta.MarkComplete(size, checksum)
 	finished := meta.Started.Add(time.Minute)
 	meta.Finished = &finished
 }

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -134,7 +134,7 @@ func (st *State) modelsToRevert(tag names.CloudCredentialTag) (map[*Model]func()
 			continue
 		}
 		// We still need to close models that did not make the cut.
-		defer closer()
+		defer func() { _ = closer() }()
 	}
 	return revert, nil
 }
@@ -192,7 +192,7 @@ func (st *State) UpdateCloudCredential(tag names.CloudCredentialTag, credential 
 			if err := m.maybeRevertModelStatus(); err != nil {
 				logger.Warningf("could not revert status for model %v: %v", m.UUID(), err)
 			}
-			defer closer()
+			defer func() { _ = closer() }()
 		}
 	}
 	return nil

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -293,7 +293,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 	if err := InitDbLogs(st.session); err != nil {
 		return nil, errors.Trace(err)
 	}
-	probablyUpdateStatusHistory(st.db(), modelGlobalKey, modelStatusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), modelGlobalKey, modelStatusDoc)
 	return ctlr, nil
 }
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -677,7 +677,7 @@ func (t *logTailer) tailOplog() error {
 
 	minOplogTs := t.lastTime.Add(-oplogOverlap)
 	oplogTailer := mongo.NewOplogTailer(mongo.NewOplogSession(oplog, oplogSel), minOplogTs)
-	defer oplogTailer.Stop()
+	defer func() { _ = oplogTailer.Stop() }()
 
 	logger.Tracef("LogTailer starting oplog tailing: recent id count=%d, lastTime=%s, minOplogTs=%s",
 		recentIds.Length(), t.lastTime, minOplogTs)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -300,7 +300,11 @@ func (i *importer) modelExtras() error {
 		if !ok {
 			return errors.Errorf("unknown block type: %q", blockName)
 		}
-		i.st.SwitchBlockOn(block, message)
+		// We should check that each switch block can be assigned.
+		err := i.st.SwitchBlockOn(block, message)
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	if err := i.importStatusHistory(modelGlobalKey, i.model.StatusHistory()); err != nil {

--- a/state/model.go
+++ b/state/model.go
@@ -454,7 +454,7 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Trace(err)
 	}
 	if args.MigrationMode != MigrationModeImporting {
-		probablyUpdateStatusHistory(newSt.db(), modelGlobalKey, modelStatusDoc)
+		_, _ = probablyUpdateStatusHistory(newSt.db(), modelGlobalKey, modelStatusDoc)
 	}
 
 	_, err = newSt.SetUserAccess(newModel.Owner(), newModel.ModelTag(), permission.AdminAccess)

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -55,7 +55,7 @@ func (st *State) suspendCredentialModels(tag names.CloudCredentialTag) error {
 			logger.Warningf("model %v error: %v", m.UUID, err)
 			continue
 		}
-		defer closer()
+		defer func() { _ = closer() }()
 		if _, err = probablyUpdateStatusHistory(one.st.db(), one.globalKey(), doc); err != nil {
 			// We do not want to stop processing the rest of the models.
 			logger.Warningf("%v", err)

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -398,7 +398,7 @@ func migStatusHistoryAndOps(st *State, phase migration.Phase, now int64, msg str
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	probablyUpdateStatusHistory(st.db(), globalKey, doc)
+	_, _ = probablyUpdateStatusHistory(st.db(), globalKey, doc)
 	return ops, nil
 }
 

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -549,7 +549,7 @@ func (op *terminateRemoteApplicationOperation) Done(err error) error {
 	if err != nil {
 		return errors.Annotatef(err, "updating unit %q", op.app.Name())
 	}
-	probablyUpdateStatusHistory(op.app.st.db(), op.app.globalKey(), op.doc)
+	_, _ = probablyUpdateStatusHistory(op.app.st.db(), op.app.globalKey(), op.doc)
 	return nil
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -1282,7 +1282,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return ops, nil
 	}
 	// At the last moment before inserting the application, prime status history.
-	probablyUpdateStatusHistory(st.db(), app.globalKey(), statusDoc)
+	_, _ = probablyUpdateStatusHistory(st.db(), app.globalKey(), statusDoc)
 
 	if err = st.db().Run(buildTxn); err == nil {
 		// Refresh to pick the txn-revno.

--- a/state/statetest/persistence_stubs.go
+++ b/state/statetest/persistence_stubs.go
@@ -111,7 +111,7 @@ func (s *StubPersistence) ApplicationExistsOps(applicationID string) []txn.Op {
 	s.AddCall("ApplicationExistsOps", applicationID)
 	// pop off an error so num errors == num calls, even though this call
 	// doesn't actually use the error.
-	s.NextErr()
+	_ = s.NextErr()
 
 	return s.ReturnApplicationExistsOps
 }
@@ -120,7 +120,7 @@ func (s *StubPersistence) IncCharmModifiedVersionOps(applicationID string) []txn
 	s.AddCall("IncCharmModifiedVersionOps", applicationID)
 	// pop off an error so num errors == num calls, even though this call
 	// doesn't actually use the error.
-	s.NextErr()
+	_ = s.NextErr()
 
 	return s.ReturnIncCharmModifiedVersionOps
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -463,7 +463,7 @@ func (op *UpdateUnitOperation) Done(err error) error {
 	// We can't include in the ops slice the necessary status history updates,
 	// so as with existing practice, do a best effort update of status history.
 	for key, doc := range op.setStatusDocs {
-		probablyUpdateStatusHistory(op.unit.st.db(), key, doc)
+		_, _ = probablyUpdateStatusHistory(op.unit.st.db(), key, doc)
 	}
 	return nil
 }

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -4236,8 +4236,8 @@ func hashSettings(db Database, id string, name string) (string, error) {
 		return "", errors.Trace(err)
 	}
 	hash := sha256.New()
-	hash.Write([]byte(name))
-	hash.Write(data)
+	_, _ = hash.Write([]byte(name))
+	_, _ = hash.Write(data)
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
@@ -4278,10 +4278,10 @@ func hashServiceAddresses(a *Application, firstCall bool) (string, error) {
 	}
 	address := addresses[0]
 	hash := sha256.New()
-	hash.Write([]byte(address.Value))
-	hash.Write([]byte(address.Type))
-	hash.Write([]byte(address.Scope))
-	hash.Write([]byte(address.SpaceID))
+	_, _ = hash.Write([]byte(address.Value))
+	_, _ = hash.Write([]byte(address.Type))
+	_, _ = hash.Write([]byte(address.Scope))
+	_, _ = hash.Write([]byte(address.SpaceID))
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -278,7 +278,7 @@ func (w *HubWatcher) Watch(collection string, id interface{}, ch chan<- Change) 
 	// We use a value of -2 to indicate that we don't know the state of the document.
 	// -1 would indicate that we think the document is deleted (and won't trigger
 	// a change event if the document really is deleted).
-	w.sendAndWaitReq(reqWatch{
+	_ = w.sendAndWaitReq(reqWatch{
 		key: watchKey{collection, id},
 		info: watchInfo{
 			ch:     ch,
@@ -302,7 +302,7 @@ func (w *HubWatcher) WatchCollection(collection string, ch chan<- Change) {
 // to change after a transaction is applied for any document in the collection, so long as the
 // specified filter function returns true when called with the document id value.
 func (w *HubWatcher) WatchCollectionWithFilter(collection string, ch chan<- Change, filter func(interface{}) bool) {
-	w.sendAndWaitReq(reqWatch{
+	_ = w.sendAndWaitReq(reqWatch{
 		key: watchKey{collection, nil},
 		info: watchInfo{
 			ch:     ch,

--- a/state/workers.go
+++ b/state/workers.go
@@ -43,7 +43,7 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 			Clock:        st.clock(),
 		}),
 	}
-	ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
+	_ = ws.StartWorker(txnLogWorker, func() (worker.Worker, error) {
 		return watcher.NewHubWatcher(watcher.HubWatcherConfig{
 			Hub:       hub,
 			Clock:     st.clock(),

--- a/testing/base.go
+++ b/testing/base.go
@@ -212,7 +212,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.JujuOSEnvSuite.SetUpTest(c)
 	c.Assert(http.OutgoingAccessAllowed, gc.Equals, false)
 	if s.InitialLoggingConfig != "" {
-		loggo.ConfigureLoggers(s.InitialLoggingConfig)
+		_ = loggo.ConfigureLoggers(s.InitialLoggingConfig)
 	}
 
 	// We do this to isolate invocations of bash from pulling in the

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -5,6 +5,7 @@ run_go() {
       exit 1
   fi
   golangci-lint run -c .github/golangci-lint.config.yaml
+  golangci-lint run -c .github/golangci-lint.config.experimental.yaml
 }
 
 run_go_tidy() {

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,7 +1,7 @@
 run_go() {
   VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-  if [ "${VER}" != "1.35" ]; then
-      (>&2 echo -e "\\nError: golangci-lint version does not match 1.35")
+  if [ "${VER}" != "1.36" ]; then
+      (>&2 echo -e "\\nError: golangci-lint version does not match 1.36. Please upgrade/downgrade to the right version.")
       exit 1
   fi
   golangci-lint run -c .github/golangci-lint.config.yaml

--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -233,7 +233,7 @@ func MigrateLegacyLeases(context Context) error {
 	defer sink.Close()
 	err = newSnapshot.Persist(sink)
 	if err != nil {
-		sink.Cancel()
+		_ = sink.Cancel()
 		return errors.Annotate(err, "persisting snapshot")
 	}
 

--- a/watcher/legacy/notifyworker.go
+++ b/watcher/legacy/notifyworker.go
@@ -82,7 +82,7 @@ func (nw *notifyWorker) loop() error {
 		if w != nil {
 			// We don't bother to propagate an error, because we
 			// already have an error
-			w.Stop()
+			_ = w.Stop()
 		}
 		return err
 	}

--- a/watcher/legacy/stringsworker.go
+++ b/watcher/legacy/stringsworker.go
@@ -62,7 +62,7 @@ func (sw *stringsWorker) loop() error {
 		if w != nil {
 			// We don't bother to propagate an error, because we
 			// already have an error.
-			w.Stop()
+			_ = w.Stop()
 		}
 		return err
 	}

--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -245,13 +245,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		EmbeddedCommand:                   execEmbeddedCommand,
 	})
 	if err != nil {
-		stTracker.Done()
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	mux.AddClient()
 	return common.NewCleanupWorker(w, func() {
 		mux.ClientDone()
-		stTracker.Done()
+		_ = stTracker.Done()
 
 		// clean up the metrics for the worker, so the next time a worker is
 		// created we can safely register the metrics again.

--- a/worker/auditconfigupdater/manifold.go
+++ b/worker/auditconfigupdater/manifold.go
@@ -69,7 +69,7 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 	}
 	defer func() {
 		if err != nil {
-			stTracker.Done()
+			_ = stTracker.Done()
 		}
 	}()
 
@@ -92,7 +92,7 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return common.NewCleanupWorker(w, func() { stTracker.Done() }), nil
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
 }
 
 type withCurrentConfig interface {

--- a/worker/caasfirewaller/worker.go
+++ b/worker/caasfirewaller/worker.go
@@ -97,22 +97,22 @@ func (p *firewaller) loop() error {
 			if !ok {
 				return errors.New("watcher closed channel")
 			}
-			for _, appId := range apps {
-				appLife, err := p.config.LifeGetter.Life(appId)
+			for _, appID := range apps {
+				appLife, err := p.config.LifeGetter.Life(appID)
 				if errors.IsNotFound(err) {
-					w, ok := appWorkers[appId]
+					w, ok := appWorkers[appID]
 					if ok {
 						if err := worker.Stop(w); err != nil {
 							logger.Errorf("error stopping caas firewaller: %v", err)
 						}
-						delete(appWorkers, appId)
+						delete(appWorkers, appID)
 					}
 					continue
 				}
 				if err != nil {
 					return errors.Trace(err)
 				}
-				if _, ok := appWorkers[appId]; ok || appLife == life.Dead {
+				if _, ok := appWorkers[appID]; ok || appLife == life.Dead {
 					// Already watching the application. or we're
 					// not yet watching it and it's dead.
 					continue
@@ -120,7 +120,7 @@ func (p *firewaller) loop() error {
 				w, err := newApplicationWorker(
 					p.config.ControllerUUID,
 					p.config.ModelUUID,
-					appId,
+					appID,
 					p.config.ApplicationGetter,
 					p.config.ServiceExposer,
 					p.config.LifeGetter,
@@ -129,8 +129,8 @@ func (p *firewaller) loop() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				appWorkers[appId] = w
-				p.catacomb.Add(w)
+				appWorkers[appID] = w
+				_ = p.catacomb.Add(w)
 			}
 		}
 	}

--- a/worker/caasoperator/action.go
+++ b/worker/caasoperator/action.go
@@ -68,7 +68,7 @@ func remoteExecute(logger Logger,
 
 	readBytes := func(r io.Reader) []byte {
 		var o bytes.Buffer
-		o.ReadFrom(r)
+		_, _ = o.ReadFrom(r)
 		return o.Bytes()
 	}
 	exitCode := func(exitErr error) int {

--- a/worker/caasunitprovisioner/application_undertaker.go
+++ b/worker/caasunitprovisioner/application_undertaker.go
@@ -77,10 +77,10 @@ func (au *applicationUndertaker) loop() (err error) {
 	// workers unbounded, use a defer to stop the running worker.
 	defer func() {
 		if brokerUnitsWatcher != nil {
-			worker.Stop(brokerUnitsWatcher)
+			_ = worker.Stop(brokerUnitsWatcher)
 		}
 		if appOperatorWatcher != nil {
-			worker.Stop(appOperatorWatcher)
+			_ = worker.Stop(appOperatorWatcher)
 		}
 	}()
 
@@ -134,7 +134,7 @@ func (au *applicationUndertaker) loop() (err error) {
 			return au.catacomb.ErrDying()
 		case _, ok := <-brokerUnitsChannel:
 			if !ok {
-				worker.Stop(brokerUnitsWatcher)
+				_ = worker.Stop(brokerUnitsWatcher)
 				brokerUnitsWatcher = nil
 				continue
 			}
@@ -148,7 +148,7 @@ func (au *applicationUndertaker) loop() (err error) {
 			continue
 		case _, ok := <-appOpertatorChannel:
 			if !ok {
-				worker.Stop(appOperatorWatcher)
+				_ = worker.Stop(appOperatorWatcher)
 				appOperatorWatcher = nil
 				continue
 			}

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -171,7 +171,7 @@ func (aw *applicationWorker) loop() error {
 			logger.Debugf("units changed: %#v", ok)
 			if !ok {
 				logger.Debugf("%v", brokerUnitsWatcher.Wait())
-				worker.Stop(brokerUnitsWatcher)
+				_ = worker.Stop(brokerUnitsWatcher)
 				brokerUnitsWatcher = nil
 				continue
 			}
@@ -188,7 +188,7 @@ func (aw *applicationWorker) loop() error {
 			logger.Debugf("deployment changed: %#v", ok)
 			if !ok {
 				logger.Debugf("%v", appDeploymentWatcher.Wait())
-				worker.Stop(appDeploymentWatcher)
+				_ = worker.Stop(appDeploymentWatcher)
 				appDeploymentWatcher = nil
 				continue
 			}
@@ -233,7 +233,7 @@ func (aw *applicationWorker) loop() error {
 		case _, ok := <-appOperatorChannel:
 			if !ok {
 				logger.Debugf("%v", appOperatorWatcher.Wait())
-				worker.Stop(appOperatorWatcher)
+				_ = worker.Stop(appOperatorWatcher)
 				appOperatorWatcher = nil
 				continue
 			}

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -91,7 +91,7 @@ func (aw *applicationWorker) loop() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		aw.catacomb.Add(deploymentWorker)
+		_ = aw.catacomb.Add(deploymentWorker)
 	}
 
 	var (
@@ -109,13 +109,13 @@ func (aw *applicationWorker) loop() error {
 	// workers unbounded, use a defer to stop the running worker.
 	defer func() {
 		if brokerUnitsWatcher != nil {
-			worker.Stop(brokerUnitsWatcher)
+			_ = worker.Stop(brokerUnitsWatcher)
 		}
 		if appOperatorWatcher != nil {
-			worker.Stop(appOperatorWatcher)
+			_ = worker.Stop(appOperatorWatcher)
 		}
 		if appDeploymentWatcher != nil {
-			worker.Stop(appDeploymentWatcher)
+			_ = worker.Stop(appDeploymentWatcher)
 		}
 	}()
 

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -75,7 +75,7 @@ func (w *deploymentWorker) loop() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	w.catacomb.Add(appScaleWatcher)
+	_ = w.catacomb.Add(appScaleWatcher)
 
 	var (
 		pw            watcher.NotifyWatcher
@@ -109,7 +109,7 @@ func (w *deploymentWorker) loop() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				w.catacomb.Add(pw)
+				_ = w.catacomb.Add(pw)
 				provisionChan = pw.Changes()
 			}
 		case _, ok := <-provisionChan:

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -132,7 +132,7 @@ func (w *deploymentWorker) loop() error {
 
 		if desiredScale == 0 {
 			if pw != nil {
-				worker.Stop(pw)
+				_ = worker.Stop(pw)
 				provisionChan = nil
 			}
 			logger.Debugf("no units for %v", w.application)

--- a/worker/caasunitprovisioner/worker.go
+++ b/worker/caasunitprovisioner/worker.go
@@ -188,7 +188,7 @@ func (p *provisioner) loop() error {
 					if err != nil {
 						return errors.Trace(err)
 					}
-					p.catacomb.Add(uw)
+					_ = p.catacomb.Add(uw)
 					continue
 				}
 				if _, ok := p.getApplicationWorker(appId); ok || appLife == life.Dead {
@@ -216,7 +216,7 @@ func (p *provisioner) loop() error {
 					return errors.Trace(err)
 				}
 				p.saveApplicationWorker(appId, w)
-				p.catacomb.Add(w)
+				_ = p.catacomb.Add(w)
 			}
 		}
 	}

--- a/worker/controller/manifold.go
+++ b/worker/controller/manifold.go
@@ -117,7 +117,7 @@ func (w *controllerWorker) loop() error {
 	if err != nil {
 		return errors.Annotate(err, "failed to obtain controller")
 	}
-	defer w.tracker.Done()
+	defer func() { _ = w.tracker.Done() }()
 
 	for {
 		select {

--- a/worker/controllerport/manifold.go
+++ b/worker/controllerport/manifold.go
@@ -100,7 +100,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	defer stTracker.Done()
+	defer func() { _ = stTracker.Done() }()
 
 	systemState := statePool.SystemState()
 	controllerConfig, err := config.GetControllerConfig(systemState)

--- a/worker/deployer/unit_agent.go
+++ b/worker/deployer/unit_agent.go
@@ -143,10 +143,12 @@ func NewUnitAgent(config UnitAgentConfig) (*UnitAgent, error) {
 	// Update the 'upgradedToVersion' in the agent.conf file if it is
 	// different to the current version.
 	if conf.UpgradedToVersion() != jujuversion.Current {
-		unit.ChangeConfig(func(setter agent.ConfigSetter) error {
+		if err := unit.ChangeConfig(func(setter agent.ConfigSetter) error {
 			setter.SetUpgradedToVersion(jujuversion.Current)
 			return nil
-		})
+		}); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	return unit, nil
 }
@@ -213,7 +215,7 @@ func (a *UnitAgent) start() (worker.Worker, error) {
 	a.mu.Unlock()
 	go func() {
 		// Wait for the worker to finish, then mark not running.
-		engine.Wait()
+		_ = engine.Wait()
 		a.mu.Lock()
 		a.workerRunning = false
 		a.mu.Unlock()

--- a/worker/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/worker/externalcontrollerupdater/externalcontrollerupdater.go
@@ -110,7 +110,7 @@ func (w *updaterWorker) loop() error {
 	if err != nil {
 		return errors.Annotate(err, "watching external controllers")
 	}
-	w.catacomb.Add(watcher)
+	_ = w.catacomb.Add(watcher)
 
 	for {
 		select {
@@ -141,7 +141,7 @@ func (w *updaterWorker) loop() error {
 				// is added or removed, so treat as a toggle.
 				if watchers.Contains(tag) {
 					logger.Infof("stopping watcher for external controller %q", tag.Id())
-					w.runner.StopWorker(tag.Id())
+					_ = w.runner.StopWorker(tag.Id())
 					watchers.Remove(tag)
 					continue
 				}
@@ -222,7 +222,7 @@ func (w *controllerWatcher) loop() error {
 			if err != nil {
 				return errors.Annotate(err, "watching external controller")
 			}
-			w.catacomb.Add(nw)
+			_ = w.catacomb.Add(nw)
 		}
 
 		select {

--- a/worker/fortress/occupy.go
+++ b/worker/fortress/occupy.go
@@ -35,7 +35,7 @@ func Occupy(fortress Guest, start StartFunc, abort Abort) (worker.Worker, error)
 			failed <- err
 		} else {
 			started <- worker
-			worker.Wait() // ignore error: worker is SEP now.
+			_ = worker.Wait() // ignore error: worker is SEP now.
 		}
 		return nil
 	}

--- a/worker/httpserver/manifold.go
+++ b/worker/httpserver/manifold.go
@@ -200,5 +200,5 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return common.NewCleanupWorker(w, func() { stTracker.Done() }), nil
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
 }

--- a/worker/httpserver/manifold.go
+++ b/worker/httpserver/manifold.go
@@ -166,7 +166,7 @@ func (config ManifoldConfig) start(context dependency.Context) (_ worker.Worker,
 	}
 	defer func() {
 		if err != nil {
-			stTracker.Done()
+			_ = stTracker.Done()
 		}
 	}()
 

--- a/worker/httpserverargs/manifold.go
+++ b/worker/httpserverargs/manifold.go
@@ -72,12 +72,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	abort := make(chan struct{})
 	authenticator, err := config.NewStateAuthenticator(statePool, mux, clock, abort)
 	if err != nil {
-		stTracker.Done()
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	w := newWorker(mux, authenticator, func() {
 		close(abort)
-		stTracker.Done()
+		_ = stTracker.Done()
 	})
 	return w, nil
 }

--- a/worker/introspection/leases.go
+++ b/worker/introspection/leases.go
@@ -65,7 +65,7 @@ func (h *leaseHandler) list(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Write(bytes)
+	_, _ = w.Write(bytes)
 }
 
 type leases struct {

--- a/worker/introspection/pprof/pprof.go
+++ b/worker/introspection/pprof/pprof.go
@@ -163,7 +163,7 @@ func Symbol(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Write(buf.Bytes())
+	_, _ = w.Write(buf.Bytes())
 }
 
 func durationExceedsWriteTimeout(r *http.Request, seconds float64) bool {
@@ -224,7 +224,7 @@ func (name handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if name == "heap" && gc > 0 {
 		runtime.GC()
 	}
-	p.WriteTo(w, debug)
+	_ = p.WriteTo(w, debug)
 	return
 }
 

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -158,7 +158,7 @@ func (w *socketListener) serve() {
 	logger.Debugf("stats worker now serving")
 	defer logger.Debugf("stats worker serving finished")
 	defer close(w.done)
-	srv.Serve(w.listener)
+	_ = srv.Serve(w.listener)
 }
 
 func (w *socketListener) run() error {
@@ -246,7 +246,7 @@ func (h depengineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
 	fmt.Fprint(w, "Dependency Engine Report\n\n")
-	w.Write(bytes)
+	_, _ = w.Write(bytes)
 }
 
 type machineLockHandler struct {
@@ -313,7 +313,7 @@ func (h presenceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
 	tw := output.TabWriter(w)
-	wrapper := output.Wrapper{tw}
+	wrapper := output.Wrapper{TabWriter: tw}
 
 	// Could be smart here and switch on the request accept header.
 	connections := h.presence.Connections()
@@ -419,11 +419,10 @@ func (h unitsHandler) publishAndAwaitResponse(w http.ResponseWriter, topic, resp
 			http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 			return
 		}
-		w.Write(bytes)
+		_, _ = w.Write(bytes)
 	case <-h.done:
 		http.Error(w, "introspection worker stopping", http.StatusServiceUnavailable)
 	case <-h.clock.After(10 * time.Second):
 		http.Error(w, "response timed out", http.StatusInternalServerError)
-
 	}
 }

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -163,10 +163,10 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		PrometheusRegisterer: s.config.PrometheusRegisterer,
 	})
 	if err != nil {
-		stTracker.Done()
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
-	return common.NewCleanupWorker(w, func() { stTracker.Done() }), nil
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
 }
 
 func (s *manifoldState) output(in worker.Worker, out interface{}) error {

--- a/worker/logforwarder/logforwarder.go
+++ b/worker/logforwarder/logforwarder.go
@@ -98,7 +98,7 @@ func (lf *LogForwarder) processNewConfig(currentSender SendCloser) (SendCloser, 
 	// Get the new config and set up log forwarding if enabled.
 	cfg, ok, err := lf.args.LogForwardConfig.LogForwardConfig()
 	if err != nil {
-		closeExisting()
+		_ = closeExisting()
 		return nil, errors.Trace(err)
 	}
 	if !ok || !cfg.Enabled {

--- a/worker/logger/logger.go
+++ b/worker/logger/logger.go
@@ -98,7 +98,7 @@ func (l *loggerWorker) setLogging() {
 			// validated by the original Config before it gets here.
 			logger.Warningf("configure loggers failed: %v", err)
 			// Try to reset to what we had before
-			context.ConfigureLoggers(l.lastConfig)
+			_ = context.ConfigureLoggers(l.lastConfig)
 			return
 		}
 		mgo.ConfigureMgoLogging()

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -226,7 +226,7 @@ type collect struct {
 
 func (w *collect) stop() {
 	if w.listener != nil {
-		w.listener.Stop()
+		_ = w.listener.Stop()
 	}
 }
 

--- a/worker/metrics/sender/sender.go
+++ b/worker/metrics/sender/sender.go
@@ -113,7 +113,7 @@ func (s *sender) Handle(c net.Conn, _ <-chan struct{}) (err error) {
 
 func (s *sender) stop() {
 	if s.listener != nil {
-		s.listener.Stop()
+		_ = s.listener.Stop()
 	}
 }
 

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -470,7 +470,7 @@ func (w *Worker) doVALIDATION(status coremigration.MigrationStatus) (coremigrati
 	if err != nil {
 		return coremigration.UNKNOWN, errors.Trace(err)
 	}
-	defer closer()
+	defer func() { _ = closer() }()
 
 	// Check that the provider and target controller agree about what
 	// machines belong to the migrated model.

--- a/worker/modelworkermanager/manifold.go
+++ b/worker/modelworkermanager/manifold.go
@@ -118,8 +118,8 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ErrorDelay:     jworker.RestartDelay,
 	})
 	if err != nil {
-		stTracker.Done()
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
-	return common.NewCleanupWorker(w, func() { stTracker.Done() }), nil
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
 }

--- a/worker/presence/presence.go
+++ b/worker/presence/presence.go
@@ -141,7 +141,7 @@ func (w *wrapper) forwarderConnect(topic string, data forwarder.OriginTarget, er
 	}
 	w.logger.Tracef("request presence info from %s", request)
 	msg := apiserver.OriginTarget{Target: request}
-	w.hub.Publish(apiserver.PresenceRequestTopic, msg)
+	_, _ = w.hub.Publish(apiserver.PresenceRequestTopic, msg)
 	w.logger.Tracef("request sent")
 }
 

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -151,7 +151,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 	tag := p.agentConfig.Tag()
 	machineTag, ok := tag.(names.MachineTag)
 	if !ok {
-		errors.Errorf("expected names.MachineTag, got %T", tag)
+		return nil, errors.Errorf("expected names.MachineTag, got %T", tag)
 	}
 
 	modelCfg, err := p.st.ModelConfig()

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -347,7 +347,7 @@ func (w *proxyWorker) TearDown() error {
 
 const noStdIn = ""
 
-// Execute the command specified with the args with optional stdin.
+// RunWithStdIn executes the command specified with the args with optional stdin.
 func RunWithStdIn(input string, command string, args ...string) (string, error) {
 	cmd := stdexec.Command(command, args...)
 
@@ -359,7 +359,7 @@ func RunWithStdIn(input string, command string, args ...string) (string, error) 
 
 		go func() {
 			defer stdin.Close()
-			io.WriteString(stdin, input)
+			_, _ = io.WriteString(stdin, input)
 		}()
 	}
 

--- a/worker/pubsub/remoteserver.go
+++ b/worker/pubsub/remoteserver.go
@@ -221,7 +221,7 @@ func (r *remoteServer) connect() bool {
 
 	var connection MessageWriter
 	r.logger.Debugf("connecting to %s", r.target)
-	retry.Call(retry.CallArgs{
+	_ = retry.Call(retry.CallArgs{
 		Func: func() error {
 			r.logger.Debugf("open api to %s: %v", r.target, r.info.Addrs)
 			conn, err := r.newWriter(r.info)

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -232,7 +232,7 @@ func (s *subscriber) apiServerChanges(topic string, details apiserver.Details, e
 				continue
 			}
 			s.servers[target] = server
-			s.catacomb.Add(server)
+			_ = s.catacomb.Add(server)
 		}
 	}
 	for name, server := range s.servers {

--- a/worker/raft/rafttransport/worker.go
+++ b/worker/raft/rafttransport/worker.go
@@ -162,7 +162,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		ModelUUID: w.config.APIInfo.ModelTag.Id(),
 	}
 
-	w.config.Mux.AddHandler("GET", w.config.Path, h)
+	_ = w.config.Mux.AddHandler("GET", w.config.Path, h)
 
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,

--- a/worker/raft/simplefsm.go
+++ b/worker/raft/simplefsm.go
@@ -67,7 +67,7 @@ type SimpleSnapshot struct {
 // Persist is part of the raft.FSMSnapshot interface.
 func (snap *SimpleSnapshot) Persist(sink raft.SnapshotSink) error {
 	if err := gob.NewEncoder(sink).Encode(snap.logs[:snap.n]); err != nil {
-		sink.Cancel()
+		_ = sink.Cancel()
 		return err
 	}
 	return sink.Close()

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -191,7 +191,7 @@ func Bootstrap(config Config) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer worker.Stop(w)
+	defer func() { _ = worker.Stop(w) }()
 
 	r, err := w.Raft()
 	if err != nil {

--- a/worker/restorewatcher/manifold.go
+++ b/worker/restorewatcher/manifold.go
@@ -70,12 +70,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		RestoreInfoWatcher: RestoreInfoWatcherShim{st},
 	})
 	if err != nil {
-		stTracker.Done()
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	return &cleanupWorker{
 		RestoreStatusWorker: w,
-		cleanup:             func() { stTracker.Done() },
+		cleanup:             func() { _ = stTracker.Done() },
 	}, nil
 }
 

--- a/worker/restorewatcher/worker.go
+++ b/worker/restorewatcher/worker.go
@@ -65,7 +65,7 @@ type restoreWorker struct {
 
 func (w *restoreWorker) loop() error {
 	rw := w.config.RestoreInfoWatcher.WatchRestoreInfoChanges()
-	w.catacomb.Add(rw)
+	_ = w.catacomb.Add(rw)
 	for {
 		select {
 		case <-w.catacomb.Dying():

--- a/worker/storageprovisioner/caasworker.go
+++ b/worker/storageprovisioner/caasworker.go
@@ -114,27 +114,27 @@ func (p *provisioner) loop() error {
 				return errors.New("watcher closed channel")
 			}
 			appTags := make([]names.Tag, len(apps))
-			for i, appId := range apps {
-				appTags[i] = names.NewApplicationTag(appId)
+			for i, appID := range apps {
+				appTags[i] = names.NewApplicationTag(appID)
 			}
 			appsLife, err := p.config.Life.Life(appTags)
 			if err != nil {
 				return errors.Annotate(err, "getting application life")
 			}
-			for i, appId := range apps {
+			for i, appID := range apps {
 				appLifeResult := appsLife[i]
 				if appLifeResult.Error != nil && params.IsCodeNotFound(appLifeResult.Error) {
-					p.config.Logger.Debugf("app %v not found", appId)
-					_, ok := p.getApplicationWorker(appId)
+					p.config.Logger.Debugf("app %v not found", appID)
+					_, ok := p.getApplicationWorker(appID)
 					if ok {
 						if err := worker.Stop(w); err != nil {
-							p.config.Logger.Errorf("stopping application storage worker for %v: %v", appId, err)
+							p.config.Logger.Errorf("stopping application storage worker for %v: %v", appID, err)
 						}
-						p.deleteApplicationWorker(appId)
+						p.deleteApplicationWorker(appID)
 					}
 					continue
 				}
-				if _, ok := p.getApplicationWorker(appId); ok || appLifeResult.Life == life.Dead {
+				if _, ok := p.getApplicationWorker(appID); ok || appLifeResult.Life == life.Dead {
 					// Already watching the application. or we're
 					// not yet watching it and it's dead.
 					continue
@@ -145,8 +145,8 @@ func (p *provisioner) loop() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				p.saveApplicationWorker(appId, w)
-				p.catacomb.Add(w)
+				p.saveApplicationWorker(appID, w)
+				_ = p.catacomb.Add(w)
 			}
 		}
 	}

--- a/worker/storageprovisioner/machines.go
+++ b/worker/storageprovisioner/machines.go
@@ -40,7 +40,7 @@ func refreshMachine(ctx *context, tag names.MachineTag) error {
 		return errors.Errorf("machine %s is not being watched", tag.Id())
 	}
 	stopAndRemove := func() error {
-		worker.Stop(w)
+		_ = worker.Stop(w)
 		delete(ctx.machines, tag)
 		return nil
 	}

--- a/worker/txnpruner/manifold.go
+++ b/worker/txnpruner/manifold.go
@@ -74,8 +74,8 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	worker := config.NewWorker(statePool.SystemState(), config.PruneInterval, clock)
 	go func() {
-		worker.Wait()
-		stTracker.Done()
+		_ = worker.Wait()
+		_ = stTracker.Done()
 	}()
 	return worker, nil
 }

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -206,7 +206,7 @@ func (u *Undertaker) processDyingModel() error {
 				return errors.Trace(err)
 			}
 			// Retry once there are changes to the model's resources.
-			u.setStatus(
+			_ = u.setStatus(
 				status.Destroying,
 				fmt.Sprintf("attempt %d to destroy model failed (will retry):  %v", attempt, err),
 			)

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -840,7 +840,7 @@ func (w *RemoteStateWatcher) relationsChanged(keys []string) error {
 		} else if err != nil {
 			return errors.Trace(err)
 		} else {
-			w.ensureRelationUnits(rel)
+			return w.ensureRelationUnits(rel)
 		}
 	}
 	return nil
@@ -1028,7 +1028,7 @@ func (w *RemoteStateWatcher) storageChanged(keys []string) error {
 		} else if params.IsCodeNotFound(result.Error) {
 			if watcher, ok := w.storageAttachmentWatchers[tag]; ok {
 				// already under catacomb management, any error tracked already
-				worker.Stop(watcher)
+				_ = worker.Stop(watcher)
 				delete(w.storageAttachmentWatchers, tag)
 			}
 			delete(w.current.Storage, tag)

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -106,7 +106,9 @@ func NewRunListener(socket sockets.Socket, logger Logger) (*RunListener, error) 
 	if err := runListener.server.Register(&JujuRunServer{runListener, logger}); err != nil {
 		return nil, errors.Trace(err)
 	}
-	go runListener.Run()
+	// TODO (stickupkid) - We should probably log out when an accept fails, so
+	// we can at least track it.
+	go func() { _ = runListener.Run() }()
 	return runListener, nil
 }
 

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -299,7 +299,7 @@ func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 // to via hooks. Furthermore, the fact that we make multiple API calls at this
 // time, rather than grabbing everything we need in one go, is unforgivably yucky.
 func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
-	defer errors.Trace(err)
+	defer func() { err = errors.Trace(err) }()
 
 	ctx.apiAddrs, err = f.state.APIAddresses()
 	if err != nil {

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -43,7 +43,7 @@ func (s *ServerSession) DebugAt() string {
 // This is a var so it can be replaced for testing.
 var waitClientExit = func(s *ServerSession) {
 	path := s.ClientExitFileLock()
-	exec.Command("flock", path, "-c", "true").Run()
+	_ = exec.Command("flock", path, "-c", "true").Run()
 }
 
 // RunHook "runs" the hook with the specified name via debug-hooks. The hookRunner

--- a/worker/uniter/runner/jujuc/jujuctesting/networking.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/networking.go
@@ -96,7 +96,7 @@ func (c *ContextNetworking) ClosePortRange(endpoint string, portRange network.Po
 // OpenedPortRanges implements jujuc.ContextNetworking.
 func (c *ContextNetworking) OpenedPortRanges() network.GroupedPortRanges {
 	c.stub.AddCall("OpenedPortRanges")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 
 	return c.info.PortRangesByEndpoint
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -69,7 +69,7 @@ type ContextRelation struct {
 // Id implements jujuc.ContextRelation.
 func (r *ContextRelation) Id() int {
 	r.stub.AddCall("Id")
-	r.stub.NextErr()
+	_ = r.stub.NextErr()
 
 	return r.info.Id
 }
@@ -77,7 +77,7 @@ func (r *ContextRelation) Id() int {
 // Name implements jujuc.ContextRelation.
 func (r *ContextRelation) Name() string {
 	r.stub.AddCall("Name")
-	r.stub.NextErr()
+	_ = r.stub.NextErr()
 
 	return r.info.Name
 }
@@ -85,7 +85,7 @@ func (r *ContextRelation) Name() string {
 // FakeId implements jujuc.ContextRelation.
 func (r *ContextRelation) FakeId() string {
 	r.stub.AddCall("FakeId")
-	r.stub.NextErr()
+	_ = r.stub.NextErr()
 
 	return fmt.Sprintf("%s:%d", r.info.Name, r.info.Id)
 }
@@ -93,7 +93,7 @@ func (r *ContextRelation) FakeId() string {
 // Life implements jujuc.ContextRelation.
 func (r *ContextRelation) Life() life.Value {
 	r.stub.AddCall("Life")
-	r.stub.NextErr()
+	_ = r.stub.NextErr()
 
 	return r.info.Life
 }
@@ -125,7 +125,7 @@ func (r *ContextRelation) ApplicationSettings() (jujuc.Settings, error) {
 // UnitNames implements jujuc.ContextRelation.
 func (r *ContextRelation) UnitNames() []string {
 	r.stub.AddCall("UnitNames")
-	r.stub.NextErr()
+	_ = r.stub.NextErr()
 
 	var s []string // initially nil to match the true context.
 	for name := range r.info.Units {

--- a/worker/uniter/runner/jujuc/jujuctesting/relationhook.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relationhook.go
@@ -43,7 +43,7 @@ func (c *ContextRelationHook) HookRelation() (jujuc.ContextRelation, error) {
 // RemoteUnitName implements jujuc.RelationHookContext.
 func (c *ContextRelationHook) RemoteUnitName() (string, error) {
 	c.stub.AddCall("RemoteUnitName")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 	var err error
 	if c.info.RemoteUnitName == "" {
 		err = errors.NotFoundf("remote unit")
@@ -55,7 +55,7 @@ func (c *ContextRelationHook) RemoteUnitName() (string, error) {
 // RemoteApplicationName implements jujuc.RelationHookContext.
 func (c *ContextRelationHook) RemoteApplicationName() (string, error) {
 	c.stub.AddCall("RemoteApplicationName")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 	var err error
 	if c.info.RemoteApplicationName == "" {
 		err = errors.NotFoundf("remote application")

--- a/worker/uniter/runner/jujuc/jujuctesting/storageattachment.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/storageattachment.go
@@ -24,7 +24,7 @@ type ContextStorageAttachment struct {
 // Tag implements jujuc.StorageAttachement.
 func (c *ContextStorageAttachment) Tag() names.StorageTag {
 	c.stub.AddCall("Tag")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 
 	return c.info.Tag
 }
@@ -32,7 +32,7 @@ func (c *ContextStorageAttachment) Tag() names.StorageTag {
 // Kind implements jujuc.StorageAttachement.
 func (c *ContextStorageAttachment) Kind() storage.StorageKind {
 	c.stub.AddCall("Kind")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 
 	return c.info.Kind
 }
@@ -40,7 +40,7 @@ func (c *ContextStorageAttachment) Kind() storage.StorageKind {
 // Location implements jujuc.StorageAttachement.
 func (c *ContextStorageAttachment) Location() string {
 	c.stub.AddCall("Location")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 
 	return c.info.Location
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/unit.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/unit.go
@@ -30,7 +30,7 @@ type ContextUnit struct {
 // UnitName implements jujuc.ContextUnit.
 func (c *ContextUnit) UnitName() string {
 	c.stub.AddCall("UnitName")
-	c.stub.NextErr()
+	_ = c.stub.NextErr()
 
 	return c.info.Name
 }

--- a/worker/uniter/runner/jujuc/status-get.go
+++ b/worker/uniter/runner/jujuc/status-get.go
@@ -97,7 +97,7 @@ func (c *StatusGetCommand) ApplicationStatus(ctx *cmd.Context) error {
 	}
 	details["units"] = units
 	statusDetails["application-status"] = details
-	c.out.Write(ctx, statusDetails)
+	_ = c.out.Write(ctx, statusDetails)
 
 	return nil
 
@@ -120,7 +120,7 @@ func (c *StatusGetCommand) unitOrApplicationStatus(ctx *cmd.Context) error {
 	if !c.includeData && c.out.Name() == "smart" {
 		return c.out.Write(ctx, unitStatus.Status)
 	}
-	c.out.Write(ctx, toDetails(*unitStatus, c.includeData))
+	_ = c.out.Write(ctx, toDetails(*unitStatus, c.includeData))
 	return nil
 }
 

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -63,6 +63,5 @@ func (s *StorageAddCommand) Init(args []string) error {
 }
 
 func (s *StorageAddCommand) Run(ctx *cmd.Context) error {
-	s.ctx.AddUnitStorage(s.all)
-	return nil
+	return s.ctx.AddUnitStorage(s.all)
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -643,7 +643,7 @@ func (runner *runner) runCharmProcessOnLocal(hook, hookName, charmDir string, en
 			go func() {
 				select {
 				case <-cancel:
-					ps.Process.Kill()
+					_ = ps.Process.Kill()
 				case <-done:
 				}
 			}()
@@ -709,7 +709,7 @@ func (runner *runner) startJujucServer(token string, rMode runMode) (*jujuc.Serv
 	if err != nil {
 		return nil, errors.Annotate(err, "starting jujuc server")
 	}
-	go srv.Run()
+	go func() { _ = srv.Run() }()
 	return srv, nil
 }
 


### PR DESCRIPTION
Follow the fallout from #12609 it became apparent that we could employ linters
to help guard and solve against panics at runtime. The problem is that in order to
use the linter we need to enable `errcheck`.

The `errcheck` didn't currently run, so the following effort is to make juju `errcheck`
friendly. The next stage after this is landed is to then enable `check-type-assertions`.

If somebody was so inclined they could make the following run for tests as well!

----

The `errcheck` found a few gotchas in the code base, either we weren't handling
the error correctly or just blindly ignoring it.

As this is an ongoing experiment I've created a new yaml file to allow us to experiment
with linters whilst not breaking the initial setup.

## QA steps

```sh
make static-analysis
```
