### PR TITLE
[2.8] Fix acceptance test bug in get_uptime

### DIFF
--- a/acceptancetests/assess_container_networking.py
+++ b/acceptancetests/assess_container_networking.py
@@ -318,7 +318,7 @@ def _assess_container_networking(client, types, hosts, containers):
 
 
 def get_uptime(client, host):
-    uptime_pattern = re.compile(r'.*(\d+)')
+    uptime_pattern = re.compile(r'.*?([\d]+)')
     uptime_output = ssh(client, host, 'uptime -p')
     log.info('uptime -p: {}'.format(uptime_output))
     match = uptime_pattern.match(uptime_output)


### PR DESCRIPTION
The original regex was too greedy and would fail to match the uptime
value thus causing get_uptime to return 0. As a result, the
assess_container_networking test assumed that the controller machine had
not rebooted yet and tried to block until the machine's ssh port became
unavailble (which never did thus causing the test to timeout).

## QA steps

```console
$ cd acceptancetests
$ ./assess_container_networking.py maas `which juju` /tmp/art nw-nethealth --series bionic  --machine-type=lxd --space-constraint=space1; echo "EXIT $?"
```