### PR TITLE
Fix asserts used when finalising an action

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -57,6 +58,12 @@ const (
 
 	// ActionAborted indicates the Action was aborted.
 	ActionAborted ActionStatus = "aborted"
+)
+
+var activeStatus = set.NewStrings(
+	string(ActionPending),
+	string(ActionRunning),
+	string(ActionAborting),
 )
 
 type actionNotificationDoc struct {
@@ -385,6 +392,19 @@ func (a *action) removeAndLog(finalStatus ActionStatus, results map[string]inter
 func (a *action) removeAndLogBuildTxn(finalStatus ActionStatus, results map[string]interface{}, message string,
 	m *Model, parentOperation Operation, completedTime time.Time) jujutxn.TransactionSource {
 	return func(attempt int) ([]txn.Op, error) {
+		// If the action is already finished, return an error.
+		if a.Status() == finalStatus {
+			return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("action %v already has status %q", a.Id(), finalStatus))
+		}
+		if attempt > 0 {
+			err := a.Refresh()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if !activeStatus.Contains(string(a.Status())) {
+				return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("action %v is already finished with status %q", a.Id(), finalStatus))
+			}
+		}
 		assertNotComplete := bson.D{{"status", bson.D{
 			{"$nin", []interface{}{
 				ActionCompleted,
@@ -409,7 +429,7 @@ func (a *action) removeAndLogBuildTxn(finalStatus ActionStatus, results map[stri
 			var numComplete int
 			for _, status := range tasks {
 				statusStats.Add(string(status))
-				if status != ActionPending && status != ActionRunning {
+				if !activeStatus.Contains(string(status)) {
 					numComplete++
 				}
 			}
@@ -438,9 +458,9 @@ func (a *action) removeAndLogBuildTxn(finalStatus ActionStatus, results map[stri
 				updateOperationOp = &txn.Op{
 					C:      operationsC,
 					Id:     a.st.docID(parentOperation.Id()),
-					Assert: bson.D{{"complete-task-count", parentOperation.(*operation).doc.CompleteTaskCount}},
-					Update: bson.D{{"$set", bson.D{
-						{"complete-task-count", numComplete + 1},
+					Assert: bson.D{{"complete-task-count", bson.D{{"$lt", len(tasks) - 1}}}},
+					Update: bson.D{{"$inc", bson.D{
+						{"complete-task-count", 1},
 					}}},
 				}
 			}

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -6,8 +6,11 @@ package state_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -384,6 +387,51 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperation(c *gc.C) {
 	// Failed task precedence over completed.
 	c.Assert(operation.Status(), gc.Equals, state.ActionFailed)
 	c.Assert(operation.Completed(), gc.Equals, anAction2.Completed())
+}
+
+func (s *ActionSuite) TestLastActionFinishCompletesOperationMany(c *gc.C) {
+	operationID, err := s.Model.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	numActions := 50
+
+	wg := sync.WaitGroup{}
+	var actions []state.Action
+	for i := 0; i < numActions; i++ {
+		anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+		c.Assert(err, jc.ErrorIsNil)
+
+		anAction, err = anAction.Begin()
+		c.Assert(err, jc.ErrorIsNil)
+		actions = append(actions, anAction)
+		wg.Add(1)
+	}
+
+	completeCount := int32(0)
+	for i := 0; i < numActions; i++ {
+		go func(a int) {
+			defer func() {
+				atomic.AddInt32(&completeCount, 1)
+				wg.Done()
+			}()
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(5)))
+			if atomic.LoadInt32(&completeCount) < int32(numActions) {
+				operation, err := s.model.Operation(operationID)
+				c.Assert(err, jc.ErrorIsNil)
+				c.Assert(operation.Status(), gc.Not(gc.Equals), state.ActionCompleted)
+			}
+
+			_, err = actions[a].Finish(state.ActionResults{
+				Status: state.ActionCompleted,
+			})
+			c.Assert(err, jc.ErrorIsNil)
+		}(i)
+	}
+	wg.Wait()
+
+	operation, err := s.model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(operation.Status(), gc.Equals, state.ActionCompleted)
 }
 
 func (s *ActionSuite) TestLastActionFinishCompletesOperationRace(c *gc.C) {
@@ -1118,15 +1166,16 @@ func (s *ActionSuite) TestActionStatusWatcher(c *gc.C) {
 		receiver state.ActionReceiver
 		name     string
 		status   state.ActionStatus
+		err      string
 	}{
-		{s.unit, "snapshot", state.ActionCancelled},
-		{s.unit2, "snapshot", state.ActionCancelled},
-		{s.unit, "snapshot", state.ActionPending},
-		{s.unit2, "snapshot", state.ActionPending},
-		{s.unit, "snapshot", state.ActionFailed},
-		{s.unit2, "snapshot", state.ActionFailed},
-		{s.unit, "snapshot", state.ActionCompleted},
-		{s.unit2, "snapshot", state.ActionCompleted},
+		{s.unit, "snapshot", state.ActionCancelled, ""},
+		{s.unit2, "snapshot", state.ActionCancelled, ""},
+		{s.unit, "snapshot", state.ActionPending, `.* already has status "pending"`},
+		{s.unit2, "snapshot", state.ActionPending, `.* already has status "pending"`},
+		{s.unit, "snapshot", state.ActionFailed, ""},
+		{s.unit2, "snapshot", state.ActionFailed, ""},
+		{s.unit, "snapshot", state.ActionCompleted, ""},
+		{s.unit2, "snapshot", state.ActionCompleted, ""},
 	}
 
 	w1 := state.NewActionStatusWatcher(s.State, []state.ActionReceiver{s.unit})
@@ -1165,7 +1214,11 @@ func (s *ActionSuite) TestActionStatusWatcher(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		_, err = action.Finish(state.ActionResults{Status: tcase.status})
-		c.Assert(err, jc.ErrorIsNil)
+		if tcase.err == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, tcase.err)
+		}
 
 		if tcase.receiver == s.unit {
 			expect[tcase.status] = append(expect[tcase.status], action)

--- a/worker/machineactions/worker.go
+++ b/worker/machineactions/worker.go
@@ -118,7 +118,9 @@ func (h *handler) Handle(_ <-chan struct{}, actionsSlice []string) error {
 		} else {
 			finishErr = h.config.Facade.ActionFinish(actionTag, params.ActionCompleted, results, "")
 		}
-		if finishErr != nil {
+		if finishErr != nil &&
+			!params.IsCodeAlreadyExists(finishErr) &&
+			!params.IsCodeNotFoundOrCodeUnauthorized(finishErr) {
 			return errors.Trace(finishErr)
 		}
 	}

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -103,7 +103,7 @@ func (opc *operationCallbacks) FailAction(actionId, message string) error {
 	}
 	tag := names.NewActionTag(actionId)
 	err := opc.u.st.ActionFinish(tag, params.ActionFailed, nil, message)
-	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
+	if params.IsCodeNotFoundOrCodeUnauthorized(err) || params.IsCodeAlreadyExists(err) {
 		err = nil
 	}
 	return err

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1233,6 +1233,11 @@ func (ctx *HookContext) finalizeAction(err, unhandledErr error) error {
 	}
 
 	callErr := ctx.state.ActionFinish(tag, actionStatus, results, message)
+	// Prevent the unit agent from looping if it's impossible to finalise the action.
+	if params.IsCodeNotFoundOrCodeUnauthorized(callErr) || params.IsCodeAlreadyExists(callErr) {
+		ctx.logger.Warningf("error finalising action %v: %v", tag.Id(), callErr)
+		callErr = nil
+	}
 	if callErr != nil {
 		unhandledErr = errors.Wrap(unhandledErr, callErr)
 	}


### PR DESCRIPTION
When finalising an action, if it's the last one to be completed for a parent operation, the parent operation also has its status set to completed/failed/cancelled.
The db assert used to prevent races with concurrent updates was too strict, and running many actions triggered a condition where the db update failed.
As well as fixing that, this PR also returns a typed error if there's an attempt to finish an action more than once. The unit agent detects this error and avoids a restart, which hopefully will prevent the uniter worker loops we've seen.

## QA steps

export JUJU_DEV_FEATURE_FLAGS=actions-v2
bootstrap and deploy say 10 units of ubuntu-lite charm
juju exec --app ubuntu pwd
juju operations

The operation status should be "completed"
juj show-task --format yaml on the task ids should also show "completed"

## Bug reference

https://bugs.launchpad.net/juju/+bug/1914619
