### PR TITLE
juju download: fix tests and improve error message

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -34,7 +34,7 @@ run_unknown_download() {
     ensure "test-${name}" "${file}"
 
     output=$(juju download meshuggah 2>&1 || echo "not found")
-    check_contains "${output}" "No charm or bundle with name"
+    check_contains "${output}" "The Charm with the given name was not found in the Store"
 }
 
 test_charmhub_download() {

--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,7 +6,7 @@ run_charmhub_download() {
 
     ensure "test-${name}" "${file}"
 
-    output=$(juju download mysql --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
+    output=$(juju download mysql --series xenial --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
     check_contains "${output}" "Fetching charm \"mysql\""
 
     juju deploy "${TEST_DIR}/mysql.charm" mysql


### PR DESCRIPTION
Improve the download failure error message when ErrorCodeRevisionNotFound received with `juju download` to include supported series to facilitate a retry.

Fix broken charmhub download test.

1. Update error message expected.
2. Download mysql with --series for success.

## QA steps

```console
# Verify the test changes
(cd tests ; ./main.sh -v  charmhub test_charmhub_download )
```

```console
# Verify the error message change
$ juju download mysql
ERROR mysql does not support focal in channel stable.  Supported series are precise, trusty, xenial, zesty.

```
