### PR TITLE
Fix service type translation for k8s applications

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -85,7 +85,7 @@ def deploy_test_workloads(caas_client, k8s_model, caas_provider):
     else:
         k8s_model.deploy(
             charm="cs:~juju/mediawiki-k8s-4",
-            config='kubernetes-service-type=LoadBalancer',
+            config='kubernetes-service-type=loadbalancer',
         )
         svc_type = 'LoadBalancer'
 

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -5,7 +5,6 @@ package uniter
 
 import (
 	"github.com/juju/errors"
-	k8score "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
@@ -112,10 +111,8 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 
 	var pollAddr bool
 	svcType := cfg.GetString(k8sprovider.ServiceTypeConfigKey, "")
-	switch svcType {
-	case string(caas.ServiceLoadBalancer), string(caas.ServiceExternal),
-		// TODO(juju4): remove k8s compatibility fallback
-		string(k8score.ServiceTypeLoadBalancer), string(k8score.ServiceTypeExternalName):
+	switch caas.ServiceType(svcType) {
+	case caas.ServiceLoadBalancer, caas.ServiceExternal:
 		pollAddr = true
 	}
 

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -8,6 +8,7 @@ import (
 	k8score "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
@@ -111,8 +112,10 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 
 	var pollAddr bool
 	svcType := cfg.GetString(k8sprovider.ServiceTypeConfigKey, "")
-	switch k8score.ServiceType(svcType) {
-	case k8score.ServiceTypeLoadBalancer, k8score.ServiceTypeExternalName:
+	switch svcType {
+	case string(caas.ServiceLoadBalancer), string(caas.ServiceExternal),
+		// TODO(juju4): remove k8s compatibility fallback
+		string(k8score.ServiceTypeLoadBalancer), string(k8score.ServiceTypeExternalName):
 		pollAddr = true
 	}
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -563,6 +563,14 @@ func caasPrecheck(
 			return errors.Errorf("block storage %q is not supported for k8s charms", s.Name)
 		}
 	}
+	serviceType, ok := args.Config[k8s.ServiceTypeConfigKey]
+	if ok {
+		switch caas.ServiceType(serviceType) {
+		case caas.ServiceCluster, caas.ServiceLoadBalancer, caas.ServiceExternal, caas.ServiceOmit:
+		default:
+			return errors.NotValidf("service type %q", serviceType)
+		}
+	}
 
 	cfg, err := model.ModelConfig()
 	if err != nil {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -563,13 +563,9 @@ func caasPrecheck(
 			return errors.Errorf("block storage %q is not supported for k8s charms", s.Name)
 		}
 	}
-	serviceType, ok := args.Config[k8s.ServiceTypeConfigKey]
-	if ok {
-		switch caas.ServiceType(serviceType) {
-		case caas.ServiceCluster, caas.ServiceLoadBalancer, caas.ServiceExternal, caas.ServiceOmit:
-		default:
-			return errors.NotValidf("service type %q", serviceType)
-		}
+	serviceType := args.Config[k8s.ServiceTypeConfigKey]
+	if _, err := k8s.CaasServiceToK8s(caas.ServiceType(serviceType)); err != nil {
+		return errors.NotValidf("service type %q", serviceType)
 	}
 
 	cfg, err := model.ModelConfig()

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -856,13 +856,13 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 			CharmURL:        "local:foo-0",
 			NumUnits:        1,
 			Config:          map[string]string{"kubernetes-service-annotations": "a=b c="},
-			ConfigYAML:      "foo:\n  stringOption: fred\n  kubernetes-service-type: NodeIP",
+			ConfigYAML:      "foo:\n  stringOption: fred\n  kubernetes-service-type: loadbalancer",
 		}, {
 			ApplicationName: "foobar",
 			CharmURL:        "local:foobar-0",
 			NumUnits:        1,
-			Config:          map[string]string{"kubernetes-service-type": "ClusterIP", "intOption": "2"},
-			ConfigYAML:      "foobar:\n  intOption: 1\n  kubernetes-service-type: NodeIP\n  kubernetes-ingress-ssl-redirect: true",
+			Config:          map[string]string{"kubernetes-service-type": "cluster", "intOption": "2"},
+			ConfigYAML:      "foobar:\n  intOption: 1\n  kubernetes-service-type: loadbalancer\n  kubernetes-ingress-ssl-redirect: true",
 		}, {
 			ApplicationName: "bar",
 			CharmURL:        "local:bar-0",
@@ -883,12 +883,39 @@ func (s *ApplicationSuite) TestDeployCAASModel(c *gc.C) {
 	c.Assert(results.Results[2].Error, gc.ErrorMatches, "AttachStorage may not be specified for k8s models")
 	c.Assert(results.Results[3].Error, gc.ErrorMatches, "only 1 placement directive is supported for k8s models, got 2")
 
-	c.Assert(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "NodeIP")
+	c.Assert(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "loadbalancer")
 	// Check parsing of k8s service annotations.
 	c.Assert(s.deployParams["foo"].ApplicationConfig.Attributes()["kubernetes-service-annotations"], jc.DeepEquals, map[string]string{"a": "b", "c": ""})
-	c.Assert(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "ClusterIP")
+	c.Assert(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-service-type"], gc.Equals, "cluster")
 	c.Assert(s.deployParams["foobar"].ApplicationConfig.Attributes()["kubernetes-ingress-ssl-redirect"], gc.Equals, true)
 	c.Assert(s.deployParams["foobar"].CharmConfig, jc.DeepEquals, charm.Settings{"intOption": int64(2)})
+}
+
+func (s *ApplicationSuite) TestDeployCAASInvalidServiceType(c *gc.C) {
+	s.model.modelType = state.ModelTypeCAAS
+	s.backend.charm = &mockCharm{
+		meta: &charm.Meta{},
+		config: &charm.Config{
+			Options: map[string]charm.Option{
+				"stringOption": {Type: "string"},
+				"intOption":    {Type: "int", Default: int(123)},
+			},
+		},
+	}
+
+	args := params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{{
+			ApplicationName: "foo",
+			CharmURL:        "local:foo-0",
+			CharmOrigin:     &params.CharmOrigin{Source: "local"},
+			NumUnits:        1,
+			Config:          map[string]string{"kubernetes-service-type": "ClusterIP", "intOption": "2"},
+		}},
+	}
+	result, err := s.api.Deploy(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.OneError(), gc.ErrorMatches, `service type "ClusterIP" not valid`)
 }
 
 func (s *ApplicationSuite) TestDeployCAASBlockStorageRejected(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -907,7 +907,6 @@ func (s *ApplicationSuite) TestDeployCAASInvalidServiceType(c *gc.C) {
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "foo",
 			CharmURL:        "local:foo-0",
-			CharmOrigin:     &params.CharmOrigin{Source: "local"},
 			NumUnits:        1,
 			Config:          map[string]string{"kubernetes-service-type": "ClusterIP", "intOption": "2"},
 		}},

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -409,7 +409,7 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string, cfg *podcfg.Boo
 		return spec, nil
 	}
 	if len(cfg.ControllerServiceType) > 0 {
-		if spec.ServiceType, err = caasServiceToK8s(caas.ServiceType(cfg.ControllerServiceType)); err != nil {
+		if spec.ServiceType, err = CaasServiceToK8s(caas.ServiceType(cfg.ControllerServiceType)); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1793,15 +1793,8 @@ func (k *kubernetesClient) deleteVolumeClaims(appName string, p *core.Pod) ([]st
 	return deletedClaimVolumes, nil
 }
 
-func caasServiceToK8s(in caas.ServiceType) (core.ServiceType, error) {
-	// TODO(juju4): remove k8s compatibility fallback
-	// There was no validation at deploy so the raw k8s types may have been used.
-	switch string(in) {
-	case string(core.ServiceTypeClusterIP),
-		string(core.ServiceTypeLoadBalancer),
-		string(core.ServiceTypeExternalName):
-		return core.ServiceType(in), nil
-	}
+// CaasServiceToK8s translates a caas service type to a k8s one.
+func CaasServiceToK8s(in caas.ServiceType) (core.ServiceType, error) {
 	serviceType := defaultServiceType
 	if in != "" {
 		switch in {
@@ -1848,7 +1841,7 @@ func (k *kubernetesClient) configureService(
 	}
 
 	serviceType := caas.ServiceType(config.GetString(ServiceTypeConfigKey, string(params.Deployment.ServiceType)))
-	k8sServiceType, err := caasServiceToK8s(serviceType)
+	k8sServiceType, err := CaasServiceToK8s(serviceType)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -715,7 +715,7 @@ var basicServiceArg = &core.Service{
 		Annotations: map[string]string{"juju.io/controller": testing.ControllerTag.Id()}},
 	Spec: core.ServiceSpec{
 		Selector: map[string]string{"juju-app": "app-name"},
-		Type:     "nodeIP",
+		Type:     "LoadBalancer",
 		Ports: []core.ServicePort{
 			{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 			{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2158,7 +2158,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2199,7 +2199,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2280,7 +2280,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2321,7 +2321,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2360,7 +2360,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceStatelessWithScalePolicyInvalid(c *gc.
 		},
 	}
 	err := s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2474,7 +2474,7 @@ password: shhhh`[1:],
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2611,7 +2611,7 @@ password: shhhh`[1:],
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2725,7 +2725,7 @@ password: shhhh`[1:],
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2873,7 +2873,7 @@ password: shhhh`[1:],
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3512,7 +3512,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -3610,7 +3610,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3674,7 +3674,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -3785,7 +3785,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 	errChan := make(chan error)
 	go func() {
 		errChan <- s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-			"kubernetes-service-type":            "nodeIP",
+			"kubernetes-service-type":            "loadbalancer",
 			"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 			"kubernetes-service-externalname":    "ext-name",
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3874,7 +3874,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -3972,7 +3972,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4052,7 +4052,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4163,7 +4163,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	errChan := make(chan error)
 	go func() {
 		errChan <- s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-			"kubernetes-service-type":            "nodeIP",
+			"kubernetes-service-type":            "loadbalancer",
 			"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 			"kubernetes-service-externalname":    "ext-name",
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4264,7 +4264,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4423,7 +4423,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4526,7 +4526,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4695,7 +4695,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4806,7 +4806,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"juju-app": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -5019,7 +5019,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -5116,7 +5116,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5219,7 +5219,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5314,7 +5314,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5461,7 +5461,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5610,7 +5610,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5785,7 +5785,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5967,7 +5967,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6142,7 +6142,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6259,7 +6259,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6381,7 +6381,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6465,7 +6465,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6540,7 +6540,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		Constraints: constraints.MustParse("mem=64 cpu-power=500"),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6628,7 +6628,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6708,7 +6708,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 		Constraints: constraints.MustParse(`zones=a,b,c`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})

--- a/state/application.go
+++ b/state/application.go
@@ -2536,7 +2536,7 @@ func (a *Application) ApplicationConfig() (application.ConfigAttributes, error) 
 	} else if err != nil {
 		return nil, errors.Annotatef(err, "application config for application %q", a.doc.Name)
 	}
-	return application.ConfigAttributes(config.Map()), nil
+	return config.Map(), nil
 }
 
 // UpdateApplicationConfig changes an application's config settings.

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/mgo.v2/txn"
+	core "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes/provider"
@@ -3075,5 +3076,48 @@ func RemoveUnusedLinkLayerDeviceProviderIDs(pool *StatePool) error {
 	}
 
 	logger.Infof("deleted %d unused link-layer device provider IDs", before-after)
+	return nil
+}
+
+// TranslateK8sServiceTypes converts any existing app config using the
+// native k8s service types to the Juju values.
+func TranslateK8sServiceTypes(pool *StatePool) error {
+	st := pool.SystemState()
+	var ops []txn.Op
+	coll, closer := st.db().GetRawCollection(settingsC)
+	defer closer()
+	iter := coll.Find(bson.M{"_id": bson.M{"$regex": "^.*:a#.*"}}).Iter()
+	defer iter.Close()
+	var doc settingsDoc
+	for iter.Next(&doc) {
+		serviceTypeVal := doc.Settings[k8s.ServiceTypeConfigKey]
+		serviceType, ok := serviceTypeVal.(string)
+		if !ok {
+			continue
+		}
+		switch core.ServiceType(serviceType) {
+		case core.ServiceTypeClusterIP:
+			serviceType = string(caas.ServiceCluster)
+		case core.ServiceTypeLoadBalancer:
+			serviceType = string(caas.ServiceLoadBalancer)
+		case core.ServiceTypeExternalName:
+			serviceType = string(caas.ServiceExternal)
+		default:
+			continue
+		}
+		doc.Settings[k8s.ServiceTypeConfigKey] = serviceType
+		ops = append(ops, txn.Op{
+			C:      settingsC,
+			Id:     doc.DocID,
+			Assert: txn.DocExists,
+			Update: bson.M{"$set": bson.M{"settings": doc.Settings}},
+		})
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	if len(ops) > 0 {
+		return errors.Trace(st.runRawTransaction(ops))
+	}
 	return nil
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4530,6 +4530,48 @@ func (s *upgradesSuite) TestRemoveUnusedLinkLayerDeviceProviderIDs(c *gc.C) {
 	}))
 }
 
+func (s *upgradesSuite) TestTranslateK8sServiceTypes(c *gc.C) {
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = settingsColl.Insert(bson.M{
+		"_id": "modelXXX:a#foo",
+		"settings": bson.M{
+			"kubernetes-service-type": "loadbalancer"},
+	}, bson.M{
+		"_id": "modelXXX:a#bar",
+		"settings": bson.M{
+			"kubernetes-service-type": "LoadBalancer"},
+	}, bson.M{
+		"_id": "modelXXX:a#baz",
+		"settings": bson.M{
+			"kubernetes-service-type": "LoadBalancer",
+			"another-setting":         "anothervalue"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSettings := []bson.M{
+		{
+			"_id": "modelXXX:a#bar",
+			"settings": bson.M{
+				"kubernetes-service-type": "loadbalancer"},
+		}, {
+			"_id": "modelXXX:a#baz",
+			"settings": bson.M{
+				"kubernetes-service-type": "loadbalancer",
+				"another-setting":         "anothervalue"},
+		}, {
+			"_id": "modelXXX:a#foo",
+			"settings": bson.M{
+				"kubernetes-service-type": "loadbalancer"},
+		}}
+
+	s.assertUpgradedData(c, TranslateK8sServiceTypes,
+		upgradedData(settingsColl, expectedSettings),
+	)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -86,6 +86,7 @@ type StateBackend interface {
 	ReplaceNeverSetWithUnset() error
 	ResetDefaultRelationLimitInCharmMetadata() error
 	RemoveUnusedLinkLayerDeviceProviderIDs() error
+	TranslateK8sServiceTypes() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -357,4 +358,8 @@ func (s stateBackend) ResetDefaultRelationLimitInCharmMetadata() error {
 
 func (s stateBackend) RemoveUnusedLinkLayerDeviceProviderIDs() error {
 	return state.RemoveUnusedLinkLayerDeviceProviderIDs(s.pool)
+}
+
+func (s stateBackend) TranslateK8sServiceTypes() error {
+	return state.TranslateK8sServiceTypes(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -44,6 +44,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.1"), stateStepsFor281()},
 		upgradeToVersion{version.MustParse("2.8.2"), stateStepsFor282()},
 		upgradeToVersion{version.MustParse("2.8.6"), stateStepsFor286()},
+		upgradeToVersion{version.MustParse("2.8.10"), stateStepsFor2810()},
 	}
 	return steps
 }

--- a/upgrades/steps_2810.go
+++ b/upgrades/steps_2810.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2810 returns database upgrade steps for Juju 2.8.10.
+func stateStepsFor2810() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "translate k8s service types",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().TranslateK8sServiceTypes()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2810_test.go
+++ b/upgrades/steps_2810_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2810 = version.MustParse("2.8.10")
+
+type steps2810Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2810Suite{})
+
+func (s *steps2810Suite) TestTranslateK8sServiceTypes(c *gc.C) {
+	step := findStateStep(c, v2810, "translate k8s service types")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -634,6 +634,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.1",
 		"2.8.2",
 		"2.8.6",
+		"2.8.10",
 	})
 }
 


### PR DESCRIPTION
When a k8s app was deployed with a user specified service type, the translation into the k8s ServiceType value was missing. So the pod was incorrectly set up with the juju value and it failed.
This PR fixes that and also adds validation. It also caters for any already deployed applications that may have worked by accident by specifying the k8s value.
The existing unit tests were testing the implemented behaviour, not the correct behaviour.

## QA steps

bootstrap on microk8s
juju deploy ks8-app --config kubernetes-service-type=cluster
kubectl get all to see the service type of the app is ClusterIP

juju deploy ks8-app --config kubernetes-service-type=xxxx
ERROR service type "xxxx" not valid

## Bug reference

https://bugs.launchpad.net/juju/+bug/1914074
