### PR TITLE
Move 2.8.10 upgrade step to 2.8.9

### DIFF
--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -44,7 +44,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.1"), stateStepsFor281()},
 		upgradeToVersion{version.MustParse("2.8.2"), stateStepsFor282()},
 		upgradeToVersion{version.MustParse("2.8.6"), stateStepsFor286()},
-		upgradeToVersion{version.MustParse("2.8.10"), stateStepsFor2810()},
+		upgradeToVersion{version.MustParse("2.8.9"), stateStepsFor289()},
 	}
 	return steps
 }

--- a/upgrades/steps_289.go
+++ b/upgrades/steps_289.go
@@ -3,8 +3,8 @@
 
 package upgrades
 
-// stateStepsFor2810 returns database upgrade steps for Juju 2.8.10.
-func stateStepsFor2810() []Step {
+// stateStepsFor289 returns database upgrade steps for Juju 2.8.9.
+func stateStepsFor289() []Step {
 	return []Step{
 		&upgradeStep{
 			description: "translate k8s service types",

--- a/upgrades/steps_289_test.go
+++ b/upgrades/steps_289_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v2810 = version.MustParse("2.8.10")
+var v289 = version.MustParse("2.8.9")
 
 type steps2810Suite struct {
 	testing.BaseSuite
@@ -21,6 +21,6 @@ type steps2810Suite struct {
 var _ = gc.Suite(&steps2810Suite{})
 
 func (s *steps2810Suite) TestTranslateK8sServiceTypes(c *gc.C) {
-	step := findStateStep(c, v2810, "translate k8s service types")
+	step := findStateStep(c, v289, "translate k8s service types")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -634,7 +634,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.1",
 		"2.8.2",
 		"2.8.6",
-		"2.8.10",
+		"2.8.9",
 	})
 }
 


### PR DESCRIPTION
The 2.8.10 upgrade steps are now going to be run in 2.8.9 instead.

## QA steps

Unit tests