### PR TITLE
Merge 2.8

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -85,7 +85,7 @@ def deploy_test_workloads(caas_client, k8s_model, caas_provider):
     else:
         k8s_model.deploy(
             charm="cs:~juju/mediawiki-k8s-4",
-            config='kubernetes-service-type=LoadBalancer',
+            config='kubernetes-service-type=loadbalancer',
         )
         svc_type = 'LoadBalancer'
 

--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -5,9 +5,9 @@ package uniter
 
 import (
 	"github.com/juju/errors"
-	k8score "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
@@ -113,8 +113,8 @@ func (n *NetworkInfoCAAS) getRelationNetworkInfo(
 
 	var pollAddr bool
 	svcType := cfg.GetString(k8sprovider.ServiceTypeConfigKey, "")
-	switch k8score.ServiceType(svcType) {
-	case k8score.ServiceTypeLoadBalancer, k8score.ServiceTypeExternalName:
+	switch caas.ServiceType(svcType) {
+	case caas.ServiceLoadBalancer, caas.ServiceExternal:
 		pollAddr = true
 	}
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -609,6 +609,10 @@ func caasPrecheck(
 			return errors.Errorf("block storage %q is not supported for k8s charms", s.Name)
 		}
 	}
+	serviceType := args.Config[k8s.ServiceTypeConfigKey]
+	if _, err := k8s.CaasServiceToK8s(caas.ServiceType(serviceType)); err != nil {
+		return errors.NotValidf("service type %q", serviceType)
+	}
 
 	cfg, err := model.ModelConfig()
 	if err != nil {

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -438,7 +438,7 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string, cfg *podcfg.Boo
 		return spec, nil
 	}
 	if len(cfg.ControllerServiceType) > 0 {
-		if spec.ServiceType, err = caasServiceToK8s(caas.ServiceType(cfg.ControllerServiceType)); err != nil {
+		if spec.ServiceType, err = CaasServiceToK8s(caas.ServiceType(cfg.ControllerServiceType)); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1744,7 +1744,8 @@ func (k *kubernetesClient) deleteVolumeClaims(appName string, p *core.Pod) ([]st
 	return deletedClaimVolumes, nil
 }
 
-func caasServiceToK8s(in caas.ServiceType) (core.ServiceType, error) {
+// CaasServiceToK8s translates a caas service type to a k8s one.
+func CaasServiceToK8s(in caas.ServiceType) (core.ServiceType, error) {
 	serviceType := defaultServiceType
 	if in != "" {
 		switch in {
@@ -1790,11 +1791,11 @@ func (k *kubernetesClient) configureService(
 		})
 	}
 
-	serviceType, err := caasServiceToK8s(params.Deployment.ServiceType)
+	serviceType := caas.ServiceType(config.GetString(ServiceTypeConfigKey, string(params.Deployment.ServiceType)))
+	k8sServiceType, err := CaasServiceToK8s(serviceType)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	serviceType = core.ServiceType(config.GetString(ServiceTypeConfigKey, string(serviceType)))
 	annotations, err := config.GetStringMap(serviceAnnotationsKey, nil)
 	if err != nil {
 		return errors.Annotatef(err, "unexpected annotations: %#v", config.Get(serviceAnnotationsKey, nil))
@@ -1807,7 +1808,7 @@ func (k *kubernetesClient) configureService(
 		},
 		Spec: core.ServiceSpec{
 			Selector:                 utils.SelectorLabelsForApp(appName, k.IsLegacyLabels()),
-			Type:                     serviceType,
+			Type:                     k8sServiceType,
 			Ports:                    ports,
 			ExternalIPs:              config.Get(serviceExternalIPsConfigKey, []string(nil)).([]string),
 			LoadBalancerIP:           config.GetString(serviceLoadBalancerIPKey, ""),

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -664,7 +664,7 @@ var basicServiceArg = &core.Service{
 		Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()}},
 	Spec: core.ServiceSpec{
 		Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-		Type:     "nodeIP",
+		Type:     "LoadBalancer",
 		Ports: []core.ServicePort{
 			{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 			{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2106,7 +2106,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2147,7 +2147,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2226,7 +2226,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2267,7 +2267,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2306,7 +2306,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceStatelessWithScalePolicyInvalid(c *gc.
 		},
 	}
 	err := s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2418,7 +2418,7 @@ password: shhhh`[1:],
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2555,7 +2555,7 @@ password: shhhh`[1:],
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -2667,7 +2667,7 @@ password: shhhh`[1:],
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -2815,7 +2815,7 @@ password: shhhh`[1:],
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3452,7 +3452,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -3550,7 +3550,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3612,7 +3612,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -3723,7 +3723,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 	errChan := make(chan error)
 	go func() {
 		errChan <- s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-			"kubernetes-service-type":            "nodeIP",
+			"kubernetes-service-type":            "loadbalancer",
 			"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 			"kubernetes-service-externalname":    "ext-name",
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3810,7 +3810,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -3908,7 +3908,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -3986,7 +3986,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4097,7 +4097,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	errChan := make(chan error)
 	go func() {
 		errChan <- s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-			"kubernetes-service-type":            "nodeIP",
+			"kubernetes-service-type":            "loadbalancer",
 			"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 			"kubernetes-service-externalname":    "ext-name",
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4196,7 +4196,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4355,7 +4355,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4456,7 +4456,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4625,7 +4625,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -4734,7 +4734,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			}},
 		Spec: core.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "app-name"},
-			Type:     "nodeIP",
+			Type:     "LoadBalancer",
 			Ports: []core.ServicePort{
 				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
 				{Port: 8080, Protocol: "TCP", Name: "fred"},
@@ -4947,7 +4947,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		OperatorImagePath: "operator/image-path",
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
@@ -5044,7 +5044,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5147,7 +5147,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5242,7 +5242,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5390,7 +5390,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5540,7 +5540,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 		}},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5716,7 +5716,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -5899,7 +5899,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6075,7 +6075,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6192,7 +6192,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6314,7 +6314,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6398,7 +6398,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 		},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6473,7 +6473,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		Constraints: constraints.MustParse("mem=64 cpu-power=500"),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6561,7 +6561,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})
@@ -6641,7 +6641,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 		Constraints: constraints.MustParse(`zones=a,b,c`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
-		"kubernetes-service-type":            "nodeIP",
+		"kubernetes-service-type":            "loadbalancer",
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
 		"kubernetes-service-externalname":    "ext-name",
 	})

--- a/state/application.go
+++ b/state/application.go
@@ -2726,7 +2726,7 @@ func (a *Application) ApplicationConfig() (application.ConfigAttributes, error) 
 	} else if err != nil {
 		return nil, errors.Annotatef(err, "application config for application %q", a.doc.Name)
 	}
-	return application.ConfigAttributes(config.Map()), nil
+	return config.Map(), nil
 }
 
 // UpdateApplicationConfig changes an application's config settings.

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4953,6 +4953,48 @@ func (s *upgradesSuite) TestRemoveUnusedLinkLayerDeviceProviderIDs(c *gc.C) {
 	}))
 }
 
+func (s *upgradesSuite) TestTranslateK8sServiceTypes(c *gc.C) {
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = settingsColl.Insert(bson.M{
+		"_id": "modelXXX:a#foo",
+		"settings": bson.M{
+			"kubernetes-service-type": "loadbalancer"},
+	}, bson.M{
+		"_id": "modelXXX:a#bar",
+		"settings": bson.M{
+			"kubernetes-service-type": "LoadBalancer"},
+	}, bson.M{
+		"_id": "modelXXX:a#baz",
+		"settings": bson.M{
+			"kubernetes-service-type": "LoadBalancer",
+			"another-setting":         "anothervalue"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSettings := []bson.M{
+		{
+			"_id": "modelXXX:a#bar",
+			"settings": bson.M{
+				"kubernetes-service-type": "loadbalancer"},
+		}, {
+			"_id": "modelXXX:a#baz",
+			"settings": bson.M{
+				"kubernetes-service-type": "loadbalancer",
+				"another-setting":         "anothervalue"},
+		}, {
+			"_id": "modelXXX:a#foo",
+			"settings": bson.M{
+				"kubernetes-service-type": "loadbalancer"},
+		}}
+
+	s.assertUpgradedData(c, TranslateK8sServiceTypes,
+		upgradedData(settingsColl, expectedSettings),
+	)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -91,6 +91,7 @@ type StateBackend interface {
 	ExposeWildcardEndpointForExposedApplications() error
 	RemoveLinkLayerDevicesRefsCollection() error
 	RemoveUnusedLinkLayerDeviceProviderIDs() error
+	TranslateK8sServiceTypes() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -382,4 +383,8 @@ func (s stateBackend) RemoveLinkLayerDevicesRefsCollection() error {
 
 func (s stateBackend) RemoveUnusedLinkLayerDeviceProviderIDs() error {
 	return state.RemoveUnusedLinkLayerDeviceProviderIDs(s.pool)
+}
+
+func (s stateBackend) TranslateK8sServiceTypes() error {
+	return state.TranslateK8sServiceTypes(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -44,6 +44,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.1"), stateStepsFor281()},
 		upgradeToVersion{version.MustParse("2.8.2"), stateStepsFor282()},
 		upgradeToVersion{version.MustParse("2.8.6"), stateStepsFor286()},
+		upgradeToVersion{version.MustParse("2.8.10"), stateStepsFor2810()},
 		upgradeToVersion{version.MustParse("2.9.0"), stateStepsFor29()},
 	}
 	return steps

--- a/upgrades/steps_2810.go
+++ b/upgrades/steps_2810.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2810 returns database upgrade steps for Juju 2.8.10.
+func stateStepsFor2810() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "translate k8s service types",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().TranslateK8sServiceTypes()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2810_test.go
+++ b/upgrades/steps_2810_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2810 = version.MustParse("2.8.10")
+
+type steps2810Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2810Suite{})
+
+func (s *steps2810Suite) TestTranslateK8sServiceTypes(c *gc.C) {
+	step := findStateStep(c, v2810, "translate k8s service types")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -634,6 +634,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.1",
 		"2.8.2",
 		"2.8.6",
+		"2.8.10",
 		"2.9.0",
 	})
 }


### PR DESCRIPTION
Merge 2.8 with these PRs:

#12644 Fix service type translation for k8s applications
#12642 Use python 3.6 compat fix for handling maas cli output
#12640 Backport python3 acceptancetest changes

```
Conflicts:
#       acceptancetests/substrate.py
#       caas/kubernetes/provider/k8s.go
#       caas/kubernetes/provider/k8s_test.go
#       upgrades/operations.go
#       upgrades/upgrade_test.go
```


## QA steps

See PRs