### PR TITLE
Move NetworkConfigSource from api/common to core/network

### DIFF
--- a/container/broker/instance_broker.go
+++ b/container/broker/instance_broker.go
@@ -11,12 +11,12 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/factory"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 )
@@ -32,7 +32,7 @@ var (
 )
 
 // NetConfigFunc returns a slice of NetworkConfig from a source config.
-type NetConfigFunc func(common.NetworkConfigSource) ([]params.NetworkConfig, error)
+type NetConfigFunc func(corenetwork.ConfigSource) ([]params.NetworkConfig, error)
 
 // Config describes the resources used by the instance broker.
 type Config struct {
@@ -146,7 +146,7 @@ func acquireLock(config Config) func(string, <-chan struct{}) (func(), error) {
 
 func observeNetwork(config Config) func() ([]params.NetworkConfig, error) {
 	return func() ([]params.NetworkConfig, error) {
-		return config.GetNetConfig(common.DefaultNetworkConfigSource())
+		return config.GetNetConfig(corenetwork.DefaultNetworkConfigSource())
 	}
 }
 

--- a/core/network/source.go
+++ b/core/network/source.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import "net"
+
+// SysClassNetRoot is the full Linux SYSFS path containing
+// information about each network interface on the system.
+// TODO (manadart 2021-02-12): This remains in the main "source.go" module
+// because there was previously only one ConfigSource implementation,
+// which presumably did not work on Windows.
+// When the NetlinkConfigSource was introduced for use on Linux,
+// we retained the old universal config source for use on Windows.
+// If there comes a time when we properly implement a Windows source,
+// this should be relocated to the Linux module and an appropriate counterpart
+// introduced for Windows.
+const SysClassNetPath = "/sys/class/net"
+
+// ConfigSource defines the necessary calls to obtain
+// the network configuration of a machine.
+type ConfigSource interface {
+	// SysClassNetPath returns the userspace SYSFS path used by this source.
+	SysClassNetPath() string
+
+	// Interfaces returns information about all
+	// network interfaces on the machine.
+	Interfaces() ([]net.Interface, error)
+
+	// InterfaceAddresses returns information about all addresses
+	// assigned to the network interface with the given name.
+	InterfaceAddresses(name string) ([]net.Addr, error)
+
+	// DefaultRoute returns the gateway IP address and device name of the
+	// default route on the machine. If there is no default route (known),
+	// then zero values are returned.
+	DefaultRoute() (net.IP, string, error)
+}

--- a/core/network/source_other.go
+++ b/core/network/source_other.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"net"
+
+	"github.com/juju/errors"
+)
+
+type netPackageConfigSource struct{}
+
+// SysClassNetPath implements NetworkConfigSource.
+func (n *netPackageConfigSource) SysClassNetPath() string {
+	return SysClassNetPath
+}
+
+// Interfaces implements NetworkConfigSource.
+func (n *netPackageConfigSource) Interfaces() ([]net.Interface, error) {
+	return net.Interfaces()
+}
+
+// InterfaceAddresses implements NetworkConfigSource.
+func (n *netPackageConfigSource) InterfaceAddresses(name string) ([]net.Addr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return iface.Addrs()
+}
+
+// DefaultRoute implements NetworkConfigSource.
+func (n *netPackageConfigSource) DefaultRoute() (net.IP, string, error) {
+	return GetDefaultRoute()
+}
+
+// DefaultNetworkConfigSource returns a NetworkConfigSource backed by the net
+// package, to be used with GetObservedNetworkConfig().
+func DefaultNetworkConfigSource() ConfigSource {
+	return &netPackageConfigSource{}
+}

--- a/network/utils.go
+++ b/network/utils.go
@@ -27,11 +27,6 @@ func SupportsIPv6() bool {
 	return true
 }
 
-// SysClassNetRoot is the full Linux SYSFS path containing information about
-// each network interface on the system. Used as argument to
-// ParseInterfaceType().
-const SysClassNetPath = "/sys/class/net"
-
 // ParseInterfaceType parses the DEVTYPE attribute from the Linux kernel
 // userspace SYSFS location "<sysPath/<interfaceName>/uevent" and returns it as
 // InterfaceType. SysClassNetPath should be passed as sysPath. Returns

--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -44,7 +44,7 @@ func (s *UtilsSuite) TestSupportsIPv6OK(c *gc.C) {
 }
 
 func (*UtilsSuite) TestParseInterfaceType(c *gc.C) {
-	fakeSysPath := filepath.Join(c.MkDir(), network.SysClassNetPath)
+	fakeSysPath := filepath.Join(c.MkDir(), corenetwork.SysClassNetPath)
 	err := os.MkdirAll(fakeSysPath, 0700)
 	c.Check(err, jc.ErrorIsNil)
 
@@ -94,7 +94,7 @@ func (*UtilsSuite) TestParseInterfaceType(c *gc.C) {
 }
 
 func (*UtilsSuite) TestGetBridgePorts(c *gc.C) {
-	fakeSysPath := filepath.Join(c.MkDir(), network.SysClassNetPath)
+	fakeSysPath := filepath.Join(c.MkDir(), corenetwork.SysClassNetPath)
 	err := os.MkdirAll(fakeSysPath, 0700)
 	c.Check(err, jc.ErrorIsNil)
 

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -175,7 +175,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 
 	life := mr.machine.Life()
 	if life == corelife.Alive {
-		observedConfig, err := getObservedNetworkConfig(common.DefaultNetworkConfigSource())
+		observedConfig, err := getObservedNetworkConfig(corenetwork.DefaultNetworkConfigSource())
 		if err != nil {
 			return errors.Annotate(err, "cannot discover observed network config")
 		} else if len(observedConfig) == 0 {

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/worker/v2"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
@@ -53,7 +52,7 @@ func (s *MachinerSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(machiner.InterfaceAddrs, func() ([]net.Addr, error) {
 		return s.addresses, nil
 	})
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(_ corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return nil, nil
 	})
 }
@@ -389,7 +388,7 @@ func (s *MachinerSuite) TestMachineAddressesWithClearFlag(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestGetObservedNetworkConfigEmpty(c *gc.C) {
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(source corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return []params.NetworkConfig{}, nil
 	})
 
@@ -408,7 +407,7 @@ func (s *MachinerSuite) TestGetObservedNetworkConfigEmpty(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestSetObservedNetworkConfig(c *gc.C) {
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(source corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return []params.NetworkConfig{{}}, nil
 	})
 
@@ -428,7 +427,7 @@ func (s *MachinerSuite) TestSetObservedNetworkConfig(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestAliveErrorGetObservedNetworkConfig(c *gc.C) {
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(source corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return nil, errors.New("no config!")
 	})
 

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -49,7 +50,7 @@ type ContainerSetup struct {
 	// been started, the container watcher can be stopped.
 	numberProvisioners int32
 	credentialAPI      workercommon.CredentialAPI
-	getNetConfig       func(common.NetworkConfigSource) ([]params.NetworkConfig, error)
+	getNetConfig       func(network.ConfigSource) ([]params.NetworkConfig, error)
 }
 
 // ContainerSetupParams are used to initialise a container setup handler.
@@ -237,7 +238,7 @@ func (cs *ContainerSetup) initContainerDependencies(abort <-chan struct{}, conta
 }
 
 func (cs *ContainerSetup) observeNetwork() ([]params.NetworkConfig, error) {
-	return cs.getNetConfig(common.DefaultNetworkConfigSource())
+	return cs.getNetConfig(network.DefaultNetworkConfigSource())
 }
 
 func (cs *ContainerSetup) acquireLock(comment string, abort <-chan struct{}) (func(), error) {

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	apimocks "github.com/juju/juju/api/base/mocks"
-	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	provisionermocks "github.com/juju/juju/api/provisioner/mocks"
 	"github.com/juju/juju/apiserver/params"
@@ -30,6 +29,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -168,7 +168,7 @@ func (s *containerSetupSuite) setUpContainerWorker(c *gc.C) (watcher.StringsHand
 	// Stub out network config getter.
 	handler := provisioner.NewContainerSetupHandler(args)
 	handler.(*provisioner.ContainerSetup).SetGetNetConfig(
-		func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+		func(_ network.ConfigSource) ([]params.NetworkConfig, error) {
 			return nil, nil
 		})
 

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/juju/version"
 
-	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -65,6 +65,6 @@ func SetupToStartMachine(p ProvisionerTask, machine apiprovisioner.MachineProvis
 	return p.(*provisionerTask).setupToStartMachine(machine, version)
 }
 
-func (cs *ContainerSetup) SetGetNetConfig(getNetConf func(common.NetworkConfigSource) ([]params.NetworkConfig, error)) {
+func (cs *ContainerSetup) SetGetNetConfig(getNetConf func(network.ConfigSource) ([]params.NetworkConfig, error)) {
 	cs.getNetConfig = getNetConf
 }


### PR DESCRIPTION
Moves `NetworkConfigSource` (now `ConfigSource`) from `api/common` to `core/network`.

Lays down some preparation and explanation for adding a new implementation of `ConfigSource` that will use an alternative to the stdlib `net` package for reading machine network interfaces and surface the `IFA_F_SECONDARY` flag.

## QA steps

Mechanical changes only; tests should pass

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1863916
