### PR TITLE
Bundle diff output with charm url names

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -518,10 +518,18 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 			charmURL = curl.Name
 		}
 
+		var channel string
+		if origin := application.CharmOrigin(); origin != nil {
+			channel = origin.Channel()
+		}
+		if channel == "" {
+			channel = application.Channel()
+		}
+
 		if application.Subordinate() {
 			newApplication = &charm.ApplicationSpec{
 				Charm:            charmURL,
-				Channel:          application.Channel(),
+				Channel:          channel,
 				Expose:           exposedFlag,
 				ExposedEndpoints: exposedEndpoints,
 				Options:          application.CharmConfig(),
@@ -556,7 +564,7 @@ func (b *BundleAPI) fillBundleData(model description.Model) (*charm.BundleData, 
 
 			newApplication = &charm.ApplicationSpec{
 				Charm:            charmURL,
-				Channel:          application.Channel(),
+				Channel:          channel,
 				NumUnits:         numUnits,
 				Scale_:           scale,
 				Placement_:       placement,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14454,6 +14454,9 @@
                         "charm": {
                             "type": "string"
                         },
+                        "charm-channel": {
+                            "type": "string"
+                        },
                         "charm-profile": {
                             "type": "string"
                         },

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -155,6 +155,7 @@ type ApplicationStatus struct {
 	WorkloadVersion  string                     `json:"workload-version"`
 	CharmVersion     string                     `json:"charm-version"`
 	CharmProfile     string                     `json:"charm-profile"`
+	CharmChannel     string                     `json:"charm-channel,omitempty"`
 	EndpointBindings map[string]string          `json:"endpoint-bindings"`
 
 	// The following are for CAAS models.
@@ -163,8 +164,8 @@ type ApplicationStatus struct {
 	PublicAddress string `json:"public-address"`
 }
 
-// TODO(wallyworld) - remove in Juju 3
 // MarshalJSON marshals a status with a typo left in for compatibility.
+// TODO(wallyworld) - remove in Juju 3
 func (as ApplicationStatus) MarshalJSON() ([]byte, error) {
 	type Alias ApplicationStatus
 	return json.Marshal(&struct {

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -63,9 +63,22 @@ func BuildModelRepresentation(
 	}
 	applications := make(map[string]*bundlechanges.Application)
 	for name, appStatus := range status.Applications {
+		curl, err := charm.ParseURL(appStatus.Charm)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		// CharmAlias is used to ensure that we use the name of the charm and
+		// not the full path of the charm url, exposing the internal
+		// representation of the charm URL.
+		charmAlias := appStatus.Charm
+		if charm.CharmHub.Matches(curl.Schema) {
+			charmAlias = curl.Name
+		}
+
 		app := &bundlechanges.Application{
 			Name:          name,
-			Charm:         appStatus.Charm,
+			Charm:         charmAlias,
 			Scale:         appStatus.Scale,
 			Exposed:       appStatus.Exposed,
 			Series:        appStatus.Series,

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -82,6 +82,7 @@ func BuildModelRepresentation(
 			Scale:         appStatus.Scale,
 			Exposed:       appStatus.Exposed,
 			Series:        appStatus.Series,
+			Channel:       appStatus.CharmChannel,
 			SubordinateTo: appStatus.SubordinateTo,
 			Offers:        offersByApplication[name],
 		}

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -111,6 +111,7 @@ func (s *buildModelRepSuite) TestBuildModelRepresentationApplicationsWithSubordi
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"wordpress": {
+				Charm:  "wordpress",
 				Series: "bionic",
 				Life:   life.Alive,
 				Units: map[string]params.UnitStatus{
@@ -118,6 +119,7 @@ func (s *buildModelRepSuite) TestBuildModelRepresentationApplicationsWithSubordi
 				},
 			},
 			"sub": {
+				Charm:         "sub",
 				Series:        "bionic",
 				Life:          life.Alive,
 				SubordinateTo: []string{"wordpress"},
@@ -271,6 +273,7 @@ func (s *buildModelRepSuite) TestBuildModelRepresentationApplicationsWithExposed
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"wordpress": {
+				Charm:  "wordpress",
 				Series: "bionic",
 				Life:   life.Alive,
 				Units: map[string]params.UnitStatus{

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -62,7 +62,7 @@ func (d *factory) GetDeployer(cfg DeployerConfig, getter ModelConfigGetter, reso
 		func() (Deployer, error) { return d.maybeReadLocalCharm(getter) },
 		d.maybePredeployedLocalCharm,
 		func() (Deployer, error) { return d.maybeReadRepositoryBundle(resolver) },
-		d.respositoryCharm, // This always returns a Deployer
+		d.repositoryCharm, // This always returns a Deployer
 	}
 	for _, d := range maybeDeployers {
 		if deploy, err := d(); err != nil {
@@ -448,8 +448,8 @@ func (d *factory) maybeReadRepositoryBundle(resolver Resolver) (Deployer, error)
 	return &repositoryBundle{deployBundle: db}, nil
 }
 
-func (d *factory) respositoryCharm() (Deployer, error) {
-	// Validate we have a charm store change
+func (d *factory) repositoryCharm() (Deployer, error) {
+	// Validate we have a charm store change.
 	userRequestedURL, err := resolveAndValidateCharmURL(d.charmOrBundle)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -330,7 +330,7 @@ Consider using a CharmStore bundle instead.`
 	// GetBundle creates the directory so we actually want to create a temp
 	// directory then add a namespace (bundle name) so that charmhub get
 	// bundle can create it.
-	dir, err := ioutil.TempDir("", "bundle-diff-")
+	dir, err := ioutil.TempDir("", "diff-bundle-")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -249,6 +249,24 @@ machines:
 `[1:])
 }
 
+func (s *diffSuite) TestCharmSeriesBundle(c *gc.C) {
+	bundleData, err := charm.ReadBundleData(strings.NewReader(withSeries))
+	c.Assert(err, jc.ErrorIsNil)
+	s.charmStore.url = &charm.URL{
+		Schema: "cs",
+		Name:   "my-bundle",
+		Series: "bundle",
+	}
+	s.charmStore.bundle = &mockBundle{data: bundleData}
+
+	ctx, err := s.runDiffBundle(c, "my-bundle")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+{}
+`[1:])
+}
+
 func (s *diffSuite) TestBundleNotFound(c *gc.C) {
 	s.charmStore.stub.SetErrors(errors.NotFoundf(`cannot resolve URL "cs:my-bundle": charm or bundle`))
 	_, err := s.runDiffBundle(c, "cs:my-bundle")
@@ -776,5 +794,34 @@ applications:
 relations:
 - - prometheus:juju-info
   - grafana
+`
+	withSeries = `
+series: bionic
+applications:
+  prometheus:
+    charm: 'cs:prometheus2-7'
+    num_units: 1
+    series: xenial
+    constraints: 'cores=3'
+    options:
+      ontology: kant
+    to:
+      - 0
+  grafana:
+    charm: 'cs:grafana-19'
+    num_units: 1
+    constraints: 'cores=3'
+    options:
+      ontology: kant
+    to:
+      - 1
+machines:
+  "0":
+    series: xenial
+  "1": {}
+relations:
+bundle-additions:
+- - prometheus:juju-info
+  - telegraf:info
 `
 )

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -539,7 +539,7 @@ func makeAPIResponsesWithRelations(relations []params.RelationStatus) map[string
 					},
 				},
 				"grafana": {
-					Charm:  "cs:grafana-19",
+					Charm:  "ch:grafana-19",
 					Series: "bionic",
 					Life:   "alive",
 					Units: map[string]params.UnitStatus{
@@ -808,7 +808,7 @@ applications:
     to:
       - 0
   grafana:
-    charm: 'cs:grafana-19'
+    charm: 'grafana'
     num_units: 1
     constraints: 'cores=3'
     options:

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v4 v4.0.0-20210217145310-ff6db9b96781
+	github.com/juju/bundlechanges/v4 v4.0.0-20210218105210-47b5b054f5f1
 	github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
@@ -109,7 +109,7 @@ require (
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
+	golang.org/x/sys v0.0.0-20210218085108-9555bcde0c6a
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/tools v0.0.0-20200725200936-102e7d357031
 	google.golang.org/api v0.29.0

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v4 v4.0.0-20210209150014-ceff3e0a516a
+	github.com/juju/bundlechanges/v4 v4.0.0-20210217145310-ff6db9b96781
 	github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v4 v4.0.0-20210217145310-ff6db9b96781 h1:OVKyVxpZ8N+QBfwCZF715BEILRZCpDgo2oFZaBTWbQc=
-github.com/juju/bundlechanges/v4 v4.0.0-20210217145310-ff6db9b96781/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
+github.com/juju/bundlechanges/v4 v4.0.0-20210218105210-47b5b054f5f1 h1:W+4DvU9kqYbImZPk0tIiG9SQYrztQJ/EwY6LYM0C9F0=
+github.com/juju/bundlechanges/v4 v4.0.0-20210218105210-47b5b054f5f1/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
@@ -886,8 +886,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210218085108-9555bcde0c6a h1:+Kiu2GijIw0WaCBk1i7AcqqRx8Xg3HIYaheQazXOu8w=
+golang.org/x/sys v0.0.0-20210218085108-9555bcde0c6a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v4 v4.0.0-20210209150014-ceff3e0a516a h1:db0bO4H9RHo4uSCG6fhZMIkiKFFntwiMjCqKlyv4ZM4=
-github.com/juju/bundlechanges/v4 v4.0.0-20210209150014-ceff3e0a516a/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
+github.com/juju/bundlechanges/v4 v4.0.0-20210217145310-ff6db9b96781 h1:OVKyVxpZ8N+QBfwCZF715BEILRZCpDgo2oFZaBTWbQc=
+github.com/juju/bundlechanges/v4 v4.0.0-20210217145310-ff6db9b96781/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -28,7 +28,7 @@ run_charmstore_deploy() {
     wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
     juju refresh ubuntu
-    wait_for "ubuntu" "$(idle_condition_for_rev "ubuntu" "7")"
+    wait_for "ubuntu" "$(idle_condition_for_rev "ubuntu" "9")"
 
     destroy_model "test-charmstore-deploy"
 }


### PR DESCRIPTION
The following allows the diff'ing of bundles when using charmhub charm
urls. The internal representation of charmhub urls are different from
what users of juju see. So prefix, arch, series charm urls should not be
shown and therefor should not be used for diff'ing exported bundles.

The code is actually simple, use the charmurl name for charmhub charms
and just update to the latest library changes. With the addition of a
few tests, the following should be possible:

    $ juju diff-bundle <(juju export-bundle)
    {}

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --channel="latest/edge"
$ juju diff-bundle <(juju export-bundle)
{}
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913631
