### PR TITLE
Run Pebble as root inside container

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -971,6 +971,11 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				Name:  "PEBBLE",
 				Value: "/charm/container/pebble",
 			}},
+			// Run Pebble as root (because it's a service manager).
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      charmVolumeName,

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -362,6 +362,10 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 					Value: "/charm/container/pebble",
 				},
 			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "charm-data",


### PR DESCRIPTION
We need to always run Pebble inside the container as the root user, otherwise if the Dockerfile overrides the user (for example the [snappass Dockerfile](https://github.com/pinterest/snappass/blob/9916076100c3c0e2708b84a217d60e89382a8fcc/Dockerfile) says `USER snappass`), we'll attempt to run Pebble as that non-privileged user, and it fails to connect to the Unix socket file with a permissions error:

> state.go:248: PANIC cannot checkpoint even after 5m0s of retries every 3s: open /charm/container/pebble/.pebble.state.Y7Q4V0qvPC0v~: permission denied

So this changes Pebble to run as root. This is reasonable anyway, as it's a service manager.

I tested this locally using microk8s and it works as expected.

## QA steps

Not very complete, but this is roughly how I got the error locally:

* bootstrap on microk8s
* deploy a container charm using snappass (my charm metadata is below)
  - `juju deploy ../snappass-test/snappass-test.charm snappass --resource snappass-image=benhoyt/snappass-test --resource redis-image=redis`
* see the error via `microk8s.kubectl -n snappass logs snappass-0 -c snappass`

```
name: snappass-test
description: TODO description
summary: TODO summary
min-juju-version: 2.9.0
platforms:
  - kubernetes
systems:
  - os: ubuntu
    channel: 20.04/stable

containers:
  snappass:
    systems:
      - resource: snappass-image
  redis:
    systems:
      - resource: redis-image

resources:
  snappass-image:
    type: oci-image
    description: Docker image for SnapPass
  redis-image:
    type: oci-image
    description: Docker image for Redis
```