### PR TITLE
Add IsSecondary to core/network addresses and factor into sort order

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -747,11 +747,11 @@ func scopeMatchHierarchy() []ScopeMatch {
 	}
 }
 
-type addressesPreferringIPv4Slice []SpaceAddress
+type addressesPreferringIPv4 []SpaceAddress
 
-func (a addressesPreferringIPv4Slice) Len() int      { return len(a) }
-func (a addressesPreferringIPv4Slice) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a addressesPreferringIPv4Slice) Less(i, j int) bool {
+func (a addressesPreferringIPv4) Len() int      { return len(a) }
+func (a addressesPreferringIPv4) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a addressesPreferringIPv4) Less(i, j int) bool {
 	addr1 := a[i]
 	addr2 := a[j]
 	order1 := addr1.sortOrder()
@@ -765,7 +765,7 @@ func (a addressesPreferringIPv4Slice) Less(i, j int) bool {
 // SortAddresses sorts the given Address slice according to the sortOrder of
 // each address. See Address.sortOrder() for more info.
 func SortAddresses(addrs []SpaceAddress) {
-	sort.Sort(addressesPreferringIPv4Slice(addrs))
+	sort.Sort(addressesPreferringIPv4(addrs))
 }
 
 // MergedAddresses provides a single list of addresses without duplicates

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -219,30 +219,30 @@ func (a MachineAddress) ValueForCIDR(cidr string) (string, error) {
 // Secondary addresses with otherwise equal weight will be sorted to come after
 // primary addresses, including host names *except* localhost.
 func (a MachineAddress) sortOrder() int {
-	order := 0xFF
+	order := 100
 
 	switch a.Scope {
 	case ScopePublic:
-		order = 0x00
+		order = 0
 		// Special case to ensure that these follow non-localhost host names.
 		if a.IsSecondary {
-			order = 0x10
+			order = 10
 		}
 	case ScopeCloudLocal:
-		order = 0x30
+		order = 30
 	case ScopeFanLocal:
-		order = 0x50
+		order = 50
 	case ScopeMachineLocal:
-		order = 0x80
+		order = 70
 	case ScopeLinkLocal:
-		order = 0xA0
+		order = 90
 	}
 
 	switch a.Type {
 	case HostName:
-		order = 0x10
+		order = 10
 		if a.Value == "localhost" {
-			order = 0x20
+			order = 20
 		}
 	case IPv6Address:
 		order++

--- a/core/network/address_options.go
+++ b/core/network/address_options.go
@@ -10,6 +10,10 @@ type AddressMutator interface {
 
 	// SetCIDR sets the CIDR property of the address.
 	SetCIDR(string)
+
+	// SetSecondary indicates that this address is not the
+	// primary address of the device it is associated with.
+	SetSecondary()
 }
 
 // SetScope (AddressMutator) sets the input
@@ -22,6 +26,12 @@ func (a *MachineAddress) SetScope(scope Scope) {
 // CIDR on the address receiver.
 func (a *MachineAddress) SetCIDR(cidr string) {
 	a.CIDR = cidr
+}
+
+// SetSecondary (AddressMutator) sets the IsSecondary
+// member to true on the address receiver.
+func (a *MachineAddress) SetSecondary() {
+	a.IsSecondary = true
 }
 
 // WithScope returns a functional option that can
@@ -37,5 +47,13 @@ func WithScope(scope Scope) func(AddressMutator) {
 func WithCIDR(cidr string) func(AddressMutator) {
 	return func(a AddressMutator) {
 		a.SetCIDR(cidr)
+	}
+}
+
+// WithSecondary returns a functional option that can be used to
+// indicate that an address is not the primary for its NIC.
+func WithSecondary() func(mutator AddressMutator) {
+	return func(a AddressMutator) {
+		a.SetSecondary()
 	}
 }

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -695,24 +695,34 @@ func (*AddressSuite) TestSortAddresses(c *gc.C) {
 		"2001:db8::1",
 		"fe80::2",
 		"7.8.8.8",
-		"172.16.0.1",
+		"172.16.0.2",
 		"example.com",
 		"8.8.8.8",
 	)
+
+	// Public and local-cloud secondary addresses.
+	addrs = append(addrs, network.NewSpaceAddress("6.8.8.8", network.WithSecondary()))
+	addrs = append(addrs, network.NewSpaceAddress("172.16.0.1", network.WithSecondary()))
+
 	network.SortAddresses(addrs)
-	c.Assert(addrs, jc.DeepEquals, network.NewSpaceAddresses(
+	c.Assert(addrs.Values(), jc.DeepEquals, []string{
 		// Public IPv4 addresses on top.
 		"7.8.8.8",
 		"8.8.8.8",
 		// After that public IPv6 addresses.
 		"2001:db8::1",
-		// Then hostnames.
+		// Then hostname.
 		"example.com",
+		// Secondary public address follows the others.
+		"6.8.8.8",
+		// With localhost last.
 		"localhost",
 		// Then IPv4 cloud-local addresses.
-		"172.16.0.1",
+		"172.16.0.2",
 		// Then IPv6 cloud-local addresses.
 		"fc00::1",
+		// Then secondary cloud-local addresses.
+		"172.16.0.1",
 		// Then fan-local addresses.
 		"243.5.1.2",
 		// Then machine-local IPv4 addresses.
@@ -723,7 +733,7 @@ func (*AddressSuite) TestSortAddresses(c *gc.C) {
 		"169.254.1.2",
 		// Finally, link-local IPv6 addresses.
 		"fe80::2",
-	))
+	})
 }
 
 func (*AddressSuite) TestExactScopeMatch(c *gc.C) {

--- a/core/network/hostport.go
+++ b/core/network/hostport.go
@@ -365,18 +365,18 @@ func SpaceAddressesWithPort(addrs SpaceAddresses, port int) SpaceHostPorts {
 	return hps
 }
 
-type hostPortsPreferringIPv4Slice []SpaceHostPort
+type hostPortsPreferringIPv4 []SpaceHostPort
 
-func (hp hostPortsPreferringIPv4Slice) Len() int      { return len(hp) }
-func (hp hostPortsPreferringIPv4Slice) Swap(i, j int) { hp[i], hp[j] = hp[j], hp[i] }
-func (hp hostPortsPreferringIPv4Slice) Less(i, j int) bool {
+func (hp hostPortsPreferringIPv4) Len() int      { return len(hp) }
+func (hp hostPortsPreferringIPv4) Swap(i, j int) { hp[i], hp[j] = hp[j], hp[i] }
+func (hp hostPortsPreferringIPv4) Less(i, j int) bool {
 	return hp[i].Less(hp[j])
 }
 
 // SortHostPorts sorts the given SpaceHostPort slice according to the sortOrder of
 // each SpaceHostPort's embedded Address. See Address.sortOrder() for more info.
 func SortHostPorts(hps []SpaceHostPort) {
-	sort.Sort(hostPortsPreferringIPv4Slice(hps))
+	sort.Sort(hostPortsPreferringIPv4(hps))
 }
 
 // APIHostPortsToNoProxyString converts list of lists of NetAddrs() to


### PR DESCRIPTION
Adds `IsSecondary` to `MachineAddress` in _core/network_, with new constructor option to set it.

This new property is factored into address sorting, coming after all
other addresses with same scope except _localhost_.

## QA steps

Unit tests verify the change. QA will accompany future changes that set the value and factor it into `network-get` results.

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1863916
