### PR TITLE
ResolveWithPreferredChannel must copy origin ID and Hash.

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -151,6 +151,8 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 	// chRepro FindDownloadURL.
 	resOrigin := params.CharmOrigin{
 		Source:       origin.Source,
+		ID:           origin.ID,
+		Hash:         origin.Hash,
 		Type:         string(entity.Type),
 		Track:        track,
 		Risk:         string(channel.Risk),


### PR DESCRIPTION
ResolveWithPreferredChannel must copy origin ID and Hash from the provide origin. Otherwise refresh of a charm with resources will fail and we keep calling refresh/install instead of refresh/refresh for the rest.

Fix the tests intended to catch this scenario, to do what they are supposed to.

## QA steps

```console
$ juju bootstrap localhost testme
$ juju add-model seven --config charmhub-url="https://api.staging.charmhub.io"
$ juju deploy ubuntu-juju-qa --channel 2.0/edge 
$ juju refresh ubuntu-juju-qa --channel 2.0/stable
```

