### PR TITLE
Merge 2.8

### DIFF
--- a/caas/kubernetes/provider/pod.go
+++ b/caas/kubernetes/provider/pod.go
@@ -18,6 +18,7 @@ type EventGetter func() ([]core.Event, error)
 
 const (
 	PodReasonCompleted                = "Completed"
+	PodReasonContainerCreating        = "ContainerCreating"
 	PodReasonContainersNotInitialized = "ContainersNotInitialized"
 	PodReasonContainersNotReady       = "ContainersNotReady"
 	PodReasonCrashLoopBackoff         = "CrashLoopBackOff"
@@ -186,6 +187,8 @@ func interrogatePodContainerStatus(containers []core.ContainerStatus) (string, b
 // description and false.
 func isContainerReasonError(reason string) (string, bool) {
 	switch reason {
+	case PodReasonContainerCreating:
+		return "creating pod container(s)", false
 	case PodReasonError:
 		return "container error", true
 	case PodReasonImagePull:

--- a/caas/kubernetes/provider/pod_test.go
+++ b/caas/kubernetes/provider/pod_test.go
@@ -254,6 +254,72 @@ func TestPodConditionListJujuStatus(t *testing.T) {
 			Message: "crash loop backoff: I am broken",
 		},
 		{
+			// We want to  test here the pod container creating message for init
+			// containers. This addresses lp-1914088
+			Name: "pod container status creating init",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.PodInitialized,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotInitialized,
+							Message: "initializing containers",
+						},
+					},
+					InitContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason: PodReasonContainerCreating,
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "initializing containers",
+		},
+		{
+			// We want to  test here the pod container creating message on pod
+			// containers. This addresses lp-1914088
+			Name: "pod container status creating",
+			Pod: core.Pod{
+				Status: core.PodStatus{
+					Conditions: []core.PodCondition{
+						{
+							Type:   core.PodScheduled,
+							Status: core.ConditionTrue,
+						},
+						{
+							Type:    core.ContainersReady,
+							Status:  core.ConditionFalse,
+							Reason:  PodReasonContainersNotReady,
+							Message: "creating containers",
+						},
+					},
+					ContainerStatuses: []core.ContainerStatus{
+						{
+							Name: "test-container",
+							State: core.ContainerState{
+								Waiting: &core.ContainerStateWaiting{
+									Reason: PodReasonContainerCreating,
+								},
+							},
+						},
+					},
+				},
+			},
+			Status:  status.Maintenance,
+			Message: "creating containers",
+		},
+		{
 			// We want to test that when the container reason is unknown we
 			// report Juju status of error and propagate the message
 			Name: "pod container unknown reason",

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -44,7 +44,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.1"), stateStepsFor281()},
 		upgradeToVersion{version.MustParse("2.8.2"), stateStepsFor282()},
 		upgradeToVersion{version.MustParse("2.8.6"), stateStepsFor286()},
-		upgradeToVersion{version.MustParse("2.8.10"), stateStepsFor2810()},
+		upgradeToVersion{version.MustParse("2.8.9"), stateStepsFor289()},
 		upgradeToVersion{version.MustParse("2.9.0"), stateStepsFor29()},
 	}
 	return steps

--- a/upgrades/steps_289.go
+++ b/upgrades/steps_289.go
@@ -3,8 +3,8 @@
 
 package upgrades
 
-// stateStepsFor2810 returns database upgrade steps for Juju 2.8.10.
-func stateStepsFor2810() []Step {
+// stateStepsFor289 returns database upgrade steps for Juju 2.8.9.
+func stateStepsFor289() []Step {
 	return []Step{
 		&upgradeStep{
 			description: "translate k8s service types",

--- a/upgrades/steps_289_test.go
+++ b/upgrades/steps_289_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v2810 = version.MustParse("2.8.10")
+var v289 = version.MustParse("2.8.9")
 
 type steps2810Suite struct {
 	testing.BaseSuite
@@ -21,6 +21,6 @@ type steps2810Suite struct {
 var _ = gc.Suite(&steps2810Suite{})
 
 func (s *steps2810Suite) TestTranslateK8sServiceTypes(c *gc.C) {
-	step := findStateStep(c, v2810, "translate k8s service types")
+	step := findStateStep(c, v289, "translate k8s service types")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -634,7 +634,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.1",
 		"2.8.2",
 		"2.8.6",
-		"2.8.10",
+		"2.8.9",
 		"2.9.0",
 	})
 }


### PR DESCRIPTION
Merge 2.8 with these PRs:

#12653  Adds missing container status of creating.
#12654 Move 2.8.10 upgrade step to 2.8.9

```
# Conflicts:
#       upgrades/operations.go
#       upgrades/upgrade_test.go
#
```
## QA steps

See PRs