### PR TITLE
Fix double upgrade edge case.

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -608,8 +608,13 @@ func (u *Uniter) charmState() (bool, *corecharm.URL, int, error) {
 	}
 
 	if _, err := corecharm.ReadCharmDir(u.paths.State.CharmDir); err != nil {
+		// use appCharmURL to avoid double upgrade.
+		appCharmURL, _, err := app.CharmURL()
+		if err != nil {
+			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
+		}
 		u.logger.Debugf("start to re-download charm because charm dir has gone which is usually caused by operator pod re-scheduling")
-		op, err := u.operationFactory.NewUpgrade(charmURL)
+		op, err := u.operationFactory.NewUpgrade(appCharmURL)
 		if err != nil {
 			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
 		}


### PR DESCRIPTION
Instead of cause a double upgrade hook call, just upgrade straight to the application's charm revision when the charm data is missing.

## QA steps

```
deploy k8s application
wait for pods to come up
get your node name
# microk8s.kubectl get nodes
cordon your node to prevent pods scheduling
# microk8s.kubectl cordon harry
delete operator pod
# microk8s.kubectl delete pod test-operator-0
refresh charm
# juju refresh ...
check your application has bumbed revision
# juju status
uncordon node
# microk8s.kubectl uncordon harry
check application only runs upgrade hook once
# juju debug-log
```

## Documentation changes

N/A

## Bug reference

N/A
