### PR TITLE
Indirection for network config sourced addresses

### DIFF
--- a/api/common/network.go
+++ b/api/common/network.go
@@ -165,6 +165,9 @@ func interfaceAddressToNetworkConfig(
 		ConfigType: configType,
 	}
 
+	if addr == nil {
+		return config, errors.Errorf("cannot parse nil address on interface %q", interfaceName)
+	}
 	ip := addr.IP()
 	if ip == nil {
 		return config, errors.Errorf("cannot parse IP address %q on interface %q", addr.String(), interfaceName)

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/network"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -151,31 +152,24 @@ var exampleObservedInterfaces = []net.Interface{{
 	Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
 }}
 
-type fakeAddr string
-
-func (f fakeAddr) Network() string { return "" }
-func (f fakeAddr) String() string  { return string(f) }
-
-var _ net.Addr = (*fakeAddr)(nil)
-
-var exampleObservedInterfaceAddrs = map[string][]net.Addr{
-	"eth0":        {fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"eth1":        {fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"eth0.50":     {fakeAddr("fe80::5054:ff:fedd:eef0:50/64")},
-	"eth0.100":    {fakeAddr("fe80::5054:ff:fedd:eef0:100/64")},
-	"eth0.25":     {fakeAddr("fe80::5054:ff:fedd:eef0:25/64")},
-	"eth1.11":     {fakeAddr("fe80::5054:ff:fedd:eef1:11/64")},
-	"eth1.12":     {fakeAddr("fe80::5054:ff:fedd:eef1:12/64")},
-	"eth1.13":     {fakeAddr("fe80::5054:ff:fedd:eef1:13/64")},
-	"lo":          {fakeAddr("127.0.0.1/8"), fakeAddr("::1/128")},
-	"br-eth0":     {fakeAddr("10.20.19.100/24"), fakeAddr("10.20.19.123/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth1":     {fakeAddr("10.20.19.105/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"br-eth0.50":  {fakeAddr("10.50.19.100/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth0.100": {fakeAddr("10.100.19.100/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth0.250": {fakeAddr("10.250.19.100/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth1.11":  {fakeAddr("10.11.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"br-eth1.12":  {fakeAddr("10.12.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"br-eth1.13":  {fakeAddr("10.13.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
+var exampleObservedInterfaceAddrs = map[string][]network.ConfigSourceAddr{
+	"eth0":        {network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"eth1":        {network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"eth0.50":     {network.NewNetAddr("fe80::5054:ff:fedd:eef0:50/64")},
+	"eth0.100":    {network.NewNetAddr("fe80::5054:ff:fedd:eef0:100/64")},
+	"eth0.25":     {network.NewNetAddr("fe80::5054:ff:fedd:eef0:25/64")},
+	"eth1.11":     {network.NewNetAddr("fe80::5054:ff:fedd:eef1:11/64")},
+	"eth1.12":     {network.NewNetAddr("fe80::5054:ff:fedd:eef1:12/64")},
+	"eth1.13":     {network.NewNetAddr("fe80::5054:ff:fedd:eef1:13/64")},
+	"lo":          {network.NewNetAddr("127.0.0.1/8"), network.NewNetAddr("::1/128")},
+	"br-eth0":     {network.NewNetAddr("10.20.19.100/24"), network.NewNetAddr("10.20.19.123/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth1":     {network.NewNetAddr("10.20.19.105/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"br-eth0.50":  {network.NewNetAddr("10.50.19.100/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth0.100": {network.NewNetAddr("10.100.19.100/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth0.250": {network.NewNetAddr("10.250.19.100/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth1.11":  {network.NewNetAddr("10.11.19.101/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"br-eth1.12":  {network.NewNetAddr("10.12.19.101/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"br-eth1.13":  {network.NewNetAddr("10.13.19.101/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
 }
 
 func (s *NetworkSuite) TestGetObservedNetworkConfigInterfacesError(c *gc.C) {
@@ -205,7 +199,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigInterfaceAddressesError(c *gc
 
 func (s *NetworkSuite) TestGetObservedNetworkConfigNoInterfaceAddresses(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[3:4] // only br-eth1
-	s.stubConfigSource.interfaceAddrs = make(map[string][]net.Addr)
+	s.stubConfigSource.interfaceAddrs = make(map[string][]network.ConfigSourceAddr)
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "br-eth1", "bridge")
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
@@ -256,10 +250,10 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigLoopbackInferred(c *gc.C) {
 
 func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[6:7] // only eth0.100
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
 		"eth0.100": {
-			fakeAddr("fe80::5054:ff:fedd:eef0:100/64"),
-			fakeAddr("10.100.19.123/24"),
+			network.NewNetAddr("fe80::5054:ff:fedd:eef0:100/64"),
+			network.NewNetAddr("10.100.19.123/24"),
 		},
 	}
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0.100", "vlan")
@@ -409,8 +403,8 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
 	// Simulate running on Windows, where net.InterfaceAddrs() returns
 	// non-CIDR-formatted addresses.
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
-		"eth0": {fakeAddr("10.20.19.42")},
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
+		"eth0": {network.NewNetAddr("10.20.19.42")},
 	}
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
@@ -430,34 +424,11 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 	s.stubConfigSource.CheckCall(c, 3, "InterfaceAddresses", "eth0")
 }
 
-func (s *NetworkSuite) TestGetObservedNetworkConfigEmptyAddressValue(c *gc.C) {
-	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
-	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
-		"eth0": {fakeAddr("")},
-	}
-
-	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(observedConfig, jc.DeepEquals, []params.NetworkConfig{{
-		DeviceIndex:   2,
-		MACAddress:    "aa:bb:cc:dd:ee:f0",
-		MTU:           1500,
-		InterfaceName: "eth0",
-		InterfaceType: "ethernet",
-		ConfigType:    "manual",
-		NetworkOrigin: "machine",
-	}})
-
-	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
-	s.stubConfigSource.CheckCall(c, 3, "InterfaceAddresses", "eth0")
-}
-
 func (s *NetworkSuite) TestGetObservedNetworkConfigInvalidAddressValue(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
-		"eth0": {fakeAddr("invalid")},
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
+		"eth0": {network.NewNetAddr("invalid")},
 	}
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
@@ -473,7 +444,7 @@ type stubNetworkConfigSource struct {
 
 	fakeSysClassNetPath   string
 	interfaces            []net.Interface
-	interfaceAddrs        map[string][]net.Addr
+	interfaceAddrs        map[string][]network.ConfigSourceAddr
 	defaultRouteGatewayIP net.IP
 	defaultRouteDevice    string
 }
@@ -537,7 +508,7 @@ func (s *stubNetworkConfigSource) Interfaces() ([]net.Interface, error) {
 }
 
 // InterfaceAddresses implements NetworkConfigSource.
-func (s *stubNetworkConfigSource) InterfaceAddresses(name string) ([]net.Addr, error) {
+func (s *stubNetworkConfigSource) InterfaceAddresses(name string) ([]network.ConfigSourceAddr, error) {
 	s.AddCall("InterfaceAddresses", name)
 	if err := s.NextErr(); err != nil {
 		return nil, err

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -284,7 +284,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 	s.stubConfigSource.CheckCall(c, 3, "InterfaceAddresses", "eth0.100")
 }
 
-func (s *NetworkSuite) TestGetObservedNetworkConfigEthernetInfrerred(c *gc.C) {
+func (s *NetworkSuite) TestGetObservedNetworkConfigEthernetInferred(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
 
@@ -424,7 +424,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 	s.stubConfigSource.CheckCall(c, 3, "InterfaceAddresses", "eth0")
 }
 
-func (s *NetworkSuite) TestGetObservedNetworkConfigInvalidAddressValue(c *gc.C) {
+func (s *NetworkSuite) TestGetObservedNetworkConfigInvalidAddressError(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
 	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
@@ -433,6 +433,21 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigInvalidAddressValue(c *gc.C) 
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
 	c.Check(err, gc.ErrorMatches, `cannot parse IP address "invalid" on interface "eth0"`)
+	c.Check(observedConfig, gc.IsNil)
+
+	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
+	s.stubConfigSource.CheckCall(c, 3, "InterfaceAddresses", "eth0")
+}
+
+func (s *NetworkSuite) TestGetObservedNetworkConfigNilAddressError(c *gc.C) {
+	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
+	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
+		"eth0": {nil},
+	}
+
+	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
+	c.Check(err, gc.ErrorMatches, `cannot parse nil address on interface "eth0"`)
 	c.Check(observedConfig, gc.IsNil)
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -9,11 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/testing"
+	"github.com/juju/testing"
 )
 
 type NetworkSuite struct {
-	testing.BaseSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&NetworkSuite{})

--- a/core/network/source.go
+++ b/core/network/source.go
@@ -17,6 +17,21 @@ import "net"
 // introduced for Windows.
 const SysClassNetPath = "/sys/class/net"
 
+// ConfigSourceAddr indirects addresses obtained
+// from local machine network interfaces.
+type ConfigSourceAddr interface {
+	// IP returns the address in net.IP form.
+	IP() net.IP
+
+	// IPNet returns the subnet corresponding with the address
+	// provided that it can be determined.
+	IPNet() *net.IPNet
+
+	// String returns the address in string form,
+	// including the subnet mask if known.
+	String() string
+}
+
 // ConfigSource defines the necessary calls to obtain
 // the network configuration of a machine.
 type ConfigSource interface {
@@ -29,7 +44,7 @@ type ConfigSource interface {
 
 	// InterfaceAddresses returns information about all addresses
 	// assigned to the network interface with the given name.
-	InterfaceAddresses(name string) ([]net.Addr, error)
+	InterfaceAddresses(name string) ([]ConfigSourceAddr, error)
 
 	// DefaultRoute returns the gateway IP address and device name of the
 	// default route on the machine. If there is no default route (known),

--- a/core/network/source_other.go
+++ b/core/network/source_other.go
@@ -9,25 +9,90 @@ import (
 	"github.com/juju/errors"
 )
 
-type netPackageConfigSource struct{}
+// netAddr implements ConfigSourceAddr based on an address in string form.
+type netAddr struct {
+	addr  string
+	ip    net.IP
+	ipNet *net.IPNet
+}
 
-// SysClassNetPath implements NetworkConfigSource.
+// NewNetAddr returns a new netAddr reference representing the input IP address
+// string. No error is returned; instead the validity of input is indicated by
+// the return having a populated ip member.
+// TODO (manadart 2021-02-15): This method is exported on account of testing in
+// the api/common package where this logic used to reside and where the actual
+// detection and conversion to params is invoked.
+// The detection should also be relocated here to core/network in order that
+// the export is no longer required.
+func NewNetAddr(a string) *netAddr {
+	res := &netAddr{
+		addr: a,
+	}
+
+	ip, ipNet, _ := net.ParseCIDR(a)
+	if ipNet != nil {
+		res.ipNet = ipNet
+	}
+
+	if ip == nil {
+		ip = net.ParseIP(a)
+	}
+	res.ip = ip
+
+	return res
+}
+
+// IP (ConfigSourceAddr) is a simple property accessor.
+func (a *netAddr) IP() net.IP {
+	return a.ip
+}
+
+// IPNet (ConfigSourceAddr) is a simple property accessor.
+func (a *netAddr) IPNet() *net.IPNet {
+	return a.ipNet
+}
+
+// String (ConfigSourceAddr) is a simple property accessor.
+func (a *netAddr) String() string {
+	return a.addr
+}
+
+type netPackageConfigSource struct {
+	interfaces      func() ([]net.Interface, error)
+	interfaceByName func(name string) (*net.Interface, error)
+}
+
+// SysClassNetPath returns the system path containing information
+// about a machine's network interfaces.
 func (n *netPackageConfigSource) SysClassNetPath() string {
 	return SysClassNetPath
 }
 
-// Interfaces implements NetworkConfigSource.
+// Interfaces returns the network interfaces on the machine.
 func (n *netPackageConfigSource) Interfaces() ([]net.Interface, error) {
 	return net.Interfaces()
 }
 
-// InterfaceAddresses implements NetworkConfigSource.
-func (n *netPackageConfigSource) InterfaceAddresses(name string) ([]net.Addr, error) {
-	iface, err := net.InterfaceByName(name)
+// InterfaceAddresses the addresses associated with the network
+// interface identified by the input name.
+func (n *netPackageConfigSource) InterfaceAddresses(name string) ([]ConfigSourceAddr, error) {
+	nic, err := n.interfaceByName(name)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "retrieving network interface %q", name)
 	}
-	return iface.Addrs()
+
+	addrs, err := nic.Addrs()
+	if err != nil {
+		return nil, errors.Annotatef(err, "retrieving addresses for interface %q", name)
+	}
+
+	result := make([]ConfigSourceAddr, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.String() != "" {
+			result = append(result, NewNetAddr(addr.String()))
+		}
+	}
+	return result, nil
 }
 
 // DefaultRoute implements NetworkConfigSource.
@@ -38,5 +103,8 @@ func (n *netPackageConfigSource) DefaultRoute() (net.IP, string, error) {
 // DefaultNetworkConfigSource returns a NetworkConfigSource backed by the net
 // package, to be used with GetObservedNetworkConfig().
 func DefaultNetworkConfigSource() ConfigSource {
-	return &netPackageConfigSource{}
+	return &netPackageConfigSource{
+		interfaces:      net.Interfaces,
+		interfaceByName: net.InterfaceByName,
+	}
 }

--- a/core/network/source_other.go
+++ b/core/network/source_other.go
@@ -70,7 +70,7 @@ func (n *netPackageConfigSource) SysClassNetPath() string {
 
 // Interfaces returns the network interfaces on the machine.
 func (n *netPackageConfigSource) Interfaces() ([]net.Interface, error) {
-	return net.Interfaces()
+	return n.interfaces()
 }
 
 // InterfaceAddresses the addresses associated with the network

--- a/core/network/source_other_test.go
+++ b/core/network/source_other_test.go
@@ -1,0 +1,1 @@
+package network

--- a/core/network/source_other_test.go
+++ b/core/network/source_other_test.go
@@ -1,1 +1,43 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package network
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type sourceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&sourceSuite{})
+
+func (s *sourceSuite) TestNewNetAddr(c *gc.C) {
+	nic := NewNetAddr("192.168.20.1/24")
+	c.Check(nic.String(), gc.Equals, "192.168.20.1/24")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "192.168.20.1")
+	c.Assert(nic.IPNet(), gc.NotNil)
+	c.Check(nic.IPNet().String(), gc.Equals, "192.168.20.0/24")
+
+	nic = NewNetAddr("192.168.20.1")
+	c.Check(nic.String(), gc.Equals, "192.168.20.1")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "192.168.20.1")
+	c.Assert(nic.IPNet(), gc.IsNil)
+
+	nic = NewNetAddr("fe80::5054:ff:fedd:eef0/64")
+	c.Check(nic.String(), gc.Equals, "fe80::5054:ff:fedd:eef0/64")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "fe80::5054:ff:fedd:eef0")
+	c.Assert(nic.IPNet(), gc.NotNil)
+	c.Check(nic.IPNet().String(), gc.Equals, "fe80::/64")
+
+	nic = NewNetAddr("fe80::5054:ff:fedd:eef0")
+	c.Check(nic.String(), gc.Equals, "fe80::5054:ff:fedd:eef0")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "fe80::5054:ff:fedd:eef0")
+	c.Assert(nic.IPNet(), gc.IsNil)
+}


### PR DESCRIPTION
Adds an indirection for addresses handled by `network.ConfigSource`, and a default implementation based on stringified `net.Addr` addresses.

This moves a little more address handling logic from `api/common` to `core/network`.

Next will be to implement the `ConfigSource` and `ConfigSourceAddr` indirections with a new implementation that includes secondary address determination.

Depends on https://github.com/juju/juju/pull/12622.

## QA steps

- Bootstrap a LXD controller.
- Connect to Mongo and ensure that `db.ip.addresses.find().pretty() shows machine-sourced addresses.

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1863916
