### PR TITLE
Add set-series integration test

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -33,8 +33,8 @@ import_subdir_files() {
 
 import_subdir_files includes
 
-# If adding a test suite, then ensure to add it here to be picked up! (Please
-# keep these in alphabetic order.)
+# If adding a test suite, then ensure to add it here to be picked up!
+# Please keep these in alphabetic order.
 TEST_NAMES="agents \
             appdata \
             backup \
@@ -55,7 +55,9 @@ TEST_NAMES="agents \
             relations \
             smoke \
             spaces_ec2 \
-            static_analysis"
+            static_analysis \
+            unit \
+            upgrade"
 
 # Show test suites, can be used to test if a test suite is available or not.
 show_test_suites() {

--- a/tests/suites/unit/task.sh
+++ b/tests/suites/unit/task.sh
@@ -1,0 +1,20 @@
+test_unit() {
+    if [ "$(skip 'test_unit')" ]; then
+        echo "==> TEST SKIPPED: unit tests"
+        return
+    fi
+
+    set_verbosity
+
+    echo "==> Checking for dependencies"
+    check_dependencies juju
+
+    file="${TEST_DIR}/test-units.log"
+
+    bootstrap "test-units" "${file}"
+
+    # Tests that need to be run are added here.
+    test_unit_series
+
+    destroy_controller "test-units"
+}

--- a/tests/suites/unit/unit_series.sh
+++ b/tests/suites/unit/unit_series.sh
@@ -6,7 +6,7 @@ run_unit_set_series() {
     file="${TEST_DIR}/test-unit-series.log"
     ensure "unit-series" "${file}"
 
-    juju deploy cs:ubuntu --series=xenial
+    juju deploy cs:ubuntu --series=bionic
 
     wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
@@ -16,6 +16,8 @@ run_unit_set_series() {
     wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"
 
     juju status --format=json | jq -r ".machines | .[\"1\"] | .series" | grep "focal"
+
+    destroy_model "unit-series"
 }
 
 test_unit_series() {

--- a/tests/suites/unit/unit_series.sh
+++ b/tests/suites/unit/unit_series.sh
@@ -1,0 +1,34 @@
+run_unit_set_series() {
+    # Echo out to ensure nice output to the test suite.
+    echo
+
+    # The following ensures that a bootstrap juju exists.
+    file="${TEST_DIR}/test-unit-series.log"
+    ensure "unit-series" "${file}"
+
+    juju deploy cs:ubuntu --series=xenial
+
+    wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+    juju set-series ubuntu focal
+    juju add-unit ubuntu
+
+    wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"
+
+    juju status --format=json | jq -r ".machines | .[\"1\"] | .series" | grep "focal"
+}
+
+test_unit_series() {
+    if [ -n "$(skip 'test_unit_series')" ]; then
+        echo "==> SKIP: Asked to skip unit series tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_unit_set_series"
+    )
+}


### PR DESCRIPTION
Set series won't currently work with charmhub charms, but we must make
sure we haven't regressed with charmstore charms. To ensure that we add
an integration test to keep that check balanced.

## QA steps

```sh
$ (cd tests && ./main.sh unit) 
```
