### PR TITLE
Add IsSecondary to IP Addresses document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v2 v2.0.0-20201013195630-fc4923d04798
+	github.com/juju/description/v2 v2.0.0-20201105134144-1b084b429eda
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQ
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
 github.com/juju/description/v2 v2.0.0-20201013195630-fc4923d04798 h1:XKm/k/o7qdofp1zZZkGW1Q0Pevow77gAjH8AnqYZLNI=
 github.com/juju/description/v2 v2.0.0-20201013195630-fc4923d04798/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
+github.com/juju/description/v2 v2.0.0-20201105134144-1b084b429eda h1:UknAzfcbVmgMxx3zDGInoiffYzB5G2f1H3Tysi24PWI=
+github.com/juju/description/v2 v2.0.0-20201105134144-1b084b429eda/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f h1:MCOvExGLpaSIzLYB4iQXEHP4jYVU6vmzLNQPdMVrxnM=

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,6 @@ github.com/juju/collections v0.0.0-20180516022642-90152009b5f3/go.mod h1:Ep+c0vn
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v2 v2.0.0-20201013195630-fc4923d04798 h1:XKm/k/o7qdofp1zZZkGW1Q0Pevow77gAjH8AnqYZLNI=
-github.com/juju/description/v2 v2.0.0-20201013195630-fc4923d04798/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/description/v2 v2.0.0-20201105134144-1b084b429eda h1:UknAzfcbVmgMxx3zDGInoiffYzB5G2f1H3Tysi24PWI=
 github.com/juju/description/v2 v2.0.0-20201105134144-1b084b429eda/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -113,6 +113,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 		DNSSearchDomains: []string{"example.com", "example.org"},
 		GatewayAddress:   "10.20.30.1",
 		IsShadow:         true,
+		IsSecondary:      true,
 	}
 	result := s.newIPAddressWithDummyState(doc)
 
@@ -126,4 +127,5 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 	c.Check(result.GatewayAddress(), gc.Equals, "10.20.30.1")
 	c.Check(result.NetworkAddress(), jc.DeepEquals, network.NewSpaceAddress(result.Value()))
 	c.Check(result.IsShadow(), jc.IsTrue)
+	c.Check(result.IsSecondary(), jc.IsTrue)
 }

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -82,6 +82,13 @@ type ipAddressDoc struct {
 	// address assigned to a NIC by a provider rather than being associated
 	// directly with a device on-machine.
 	IsShadow bool `bson:"is-shadow,omitempty"`
+
+	// IsSecondary if true, indicates that this address is not the primary
+	// address associated with the NIC.
+	// Such addresses can be added by clustering solutions like Pacemaker.
+	// We need to prevent these addresses being supplied with higher
+	// priority than primary addresses in returns to network-get calls.
+	IsSecondary bool `bson:"is-secondary,omitempty"`
 }
 
 // Address represents the state of an IP address assigned to a link-layer
@@ -212,6 +219,12 @@ func (addr *Address) Origin() network.Origin {
 // subnet.
 func (addr *Address) IsShadow() bool {
 	return addr.doc.IsShadow
+}
+
+// IsSecondary if true, indicates that this address is not the primary
+// address associated with the NIC.
+func (addr *Address) IsSecondary() bool {
+	return addr.doc.IsSecondary
 }
 
 // String returns a human-readable representation of the IP address.

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2034,6 +2034,7 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 		ProviderSubnetID:  addr.ProviderSubnetID(),
 		Origin:            network.Origin(addr.Origin()),
 		IsShadow:          addr.IsShadow(),
+		IsSecondary:       addr.IsSecondary(),
 	}
 
 	ops := []txn.Op{{

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -692,6 +692,7 @@ func (s *MigrationSuite) TestIPAddressDocFields(c *gc.C) {
 		"Value",
 		"Origin",
 		"IsShadow",
+		"IsSecondary",
 	)
 	s.AssertExportedFields(c, ipAddressDoc{}, migrated.Union(ignored))
 }


### PR DESCRIPTION
This patch adds a new boolean, `IsSecondary` to the `ipAddressDoc` in state. Included are changes to handle the field in migrations.

Future patches will (1) populate this field when detecting local link-layer devices and (2) use it to ensure that primary addresses are sorted first in calls to `network-get`.

## QA steps

Changes are mechanical at this point. QA for the ultimate feature will accompany future patches.

Unit tests cover changes-to-date.

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1863916
