### PR TITLE
Lp1910989

### DIFF
--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -55,8 +55,21 @@ EOF
   kubectl --kubeconfig "${KUBE_CONFIG}" config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
 
 
-  # Short sleep to let juju controller watchers catch up.
-  sleep 15
+  # Wait for the model operator to be ready
+  echo "waiting for modeloperator to become available"
+  while :
+  do
+    # shellcheck disable=SC2046
+    if [ $(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get deploy -n "${namespace}" "modeloperator" -o=jsonpath='{.status.readyReplicas}' || echo "0") -eq 1 ]
+    then
+      break
+    fi
+    sleep 1
+  done
+
+  # We still sleep quickly here to let everything settle down. By adding
+  # propper probes we could avoid this.
+  sleep 5
 
  kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json apply -f - <<EOF
 apiVersion: v1
@@ -121,8 +134,21 @@ EOF
 
   kubectl --kubeconfig "${TEST_DIR}"/kube.conf config view --raw -o json | jq "del(.users[0]) | .contexts[0].context.user = \"test\" | .users[0] = {\"name\": \"test\", \"user\": {\"token\": \"$bearer_token\"}}" > "${TEST_DIR}"/kube-sa.json
 
-  # Short sleep to let juju controller watchers catch up.
-  sleep 15
+  # Wait for the model operator to be ready
+  echo "waiting for modeloperator to become available"
+  while :
+  do
+    # shellcheck disable=SC2046
+    if [ $(kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json get deploy -n "${namespace}" "modeloperator" -o=jsonpath='{.status.readyReplicas}' || echo "0") -eq 1 ]
+    then
+      break
+    fi
+    sleep 1
+  done
+
+  # We still sleep quickly here to let everything settle down. By adding
+  # propper probes we could avoid this.
+  sleep 5
 
  kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json apply -f - <<EOF
 apiVersion: v1

--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -11,7 +11,7 @@ test_caasadmission() {
 
     run_deploy_microk8s "$(petname)"
 
-    #test_controller_model_admission
-    #test_new_model_admission
+    test_controller_model_admission
+    test_new_model_admission
     test_model_chicken_and_egg
 }

--- a/worker/caasadmission/filter.go
+++ b/worker/caasadmission/filter.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasadmission
+
+import (
+	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// admissionObjectIgnores defines a slice of GVK's that should be ignored by
+// the caasadmission controller.
+var admissionObjectIgnores = []apis.GroupVersionKind{
+	// ignoring SelfSubjectAccessReview checks because of bug lp-1910989
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "SelfSubjectAccessReview",
+		Version: "v1",
+	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "SelfSubjectRulesReview",
+		Version: "v1",
+	},
+}
+
+// compareAPIGroupVersionKind compares two api GroupVersionKind objects for
+// eqauoity.
+func compareAPIGroupVersionKind(a apis.GroupVersionKind, b apis.GroupVersionKind) bool {
+	return a.Group == b.Group && a.Kind == b.Kind && a.Version == b.Version
+}

--- a/worker/caasadmission/handler_test.go
+++ b/worker/caasadmission/handler_test.go
@@ -33,7 +33,7 @@ type HandlerSuite struct {
 
 var _ = gc.Suite(&HandlerSuite{})
 
-func (h *HandlerSuite) SetupTest(c *gc.C) {
+func (h *HandlerSuite) SetUpTest(c *gc.C) {
 	h.logger = loggo.Logger{}
 }
 
@@ -326,4 +326,47 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 		}
 		c.Assert(found, jc.IsTrue)
 	}
+}
+
+func (h *HandlerSuite) TestSelfSubjectAccessReviewIgnore(c *gc.C) {
+	inReview := &admission.AdmissionReview{
+		Request: &admission.AdmissionRequest{
+			Kind: meta.GroupVersionKind{
+				Group:   "authorization.k8s.io",
+				Kind:    "SelfSubjectAccessReview",
+				Version: "v1",
+			},
+			UID: types.UID("test"),
+			UserInfo: authentication.UserInfo{
+				UID: "juju-tst-sa",
+			},
+		},
+	}
+
+	body, err := json.Marshal(inReview)
+	c.Assert(err, jc.ErrorIsNil)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set(HeaderContentType, ExpectedContentType)
+	recorder := httptest.NewRecorder()
+
+	appName := "test-app"
+	rbacMapper := rbacmappertest.Mapper{
+		AppNameForServiceAccountFunc: func(_ types.UID) (string, error) {
+			return appName, nil
+		},
+	}
+
+	admissionHandler(h.logger, &rbacMapper).ServeHTTP(recorder, req)
+	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
+	c.Assert(recorder.Body, gc.NotNil)
+
+	outReview := admission.AdmissionReview{}
+	err = json.Unmarshal(recorder.Body.Bytes(), &outReview)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(outReview.Response.Allowed, jc.IsTrue)
+	c.Assert(outReview.Response.UID, gc.Equals, inReview.Request.UID)
+
+	c.Assert(len(outReview.Response.Patch), gc.Equals, 0)
 }


### PR DESCRIPTION
Fixes a bug where Juju is adding unwanted labels to certain deployments that is making the deployment fail. Specifically around SelfSubjectAccessReview checks.

This change disables the model admission on such Kubernetes resources.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Follow steps outlined in original bug below.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1910989
