### PR TITLE
[2.9] Improve maas cli output handling in acceptance tests

### DIFF
--- a/acceptancetests/substrate.py
+++ b/acceptancetests/substrate.py
@@ -622,14 +622,16 @@ class MAASAccount:
 
     def _maas(self, *args):
         """Call maas api with given arguments and parse json result."""
-        try:
-            command = ('maas',) + args
-            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
-            if not output:
+        command = ('maas',) + args
+        res = subprocess.run(command, shell=True, capture_output=True,
+                             text=True)
+        if res.returncode == 0:
+            if not res.stdout:
                 return None
-            return json.loads(output)
-        except subprocess.CalledProcessError as e:
-            raise Exception('%s failed:\n %s' % (command, e.output))
+            return json.loads(res.stdout)
+
+        raise Exception('%s failed:\n %s%s' % (command, res.stdout,
+                                               res.stderr))
 
     def login(self):
         """Login with the maas cli."""


### PR DESCRIPTION
Due to python related incompatibility issues, the maas cli emits a
python warning to stderr. Prioir to this change, the acceptance tests
would attempt to parse the combined stdout/-err output as json causing
tests to fail.

## QA steps

```sh
cd acceptancetests
mkdir /tmp/art
./assess_network_health.py maas `which juju` /tmp/art nw-health --series bionic --bundle ./repository/network-health-2-machines.yaml; echo "EXIT $?"
```