### PR TITLE
Update how channel is created in ApplicationsInfo.

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2751,11 +2751,20 @@ func (api *APIBase) ApplicationsInfo(in params.Entities) (params.ApplicationInfo
 			continue
 		}
 
+		var channel string
+		origin := app.CharmOrigin()
+		if origin != nil && origin.Channel != nil {
+			ch := origin.Channel
+			channel = corecharm.MakePermissiveChannel(ch.Track, ch.Risk, ch.Branch).String()
+		} else {
+			channel = details.Channel
+		}
+
 		out[i].Result = &params.ApplicationResult{
 			Tag:              tag.String(),
 			Charm:            details.Charm,
 			Series:           details.Series,
-			Channel:          details.Channel,
+			Channel:          channel,
 			Constraints:      details.Constraints,
 			Principal:        app.IsPrincipal(),
 			Exposed:          app.IsExposed(),

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -89,6 +89,7 @@ type mockApplication struct {
 
 	bindings         map[string]string
 	charm            *mockCharm
+	charmOrigin      *state.CharmOrigin
 	curl             *charm.URL
 	endpoints        []state.Endpoint
 	exposedEndpoints map[string]state.ExposedEndpoint
@@ -269,6 +270,11 @@ func (a *mockApplication) Relations() ([]application.Relation, error) {
 	return []application.Relation{
 		&mockRelation{},
 	}, nil
+}
+
+func (a *mockApplication) CharmOrigin() *state.CharmOrigin {
+	a.MethodCall(a, "CharmOrigin")
+	return a.charmOrigin
 }
 
 type mockBindings struct {

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -94,6 +94,17 @@ func MakeChannel(track, risk, branch string) (Channel, error) {
 	}, nil
 }
 
+// MakePermissiveChannel creates a normalized core charm channel which
+// never fails.  It assumes that the risk has been prechecked.
+func MakePermissiveChannel(track, risk, branch string) Channel {
+	ch := Channel{
+		Track:  track,
+		Risk:   Risk(risk),
+		Branch: branch,
+	}
+	return ch.Normalize()
+}
+
 // MustParseChannel parses a given string or returns a panic.
 func MustParseChannel(s string) Channel {
 	c, err := ParseChannelNormalize(s)


### PR DESCRIPTION
Create a full channel name with track and risk for CharmHub charms.
Fallback to the old channel which is really a risk.

## QA steps

```console
$ juju add-model seven --config charmhub-url="https://api.staging.charmhub.io"
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 18
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 18 in channel stable
$ juju deploy ubuntu-juju-qa --channel 2.0/edge
Located charm "ubuntu-juju-qa" in charm-hub, revision 13
Deploying "ubuntu-juju-qa" from charm-hub charm "ubuntu-juju-qa", revision 13 in channel 2.0/edge
$ juju show-application ubuntu-juju-qa
ubuntu-juju-qa:
  charm: ubuntu-juju-qa
  series: bionic
  channel: 2.0/edge
  constraints:
    arch: amd64
  principal: true
  exposed: false
  remote: false
  endpoint-bindings:
    "": alpha
$ juju show-application ubuntu
ubuntu:
  charm: ubuntu
  series: xenial
  channel: stable
  constraints:
    arch: amd64
  principal: true
  exposed: false
  remote: false
  endpoint-bindings:
    "": alpha
```
