### PR TITLE
Merge 2.8

### DIFF
--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -384,7 +385,12 @@ func (r *relationStateTracker) PrepareHook(hookInfo hook.Info) (string, error) {
 	}
 	relationer, found := r.relationers[hookInfo.RelationId]
 	if !found {
-		return "", errors.Errorf("unknown relation: %d", hookInfo.RelationId)
+		// There may have been a hook queued prior to a restart
+		// and the relation has since been deleted.
+		// There's nothing to prepare so allow the uniter
+		// to continue with the next operation.
+		r.logger.Warningf("preparing hook %v for %v, relation %d has been removed", hookInfo.Kind, r.principalName, hookInfo.RelationId)
+		return "", operation.ErrSkipExecute
 	}
 	return relationer.PrepareHook(hookInfo)
 }
@@ -409,7 +415,12 @@ func (r *relationStateTracker) CommitHook(hookInfo hook.Info) (err error) {
 	}
 	relationer, found := r.relationers[hookInfo.RelationId]
 	if !found {
-		return errors.Errorf("unknown relation: %d", hookInfo.RelationId)
+		// There may have been a hook queued prior to a restart
+		// and the relation has since been deleted.
+		// There's nothing to commit so allow the uniter
+		// to continue with the next operation.
+		r.logger.Warningf("committing hook %v for %v, relation %d has been removed", hookInfo.Kind, r.principalName, hookInfo.RelationId)
+		return nil
 	}
 	return relationer.CommitHook(hookInfo)
 }

--- a/worker/uniter/relation/statetracker_test.go
+++ b/worker/uniter/relation/statetracker_test.go
@@ -183,7 +183,7 @@ func (s *stateTrackerSuite) TestPrepareHookNotFound(c *gc.C) {
 		RelationId: 1,
 	}
 	_, err = rst.PrepareHook(info)
-	c.Assert(err, gc.ErrorMatches, "unknown relation: 1")
+	c.Assert(err, gc.ErrorMatches, "operation already executed")
 }
 
 func (s *stateTrackerSuite) TestPrepareHookOnlyRelationHooks(c *gc.C) {
@@ -234,7 +234,7 @@ func (s *stateTrackerSuite) TestCommitHookNotFound(c *gc.C) {
 		RelationId: 1,
 	}
 	err = rst.CommitHook(info)
-	c.Assert(err, gc.ErrorMatches, "unknown relation: 1")
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *stateTrackerSuite) TestCommitHookRelationCreated(c *gc.C) {


### PR DESCRIPTION
Merge 2.8 with #12634 Fix uniter loop when a relation is removed out of band

## QA steps

See PR.