### PR TITLE
Fix intermittent TestEntityWatcherFirstEvent failure

### DIFF
--- a/state/backend.go
+++ b/state/backend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/state/watcher"
 )
 


### PR DESCRIPTION
Fix an intermittent failure in the TestEntityWatcherFirstEvent test.
As seen in CI runs.
Sometimes the machine creation event was being received separately to the initial watcher event which caused the test to fail.

## QA steps

Unit test.

