### PR TITLE
Merge 2.8 into 2.9

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -95,15 +95,11 @@ func (c *Client) StatusHistory(kind status.HistoryKind, tag names.Tag, filter st
 	}
 	for i, h := range results.Results[0].History.Statuses {
 		history[i] = status.DetailedStatus{
-			Status:  status.Status(h.Status),
-			Info:    h.Info,
-			Data:    h.Data,
-			Since:   h.Since,
-			Kind:    status.HistoryKind(h.Kind),
-			Version: h.Version,
-			// TODO(perrito666) make sure these are still used.
-			Life: h.Life,
-			Err:  h.Err,
+			Status: status.Status(h.Status),
+			Info:   h.Info,
+			Data:   h.Data,
+			Since:  h.Since,
+			Kind:   status.HistoryKind(h.Kind),
 		}
 		// TODO(perrito666) https://launchpad.net/bugs/1577589
 		if !history[i].Kind.Valid() {

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/network"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -152,31 +153,24 @@ var exampleObservedInterfaces = []net.Interface{{
 	Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
 }}
 
-type fakeAddr string
-
-func (f fakeAddr) Network() string { return "" }
-func (f fakeAddr) String() string  { return string(f) }
-
-var _ net.Addr = (*fakeAddr)(nil)
-
-var exampleObservedInterfaceAddrs = map[string][]net.Addr{
-	"eth0":        {fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"eth1":        {fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"eth0.50":     {fakeAddr("fe80::5054:ff:fedd:eef0:50/64")},
-	"eth0.100":    {fakeAddr("fe80::5054:ff:fedd:eef0:100/64")},
-	"eth0.25":     {fakeAddr("fe80::5054:ff:fedd:eef0:25/64")},
-	"eth1.11":     {fakeAddr("fe80::5054:ff:fedd:eef1:11/64")},
-	"eth1.12":     {fakeAddr("fe80::5054:ff:fedd:eef1:12/64")},
-	"eth1.13":     {fakeAddr("fe80::5054:ff:fedd:eef1:13/64")},
-	"lo":          {fakeAddr("127.0.0.1/8"), fakeAddr("::1/128")},
-	"br-eth0":     {fakeAddr("10.20.19.100/24"), fakeAddr("10.20.19.123/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth1":     {fakeAddr("10.20.19.105/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"br-eth0.50":  {fakeAddr("10.50.19.100/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth0.100": {fakeAddr("10.100.19.100/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth0.250": {fakeAddr("10.250.19.100/24"), fakeAddr("fe80::5054:ff:fedd:eef0/64")},
-	"br-eth1.11":  {fakeAddr("10.11.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"br-eth1.12":  {fakeAddr("10.12.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
-	"br-eth1.13":  {fakeAddr("10.13.19.101/24"), fakeAddr("fe80::5054:ff:fedd:eef1/64")},
+var exampleObservedInterfaceAddrs = map[string][]network.ConfigSourceAddr{
+	"eth0":        {network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"eth1":        {network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"eth0.50":     {network.NewNetAddr("fe80::5054:ff:fedd:eef0:50/64")},
+	"eth0.100":    {network.NewNetAddr("fe80::5054:ff:fedd:eef0:100/64")},
+	"eth0.25":     {network.NewNetAddr("fe80::5054:ff:fedd:eef0:25/64")},
+	"eth1.11":     {network.NewNetAddr("fe80::5054:ff:fedd:eef1:11/64")},
+	"eth1.12":     {network.NewNetAddr("fe80::5054:ff:fedd:eef1:12/64")},
+	"eth1.13":     {network.NewNetAddr("fe80::5054:ff:fedd:eef1:13/64")},
+	"lo":          {network.NewNetAddr("127.0.0.1/8"), network.NewNetAddr("::1/128")},
+	"br-eth0":     {network.NewNetAddr("10.20.19.100/24"), network.NewNetAddr("10.20.19.123/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth1":     {network.NewNetAddr("10.20.19.105/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"br-eth0.50":  {network.NewNetAddr("10.50.19.100/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth0.100": {network.NewNetAddr("10.100.19.100/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth0.250": {network.NewNetAddr("10.250.19.100/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef0/64")},
+	"br-eth1.11":  {network.NewNetAddr("10.11.19.101/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"br-eth1.12":  {network.NewNetAddr("10.12.19.101/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
+	"br-eth1.13":  {network.NewNetAddr("10.13.19.101/24"), network.NewNetAddr("fe80::5054:ff:fedd:eef1/64")},
 }
 
 func (s *NetworkSuite) TestGetObservedNetworkConfigInterfacesError(c *gc.C) {
@@ -207,7 +201,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigInterfaceAddressesError(c *gc
 
 func (s *NetworkSuite) TestGetObservedNetworkConfigNoInterfaceAddresses(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[3:4] // only br-eth1
-	s.stubConfigSource.interfaceAddrs = make(map[string][]net.Addr)
+	s.stubConfigSource.interfaceAddrs = make(map[string][]network.ConfigSourceAddr)
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "br-eth1", "bridge")
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
@@ -258,10 +252,10 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigLoopbackInferred(c *gc.C) {
 
 func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[6:7] // only eth0.100
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
 		"eth0.100": {
-			fakeAddr("fe80::5054:ff:fedd:eef0:100/64"),
-			fakeAddr("10.100.19.123/24"),
+			network.NewNetAddr("fe80::5054:ff:fedd:eef0:100/64"),
+			network.NewNetAddr("10.100.19.123/24"),
 		},
 	}
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0.100", "vlan")
@@ -292,7 +286,7 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigVLANInferred(c *gc.C) {
 	s.stubConfigSource.CheckCall(c, 4, "InterfaceAddresses", "eth0.100")
 }
 
-func (s *NetworkSuite) TestGetObservedNetworkConfigEthernetInfrerred(c *gc.C) {
+func (s *NetworkSuite) TestGetObservedNetworkConfigEthernetInferred(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
 
@@ -451,8 +445,8 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
 	// Simulate running on Windows, where net.InterfaceAddrs() returns
 	// non-CIDR-formatted addresses.
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
-		"eth0": {fakeAddr("10.20.19.42")},
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
+		"eth0": {network.NewNetAddr("10.20.19.42")},
 	}
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
@@ -472,38 +466,30 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigAddressNotInCIDRFormat(c *gc.
 	s.stubConfigSource.CheckCall(c, 4, "InterfaceAddresses", "eth0")
 }
 
-func (s *NetworkSuite) TestGetObservedNetworkConfigEmptyAddressValue(c *gc.C) {
+func (s *NetworkSuite) TestGetObservedNetworkConfigInvalidAddressError(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
-		"eth0": {fakeAddr("")},
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
+		"eth0": {network.NewNetAddr("invalid")},
 	}
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(observedConfig, jc.DeepEquals, []params.NetworkConfig{{
-		DeviceIndex:   2,
-		MACAddress:    "aa:bb:cc:dd:ee:f0",
-		MTU:           1500,
-		InterfaceName: "eth0",
-		InterfaceType: "ethernet",
-		ConfigType:    "manual",
-		NetworkOrigin: "machine",
-	}})
+	c.Check(err, gc.ErrorMatches, `cannot parse IP address "invalid" on interface "eth0"`)
+	c.Check(observedConfig, gc.IsNil)
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "OvsManagedBridges", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
 	s.stubConfigSource.CheckCall(c, 4, "InterfaceAddresses", "eth0")
 }
 
-func (s *NetworkSuite) TestGetObservedNetworkConfigInvalidAddressValue(c *gc.C) {
+func (s *NetworkSuite) TestGetObservedNetworkConfigNilAddressError(c *gc.C) {
 	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:2] // only eth0
 	s.stubConfigSource.makeSysClassNetInterfacePath(c, "eth0", "")
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
-		"eth0": {fakeAddr("invalid")},
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
+		"eth0": {nil},
 	}
 
 	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
-	c.Check(err, gc.ErrorMatches, `cannot parse IP address "invalid" on interface "eth0"`)
+	c.Check(err, gc.ErrorMatches, `cannot parse nil address on interface "eth0"`)
 	c.Check(observedConfig, gc.IsNil)
 
 	s.stubConfigSource.CheckCallNames(c, "Interfaces", "OvsManagedBridges", "DefaultRoute", "SysClassNetPath", "InterfaceAddresses")
@@ -515,7 +501,7 @@ type stubNetworkConfigSource struct {
 
 	fakeSysClassNetPath   string
 	interfaces            []net.Interface
-	interfaceAddrs        map[string][]net.Addr
+	interfaceAddrs        map[string][]network.ConfigSourceAddr
 	defaultRouteGatewayIP net.IP
 	defaultRouteDevice    string
 	ovsBridges            set.Strings
@@ -580,7 +566,7 @@ func (s *stubNetworkConfigSource) Interfaces() ([]net.Interface, error) {
 }
 
 // InterfaceAddresses implements NetworkConfigSource.
-func (s *stubNetworkConfigSource) InterfaceAddresses(name string) ([]net.Addr, error) {
+func (s *stubNetworkConfigSource) InterfaceAddresses(name string) ([]network.ConfigSourceAddr, error) {
 	s.AddCall("InterfaceAddresses", name)
 	if err := s.NextErr(); err != nil {
 		return nil, err

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -316,9 +316,9 @@ func (s *NetworkSuite) TestGetObservedNetworkConfigForOVSDevices(c *gc.C) {
 			Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
 		},
 	}
-	s.stubConfigSource.interfaceAddrs = map[string][]net.Addr{
+	s.stubConfigSource.interfaceAddrs = map[string][]network.ConfigSourceAddr{
 		"ovsbr0": {
-			fakeAddr("10.100.19.123/24"),
+			network.NewNetAddr("10.100.19.123/24"),
 		},
 	}
 	s.stubConfigSource.ovsBridges = set.NewStrings("ovsbr0")

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -39,7 +39,7 @@ var facadeVersions = map[string]int{
 	"CharmRevisionUpdater":         2,
 	"Charms":                       4,
 	"Cleaner":                      2,
-	"Client":                       2,
+	"Client":                       3,
 	"Cloud":                        7,
 	"Controller":                   9,
 	"CredentialManager":            1,

--- a/api/modelmanager/modelmanager.go
+++ b/api/modelmanager/modelmanager.go
@@ -246,8 +246,6 @@ func (c *Client) ListModelSummaries(user string, all bool) ([]base.UserModelSumm
 			Data:   make(map[string]interface{}),
 			Since:  summary.Status.Since,
 		}
-		//TODO (anastasiamac 2017-11-24) do we need status data for summaries?
-		// we do not translate it at cmd/presentation layer and is it really a summary?...
 		for k, v := range summary.Status.Data {
 			summaries[i].Status.Data[k] = v
 		}

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -234,7 +234,7 @@ func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
 }
 
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
-	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 2)
+	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 3)
 }
 
 func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -178,7 +178,8 @@ func AllFacades() *facade.Registry {
 	reg("Charms", 4, charms.NewFacadeV4)
 	reg("Cleaner", 2, cleaner.NewCleanerAPI)
 	reg("Client", 1, client.NewFacadeV1)
-	reg("Client", 2, client.NewFacade)
+	reg("Client", 2, client.NewFacadeV2)
+	reg("Client", 3, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacadeV1)
 	reg("Cloud", 2, cloud.NewFacadeV2) // adds AddCloud, AddCredentials, CredentialContents, RemoveClouds
 	reg("Cloud", 3, cloud.NewFacadeV3) // changes signature of UpdateCredentials, adds ModifyCloudAccess

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -60,7 +60,7 @@ type Backend interface {
 	LatestMigration() (state.ModelMigration, error)
 	LatestPlaceholderCharm(*charm.URL) (*state.Charm, error)
 	Machine(string) (*state.Machine, error)
-	Model() (*state.Model, error)
+	Model() (Model, error)
 	ModelConfig() (*config.Config, error)
 	ModelConstraints() (constraints.Value, error)
 	ModelTag() names.ModelTag
@@ -83,7 +83,23 @@ type MongoSession interface {
 
 // Model contains the state.Model methods used in this package.
 type Model interface {
+	Name() string
+	Type() state.ModelType
+	UUID() string
+	Life() state.Life
+	CloudName() string
+	CloudRegion() string
+	CloudCredentialTag() (names.CloudCredentialTag, bool)
+	Config() (*config.Config, error)
+	Owner() names.UserTag
 	AddUser(state.UserAccessSpec) (permission.UserAccess, error)
+	Users() ([]permission.UserAccess, error)
+	StatusHistory(status.StatusHistoryFilter) ([]status.StatusInfo, error)
+	SLAOwner() string
+	SLALevel() string
+	LatestToolsVersion() version.Number
+	MeterStatus() state.MeterStatus
+	Status() (status.StatusInfo, error)
 }
 
 // Pool contains the StatePool functionality used in this package.
@@ -170,6 +186,14 @@ func (s stateShim) ModelTag() names.ModelTag {
 	return names.NewModelTag(s.State.ModelUUID())
 }
 
+func (s stateShim) Model() (Model, error) {
+	m, err := s.State.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &modelShim{m}, nil
+}
+
 func (s stateShim) ControllerNodes() ([]state.ControllerNode, error) {
 	nodes, err := s.State.ControllerNodes()
 	if err != nil {
@@ -187,6 +211,10 @@ func (s stateShim) MongoSession() MongoSession {
 		return s.session
 	}
 	return MongoSessionShim{s.State.MongoSession()}
+}
+
+type modelShim struct {
+	*state.Model
 }
 
 // MongoSessionShim wraps a *mgo.Session to conform to the

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -83,6 +83,11 @@ type Client struct {
 
 // ClientV1 serves the (v1) client-specific API methods.
 type ClientV1 struct {
+	*ClientV2
+}
+
+// ClientV2 serves the (v2) client-specific API methods.
+type ClientV2 struct {
 	*Client
 }
 
@@ -141,11 +146,20 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 
 // NewFacadeV1 creates a version 1 Client facade to handle API requests.
 func NewFacadeV1(ctx facade.Context) (*ClientV1, error) {
-	client, err := newFacade(ctx)
+	client, err := NewFacadeV2(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &ClientV1{client}, nil
+}
+
+// NewFacadeV2 creates a version 2 Client facade to handle API requests.
+func NewFacadeV2(ctx facade.Context) (*ClientV2, error) {
+	client, err := newFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ClientV2{client}, nil
 }
 
 func newFacade(ctx facade.Context) (*Client, error) {
@@ -252,7 +266,7 @@ func (c *Client) WatchAll() (params.AllWatcherId, error) {
 	if err := c.checkCanRead(); err != nil {
 		return params.AllWatcherId{}, err
 	}
-	model, err := c.api.stateAccessor.Model()
+	model, err := c.api.state().Model()
 	if err != nil {
 		return params.AllWatcherId{}, errors.Trace(err)
 	}

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -106,6 +106,20 @@ func (c *Client) machineStatusHistory(machineTag names.MachineTag, filter status
 	return agentStatusFromStatusInfo(sInfo, kind), nil
 }
 
+// modelStatusHistory returns status history for the current model.
+func (c *Client) modelStatusHistory(filter status.StatusHistoryFilter) ([]params.DetailedStatus, error) {
+	m, err := c.api.stateAccessor.Model()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get model")
+	}
+
+	sInfo, err := m.StatusHistory(filter)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return agentStatusFromStatusInfo(sInfo, status.KindModel), nil
+}
+
 // StatusHistory returns a slice of past statuses for several entities.
 func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.StatusHistoryResults {
 	results := params.StatusHistoryResults{}
@@ -141,6 +155,8 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 		)
 		kind := status.HistoryKind(request.Kind)
 		switch kind {
+		case status.KindModel:
+			hist, err = c.modelStatusHistory(filter)
 		case status.KindUnit, status.KindWorkload, status.KindUnitAgent:
 			var u names.UnitTag
 			if u, err = names.ParseUnitTag(request.Tag); err == nil {
@@ -190,7 +206,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	if context.spaceInfos, err = c.api.stateAccessor.AllSpaceInfos(); err != nil {
 		return noStatus, errors.Annotate(err, "cannot obtain space information")
 	}
-	if context.model, err = c.api.stateAccessor.Model(); err != nil {
+	if context.model, err = c.api.state().Model(); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch model")
 	}
 	if context.status, err = context.model.LoadModelStatus(); err != nil {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -13867,7 +13867,7 @@
     {
         "Name": "Client",
         "Description": "Client serves client-specific API methods.",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",

--- a/cmd/juju/common/model.go
+++ b/cmd/juju/common/model.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -53,6 +54,7 @@ type ModelMachineInfo struct {
 type ModelStatus struct {
 	Current        status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message        string        `json:"message,omitempty" yaml:"message,omitempty"`
+	Reason         string        `json:"reason,omitempty" yaml:"reason,omitempty"`
 	Since          string        `json:"since,omitempty" yaml:"since,omitempty"`
 	Migration      string        `json:"migration,omitempty" yaml:"migration,omitempty"`
 	MigrationStart string        `json:"migration-start,omitempty" yaml:"migration-start,omitempty"`
@@ -82,6 +84,12 @@ type ModelCredential struct {
 	Owner    string `json:"owner" yaml:"owner"`
 	Cloud    string `json:"cloud" yaml:"cloud"`
 	Validity string `json:"validity-check,omitempty" yaml:"validity-check,omitempty"`
+}
+
+// ModelStatusReason extracts the reason, if any, from a status data bag.
+func ModelStatusReason(data map[string]interface{}) string {
+	reason, _ := data["reason"].(string)
+	return strings.Trim(reason, "\n")
 }
 
 // ModelInfoFromParams translates a params.ModelInfo to ModelInfo.
@@ -116,6 +124,7 @@ func ModelInfoFromParams(info params.ModelInfo, now time.Time) (ModelInfo, error
 		modelInfo.Status = &ModelStatus{
 			Current: info.Status.Status,
 			Message: info.Status.Info,
+			Reason:  ModelStatusReason(info.Status.Data),
 			Since:   FriendlyDuration(info.Status.Since, now),
 		}
 	}

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -278,6 +278,7 @@ type statusInfoContents struct {
 	Err     error         `json:"-" yaml:",omitempty"`
 	Current status.Status `json:"current,omitempty" yaml:"current,omitempty"`
 	Message string        `json:"message,omitempty" yaml:"message,omitempty"`
+	Reason  string        `json:"reason,omitempty" yaml:"reason,omitempty"`
 	Since   string        `json:"since,omitempty" yaml:"since,omitempty"`
 	Version string        `json:"version,omitempty" yaml:"version,omitempty"`
 	Life    string        `json:"life,omitempty" yaml:"life,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -458,6 +458,7 @@ func (sf *statusFormatter) getStatusInfoContents(inst params.DetailedStatus) sta
 		// NOTE: why use a status.Status here, but a string for Life?
 		Current: status.Status(inst.Status),
 		Message: inst.Info,
+		Reason:  common.ModelStatusReason(inst.Data),
 		Version: inst.Version,
 		Life:    string(inst.Life),
 	}

--- a/cmd/juju/status/history_test.go
+++ b/cmd/juju/status/history_test.go
@@ -29,31 +29,7 @@ var _ = gc.Suite(&StatusHistorySuite{})
 
 func (s *StatusHistorySuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.api = nil
 	s.now = time.Date(2017, 11, 28, 12, 34, 56, 0, time.UTC)
-}
-
-func (s *StatusHistorySuite) newCommand() cmd.Command {
-	return statuscmd.NewTestStatusHistoryCommand(s.api)
-}
-
-func (s *StatusHistorySuite) next() *time.Time {
-	value := s.now
-	s.now = s.now.Add(time.Minute)
-	return &value
-}
-
-func (s *StatusHistorySuite) TestMissingEntity(c *gc.C) {
-	s.api = &fakeHistoryAPI{err: errors.NotFoundf("missing/0")}
-	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0")
-	c.Assert(err, gc.ErrorMatches, "missing/0 not found")
-	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
-	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
-}
-
-func (s *StatusHistorySuite) TestResults(c *gc.C) {
-	c.Log(os.Environ())
-
 	s.api = &fakeHistoryAPI{
 		history: status.History{
 			{
@@ -90,20 +66,93 @@ func (s *StatusHistorySuite) TestResults(c *gc.C) {
 				Status: status.Executing,
 				Info:   "running config-changed hoook",
 				Since:  s.next(),
+			}, {
+				Kind:   status.KindModel,
+				Status: status.Suspended,
+				Info:   "invalid credentials",
+				Data:   map[string]interface{}{"reason": "bad password"},
+				Since:  s.next(),
 			},
 		},
 	}
-	expected := "" +
-		"Time                  Type       Status       Message\n" +
-		"2017-11-28 12:34:56Z  juju-unit  allocating   \n" +
-		"2017-11-28 12:35:56Z  workload   waiting      waiting for machine\n" +
-		"2017-11-28 12:36:56Z  workload   waiting      installing agent\n" +
-		"2017-11-28 12:37:56Z  workload   waiting      agent initializing\n" +
-		"2017-11-28 12:38:56Z  workload   maintenance  installing charm software\n" +
-		"2017-11-28 12:39:56Z  juju-unit  executing    running install hoook\n" +
-		"2017-11-28 12:40:56Z  juju-unit  executing    running config-changed hoook\n"
+}
 
+func (s *StatusHistorySuite) newCommand() cmd.Command {
+	return statuscmd.NewTestStatusHistoryCommand(s.api)
+}
+
+func (s *StatusHistorySuite) next() *time.Time {
+	value := s.now
+	s.now = s.now.Add(time.Minute)
+	return &value
+}
+
+func (s *StatusHistorySuite) TestMissingEntity(c *gc.C) {
+	s.api = &fakeHistoryAPI{err: errors.NotFoundf("missing/0")}
+	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0")
+	c.Assert(err, gc.ErrorMatches, "missing/0 not found")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
+}
+
+func (s *StatusHistorySuite) TestTabular(c *gc.C) {
+	c.Log(os.Environ())
+	expected := `
+Time                  Type       Status       Message
+2017-11-28 12:34:56Z  juju-unit  allocating   
+2017-11-28 12:35:56Z  workload   waiting      waiting for machine
+2017-11-28 12:36:56Z  workload   waiting      installing agent
+2017-11-28 12:37:56Z  workload   waiting      agent initializing
+2017-11-28 12:38:56Z  workload   maintenance  installing charm software
+2017-11-28 12:39:56Z  juju-unit  executing    running install hoook
+2017-11-28 12:40:56Z  juju-unit  executing    running config-changed hoook
+2017-11-28 12:41:56Z  model      suspended    invalid credentials
+
+`[1:]
 	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0", "--utc")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+}
+
+func (s *StatusHistorySuite) TestYaml(c *gc.C) {
+	c.Log(os.Environ())
+	expected := `
+- status: allocating
+  since: 2017-11-28T12:34:56Z
+  type: juju-unit
+- status: waiting
+  message: waiting for machine
+  since: 2017-11-28T12:35:56Z
+  type: workload
+- status: waiting
+  message: installing agent
+  since: 2017-11-28T12:36:56Z
+  type: workload
+- status: waiting
+  message: agent initializing
+  since: 2017-11-28T12:37:56Z
+  type: workload
+- status: maintenance
+  message: installing charm software
+  since: 2017-11-28T12:38:56Z
+  type: workload
+- status: executing
+  message: running install hoook
+  since: 2017-11-28T12:39:56Z
+  type: juju-unit
+- status: executing
+  message: running config-changed hoook
+  since: 2017-11-28T12:40:56Z
+  type: juju-unit
+- status: suspended
+  message: invalid credentials
+  data:
+    reason: bad password
+  since: 2017-11-28T12:41:56Z
+  type: model
+`[1:]
+	ctx, err := cmdtesting.RunCommand(c, s.newCommand(), "missing/0", "--utc", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
@@ -120,4 +169,8 @@ func (*fakeHistoryAPI) Close() error {
 
 func (f *fakeHistoryAPI) StatusHistory(kind status.HistoryKind, tag names.Tag, filter status.StatusHistoryFilter) (status.History, error) {
 	return f.history, f.err
+}
+
+func (*fakeHistoryAPI) BestAPIVersion() int {
+	return 3
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -3658,6 +3658,37 @@ var statusTests = []testCase{
 			},
 		},
 	),
+	test( // 28
+		"suspended model",
+		setModelSuspended{"invalid credential", "bad password"},
+		expect{
+			what: "suspend a model due to bad credential",
+			output: M{
+				"model": M{
+					"name":       "controller",
+					"type":       "iaas",
+					"controller": "kontroll",
+					"cloud":      "dummy",
+					"region":     "dummy-region",
+					"version":    "1.2.3",
+					"model-status": M{
+						"current": "suspended",
+						"message": "invalid credential",
+						"reason":  "bad password",
+						"since":   "01 Apr 15 01:23+10:00",
+					},
+					"sla": "unsupported",
+				},
+				"machines":     M{},
+				"applications": M{},
+				"storage":      M{},
+				"controller": M{
+					"timestamp": "15:04:05+07:00",
+				},
+			},
+			stderr: "Model \"controller\" is empty.\n",
+		},
+	),
 }
 
 func mysqlCharm(extras M) M {
@@ -3754,6 +3785,24 @@ type setSLA struct {
 
 func (s setSLA) step(c *gc.C, ctx *context) {
 	err := ctx.st.SetSLA(s.level, "test-user", []byte(""))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type setModelSuspended struct {
+	message string
+	reason  string
+}
+
+func (s setModelSuspended) step(c *gc.C, ctx *context) {
+	m, err := ctx.st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	err = m.SetStatus(status.StatusInfo{
+		Status:  status.Suspended,
+		Message: s.message,
+		Data: map[string]interface{}{
+			"reason": s.reason,
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -114,9 +114,9 @@ func finishNetworkConfig(bridgeDevice string, interfaces corenetwork.InterfaceIn
 // configuration. Currently the only rule that is implemented is that common
 // configuration files are parsed until a configuration is found that is not a
 // loopback address (i.e systemd/resolved stub address).
-func findDNSServerConfig() (*network.DNSConfig, error) {
+func findDNSServerConfig() (*corenetwork.DNSConfig, error) {
 	for _, dnsConfigFile := range resolvConfFiles {
-		dnsConfig, err := network.ParseResolvConf(dnsConfigFile)
+		dnsConfig, err := corenetwork.ParseResolvConf(dnsConfigFile)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/container/broker/instance_broker.go
+++ b/container/broker/instance_broker.go
@@ -11,12 +11,12 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/factory"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
+	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/network"
 )
@@ -31,7 +31,7 @@ var (
 )
 
 // NetConfigFunc returns a slice of NetworkConfig from a source config.
-type NetConfigFunc func(common.NetworkConfigSource) ([]params.NetworkConfig, error)
+type NetConfigFunc func(corenetwork.ConfigSource) ([]params.NetworkConfig, error)
 
 // Config describes the resources used by the instance broker.
 type Config struct {
@@ -145,7 +145,7 @@ func acquireLock(config Config) func(string, <-chan struct{}) (func(), error) {
 
 func observeNetwork(config Config) func() ([]params.NetworkConfig, error) {
 	return func() ([]params.NetworkConfig, error) {
-		return config.GetNetConfig(common.DefaultNetworkConfigSource())
+		return config.GetNetConfig(corenetwork.DefaultNetworkConfigSource())
 	}
 }
 

--- a/core/constraints/package_test.go
+++ b/core/constraints/package_test.go
@@ -25,5 +25,5 @@ func (*ImportTest) TestImports(c *gc.C) {
 
 	// This package should only depend on other core packages.
 	// If this test fails with a non-core package, please check the dependencies.
-	c.Assert(found, jc.SameContents, []string{"core/instance", "core/life", "core/status"})
+	c.Assert(found, jc.SameContents, []string{"core/instance", "core/status"})
 }

--- a/core/network/dns.go
+++ b/core/network/dns.go
@@ -1,0 +1,164 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// DNSConfig holds a list of DNS nameserver addresses
+// and default search domains.
+type DNSConfig struct {
+	Nameservers   []ProviderAddress
+	SearchDomains []string
+}
+
+// ParseResolvConf parses a resolv.conf(5) file at the given path (usually
+// "/etc/resolv.conf"), if present. Returns the values of any 'nameserver'
+// stanzas, and the last 'search' stanza found. Values in the result will
+// appear in the order found, including duplicates.
+// Parsing errors will be returned in these cases:
+//
+// 1. if a 'nameserver' or 'search' without a value is found;
+// 2. 'nameserver' with more than one value (trailing comments starting with
+//    '#' or ';' after the value are allowed).
+// 3. if any value containing '#' or ';' (e.g. 'nameserver 8.8.8.8#bad'),
+//    because values and comments following them must be separated by
+//    whitespace.
+//
+// No error is returned if the file is missing.
+// See resolv.conf(5) man page for details.
+func ParseResolvConf(path string) (*DNSConfig, error) {
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		logger.Debugf("%q does not exist - not parsing", path)
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	defer file.Close()
+
+	var (
+		nameservers   []string
+		searchDomains []string
+	)
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		values, err := parseResolvStanza(line, "nameserver")
+		if err != nil {
+			return nil, errors.Annotatef(err, "parsing %q, line %d", path, lineNum)
+		}
+
+		if numValues := len(values); numValues > 1 {
+			return nil, errors.Errorf(
+				"parsing %q, line %d: one value expected for \"nameserver\", got %d",
+				path, lineNum, numValues,
+			)
+		} else if numValues == 1 {
+			nameservers = append(nameservers, values[0])
+			continue
+		}
+
+		values, err = parseResolvStanza(line, "search")
+		if err != nil {
+			return nil, errors.Annotatef(err, "parsing %q, line %d", path, lineNum)
+		}
+
+		if len(values) > 0 {
+			// Last 'search' found wins.
+			searchDomains = values
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Annotatef(err, "reading %q", path)
+	}
+
+	return &DNSConfig{
+		Nameservers:   NewProviderAddresses(nameservers...),
+		SearchDomains: searchDomains,
+	}, nil
+}
+
+// parseResolvStanza parses a single line from a resolv.conf(5) file, beginning
+// with the given stanza ('nameserver' or 'search' ). If the line does not
+// contain the stanza, no results and no error is returned. Leading and trailing
+// whitespace is removed first, then lines starting with ";" or "#" are treated
+// as comments.
+//
+// Examples:
+// parseResolvStanza(`   # nothing ;to see here`, "doesn't matter")
+// will return (nil, nil) - comments and whitespace are ignored, nothing left.
+//
+// parseResolvStanza(`   nameserver    ns1.example.com   # preferred`, "nameserver")
+// will return ([]string{"ns1.example.com"}, nil).
+//
+// parseResolvStanza(`search ;; bad: no value`, "search")
+// will return (nil, err: `"search": required value(s) missing`)
+//
+// parseResolvStanza(`search foo bar foo foo.bar bar.foo ;; try all`, "search")
+// will return ([]string("foo", "bar", "foo", "foo.bar", "bar.foo"}, nil)
+//
+// parseResolvStanza(`search foo#bad comment`, "nameserver")
+// will return (nil, nil) - line does not start with "nameserver".
+//
+// parseResolvStanza(`search foo#bad comment`, "search")
+// will return (nil, err: `"search": invalid value "foo#bad"`) - no whitespace
+// between the value "foo" and the following comment "#bad comment".
+func parseResolvStanza(line, stanza string) ([]string, error) {
+	const commentChars = ";#"
+	isComment := func(s string) bool {
+		return strings.IndexAny(s, commentChars) == 0
+	}
+
+	line = strings.TrimSpace(line)
+	fields := strings.Fields(line)
+	noFields := len(fields) == 0 // line contains only whitespace
+
+	if isComment(line) || noFields || fields[0] != stanza {
+		// Lines starting with ';' or '#' are comments and are ignored. Empty
+		// lines and those not starting with stanza are ignored.
+		return nil, nil
+	}
+
+	// Mostly for convenience, comments starting with ';' or '#' after a value
+	// are allowed and ignored, assuming there's whitespace between the value
+	// and the comment (e.g. 'search foo #bar' is OK, but 'search foo#bar'
+	// isn't).
+	var parsedValues []string
+	rawValues := fields[1:] // skip the stanza itself
+	for _, value := range rawValues {
+		if isComment(value) {
+			// We're done parsing as the rest of the line is still part of the
+			// same comment.
+			break
+		}
+
+		if strings.ContainsAny(value, commentChars) {
+			// This will catch cases like 'nameserver 8.8.8.8#foo', because
+			// fields[1] will be '8.8.8.8#foo'.
+			return nil, errors.Errorf("%q: invalid value %q", stanza, value)
+		}
+
+		parsedValues = append(parsedValues, value)
+	}
+
+	// resolv.conf(5) states that to be recognized as valid, the line must begin
+	// with the stanza, followed by whitespace, then at least one value (for
+	// 'nameserver', more values separated by whitespace are allowed for
+	// 'search').
+	if len(parsedValues) == 0 {
+		return nil, errors.Errorf("%q: required value(s) missing", stanza)
+	}
+
+	return parsedValues, nil
+}

--- a/core/network/dns_test.go
+++ b/core/network/dns_test.go
@@ -1,0 +1,121 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// +build !windows
+
+package network_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+)
+
+type dnsSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&dnsSuite{})
+
+func (*dnsSuite) TestParseResolvConfEmptyOrMissingPath(c *gc.C) {
+	emptyPath := ""
+	missingPath := filepath.Join(c.MkDir(), "missing")
+
+	for _, path := range []string{emptyPath, missingPath} {
+		result, err := network.ParseResolvConf(path)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(result, gc.IsNil)
+	}
+}
+
+func (*dnsSuite) TestParseResolvConfNotReadablePath(c *gc.C) {
+	unreadableConf := makeResolvConf(c, "#empty", 0000)
+	result, err := network.ParseResolvConf(unreadableConf)
+	expected := fmt.Sprintf("open %s: permission denied", unreadableConf)
+	c.Check(err, gc.ErrorMatches, expected)
+	c.Check(result, gc.IsNil)
+}
+
+func makeResolvConf(c *gc.C, content string, perms os.FileMode) string {
+	fakeConfPath := filepath.Join(c.MkDir(), "fake")
+	err := ioutil.WriteFile(fakeConfPath, []byte(content), perms)
+	c.Check(err, jc.ErrorIsNil)
+	return fakeConfPath
+}
+
+func (*dnsSuite) TestParseResolvConfEmptyFile(c *gc.C) {
+	emptyConf := makeResolvConf(c, "", 0644)
+	result, err := network.ParseResolvConf(emptyConf)
+	c.Check(err, jc.ErrorIsNil)
+	// Expected non-nil, but empty result.
+	c.Check(result, jc.DeepEquals, &network.DNSConfig{})
+}
+
+func (*dnsSuite) TestParseResolvConfCommentsAndWhitespaceHandling(c *gc.C) {
+	const exampleConf = `
+  ;; comment
+# also comment
+;# ditto
+  #nameserver ;still comment
+
+  search    foo example.com       bar.     ;comment, leading/trailing ignored
+nameserver 8.8.8.8 #comment #still the same comment
+`
+	fakeConf := makeResolvConf(c, exampleConf, 0644)
+	result, err := network.ParseResolvConf(fakeConf)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result, jc.DeepEquals, &network.DNSConfig{
+		Nameservers:   network.NewProviderAddresses("8.8.8.8"),
+		SearchDomains: []string{"foo", "example.com", "bar."},
+	})
+}
+
+func (*dnsSuite) TestParseResolvConfSearchWithoutValue(c *gc.C) {
+	badConf := makeResolvConf(c, "search # no value\n", 0644)
+	result, err := network.ParseResolvConf(badConf)
+	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: "search": required value\(s\) missing`)
+	c.Check(result, gc.IsNil)
+}
+
+func (*dnsSuite) TestParseResolvConfNameserverWithoutValue(c *gc.C) {
+	badConf := makeResolvConf(c, "nameserver", 0644)
+	result, err := network.ParseResolvConf(badConf)
+	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: "nameserver": required value\(s\) missing`)
+	c.Check(result, gc.IsNil)
+}
+
+func (*dnsSuite) TestParseResolvConfValueFollowedByCommentWithoutWhitespace(c *gc.C) {
+	badConf := makeResolvConf(c, "search foo bar#bad rest;is#ignored: still part of the comment", 0644)
+	result, err := network.ParseResolvConf(badConf)
+	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: "search": invalid value "bar#bad"`)
+	c.Check(result, gc.IsNil)
+}
+
+func (*dnsSuite) TestParseResolvConfNameserverWithMultipleValues(c *gc.C) {
+	badConf := makeResolvConf(c, "nameserver one two 42 ;;; comment still-inside-comment\n", 0644)
+	result, err := network.ParseResolvConf(badConf)
+	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: one value expected for "nameserver", got 3`)
+	c.Check(result, gc.IsNil)
+}
+
+func (*dnsSuite) TestParseResolvConfLastSearchWins(c *gc.C) {
+	const multiSearchConf = `
+search zero five
+search one
+# this below overrides all of the above
+search two three #comment ;also-comment still-comment
+`
+	fakeConf := makeResolvConf(c, multiSearchConf, 0644)
+	result, err := network.ParseResolvConf(fakeConf)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result, jc.DeepEquals, &network.DNSConfig{
+		SearchDomains: []string{"two", "three"},
+	})
+}

--- a/core/network/network_test.go
+++ b/core/network/network_test.go
@@ -9,11 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/testing"
+	"github.com/juju/testing"
 )
 
 type NetworkSuite struct {
-	testing.BaseSuite
+	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&NetworkSuite{})

--- a/core/network/source.go
+++ b/core/network/source.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"net"
+
+	"github.com/juju/collections/set"
+)
+
+// SysClassNetRoot is the full Linux SYSFS path containing
+// information about each network interface on the system.
+// TODO (manadart 2021-02-12): This remains in the main "source.go" module
+// because there was previously only one ConfigSource implementation,
+// which presumably did not work on Windows.
+// When the NetlinkConfigSource was introduced for use on Linux,
+// we retained the old universal config source for use on Windows.
+// If there comes a time when we properly implement a Windows source,
+// this should be relocated to the Linux module and an appropriate counterpart
+// introduced for Windows.
+const SysClassNetPath = "/sys/class/net"
+
+// ConfigSourceAddr indirects addresses obtained
+// from local machine network interfaces.
+type ConfigSourceAddr interface {
+	// IP returns the address in net.IP form.
+	IP() net.IP
+
+	// IPNet returns the subnet corresponding with the address
+	// provided that it can be determined.
+	IPNet() *net.IPNet
+
+	// String returns the address in string form,
+	// including the subnet mask if known.
+	String() string
+}
+
+// ConfigSource defines the necessary calls to obtain
+// the network configuration of a machine.
+type ConfigSource interface {
+	// SysClassNetPath returns the userspace SYSFS path used by this source.
+	SysClassNetPath() string
+
+	// Interfaces returns information about all
+	// network interfaces on the machine.
+	Interfaces() ([]net.Interface, error)
+
+	// InterfaceAddresses returns information about all addresses
+	// assigned to the network interface with the given name.
+	InterfaceAddresses(name string) ([]ConfigSourceAddr, error)
+
+	// DefaultRoute returns the gateway IP address and device name of the
+	// default route on the machine. If there is no default route (known),
+	// then zero values are returned.
+	DefaultRoute() (net.IP, string, error)
+
+	// OvsManagedBridges returns the names of network interfaces that
+	// correspond to OVS-managed bridges.
+	OvsManagedBridges() (set.Strings, error)
+}

--- a/core/network/source_other.go
+++ b/core/network/source_other.go
@@ -1,0 +1,115 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"net"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+// netAddr implements ConfigSourceAddr based on an address in string form.
+type netAddr struct {
+	addr  string
+	ip    net.IP
+	ipNet *net.IPNet
+}
+
+// NewNetAddr returns a new netAddr reference representing the input IP address
+// string. No error is returned; instead the validity of input is indicated by
+// the return having a populated ip member.
+// TODO (manadart 2021-02-15): This method is exported on account of testing in
+// the api/common package where this logic used to reside and where the actual
+// detection and conversion to params is invoked.
+// The detection should also be relocated here to core/network in order that
+// the export is no longer required.
+func NewNetAddr(a string) *netAddr {
+	res := &netAddr{
+		addr: a,
+	}
+
+	ip, ipNet, _ := net.ParseCIDR(a)
+	if ipNet != nil {
+		res.ipNet = ipNet
+	}
+
+	if ip == nil {
+		ip = net.ParseIP(a)
+	}
+	res.ip = ip
+
+	return res
+}
+
+// IP (ConfigSourceAddr) is a simple property accessor.
+func (a *netAddr) IP() net.IP {
+	return a.ip
+}
+
+// IPNet (ConfigSourceAddr) is a simple property accessor.
+func (a *netAddr) IPNet() *net.IPNet {
+	return a.ipNet
+}
+
+// String (ConfigSourceAddr) is a simple property accessor.
+func (a *netAddr) String() string {
+	return a.addr
+}
+
+type netPackageConfigSource struct {
+	interfaces      func() ([]net.Interface, error)
+	interfaceByName func(name string) (*net.Interface, error)
+}
+
+// SysClassNetPath returns the system path containing information
+// about a machine's network interfaces.
+func (n *netPackageConfigSource) SysClassNetPath() string {
+	return SysClassNetPath
+}
+
+// Interfaces returns the network interfaces on the machine.
+func (n *netPackageConfigSource) Interfaces() ([]net.Interface, error) {
+	return n.interfaces()
+}
+
+// InterfaceAddresses the addresses associated with the network
+// interface identified by the input name.
+func (n *netPackageConfigSource) InterfaceAddresses(name string) ([]ConfigSourceAddr, error) {
+	nic, err := n.interfaceByName(name)
+	if err != nil {
+		return nil, errors.Annotatef(err, "retrieving network interface %q", name)
+	}
+
+	addrs, err := nic.Addrs()
+	if err != nil {
+		return nil, errors.Annotatef(err, "retrieving addresses for interface %q", name)
+	}
+
+	result := make([]ConfigSourceAddr, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.String() != "" {
+			result = append(result, NewNetAddr(addr.String()))
+		}
+	}
+	return result, nil
+}
+
+func (n *netPackageConfigSource) OvsManagedBridges() (set.Strings, error) {
+	return OvsManagedBridges()
+}
+
+// DefaultRoute implements NetworkConfigSource.
+func (n *netPackageConfigSource) DefaultRoute() (net.IP, string, error) {
+	return GetDefaultRoute()
+}
+
+// DefaultNetworkConfigSource returns a NetworkConfigSource backed by the net
+// package, to be used with GetObservedNetworkConfig().
+func DefaultNetworkConfigSource() ConfigSource {
+	return &netPackageConfigSource{
+		interfaces:      net.Interfaces,
+		interfaceByName: net.InterfaceByName,
+	}
+}

--- a/core/network/source_other_test.go
+++ b/core/network/source_other_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type sourceSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&sourceSuite{})
+
+func (s *sourceSuite) TestNewNetAddr(c *gc.C) {
+	nic := NewNetAddr("192.168.20.1/24")
+	c.Check(nic.String(), gc.Equals, "192.168.20.1/24")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "192.168.20.1")
+	c.Assert(nic.IPNet(), gc.NotNil)
+	c.Check(nic.IPNet().String(), gc.Equals, "192.168.20.0/24")
+
+	nic = NewNetAddr("192.168.20.1")
+	c.Check(nic.String(), gc.Equals, "192.168.20.1")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "192.168.20.1")
+	c.Assert(nic.IPNet(), gc.IsNil)
+
+	nic = NewNetAddr("fe80::5054:ff:fedd:eef0/64")
+	c.Check(nic.String(), gc.Equals, "fe80::5054:ff:fedd:eef0/64")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "fe80::5054:ff:fedd:eef0")
+	c.Assert(nic.IPNet(), gc.NotNil)
+	c.Check(nic.IPNet().String(), gc.Equals, "fe80::/64")
+
+	nic = NewNetAddr("fe80::5054:ff:fedd:eef0")
+	c.Check(nic.String(), gc.Equals, "fe80::5054:ff:fedd:eef0")
+	c.Assert(nic.IP(), gc.NotNil)
+	c.Check(nic.IP().String(), gc.Equals, "fe80::5054:ff:fedd:eef0")
+	c.Assert(nic.IPNet(), gc.IsNil)
+}

--- a/core/status/package_test.go
+++ b/core/status/package_test.go
@@ -6,7 +6,6 @@ package status_test
 import (
 	"testing"
 
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	coretesting "github.com/juju/juju/testing"
@@ -22,6 +21,5 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/status")
-
-	c.Assert(found, jc.SameContents, []string{"core/life"})
+	c.Assert(found, gc.HasLen, 0)
 }

--- a/core/status/status_history.go
+++ b/core/status/status_history.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/life"
 )
 
 // StatusHistoryFilter holds arguments that can be use to filter a status history backlog.
@@ -60,10 +59,6 @@ type DetailedStatus struct {
 	Data   map[string]interface{}
 	Since  *time.Time
 	Kind   HistoryKind
-	// TODO(perrito666) make sure this is not used and remove.
-	Version string
-	Life    life.Value
-	Err     error
 }
 
 // History holds many DetailedStatus,
@@ -80,6 +75,8 @@ type HistoryKind string
 // * AllHistoryKind()
 // * command help for 'show-status-log' describing these kinds.
 const (
+	// KindModel represents the model itself.
+	KindModel HistoryKind = "model"
 	// KindUnit represents agent and workload combined.
 	KindUnit HistoryKind = "unit"
 	// KindUnitAgent represent a unit agent status history entry.
@@ -104,7 +101,7 @@ func (k HistoryKind) String() string {
 // Valid will return true if the current kind is a valid one.
 func (k HistoryKind) Valid() bool {
 	switch k {
-	case KindUnit, KindUnitAgent, KindWorkload,
+	case KindModel, KindUnit, KindUnitAgent, KindWorkload,
 		KindMachineInstance, KindMachine,
 		KindContainerInstance, KindContainer:
 		return true
@@ -115,6 +112,7 @@ func (k HistoryKind) Valid() bool {
 // AllHistoryKind will return all valid HistoryKinds.
 func AllHistoryKind() map[HistoryKind]string {
 	return map[HistoryKind]string{
+		KindModel:             "statuses for the model itself",
 		KindUnit:              "statuses for specified unit and its workload",
 		KindUnitAgent:         "statuses from the agent that is managing a unit",
 		KindWorkload:          "statuses for unit's workload",

--- a/go.sum
+++ b/go.sum
@@ -356,7 +356,6 @@ github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx
 github.com/juju/bundlechanges/v4 v4.0.0-20210209150014-ceff3e0a516a h1:db0bO4H9RHo4uSCG6fhZMIkiKFFntwiMjCqKlyv4ZM4=
 github.com/juju/bundlechanges/v4 v4.0.0-20210209150014-ceff3e0a516a/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
-github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f h1:esltimJsCcUSaC9ahxBpC70Gumqnnmgm0Ah+BLVQBTY=

--- a/network/utils.go
+++ b/network/utils.go
@@ -4,168 +4,13 @@
 package network
 
 import (
-	"bufio"
 	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/network"
 )
-
-// DNSConfig holds a list of DNS nameserver addresses and default search
-// domains.
-type DNSConfig struct {
-	Nameservers   []network.ProviderAddress
-	SearchDomains []string
-}
-
-// ParseResolvConf parses a resolv.conf(5) file at the given path (usually
-// "/etc/resolv.conf"), if present. Returns the values of any 'nameserver'
-// stanzas, and the last 'search' stanza found. Values in the result will appear
-// in the order found, including duplicates. Parsing errors will be returned in
-// these cases:
-//
-// 1. if a 'nameserver' or 'search' without a value is found;
-// 2. 'nameserver' with more than one value (trailing comments starting with '#'
-//    or ';' after the value are allowed).
-// 3. if any value containing '#' or ';' (e.g. 'nameserver 8.8.8.8#bad'), because
-//    values and comments following them must be separated by whitespace.
-//
-// No error is returned if the file is missing. See resolv.conf(5) man page for
-// details.
-func ParseResolvConf(path string) (*DNSConfig, error) {
-	file, err := os.Open(path)
-	if os.IsNotExist(err) {
-		logger.Debugf("%q does not exist - not parsing", path)
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer file.Close()
-
-	var (
-		nameservers   []string
-		searchDomains []string
-	)
-	scanner := bufio.NewScanner(file)
-	lineNum := 0
-	for scanner.Scan() {
-		line := scanner.Text()
-		lineNum++
-
-		values, err := parseResolvStanza(line, "nameserver")
-		if err != nil {
-			return nil, errors.Annotatef(err, "parsing %q, line %d", path, lineNum)
-		}
-
-		if numValues := len(values); numValues > 1 {
-			return nil, errors.Errorf(
-				"parsing %q, line %d: one value expected for \"nameserver\", got %d",
-				path, lineNum, numValues,
-			)
-		} else if numValues == 1 {
-			nameservers = append(nameservers, values[0])
-			continue
-		}
-
-		values, err = parseResolvStanza(line, "search")
-		if err != nil {
-			return nil, errors.Annotatef(err, "parsing %q, line %d", path, lineNum)
-		}
-
-		if len(values) > 0 {
-			// Last 'search' found wins.
-			searchDomains = values
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, errors.Annotatef(err, "reading %q", path)
-	}
-
-	return &DNSConfig{
-		Nameservers:   network.NewProviderAddresses(nameservers...),
-		SearchDomains: searchDomains,
-	}, nil
-}
-
-// parseResolvStanza parses a single line from a resolv.conf(5) file, beginning
-// with the given stanza ('nameserver' or 'search' ). If the line does not
-// contain the stanza, no results and no error is returned. Leading and trailing
-// whitespace is removed first, then lines starting with ";" or "#" are treated
-// as comments.
-//
-// Examples:
-// parseResolvStanza(`   # nothing ;to see here`, "doesn't matter")
-// will return (nil, nil) - comments and whitespace are ignored, nothing left.
-//
-// parseResolvStanza(`   nameserver    ns1.example.com   # preferred`, "nameserver")
-// will return ([]string{"ns1.example.com"}, nil).
-//
-// parseResolvStanza(`search ;; bad: no value`, "search")
-// will return (nil, err: `"search": required value(s) missing`)
-//
-// parseResolvStanza(`search foo bar foo foo.bar bar.foo ;; try all`, "search")
-// will return ([]string("foo", "bar", "foo", "foo.bar", "bar.foo"}, nil)
-//
-// parseResolvStanza(`search foo#bad comment`, "nameserver")
-// will return (nil, nil) - line does not start with "nameserver".
-//
-// parseResolvStanza(`search foo#bad comment`, "search")
-// will return (nil, err: `"search": invalid value "foo#bad"`) - no whitespace
-// between the value "foo" and the following comment "#bad comment".
-func parseResolvStanza(line, stanza string) ([]string, error) {
-	const commentChars = ";#"
-	isComment := func(s string) bool {
-		return strings.IndexAny(s, commentChars) == 0
-	}
-
-	line = strings.TrimSpace(line)
-	fields := strings.Fields(line)
-	noFields := len(fields) == 0 // line contains only whitespace
-
-	if isComment(line) || noFields || fields[0] != stanza {
-		// Lines starting with ';' or '#' are comments and are ignored. Empty
-		// lines and those not starting with stanza are ignored.
-		return nil, nil
-	}
-
-	// Mostly for convenience, comments starting with ';' or '#' after a value
-	// are allowed and ignored, assuming there's whitespace between the value
-	// and the comment (e.g. 'search foo #bar' is OK, but 'search foo#bar'
-	// isn't).
-	var parsedValues []string
-	rawValues := fields[1:] // skip the stanza itself
-	for _, value := range rawValues {
-		if isComment(value) {
-			// We're done parsing as the rest of the line is still part of the
-			// same comment.
-			break
-		}
-
-		if strings.ContainsAny(value, commentChars) {
-			// This will catch cases like 'nameserver 8.8.8.8#foo', because
-			// fields[1] will be '8.8.8.8#foo'.
-			return nil, errors.Errorf("%q: invalid value %q", stanza, value)
-		}
-
-		parsedValues = append(parsedValues, value)
-	}
-
-	// resolv.conf(5) states that to be recognized as valid, the line must begin
-	// with the stanza, followed by whitespace, then at least one value (for
-	// 'nameserver', more values separated by whitespace are allowed for
-	// 'search').
-	if len(parsedValues) == 0 {
-		return nil, errors.Errorf("%q: required value(s) missing", stanza)
-	}
-
-	return parsedValues, nil
-}
 
 var netListen = net.Listen
 
@@ -181,11 +26,6 @@ func SupportsIPv6() bool {
 	ln.Close()
 	return true
 }
-
-// SysClassNetRoot is the full Linux SYSFS path containing information about
-// each network interface on the system. Used as argument to
-// ParseInterfaceType().
-const SysClassNetPath = "/sys/class/net"
 
 // ParseInterfaceType parses the DEVTYPE attribute from the Linux kernel
 // userspace SYSFS location "<sysPath/<interfaceName>/uevent" and returns it as

--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -7,7 +7,6 @@ package network_test
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -28,102 +27,6 @@ type UtilsSuite struct {
 
 var _ = gc.Suite(&UtilsSuite{})
 
-func (*UtilsSuite) TestParseResolvConfEmptyOrMissingPath(c *gc.C) {
-	emptyPath := ""
-	missingPath := filepath.Join(c.MkDir(), "missing")
-
-	for _, path := range []string{emptyPath, missingPath} {
-		result, err := network.ParseResolvConf(path)
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(result, gc.IsNil)
-	}
-}
-
-func (*UtilsSuite) TestParseResolvConfNotReadablePath(c *gc.C) {
-	unreadableConf := makeResolvConf(c, "#empty", 0000)
-	result, err := network.ParseResolvConf(unreadableConf)
-	expected := fmt.Sprintf("open %s: permission denied", unreadableConf)
-	c.Check(err, gc.ErrorMatches, expected)
-	c.Check(result, gc.IsNil)
-}
-
-func makeResolvConf(c *gc.C, content string, perms os.FileMode) string {
-	fakeConfPath := filepath.Join(c.MkDir(), "fake")
-	err := ioutil.WriteFile(fakeConfPath, []byte(content), perms)
-	c.Check(err, jc.ErrorIsNil)
-	return fakeConfPath
-}
-
-func (*UtilsSuite) TestParseResolvConfEmptyFile(c *gc.C) {
-	emptyConf := makeResolvConf(c, "", 0644)
-	result, err := network.ParseResolvConf(emptyConf)
-	c.Check(err, jc.ErrorIsNil)
-	// Expected non-nil, but empty result.
-	c.Check(result, jc.DeepEquals, &network.DNSConfig{})
-}
-
-func (*UtilsSuite) TestParseResolvConfCommentsAndWhitespaceHandling(c *gc.C) {
-	const exampleConf = `
-  ;; comment
-# also comment
-;# ditto
-  #nameserver ;still comment
-
-  search    foo example.com       bar.     ;comment, leading/trailing ignored
-nameserver 8.8.8.8 #comment #still the same comment
-`
-	fakeConf := makeResolvConf(c, exampleConf, 0644)
-	result, err := network.ParseResolvConf(fakeConf)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(result, jc.DeepEquals, &network.DNSConfig{
-		Nameservers:   corenetwork.NewProviderAddresses("8.8.8.8"),
-		SearchDomains: []string{"foo", "example.com", "bar."},
-	})
-}
-
-func (*UtilsSuite) TestParseResolvConfSearchWithoutValue(c *gc.C) {
-	badConf := makeResolvConf(c, "search # no value\n", 0644)
-	result, err := network.ParseResolvConf(badConf)
-	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: "search": required value\(s\) missing`)
-	c.Check(result, gc.IsNil)
-}
-
-func (*UtilsSuite) TestParseResolvConfNameserverWithoutValue(c *gc.C) {
-	badConf := makeResolvConf(c, "nameserver", 0644)
-	result, err := network.ParseResolvConf(badConf)
-	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: "nameserver": required value\(s\) missing`)
-	c.Check(result, gc.IsNil)
-}
-
-func (*UtilsSuite) TestParseResolvConfValueFollowedByCommentWithoutWhitespace(c *gc.C) {
-	badConf := makeResolvConf(c, "search foo bar#bad rest;is#ignored: still part of the comment", 0644)
-	result, err := network.ParseResolvConf(badConf)
-	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: "search": invalid value "bar#bad"`)
-	c.Check(result, gc.IsNil)
-}
-
-func (*UtilsSuite) TestParseResolvConfNameserverWithMultipleValues(c *gc.C) {
-	badConf := makeResolvConf(c, "nameserver one two 42 ;;; comment still-inside-comment\n", 0644)
-	result, err := network.ParseResolvConf(badConf)
-	c.Check(err, gc.ErrorMatches, `parsing ".*", line 1: one value expected for "nameserver", got 3`)
-	c.Check(result, gc.IsNil)
-}
-
-func (*UtilsSuite) TestParseResolvConfLastSearchWins(c *gc.C) {
-	const multiSearchConf = `
-search zero five
-search one
-# this below overrides all of the above
-search two three #comment ;also-comment still-comment
-`
-	fakeConf := makeResolvConf(c, multiSearchConf, 0644)
-	result, err := network.ParseResolvConf(fakeConf)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(result, jc.DeepEquals, &network.DNSConfig{
-		SearchDomains: []string{"two", "three"},
-	})
-}
-
 func (s *UtilsSuite) TestSupportsIPv6Error(c *gc.C) {
 	s.PatchValue(network.NetListen, func(netFamily, bindAddress string) (net.Listener, error) {
 		c.Check(netFamily, gc.Equals, "tcp6")
@@ -141,7 +44,7 @@ func (s *UtilsSuite) TestSupportsIPv6OK(c *gc.C) {
 }
 
 func (*UtilsSuite) TestParseInterfaceType(c *gc.C) {
-	fakeSysPath := filepath.Join(c.MkDir(), network.SysClassNetPath)
+	fakeSysPath := filepath.Join(c.MkDir(), corenetwork.SysClassNetPath)
 	err := os.MkdirAll(fakeSysPath, 0700)
 	c.Check(err, jc.ErrorIsNil)
 
@@ -191,7 +94,7 @@ func (*UtilsSuite) TestParseInterfaceType(c *gc.C) {
 }
 
 func (*UtilsSuite) TestGetBridgePorts(c *gc.C) {
-	fakeSysPath := filepath.Join(c.MkDir(), network.SysClassNetPath)
+	fakeSysPath := filepath.Join(c.MkDir(), corenetwork.SysClassNetPath)
 	err := os.MkdirAll(fakeSysPath, 0700)
 	c.Check(err, jc.ErrorIsNil)
 

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -61,7 +61,8 @@ func MaybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool 
 		return false
 	}
 
-	invalidateErr := ctx.InvalidateCredential("azure cloud denied access")
+	converted := common.CredentialNotValidf(err, "azure cloud denied access")
+	invalidateErr := ctx.InvalidateCredential(converted.Error())
 	if invalidateErr != nil {
 		logger.Warningf("could not invalidate stored azure cloud credential on the controller: %v", invalidateErr)
 	}

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -59,7 +59,7 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "azure cloud denied access")
+		c.Assert(msg, gc.Matches, "azure cloud denied access: .*")
 		called = true
 		return nil
 	}

--- a/provider/common/errors.go
+++ b/provider/common/errors.go
@@ -88,7 +88,8 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx context.ProviderCallContext) bool {
 	denied := isAuthError(errors.Cause(err))
 	if ctx != nil && denied {
-		invalidateErr := ctx.InvalidateCredential("cloud denied access")
+		converted := CredentialNotValidf(err, "cloud denied access")
+		invalidateErr := ctx.InvalidateCredential(converted.Error())
 		if invalidateErr != nil {
 			logger.Warningf("could not invalidate stored cloud credential on the controller: %v", invalidateErr)
 		}

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -113,7 +113,7 @@ func (s *ErrorsSuite) checkPermissionHandling(c *gc.C, e error, handled bool) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "cloud denied access")
+		c.Assert(msg, gc.Matches, "cloud denied access:.*auth failure")
 		called = true
 		return nil
 	}

--- a/provider/gce/google/errors.go
+++ b/provider/gce/google/errors.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/api/googleapi"
 
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/provider/common"
 )
 
 // InvalidConfigValueError indicates that one of the config values failed validation.
@@ -77,7 +78,8 @@ func maybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool 
 		return false
 	}
 
-	invalidateErr := ctx.InvalidateCredential("google cloud denied access")
+	converted := common.CredentialNotValidf(err, "google cloud denied access")
+	invalidateErr := ctx.InvalidateCredential(converted.Error())
 	if invalidateErr != nil {
 		logger.Warningf("could not invalidate stored google cloud credential on the controller: %v", invalidateErr)
 	}

--- a/provider/gce/google/errors_test.go
+++ b/provider/gce/google/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +52,8 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "google cloud denied access")
+		c.Assert(msg, gc.Matches,
+			regexp.QuoteMeta(`google cloud denied access: Get "http://notforreal.com/": 40`)+".*")
 		called = true
 		return nil
 	}

--- a/provider/maas/errors_test.go
+++ b/provider/maas/errors_test.go
@@ -80,7 +80,7 @@ func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
 	ctx := context.NewCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
-		c.Assert(msg, gc.DeepEquals, "cloud denied access")
+		c.Assert(msg, gc.Matches, "cloud denied access:.*")
 		called = true
 		return nil
 	}

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -510,7 +510,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceLoginErrorInvalidatesCreds(c
 	}
 	_, err := s.env.StartInstance(ctx, s.createStartInstanceArgs(c))
 	c.Assert(err, gc.ErrorMatches, "dialing client: ServerFaultCode: You passed an incorrect user name or password, bucko.")
-	c.Assert(passedReason, gc.Equals, "cloud denied access")
+	c.Assert(passedReason, gc.Equals, "cloud denied access: ServerFaultCode: You passed an incorrect user name or password, bucko.")
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstancePermissionError(c *gc.C) {

--- a/state/action.go
+++ b/state/action.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -59,6 +60,12 @@ const (
 
 	// ActionAborted indicates the Action was aborted.
 	ActionAborted ActionStatus = "aborted"
+)
+
+var activeStatus = set.NewStrings(
+	string(ActionPending),
+	string(ActionRunning),
+	string(ActionAborting),
 )
 
 type actionNotificationDoc struct {
@@ -387,6 +394,19 @@ func (a *action) removeAndLog(finalStatus ActionStatus, results map[string]inter
 func (a *action) removeAndLogBuildTxn(finalStatus ActionStatus, results map[string]interface{}, message string,
 	m *Model, parentOperation Operation, completedTime time.Time) jujutxn.TransactionSource {
 	return func(attempt int) ([]txn.Op, error) {
+		// If the action is already finished, return an error.
+		if a.Status() == finalStatus {
+			return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("action %v already has status %q", a.Id(), finalStatus))
+		}
+		if attempt > 0 {
+			err := a.Refresh()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if !activeStatus.Contains(string(a.Status())) {
+				return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("action %v is already finished with status %q", a.Id(), finalStatus))
+			}
+		}
 		assertNotComplete := bson.D{{"status", bson.D{
 			{"$nin", []interface{}{
 				ActionCompleted,
@@ -411,7 +431,7 @@ func (a *action) removeAndLogBuildTxn(finalStatus ActionStatus, results map[stri
 			var numComplete int
 			for _, status := range tasks {
 				statusStats.Add(string(status))
-				if status != ActionPending && status != ActionRunning {
+				if !activeStatus.Contains(string(status)) {
 					numComplete++
 				}
 			}
@@ -440,9 +460,9 @@ func (a *action) removeAndLogBuildTxn(finalStatus ActionStatus, results map[stri
 				updateOperationOp = &txn.Op{
 					C:      operationsC,
 					Id:     a.st.docID(parentOperation.Id()),
-					Assert: bson.D{{"complete-task-count", parentOperation.(*operation).doc.CompleteTaskCount}},
-					Update: bson.D{{"$set", bson.D{
-						{"complete-task-count", numComplete + 1},
+					Assert: bson.D{{"complete-task-count", bson.D{{"$lt", len(tasks) - 1}}}},
+					Update: bson.D{{"$inc", bson.D{
+						{"complete-task-count", 1},
 					}}},
 				}
 			}

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -6,8 +6,11 @@ package state_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -385,6 +388,51 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperation(c *gc.C) {
 	// Failed task precedence over completed.
 	c.Assert(operation.Status(), gc.Equals, state.ActionFailed)
 	c.Assert(operation.Completed(), gc.Equals, anAction2.Completed())
+}
+
+func (s *ActionSuite) TestLastActionFinishCompletesOperationMany(c *gc.C) {
+	operationID, err := s.Model.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	numActions := 50
+
+	wg := sync.WaitGroup{}
+	var actions []state.Action
+	for i := 0; i < numActions; i++ {
+		anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+		c.Assert(err, jc.ErrorIsNil)
+
+		anAction, err = anAction.Begin()
+		c.Assert(err, jc.ErrorIsNil)
+		actions = append(actions, anAction)
+		wg.Add(1)
+	}
+
+	completeCount := int32(0)
+	for i := 0; i < numActions; i++ {
+		go func(a int) {
+			defer func() {
+				atomic.AddInt32(&completeCount, 1)
+				wg.Done()
+			}()
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(5)))
+			if atomic.LoadInt32(&completeCount) < int32(numActions) {
+				operation, err := s.model.Operation(operationID)
+				c.Assert(err, jc.ErrorIsNil)
+				c.Assert(operation.Status(), gc.Not(gc.Equals), state.ActionCompleted)
+			}
+
+			_, err = actions[a].Finish(state.ActionResults{
+				Status: state.ActionCompleted,
+			})
+			c.Assert(err, jc.ErrorIsNil)
+		}(i)
+	}
+	wg.Wait()
+
+	operation, err := s.model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(operation.Status(), gc.Equals, state.ActionCompleted)
 }
 
 func (s *ActionSuite) TestLastActionFinishCompletesOperationRace(c *gc.C) {
@@ -1119,15 +1167,16 @@ func (s *ActionSuite) TestActionStatusWatcher(c *gc.C) {
 		receiver state.ActionReceiver
 		name     string
 		status   state.ActionStatus
+		err      string
 	}{
-		{s.unit, "snapshot", state.ActionCancelled},
-		{s.unit2, "snapshot", state.ActionCancelled},
-		{s.unit, "snapshot", state.ActionPending},
-		{s.unit2, "snapshot", state.ActionPending},
-		{s.unit, "snapshot", state.ActionFailed},
-		{s.unit2, "snapshot", state.ActionFailed},
-		{s.unit, "snapshot", state.ActionCompleted},
-		{s.unit2, "snapshot", state.ActionCompleted},
+		{s.unit, "snapshot", state.ActionCancelled, ""},
+		{s.unit2, "snapshot", state.ActionCancelled, ""},
+		{s.unit, "snapshot", state.ActionPending, `.* already has status "pending"`},
+		{s.unit2, "snapshot", state.ActionPending, `.* already has status "pending"`},
+		{s.unit, "snapshot", state.ActionFailed, ""},
+		{s.unit2, "snapshot", state.ActionFailed, ""},
+		{s.unit, "snapshot", state.ActionCompleted, ""},
+		{s.unit2, "snapshot", state.ActionCompleted, ""},
 	}
 
 	w1 := state.NewActionStatusWatcher(s.State, []state.ActionReceiver{s.unit})
@@ -1166,7 +1215,11 @@ func (s *ActionSuite) TestActionStatusWatcher(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		_, err = action.Finish(state.ActionResults{Status: tcase.status})
-		c.Assert(err, jc.ErrorIsNil)
+		if tcase.err == "" {
+			c.Assert(err, jc.ErrorIsNil)
+		} else {
+			c.Assert(err, gc.ErrorMatches, tcase.err)
+		}
 
 		if tcase.receiver == s.unit {
 			expect[tcase.status] = append(expect[tcase.status], action)

--- a/state/model.go
+++ b/state/model.go
@@ -704,8 +704,14 @@ func (m *Model) Owner() names.UserTag {
 	return names.NewUserTag(m.doc.Owner)
 }
 
-func modelStatusInvalidCredential() status.StatusInfo {
-	return status.StatusInfo{Status: status.Suspended, Message: "suspended since cloud credential is not valid"}
+func modelStatusInvalidCredential(reason string) status.StatusInfo {
+	return status.StatusInfo{
+		Status:  status.Suspended,
+		Message: "suspended since cloud credential is not valid",
+		Data: map[string]interface{}{
+			"reason": reason,
+		},
+	}
 }
 
 // Status returns the status of the model.
@@ -717,7 +723,7 @@ func (m *Model) Status() (status.StatusInfo, error) {
 			return status.StatusInfo{}, errors.Annotatef(err, "could not get model credential %v", credentialTag.Id())
 		}
 		if !credential.IsValid() {
-			return modelStatusInvalidCredential(), nil
+			return modelStatusInvalidCredential(credential.InvalidReason), nil
 		}
 	}
 

--- a/state/modelcredential_test.go
+++ b/state/modelcredential_test.go
@@ -64,6 +64,16 @@ func (s *ModelCredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(invalidated.IsValid(), jc.IsFalse)
 	c.Assert(invalidated.InvalidReason, gc.DeepEquals, reason)
+
+	m, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	info, err := m.Status()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, status.StatusInfo{
+		Status:  "suspended",
+		Message: "suspended since cloud credential is not valid",
+		Data:    map[string]interface{}{"reason": "special invalidation"},
+	})
 }
 
 func (s *ModelCredentialSuite) TestValidateCloudCredentialWrongCloud(c *gc.C) {

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -505,7 +505,7 @@ func (p *modelSummaryProcessor) substituteModelStatusForInvalidCredentials(crede
 					continue
 				}
 				details := &p.summaries[idx]
-				details.Status = modelStatusInvalidCredential()
+				details.Status = modelStatusInvalidCredential(doc.InvalidReason)
 			}
 		}
 	}

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -325,10 +325,12 @@ func (s *ModelSummariesSuite) TestContainsModelStatusSuspended(c *gc.C) {
 		"shared": {
 			Status:  status.Suspended,
 			Message: "suspended since cloud credential is not valid",
+			Data:    map[string]interface{}{"reason": "test"},
 		},
 		"user1model": {
 			Status:  status.Busy,
 			Message: "human message",
+			Data:    map[string]interface{}{},
 		},
 	}
 	shared, err := s.StatePool.Get(modelNameToUUID["shared"])
@@ -351,7 +353,6 @@ func (s *ModelSummariesSuite) TestContainsModelStatusSuspended(c *gc.C) {
 		// empty map to a nil map
 		st := summary.Status
 		st.Since = nil
-		st.Data = nil
 		statuses[summary.Name] = st
 	}
 	c.Check(statuses, jc.DeepEquals, expectedStatus)

--- a/worker/machineactions/worker.go
+++ b/worker/machineactions/worker.go
@@ -118,7 +118,9 @@ func (h *handler) Handle(_ <-chan struct{}, actionsSlice []string) error {
 		} else {
 			finishErr = h.config.Facade.ActionFinish(actionTag, params.ActionCompleted, results, "")
 		}
-		if finishErr != nil {
+		if finishErr != nil &&
+			!params.IsCodeAlreadyExists(finishErr) &&
+			!params.IsCodeNotFoundOrCodeUnauthorized(finishErr) {
 			return errors.Trace(finishErr)
 		}
 	}

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -175,7 +175,7 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 
 	life := mr.machine.Life()
 	if life == corelife.Alive {
-		observedConfig, err := getObservedNetworkConfig(common.DefaultNetworkConfigSource())
+		observedConfig, err := getObservedNetworkConfig(corenetwork.DefaultNetworkConfigSource())
 		if err != nil {
 			return errors.Annotate(err, "cannot discover observed network config")
 		} else if len(observedConfig) == 0 {

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/worker/v2"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/life"
 	corenetwork "github.com/juju/juju/core/network"
@@ -53,7 +52,7 @@ func (s *MachinerSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(machiner.InterfaceAddrs, func() ([]net.Addr, error) {
 		return s.addresses, nil
 	})
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(_ corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return nil, nil
 	})
 }
@@ -389,7 +388,7 @@ func (s *MachinerSuite) TestMachineAddressesWithClearFlag(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestGetObservedNetworkConfigEmpty(c *gc.C) {
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(source corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return []params.NetworkConfig{}, nil
 	})
 
@@ -408,7 +407,7 @@ func (s *MachinerSuite) TestGetObservedNetworkConfigEmpty(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestSetObservedNetworkConfig(c *gc.C) {
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(source corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return []params.NetworkConfig{{}}, nil
 	})
 
@@ -428,7 +427,7 @@ func (s *MachinerSuite) TestSetObservedNetworkConfig(c *gc.C) {
 }
 
 func (s *MachinerSuite) TestAliveErrorGetObservedNetworkConfig(c *gc.C) {
-	s.PatchValue(machiner.GetObservedNetworkConfig, func(common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+	s.PatchValue(machiner.GetObservedNetworkConfig, func(source corenetwork.ConfigSource) ([]params.NetworkConfig, error) {
 		return nil, errors.New("no config!")
 	})
 

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -22,6 +22,7 @@ import (
 	corecontainer "github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -49,7 +50,7 @@ type ContainerSetup struct {
 	// been started, the container watcher can be stopped.
 	numberProvisioners int32
 	credentialAPI      workercommon.CredentialAPI
-	getNetConfig       func(common.NetworkConfigSource) ([]params.NetworkConfig, error)
+	getNetConfig       func(network.ConfigSource) ([]params.NetworkConfig, error)
 }
 
 // ContainerSetupParams are used to initialise a container setup handler.
@@ -237,7 +238,7 @@ func (cs *ContainerSetup) initContainerDependencies(abort <-chan struct{}, conta
 }
 
 func (cs *ContainerSetup) observeNetwork() ([]params.NetworkConfig, error) {
-	return cs.getNetConfig(common.DefaultNetworkConfigSource())
+	return cs.getNetConfig(network.DefaultNetworkConfigSource())
 }
 
 func (cs *ContainerSetup) acquireLock(comment string, abort <-chan struct{}) (func(), error) {

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	apimocks "github.com/juju/juju/api/base/mocks"
-	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	provisionermocks "github.com/juju/juju/api/provisioner/mocks"
 	"github.com/juju/juju/apiserver/params"
@@ -30,6 +29,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -168,7 +168,7 @@ func (s *containerSetupSuite) setUpContainerWorker(c *gc.C) (watcher.StringsHand
 	// Stub out network config getter.
 	handler := provisioner.NewContainerSetupHandler(args)
 	handler.(*provisioner.ContainerSetup).SetGetNetConfig(
-		func(_ common.NetworkConfigSource) ([]params.NetworkConfig, error) {
+		func(_ network.ConfigSource) ([]params.NetworkConfig, error) {
 			return nil, nil
 		})
 

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/juju/version"
 
-	"github.com/juju/juju/api/common"
 	apiprovisioner "github.com/juju/juju/api/provisioner"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -65,6 +65,6 @@ func SetupToStartMachine(p ProvisionerTask, machine apiprovisioner.MachineProvis
 	return p.(*provisionerTask).setupToStartMachine(machine, version)
 }
 
-func (cs *ContainerSetup) SetGetNetConfig(getNetConf func(common.NetworkConfigSource) ([]params.NetworkConfig, error)) {
+func (cs *ContainerSetup) SetGetNetConfig(getNetConf func(network.ConfigSource) ([]params.NetworkConfig, error)) {
 	cs.getNetConfig = getNetConf
 }

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -106,7 +106,7 @@ func (opc *operationCallbacks) FailAction(actionId, message string) error {
 	}
 	tag := names.NewActionTag(actionId)
 	err := opc.u.st.ActionFinish(tag, params.ActionFailed, nil, message)
-	if params.IsCodeNotFoundOrCodeUnauthorized(err) {
+	if params.IsCodeNotFoundOrCodeUnauthorized(err) || params.IsCodeAlreadyExists(err) {
 		err = nil
 	}
 	return err

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1219,6 +1219,11 @@ func (ctx *HookContext) finalizeAction(err, unhandledErr error) error {
 	}
 
 	callErr := ctx.state.ActionFinish(tag, actionStatus, results, message)
+	// Prevent the unit agent from looping if it's impossible to finalise the action.
+	if params.IsCodeNotFoundOrCodeUnauthorized(callErr) || params.IsCodeAlreadyExists(callErr) {
+		ctx.logger.Warningf("error finalising action %v: %v", tag.Id(), callErr)
+		callErr = nil
+	}
 	if callErr != nil {
 		unhandledErr = errors.Wrap(unhandledErr, callErr)
 	}


### PR DESCRIPTION
Merge from 2.8 to bring forward:
- #12629 from wallyworld/invalid-model-credentials
- #12630 from hpidcock/fix-double-upgrade
- #12623 from manadart/2.8-net-config-addr
- #12620 from wallyworld/many-actions-finish
- #12622 from manadart/2.8-relocate-net-config-source
- #12621 from manadart/2.8-relocate-net-dns
- #12608 from achilleasa/2.8-allow-bundle-to-update-existing-offers
- #12606 from jujubot/increment-to-2.8.9

Conflict resolution required for:
- api/common/network.go
- apiserver/facades/client/applicationoffers/applicationoffers.go
- apiserver/facades/client/client/status.go
- cmd/juju/application/deployer/bundlehandler.go
- go.mod
- go.sum
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go