### PR TITLE
Remove all model security groups on destroy

### DIFF
--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -46,7 +46,15 @@ func AllModelVolumes(e environs.Environ, ctx context.ProviderCallContext) ([]str
 }
 
 func AllModelGroups(e environs.Environ, ctx context.ProviderCallContext) ([]string, error) {
-	return e.(*environ).modelSecurityGroupIDs(ctx)
+	groups, err := e.(*environ).modelSecurityGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+	groupIds := make([]string, len(groups))
+	for i, g := range groups {
+		groupIds[i] = g.Id
+	}
+	return groupIds, nil
 }
 
 var (

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -623,7 +623,7 @@ func (t *localServerSuite) TestDestroyControllerModelDeleteSecurityGroupInsisten
 		return errors.New(msg)
 	})
 	err := env.DestroyController(t.callCtx, t.ControllerUUID)
-	c.Assert(err, gc.ErrorMatches, "destroying managed environs: cannot delete security group .*: "+msg)
+	c.Assert(err, gc.ErrorMatches, "destroying managed models: "+msg)
 }
 
 func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyError(c *gc.C) {
@@ -641,13 +641,13 @@ func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyE
 		return errors.New(msg)
 	})
 	err = hostedEnv.Destroy(t.callCtx)
-	c.Assert(err, gc.ErrorMatches, "cannot delete environment security groups: cannot delete default security group: "+msg)
+	c.Assert(err, gc.ErrorMatches, "cannot delete model security groups: "+msg)
 }
 
 func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *gc.C) {
 	controllerEnv := t.prepareAndBootstrap(c)
 
-	// Create a hosted model environment with an instance and a volume.
+	// Create a hosted model with an instance and a volume.
 	hostedModelUUID := "7e386e08-cba7-44a4-a76e-7c1633584210"
 	t.srv.ec2srv.SetInitialInstanceState(ec2test.Running)
 	cfg, err := controllerEnv.Config().Apply(map[string]interface{}{
@@ -719,7 +719,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 	)
 
 	// Destroy the controller resources. This should destroy the hosted
-	// environment too.
+	// model too.
 	err = controllerEnv.DestroyController(t.callCtx, t.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1914,7 +1914,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	controllerGroups, err := ec2.AllModelGroups(controllerEnv, s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Create a hosted model environment with an instance and a volume.
+	// Create a hosted model with an instance and a volume.
 	hostedModelUUID := "7e386e08-cba7-44a4-a76e-7c1633584210"
 	s.srv.ec2srv.SetInitialInstanceState(ec2test.Running)
 	cfg, err := controllerEnv.Config().Apply(map[string]interface{}{


### PR DESCRIPTION
Earlier version of Juju did not always delete all EC2 security groups when destroying a model.
This has since been fixed, but there's a possibility orphaned security groups can still occur, according to the bug report below.

This PR add 2 enhancements to EC2 to make things more robust:
- on destroy model, query all security groups tagged against the model and delete them (not just the model group, also include any others that may have been orphaned when the corresponding instance was deleted)
- log warnings if an instance is terminated but does not appear in the expected state (this is a possible reason why subsequent deletion of the security group may be skipped)

Also do little error message cleanup to remove some stuttering.

## QA steps

deploy an EC2 model with a few charms
remove an app and verify that the instance security groups are deleted
destroy the model and verify that all model tagged security groups are deleted
destroy the controller and ensure all remaining security groups are deleted

## Bug reference

https://bugs.launchpad.net/juju/+bug/1720571
