### PR TITLE
Charmhub bundle channel

### DIFF
--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -187,6 +187,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -207,6 +208,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
@@ -259,6 +261,7 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			1,
+			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -279,6 +282,7 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
@@ -328,6 +332,7 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -347,6 +352,7 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {
@@ -388,6 +394,7 @@ func (s *bundleSuite) TestGetChangesBundleEndpointBindingsSuccess(c *gc.C) {
 					map[string]string{"url": "public"},
 					map[string]int{},
 					0,
+					"",
 				},
 				Requires: []string{"addCharm-0"},
 			})

--- a/apiserver/facades/client/client/bundles_test.go
+++ b/apiserver/facades/client/client/bundles_test.go
@@ -50,6 +50,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-0"},
 	}, {
@@ -69,6 +70,7 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 			map[string]string{},
 			map[string]int{},
 			0,
+			"",
 		},
 		Requires: []string{"addCharm-2"},
 	}, {

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -83,6 +83,7 @@ func BuildModelRepresentation(
 			Exposed:       appStatus.Exposed,
 			Series:        appStatus.Series,
 			Channel:       appStatus.CharmChannel,
+			Revision:      curl.Revision,
 			SubordinateTo: appStatus.SubordinateTo,
 			Offers:        offersByApplication[name],
 		}

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -624,7 +624,7 @@ negative number of units specified on application "mysql"`,
                 charm: local:wordpress
                 num_units: 1
     `,
-	err: `cannot resolve charm or bundle "wordpress": unknown schema for charm URL "local:wordpress"`,
+	err: `cannot resolve "wordpress": unknown schema for charm URL "local:wordpress"`,
 }}
 
 func (s *BundleDeployCharmStoreSuite) TestDeployBundleErrors(c *gc.C) {

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -48,13 +48,6 @@ import (
 	"github.com/juju/juju/storage"
 )
 
-// localCharmChannel is used to identify a standard channel that all local
-// charms will adhere to. THis isn't actually required, but it makes things a
-// lot simpler when using a selecting algorithm based on channels for charms.
-var localCharmChannel = corecharm.Channel{
-	Risk: corecharm.Risk("stable"),
-}
-
 type bundleDeploySpec struct {
 	ctx        *cmd.Context
 	filesystem modelcmd.Filesystem
@@ -385,8 +378,7 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, ch
 	// attempting to resolve a revision from any charm store. We can ignore the
 	// error here, as we want to just parse out the charm URL.
 	// Resolution and validation of the charm URL happens further down.
-	curl, err := charm.ParseURL(charmURL)
-	if err == nil {
+	if curl, err := charm.ParseURL(charmURL); err == nil {
 		if charm.Local.Matches(curl.Schema) {
 			return charmChannel, -1, nil
 		} else if curl.Revision >= 0 && charmChannel != "" {
@@ -429,8 +421,7 @@ func (h *bundleHandler) constructChannelAndOrigin(curl *charm.URL, charmSeries, 
 	var channel corecharm.Channel
 	if charmChannel != "" {
 		var err error
-		channel, err = corecharm.ParseChannelNormalize(charmChannel)
-		if err != nil {
+		if channel, err = corecharm.ParseChannelNormalize(charmChannel); err != nil {
 			return corecharm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
 		}
 	}
@@ -604,7 +595,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 			// We know we're a local charm and local charms don't require an
 			// explicit tailored origin. Instead we can just use a placeholder
 			// to ensure correctness for later on in addApplication.
-			h.addOrigin(*curl, localCharmChannel, commoncharm.Origin{
+			h.addOrigin(*curl, corecharm.DefaultRiskChannel, commoncharm.Origin{
 				Source: commoncharm.OriginLocal,
 			})
 			return nil

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -48,6 +48,13 @@ import (
 	"github.com/juju/juju/storage"
 )
 
+// localCharmChannel is used to identify a standard channel that all local
+// charms will adhere to. THis isn't actually required, but it makes things a
+// lot simpler when using a selecting algorithm based on channels for charms.
+var localCharmChannel = corecharm.Channel{
+	Risk: corecharm.Risk("stable"),
+}
+
 type bundleDeploySpec struct {
 	ctx        *cmd.Context
 	filesystem modelcmd.Filesystem
@@ -182,7 +189,10 @@ type bundleHandler struct {
 	model *bundlechanges.Model
 
 	macaroons map[charm.URL]*macaroon.Macaroon
-	origins   map[charm.URL]commoncharm.Origin
+
+	// origins holds a different origins based on the charm URL and channels for
+	// each origin.
+	origins map[charm.URL]map[string]commoncharm.Origin
 
 	// watcher holds an environment mega-watcher used to keep the environment
 	// status up to date.
@@ -236,7 +246,7 @@ func makeBundleHandler(bundleData *charm.BundleData, spec bundleDeploySpec) *bun
 		bundleURL:            spec.bundleURL,
 		unitStatus:           make(map[string]string),
 		macaroons:            make(map[charm.URL]*macaroon.Macaroon),
-		origins:              make(map[charm.URL]commoncharm.Origin),
+		origins:              make(map[charm.URL]map[string]commoncharm.Origin),
 
 		targetModelName: spec.targetModelName,
 		targetModelUUID: spec.targetModelUUID,
@@ -370,7 +380,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		// charm origins as well as any potential new ones.
 		// Specifically this happens when a bundle is re-using a charm from
 		// another application, but giving it a new name.
-		h.origins[*url] = origin
+		h.addOrigin(*url, channel, origin)
 	}
 
 	// TODO(thumper): the InferEndpoints code is deeply wedged in the
@@ -378,6 +388,54 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 	// effort, so for now the bundle handling is doing no implicit endpoint
 	// handling.
 	return nil
+}
+
+func (h *bundleHandler) resolveCharmRevision(charmURL, charmSeries, charmChannel, arch string) (int, error) {
+	curl, err := charm.ParseURL(charmURL)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	if curl.Revision >= 0 {
+		return curl.Revision, nil
+	}
+
+	ch, err := resolveAndValidateCharmURL(charmURL)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	var channel corecharm.Channel
+	if charmChannel != "" {
+		channel, err = corecharm.ParseChannelNormalize(charmChannel)
+		if err != nil {
+			return -1, errors.Trace(err)
+		}
+	}
+
+	var cons constraints.Value
+	if arch != "" {
+		cons = constraints.Value{Arch: &arch}
+	}
+
+	platform, err := utils.DeducePlatform(cons, charmSeries, h.modelConstraints)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	origin, err := utils.DeduceOrigin(ch, channel, platform)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+
+	_, origin, _, err = h.bundleResolver.ResolveCharm(ch, origin)
+	if err != nil {
+		return -1, errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
+	}
+	if rev := origin.Revision; rev != nil {
+		fmt.Println("!!", *rev)
+		return *rev, nil
+	}
+	return -1, nil
 }
 
 func (h *bundleHandler) getChanges() error {
@@ -401,7 +459,9 @@ func (h *bundleHandler) getChanges() error {
 		BundleURL:        bundleURL,
 		Model:            h.model,
 		ConstraintGetter: addCharmConstraintsParser,
+		RevisionGetter:   h.resolveCharmRevision,
 		Logger:           logger,
+		Force:            h.force,
 	}
 	logger.Tracef("bundlechanges.ChangesConfig.Bundle %s", pretty.Sprint(cfg.Bundle))
 	logger.Tracef("bundlechanges.ChangesConfig.BundleURL %s", pretty.Sprint(cfg.BundleURL))
@@ -535,9 +595,9 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 			// We know we're a local charm and local charms don't require an
 			// explicit tailored origin. Instead we can just use a placeholder
 			// to ensure correctness for later on in addApplication.
-			h.origins[*curl] = commoncharm.Origin{
+			h.addOrigin(*curl, localCharmChannel, commoncharm.Origin{
 				Source: commoncharm.OriginLocal,
-			}
+			})
 			return nil
 		}
 	}
@@ -596,10 +656,11 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Errorf("unexpected charm URL %q", ch.Name)
 	}
 
-	logger.Debugf("added charm %s", url)
-	h.results[id] = url.String()
+	logger.Debugf("added charm %s for channel %s", url, channel)
+	charmAlias := url.String()
+	h.results[id] = charmAlias
 	h.macaroons[*url] = macaroon
-	h.origins[*url] = charmOrigin
+	h.addOrigin(*url, channel, charmOrigin)
 	return nil
 }
 
@@ -633,22 +694,23 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	}
 
 	p := change.Params
-	cURL, err := resolveCharmURL(resolve(p.Charm, h.results))
+	curl, err := resolveCharmURL(resolve(p.Charm, h.results))
 	if err != nil {
 		return errors.Trace(err)
-	} else if cURL == nil {
+	} else if curl == nil {
 		return errors.Errorf("unexpected application charm URL %q", p.Charm)
 	}
 
-	origin, ok := h.origins[*cURL]
-	if !ok {
+	channel, err := constructNormalizedChannel(p.Channel)
+	if err != nil {
 		// This should never happen, essentially we have a charm url that has
 		// never been deployed previously, or has never been added with
 		// setCharm.
-		// TODO (stickupkid): We could in theory deduce the origin, but that
-		// will be ok for charmstore and local, but will be horribly wrong
-		// for charmhub.
-		return errors.Annotatef(err, "unexpected charm %q, charm not found for application %q", cURL.Name, p.Application)
+		return errors.Trace(err)
+	}
+	origin, ok := h.getOrigin(*curl, channel)
+	if !ok {
+		return errors.Errorf("unexpected charm %q, charm not found for application %q", curl.Name, p.Application)
 	}
 
 	// Handle application constraints.
@@ -658,17 +720,17 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		return errors.Annotate(err, "invalid constraints for application")
 	}
 
-	if charm.CharmHub.Matches(cURL.Schema) {
+	if charm.CharmHub.Matches(curl.Schema) {
 		if cons.HasArch() && *cons.Arch != origin.Architecture {
 			return errors.Errorf("unexpected %s application architecture (%s), charm already exists with architecture (%s)", p.Application, *cons.Arch, origin.Architecture)
 		}
 	}
 
 	chID := application.CharmID{
-		URL:    cURL,
+		URL:    curl,
 		Origin: origin,
 	}
-	macaroon := h.macaroons[*cURL]
+	macaroon := h.macaroons[*curl]
 
 	h.results[change.Id()] = p.Application
 	ch := chID.URL.String()
@@ -778,7 +840,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		fromBundle:          true,
 	}
 	series, err := selector.charmSeries()
-	if err = charmValidationError(series, cURL.Name, errors.Trace(err)); err != nil {
+	if err = charmValidationError(series, curl.Name, errors.Trace(err)); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1047,20 +1109,34 @@ func (h *bundleHandler) upgradeCharm(change *bundlechanges.UpgradeCharmChange) e
 	}
 
 	p := change.Params
-	cURL, err := resolveAndValidateCharmURL(resolve(p.Charm, h.results))
+	resolvedCharm := resolve(p.Charm, h.results)
+	curl, err := resolveCharmURL(resolvedCharm)
 	if err != nil {
 		return errors.Trace(err)
-	} else if cURL == nil {
+	}
+	if curl == nil {
 		return errors.Errorf("unexpected upgrade charm URL %q", p.Charm)
 	}
 
-	chID := application.CharmID{
-		URL:    cURL,
-		Origin: h.origins[*cURL],
+	channel, err := constructNormalizedChannel(p.Channel)
+	if err != nil {
+		// This should never happen, essentially we have a charm url that has
+		// never been deployed previously, or has never been added with
+		// setCharm.
+		return errors.Trace(err)
 	}
-	macaroon := h.macaroons[*cURL]
+	origin, ok := h.getOrigin(*curl, channel)
+	if !ok {
+		return errors.Errorf("unexpected charm %q, charm not found for application %q", curl.Name, p.Application)
+	}
 
-	meta, err := utils.GetMetaResources(cURL, h.deployAPI)
+	chID := application.CharmID{
+		URL:    curl,
+		Origin: origin,
+	}
+	macaroon := h.macaroons[*curl]
+
+	meta, err := utils.GetMetaResources(curl, h.deployAPI)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1409,6 +1485,33 @@ func (h *bundleHandler) topLevelMachine(id string) string {
 	}
 	tag := names.NewMachineTag(id)
 	return tag.Parent().Id()
+}
+
+func (h *bundleHandler) addOrigin(curl charm.URL, channel corecharm.Channel, origin commoncharm.Origin) {
+	if _, ok := h.origins[curl]; !ok {
+		h.origins[curl] = make(map[string]commoncharm.Origin)
+	}
+	h.origins[curl][channel.Normalize().String()] = origin
+}
+
+func (h *bundleHandler) getOrigin(curl charm.URL, channel corecharm.Channel) (commoncharm.Origin, bool) {
+	c, ok := h.origins[curl]
+	if !ok {
+		return commoncharm.Origin{}, false
+	}
+	o, ok := c[channel.Normalize().String()]
+	return o, ok
+}
+
+func constructNormalizedChannel(channel string) (corecharm.Channel, error) {
+	if channel == "" {
+		return corecharm.Channel{}, errors.NotValidf("empty channel")
+	}
+	ch, err := corecharm.ParseChannelNormalize(channel)
+	if err != nil {
+		return corecharm.Channel{}, errors.Trace(err)
+	}
+	return ch, nil
 }
 
 // resolveRelation returns the relation name resolving the included application

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -1173,4 +1174,158 @@ func (s *BundleHandlerOriginSuite) TestGetOriginNotFound(c *gc.C) {
 	handler.addOrigin(*curl, channelB, origin)
 	_, found = handler.getOrigin(*curl, channel)
 	c.Assert(found, jc.IsFalse)
+}
+
+func (s *BundleHandlerOriginSuite) TestConstructChannelAndOrigin(c *gc.C) {
+	handler := &bundleHandler{}
+
+	arch := "arm64"
+	curl := charm.MustParseURL("ch:mysql")
+	series := "focal"
+	channel := "stable"
+	cons := constraints.Value{
+		Arch: &arch,
+	}
+
+	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(curl, series, channel, cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resultChannel, gc.DeepEquals, corecharm.MustParseChannel("stable"))
+	c.Assert(resultOrigin, gc.DeepEquals, commoncharm.Origin{
+		Source:       "charm-hub",
+		OS:           "ubuntu",
+		Series:       "focal",
+		Risk:         "stable",
+		Architecture: "arm64",
+	})
+}
+
+func (s *BundleHandlerOriginSuite) TestConstructChannelAndOriginUsingArchFallback(c *gc.C) {
+	handler := &bundleHandler{}
+
+	curl := charm.MustParseURL("ch:mysql")
+	series := "focal"
+	channel := "stable"
+	cons := constraints.Value{}
+
+	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(curl, series, channel, cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resultChannel, gc.DeepEquals, corecharm.MustParseChannel("stable"))
+	c.Assert(resultOrigin, gc.DeepEquals, commoncharm.Origin{
+		Source:       "charm-hub",
+		OS:           "ubuntu",
+		Series:       "focal",
+		Risk:         "stable",
+		Architecture: "amd64",
+	})
+}
+
+func (s *BundleHandlerOriginSuite) TestConstructChannelAndOriginEmptyChannel(c *gc.C) {
+	handler := &bundleHandler{}
+
+	arch := "arm64"
+	curl := charm.MustParseURL("ch:mysql")
+	series := "focal"
+	channel := ""
+	cons := constraints.Value{
+		Arch: &arch,
+	}
+
+	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(curl, series, channel, cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resultChannel, gc.DeepEquals, corecharm.Channel{})
+	c.Assert(resultOrigin, gc.DeepEquals, commoncharm.Origin{
+		Source:       "charm-hub",
+		OS:           "ubuntu",
+		Series:       "focal",
+		Architecture: "arm64",
+	})
+}
+
+type BundleHandlerResolverSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&BundleHandlerResolverSuite{})
+
+func (s *BundleHandlerResolverSuite) TestResolveCharmChannelAndRevision(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	resolver := mocks.NewMockResolver(ctrl)
+
+	handler := &bundleHandler{
+		bundleResolver: resolver,
+	}
+
+	charmURL := charm.MustParseURL("ch:ubuntu")
+	charmSeries := "focal"
+	charmChannel := "stable"
+	arch := "amd64"
+	rev := 33
+
+	origin := commoncharm.Origin{
+		Source:       "charm-hub",
+		Architecture: arch,
+		Risk:         charmChannel,
+		OS:           "ubuntu",
+		Series:       charmSeries,
+	}
+	resolvedOrigin := origin
+	resolvedOrigin.Revision = &rev
+
+	resolver.EXPECT().ResolveCharm(charmURL, origin).Return(charmURL, resolvedOrigin, nil, nil)
+
+	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(channel, gc.DeepEquals, "stable")
+	c.Assert(rev, gc.Equals, rev)
+}
+
+func (s *BundleHandlerResolverSuite) TestResolveCharmChannelWithoutRevision(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	resolver := mocks.NewMockResolver(ctrl)
+
+	handler := &bundleHandler{
+		bundleResolver: resolver,
+	}
+
+	charmURL := charm.MustParseURL("ch:ubuntu")
+	charmSeries := "focal"
+	charmChannel := "stable"
+	arch := "amd64"
+
+	origin := commoncharm.Origin{
+		Source:       "charm-hub",
+		Architecture: arch,
+		Risk:         charmChannel,
+		OS:           "ubuntu",
+		Series:       charmSeries,
+	}
+	resolvedOrigin := origin
+
+	resolver.EXPECT().ResolveCharm(charmURL, origin).Return(charmURL, resolvedOrigin, nil, nil)
+
+	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(channel, gc.DeepEquals, "stable")
+	c.Assert(rev, gc.Equals, -1)
+}
+
+func (s *BundleHandlerResolverSuite) TestResolveLocalCharm(c *gc.C) {
+	handler := &bundleHandler{}
+
+	charmURL := charm.URL{
+		Schema: string(charm.Local),
+		Name:   "local",
+	}
+	charmSeries := "focal"
+	charmChannel := "stable"
+	arch := "amd64"
+
+	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(channel, gc.DeepEquals, "stable")
+	c.Assert(rev, gc.Equals, -1)
 }

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -20,7 +20,11 @@ var (
 	// DefaultChannel represents the default track and risk.
 	DefaultChannel = Channel{
 		Track: "latest",
-		Risk:  Risk("stable"),
+		Risk:  Stable,
+	}
+	// DefaultRiskChannel represents the default only risk channel.
+	DefaultRiskChannel = Channel{
+		Risk: Stable,
 	}
 )
 

--- a/go.mod
+++ b/go.mod
@@ -166,4 +166,3 @@ replace (
 )
 
 replace github.com/canonical/pebble v0.0.0 => github.com/hpidcock/pebble v0.0.0-20210216034042-e91a98784399
-

--- a/go.mod
+++ b/go.mod
@@ -167,4 +167,3 @@ replace (
 
 replace github.com/canonical/pebble v0.0.0 => github.com/hpidcock/pebble v0.0.0-20210216034042-e91a98784399
 
-replace github.com/juju/bundlechanges/v4 => /home/simon/go/src/github.com/juju/bundlechanges

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v4 v4.0.0-20210218105210-47b5b054f5f1
+	github.com/juju/bundlechanges/v4 v4.0.0-20210222102016-889cd226f514
 	github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
@@ -105,11 +105,11 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20210218085108-9555bcde0c6a
+	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/tools v0.0.0-20200725200936-102e7d357031
 	google.golang.org/api v0.29.0

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/juju/bundlechanges/v4 v4.0.0-20210222102016-889cd226f514
+	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
 	github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e
 	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
@@ -106,10 +106,10 @@ require (
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
-	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d
+	golang.org/x/net v0.0.0-20210222171744-9060382bd457
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43
+	golang.org/x/sys v0.0.0-20210223095934-7937bea0104d
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/tools v0.0.0-20200725200936-102e7d357031
 	google.golang.org/api v0.29.0
@@ -166,3 +166,5 @@ replace (
 )
 
 replace github.com/canonical/pebble v0.0.0 => github.com/hpidcock/pebble v0.0.0-20210216034042-e91a98784399
+
+replace github.com/juju/bundlechanges/v4 => /home/simon/go/src/github.com/juju/bundlechanges

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v4 v4.0.0-20210222102016-889cd226f514 h1:ArOenNsgzF5pWlMg9wKUR34nqYWtP8596LZrNaSQySc=
-github.com/juju/bundlechanges/v4 v4.0.0-20210222102016-889cd226f514/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
@@ -832,8 +830,8 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d h1:1aflnvSoWWLI2k/dMUAl5lvU1YO4Mb4hz0gh+1rjcxU=
-golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210222171744-9060382bd457 h1:hMm9lBjyNLe/c9C6bElQxp4wsrleaJn1vXMZIQkNN44=
+golang.org/x/net v0.0.0-20210222171744-9060382bd457/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -890,8 +888,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 h1:SgQ6LNaYJU0JIuEHv9+s6EbhSCwYeAf5Yvj6lpYlqAE=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210223095934-7937bea0104d h1:u0GOGnBJ3EKE/tNqREhhGiCzE9jFXydDo2lf7hOwGuc=
+golang.org/x/sys v0.0.0-20210223095934-7937bea0104d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
+github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c h1:j/fq5b7yRcBuhWt6ltScogsh/4+xFOy/R5U+J83NvQ4=
+github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/bundlechanges/v4 v4.0.0-20210218105210-47b5b054f5f1 h1:W+4DvU9kqYbImZPk0tIiG9SQYrztQJ/EwY6LYM0C9F0=
-github.com/juju/bundlechanges/v4 v4.0.0-20210218105210-47b5b054f5f1/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
+github.com/juju/bundlechanges/v4 v4.0.0-20210222102016-889cd226f514 h1:ArOenNsgzF5pWlMg9wKUR34nqYWtP8596LZrNaSQySc=
+github.com/juju/bundlechanges/v4 v4.0.0-20210222102016-889cd226f514/go.mod h1:J4ERN6z0gqR0VXtVlZD+DVJoh1aUd4XbL/F/AJFBZbM=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI+e5qUP4jS1FPCRPdyTxqCqhJQg=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
@@ -762,6 +762,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -830,6 +832,8 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d h1:1aflnvSoWWLI2k/dMUAl5lvU1YO4Mb4hz0gh+1rjcxU=
+golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -886,8 +890,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210218085108-9555bcde0c6a h1:+Kiu2GijIw0WaCBk1i7AcqqRx8Xg3HIYaheQazXOu8w=
-golang.org/x/sys v0.0.0-20210218085108-9555bcde0c6a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 h1:SgQ6LNaYJU0JIuEHv9+s6EbhSCwYeAf5Yvj6lpYlqAE=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
When re-deploying a bundle again, against the same applications,
essentially performing an upgrade we should also take into account the
channel.

Previously channel was only viewed when deploying the first time around. 
The following also takes this into account when re-deploying. It will warn
you to use force in certain situations to ensure that you're doing
something that isn't exactly supported (swapping channels etc).

Most of the code here isn't actually complicated, it wired in the new
library updates from bundlechanges. The code essentially does another
request to the store when it notices an update to ensure that we know
what revision we can move to. All this code is super accessible and
because of the reusability of resolve charm it makes it nice and easy to
call when performing a bundle upgrade.

----

There are some potential optimisations that we could consider, but
for the first pass, I believe we can ignore it for now.

 1. Deploying the same bundle shouldn't upload a charm if we already have it. Unfortunately, this occurs because of the two-step nature of adding charms in bundle changes, where we don't have enough information at the time. This can be optimized later if required.
 2. Requesting the same charm for multiple applications could be cached per bundle resolving. Again, I'm unsure how much this would be required, but we can optimize if it becomes a problem.

## QA steps

The test needs to test quite a few scenarios:

```sh
$ juju bootstrap lxd test --no-gui
```

#### Charmstore Test

```yaml
series: bionic
applications:
  ubuntu-juju-qa:
    charm: cs:ubuntu
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
```

```sh
$ juju add-model cs-test-1
$ juju deploy ./bundle.bundle
$ juju status
Model      Controller  Cloud/Region  Version    SLA          Timestamp
cs-test-1  test        lxd/default   2.9-rc6.1  unsupported  12:24:17Z

App             Version  Status  Scale  Charm   Store       Channel  Rev  OS      Message
ubuntu-juju-qa  18.04    active      1  ubuntu  charmstore  stable    17  ubuntu  ready

Unit               Workload  Agent  Machine  Public address  Ports  Message
ubuntu-juju-qa/0*  active    idle   0        10.132.183.2           ready

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.132.183.2  juju-d689fd-0  bionic      Running
```

With a channel that is the same as the default "" channel.

```yaml
series: bionic
applications:
  ubuntu-juju-qa:
    charm: cs:ubuntu
    channel: stable
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
```

```sh
$ juju deploy ./bundle.bundle
$ juju status
Model      Controller  Cloud/Region  Version    SLA          Timestamp
cs-test-1  test        lxd/default   2.9-rc6.1  unsupported  12:24:17Z

App             Version  Status  Scale  Charm   Store       Channel  Rev  OS      Message
ubuntu-juju-qa  18.04    active      1  ubuntu  charmstore  stable    17  ubuntu  ready

Unit               Workload  Agent  Machine  Public address  Ports  Message
ubuntu-juju-qa/0*  active    idle   0        10.132.183.2           ready

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.132.183.2  juju-d689fd-0  bionic      Running
```

```yaml
series: bionic
applications:
  ubuntu-juju-qa:
    charm: cs:ubuntu
    channel: edge
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
```

Stable and edge channels point to the same revision, so no update is performed.

```sh
$ juju deploy ./bundle.bundle
ERROR cannot deploy bundle: upgrades not supported across channels (existing: "stable", requested: "edge"); use --force to override
$ juju deploy ./bundle.bundle --force
Located charm "ubuntu" in charm-store
Executing changes:
- upload charm ubuntu from charm-store for series bionic from channel edge with architecture=amd64
Deploy of bundle completed.
$ juju status
Model      Controller  Cloud/Region  Version    SLA          Timestamp
cs-test-1  test        lxd/default   2.9-rc6.1  unsupported  12:24:17Z

App             Version  Status  Scale  Charm   Store       Channel  Rev  OS      Message
ubuntu-juju-qa  18.04    active      1  ubuntu  charmstore  stable    17  ubuntu  ready

Unit               Workload  Agent  Machine  Public address  Ports  Message
ubuntu-juju-qa/0*  active    idle   0        10.132.183.2           ready

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.132.183.2  juju-d689fd-0  bionic      Running
```

#### Charmhub Test

```yaml
series: bionic
applications:
  ubuntu-juju-qa:
    charm: ubuntu-juju-qa
    channel: stable
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
  ubuntu-juju-qa2:
    charm: ubuntu-juju-qa
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
```

```sh
$ juju add-model one  --config charmhub-url="https://api.staging.snapcraft.io"

$ juju deploy ./bundle.bundle
Located charm "ubuntu-juju-qa" in charm-hub
Located charm "ubuntu-juju-qa" in charm-hub
Executing changes:
- upload charm ubuntu-juju-qa from charm-hub for series bionic from channel stable with architecture=amd64
- deploy application ubuntu-juju-qa from charm-hub on bionic with stable
- upload charm ubuntu-juju-qa from charm-hub for series bionic with architecture=amd64
- deploy application ubuntu-juju-qa2 from charm-hub on bionic using ubuntu-juju-qa
- add new machine 0
- add new machine 1
- add unit ubuntu-juju-qa/0 to new machine 0
- add unit ubuntu-juju-qa2/0 to new machine 1
Deploy of bundle completed.

$ juju status
Model  Controller  Cloud/Region  Version    SLA          Timestamp
one    test        lxd/default   2.9-rc6.1  unsupported  12:14:28Z

App              Version  Status   Scale  Charm           Store     Channel  Rev  OS      Message
ubuntu-juju-qa            waiting    0/1  ubuntu-juju-qa  charmhub  stable    14  ubuntu  waiting for machine
ubuntu-juju-qa2           waiting    0/1  ubuntu-juju-qa  charmhub  stable    14  ubuntu  waiting for machine

Unit               Workload  Agent       Machine  Public address  Ports  Message
ubuntu-juju-qa2/0  waiting   allocating  1        10.132.183.195         waiting for machine
ubuntu-juju-qa/0   waiting   allocating  0        10.132.183.124         waiting for machine

Machine  State    DNS             Inst id        Series  AZ  Message
0        pending  10.132.183.124  juju-e2ceb5-0  bionic      Running
1        pending  10.132.183.195  juju-e2ceb5-1  bionic      Running
```

Edit the bundle to the following:

```yaml
series: bionic
applications:
  ubuntu-juju-qa:
    charm: ubuntu-juju-qa
    channel: edge
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
  ubuntu-juju-qa2:
    charm: ubuntu-juju-qa
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
```

```sh
$ juju deploy ./bundle.bundle
ERROR cannot deploy bundle: upgrades not supported across channels (existing: "stable", requested: "edge"); use --force to override
$ juju deploy ./bundle.bundle --force
Executing changes:
- upload charm ubuntu-juju-qa from charm-hub for series bionic from channel edge with architecture=amd64
- upgrade ubuntu-juju-qa from charm-hub using charm ubuntu-juju-qa for series bionic from channel edge
- upload charm ubuntu-juju-qa from charm-hub for series bionic with architecture=amd64
Deploy of bundle completed.
$ juju status
Model  Controller  Cloud/Region  Version    SLA          Timestamp
one    test        lxd/default   2.9-rc6.1  unsupported  12:16:25Z

App              Version  Status  Scale  Charm           Store     Channel  Rev  OS      Message
ubuntu-juju-qa            active      1  ubuntu-juju-qa  charmhub  edge      17  ubuntu  hello
ubuntu-juju-qa2           active      1  ubuntu-juju-qa  charmhub  stable    14  ubuntu  hello

Unit                Workload  Agent  Machine  Public address  Ports  Message
ubuntu-juju-qa2/0*  active    idle   1        10.132.183.195         hello
ubuntu-juju-qa/0*   active    idle   0        10.132.183.124         hello

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.132.183.124  juju-e2ceb5-0  bionic      Running
1        started  10.132.183.195  juju-e2ceb5-1  bionic      Running
```

Again to a different track:

```yaml
series: bionic
applications:
  ubuntu-juju-qa:
    charm: ubuntu-juju-qa
    channel: 2.0/edge
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
  ubuntu-juju-qa2:
    charm: ubuntu-juju-qa
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
```

```sh
$ juju deploy ./bundle.bundle
ERROR cannot deploy bundle: upgrades not supported across channels (existing: "edge", requested: "2.0/edge"); use --force to override
$ juju deploy ./bundle.bundle --force
Executing changes:
- upload charm ubuntu-juju-qa from charm-hub for series bionic from channel 2.0/edge with architecture=amd64
- upgrade ubuntu-juju-qa from charm-hub using charm ubuntu-juju-qa for series bionic from channel 2.0/edge
  added resource foo-file
- upload charm ubuntu-juju-qa from charm-hub for series bionic with architecture=amd64
Deploy of bundle completed.
$ juju status
Model  Controller  Cloud/Region  Version    SLA          Timestamp
one    test        lxd/default   2.9-rc6.1  unsupported  12:17:53Z

App              Version  Status  Scale  Charm           Store     Channel   Rev  OS      Message
ubuntu-juju-qa            active      1  ubuntu-juju-qa  charmhub  2.0/edge   19  ubuntu  hello
ubuntu-juju-qa2           active      1  ubuntu-juju-qa  charmhub  stable     14  ubuntu  hello

Unit                Workload  Agent  Machine  Public address  Ports  Message
ubuntu-juju-qa2/0*  active    idle   1        10.132.183.195         hello
ubuntu-juju-qa/0*   active    idle   0        10.132.183.124         hello

Machine  State    DNS             Inst id        Series  AZ  Message
0        started  10.132.183.124  juju-e2ceb5-0  bionic      Running
1        started  10.132.183.195  juju-e2ceb5-1  bionic      Running
```

Deploying the same thing again does not upgrade the charm.

```sh
$ juju deploy ./bundle.bundle
Executing changes:
- upload charm ubuntu-juju-qa from charm-hub for series bionic from channel 2.0/edge with architecture=amd64
- upload charm ubuntu-juju-qa from charm-hub for series bionic from channel stable with architecture=amd64
Deploy of bundle completed.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913631
