### PR TITLE
Fix incomplete sentence in "juju help relate" output

### DIFF
--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -36,8 +36,7 @@ within the same model:
     juju relate <application> <application> 
 
 Occasionally, more explicit syntax is required. Juju is able to relate 
-units that span models, controllers and clouds. This functionality requires
-more complex.
+units that span models, controllers and clouds, as described below.
 
 
 Relating applications in the same model


### PR DESCRIPTION
Quick drive-by fix for an incomplete sentence in the `juju help relate` output:

> Occasionally, more explicit syntax is required. Juju is able to relate 
> units that span models, controllers and clouds. This functionality requires
> more complex.
