### PR TITLE
Bundle export with channel

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -508,24 +508,20 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 		if application.Subordinate() {
 			newApplication = &charm.ApplicationSpec{
 				Charm:            application.CharmURL(),
+				Channel:          application.Channel(),
 				Expose:           exposedFlag,
 				ExposedEndpoints: exposedEndpoints,
 				Options:          application.CharmConfig(),
 				Annotations:      application.Annotations(),
 				EndpointBindings: endpointsWithSpaceNames,
 			}
-			if appSeries != defaultSeries {
-				newApplication.Series = appSeries
-			}
-			if result := b.constraints(application.Constraints()); len(result) != 0 {
-				newApplication.Constraints = strings.Join(result, " ")
-			}
 		} else {
-			ut := []string{}
-			placement := ""
-			numUnits := 0
-			scale := 0
-
+			var (
+				numUnits  int
+				scale     int
+				placement string
+				ut        []string
+			)
 			if isCAAS {
 				placement = application.Placement()
 				scale = len(application.Units())
@@ -547,6 +543,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 
 			newApplication = &charm.ApplicationSpec{
 				Charm:            application.CharmURL(),
+				Channel:          application.Channel(),
 				NumUnits:         numUnits,
 				Scale_:           scale,
 				Placement_:       placement,
@@ -557,13 +554,13 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 				Annotations:      application.Annotations(),
 				EndpointBindings: endpointsWithSpaceNames,
 			}
+		}
 
-			if appSeries != defaultSeries {
-				newApplication.Series = appSeries
-			}
-			if result := b.constraints(application.Constraints()); len(result) != 0 {
-				newApplication.Constraints = strings.Join(result, " ")
-			}
+		if appSeries != defaultSeries {
+			newApplication.Series = appSeries
+		}
+		if result := b.constraints(application.Constraints()); len(result) != 0 {
+			newApplication.Constraints = strings.Join(result, " ")
 		}
 
 		// If this application has been trusted by the operator, set the

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -505,9 +505,22 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 		}
 		exposedFlag := application.Exposed() && len(exposedEndpoints) == 0
 
+		// We need to correctly handle charmhub urls. The internal
+		// representation of a charm url is not the same as a external
+		// representation, in that only the application name should be rendered.
+		curl, err := charm.ParseURL(application.CharmURL())
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		charmURL := application.CharmURL()
+		if charm.CharmHub.Matches(curl.Schema) {
+			charmURL = curl.Name
+		}
+
 		if application.Subordinate() {
 			newApplication = &charm.ApplicationSpec{
-				Charm:            application.CharmURL(),
+				Charm:            charmURL,
 				Channel:          application.Channel(),
 				Expose:           exposedFlag,
 				ExposedEndpoints: exposedEndpoints,
@@ -542,7 +555,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 			}
 
 			newApplication = &charm.ApplicationSpec{
-				Charm:            application.CharmURL(),
+				Charm:            charmURL,
 				Channel:          application.Channel(),
 				NumUnits:         numUnits,
 				Scale_:           scale,
@@ -643,7 +656,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 	}
 
 	for _, relation := range model.Relations() {
-		endpointRelation := []string{}
+		var endpointRelation []string
 		for _, endpoint := range relation.Endpoints() {
 			// skipping the 'peer' role which is not of concern in exporting the current model configuration.
 			if endpoint.Role() == "peer" {

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -763,6 +763,7 @@ series: trusty
 applications:
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     num_units: 1
     to:
     - "0"
@@ -805,6 +806,7 @@ series: trusty
 applications:
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     num_units: 1
     to:
     - "0"
@@ -868,6 +870,7 @@ series: trusty
 applications:
   foo:
     charm: cs:trusty/ubuntu
+    channel: stable
     options:
       key: value
     bindings:
@@ -875,6 +878,7 @@ applications:
       juju-info: vlan2
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     num_units: 1
     to:
     - "0"
@@ -1014,6 +1018,7 @@ series: trusty
 applications:
   foo:
     charm: cs:trusty/ubuntu
+    channel: stable
     options:
       key: value
     bindings:
@@ -1021,6 +1026,7 @@ applications:
       juju-info: vlan2
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     num_units: 1
     to:
     - "0"
@@ -1144,6 +1150,7 @@ saas:
 applications:
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     num_units: 1
     to:
     - "0"
@@ -1382,6 +1389,7 @@ series: zesty
 applications:
   magic:
     charm: cs:zesty/magic
+    channel: stable
     expose: true
     options:
       key: value
@@ -1437,10 +1445,12 @@ func (s *bundleSuite) TestExportBundleNoEndpointBindingsPrinted(c *gc.C) {
 applications:
   magic:
     charm: cs:zesty/magic
+    channel: stable
     series: zesty
     expose: true
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     series: trusty
     options:
       key: value
@@ -1457,6 +1467,7 @@ func (s *bundleSuite) TestExportBundleEndpointBindingsPrinted(c *gc.C) {
 applications:
   magic:
     charm: cs:zesty/magic
+    channel: stable
     series: zesty
     expose: true
     bindings:
@@ -1464,6 +1475,7 @@ applications:
       rel-name: alpha
   ubuntu:
     charm: cs:trusty/ubuntu
+    channel: stable
     series: trusty
     options:
       key: value
@@ -1505,6 +1517,7 @@ series: zesty
 applications:
   magic:
     charm: cs:zesty/magic
+    channel: stable
     expose: true
     options:
       key: value
@@ -1889,6 +1902,7 @@ series: focal
 applications:
   magic:
     charm: cs:focal/magic
+    channel: stable
     expose: true
     bindings:
       hat: some-space
@@ -1909,6 +1923,7 @@ series: focal
 applications:
   magic:
     charm: cs:focal/magic
+    channel: stable
     expose: true
     bindings:
       hat: some-space
@@ -1933,6 +1948,7 @@ series: focal
 applications:
   magic:
     charm: cs:focal/magic
+    channel: stable
     bindings:
       hat: some-space
       rabbit: alpha

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -1172,15 +1172,18 @@ func (s *bundleSuite) addApplicationToModel(model description.Model, name string
 		series = "kubernetes"
 	}
 	var charmURL string
+	var channel string
 	if strings.HasPrefix(name, "ch:") {
 		charmURL = name
 		name = name[3:]
+		channel = "stable"
 	} else {
 		charmURL = "cs:" + name
 	}
 	application := model.AddApplication(description.ApplicationArgs{
 		Tag:                names.NewApplicationTag(name),
 		CharmURL:           charmURL,
+		Channel:            channel,
 		Series:             series,
 		CharmConfig:        map[string]interface{}{},
 		LeadershipSettings: map[string]interface{}{},
@@ -1907,11 +1910,13 @@ series: xenial
 applications:
   mysql:
     charm: mysql
+    channel: stable
     num_units: 1
     to:
     - "0"
   wordpress:
     charm: wordpress
+    channel: stable
     num_units: 2
     to:
     - "0"


### PR DESCRIPTION
Charmhub relies on channels as a way to identify the correct way to
install a given charm, we need to ensure that this is correctly exported
with the bundle.

Interestingly channel was never outputted for charmstore or local
charms, which could have been a cause of potential bugs when to
replicate an existing deployment based on revision alone.

As a driveby:

When deploying charmhub charms, only the application name should be used
to identify the charm (this is actually wrong as well, but more on that
later), so the additional information that's within the URL is only
used to identify a charm and nothing more.

The fix here is that we correctly output just the charm application name
so you can identify it correctly.

---

The real issue is that the application name could have changed since the
charm was originally deployed and instead, we should allow charmhub
identifiers to be used instead. The problem I have with this is that it
becomes very hard to identify what the charm is, we're also leaking out
charmhub implementation details, but that might be an unnecessary evil?

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy cs:ubuntu --channel=edge
$ juju deploy ubuntu --channel="latest/candidate"
$ juju export-bundle
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913631