### PR TITLE
[dev] Allow bundle to update existing offers

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -161,7 +161,13 @@ func (api *OffersAPI) Offer(all params.AddApplicationOffers) (params.ErrorResult
 			result[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		_, err = api.GetApplicationOffers(backend).AddOffer(applicationOfferParams)
+
+		offerBackend := api.GetApplicationOffers(backend)
+		if _, err = offerBackend.ApplicationOffer(applicationOfferParams.OfferName); err == nil {
+			_, err = offerBackend.UpdateOffer(applicationOfferParams)
+		} else {
+			_, err = offerBackend.AddOffer(applicationOfferParams)
+		}
 		result[i].Error = apiservererrors.ServerError(err)
 	}
 	return params.ErrorResults{Results: result}, nil

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -37,7 +37,13 @@ var _ = gc.Suite(&applicationOffersSuite{})
 
 func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	s.baseSuite.SetUpTest(c)
-	s.applicationOffers = &stubApplicationOffers{}
+	s.applicationOffers = &stubApplicationOffers{
+		// Ensure that calls to "Offer" made by the test suite call
+		// AddOffer by default.
+		applicationOffer: func(string) (*jujucrossmodel.ApplicationOffer, error) {
+			return nil, errors.NotFoundf("offer")
+		},
+	}
 	getApplicationOffers := func(interface{}) jujucrossmodel.ApplicationOffers {
 		return s.applicationOffers
 	}
@@ -111,12 +117,49 @@ func (s *applicationOffersSuite) assertOffer(c *gc.C, expectedErr error) {
 		return
 	}
 	c.Assert(errs.Results[0].Error, gc.IsNil)
-	s.applicationOffers.CheckCallNames(c, addOffersBackendCall)
+	s.applicationOffers.CheckCallNames(c, offerCall, addOffersBackendCall)
 }
 
 func (s *applicationOffersSuite) TestOffer(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("admin")
 	s.assertOffer(c, nil)
+}
+
+func (s *applicationOffersSuite) TestAddOfferUpdatesExistingOffer(c *gc.C) {
+	s.authorizer.Tag = names.NewUserTag("admin")
+	applicationName := "test"
+	s.addApplication(c, applicationName)
+	one := params.AddApplicationOffer{
+		ModelTag:        testing.ModelTag.String(),
+		OfferName:       "offer-test",
+		ApplicationName: applicationName,
+		Endpoints:       map[string]string{"db": "db"},
+	}
+	all := params.AddApplicationOffers{Offers: []params.AddApplicationOffer{one}}
+	s.applicationOffers.applicationOffer = func(name string) (*jujucrossmodel.ApplicationOffer, error) {
+		c.Assert(name, gc.Equals, one.OfferName)
+		return &jujucrossmodel.ApplicationOffer{}, nil
+	}
+	s.applicationOffers.addOffer = func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
+		return nil, errors.BadRequestf("unexpected call to AddOffer; expected a call to UpdateOffer instead")
+	}
+	s.applicationOffers.updateOffer = func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
+		c.Assert(offer.OfferName, gc.Equals, one.OfferName)
+		c.Assert(offer.ApplicationName, gc.Equals, one.ApplicationName)
+		c.Assert(offer.ApplicationDescription, gc.Equals, "A pretty popular blog engine")
+		c.Assert(offer.Owner, gc.Equals, "admin")
+		c.Assert(offer.HasRead, gc.DeepEquals, []string{"everyone@external"})
+		return &jujucrossmodel.ApplicationOffer{}, nil
+	}
+	ch := &mockCharm{meta: &charm.Meta{Description: "A pretty popular blog engine"}}
+	s.mockState.applications = map[string]crossmodel.Application{
+		applicationName: &mockApplication{charm: ch, bindings: map[string]string{"db": "myspace"}},
+	}
+	errs, err := s.api.Offer(all)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs.Results, gc.HasLen, len(all.Offers))
+	c.Assert(errs.Results[0].Error, gc.IsNil)
+	s.applicationOffers.CheckCallNames(c, offerCall, updateOfferBackendCall)
 }
 
 func (s *applicationOffersSuite) TestOfferPermission(c *gc.C) {
@@ -174,7 +217,7 @@ func (s *applicationOffersSuite) TestOfferSomeFail(c *gc.C) {
 	c.Assert(errs.Results[3].Error, gc.IsNil)
 	c.Assert(errs.Results[1].Error, gc.ErrorMatches, `getting offered application notthere: application "notthere" not found`)
 	c.Assert(errs.Results[2].Error, gc.ErrorMatches, `params fail`)
-	s.applicationOffers.CheckCallNames(c, addOffersBackendCall, addOffersBackendCall, addOffersBackendCall)
+	s.applicationOffers.CheckCallNames(c, offerCall, addOffersBackendCall, offerCall, addOffersBackendCall, offerCall, addOffersBackendCall)
 }
 
 func (s *applicationOffersSuite) TestOfferError(c *gc.C) {
@@ -203,7 +246,7 @@ func (s *applicationOffersSuite) TestOfferError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errs.Results, gc.HasLen, len(all.Offers))
 	c.Assert(errs.Results[0].Error, gc.ErrorMatches, fmt.Sprintf(".*%v.*", msg))
-	s.applicationOffers.CheckCallNames(c, addOffersBackendCall)
+	s.applicationOffers.CheckCallNames(c, offerCall, addOffersBackendCall)
 }
 
 func (s *applicationOffersSuite) assertList(c *gc.C, expectedErr error, expectedCIDRS []string) {

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	addOffersBackendCall  = "addOffersCall"
-	listOffersBackendCall = "listOffersCall"
+	addOffersBackendCall   = "addOffersCall"
+	updateOfferBackendCall = "updateOfferCall"
+	listOffersBackendCall  = "listOffersCall"
 )
 
 type baseSuite struct {

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -45,8 +45,10 @@ type stubApplicationOffers struct {
 	jtesting.Stub
 	jujucrossmodel.ApplicationOffers
 
-	addOffer   func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error)
-	listOffers func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error)
+	applicationOffer func(name string) (*jujucrossmodel.ApplicationOffer, error)
+	addOffer         func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error)
+	updateOffer      func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error)
+	listOffers       func(filters ...jujucrossmodel.ApplicationOfferFilter) ([]jujucrossmodel.ApplicationOffer, error)
 }
 
 func (m *stubApplicationOffers) AddOffer(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
@@ -61,7 +63,7 @@ func (m *stubApplicationOffers) ListOffers(filters ...jujucrossmodel.Application
 
 func (m *stubApplicationOffers) UpdateOffer(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
 	m.AddCall(updateOfferCall)
-	panic("not implemented")
+	return m.updateOffer(offer)
 }
 
 func (m *stubApplicationOffers) Remove(url string, force bool) error {
@@ -71,7 +73,7 @@ func (m *stubApplicationOffers) Remove(url string, force bool) error {
 
 func (m *stubApplicationOffers) ApplicationOffer(name string) (*jujucrossmodel.ApplicationOffer, error) {
 	m.AddCall(offerCall)
-	panic("not implemented")
+	return m.applicationOffer(name)
 }
 
 func (m *stubApplicationOffers) ApplicationOfferForUUID(uuid string) (*jujucrossmodel.ApplicationOffer, error) {

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -52,6 +52,14 @@ func BuildModelRepresentation(
 			machineMap[id] = id
 		}
 	}
+
+	offersByApplication := make(map[string][]string)
+	for _, offer := range status.Offers {
+		appOffers := offersByApplication[offer.ApplicationName]
+		appOffers = append(appOffers, offer.OfferName)
+		offersByApplication[offer.ApplicationName] = appOffers
+	}
+
 	// Now iterate over the bundleMachines that the user specified.
 	for bundleMachine, modelMachine := range bundleMachines {
 		machineMap[bundleMachine] = modelMachine
@@ -65,6 +73,7 @@ func BuildModelRepresentation(
 			Exposed:       appStatus.Exposed,
 			Series:        appStatus.Series,
 			SubordinateTo: appStatus.SubordinateTo,
+			Offers:        offersByApplication[name],
 		}
 		if len(appStatus.ExposedEndpoints) != 0 {
 			app.ExposedEndpoints = make(map[string]bundlechanges.ExposedEndpoint)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1220,10 +1220,7 @@ func (h *bundleHandler) createOffer(change *bundlechanges.CreateOfferChange) err
 	if err == nil && len(result) > 0 && result[0].Error != nil {
 		err = result[0].Error
 	}
-	if err != nil {
-		return errors.Annotatef(err, "cannot create offer %s", p.OfferName)
-	}
-	return nil
+	return err
 }
 
 // consumeOffer consumes an existing offer

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1447,7 +1447,7 @@ func resolve(placeholder string, results map[string]string) string {
 }
 
 // applicationRequiresTrust returns true if this app requires the operator to
-// explicitly trust it. trust requirements may be either specified as an option
+// explicitly trust it. Trust requirements may be either specified as an option
 // or via the "trust" field at the application spec level
 func applicationRequiresTrust(appSpec *charm.ApplicationSpec) bool {
 	optRequiresTrust := appSpec.Options != nil && appSpec.Options["trust"] == true

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hpidcock/juju-fake-init v0.0.0-20201026041434-e95018795575
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v5 v5.0.0-20210125113555-1cef9f67c982
+	github.com/juju/bundlechanges/v5 v5.0.0-20210209144148-1bde07afeabe
 	github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c
 	github.com/juju/charmrepo/v7 v7.0.0-20210125112315-0c95be42cafc
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf h1:1Bxg7u1ZVppXGJxN7
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v5 v5.0.0-20210125113555-1cef9f67c982 h1:Ats1/+6OaRdWkMHuYQbLSR7PM9x3zm+StCC/GzK5H98=
-github.com/juju/bundlechanges/v5 v5.0.0-20210125113555-1cef9f67c982/go.mod h1:mT/Dl3rwNoIlbRGvHQlWO34KzfnFwFewSbguSsuF1oU=
+github.com/juju/bundlechanges/v5 v5.0.0-20210209144148-1bde07afeabe h1:xjvoxwNYeJh42UFGha3YCrB0limBsX7qNq/13rXhxZc=
+github.com/juju/bundlechanges/v5 v5.0.0-20210209144148-1bde07afeabe/go.mod h1:mT/Dl3rwNoIlbRGvHQlWO34KzfnFwFewSbguSsuF1oU=
 github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c h1:5Apo+om/um+exGB0k3WgFBkeDqstaxU13bF/ITOCYlA=
 github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
 github.com/juju/charmrepo/v7 v7.0.0-20210125112315-0c95be42cafc h1:m4aHwATWf3D9MddTI56S/7cB268zq/oiqH1quJwjnB0=


### PR DESCRIPTION
This is a forward port of #12615 from 2.9 -> develop. The only difference between 2.9 and develop is that develop uses a different bundlechanges (v5) version.

## QA steps

Same as #12608 (#12615 is a forward port of this one). 