### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/api/highavailability/client_test.go
+++ b/api/highavailability/client_test.go
@@ -36,9 +36,9 @@ func assertEnableHA(c *gc.C, s *jujutesting.JujuConnSuite) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = m.SetMachineAddresses(
-		network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedSpaceAddress("cloud-local0.internal", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("fc00::1", network.ScopePublic),
+		network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		network.NewSpaceAddress("cloud-local0.internal", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("fc00::1", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -248,17 +248,17 @@ func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {
 
 	// We intentionally set this to invalid values
 	badValue := network.MachineHostPort{
-		MachineAddress: network.NewScopedMachineAddress("0.1.2.3", network.ScopeMachineLocal),
+		MachineAddress: network.NewMachineAddress("0.1.2.3", network.WithScope(network.ScopeMachineLocal)),
 		NetPort:        1234,
 	}
 	badServer := []network.MachineHostPort{badValue}
 
 	extraAddress := network.MachineHostPort{
-		MachineAddress: network.NewScopedMachineAddress("0.1.2.4", network.ScopeMachineLocal),
+		MachineAddress: network.NewMachineAddress("0.1.2.4", network.WithScope(network.ScopeMachineLocal)),
 		NetPort:        5678,
 	}
 	extraAddress2 := network.MachineHostPort{
-		MachineAddress: network.NewScopedMachineAddress("0.1.2.1", network.ScopeMachineLocal),
+		MachineAddress: network.NewMachineAddress("0.1.2.1", network.WithScope(network.ScopeMachineLocal)),
 		NetPort:        9012,
 	}
 

--- a/api/testing/apiaddresser.go
+++ b/api/testing/apiaddresser.go
@@ -49,7 +49,7 @@ func (s *APIAddresserTests) TestAPIAddresses(c *gc.C) {
 }
 
 func (s *APIAddresserTests) TestAPIHostPorts(c *gc.C) {
-	ipv6Addr := network.NewScopedSpaceAddress("2001:DB8::1", network.ScopeCloudLocal)
+	ipv6Addr := network.NewSpaceAddress("2001:DB8::1", network.WithScope(network.ScopeCloudLocal))
 
 	setServerAddrs := []network.SpaceHostPorts{
 		network.NewSpaceHostPorts(999, "0.1.2.24"),

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -286,13 +286,13 @@ func (s *loginSuite) assertAgentLogin(c *gc.C, info *api.Info, mgmtSpace *state.
 	// After storing APIHostPorts in state, Login should return the list
 	// filtered for agents along with the address we connected to.
 	server1Addresses := network.SpaceAddresses{
-		network.NewScopedSpaceAddress("server-1", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewSpaceAddress("server-1", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}
 	server1Addresses[1].SpaceID = mgmtSpace.Id()
 
 	server2Addresses := network.SpaceAddresses{
-		network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal),
+		network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)),
 	}
 
 	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{
@@ -321,13 +321,13 @@ func (s *loginSuite) TestLoginAddressesForClients(c *gc.C) {
 	info = s.infoForNewUser(c, info)
 
 	server1Addresses := network.SpaceAddresses{
-		network.NewScopedSpaceAddress("server-1", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewSpaceAddress("server-1", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}
 	server1Addresses[1].SpaceID = mgmtSpace.Id()
 
 	server2Addresses := network.SpaceAddresses{
-		network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal),
+		network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)),
 	}
 
 	newAPIHostPorts := []network.SpaceHostPorts{
@@ -340,16 +340,16 @@ func (s *loginSuite) TestLoginAddressesForClients(c *gc.C) {
 	exp := []network.MachineHostPorts{
 		{
 			{
-				MachineAddress: network.NewScopedMachineAddress("server-1", network.ScopePublic),
+				MachineAddress: network.NewMachineAddress("server-1", network.WithScope(network.ScopePublic)),
 				NetPort:        123,
 			},
 			{
-				MachineAddress: network.NewScopedMachineAddress("10.0.0.1", network.ScopeCloudLocal),
+				MachineAddress: network.NewMachineAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:        123,
 			},
 		}, {
 			{
-				MachineAddress: network.NewScopedMachineAddress("::1", network.ScopeMachineLocal),
+				MachineAddress: network.NewMachineAddress("::1", network.WithScope(network.ScopeMachineLocal)),
 				NetPort:        456,
 			},
 		},

--- a/apiserver/common/firewall/firewall_test.go
+++ b/apiserver/common/firewall/firewall_test.go
@@ -71,11 +71,11 @@ func (s *FirewallSuite) TestWatchEgressAddressesForRelations(c *gc.C) {
 	}
 
 	unit := newMockUnit("django/0")
-	unit.publicAddress = network.NewScopedSpaceAddress("1.2.3.4", network.ScopePublic)
+	unit.publicAddress = network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopePublic))
 	unit.machineId = "0"
 	s.st.units["django/0"] = unit
 	unit1 := newMockUnit("django/1")
-	unit1.publicAddress = network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)
+	unit1.publicAddress = network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic))
 	unit1.machineId = "1"
 	s.st.units["django/1"] = unit1
 	s.st.machines["0"] = newMockMachine("0")

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -326,8 +326,8 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 }
 
 func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
-	err := s.machine0.SetProviderAddresses(network.NewScopedSpaceAddress("0.1.2.3", network.ScopePublic),
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal))
+	err := s.machine0.SetProviderAddresses(network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Default host port scope is public, so change the cloud-local one

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -58,8 +58,8 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		network.NewSpaceAddress("10.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -69,7 +69,7 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewSpaceAddress("10.2.3.4", network.WithScope(network.ScopeCloudLocal))})
 	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
@@ -233,7 +233,7 @@ func (s *networkInfoSuite) TestAPIRequestForRelationCAASHostNameNoIngress(c *gc.
 	}
 
 	err := app.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress(host, network.ScopePublic),
+		network.NewSpaceAddress(host, network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -282,10 +282,10 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	addresses := []network.SpaceAddress{
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("2.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("2.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("10.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	}
 	err = machine.SetProviderAddresses(addresses...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -298,7 +298,7 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, spaceID3)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("10.2.3.4", network.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewSpaceAddress("10.2.3.4", network.WithScope(network.ScopeCloudLocal))})
 	c.Assert(egress, gc.DeepEquals, []string{"10.2.3.4/32"})
 }
 
@@ -312,8 +312,8 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -323,7 +323,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
+		network.SpaceAddresses{network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic))})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -337,7 +337,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -347,7 +347,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal))})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -368,7 +368,8 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic))
+					err := machine.SetProviderAddresses(
+						network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)))
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -381,7 +382,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic)})
+		network.SpaceAddresses{network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic))})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -416,7 +417,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 			NotifyFunc: func(lastError error, attempt int) {
 				// Set the private address after one failed retrieval attempt.
 				if attempt == 1 {
-					err := machine.SetProviderAddresses(network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal))
+					err := machine.SetProviderAddresses(network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopeCloudLocal)))
 					c.Assert(err, jc.ErrorIsNil)
 				}
 			},
@@ -429,7 +430,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopeCloudLocal))})
 	c.Assert(egress, gc.DeepEquals, []string{"4.3.2.1/32"})
 }
 
@@ -459,7 +460,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	// Add an application address.
 	err = mysql.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.pu0.Refresh()
@@ -474,7 +475,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal)})
+		network.SpaceAddresses{network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal))})
 	c.Assert(egress, gc.DeepEquals, []string{"1.2.3.4/32"})
 }
 
@@ -514,7 +515,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 	// It simulates the same thing.
 	// This should never be returned as an ingress address.
 	err := gitLab.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeMachineLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeMachineLocal)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -570,7 +571,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 
 	// Now set a public address. This is a suitable ingress address.
 	err = gitLab.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress("2.3.4.5", network.ScopePublic),
+		network.NewSpaceAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = prr.ru0.Refresh()
@@ -585,7 +586,7 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 
 	c.Assert(boundSpace, gc.Equals, network.AlphaSpaceId)
 	c.Assert(ingress, gc.DeepEquals,
-		network.SpaceAddresses{network.NewScopedSpaceAddress("2.3.4.5", network.ScopePublic)})
+		network.SpaceAddresses{network.NewSpaceAddress("2.3.4.5", network.WithScope(network.ScopePublic))})
 	c.Assert(egress, gc.DeepEquals, []string{"2.3.4.5/32"})
 }
 
@@ -616,10 +617,10 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("10.0.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.30", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.20", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.10.0.20", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.10.0.30", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.20.0.20", network.WithScope(network.ScopeCloudLocal)))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil, nil)
@@ -681,10 +682,10 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth1", "10.10.0.20/24")
 	s.createNICWithIP(c, machine, network.EthernetDevice, "eth2", "10.20.0.20/24")
 
-	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("10.0.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.20", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.10.0.30", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.20.0.20", network.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("10.0.0.20", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.10.0.20", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.10.0.30", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.20.0.20", network.WithScope(network.ScopeCloudLocal)))
 	c.Assert(err, jc.ErrorIsNil)
 
 	ni := s.newNetworkInfo(c, unit.UnitTag(), nil, nil)

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -347,7 +347,7 @@ func spaceAddressesFromNetworkInfo(netInfos []params.NetworkInfo) network.SpaceA
 		}
 
 		for _, addr := range nwInfo.Addresses {
-			addrs = append(addrs, network.NewScopedSpaceAddress(addr.Address, scope))
+			addrs = append(addrs, network.NewSpaceAddress(addr.Address, network.WithScope(scope)))
 		}
 	}
 	return addrs

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -566,7 +566,7 @@ func (s *uniterSuite) TestPublicAddress(c *gc.C) {
 
 	// Now set it an try again.
 	err = s.machine0.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopePublic),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	address, err := s.wordpressUnit.PublicAddress()
@@ -606,7 +606,7 @@ func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
 
 	// Now set it and try again.
 	err = s.machine0.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	address, err := s.wordpressUnit.PrivateAddress()
@@ -628,7 +628,7 @@ func (s *uniterSuite) TestPrivateAddress(c *gc.C) {
 // all the spaces set up.
 func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 	err := s.machine0.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2025,7 +2025,7 @@ func (s *uniterSuite) TestProviderType(c *gc.C) {
 func (s *uniterSuite) TestEnterScope(c *gc.C) {
 	// Set wordpressUnit's private address first.
 	err := s.machine0.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -3568,8 +3568,8 @@ func (s *uniterSuite) setupRemoteRelationScenario(c *gc.C) (names.Tag, *state.Re
 
 	// Set mysql's addresses first.
 	err := s.machine1.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("4.3.2.1", network.ScopePublic),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -3614,7 +3614,7 @@ func (s *uniterSuite) TestPrivateAddressWithRemoteRelationNoPublic(c *gc.C) {
 	thisUniter := s.makeMysqlUniter(c)
 	// Set mysql's addresses - no public address.
 	err := s.machine1.SetProviderAddresses(
-		network.NewScopedSpaceAddress("1.2.3.4", network.ScopeCloudLocal),
+		network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -5394,8 +5394,8 @@ func (s *uniterSuite) TestNetworkInfoCAASModelRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = gitlab.UpdateCloudService("", []network.SpaceAddress{
-		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -5442,8 +5442,8 @@ func (s *uniterSuite) TestNetworkInfoCAASModelNoRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = wp.UpdateCloudService("", []network.SpaceAddress{
-		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -1203,8 +1203,8 @@ func (s *clientSuite) TestClientPublicAddressMachine(c *gc.C) {
 	// address is returned.
 	m1, err := s.State.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
-	cloudLocalAddress := network.NewScopedSpaceAddress("cloudlocal", network.ScopeCloudLocal)
-	publicAddress := network.NewScopedSpaceAddress("public", network.ScopePublic)
+	cloudLocalAddress := network.NewSpaceAddress("cloudlocal", network.WithScope(network.ScopeCloudLocal))
+	publicAddress := network.NewSpaceAddress("public", network.WithScope(network.ScopePublic))
 	err = m1.SetProviderAddresses(cloudLocalAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PublicAddress("1")
@@ -1222,7 +1222,7 @@ func (s *clientSuite) TestClientPublicAddressUnit(c *gc.C) {
 
 	m1, err := s.State.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
-	publicAddress := network.NewScopedSpaceAddress("public", network.ScopePublic)
+	publicAddress := network.NewSpaceAddress("public", network.WithScope(network.ScopePublic))
 	err = m1.SetProviderAddresses(publicAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PublicAddress("wordpress/0")
@@ -1247,8 +1247,8 @@ func (s *clientSuite) TestClientPrivateAddress(c *gc.C) {
 	// address if no cloud-local one is available.
 	m1, err := s.State.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
-	cloudLocalAddress := network.NewScopedSpaceAddress("cloudlocal", network.ScopeCloudLocal)
-	publicAddress := network.NewScopedSpaceAddress("public", network.ScopePublic)
+	cloudLocalAddress := network.NewSpaceAddress("cloudlocal", network.WithScope(network.ScopeCloudLocal))
+	publicAddress := network.NewSpaceAddress("public", network.WithScope(network.ScopePublic))
 	err = m1.SetProviderAddresses(publicAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PrivateAddress("1")
@@ -1266,7 +1266,7 @@ func (s *clientSuite) TestClientPrivateAddressUnit(c *gc.C) {
 
 	m1, err := s.State.Machine("1")
 	c.Assert(err, jc.ErrorIsNil)
-	privateAddress := network.NewScopedSpaceAddress("private", network.ScopeCloudLocal)
+	privateAddress := network.NewSpaceAddress("private", network.WithScope(network.ScopeCloudLocal))
 	err = m1.SetProviderAddresses(privateAddress)
 	c.Assert(err, jc.ErrorIsNil)
 	addr, err := s.APIState.Client().PrivateAddress("wordpress/0")
@@ -1801,13 +1801,13 @@ func (s *clientSuite) TestBlockChangesRetryProvisioning(c *gc.C) {
 
 func (s *clientSuite) TestAPIHostPorts(c *gc.C) {
 	server1Addresses := []network.SpaceAddress{
-		network.NewScopedSpaceAddress("server-1", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewSpaceAddress("server-1", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}
 	server1Addresses[1].SpaceID = s.mgmtSpace.Id()
 
 	server2Addresses := []network.SpaceAddress{
-		network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal),
+		network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)),
 	}
 	stateAPIHostPorts := []network.SpaceHostPorts{
 		network.SpaceAddressesWithPort(server1Addresses, 123),

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -67,9 +67,9 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 		Jobs:        []state.MachineJob{state.JobManageModel},
 		Constraints: controllerCons,
 		Addresses: []network.SpaceAddress{
-			network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
-			network.NewScopedSpaceAddress("cloud-local0.internal", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("fc00::0", network.ScopePublic),
+			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+			network.NewSpaceAddress("cloud-local0.internal", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("fc00::0", network.WithScope(network.ScopePublic)),
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -84,9 +84,9 @@ func (s *clientSuite) setMachineAddresses(c *gc.C, machineId string) {
 	m, err := s.State.Machine(machineId)
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetMachineAddresses(
-		network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedSpaceAddress(fmt.Sprintf("cloud-local%s.internal", machineId), network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress(fmt.Sprintf("fc0%s::1", machineId), network.ScopePublic),
+		network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		network.NewSpaceAddress(fmt.Sprintf("cloud-local%s.internal", machineId), network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress(fmt.Sprintf("fc0%s::1", machineId), network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -173,8 +173,8 @@ func (s *clientSuite) TestEnableHAErrorForMultiCloudLocal(c *gc.C) {
 	c.Assert(machines[0].Series(), gc.Equals, "quantal")
 
 	err = machines[0].SetMachineAddresses(
-		network.NewScopedSpaceAddress("cloud-local2.internal", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("cloud-local22.internal", network.ScopeCloudLocal),
+		network.NewSpaceAddress("cloud-local2.internal", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("cloud-local22.internal", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -191,7 +191,7 @@ func (s *clientSuite) TestEnableHAErrorForNoCloudLocal(c *gc.C) {
 
 	// remove the extra provider addresses, so we have no valid CloudLocal addresses
 	c.Assert(m0.SetProviderAddresses(
-		network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
+		network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
 	), jc.ErrorIsNil)
 
 	_, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
@@ -231,8 +231,8 @@ func (s *clientSuite) TestEnableHAAddMachinesErrorForMultiCloudLocal(c *gc.C) {
 	m, err := s.State.Machine("2")
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetMachineAddresses(
-		network.NewScopedSpaceAddress("cloud-local2.internal", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("cloud-local22.internal", network.ScopeCloudLocal),
+		network.NewSpaceAddress("cloud-local2.internal", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("cloud-local22.internal", network.WithScope(network.ScopeCloudLocal)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -226,7 +226,7 @@ func mapNetworkConfigsToProviderAddresses(
 
 			addrs = append(
 				addrs,
-				network.NewScopedProviderAddressInSpace(string(spaceInfo.Name), addr.Value, addr.Scope),
+				network.NewProviderAddressInSpace(string(spaceInfo.Name), addr.Value, network.WithScope(addr.Scope)),
 			)
 		}
 
@@ -246,7 +246,7 @@ func mapNetworkConfigsToProviderAddresses(
 			}
 			addrs = append(
 				addrs,
-				network.NewScopedProviderAddressInSpace(string(spaceInfo.Name), addr.Value, addr.Scope),
+				network.NewProviderAddressInSpace(string(spaceInfo.Name), addr.Value, network.WithScope(addr.Scope)),
 			)
 		}
 	}

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -1166,7 +1166,7 @@ func (s *InstancePollerSuite) setDefaultSpaceInfo() {
 }
 
 func makeSpaceAddress(ip string, scope network.Scope, spaceID string) network.SpaceAddress {
-	addr := network.NewScopedSpaceAddress(ip, scope)
+	addr := network.NewSpaceAddress(ip, network.WithScope(scope))
 	addr.SpaceID = spaceID
 	return addr
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14315,6 +14315,8 @@
                     "additionalProperties": false,
                     "required": [
                         "charm",
+                        "charm-version",
+                        "charm-profile",
                         "series",
                         "exposed",
                         "life",
@@ -14325,8 +14327,6 @@
                         "meter-statuses",
                         "status",
                         "workload-version",
-                        "charm-version",
-                        "charm-profile",
                         "endpoint-bindings",
                         "public-address"
                     ]

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -260,8 +260,8 @@ func (s *NetworkSuite) TestPortRangeConvenience(c *gc.C) {
 
 func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 	pAddrs := network.ProviderAddresses{
-		network.NewScopedProviderAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedProviderAddress("2.3.4.5", network.ScopePublic),
+		network.NewProviderAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewProviderAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	}
 	pAddrs[0].SpaceName = "test-space"
 	pAddrs[0].ProviderSpaceID = "666"
@@ -272,8 +272,8 @@ func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 
 func (s *NetworkSuite) TestMachineAddressConversion(c *gc.C) {
 	mAddrs := []network.MachineAddress{
-		network.NewScopedMachineAddress("1.2.3.4", network.ScopeCloudLocal),
-		network.NewScopedMachineAddress("2.3.4.5", network.ScopePublic),
+		network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	}
 
 	exp := []params.Address{
@@ -287,17 +287,17 @@ func (s *NetworkSuite) TestProviderHostPortConversion(c *gc.C) {
 	pHPs := []network.ProviderHostPorts{
 		{
 			{
-				ProviderAddress: network.NewScopedProviderAddress("1.2.3.4", network.ScopeCloudLocal),
+				ProviderAddress: network.NewProviderAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:         1234,
 			},
 			{
-				ProviderAddress: network.NewScopedProviderAddress("2.3.4.5", network.ScopePublic),
+				ProviderAddress: network.NewProviderAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 				NetPort:         2345,
 			},
 		},
 		{
 			{
-				ProviderAddress: network.NewScopedProviderAddress("3.4.5.6", network.ScopeCloudLocal),
+				ProviderAddress: network.NewProviderAddress("3.4.5.6", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:         3456,
 			},
 		},
@@ -344,17 +344,17 @@ func (s *NetworkSuite) TestMachineHostPortConversion(c *gc.C) {
 	exp := []network.MachineHostPorts{
 		{
 			{
-				MachineAddress: network.NewScopedMachineAddress("1.2.3.4", network.ScopeCloudLocal),
+				MachineAddress: network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:        1234,
 			},
 			{
-				MachineAddress: network.NewScopedMachineAddress("2.3.4.5", network.ScopePublic),
+				MachineAddress: network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 				NetPort:        2345,
 			},
 		},
 		{
 			{
-				MachineAddress: network.NewScopedMachineAddress("3.4.5.6", network.ScopeCloudLocal),
+				MachineAddress: network.NewMachineAddress("3.4.5.6", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:        3456,
 			},
 		},
@@ -367,17 +367,17 @@ func (s *NetworkSuite) TestHostPortConversion(c *gc.C) {
 	mHPs := []network.MachineHostPorts{
 		{
 			{
-				MachineAddress: network.NewScopedMachineAddress("1.2.3.4", network.ScopeCloudLocal),
+				MachineAddress: network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:        1234,
 			},
 			{
-				MachineAddress: network.NewScopedMachineAddress("2.3.4.5", network.ScopePublic),
+				MachineAddress: network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 				NetPort:        2345,
 			},
 		},
 		{
 			{
-				MachineAddress: network.NewScopedMachineAddress("3.4.5.6", network.ScopeCloudLocal),
+				MachineAddress: network.NewMachineAddress("3.4.5.6", network.WithScope(network.ScopeCloudLocal)),
 				NetPort:        3456,
 			},
 		},

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -142,6 +142,9 @@ type LXDProfile struct {
 type ApplicationStatus struct {
 	Err              *Error                     `json:"err,omitempty"`
 	Charm            string                     `json:"charm"`
+	CharmVersion     string                     `json:"charm-version"`
+	CharmProfile     string                     `json:"charm-profile"`
+	CharmChannel     string                     `json:"charm-channel,omitempty"`
 	Series           string                     `json:"series"`
 	Exposed          bool                       `json:"exposed"`
 	ExposedEndpoints map[string]ExposedEndpoint `json:"exposed-endpoints,omitempty"`
@@ -153,9 +156,6 @@ type ApplicationStatus struct {
 	MeterStatuses    map[string]MeterStatus     `json:"meter-statuses"`
 	Status           DetailedStatus             `json:"status"`
 	WorkloadVersion  string                     `json:"workload-version"`
-	CharmVersion     string                     `json:"charm-version"`
-	CharmProfile     string                     `json:"charm-profile"`
-	CharmChannel     string                     `json:"charm-channel,omitempty"`
 	EndpointBindings map[string]string          `json:"endpoint-bindings"`
 
 	// The following are for CAAS models.

--- a/apiserver/params/status_test.go
+++ b/apiserver/params/status_test.go
@@ -5,7 +5,6 @@ package params_test
 
 import (
 	"encoding/json"
-	"strings"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -23,9 +22,11 @@ func (s *StatusSuite) TestMarshallApplicationStatusCharmVersion(c *gc.C) {
 	}
 	data, err := json.Marshal(as)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(data), gc.Equals, strings.Replace(`
-{"charm-verion":"666","charm":"","series":"","exposed":false,"life":"","relations":null,"can-upgrade-to":"","subordinate-to":null,
-"units":null,"meter-statuses":null,"status":{"status":"","info":"","data":null,"since":null,"kind":"",
-"version":"","life":""},"workload-version":"","charm-version":"666",
-"charm-profile":"","endpoint-bindings":null,"public-address":""}`, "\n", "", -1))
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(m["charm-verion"], gc.Equals, "666")
+	c.Assert(m["charm-version"], gc.Equals, "666")
 }

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -971,6 +971,11 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				Name:  "PEBBLE",
 				Value: "/charm/container/pebble",
 			}},
+			// Run Pebble as root (because it's a service manager).
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      charmVolumeName,

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -362,6 +362,10 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 					Value: "/charm/container/pebble",
 				},
 			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "charm-data",

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -107,14 +107,13 @@ func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *k8s.ClusterMetadata,
 	// Record the operator storage to use.
 	if clusterMetadata.OperatorStorageClass != nil {
 		operatorSC = clusterMetadata.OperatorStorageClass.Name
-		storageMsg += "."
 	} else {
 		if storageMsg == "" {
 			storageMsg += "\nwith "
 		} else {
 			storageMsg += "\nand "
 		}
-		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class.")
+		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class")
 	}
 
 	if clusterMetadata.NominatedStorageClass != nil {

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -578,7 +578,7 @@ func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.Provide
 	appendUniqueAddrs := func(scope network.Scope, addrs ...string) {
 		for _, v := range addrs {
 			if v != "" && !addressExist(v) {
-				netAddrs = append(netAddrs, network.NewScopedProviderAddress(v, scope))
+				netAddrs = append(netAddrs, network.NewProviderAddress(v, network.WithScope(scope)))
 			}
 		}
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2916,7 +2916,7 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundNoWorkload(c *gc.C) {
 		&caas.Service{
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("10.0.0.1", network.ScopePublic),
+				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 			},
 		},
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
@@ -3006,7 +3006,7 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 		&caas.Service{
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("10.0.0.1", network.ScopePublic),
+				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 			},
 			Scale:      intPtr(2),
 			Generation: int64Ptr(1),
@@ -3097,7 +3097,7 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 		&caas.Service{
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("10.0.0.1", network.ScopePublic),
+				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 			},
 			Scale:      intPtr(2),
 			Generation: int64Ptr(1),
@@ -3160,7 +3160,7 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 		&caas.Service{
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress("10.0.0.1", network.ScopePublic),
+				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 			},
 			Scale:      intPtr(2),
 			Generation: int64Ptr(1),

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -497,7 +497,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 		Clock:              c.clock,
 	}
 
-	newCloud, newcredential, err := provider.CloudFromKubeConfig(rdr, config)
+	newCloud, newCredential, err := provider.CloudFromKubeConfig(rdr, config)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -507,7 +507,7 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 		}
 		logger.Warningf("k8s cloud %v is configured to skip server certificate validity checks", newCloud.Name)
 	}
-	newcredential, err = ensureCredentialUID(credentialName, credentialUID, newcredential)
+	newCredential, err = ensureCredentialUID(credentialName, credentialUID, newCredential)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -519,13 +519,13 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Trace(err)
 	}
 
-	broker, err := c.brokerGetter(newCloud, newcredential)
+	broker, err := c.brokerGetter(newCloud, newCredential)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	var storageMsg string
 	if c.skipStorage {
-		storageMsg = " with no configured storage provisioning capability."
+		storageMsg = " with no configured storage provisioning capability"
 	} else {
 		storageParams := provider.KubeCloudStorageParams{
 			WorkloadStorage:        c.workloadStorage,
@@ -576,12 +576,27 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	if newCloud.HostCloudRegion == "" {
 		newCloud.HostCloudRegion = k8s.K8sCloudOther
 	}
+
+	var returnErr error
 	if c.Client {
-		if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
+		personal, err := c.cloudMetadataStore.PersonalCloudMetadata()
+		if err != nil {
 			return errors.Trace(err)
 		}
-		if err := c.addCredentialToLocal(c.credentialStoreAPI, cloudName, newcredential, credentialName); err != nil {
-			return errors.Trace(err)
+		for name := range personal {
+			if name == newCloud.Name {
+				returnErr = errors.AlreadyExistsf("use `update-k8s %s --client` to override known local definition: k8s %q", newCloud.Name, newCloud.Name)
+				break
+			}
+		}
+		if returnErr == nil {
+			if err := addCloudToLocal(c.cloudMetadataStore, newCloud); err != nil {
+				returnErr = err
+			} else {
+				if err := c.addCredentialToLocal(c.credentialStoreAPI, cloudName, newCredential, credentialName); err != nil {
+					returnErr = err
+				}
+			}
 		}
 	}
 
@@ -593,30 +608,44 @@ func (c *AddCAASCommand) Run(ctx *cmd.Context) (err error) {
 	}
 	successMsg := fmt.Sprintf("k8s substrate %sadded as cloud %q%s", clusterName, c.caasName, storageMsg)
 	var msgDisplayed bool
-	if c.Client {
+	if c.Client && returnErr == nil {
 		msgDisplayed = true
-		successMsg += fmt.Sprintf("\nYou can now bootstrap to this cloud by running 'juju bootstrap %s'.", c.caasName)
+		successMsg += fmt.Sprintf(".\nYou can now bootstrap to this cloud by running 'juju bootstrap %s'.", c.caasName)
 		fmt.Fprintln(ctx.Stdout, successMsg)
 	}
 	if c.ControllerName != "" {
-		if err := jujuclient.ValidateControllerName(c.ControllerName); err != nil {
-			return errors.Trace(err)
+		// If there was an error adding locally, adjust the success message.
+		if returnErr != nil {
+			successMsg += "."
+		} else {
+			successMsg += fmt.Sprintf(" on controller %s.", c.ControllerName)
 		}
-		cloudClient, err := c.addCloudAPIFunc()
-		if err != nil {
-			return errors.Trace(err)
+		if err := c.addRemoteCloud(newCloud, newCredential, credentialName); err == nil {
+			if !msgDisplayed {
+				fmt.Fprintln(ctx.Stdout, successMsg)
+			}
+		} else {
+			returnErr = errors.Annotate(err, "could not upload k8s cloud to a controller")
 		}
-		defer cloudClient.Close()
+	}
+	return returnErr
+}
 
-		if err := addCloudToController(cloudClient, newCloud); err != nil {
-			return errors.Trace(err)
-		}
-		if err := c.addCredentialToController(cloudClient, newcredential, cloudName, credentialName); err != nil {
-			return errors.Trace(err)
-		}
-		if !msgDisplayed {
-			fmt.Fprintln(ctx.Stdout, successMsg)
-		}
+func (c *AddCAASCommand) addRemoteCloud(newCloud jujucloud.Cloud, newCredential jujucloud.Credential, credentialName string) error {
+	if err := jujuclient.ValidateControllerName(c.ControllerName); err != nil {
+		return errors.Trace(err)
+	}
+	cloudClient, err := c.addCloudAPIFunc()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer cloudClient.Close()
+
+	if err := addCloudToController(cloudClient, newCloud); err != nil {
+		return errors.Trace(err)
+	}
+	if err := c.addCredentialToController(cloudClient, newCredential, newCloud.Name, credentialName); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }

--- a/cmd/juju/commands/enableha_test.go
+++ b/cmd/juju/commands/enableha_test.go
@@ -248,9 +248,9 @@ func (s *EnableHASuite) TestEnableHAEndToEnd(c *gc.C) {
 		Jobs: []state.MachineJob{state.JobManageModel},
 	})
 	err := m.SetMachineAddresses(
-		network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedSpaceAddress("cloud-local0.internal", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("fc00::1", network.ScopePublic),
+		network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		network.NewSpaceAddress("cloud-local0.internal", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("fc00::1", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/commands/ssh_machine_test.go
+++ b/cmd/juju/commands/ssh_machine_test.go
@@ -231,13 +231,13 @@ func (s *SSHMachineSuite) getMachineForUnit(c *gc.C, u *state.Unit) *state.Machi
 }
 
 func (s *SSHMachineSuite) setAddresses(c *gc.C, m *state.Machine) {
-	addrPub := network.NewScopedSpaceAddress(
+	addrPub := network.NewSpaceAddress(
 		fmt.Sprintf("%s.public", m.Id()),
-		network.ScopePublic,
+		network.WithScope(network.ScopePublic),
 	)
-	addrPriv := network.NewScopedSpaceAddress(
+	addrPriv := network.NewSpaceAddress(
 		fmt.Sprintf("%s.private", m.Id()),
-		network.ScopeCloudLocal,
+		network.WithScope(network.ScopeCloudLocal),
 	)
 	err := m.SetProviderAddresses(addrPub, addrPriv)
 	c.Assert(err, jc.ErrorIsNil)
@@ -268,8 +268,8 @@ func (s *SSHMachineSuite) setLinkLayerDevicesAddresses(c *gc.C, m *state.Machine
 }
 
 func (s *SSHMachineSuite) setAddresses6(c *gc.C, m *state.Machine) {
-	addrPub := network.NewScopedSpaceAddress("2001:db8::1", network.ScopePublic)
-	addrPriv := network.NewScopedSpaceAddress("fc00:bbb::1", network.ScopeCloudLocal)
+	addrPub := network.NewSpaceAddress("2001:db8::1", network.WithScope(network.ScopePublic))
+	addrPriv := network.NewSpaceAddress("fc00:bbb::1", network.WithScope(network.ScopeCloudLocal))
 	err := m.SetProviderAddresses(addrPub, addrPriv)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -121,6 +121,7 @@ type applicationStatus struct {
 	CharmOrigin      string                `json:"charm-origin" yaml:"charm-origin"`
 	CharmName        string                `json:"charm-name" yaml:"charm-name"`
 	CharmRev         int                   `json:"charm-rev" yaml:"charm-rev"`
+	CharmChannel     string                `json:"charm-channel,omitempty" yaml:"charm-channel,omitempty"`
 	CharmVersion     string                `json:"charm-version,omitempty" yaml:"charm-version,omitempty"`
 	CharmProfile     string                `json:"charm-profile,omitempty" yaml:"charm-profile,omitempty"`
 	CanUpgradeTo     string                `json:"can-upgrade-to,omitempty" yaml:"can-upgrade-to,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -239,6 +239,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		osInfo = application.Series
 	}
 	var (
+		charmAlias  = ""
 		charmOrigin = ""
 		charmName   = ""
 		charmRev    = 0
@@ -251,20 +252,24 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		switch curl.Schema {
 		case "ch":
 			charmOrigin = "charmhub"
+			charmAlias = curl.Name
 		case "cs":
 			charmOrigin = "charmstore"
+			charmAlias = application.Charm
 		case "local":
 			charmOrigin = "local"
+			charmAlias = application.Charm
 		default:
 			charmOrigin = "unknown"
+			charmAlias = application.Charm
 		}
-		charmName = curl.Name
 		charmRev = curl.Revision
+		charmName = curl.Name
 	}
 
 	out := applicationStatus{
 		Err:              typedNilCheck(application.Err),
-		Charm:            application.Charm,
+		Charm:            charmAlias,
 		Series:           application.Series,
 		OS:               osInfo,
 		CharmOrigin:      charmOrigin,
@@ -272,6 +277,7 @@ func (sf *statusFormatter) formatApplication(name string, application params.App
 		CharmRev:         charmRev,
 		CharmVersion:     application.CharmVersion,
 		CharmProfile:     application.CharmProfile,
+		CharmChannel:     application.CharmChannel,
 		Exposed:          application.Exposed,
 		Life:             string(application.Life),
 		Scale:            application.Scale,

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -131,12 +131,12 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Address", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Channel", "Rev", "OS", "Address", "Message")
 	} else {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Rev", "OS", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Channel", "Rev", "OS", "Message")
 	}
 	tw.SetColumnAlignRight(3)
-	tw.SetColumnAlignRight(6)
+	tw.SetColumnAlignRight(7)
 	for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
 		app := fs.Applications[appName]
 		version := app.Version
@@ -162,6 +162,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 
 		w.Print(app.CharmName,
 			app.CharmOrigin,
+			app.CharmChannel,
 			app.CharmRev,
 			app.OS)
 		if fs.Model.Type == caasModelType {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -550,7 +550,7 @@ var statusTests = []testCase{
 
 		startAliveMachine{"0", ""},
 		setAddresses{"0", []network.SpaceAddress{
-			network.NewScopedSpaceAddress("10.0.0.1", network.ScopePublic),
+			network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 			network.NewSpaceAddress("10.0.0.2"),
 		}},
 		expect{
@@ -698,7 +698,7 @@ var statusTests = []testCase{
 		"instance with different hardware characteristics",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
 		setAddresses{"0", []network.SpaceAddress{
-			network.NewScopedSpaceAddress("10.0.0.1", network.ScopePublic),
+			network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 			network.NewSpaceAddress("10.0.0.2"),
 		}},
 		startAliveMachine{"0", ""},
@@ -3222,12 +3222,12 @@ var statusTests = []testCase{
 		"instance with localhost addresses",
 		addMachine{machineId: "0", job: state.JobManageModel},
 		setAddresses{"0", []network.SpaceAddress{
-			network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
+			network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
 			// TODO(macgreagoir) setAddresses step method needs to
 			// set netmask correctly before we can test IPv6
 			// loopback.
-			// network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal),
+			// network.NewSpaceAddress("::1", network.ScopeMachineLocal),
 		}},
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
@@ -3250,11 +3250,11 @@ var statusTests = []testCase{
 		"instance with IPv6 addresses",
 		addMachine{machineId: "0", cons: machineCons, job: state.JobManageModel},
 		setAddresses{"0", []network.SpaceAddress{
-			network.NewScopedSpaceAddress("2001:db8::1", network.ScopeCloudLocal),
+			network.NewSpaceAddress("2001:db8::1", network.WithScope(network.ScopeCloudLocal)),
 			// TODO(macgreagoir) setAddresses step method needs to
 			// set netmask correctly before we can test IPv6
 			// loopback.
-			// network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal),
+			// network.NewSpaceAddress("::1", network.ScopeMachineLocal),
 		}},
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
@@ -5094,10 +5094,10 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
 
-App        Version          Status       Scale  Charm      Store       Rev  OS      Message
-logging    a bit too lo...  error            2  logging    charmstore    1  ubuntu  somehow lost in all those logs
-mysql      5.7.13           maintenance    1/2  mysql      charmstore    1  ubuntu  installing all the things
-wordpress  4.5.3            active           1  wordpress  charmhub      3  ubuntu  
+App        Version          Status       Scale  Charm      Store       Channel  Rev  OS      Message
+logging    a bit too lo...  error            2  logging    charmstore             1  ubuntu  somehow lost in all those logs
+mysql      5.7.13           maintenance    1/2  mysql      charmstore             1  ubuntu  installing all the things
+wordpress  4.5.3            active           1  wordpress  charmhub               3  ubuntu  
 
 Unit          Workload     Agent  Machine  Public address  Ports  Message
 mysql/0*      maintenance  idle   2        10.0.2.1               installing all the things
@@ -5202,8 +5202,8 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Message
-foo                       2                  0      
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Message
+foo                       2                           0      
 
 Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
@@ -5250,8 +5250,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Message
-foo                     1/2                  0      54.32.1.2  
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
+foo                     1/2                           0      54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
@@ -5293,8 +5293,8 @@ func (s *StatusSuite) TestFormatTabularStatusMessage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Address    Message
-foo                     0/1                  0      54.32.1.2  Error: ImagePullBackOff
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
+foo                     0/1                           0      54.32.1.2  Error: ImagePullBackOff
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  waiting   allocating  10.0.0.1  80/TCP  
@@ -5357,8 +5357,8 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Rev  OS  Message
-foo                     0/2                  0      
+App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Message
+foo                     0/2                           0      
 
 Unit   Workload  Agent  Machine  Public address  Ports  Message
 foo/0                                                   

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -243,7 +243,7 @@ func (s *containerSuite) TestContainerAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []corenetwork.ProviderAddress{
-		corenetwork.NewScopedProviderAddress("10.0.8.173", corenetwork.ScopeCloudLocal),
+		corenetwork.NewProviderAddress("10.0.8.173", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 	}
 	c.Check(addrs, gc.DeepEquals, expected)
 }

--- a/core/network/address_options.go
+++ b/core/network/address_options.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+// AddressMutator describes setter methods for an address.
+type AddressMutator interface {
+	// SetScope sets the scope property of the address.
+	SetScope(Scope)
+
+	// SetCIDR sets the CIDR property of the address.
+	SetCIDR(string)
+}
+
+// SetScope (AddressMutator) sets the input
+// scope on the address receiver.
+func (a *MachineAddress) SetScope(scope Scope) {
+	a.Scope = scope
+}
+
+// SetCIDR (AddressMutator) sets the input
+// CIDR on the address receiver.
+func (a *MachineAddress) SetCIDR(cidr string) {
+	a.CIDR = cidr
+}
+
+// WithScope returns a functional option that can
+// be used to set the input scope on an address.
+func WithScope(scope Scope) func(AddressMutator) {
+	return func(a AddressMutator) {
+		a.SetScope(scope)
+	}
+}
+
+// WithCIDR returns a functional option that can
+// be used to set the input CIDR on an address.
+func WithCIDR(cidr string) func(AddressMutator) {
+	return func(a AddressMutator) {
+		a.SetCIDR(cidr)
+	}
+}

--- a/core/network/hostport_test.go
+++ b/core/network/hostport_test.go
@@ -255,7 +255,7 @@ var netAddrTests = []struct {
 	port:   9999,
 	expect: "example.com:9999",
 }, {
-	addr:   network.NewScopedSpaceAddress("example.com", network.ScopePublic),
+	addr:   network.NewSpaceAddress("example.com", network.WithScope(network.ScopePublic)),
 	port:   1234,
 	expect: "example.com:1234",
 }, {
@@ -416,32 +416,32 @@ var prioritizeInternalHostPortsTests = []selectInternalHostPortsTest{{
 }, {
 	"a public IPv4 address is selected",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 9999},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 9999},
 	},
 	[]string{"8.8.8.8:9999"},
 }, {
 	"cloud local IPv4 addresses are selected",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("10.1.0.1", network.ScopeCloudLocal), 8888},
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal), 1234},
+		{network.NewSpaceAddress("10.1.0.1", network.WithScope(network.ScopeCloudLocal)), 8888},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)), 1234},
 	},
 	[]string{"10.1.0.1:8888", "10.0.0.1:1234", "8.8.8.8:123"},
 }, {
 	"a machine local or link-local address is not selected",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal), 111},
-		{network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal), 222},
-		{network.NewScopedSpaceAddress("fe80::1", network.ScopeLinkLocal), 333},
+		{network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)), 111},
+		{network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)), 222},
+		{network.NewSpaceAddress("fe80::1", network.WithScope(network.ScopeLinkLocal)), 333},
 	},
 	[]string{},
 }, {
 	"cloud local addresses are preferred to a public addresses",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("2001:db8::1", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("fc00::1", network.ScopeCloudLocal), 123},
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal), 4444},
+		{network.NewSpaceAddress("2001:db8::1", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("fc00::1", network.WithScope(network.ScopeCloudLocal)), 123},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)), 4444},
 	},
 	[]string{"10.0.0.1:4444", "[fc00::1]:123", "8.8.8.8:123", "[2001:db8::1]:123"},
 }}
@@ -461,40 +461,40 @@ var selectInternalHostPortsTests = []selectInternalHostPortsTest{{
 }, {
 	"a public IPv4 address is selected",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 9999},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 9999},
 	},
 	[]string{"8.8.8.8:9999"},
 }, {
 	"cloud local IPv4 addresses are selected",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("10.1.0.1", network.ScopeCloudLocal), 8888},
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal), 1234},
+		{network.NewSpaceAddress("10.1.0.1", network.WithScope(network.ScopeCloudLocal)), 8888},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)), 1234},
 	},
 	[]string{"10.1.0.1:8888", "10.0.0.1:1234"},
 }, {
 	"a machine local or link-local address is not selected",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal), 111},
-		{network.NewScopedSpaceAddress("::1", network.ScopeMachineLocal), 222},
-		{network.NewScopedSpaceAddress("fe80::1", network.ScopeLinkLocal), 333},
+		{network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)), 111},
+		{network.NewSpaceAddress("::1", network.WithScope(network.ScopeMachineLocal)), 222},
+		{network.NewSpaceAddress("fe80::1", network.WithScope(network.ScopeLinkLocal)), 333},
 	},
 	[]string{},
 }, {
 	"cloud local IPv4 addresses are preferred to a public addresses",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("2001:db8::1", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("fc00::1", network.ScopeCloudLocal), 123},
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal), 4444},
+		{network.NewSpaceAddress("2001:db8::1", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("fc00::1", network.WithScope(network.ScopeCloudLocal)), 123},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)), 4444},
 	},
 	[]string{"10.0.0.1:4444"},
 }, {
 	"cloud local IPv6 addresses are preferred to a public addresses",
 	[]network.SpaceHostPort{
-		{network.NewScopedSpaceAddress("2001:db8::1", network.ScopePublic), 123},
-		{network.NewScopedSpaceAddress("fc00::1", network.ScopeCloudLocal), 123},
-		{network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic), 123},
+		{network.NewSpaceAddress("2001:db8::1", network.WithScope(network.ScopePublic)), 123},
+		{network.NewSpaceAddress("fc00::1", network.WithScope(network.ScopeCloudLocal)), 123},
+		{network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic)), 123},
 	},
 	[]string{"[fc00::1]:123"},
 }}

--- a/environs/manual/addresses_test.go
+++ b/environs/manual/addresses_test.go
@@ -42,7 +42,7 @@ func (s *addressesSuite) TestHostAddress(c *gc.C) {
 	addr, err := manual.HostAddress(validHost)
 	c.Assert(s.netLookupHostCalled, gc.Equals, 1)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, gc.Equals, network.NewScopedProviderAddress(validHost, network.ScopePublic))
+	c.Assert(addr, gc.Equals, network.NewProviderAddress(validHost, network.WithScope(network.ScopePublic)))
 }
 
 func (s *addressesSuite) TestHostAddressError(c *gc.C) {
@@ -56,12 +56,12 @@ func (s *addressesSuite) TestHostAddressIPv4(c *gc.C) {
 	addr, err := manual.HostAddress("127.0.0.1")
 	c.Assert(s.netLookupHostCalled, gc.Equals, 0)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, gc.Equals, network.NewScopedProviderAddress("127.0.0.1", network.ScopePublic))
+	c.Assert(addr, gc.Equals, network.NewProviderAddress("127.0.0.1", network.WithScope(network.ScopePublic)))
 }
 
 func (s *addressesSuite) TestHostAddressIPv6(c *gc.C) {
 	addr, err := manual.HostAddress("::1")
 	c.Assert(s.netLookupHostCalled, gc.Equals, 0)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, gc.Equals, network.NewScopedProviderAddress("::1", network.ScopePublic))
+	c.Assert(addr, gc.Equals, network.NewProviderAddress("::1", network.WithScope(network.ScopePublic)))
 }

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -165,10 +165,10 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 
 	context := s.run(c, "status")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Message
-another             waiting    0/1  mysql      charmstore    5  ubuntu  waiting for machine
-mysql               waiting    0/1  mysql      charmstore    1  ubuntu  waiting for machine
-wordpress           waiting    0/1  wordpress  charmstore    3  ubuntu  waiting for machine
+App        Version  Status   Scale  Charm      Store       Channel  Rev  OS      Message
+another             waiting    0/1  mysql      charmstore             5  ubuntu  waiting for machine
+mysql               waiting    0/1  mysql      charmstore             1  ubuntu  waiting for machine
+wordpress           waiting    0/1  wordpress  charmstore             3  ubuntu  waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 another/0    waiting   allocating  1                               waiting for machine
@@ -182,9 +182,9 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 	context = s.run(c, "status", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Rev  OS      Message
-mysql               waiting    0/1  mysql      charmstore    1  ubuntu  waiting for machine
-wordpress           waiting    0/1  wordpress  charmstore    3  ubuntu  waiting for machine
+App        Version  Status   Scale  Charm      Store       Channel  Rev  OS      Message
+mysql               waiting    0/1  mysql      charmstore             1  ubuntu  waiting for machine
+wordpress           waiting    0/1  wordpress  charmstore             3  ubuntu  waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -242,9 +242,9 @@ func (s *MongoSuite) TestNoMongoDir(c *gc.C) {
 
 func (s *MongoSuite) TestSelectPeerAddress(c *gc.C) {
 	addresses := network.ProviderAddresses{
-		network.NewScopedProviderAddress("126.0.0.1", network.ScopeMachineLocal),
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
-		network.NewScopedProviderAddress("8.8.8.8", network.ScopePublic),
+		network.NewProviderAddress("126.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+		network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
+		network.NewProviderAddress("8.8.8.8", network.WithScope(network.ScopePublic)),
 	}
 
 	address := mongo.SelectPeerAddress(addresses)

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -164,9 +164,9 @@ func (inst *azureInstance) Addresses(ctx context.ProviderCallContext) (corenetwo
 			if privateIpAddress == nil {
 				continue
 			}
-			addresses = append(addresses, corenetwork.NewScopedProviderAddress(
+			addresses = append(addresses, corenetwork.NewProviderAddress(
 				to.String(privateIpAddress),
-				corenetwork.ScopeCloudLocal,
+				corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			))
 		}
 	}
@@ -174,9 +174,9 @@ func (inst *azureInstance) Addresses(ctx context.ProviderCallContext) (corenetwo
 		if pip.IPAddress == nil {
 			continue
 		}
-		addresses = append(addresses, corenetwork.NewScopedProviderAddress(
+		addresses = append(addresses, corenetwork.NewProviderAddress(
 			to.String(pip.IPAddress),
-			corenetwork.ScopePublic,
+			corenetwork.WithScope(corenetwork.ScopePublic),
 		))
 	}
 	return addresses, nil
@@ -226,9 +226,9 @@ func primarySecurityGroupInfo(ctx stdcontext.Context, env *azureEnviron, nic net
 		return &securityGroupInfo{
 			resourceGroup: resourceGroup,
 			securityGroup: securityGroup,
-			primaryAddress: corenetwork.NewScopedSpaceAddress(
+			primaryAddress: corenetwork.NewSpaceAddress(
 				to.String(privateIpAddress),
-				corenetwork.ScopeCloudLocal,
+				corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			),
 		}, nil
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1358,7 +1358,7 @@ func mapNetworkInterface(iface amzec2.NetworkInterface, subnet amzec2.Subnet) co
 		// the primary IP is always added first with any additional
 		// private IPs appended after it.
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress(iface.PrivateIPAddress, corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress(iface.PrivateIPAddress, corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}
@@ -1367,7 +1367,8 @@ func mapNetworkInterface(iface amzec2.NetworkInterface, subnet amzec2.Subnet) co
 		if privAddr.Association.PublicIP != "" {
 			ni.ShadowAddresses = append(
 				ni.ShadowAddresses,
-				corenetwork.NewScopedProviderAddress(privAddr.Association.PublicIP, corenetwork.ScopePublic),
+				corenetwork.NewProviderAddress(
+					privAddr.Association.PublicIP, corenetwork.WithScope(corenetwork.ScopePublic)),
 			)
 		}
 
@@ -1377,7 +1378,7 @@ func mapNetworkInterface(iface amzec2.NetworkInterface, subnet amzec2.Subnet) co
 
 		ni.Addresses = append(
 			ni.Addresses,
-			corenetwork.NewScopedProviderAddress(privAddr.Address, corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress(iface.PrivateIPAddress, corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		)
 	}
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1369,8 +1369,8 @@ func (t *localServerSuite) TestAddresses(c *gc.C) {
 	// Expected values use Address type but really contain a regexp for
 	// the value rather than a valid ip or hostname.
 	expected := corenetwork.ProviderAddresses{
-		corenetwork.NewScopedProviderAddress("8.0.0.*", corenetwork.ScopePublic),
-		corenetwork.NewScopedProviderAddress("127.0.0.*", corenetwork.ScopeCloudLocal),
+		corenetwork.NewProviderAddress("8.0.0.*", corenetwork.WithScope(corenetwork.ScopePublic)),
+		corenetwork.NewProviderAddress("127.0.0.*", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 	}
 	expected[0].Type = corenetwork.IPv4Address
 	expected[1].Type = corenetwork.IPv4Address
@@ -1717,14 +1717,14 @@ func (t *localServerSuite) assertInterfaceLooksValid(c *gc.C, expIfaceID, expDev
 		ConfigType:       corenetwork.ConfigDHCP,
 		InterfaceType:    corenetwork.EthernetInterface,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress(addr, corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress(addr, corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		// Each machine is also assigned a shadow IP with the pattern:
 		// 73.37.0.X where X=(provider iface ID + 1)
 		ShadowAddresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress(
+			corenetwork.NewProviderAddress(
 				fmt.Sprintf("73.37.0.%d", expIfaceID+1),
-				corenetwork.ScopePublic,
+				corenetwork.WithScope(corenetwork.ScopePublic),
 			),
 		},
 		AvailabilityZones: zones,

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -200,7 +200,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 				}
 
 				shadowAddrs = append(shadowAddrs,
-					corenetwork.NewScopedProviderAddress(accessConf.NatIP, corenetwork.ScopePublic),
+					corenetwork.NewProviderAddress(accessConf.NatIP, corenetwork.WithScope(corenetwork.ScopePublic)),
 				)
 			}
 
@@ -215,7 +215,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 				AvailabilityZones: copyStrings(zones),
 				InterfaceName:     iface.Name,
 				Addresses: corenetwork.ProviderAddresses{
-					corenetwork.NewScopedProviderAddress(iface.NetworkIP, corenetwork.ScopeCloudLocal),
+					corenetwork.NewProviderAddress(iface.NetworkIP, corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 				},
 				ShadowAddresses: shadowAddrs,
 				InterfaceType:   corenetwork.EthernetInterface,

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -215,7 +215,7 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -301,7 +301,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -321,10 +321,10 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.42", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.42", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		ShadowAddresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
+			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}, {
@@ -340,7 +340,7 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.20.42", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.20.42", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -370,7 +370,7 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -416,7 +416,7 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}, {
@@ -432,10 +432,10 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.20.3", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.20.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		ShadowAddresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
+			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -477,10 +477,10 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.240.0.2", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.240.0.2", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		ShadowAddresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
+			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -523,7 +523,7 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.3", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}, {
@@ -539,10 +539,10 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("10.0.10.4", corenetwork.ScopeCloudLocal),
+			corenetwork.NewProviderAddress("10.0.10.4", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
 		},
 		ShadowAddresses: corenetwork.ProviderAddresses{
-			corenetwork.NewScopedProviderAddress("25.185.142.227", corenetwork.ScopePublic),
+			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}})

--- a/provider/gce/google/network_test.go
+++ b/provider/gce/google/network_test.go
@@ -90,7 +90,7 @@ func (s *networkSuite) TestExtractAddresses(c *gc.C) {
 	addresses := google.ExtractAddresses(&s.NetworkInterface)
 
 	c.Check(addresses, jc.DeepEquals, []network.ProviderAddress{
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	})
 }
 
@@ -100,7 +100,7 @@ func (s *networkSuite) TestExtractAddressesExternal(c *gc.C) {
 	addresses := google.ExtractAddresses(&s.NetworkInterface)
 
 	c.Check(addresses, jc.DeepEquals, []network.ProviderAddress{
-		network.NewScopedProviderAddress("8.8.8.8", network.ScopePublic),
+		network.NewProviderAddress("8.8.8.8", network.WithScope(network.ScopePublic)),
 	})
 }
 

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -93,7 +93,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 		}},
 	}
 	s.Addresses = []network.ProviderAddress{
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}
 	s.RawMetadata = compute.Metadata{
 		Items: []*compute.MetadataItems{{

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -187,7 +187,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 		metadataKeyWindowsSysprep:  fmt.Sprintf(winSetHostnameScript, "juju.*"),
 	}
 	s.Addresses = []network.ProviderAddress{
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}
 	s.Instance = s.NewInstance(c, "spam")
 	s.BaseInstance = s.Instance.base

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -218,7 +218,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 		"limits.memory":                                          strconv.Itoa(3750 * 1024 * 1024),
 	}
 	s.Addresses = network.ProviderAddresses{
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}
 
 	// NOTE: the instance ids used throughout this package are not at all
@@ -651,7 +651,7 @@ func (conn *StubClient) ContainerAddresses(name string) ([]network.ProviderAddre
 	}
 
 	return network.ProviderAddresses{
-		network.NewScopedProviderAddress("10.0.0.1", network.ScopeCloudLocal),
+		network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
 	}, nil
 }
 

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1090,9 +1090,9 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 			ProviderId:  network.Id(*iface.Vnic.Id),
 			MACAddress:  *iface.Vnic.MacAddress,
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddress(
+				network.NewProviderAddress(
 					*iface.Vnic.PrivateIp,
-					network.ScopeCloudLocal,
+					network.WithScope(network.ScopeCloudLocal),
 				),
 			},
 			InterfaceType:    network.EthernetInterface,
@@ -1102,9 +1102,9 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 		}
 		if iface.Vnic.PublicIp != nil {
 			nic.ShadowAddresses = append(nic.ShadowAddresses,
-				network.NewScopedProviderAddress(
+				network.NewProviderAddress(
 					*iface.Vnic.PublicIp,
-					network.ScopePublic,
+					network.WithScope(network.ScopePublic),
 				),
 			)
 		}

--- a/provider/oci/networking_test.go
+++ b/provider/oci/networking_test.go
@@ -243,8 +243,10 @@ func (n *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 	info := infoList[0]
 
 	c.Assert(info, gc.HasLen, 1)
-	c.Assert(info[0].Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{corenetwork.NewScopedProviderAddress("1.1.1.1", corenetwork.ScopeCloudLocal)})
-	c.Assert(info[0].ShadowAddresses, gc.DeepEquals, corenetwork.ProviderAddresses{corenetwork.NewScopedProviderAddress("2.2.2.2", corenetwork.ScopePublic)})
+	c.Assert(info[0].Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{
+		corenetwork.NewProviderAddress("1.1.1.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal))})
+	c.Assert(info[0].ShadowAddresses, gc.DeepEquals, corenetwork.ProviderAddresses{
+		corenetwork.NewProviderAddress("2.2.2.2", corenetwork.WithScope(corenetwork.ScopePublic))})
 	c.Assert(info[0].DeviceIndex, gc.Equals, 0)
 	c.Assert(info[0].ProviderId, gc.Equals, corenetwork.Id(vnicID))
 	c.Assert(info[0].MACAddress, gc.Equals, "aa:aa:aa:aa:aa:aa")

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -421,11 +421,11 @@ func (s *localServerSuite) assertAddressesWithPublicIP(c *gc.C, cons constraints
 		addr, err := inst.Addresses(s.callCtx)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(addr, jc.SameContents, network.ProviderAddresses{
-			network.NewScopedProviderAddress("10.0.0.1", network.ScopePublic),
-			network.NewScopedProviderAddress("127.0.0.1", network.ScopeMachineLocal),
-			network.NewScopedProviderAddress("::face::000f", network.ScopeUnknown),
-			network.NewScopedProviderAddress("127.10.0.1", network.ScopePublic),
-			network.NewScopedProviderAddress("::dead:beef:f00d", network.ScopePublic),
+			network.NewProviderAddress("10.0.0.1", corenetwork.WithScope(corenetwork.ScopePublic)),
+			network.NewProviderAddress("127.0.0.1", corenetwork.WithScope(corenetwork.ScopeMachineLocal)),
+			network.NewProviderAddress("::face::000f"),
+			network.NewProviderAddress("127.10.0.1", corenetwork.WithScope(corenetwork.ScopePublic)),
+			network.NewProviderAddress("::dead:beef:f00d", corenetwork.WithScope(corenetwork.ScopePublic)),
 		})
 		bootstrapFinished = true
 		return nil
@@ -462,10 +462,10 @@ func (s *localServerSuite) assertAddressesWithoutPublicIP(c *gc.C, cons constrai
 		addr, err := inst.Addresses(s.callCtx)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(addr, jc.SameContents, network.ProviderAddresses{
-			network.NewScopedProviderAddress("127.0.0.1", network.ScopeMachineLocal),
-			network.NewScopedProviderAddress("::face::000f", network.ScopeUnknown),
-			network.NewScopedProviderAddress("127.10.0.1", network.ScopePublic),
-			network.NewScopedProviderAddress("::dead:beef:f00d", network.ScopePublic),
+			network.NewProviderAddress("127.0.0.1", corenetwork.WithScope(corenetwork.ScopeMachineLocal)),
+			network.NewProviderAddress("::face::000f"),
+			network.NewProviderAddress("127.10.0.1", corenetwork.WithScope(corenetwork.ScopePublic)),
+			network.NewProviderAddress("::dead:beef:f00d", corenetwork.WithScope(corenetwork.ScopePublic)),
 		})
 		bootstrapFinished = true
 		return nil

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -493,7 +493,7 @@ func (inst *openstackInstance) Addresses(ctx context.ProviderCallContext) (coren
 func convertNovaAddresses(publicIP string, addresses map[string][]nova.IPAddress) corenetwork.ProviderAddresses {
 	var machineAddresses []corenetwork.ProviderAddress
 	if publicIP != "" {
-		publicAddr := corenetwork.NewScopedProviderAddress(publicIP, corenetwork.ScopePublic)
+		publicAddr := corenetwork.NewProviderAddress(publicIP, corenetwork.WithScope(corenetwork.ScopePublic))
 		machineAddresses = append(machineAddresses, publicAddr)
 	}
 	// TODO(gz) Network ordering may be significant but is not preserved by
@@ -514,7 +514,7 @@ func convertNovaAddresses(publicIP string, addresses map[string][]nova.IPAddress
 			if address.Version == 6 {
 				addrType = corenetwork.IPv6Address
 			}
-			machineAddr := corenetwork.NewScopedProviderAddress(address.Address, networkScope)
+			machineAddr := corenetwork.NewProviderAddress(address.Address, corenetwork.WithScope(networkScope))
 			if machineAddr.Type != addrType {
 				logger.Warningf("derived address type %v, nova reports %v", machineAddr.Type, addrType)
 			}

--- a/state/address.go
+++ b/state/address.go
@@ -312,9 +312,9 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 	controllerName := controllerConfig.ControllerName()
 	if controllerName != "" {
 		hostAddresses = append(
-			hostAddresses, network.NewScopedSpaceAddress(
+			hostAddresses, network.NewSpaceAddress(
 				fmt.Sprintf(k8sprovider.ControllerServiceFQDNTemplate, controllerName),
-				network.ScopeCloudLocal,
+				network.WithScope(network.ScopeCloudLocal),
 			))
 	}
 

--- a/state/address_test.go
+++ b/state/address_test.go
@@ -86,13 +86,13 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 	c.Assert(addrs, gc.HasLen, 0)
 
 	newHostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}, {
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.8.16", network.ScopePublic),
+		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
 	}}, {{
-		SpaceAddress: network.NewScopedSpaceAddress("0.6.1.2", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.6.1.2", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      5,
 	}}}
 	err = s.State.SetAPIHostPorts(newHostPorts)
@@ -108,7 +108,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
 	newHostPorts = []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      13,
 	}}}
 	err = s.State.SetAPIHostPorts(newHostPorts)
@@ -125,10 +125,10 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 	hostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.8.16", network.ScopePublic),
+		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
 	}}, {{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}
 
@@ -165,11 +165,11 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(
 
 func (s *ControllerAddressesSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) {
 	hostPorts0 := []network.SpaceHostPort{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.8.16", network.ScopePublic),
+		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
 	}}
 	hostPorts1 := []network.SpaceHostPort{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}
 
@@ -224,7 +224,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 	c.Assert(addrs, gc.HasLen, 0)
 
 	hostPort1 := network.SpaceHostPort{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}
 	hostPort2 := network.SpaceHostPort{
@@ -239,7 +239,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 		NetPort: 2,
 	}
 	hostPort3 := network.SpaceHostPort{
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.1.2", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.4.1.2", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      5,
 	}
 	newHostPorts := []network.SpaceHostPorts{{hostPort1, hostPort2}, {hostPort3}}
@@ -265,7 +265,7 @@ func (s *ControllerAddressesSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.
 	c.Assert(addrs, gc.HasLen, 0)
 
 	newHostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}
 
@@ -291,7 +291,7 @@ func (s *ControllerAddressesSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) 
 	c.Assert(addrs, gc.HasLen, 0)
 
 	newHostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}
 
@@ -363,7 +363,7 @@ func (s *ControllerAddressesSuite) TestWatchAPIHostPortsForAgents(c *gc.C) {
 	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{{
 		mgmtHP,
 		network.SpaceHostPort{
-			SpaceAddress: network.NewScopedSpaceAddress("0.1.2.3", network.ScopeCloudLocal),
+			SpaceAddress: network.NewSpaceAddress("0.1.2.3", network.WithScope(network.ScopeCloudLocal)),
 			NetPort:      99,
 		},
 	}})

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -1039,8 +1039,8 @@ func (s *allWatcherStateSuite) TestClosingPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = u.AssignToMachine(m)
 	c.Assert(err, jc.ErrorIsNil)
-	publicAddress := network.NewScopedSpaceAddress("1.2.3.4", network.ScopePublic)
-	privateAddress := network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal)
+	publicAddress := network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopePublic))
+	privateAddress := network.NewSpaceAddress("4.3.2.1", network.WithScope(network.ScopeCloudLocal))
 	MustOpenUnitPortRange(c, s.state, m, u.Name(), allEndpoints, corenetwork.MustParsePortRange("12345/tcp"))
 	// Create all watcher state backing.
 	b := NewAllWatcherBacking(s.pool)
@@ -2798,8 +2798,8 @@ func testChangeUnits(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, []
 			err = u.AssignToMachine(m)
 			c.Assert(err, jc.ErrorIsNil)
 			MustOpenUnitPortRange(c, st, m, u.Name(), allEndpoints, corenetwork.MustParsePortRange("12345/tcp"))
-			publicAddress := network.NewScopedSpaceAddress("public", network.ScopePublic)
-			privateAddress := network.NewScopedSpaceAddress("private", network.ScopeCloudLocal)
+			publicAddress := network.NewSpaceAddress("public", corenetwork.WithScope(corenetwork.ScopePublic))
+			privateAddress := network.NewSpaceAddress("private", corenetwork.WithScope(corenetwork.ScopeCloudLocal))
 			now := st.clock().Now()
 			sInfo := status.StatusInfo{
 				Status:  status.Error,
@@ -3190,8 +3190,8 @@ func testChangeUnitsNonNilPorts(c *gc.C, owner names.UserTag, runChangeTests fun
 		}
 		if flag&openPorts != 0 {
 			// Add a network to the machine and open a port.
-			publicAddress := network.NewScopedSpaceAddress("1.2.3.4", network.ScopePublic)
-			privateAddress := network.NewScopedSpaceAddress("4.3.2.1", network.ScopeCloudLocal)
+			publicAddress := network.NewSpaceAddress("1.2.3.4", corenetwork.WithScope(corenetwork.ScopePublic))
+			privateAddress := network.NewSpaceAddress("4.3.2.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal))
 			err = m.SetProviderAddresses(publicAddress, privateAddress)
 			c.Assert(err, jc.ErrorIsNil)
 

--- a/state/application.go
+++ b/state/application.go
@@ -2210,7 +2210,7 @@ func (a *Application) addUnitOpsWithCons(args applicationAddUnitOpsArgs) (string
 				containerDoc.ProviderId = *args.providerId
 			}
 			if args.address != nil {
-				networkAddr := network.NewScopedSpaceAddress(*args.address, network.ScopeMachineLocal)
+				networkAddr := network.NewSpaceAddress(*args.address, network.WithScope(network.ScopeMachineLocal))
 				addr := fromNetworkAddress(networkAddr, network.OriginProvider)
 				containerDoc.Address = &addr
 			}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -4327,7 +4327,8 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	c.Assert(ok, jc.IsTrue)
 	c.Check(u.Name(), gc.Equals, existingUnit.Name())
 	c.Check(info.Address(), gc.NotNil)
-	c.Check(*info.Address(), gc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.2", network.ScopeMachineLocal))
+	c.Check(*info.Address(), gc.DeepEquals,
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeMachineLocal)))
 	c.Check(info.Ports(), jc.DeepEquals, []string{"443"})
 	statusInfo, err := u.AgentStatus()
 	c.Assert(err, jc.ErrorIsNil)
@@ -4394,12 +4395,13 @@ func (s *CAASApplicationSuite) assertUpdateCAASUnits(c *gc.C, aliveApp bool) {
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(u.Name(), gc.Equals, "gitlab/3")
 	c.Check(info.Address(), gc.NotNil)
-	c.Check(*info.Address(), gc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal))
+	c.Check(*info.Address(), gc.DeepEquals,
+		network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeMachineLocal)))
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 
 	addr, err := u.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal))
+	c.Assert(addr, jc.DeepEquals, network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeMachineLocal)))
 
 	statusInfo, err = u.Status()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -113,6 +113,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 		DNSSearchDomains: []string{"example.com", "example.org"},
 		GatewayAddress:   "10.20.30.1",
 		IsShadow:         true,
+		IsSecondary:      true,
 	}
 	result := s.newIPAddressWithDummyState(doc)
 
@@ -126,4 +127,5 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 	c.Check(result.GatewayAddress(), gc.Equals, "10.20.30.1")
 	c.Check(result.NetworkAddress(), jc.DeepEquals, network.NewSpaceAddress(result.Value()))
 	c.Check(result.IsShadow(), jc.IsTrue)
+	c.Check(result.IsSecondary(), jc.IsTrue)
 }

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -82,6 +82,13 @@ type ipAddressDoc struct {
 	// address assigned to a NIC by a provider rather than being associated
 	// directly with a device on-machine.
 	IsShadow bool `bson:"is-shadow,omitempty"`
+
+	// IsSecondary if true, indicates that this address is not the primary
+	// address associated with the NIC.
+	// Such addresses can be added by clustering solutions like Pacemaker.
+	// We need to prevent these addresses being supplied with higher
+	// priority than primary addresses in returns to network-get calls.
+	IsSecondary bool `bson:"is-secondary,omitempty"`
 }
 
 // Address represents the state of an IP address assigned to a link-layer
@@ -212,6 +219,12 @@ func (addr *Address) Origin() network.Origin {
 // subnet.
 func (addr *Address) IsShadow() bool {
 	return addr.doc.IsShadow
+}
+
+// IsSecondary if true, indicates that this address is not the primary
+// address associated with the NIC.
+func (addr *Address) IsSecondary() bool {
+	return addr.doc.IsSecondary
 }
 
 // String returns a human-readable representation of the IP address.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2826,12 +2826,12 @@ func (s *MachineSuite) TestWatchAddresses(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Set provider addresses eclipsing machine addresses: reported.
-	err = machine.SetProviderAddresses(network.NewScopedSpaceAddress("abc", network.ScopePublic))
+	err = machine.SetProviderAddresses(network.NewSpaceAddress("abc", network.WithScope(network.ScopePublic)))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Set same machine eclipsed by provider addresses: not reported.
-	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("abc", network.ScopeCloudLocal))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("abc", network.WithScope(network.ScopeCloudLocal)))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -2841,7 +2841,7 @@ func (s *MachineSuite) TestWatchAddresses(c *gc.C) {
 	wc.AssertOneChange()
 
 	// Set different provider addresses: reported.
-	err = machine.SetMachineAddresses(network.NewScopedSpaceAddress("def", network.ScopePublic))
+	err = machine.SetMachineAddresses(network.NewSpaceAddress("def", network.WithScope(network.ScopePublic)))
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -487,7 +487,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, st *state.Stat
 		c.Assert(err, jc.ErrorIsNil)
 		err = caasModel.SetPodSpec(nil, application.ApplicationTag(), strPtr("pod spec"))
 		c.Assert(err, jc.ErrorIsNil)
-		addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
+		addr := network.NewSpaceAddress("192.168.1.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal))
 		err = application.UpdateCloudService("provider-id", []network.SpaceAddress{addr})
 		c.Assert(err, jc.ErrorIsNil)
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2034,6 +2034,7 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 		ProviderSubnetID:  addr.ProviderSubnetID(),
 		Origin:            network.Origin(addr.Origin()),
 		IsShadow:          addr.IsShadow(),
+		IsSecondary:       addr.IsSecondary(),
 	}
 
 	ops := []txn.Op{{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -754,7 +754,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = caasModel.SetPodSpec(nil, application.ApplicationTag(), strPtr("pod spec"))
 	c.Assert(err, jc.ErrorIsNil)
-	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
+	addr := network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeCloudLocal))
 	addr.SpaceID = "0"
 	err = application.UpdateCloudService("provider-id", []network.SpaceAddress{addr})
 	c.Assert(err, jc.ErrorIsNil)
@@ -830,7 +830,7 @@ func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = caasModel.SetPodSpec(nil, application.ApplicationTag(), strPtr("pod spec"))
 	c.Assert(err, jc.ErrorIsNil)
-	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal)
+	addr := network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeCloudLocal))
 	err = application.UpdateCloudService("provider-id", []network.SpaceAddress{addr})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1212,7 +1212,7 @@ func (s *MigrationImportSuite) assertUnitsMigrated(c *gc.C, st *state.State, con
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(containerInfo.ProviderId(), gc.Equals, "provider-id")
 		c.Assert(containerInfo.Ports(), jc.DeepEquals, []string{"80"})
-		addr := network.NewScopedSpaceAddress("192.168.1.2", network.ScopeMachineLocal)
+		addr := network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeMachineLocal))
 		addr.SpaceID = "0"
 		c.Assert(containerInfo.Address(), jc.DeepEquals, &addr)
 	}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -689,6 +689,7 @@ func (s *MigrationSuite) TestIPAddressDocFields(c *gc.C) {
 		"Value",
 		"Origin",
 		"IsShadow",
+		"IsSecondary",
 	)
 	s.AssertExportedFields(c, ipAddressDoc{}, migrated.Union(ignored))
 }

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -1176,9 +1176,9 @@ func (s *WatchRelationUnitsSuite) TestPeer(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		machine, err := s.State.Machine(mId)
 		c.Assert(err, jc.ErrorIsNil)
-		privateAddr := network.NewScopedSpaceAddress(
+		privateAddr := network.NewSpaceAddress(
 			fmt.Sprintf("riak%d.example.com", i),
-			network.ScopeCloudLocal,
+			network.WithScope(network.ScopeCloudLocal),
 		)
 		err = machine.SetProviderAddresses(privateAddr)
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -775,10 +775,10 @@ func (s *StateSuite) TestAddresses(c *gc.C) {
 
 	for i, m := range machines {
 		err := m.SetProviderAddresses(
-			network.NewScopedSpaceAddress(fmt.Sprintf("10.0.0.%d", i), network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("::1", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("127.0.0.1", network.ScopeMachineLocal),
-			network.NewScopedSpaceAddress("5.4.3.2", network.ScopePublic),
+			network.NewSpaceAddress(fmt.Sprintf("10.0.0.%d", i), network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("::1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeMachineLocal)),
+			network.NewSpaceAddress("5.4.3.2", network.WithScope(network.ScopePublic)),
 		)
 		c.Assert(err, jc.ErrorIsNil)
 	}
@@ -4064,13 +4064,13 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 	c.Assert(addrs, gc.HasLen, 0)
 
 	newHostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}, {
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.8.16", network.ScopePublic),
+		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
 	}}, {{
-		SpaceAddress: network.NewScopedSpaceAddress("0.6.1.2", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.6.1.2", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      5,
 	}}}
 	err = s.State.SetAPIHostPorts(newHostPorts)
@@ -4086,7 +4086,7 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 	c.Assert(gotHostPorts, jc.DeepEquals, newHostPorts)
 
 	newHostPorts = []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      13,
 	}}}
 	err = s.State.SetAPIHostPorts(newHostPorts)
@@ -4103,10 +4103,10 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpace(c *gc.C) {
 
 func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 	hostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.8.16", network.ScopePublic),
+		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
 	}}, {{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}
 
@@ -4143,11 +4143,11 @@ func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentSame(c *gc.C) {
 
 func (s *StateSuite) TestSetAPIHostPortsNoMgmtSpaceConcurrentDifferent(c *gc.C) {
 	hostPorts0 := network.SpaceHostPorts{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.4.8.16", network.ScopePublic),
+		SpaceAddress: network.NewSpaceAddress("0.4.8.16", network.WithScope(network.ScopePublic)),
 		NetPort:      2,
 	}}
 	hostPorts1 := network.SpaceHostPorts{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}
 
@@ -4202,7 +4202,7 @@ func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 	c.Assert(addrs, gc.HasLen, 0)
 
 	hostPort1 := network.SpaceHostPort{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}
 	hostPort2 := network.SpaceHostPort{
@@ -4217,7 +4217,7 @@ func (s *StateSuite) TestSetAPIHostPortsWithMgmtSpace(c *gc.C) {
 		NetPort: 2,
 	}
 	hostPort3 := network.SpaceHostPort{
-		SpaceAddress: network.NewScopedSpaceAddress("0.6.1.2", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.6.1.2", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      5,
 	}
 	newHostPorts := []network.SpaceHostPorts{{hostPort1, hostPort2}, {hostPort3}}
@@ -4243,7 +4243,7 @@ func (s *StateSuite) TestSetAPIHostPortsForAgentsNoDocument(c *gc.C) {
 	c.Assert(addrs, gc.HasLen, 0)
 
 	newHostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}
 
@@ -4269,7 +4269,7 @@ func (s *StateSuite) TestAPIHostPortsForAgentsNoDocument(c *gc.C) {
 	c.Assert(addrs, gc.HasLen, 0)
 
 	newHostPorts := []network.SpaceHostPorts{{{
-		SpaceAddress: network.NewScopedSpaceAddress("0.2.4.6", network.ScopeCloudLocal),
+		SpaceAddress: network.NewSpaceAddress("0.2.4.6", network.WithScope(network.ScopeCloudLocal)),
 		NetPort:      1,
 	}}}
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -375,7 +375,7 @@ func (op *UpdateUnitOperation) Build(attempt int) ([]txn.Op, error) {
 		containerInfo.ProviderId = newProviderId
 	}
 	if op.props.Address != nil {
-		networkAddr := network.NewScopedSpaceAddress(*op.props.Address, network.ScopeMachineLocal)
+		networkAddr := network.NewSpaceAddress(*op.props.Address, network.WithScope(network.ScopeMachineLocal))
 		addr := fromNetworkAddress(networkAddr, network.OriginProvider)
 		containerInfo.Address = &addr
 	}

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -796,8 +796,8 @@ func (s *UnitSuite) setAssignedMachineAddresses(c *gc.C, u *state.Unit) {
 	err = machine.SetProvisioned("i-exist", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("private.address.example.com", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("public.address.example.com", network.ScopePublic),
+		network.NewSpaceAddress("private.address.example.com", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("public.address.example.com", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -828,8 +828,8 @@ func (s *UnitSuite) TestPublicAddress(c *gc.C) {
 	_, err = s.unit.PublicAddress()
 	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
-	public := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
-	private := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
+	public := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
+	private := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -885,8 +885,8 @@ func (s *UnitSuite) TestPublicAddressMachineAddresses(c *gc.C) {
 	err = s.unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
-	publicProvider := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
-	privateProvider := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
+	publicProvider := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
+	privateProvider := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 	privateMachine := network.NewSpaceAddress("127.0.0.2")
 
 	err = machine.SetProviderAddresses(privateProvider)
@@ -923,8 +923,8 @@ func (s *UnitSuite) TestPrivateAddress(c *gc.C) {
 	_, err = s.unit.PrivateAddress()
 	c.Assert(err, jc.Satisfies, network.IsNoAddressError)
 
-	public := network.NewScopedSpaceAddress("8.8.8.8", network.ScopePublic)
-	private := network.NewScopedSpaceAddress("127.0.0.1", network.ScopeCloudLocal)
+	public := network.NewSpaceAddress("8.8.8.8", network.WithScope(network.ScopePublic))
+	private := network.NewSpaceAddress("127.0.0.1", network.WithScope(network.ScopeCloudLocal))
 
 	err = machine.SetProviderAddresses(public, private)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2816,7 +2816,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitProviderId(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
-	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal)
+	addr := network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeMachineLocal))
 	c.Assert(info.Address(), gc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
@@ -2839,7 +2839,8 @@ func (s *CAASUnitSuite) TestAddCAASUnitProviderId(c *gc.C) {
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "another-uuid")
 	c.Check(info.Address(), gc.NotNil)
-	c.Check(*info.Address(), jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal))
+	c.Check(*info.Address(), jc.DeepEquals,
+		network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeMachineLocal)))
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
 
@@ -2861,7 +2862,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	addr := network.NewScopedSpaceAddress("192.168.1.2", network.ScopeMachineLocal)
+	addr := network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeMachineLocal))
 	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"80"})
 }
@@ -2884,7 +2885,7 @@ func (s *CAASUnitSuite) TestUpdateCAASUnitPorts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Unit(), gc.Equals, existingUnit.Name())
 	c.Assert(info.ProviderId(), gc.Equals, "unit-uuid")
-	addr := network.NewScopedSpaceAddress("192.168.1.1", network.ScopeMachineLocal)
+	addr := network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeMachineLocal))
 	c.Assert(info.Address(), jc.DeepEquals, &addr)
 	c.Assert(info.Ports(), jc.DeepEquals, []string{"443"})
 }
@@ -2906,36 +2907,36 @@ func (s *CAASUnitSuite) TestPrivateAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.application.UpdateCloudService("", network.SpaceAddresses{
-		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := existingUnit.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal))
+	c.Assert(addr, jc.DeepEquals, network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)))
 }
 
 func (s *CAASUnitSuite) TestPublicAddress(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.application.UpdateCloudService("", []network.SpaceAddress{
-		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	addr, err := existingUnit.PublicAddress()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(addr, jc.DeepEquals, network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic))
+	c.Assert(addr, jc.DeepEquals, network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)))
 }
 
 func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 	existingUnit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.application.UpdateCloudService("", []network.SpaceAddress{
-		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2951,9 +2952,9 @@ func (s *CAASUnitSuite) TestAllAddresses(c *gc.C) {
 	addrs, err := existingUnit.AllAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addrs, jc.DeepEquals, network.SpaceAddresses{
-		network.NewScopedSpaceAddress("192.168.1.2", network.ScopeCloudLocal),
-		network.NewScopedSpaceAddress("54.32.1.2", network.ScopePublic),
-		network.NewScopedSpaceAddress("10.0.0.1", network.ScopeMachineLocal),
+		network.NewSpaceAddress("192.168.1.2", network.WithScope(network.ScopeCloudLocal)),
+		network.NewSpaceAddress("54.32.1.2", network.WithScope(network.ScopePublic)),
+		network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeMachineLocal)),
 	})
 }
 

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -88,8 +88,8 @@ type mockAPIHostGetter struct{}
 
 func (g *mockAPIHostGetter) APIHostPortsForClients() ([]network.SpaceHostPorts, error) {
 	return []network.SpaceHostPorts{{
-		{SpaceAddress: network.NewScopedSpaceAddress("192.168.1.1", network.ScopeCloudLocal), NetPort: 17070},
-		{SpaceAddress: network.NewScopedSpaceAddress("10.1.1.1", network.ScopeMachineLocal), NetPort: 17070},
+		{SpaceAddress: network.NewSpaceAddress("192.168.1.1", network.WithScope(network.ScopeCloudLocal)), NetPort: 17070},
+		{SpaceAddress: network.NewSpaceAddress("10.1.1.1", network.WithScope(network.ScopeMachineLocal)), NetPort: 17070},
 	}}, nil
 }
 

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -36,8 +36,10 @@ var (
 	_ = gc.Suite(&workerSuite{})
 
 	testAddrs = network.ProviderAddresses{
-		network.NewScopedProviderAddressWithNetwork("10.0.0.1", "10.0.0.0/24", network.ScopeCloudLocal),
-		network.NewScopedProviderAddressWithNetwork("1.1.1.42", "1.1.1.0/24", network.ScopePublic),
+		network.NewProviderAddress(
+			"10.0.0.1", network.WithCIDR("10.0.0.0/24"), network.WithScope(network.ScopeCloudLocal)),
+		network.NewProviderAddress(
+			"1.1.1.42", network.WithCIDR("1.1.1.0/24"), network.WithScope(network.ScopePublic)),
 	}
 
 	testNetIfs = network.InterfaceInfos{
@@ -47,10 +49,12 @@ var (
 			MACAddress:    "de:ad:be:ef:00:00",
 			CIDR:          "10.0.0.0/24",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddressWithNetwork("10.0.0.1", "10.0.0.0/24", network.ScopeCloudLocal),
+				network.NewProviderAddress(
+					"10.0.0.1", network.WithCIDR("10.0.0.0/24"), network.WithScope(network.ScopeCloudLocal)),
 			},
 			ShadowAddresses: network.ProviderAddresses{
-				network.NewScopedProviderAddressWithNetwork("1.1.1.42", "1.1.1.0/24", network.ScopePublic),
+				network.NewProviderAddress(
+					"1.1.1.42", network.WithCIDR("1.1.1.0/24"), network.WithScope(network.ScopePublic)),
 			},
 		},
 	}
@@ -60,14 +64,16 @@ var (
 			DeviceIndex: 0,
 			CIDR:        "10.0.0.0/24",
 			Addresses: network.ProviderAddresses{
-				network.NewScopedProviderAddressWithNetwork("10.0.0.1", "10.0.0.0/24", network.ScopeCloudLocal),
+				network.NewProviderAddress(
+					"10.0.0.1", network.WithCIDR("10.0.0.0/24"), network.WithScope(network.ScopeCloudLocal)),
 			},
 		},
 		{
 			DeviceIndex: 1,
 			CIDR:        "1.1.1.0/24",
 			ShadowAddresses: network.ProviderAddresses{
-				network.NewScopedProviderAddressWithNetwork("1.1.1.42", "1.1.1.0/24", network.ScopePublic),
+				network.NewProviderAddress(
+					"1.1.1.42", network.WithCIDR("1.1.1.0/24"), network.WithScope(network.ScopePublic)),
 			},
 		},
 	}

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -366,9 +366,9 @@ LXC_BRIDGE="ignored"`[1:])
 	mr := s.makeMachiner(c, false)
 	c.Assert(stopWorker(mr), jc.ErrorIsNil)
 	s.accessor.machine.CheckCall(c, 1, "SetMachineAddresses", []corenetwork.MachineAddress{
-		corenetwork.NewScopedMachineAddress("10.0.0.1", corenetwork.ScopeCloudLocal),
-		corenetwork.NewScopedMachineAddress("127.0.0.1", corenetwork.ScopeMachineLocal),
-		corenetwork.NewScopedMachineAddress("::1", corenetwork.ScopeMachineLocal),
+		corenetwork.NewMachineAddress("10.0.0.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
+		corenetwork.NewMachineAddress("127.0.0.1", corenetwork.WithScope(corenetwork.ScopeMachineLocal)),
+		corenetwork.NewMachineAddress("::1", corenetwork.WithScope(corenetwork.ScopeMachineLocal)),
 		corenetwork.NewMachineAddress("2001:db8::1"),
 	})
 }

--- a/worker/peergrouper/controllertracker_test.go
+++ b/worker/peergrouper/controllertracker_test.go
@@ -26,9 +26,9 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddre
 
 	m := &controllerTracker{
 		addresses: []network.SpaceAddress{
-			network.NewScopedSpaceAddress("192.168.5.5", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("192.168.10.5", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("localhost", network.ScopeMachineLocal),
+			network.NewSpaceAddress("192.168.5.5", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("192.168.10.5", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("localhost", network.WithScope(network.ScopeMachineLocal)),
 		},
 	}
 	m.addresses[0].SpaceID = space.ID
@@ -41,8 +41,9 @@ func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceReturnsCorrectAddre
 
 func (s *machineTrackerSuite) TestSelectMongoAddressFromSpaceEmptyWhenNoAddressFound(c *gc.C) {
 	m := &controllerTracker{
-		id:        "3",
-		addresses: []network.SpaceAddress{network.NewScopedSpaceAddress("localhost", network.ScopeMachineLocal)},
+		id: "3",
+		addresses: []network.SpaceAddress{
+			network.NewSpaceAddress("localhost", network.WithScope(network.ScopeMachineLocal))},
 	}
 
 	addrs, err := m.SelectMongoAddressFromSpace(666, network.SpaceInfo{ID: "whatever", Name: "bad-space"})
@@ -63,9 +64,9 @@ func (s *machineTrackerSuite) TestGetPotentialMongoHostPortsReturnsAllAddresses(
 	m := &controllerTracker{
 		id: "3",
 		addresses: []network.SpaceAddress{
-			network.NewScopedSpaceAddress("192.168.5.5", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("10.0.0.1", network.ScopeCloudLocal),
-			network.NewScopedSpaceAddress("185.159.16.82", network.ScopePublic),
+			network.NewSpaceAddress("192.168.5.5", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)),
+			network.NewSpaceAddress("185.159.16.82", network.WithScope(network.ScopePublic)),
 		},
 	}
 

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -688,7 +688,8 @@ func haSpaceTestCommonSetup(c *gc.C, ipVersion TestIPVersion, members string) *f
 		// ...
 		addrs := make(network.SpaceAddresses, 3)
 		for i, name := range spaces {
-			addr := network.NewScopedSpaceAddress(fmt.Sprintf(ipVersion.formatHost, i*10+id), network.ScopeCloudLocal)
+			addr := network.NewSpaceAddress(
+				fmt.Sprintf(ipVersion.formatHost, i*10+id), network.WithScope(network.ScopeCloudLocal))
 			addr.SpaceID = name
 			addrs[i] = addr
 		}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -222,7 +222,7 @@ func (s *InterfaceSuite) TestUnitCaching(c *gc.C) {
 
 	// Change remote state.
 	err = s.machine.SetProviderAddresses(
-		network.NewScopedSpaceAddress("blah.testing.invalid", network.ScopePublic),
+		network.NewSpaceAddress("blah.testing.invalid", network.WithScope(network.ScopePublic)),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -158,7 +158,7 @@ func (s *HookContextSuite) addUnit(c *gc.C, app *state.Application) *state.Unit 
 func (s *HookContextSuite) AddUnit(c *gc.C, app *state.Application) *state.Unit {
 	unit := s.addUnit(c, app)
 	name := strings.Replace(unit.Name(), "/", "-", 1)
-	privateAddr := network.NewScopedSpaceAddress(name+".testing.invalid", network.ScopeCloudLocal)
+	privateAddr := network.NewSpaceAddress(name+".testing.invalid", network.WithScope(network.ScopeCloudLocal))
 	err := s.machine.SetProviderAddresses(privateAddr)
 	c.Assert(err, jc.ErrorIsNil)
 	return unit

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -164,7 +164,7 @@ func (s *ContextSuite) AddUnit(c *gc.C, svc *state.Application) *state.Unit {
 	c.Assert(err, jc.ErrorIsNil)
 
 	name := strings.Replace(unit.Name(), "/", "-", 1)
-	privateAddr := network.NewScopedSpaceAddress(name+".testing.invalid", network.ScopeCloudLocal)
+	privateAddr := network.NewSpaceAddress(name+".testing.invalid", network.WithScope(network.ScopeCloudLocal))
 	err = s.machine.SetProviderAddresses(privateAddr)
 	c.Assert(err, jc.ErrorIsNil)
 	return unit

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -60,8 +60,8 @@ var (
 	// These addresses must always be IPs. If not, the facade code
 	// (NetworksForRelation in particular) will attempt to resolve them and
 	// cause the uniter tests to fail with an "unknown host" error.
-	dummyPrivateAddress = network.NewScopedSpaceAddress("172.0.30.1", network.ScopeCloudLocal)
-	dummyPublicAddress  = network.NewScopedSpaceAddress("1.1.1.1", network.ScopePublic)
+	dummyPrivateAddress = network.NewSpaceAddress("172.0.30.1", network.WithScope(network.ScopeCloudLocal))
+	dummyPublicAddress  = network.NewSpaceAddress("1.1.1.1", network.WithScope(network.ScopePublic))
 )
 
 // worstCase is used for timeouts when timing out


### PR DESCRIPTION
Merge from 2.9 to bring forward the following patches:
- #12663 from manadart/2.9-address-options
- #12661 from manadart/2.9-add-is-secondary
- #12636 from wallyworld/addk8s-existing
- #12643 from SimonRichardson/charmhub-status-fixes
- #12656 from benhoyt/run-pebble-as-root

Only conflict was the updated version of `juju/description`, which is further ahead on the develop branch.