### PR TITLE
Fixes permission for model operator.

### DIFF
--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 
 	"github.com/juju/juju/caas"
 )
@@ -19,13 +20,18 @@ var _ = gc.Suite(&ModelOperatorSuite{})
 
 func (m *ModelOperatorSuite) Test(c *gc.C) {
 	var (
-		ensureConfigMapCalled  = false
-		ensureDeploymentCalled = false
-		ensureServiceCalled    = false
-		namespaceCalled        = false
-		modelUUID              = "abcd-efff-face"
-		agentPath              = "/var/app/juju"
-		namespace              = "test-namespace"
+		ensureClusterRoleCalled        = false
+		ensureClusterRoleBindingCalled = false
+		ensureConfigMapCalled          = false
+		ensureDeploymentCalled         = false
+		ensureRoleCalled               = false
+		ensureRoleBindingCalled        = false
+		ensureServiceCalled            = false
+		ensureServiceAccountCalled     = false
+		namespaceCalled                = false
+		modelUUID                      = "abcd-efff-face"
+		agentPath                      = "/var/app/juju"
+		namespace                      = "test-namespace"
 	)
 
 	config := caas.ModelOperatorConfig{
@@ -35,7 +41,23 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 	}
 
 	bridge := &modelOperatorBrokerBridge{
-		ensureConfigMap: func(cm *core.ConfigMap) error {
+		ensureClusterRole: func(cr *rbac.ClusterRole) ([]func(), error) {
+			ensureClusterRoleCalled = true
+			c.Assert(cr.Name, gc.Equals, modelOperatorName)
+			c.Assert(cr.Rules[0].APIGroups, jc.DeepEquals, []string{""})
+			c.Assert(cr.Rules[0].Resources, jc.DeepEquals, []string{"namespaces"})
+			c.Assert(cr.Rules[0].Verbs, jc.DeepEquals, []string{"get"})
+			return nil, nil
+		},
+		ensureClusterRoleBinding: func(crb *rbac.ClusterRoleBinding) ([]func(), error) {
+			ensureClusterRoleBindingCalled = true
+			c.Assert(crb.Name, gc.Equals, modelOperatorName)
+			c.Assert(crb.RoleRef.APIGroup, gc.Equals, "rbac.authorization.k8s.io")
+			c.Assert(crb.RoleRef.Kind, gc.Equals, "ClusterRole")
+			c.Assert(crb.RoleRef.Name, gc.Equals, modelOperatorName)
+			return nil, nil
+		},
+		ensureConfigMap: func(cm *core.ConfigMap) ([]func(), error) {
 			ensureConfigMapCalled = true
 			c.Assert(cm.Name, gc.Equals, modelOperatorName)
 			c.Assert(cm.Namespace, gc.Equals, namespace)
@@ -43,22 +65,61 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 			conf, ok := cm.Data[modelOperatorConfigMapAgentConfKey(modelOperatorName)]
 			c.Assert(ok, gc.Equals, true)
 			c.Assert(conf, jc.DeepEquals, string(config.AgentConf))
-			return nil
+			return nil, nil
 		},
-		ensureDeployment: func(d *apps.Deployment) error {
+		ensureDeployment: func(d *apps.Deployment) ([]func(), error) {
 			ensureDeploymentCalled = true
 			c.Assert(d.Name, gc.Equals, modelOperatorName)
 			c.Assert(d.Namespace, gc.Equals, namespace)
 			c.Assert(d.Spec.Template.Spec.Containers[0].Image, gc.Equals, config.OperatorImagePath)
 			c.Assert(d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort, gc.Equals, config.Port)
-			return nil
+			return nil, nil
 		},
-		ensureService: func(s *core.Service) error {
+		ensureRole: func(r *rbac.Role) ([]func(), error) {
+			ensureRoleCalled = true
+			c.Assert(r.Name, gc.Equals, modelOperatorName)
+			c.Assert(r.Namespace, gc.Equals, namespace)
+			c.Assert(r.Rules[0].APIGroups, jc.DeepEquals, []string{"admissionregistration.k8s.io"})
+			c.Assert(r.Rules[0].Resources, jc.DeepEquals, []string{"mutatingwebhookconfigurations"})
+			c.Assert(r.Rules[0].Verbs, jc.DeepEquals, []string{
+				"create",
+				"delete",
+				"get",
+				"list",
+				"update",
+			})
+			c.Assert(r.Rules[1].APIGroups, jc.DeepEquals, []string{""})
+			c.Assert(r.Rules[1].Resources, jc.DeepEquals, []string{"serviceaccounts"})
+			c.Assert(r.Rules[1].Verbs, jc.DeepEquals, []string{
+				"get",
+				"list",
+				"watch",
+			})
+			return nil, nil
+		},
+		ensureRoleBinding: func(rb *rbac.RoleBinding) ([]func(), error) {
+			ensureRoleBindingCalled = true
+			c.Assert(rb.Name, gc.Equals, modelOperatorName)
+			c.Assert(rb.Namespace, gc.Equals, namespace)
+			c.Assert(rb.RoleRef.APIGroup, gc.Equals, "rbac.authorization.k8s.io")
+			c.Assert(rb.RoleRef.Kind, gc.Equals, "Role")
+			c.Assert(rb.RoleRef.Name, gc.Equals, modelOperatorName)
+			return nil, nil
+		},
+		ensureServiceAccount: func(s *core.ServiceAccount) ([]func(), error) {
+			trueVar := true
+			ensureServiceAccountCalled = true
+			c.Assert(s.Name, gc.Equals, modelOperatorName)
+			c.Assert(s.Namespace, gc.Equals, namespace)
+			c.Assert(s.AutomountServiceAccountToken, jc.DeepEquals, &trueVar)
+			return nil, nil
+		},
+		ensureService: func(s *core.Service) ([]func(), error) {
 			ensureServiceCalled = true
 			c.Assert(s.Name, gc.Equals, modelOperatorName)
 			c.Assert(s.Namespace, gc.Equals, namespace)
 			c.Assert(s.Spec.Ports[0].Port, gc.Equals, config.Port)
-			return nil
+			return nil, nil
 		},
 		namespace: func() string {
 			namespaceCalled = true
@@ -69,8 +130,13 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 	err := ensureModelOperator(modelUUID, agentPath, &config, bridge)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(ensureConfigMapCalled, gc.Equals, true)
-	c.Assert(ensureDeploymentCalled, gc.Equals, true)
-	c.Assert(ensureServiceCalled, gc.Equals, true)
-	c.Assert(namespaceCalled, gc.Equals, true)
+	c.Assert(ensureClusterRoleCalled, jc.IsTrue)
+	c.Assert(ensureClusterRoleBindingCalled, jc.IsTrue)
+	c.Assert(ensureConfigMapCalled, jc.IsTrue)
+	c.Assert(ensureDeploymentCalled, jc.IsTrue)
+	c.Assert(ensureRoleCalled, jc.IsTrue)
+	c.Assert(ensureRoleBindingCalled, jc.IsTrue)
+	c.Assert(ensureServiceAccountCalled, jc.IsTrue)
+	c.Assert(ensureServiceCalled, jc.IsTrue)
+	c.Assert(namespaceCalled, jc.IsTrue)
 }

--- a/caas/kubernetes/provider/utils/cleanup.go
+++ b/caas/kubernetes/provider/utils/cleanup.go
@@ -1,0 +1,13 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+// RunCleanUps runs the functions provided in the cleanUps slice in reverse
+// order. This is a utility function for Kubernetes to help remove resources
+// created when there is an error
+func RunCleanUps(cleanUps []func()) {
+	for j := len(cleanUps) - 1; j >= 0; j-- {
+		cleanUps[j]()
+	}
+}

--- a/caas/kubernetes/provider/utils/cleanup_test.go
+++ b/caas/kubernetes/provider/utils/cleanup_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
+)
+
+func TestCleanupsHappenInReverse(t *testing.T) {
+	var (
+		firstCleanUpCalled  = false
+		secondCleanUpCalled = false
+	)
+
+	utils.RunCleanUps([]func(){
+		func() {
+			firstCleanUpCalled = true
+		},
+		func() {
+			secondCleanUpCalled = true
+			if firstCleanUpCalled {
+				t.Error("cleanup functions not called in reverse order")
+			}
+		},
+	})
+
+	if !firstCleanUpCalled || !secondCleanUpCalled {
+		t.Error("not all cleanup functions called")
+	}
+}
+
+func TestEmptyCleanUps(_ *testing.T) {
+	utils.RunCleanUps([]func(){})
+}


### PR DESCRIPTION
A bug was introduced in the 2.9 branch where local run juju binaries in
a kube cluster default to using the service account attached to their
pod. This change wasn't ported to the model operator so it was using a
service account without any permissions.

This change give the model operator it's own service account with the
need permissions to run.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

The easiest way to verify the fix is bootstrap juju and check the model operator logs for errors. The more thorough test all though not needed is to follow the steps outline in the bug report below.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1915320
