### PR TITLE
Fixes bug of incorrect rbac for model operator.

### DIFF
--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -557,6 +557,17 @@ func ensureModelOperatorRBAC(
 				Resources: []string{"namespaces"},
 				Verbs:     []string{"get"},
 			},
+			{
+				APIGroups: []string{"admissionregistration.k8s.io"},
+				Resources: []string{"mutatingwebhookconfigurations"},
+				Verbs: []string{
+					"create",
+					"delete",
+					"get",
+					"list",
+					"update",
+				},
+			},
 		},
 	}
 
@@ -598,17 +609,6 @@ func ensureModelOperatorRBAC(
 			Labels:    labels,
 		},
 		Rules: []rbac.PolicyRule{
-			{
-				APIGroups: []string{"admissionregistration.k8s.io"},
-				Resources: []string{"mutatingwebhookconfigurations"},
-				Verbs: []string{
-					"create",
-					"delete",
-					"get",
-					"list",
-					"update",
-				},
-			},
 			{
 				APIGroups: []string{""},
 				Resources: []string{"serviceaccounts"},

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -47,6 +47,15 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 			c.Assert(cr.Rules[0].APIGroups, jc.DeepEquals, []string{""})
 			c.Assert(cr.Rules[0].Resources, jc.DeepEquals, []string{"namespaces"})
 			c.Assert(cr.Rules[0].Verbs, jc.DeepEquals, []string{"get"})
+			c.Assert(cr.Rules[1].APIGroups, jc.DeepEquals, []string{"admissionregistration.k8s.io"})
+			c.Assert(cr.Rules[1].Resources, jc.DeepEquals, []string{"mutatingwebhookconfigurations"})
+			c.Assert(cr.Rules[1].Verbs, jc.DeepEquals, []string{
+				"create",
+				"delete",
+				"get",
+				"list",
+				"update",
+			})
 			return nil, nil
 		},
 		ensureClusterRoleBinding: func(crb *rbac.ClusterRoleBinding) ([]func(), error) {
@@ -79,18 +88,9 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 			ensureRoleCalled = true
 			c.Assert(r.Name, gc.Equals, modelOperatorName)
 			c.Assert(r.Namespace, gc.Equals, namespace)
-			c.Assert(r.Rules[0].APIGroups, jc.DeepEquals, []string{"admissionregistration.k8s.io"})
-			c.Assert(r.Rules[0].Resources, jc.DeepEquals, []string{"mutatingwebhookconfigurations"})
+			c.Assert(r.Rules[0].APIGroups, jc.DeepEquals, []string{""})
+			c.Assert(r.Rules[0].Resources, jc.DeepEquals, []string{"serviceaccounts"})
 			c.Assert(r.Rules[0].Verbs, jc.DeepEquals, []string{
-				"create",
-				"delete",
-				"get",
-				"list",
-				"update",
-			})
-			c.Assert(r.Rules[1].APIGroups, jc.DeepEquals, []string{""})
-			c.Assert(r.Rules[1].Resources, jc.DeepEquals, []string{"serviceaccounts"})
-			c.Assert(r.Rules[1].Verbs, jc.DeepEquals, []string{
 				"get",
 				"list",
 				"watch",


### PR DESCRIPTION
Introduced earlier was changes to the RBAC permissions required for the
model operator. This fixes an error where the mutating web hook
permissions where placed on role and not the cluster role

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Follow steps in bug below

## Bug reference

https://bugs.launchpad.net/juju/+bug/1915320
