### PR TITLE
Error if add-k8s is used with an existing cloud name

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -107,14 +107,13 @@ func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *caas.ClusterMetadata
 	// Record the operator storage to use.
 	if clusterMetadata.OperatorStorageClass != nil {
 		operatorSC = clusterMetadata.OperatorStorageClass.Name
-		storageMsg += "."
 	} else {
 		if storageMsg == "" {
 			storageMsg += "\nwith "
 		} else {
 			storageMsg += "\nand "
 		}
-		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class.")
+		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class")
 	}
 
 	if clusterMetadata.NominatedStorageClass != nil {


### PR DESCRIPTION
Unlike add-cloud, add-k8s allowed an existing cloud name to be used and would overwrite a local cloud definition.
The behaviour of add-k8s is now in line with what add-cloud does.

## QA steps

```
$ microk8s.config | juju add-k8s foo --client

k8s substrate "microk8s/localhost" added as cloud "foo".
You can now bootstrap to this cloud by running 'juju bootstrap xyzzz'.

$ microk8s.config | juju add-k8s foo --client

ERROR use `update-k8s foo --client` to override known local definition: k8s "foo" already exists

$ microk8s.config | juju add-k8s foo --controller test

k8s substrate "microk8s/localhost" added as cloud "foo"
$ microk8s.config | juju add-k8s foo --controller test

ERROR could not upload k8s cloud to a controller: cloud "foo" already exists (already exists)
```

## Bug reference

https://bugs.launchpad.net/bugs/1913974
