### PR TITLE
Allow for SSH options to be overridden when bootstrapping. Needed for specific use cases

### DIFF
--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/tools"
+	"github.com/juju/utils/v2/ssh"
 )
 
 // BootstrapParams holds the parameters for bootstrapping an environment.
@@ -42,6 +43,10 @@ type BootstrapParams struct {
 	// are used to choose the initial instance. BootstrapConstraints
 	// will not be stored in state for the environment.
 	BootstrapConstraints constraints.Value
+
+	// BootstrapSSHOptions may be specified to provide custom SSH
+	// connection settings when attempting to bootstrap the controller.
+	BootstrapSSHOptions InstanceSSHOptionsFunc
 
 	// StoragePools is one or more named storage pools to create
 	// in the controller model.
@@ -79,6 +84,12 @@ type BootstrapParams struct {
 	// Force is used to allow a bootstrap to be run on unsupported series.
 	Force bool
 }
+
+// InstanceSSHOptionsFunc is a function that given an instance config, returns
+// a HostSSHOptionsFunc that can generate SSH options for accessing an instance.
+type InstanceSSHOptionsFunc func(*instancecfg.InstanceConfig) SSHOptionsFunc
+
+type SSHOptionsFunc func(host string) (*ssh.Options, func(), error)
 
 // CloudBootstrapFinalizer is a function returned from Environ.Bootstrap.
 // The caller must pass a InstanceConfig with the Tools field set.

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -89,6 +89,7 @@ type BootstrapParams struct {
 // a HostSSHOptionsFunc that can generate SSH options for accessing an instance.
 type InstanceSSHOptionsFunc func(*instancecfg.InstanceConfig) SSHOptionsFunc
 
+// SSHOptionsFunc generates SSH options for accessing an instance.
 type SSHOptionsFunc func(host string) (*ssh.Options, func(), error)
 
 // CloudBootstrapFinalizer is a function returned from Environ.Bootstrap.

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,8 @@ github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4Rq
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd h1:JdtityihAc6A+gVfYh6vGXfZQg+XOLyBvla/7NbXFCg=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -785,7 +783,6 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1017,7 +1014,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b h1:tdSyAzD5FHJmZAZ13d5WexAo7YJkiyGphhzFfInMnDw=
 gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b/go.mod h1:cE0dCGx2UfBTjLFlzEx4EXJUmoX6BXBoX9GjKOvqha4=

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,10 @@ github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4Rq
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd h1:JdtityihAc6A+gVfYh6vGXfZQg+XOLyBvla/7NbXFCg=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -783,6 +785,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1014,6 +1017,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b h1:tdSyAzD5FHJmZAZ13d5WexAo7YJkiyGphhzFfInMnDw=
 gopkg.in/amz.v3 v3.0.0-20201001071545-24fc1eceb27b/go.mod h1:cE0dCGx2UfBTjLFlzEx4EXJUmoX6BXBoX9GjKOvqha4=

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -316,7 +316,16 @@ func BootstrapInstance(
 			return err
 		}
 		maybeSetBridge(icfg)
-		return FinishBootstrap(ctx, client, env, callCtx, result.Instance, icfg, opts)
+
+		var hostSSHOptions HostSSHOptionsFunc
+		if args.BootstrapSSHOptions != nil {
+			hostSSHOptions = HostSSHOptionsFunc(args.BootstrapSSHOptions(icfg))
+		} else {
+			hostSSHOptions = func(host string) (*ssh.Options, func(), error) {
+				return BootstrapSSHOptionsFunc(host, instanceConfig)
+			}
+		}
+		return FinishBootstrap(ctx, client, hostSSHOptions, env, callCtx, result.Instance, icfg, opts)
 	}
 	return result, selectedSeries, finalizer, nil
 }
@@ -384,6 +393,7 @@ func formatMemory(m uint64) string {
 var FinishBootstrap = func(
 	ctx environs.BootstrapContext,
 	client ssh.Client,
+	hostSSHOptions HostSSHOptionsFunc,
 	env environs.Environ,
 	callCtx envcontext.ProviderCallContext,
 	inst instances.Instance,
@@ -394,7 +404,6 @@ var FinishBootstrap = func(
 	ctx.InterruptNotify(interrupted)
 	defer ctx.StopInterruptNotify(interrupted)
 
-	hostSSHOptions := bootstrapSSHOptionsFunc(instanceConfig)
 	addr, err := WaitSSH(
 		ctx.Context(),
 		ctx.GetStderr(),
@@ -500,18 +509,9 @@ func DefaultHostSSHOptions(host string) (*ssh.Options, func(), error) {
 	return nil, func() {}, nil
 }
 
-// bootstrapSSHOptionsFunc that takes a bootstrap machine's InstanceConfig
+// BootstrapSSHOptionsFunc that takes a bootstrap machine's InstanceConfig
 // and returns a HostSSHOptionsFunc.
-func bootstrapSSHOptionsFunc(instanceConfig *instancecfg.InstanceConfig) HostSSHOptionsFunc {
-	return func(host string) (*ssh.Options, func(), error) {
-		return hostBootstrapSSHOptions(host, instanceConfig)
-	}
-}
-
-func hostBootstrapSSHOptions(
-	host string,
-	instanceConfig *instancecfg.InstanceConfig,
-) (_ *ssh.Options, cleanup func(), err error) {
+func BootstrapSSHOptionsFunc(host string, instanceConfig *instancecfg.InstanceConfig) (_ *ssh.Options, cleanup func(), err error) {
 	cleanup = func() {}
 	defer func() {
 		if err != nil {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -412,6 +412,7 @@ func (s *localServerSuite) assertAddressesWithPublicIP(c *gc.C, cons constraints
 	s.PatchValue(&common.FinishBootstrap, func(
 		ctx environs.BootstrapContext,
 		client ssh.Client,
+		sshOptionsFunc common.HostSSHOptionsFunc,
 		env environs.Environ,
 		callCtx context.ProviderCallContext,
 		inst instances.Instance,
@@ -453,6 +454,7 @@ func (s *localServerSuite) assertAddressesWithoutPublicIP(c *gc.C, cons constrai
 	s.PatchValue(&common.FinishBootstrap, func(
 		ctx environs.BootstrapContext,
 		client ssh.Client,
+		sshOptionsFunc common.HostSSHOptionsFunc,
 		env environs.Environ,
 		callCtx context.ProviderCallContext,
 		inst instances.Instance,


### PR DESCRIPTION
This PR allow for SSH options to be passed to bootstrap. This is needed for specific provider requirements where it is needed to pass `ssh.StrictHostChecksNo`

//CC @achilleasa 
Signed-off-by: root <jasmin.gacic@gmail.com>


