### PR TITLE
Ensure we normalize the charm url in bundle handler

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -347,7 +347,14 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
 		}
 		if charm.CharmHub.Matches(url.Schema) {
-			url = url.WithSeries("")
+			// Although we've resolved the charm URL, we actually don't want the
+			// whole URL (architecture, series and revision), only the name is
+			// verified that it exists.
+			url = &charm.URL{
+				Schema:   charm.CharmHub.String(),
+				Name:     url.Name,
+				Revision: -1,
+			}
 			origin = origin.WithSeries("")
 		}
 


### PR DESCRIPTION
The resolve charms and endpoints were doing its job by resolving the
charm urls, except that for charmhub we actually only need the name and
the schema from the resolution.

This is done this way so that we can handle potential renames from the
API at the resolving code (redis to memcache behind the scenes).

There is more work to be done here as channels aren't handled correctly,
but that's doable via changes to bundle changes repo.

## QA steps

```sh
series: bionic
applications:
  ubuntu-juju-qa:
    charm: ubuntu-juju-qa
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
  ubuntu-juju-qa2:
    charm: ubuntu-juju-qa
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
```
