### PR TITLE
Expose charm channel in juju status

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14543,6 +14543,8 @@
                     "additionalProperties": false,
                     "required": [
                         "charm",
+                        "charm-version",
+                        "charm-profile",
                         "series",
                         "exposed",
                         "life",
@@ -14553,8 +14555,6 @@
                         "meter-statuses",
                         "status",
                         "workload-version",
-                        "charm-version",
-                        "charm-profile",
                         "endpoint-bindings",
                         "public-address"
                     ]

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -142,6 +142,9 @@ type LXDProfile struct {
 type ApplicationStatus struct {
 	Err              *Error                     `json:"err,omitempty"`
 	Charm            string                     `json:"charm"`
+	CharmVersion     string                     `json:"charm-version"`
+	CharmProfile     string                     `json:"charm-profile"`
+	CharmChannel     string                     `json:"charm-channel,omitempty"`
 	Series           string                     `json:"series"`
 	Exposed          bool                       `json:"exposed"`
 	ExposedEndpoints map[string]ExposedEndpoint `json:"exposed-endpoints,omitempty"`
@@ -153,9 +156,6 @@ type ApplicationStatus struct {
 	MeterStatuses    map[string]MeterStatus     `json:"meter-statuses"`
 	Status           DetailedStatus             `json:"status"`
 	WorkloadVersion  string                     `json:"workload-version"`
-	CharmVersion     string                     `json:"charm-version"`
-	CharmProfile     string                     `json:"charm-profile"`
-	CharmChannel     string                     `json:"charm-channel,omitempty"`
 	EndpointBindings map[string]string          `json:"endpoint-bindings"`
 
 	// The following are for CAAS models.

--- a/apiserver/params/status_test.go
+++ b/apiserver/params/status_test.go
@@ -5,7 +5,6 @@ package params_test
 
 import (
 	"encoding/json"
-	"strings"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -23,9 +22,11 @@ func (s *StatusSuite) TestMarshallApplicationStatusCharmVersion(c *gc.C) {
 	}
 	data, err := json.Marshal(as)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(data), gc.Equals, strings.Replace(`
-{"charm-verion":"666","charm":"","series":"","exposed":false,"life":"","relations":null,"can-upgrade-to":"","subordinate-to":null,
-"units":null,"meter-statuses":null,"status":{"status":"","info":"","data":null,"since":null,"kind":"",
-"version":"","life":""},"workload-version":"","charm-version":"666",
-"charm-profile":"","endpoint-bindings":null,"public-address":""}`, "\n", "", -1))
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(m["charm-verion"], gc.Equals, "666")
+	c.Assert(m["charm-version"], gc.Equals, "666")
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -121,6 +121,7 @@ type applicationStatus struct {
 	CharmOrigin      string                `json:"charm-origin" yaml:"charm-origin"`
 	CharmName        string                `json:"charm-name" yaml:"charm-name"`
 	CharmRev         int                   `json:"charm-rev" yaml:"charm-rev"`
+	CharmChannel     string                `json:"charm-channel,omitempty" yaml:"charm-channel,omitempty"`
 	CharmVersion     string                `json:"charm-version,omitempty" yaml:"charm-version,omitempty"`
 	CharmProfile     string                `json:"charm-profile,omitempty" yaml:"charm-profile,omitempty"`
 	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -239,6 +239,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		osInfo = application.Series
 	}
 	var (
+		charmAlias  = ""
 		charmOrigin = ""
 		charmName   = ""
 		charmRev    = 0
@@ -251,20 +252,24 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		switch curl.Schema {
 		case "ch":
 			charmOrigin = "charmhub"
+			charmAlias = curl.Name
 		case "cs":
 			charmOrigin = "charmstore"
+			charmAlias = application.Charm
 		case "local":
 			charmOrigin = "local"
+			charmAlias = application.Charm
 		default:
 			charmOrigin = "unknown"
+			charmAlias = application.Charm
 		}
-		charmName = curl.Name
 		charmRev = curl.Revision
+		charmName = curl.Name
 	}
 
 	out := applicationStatus{
 		Err:              typedNilCheck(application.Err),
-		Charm:            application.Charm,
+		Charm:            charmAlias,
 		Series:           application.Series,
 		OS:               osInfo,
 		CharmOrigin:      charmOrigin,
@@ -272,6 +277,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		CharmRev:         charmRev,
 		CharmVersion:     application.CharmVersion,
 		CharmProfile:     application.CharmProfile,
+		CharmChannel:     application.CharmChannel,
 		Exposed:          application.Exposed,
 		Life:             string(application.Life),
 		Scale:            application.Scale,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -131,12 +131,12 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Channel", "Rev", "OS", "Address", "Message")
 	} else {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Channel", "Rev", "OS", "Message")
 	}
 	tw.SetColumnAlignRight(3)
-	tw.SetColumnAlignRight(6)
+	tw.SetColumnAlignRight(7)
 	for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
 		app := fs.Applications[appName]
 		version := app.Version
@@ -162,6 +162,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 
 		w.Print(app.CharmName,
 			app.CharmOrigin,
+			app.CharmChannel,
 			app.CharmRev,
 			app.OS)
 		if fs.Model.Type == caasModelType {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5094,10 +5094,10 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
 
-App        Version          Status       Scale  Charm      Store       Rev  OS      Message
-logging    a bit too lo...  error            2  logging    charmstore    1  ubuntu  somehow lost in all those logs
-mysql      5.7.13           maintenance    1/2  mysql      charmstore    1  ubuntu  installing all the things
-wordpress  4.5.3            active           1  wordpress  charmhub      3  ubuntu  
+App        Version          Status       Scale  Charm      Store       Channel  Rev  OS      Message
+logging    a bit too lo...  error            2  logging    charmstore             1  ubuntu  somehow lost in all those logs
+mysql      5.7.13           maintenance    1/2  mysql      charmstore             1  ubuntu  installing all the things
+wordpress  4.5.3            active           1  wordpress  charmhub               3  ubuntu  
 
 Unit          Workload     Agent  Machine  Public address  Ports  Message
 mysql/0*      maintenance  idle   2        10.0.2.1               installing all the things
@@ -5202,8 +5202,8 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Message
-foo                       2                  0      
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Message
+foo                       2                           0      
 
 Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
@@ -5250,8 +5250,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Message
-foo                     1/2                  0      54.32.1.2  
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
+foo                     1/2                           0      54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
@@ -5293,8 +5293,8 @@ func (s *StatusSuite) TestFormatTabularStatusMessage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Message
-foo                     0/1                  0      54.32.1.2  Error: ImagePullBackOff
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
+foo                     0/1                           0      54.32.1.2  Error: ImagePullBackOff
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  waiting   allocating  10.0.0.1  80/TCP  
@@ -5357,8 +5357,8 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Message
-foo                     0/2                  0      
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Message
+foo                     0/2                           0      
 
 Unit   Workload  Agent  Machine  Public address  Ports  Message
 foo/0                                                   

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -165,10 +165,10 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 
 	context := s.run(c, "status")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Message
-another             waiting    0/1  mysql      charmstore    5  ubuntu  waiting for machine
-mysql               waiting    0/1  mysql      charmstore    1  ubuntu  waiting for machine
-wordpress           waiting    0/1  wordpress  charmstore    3  ubuntu  waiting for machine
+App        Version  Status   Scale  Charm      Store       Channel  Rev  OS      Message
+another             waiting    0/1  mysql      charmstore             5  ubuntu  waiting for machine
+mysql               waiting    0/1  mysql      charmstore             1  ubuntu  waiting for machine
+wordpress           waiting    0/1  wordpress  charmstore             3  ubuntu  waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 another/0    waiting   allocating  1                               waiting for machine
@@ -182,9 +182,9 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 	context = s.run(c, "status", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Message
-mysql               waiting    0/1  mysql      charmstore    1  ubuntu  waiting for machine
-wordpress           waiting    0/1  wordpress  charmstore    3  ubuntu  waiting for machine
+App        Version  Status   Scale  Charm      Store       Channel  Rev  OS      Message
+mysql               waiting    0/1  mysql      charmstore             1  ubuntu  waiting for machine
+wordpress           waiting    0/1  wordpress  charmstore             3  ubuntu  waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine


### PR DESCRIPTION
The following makes it possible to see the channel of the charm when
deploying a charm. This not only makes it good for charmhub charms, but
should really be done for charmstore charms. Although the channels are
different it highlights there could be an issue if you're dependant on
a given charm being from a given channel.

The code itself is really simple, just push the channel through the
apiserver and let it land in the status.

Originally revision wasn't shown for charmhub charms, but ongoing
discussion states that it probably should.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --channel=latest/edge
```

Output should be the following:

```sh
$ juju status
Model  Controller  Cloud/Region  Version    SLA          Timestamp
three  test        lxd/default   2.9-rc6.5  unsupported  16:33:01Z

App     Version  Status  Scale  Charm   Store     Channel  Rev  OS      Message
ubuntu  16.04    active      1  ubuntu  charmhub  edge      17  ubuntu  ready

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.132.183.237         ready

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.132.183.237  juju-9b3551-0  xenial      Running

```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913631