### PR TITLE
Adds missing container status of creating.

### DIFF
--- a/caas/kubernetes/provider/pod.go
+++ b/caas/kubernetes/provider/pod.go
@@ -18,6 +18,7 @@ type EventGetter func() ([]core.Event, error)
 
 const (
 	PodReasonCompleted                = "Completed"
+	PodReasonContainerCreating        = "ContainerCreating"
 	PodReasonContainersNotInitialized = "ContainersNotInitialized"
 	PodReasonContainersNotReady       = "ContainersNotReady"
 	PodReasonCrashLoopBackoff         = "CrashLoopBackOff"
@@ -215,6 +216,8 @@ func interrogatePodContainerStatus(containers []core.ContainerStatus) (string, b
 // description and false.
 func isContainerReasonError(reason string) (string, bool) {
 	switch reason {
+	case PodReasonContainerCreating:
+		return "creating pod container(s)", false
 	case PodReasonError:
 		return "container error", true
 	case PodReasonImagePull:

--- a/caas/kubernetes/provider/pod_test.go
+++ b/caas/kubernetes/provider/pod_test.go
@@ -254,6 +254,72 @@ func TestPodConditionListJujuStatus(t *testing.T) {
 			Message: "crash loop backoff: I am broken",
 		},
 		{
+			// We want to  test here the pod container creating message for init
+			// containers. This addresses lp-1914088
+			Name: "pod container status creating init",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotInitialized,
+							Message: "initializing containers",
+						},
+					},
+					InitContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason: PodReasonContainerCreating,
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "initializing containers",
+		},
+		{
+			// We want to  test here the pod container creating message on pod
+			// containers. This addresses lp-1914088
+			Name: "pod container status creating",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "creating containers",
+						},
+					},
+					ContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason: PodReasonContainerCreating,
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "creating containers",
+		},
+		{
 			// We want to test that when the container reason is unknown we
 			// report Juju status of error and propagate the message
 			Name: "pod container unknown reason",


### PR DESCRIPTION
Adds missing container status of creating

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Deploy a workload to kubernetes have Juju status updates constantly stream to a file. This will catch all the states status goes through.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1914088/
