### PR TITLE
Record why a cloud credential gets marked invalid and expose via show-model, status

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -95,15 +95,11 @@ func (c *Client) StatusHistory(kind status.HistoryKind, tag names.Tag, filter st
 	}
 	for i, h := range results.Results[0].History.Statuses {
 		history[i] = status.DetailedStatus{
-			Status:  status.Status(h.Status),
-			Info:    h.Info,
-			Data:    h.Data,
-			Since:   h.Since,
-			Kind:    status.HistoryKind(h.Kind),
-			Version: h.Version,
-			// TODO(perrito666) make sure these are still used.
-			Life: h.Life,
-			Err:  h.Err,
+			Status: status.Status(h.Status),
+			Info:   h.Info,
+			Data:   h.Data,
+			Since:  h.Since,
+			Kind:   status.HistoryKind(h.Kind),
 		}
 		// TODO(perrito666) https://launchpad.net/bugs/1577589
 		if !history[i].Kind.Valid() {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -35,7 +35,7 @@ var facadeVersions = map[string]int{
 	"CharmRevisionUpdater":         2,
 	"Charms":                       2,
 	"Cleaner":                      2,
-	"Client":                       2,
+	"Client":                       3,
 	"Cloud":                        7,
 	"Controller":                   9,
 	"CredentialManager":            1,

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -246,8 +246,6 @@ func (c *Client) ListModelSummaries(user string, all bool) ([]base.UserModelSumm
 			Data:   make(map[string]interface{}),
 			Since:  summary.Status.Since,
 		}
-		//TODO (anastasiamac 2017-11-24) do we need status data for summaries?
-		// we do not translate it at cmd/presentation layer and is it really a summary?...
 		for k, v := range summary.Status.Data {
 			summaries[i].Status.Data[k] = v
 		}

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -234,7 +234,7 @@ func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
 }
 
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
-	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 2)
+	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 3)
 }
 
 func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -170,7 +170,8 @@ func AllFacades() *facade.Registry {
 	reg("Charms", 2, charms.NewFacade)
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)
 	reg("Client", 1, client.NewFacadeV1)
-	reg("Client", 2, client.NewFacade)
+	reg("Client", 2, client.NewFacadeV2)
+	reg("Client", 3, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacadeV1)
 	reg("Cloud", 2, cloud.NewFacadeV2) // adds AddCloud, AddCredentials, CredentialContents, RemoveClouds
 	reg("Cloud", 3, cloud.NewFacadeV3) // changes signature of UpdateCredentials, adds ModifyCloudAccess

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -82,6 +82,11 @@ type Client struct {
 
 // ClientV1 serves the (v1) client-specific API methods.
 type ClientV1 struct {
+	*ClientV2
+}
+
+// ClientV2 serves the (v2) client-specific API methods.
+type ClientV2 struct {
 	*Client
 }
 
@@ -140,11 +145,20 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 
 // NewFacadeV1 creates a version 1 Client facade to handle API requests.
 func NewFacadeV1(ctx facade.Context) (*ClientV1, error) {
-	client, err := newFacade(ctx)
+	client, err := NewFacadeV2(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &ClientV1{client}, nil
+}
+
+// NewFacadeV2 creates a version 2 Client facade to handle API requests.
+func NewFacadeV2(ctx facade.Context) (*ClientV2, error) {
+	client, err := newFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ClientV2{client}, nil
 }
 
 func newFacade(ctx facade.Context) (*Client, error) {
@@ -251,7 +265,7 @@ func (c *Client) WatchAll() (params.AllWatcherId, error) {
 	if err := c.checkCanRead(); err != nil {
 		return params.AllWatcherId{}, err
 	}
-	model, err := c.api.stateAccessor.Model()
+	model, err := c.api.state().Model()
 	if err != nil {
 		return params.AllWatcherId{}, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10175,7 +10175,7 @@
     {
         "Name": "Client",
         "Description": "Client serves client-specific API methods.",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -53,6 +54,7 @@ type ModelMachineInfo struct {
 type ModelStatus struct {
 	Current        status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message        string        `json:"message,omitempty" yaml:"message,omitempty"`
+	Reason         string        `json:"reason,omitempty" yaml:"reason,omitempty"`
 	Since          string        `json:"since,omitempty" yaml:"since,omitempty"`
 	Migration      string        `json:"migration,omitempty" yaml:"migration,omitempty"`
 	MigrationStart string        `json:"migration-start,omitempty" yaml:"migration-start,omitempty"`
@@ -82,6 +84,12 @@ type ModelCredential struct {
 	Owner    string `json:"owner" yaml:"owner"`
 	Cloud    string `json:"cloud" yaml:"cloud"`
 	Validity string `json:"validity-check,omitempty" yaml:"validity-check,omitempty"`
+}
+
+// ModelStatusReason extracts the reason, if any, from a status data bag.
+func ModelStatusReason(data map[string]interface{}) string {
+	reason, _ := data["reason"].(string)
+	return strings.Trim(reason, "\n")
 }
 
 // ModelInfoFromParams translates a params.ModelInfo to ModelInfo.
@@ -116,6 +124,7 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		modelInfo.Status = &ModelStatus{
 			Current: info.Status.Status,
 			Message: info.Status.Info,
+			Reason:  ModelStatusReason(info.Status.Data),
 			Since:   FriendlyDuration(info.Status.Since, now),
 		}
 	}

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -278,6 +278,7 @@ type statusInfoContents struct {
 	Err     error         `json:"-" yaml:",omitempty"`
 	Current status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
+	Reason  string        `json:"reason,omitempty" yaml:"reason,omitempty"`
 	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
 	Version string        `json:"version,omitempty" yaml:"version,omitempty"`
 	Life    string        `json:"life,omitempty" yaml:"life,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -456,6 +456,7 @@ func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) sta
 		// NOTE: why use a status.Status here, but a string for Life?
 		Current: status.Status(inst.Status),
 		Message: inst.Info,
+		Reason:  common.ModelStatusReason(inst.Data),
 		Version: inst.Version,
 		Life:    string(inst.Life),
 	}

--- a/cmd/juju/status/history_test.go
+++ b/cmd/juju/status/history_test.go
@@ -29,31 +29,7 @@ var _ = gc.Suite(&StatusHistorySuite{})
 
 func (s *StatusHistorySuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.api = nil
 	s.now = time.Date(2017, 11, 28, 12, 34, 56, 0, time.UTC)
-}
-
-func (s *StatusHistorySuite) newCommand() cmd.Command {
-	return statuscmd.NewTestStatusHistoryCommand(s.api)
-}
-
-func (s *StatusHistorySuite) next() *time.Time {
-	value := s.now
-	s.now = s.now.Add(time.Minute)
-	return &value
-}
-
-func (s *StatusHistorySuite) TestMissingEntity(c *gc.C) {
-	s.api = &fakeHistoryAPI{err: errors.NotFoundf("missing/0")}
-	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0")
-	c.Assert(err, gc.ErrorMatches, "missing/0 not found")
-	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
-}
-
-func (s *StatusHistorySuite) TestResults(c *gc.C) {
-	c.Log(os.Environ())
-
 	s.api = &fakeHistoryAPI{
 		history: status.History{
 			{
@@ -90,20 +66,93 @@ func (s *StatusHistorySuite) TestResults(c *gc.C) {
 				Status: status.Executing,
 				Info:   "running config-changed hoook",
 				Since:  s.next(),
+			}, {
+				Kind:   status.KindModel,
+				Status: status.Suspended,
+				Info:   "invalid credentials",
+				Data:   map[string]interface{}{"reason": "bad password"},
+				Since:  s.next(),
 			},
 		},
 	}
-	expected := "" +
-		"Time                  Type       Status       Message\n" +
-		"2017-11-28 12:34:56Z  juju-unit  allocating   \n" +
-		"2017-11-28 12:35:56Z  workload   waiting      waiting for machine\n" +
-		"2017-11-28 12:36:56Z  workload   waiting      installing agent\n" +
-		"2017-11-28 12:37:56Z  workload   waiting      agent initializing\n" +
-		"2017-11-28 12:38:56Z  workload   maintenance  installing charm software\n" +
-		"2017-11-28 12:39:56Z  juju-unit  executing    running install hoook\n" +
-		"2017-11-28 12:40:56Z  juju-unit  executing    running config-changed hoook\n"
+}
 
+func (s *StatusHistorySuite) newCommand() cmd.Command {
+	return statuscmd.NewTestStatusHistoryCommand(s.api)
+}
+
+func (s *StatusHistorySuite) next() *time.Time {
+	value := s.now
+	s.now = s.now.Add(time.Minute)
+	return &value
+}
+
+func (s *StatusHistorySuite) TestMissingEntity(c *gc.C) {
+	s.api = &fakeHistoryAPI{err: errors.NotFoundf("missing/0")}
+	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0")
+	c.Assert(err, gc.ErrorMatches, "missing/0 not found")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
+}
+
+func (s *StatusHistorySuite) TestTabular(c *gc.C) {
+	c.Log(os.Environ())
+	expected := `
+Time                  Type       Status       Message
+2017-11-28 12:34:56Z  juju-unit  allocating   
+2017-11-28 12:35:56Z  workload   waiting      waiting for machine
+2017-11-28 12:36:56Z  workload   waiting      installing agent
+2017-11-28 12:37:56Z  workload   waiting      agent initializing
+2017-11-28 12:38:56Z  workload   maintenance  installing charm software
+2017-11-28 12:39:56Z  juju-unit  executing    running install hoook
+2017-11-28 12:40:56Z  juju-unit  executing    running config-changed hoook
+2017-11-28 12:41:56Z  model      suspended    invalid credentials
+
+`[1:]
 	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0", "--utc")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+}
+
+func (s *StatusHistorySuite) TestYaml(c *gc.C) {
+	c.Log(os.Environ())
+	expected := `
+- status: allocating
+  since: 2017-11-28T12:34:56Z
+  type: juju-unit
+- status: waiting
+  message: waiting for machine
+  since: 2017-11-28T12:35:56Z
+  type: workload
+- status: waiting
+  message: installing agent
+  since: 2017-11-28T12:36:56Z
+  type: workload
+- status: waiting
+  message: agent initializing
+  since: 2017-11-28T12:37:56Z
+  type: workload
+- status: maintenance
+  message: installing charm software
+  since: 2017-11-28T12:38:56Z
+  type: workload
+- status: executing
+  message: running install hoook
+  since: 2017-11-28T12:39:56Z
+  type: juju-unit
+- status: executing
+  message: running config-changed hoook
+  since: 2017-11-28T12:40:56Z
+  type: juju-unit
+- status: suspended
+  message: invalid credentials
+  data:
+    reason: bad password
+  since: 2017-11-28T12:41:56Z
+  type: model
+`[1:]
+	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0", "--utc", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
@@ -120,4 +169,8 @@ func (*fakeHistoryAPI) Close() error {
 
 func (f *fakeHistoryAPI) StatusHistory(kind status.HistoryKind, tag names.Tag, filter status.StatusHistoryFilter) (status.History, error) {
 	return f.history, f.err
+}
+
+func (*fakeHistoryAPI) BestAPIVersion() int {
+	return 3
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -3660,6 +3660,37 @@ var statusTests = []testCase{
 			},
 		},
 	),
+	test( // 28
+		"suspended model",
+		setModelSuspended{"invalid credential", "bad password"},
+		expect{
+			what: "suspend a model due to bad credential",
+			output: M{
+				"model": M{
+					"name":       "controller",
+					"type":       "iaas",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"region":     "dummy-region",
+					"version":    "1.2.3",
+					"model-status": M{
+						"current": "suspended",
+						"message": "invalid credential",
+						"reason":  "bad password",
+						"since":   "01 Apr 15 01:23+10:00",
+					},
+					"sla": "unsupported",
+				},
+				"machines":     M{},
+				"applications": M{},
+				"storage":      M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
+			},
+			stderr: "Model \"controller\" is empty.\n",
+		},
+	),
 }
 
 func mysqlCharm(extras M) M {
@@ -3756,6 +3787,24 @@ type setSLA struct {
 
 func (s setSLA) step(c *gc.C, ctx *context) {
 	err := ctx.st.SetSLA(s.level, "test-user", []byte(""))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type setModelSuspended struct {
+	message string
+	reason  string
+}
+
+func (s setModelSuspended) step(c *gc.C, ctx *context) {
+	m, err := ctx.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetStatus(status.StatusInfo{
+		Status:  status.Suspended,
+		Message: s.message,
+		Data: map[string]interface{}{
+			"reason": s.reason,
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/core/constraints/package_test.go
+++ b/core/constraints/package_test.go
@@ -25,5 +25,5 @@ func (*ImportTest) TestImports(c *gc.C) {
 
 	// This package should only depend on other core packages.
 	// If this test fails with a non-core package, please check the dependencies.
-	c.Assert(found, jc.SameContents, []string{"core/instance", "core/life", "core/status"})
+	c.Assert(found, jc.SameContents, []string{"core/instance", "core/status"})
 }

--- a/core/status/package_test.go
+++ b/core/status/package_test.go
@@ -6,7 +6,6 @@ package status_test
 import (
 	"testing"
 
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
@@ -22,6 +21,5 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/status")
-
-	c.Assert(found, jc.SameContents, []string{"core/life"})
+	c.Assert(found, gc.HasLen, 0)
 }

--- a/core/status/status_history.go
+++ b/core/status/status_history.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/life"
 )
 
 // StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
@@ -60,10 +59,6 @@ type DetailedStatus struct {
 	Data   map[string]interface{}
 	Since  *time.Time
 	Kind   HistoryKind
-	// TODO(perrito666) make sure this is not used and remove.
-	Version string
-	Life    life.Value
-	Err     error
 }
 
 // History holds many DetailedStatus,
@@ -80,6 +75,8 @@ type HistoryKind string
 // * AllHistoryKind()
 // * command help for 'show-status-log' describing these kinds.
 const (
+	// KindModel represents the model itself.
+	KindModel HistoryKind = "model"
 	// KindUnit represents agent and workload combined.
 	KindUnit HistoryKind = "unit"
 	// KindUnitAgent represent a unit agent status history entry.
@@ -104,7 +101,7 @@ func (k HistoryKind) String() string {
 // Valid will return true if the current kind is a valid one.
 func (k HistoryKind) Valid() bool {
 	switch k {
-	case KindUnit, KindUnitAgent, KindWorkload,
+	case KindModel, KindUnit, KindUnitAgent, KindWorkload,
 		KindMachineInstance, KindMachine,
 		KindContainerInstance, KindContainer:
 		return true
@@ -115,6 +112,7 @@ func (k HistoryKind) Valid() bool {
 // AllHistoryKind will return all valid HistoryKinds.
 func AllHistoryKind() map[HistoryKind]string {
 	return map[HistoryKind]string{
+		KindModel:             "statuses for the model itself",
 		KindUnit:              "statuses for specified unit and its workload",
 		KindUnitAgent:         "statuses from the agent that is managing a unit",
 		KindWorkload:          "statuses for unit's workload",

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -61,7 +61,8 @@ func MaybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool 
 		return false
 	}
 
-	invalidateErr := ctx.InvalidateCredential("azure cloud denied access")
+	converted := common.CredentialNotValidf(err, "azure cloud denied access")
+	invalidateErr := ctx.InvalidateCredential(converted.Error())
 	if invalidateErr != nil {
 		logger.Warningf("could not invalidate stored azure cloud credential on the controller: %v", invalidateErr)
 	}

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -59,7 +59,7 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "azure cloud denied access")
+		c.Assert(msg, gc.Matches, "azure cloud denied access: .*")
 		called = true
 		return nil
 	}

--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -88,7 +88,8 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) bool {
 	denied := isAuthError(errors.Cause(err))
 	if ctx != nil && denied {
-		invalidateErr := ctx.InvalidateCredential("cloud denied access")
+		converted := CredentialNotValidf(err, "cloud denied access")
+		invalidateErr := ctx.InvalidateCredential(converted.Error())
 		if invalidateErr != nil {
 			logger.Warningf("could not invalidate stored cloud credential on the controller: %v", invalidateErr)
 		}

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -113,7 +113,7 @@ func (s *ErrorsSuite) checkPermissionHandling(c *gc.C, e error, handled bool) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "cloud denied access")
+		c.Assert(msg, gc.Matches, "cloud denied access:.*auth failure")
 		called = true
 		return nil
 	}

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/api/googleapi"
 
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
 )
 
 // InvalidConfigValueError indicates that one of the config values failed validation.
@@ -77,7 +78,8 @@ func maybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool 
 		return false
 	}
 
-	invalidateErr := ctx.InvalidateCredential("google cloud denied access")
+	converted := common.CredentialNotValidf(err, "google cloud denied access")
+	invalidateErr := ctx.InvalidateCredential(converted.Error())
 	if invalidateErr != nil {
 		logger.Warningf("could not invalidate stored google cloud credential on the controller: %v", invalidateErr)
 	}

--- a/provider/gce/google/errors_test.go
+++ b/provider/gce/google/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +52,8 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "google cloud denied access")
+		c.Assert(msg, gc.Matches,
+			regexp.QuoteMeta(`google cloud denied access: Get "http://notforreal.com/": 40`)+".*")
 		called = true
 		return nil
 	}

--- a/provider/maas/errors_test.go
+++ b/provider/maas/errors_test.go
@@ -80,7 +80,7 @@ func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "cloud denied access")
+		c.Assert(msg, gc.Matches, "cloud denied access:.*")
 		called = true
 		return nil
 	}

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -509,7 +509,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceLoginErrorInvalidatesCreds(c
 	}
 	_, err := s.env.StartInstance(ctx, s.createStartInstanceArgs(c))
 	c.Assert(err, gc.ErrorMatches, "dialing client: ServerFaultCode: You passed an incorrect user name or password, bucko.")
-	c.Assert(passedReason, gc.Equals, "cloud denied access")
+	c.Assert(passedReason, gc.Equals, "cloud denied access: ServerFaultCode: You passed an incorrect user name or password, bucko.")
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstancePermissionError(c *gc.C) {

--- a/state/model.go
+++ b/state/model.go
@@ -703,8 +703,14 @@ func (m *Model) Owner() names.UserTag {
 	return names.NewUserTag(m.doc.Owner)
 }
 
-func modelStatusInvalidCredential() status.StatusInfo {
-	return status.StatusInfo{Status: status.Suspended, Message: "suspended since cloud credential is not valid"}
+func modelStatusInvalidCredential(reason string) status.StatusInfo {
+	return status.StatusInfo{
+		Status:  status.Suspended,
+		Message: "suspended since cloud credential is not valid",
+		Data: map[string]interface{}{
+			"reason": reason,
+		},
+	}
 }
 
 // Status returns the status of the model.
@@ -716,7 +722,7 @@ func (m *Model) Status() (status.StatusInfo, error) {
 			return status.StatusInfo{}, errors.Annotatef(err, "could not get model credential %v", credentialTag.Id())
 		}
 		if !credential.IsValid() {
-			return modelStatusInvalidCredential(), nil
+			return modelStatusInvalidCredential(credential.InvalidReason), nil
 		}
 	}
 

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -64,6 +64,16 @@ func (s *ModelCredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(invalidated.IsValid(), jc.IsFalse)
 	c.Assert(invalidated.InvalidReason, gc.DeepEquals, reason)
+
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, status.StatusInfo{
+		Status:  "suspended",
+		Message: "suspended since cloud credential is not valid",
+		Data:    map[string]interface{}{"reason": "special invalidation"},
+	})
 }
 
 func (s *ModelCredentialSuite) TestValidateCloudCredentialWrongCloud(c *gc.C) {

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -505,7 +505,7 @@ func (p *modelSummaryProcessor) substituteModelStatusForInvalidCredentials(crede
 					continue
 				}
 				details := &p.summaries[idx]
-				details.Status = modelStatusInvalidCredential()
+				details.Status = modelStatusInvalidCredential(doc.InvalidReason)
 			}
 		}
 	}

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -324,10 +324,12 @@ func (s *ModelSummariesSuite) TestContainsModelStatusSuspended(c *gc.C) {
 		"shared": {
 			Status:  status.Suspended,
 			Message: "suspended since cloud credential is not valid",
+			Data:    map[string]interface{}{"reason": "test"},
 		},
 		"user1model": {
 			Status:  status.Busy,
 			Message: "human message",
+			Data:    map[string]interface{}{},
 		},
 	}
 	shared, err := s.StatePool.Get(modelNameToUUID["shared"])
@@ -350,7 +352,6 @@ func (s *ModelSummariesSuite) TestContainsModelStatusSuspended(c *gc.C) {
 		// empty map to a nil map
 		st := summary.Status
 		st.Since = nil
-		st.Data = nil
 		statuses[summary.Name] = st
 	}
 	c.Check(statuses, jc.DeepEquals, expectedStatus)


### PR DESCRIPTION
When a cloud APi call is deemed to fail due to an invalid credential, the model is suspended and the model status has a message saying the credential is invalid. We also record this in status history for the model. However, there are deficiencies in how this is exposed to the user. There's no way to see the exact reason / error that came from the cloud which triggered the suspension, and there's no way to see the history of model status changes to see things like how often invalid credential calls are made etc.

This PR makes several UX changes:
- show-status-log now supports model status history
- show-status-log now supports YAML output (to expose the reason string)
- model-status in juju status now has the reason from the cloud for the invalid credential
- show-model now has the reason form the cloud for the invalid credential
- marking a model as suspended is logged as WARNING with the reason to aid in post hoc debugging

The providers themselves were simply using a string like "cloud denied access" when flagging an invalid credential, which is pretty meaningless. We now pass the error string from the API error which was deemed to be an invalid credential. This can then be inspected using the improved show-model and show-status-log etc.

## QA steps

bootstrap an aws cloud (or azure or google)
edit the local credential to make it invalid
run juju update-credentials -c controller which will fail
then
juju show-status-log --type model
juju show-status-log --type model --format yaml
juju show-model
juju status --format yaml

The YAML formats will contain the error string as reported by the cloud.
