### PR TITLE
Merge pull request #12677 from wallyworld/delete-ec2-secgroups

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1519,7 +1519,7 @@ func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	if err != nil {
 		return errors.Trace(err)
 	}
-	groupIds, err := e.modelSecurityGroupIDs(ctx)
+	groups, err := e.modelSecurityGroups(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1527,6 +1527,10 @@ func (e *environ) AdoptResources(ctx context.ProviderCallContext, controllerUUID
 	resourceIds := make([]string, len(instances))
 	for i, instance := range instances {
 		resourceIds[i] = string(instance.Id())
+	}
+	groupIds := make([]string, len(groups))
+	for i, g := range groups {
+		groupIds[i] = g.Id
 	}
 	resourceIds = append(resourceIds, volumeIds...)
 	resourceIds = append(resourceIds, groupIds...)
@@ -1540,7 +1544,7 @@ func (e *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Ins
 	// We want to return everything we find here except for instances that are
 	// "shutting-down" - they are on the way to be terminated - or already "terminated".
 	// From https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
-	return e.allInstancesByState(ctx, "rebooting", "pending", "running", "stopping", "stopped")
+	return e.allInstancesByState(ctx, activeStates.Values()...)
 }
 
 // AllRunningInstances is part of the environs.InstanceBroker interface.
@@ -1660,8 +1664,8 @@ func (e *environ) Destroy(ctx context.ProviderCallContext) error {
 	if err := common.Destroy(e, ctx); err != nil {
 		return errors.Trace(maybeConvertCredentialError(err, ctx))
 	}
-	if err := e.cleanEnvironmentSecurityGroups(ctx); err != nil {
-		return errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot delete environment security groups")
+	if err := e.cleanModelSecurityGroups(ctx); err != nil {
+		return errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot delete model security groups")
 	}
 	return nil
 }
@@ -1671,15 +1675,15 @@ func (e *environ) DestroyController(ctx context.ProviderCallContext, controllerU
 	// In case any hosted environment hasn't been cleaned up yet,
 	// we also attempt to delete their resources when the controller
 	// environment is destroyed.
-	if err := e.destroyControllerManagedEnvirons(ctx, controllerUUID); err != nil {
-		return errors.Annotate(err, "destroying managed environs")
+	if err := e.destroyControllerManagedModels(ctx, controllerUUID); err != nil {
+		return errors.Annotate(err, "destroying managed models")
 	}
 	return e.Destroy(ctx)
 }
 
-// destroyControllerManagedEnvirons destroys all environments managed by this
-// environment's controller.
-func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallContext, controllerUUID string) error {
+// destroyControllerManagedModels destroys all models managed by this
+// model's controller.
+func (e *environ) destroyControllerManagedModels(ctx context.ProviderCallContext, controllerUUID string) error {
 	// Terminate all instances managed by the controller.
 	instIds, err := e.allControllerManagedInstances(ctx, controllerUUID)
 	if err != nil {
@@ -1712,10 +1716,7 @@ func (e *environ) destroyControllerManagedEnvirons(ctx context.ProviderCallConte
 	}
 	for _, g := range groups {
 		if err := deleteSecurityGroupInsistently(e.ec2, ctx, g, clock.WallClock); err != nil {
-			return errors.Annotatef(
-				err, "cannot delete security group %q (%q)",
-				g.Name, g.Id,
-			)
+			return errors.Trace(err)
 		}
 	}
 	return nil
@@ -1905,36 +1906,44 @@ func (e *environ) controllerSecurityGroups(ctx context.ProviderCallContext, cont
 	return groups, nil
 }
 
-func (e *environ) modelSecurityGroupIDs(ctx context.ProviderCallContext) ([]string, error) {
+func (e *environ) modelSecurityGroups(ctx context.ProviderCallContext) ([]amzec2.SecurityGroup, error) {
 	filter := amzec2.NewFilter()
 	e.addModelFilter(filter)
 	resp, err := e.ec2.SecurityGroups(nil, filter)
 	if err != nil {
 		return nil, errors.Annotate(maybeConvertCredentialError(err, ctx), "listing security groups")
 	}
-	groupIDs := make([]string, len(resp.Groups))
+	groups := make([]amzec2.SecurityGroup, len(resp.Groups))
 	for i, info := range resp.Groups {
-		groupIDs[i] = info.Id
+		groups[i] = amzec2.SecurityGroup{Id: info.Id, Name: info.Name}
 	}
-	return groupIDs, nil
+	return groups, nil
 }
 
-// cleanEnvironmentSecurityGroups attempts to delete all security groups owned
-// by the environment.
-func (e *environ) cleanEnvironmentSecurityGroups(ctx context.ProviderCallContext) error {
-	jujuGroup := e.jujuGroupName()
-	g, err := e.groupByName(ctx, jujuGroup)
-	if isNotFoundError(err) {
-		return nil
-	}
+// cleanModelSecurityGroups attempts to delete all security groups owned
+// by the model. These include any security groups belonging to instances
+// in the model which may not have been cleaned up.
+func (e *environ) cleanModelSecurityGroups(ctx context.ProviderCallContext) error {
+	// Delete security groups managed by the model.
+	groups, err := e.modelSecurityGroups(ctx)
 	if err != nil {
-		return errors.Annotatef(err, "cannot retrieve default security group: %q", jujuGroup)
+		return errors.Annotatef(err, "cannot retrieve security groups for model %q", e.uuid())
 	}
-	if err := deleteSecurityGroupInsistently(e.ec2, ctx, g, clock.WallClock); err != nil {
-		return errors.Annotate(err, "cannot delete default security group")
+	for _, g := range groups {
+		logger.Debugf("deleting model security group %q (%q)", g.Name, g.Id)
+		if err := deleteSecurityGroupInsistently(e.ec2, ctx, g, clock.WallClock); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	return nil
 }
+
+var (
+	activeStates = set.NewStrings(
+		"rebooting", "pending", "running", "stopping", "stopped")
+	terminatingStates = set.NewStrings(
+		"shutting-down", "terminated")
+)
 
 func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []instance.Id) error {
 	if len(ids) == 0 {
@@ -1950,9 +1959,15 @@ func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	// TODO (anastasiamac 2016-04-7) instance termination would benefit
 	// from retry with exponential delay just like security groups
 	// in defer. Bug#1567179.
-	var err error
 	for a := shortAttempt.Start(); a.Next(); {
-		_, err = terminateInstancesById(e.ec2, ctx, ids...)
+		resp, err := terminateInstancesById(e.ec2, ctx, ids...)
+		if err == nil {
+			for i, sc := range resp.StateChanges {
+				if !terminatingStates.Contains(sc.CurrentState.Name) {
+					logger.Warningf("instance %d has been terminated but is in state %q", ids[i], sc.CurrentState.Name)
+				}
+			}
+		}
 		if err == nil || ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
 			// This will return either success at terminating all instances (1st condition) or
 			// encountered error as long as it's not NotFound (2nd condition).
@@ -1971,8 +1986,11 @@ func (e *environ) terminateInstances(ctx context.ProviderCallContext, ids []inst
 	// So try each instance individually, ignoring a NotFound error this time.
 	deletedIDs := []instance.Id{}
 	for _, id := range ids {
-		_, err = terminateInstancesById(e.ec2, ctx, id)
+		resp, err := terminateInstancesById(e.ec2, ctx, id)
 		if err == nil {
+			if !terminatingStates.Contains(resp.StateChanges[0].CurrentState.Name) {
+				logger.Warningf("instance %d has been terminated but is in state %q", id, resp.StateChanges[0].CurrentState.Name)
+			}
 			deletedIDs = append(deletedIDs, id)
 		}
 		if err != nil && ec2ErrCode(err) != "InvalidInstanceID.NotFound" {
@@ -2006,7 +2024,7 @@ func (e *environ) deleteSecurityGroupsForInstances(ctx context.ProviderCallConte
 
 	// We only want to attempt deleting security groups for the
 	// instances that have been successfully terminated.
-	securityGroups, err := e.instanceSecurityGroups(ctx, ids, "shutting-down", "terminated")
+	securityGroups, err := e.instanceSecurityGroups(ctx, ids, terminatingStates.Values()...)
 	if err != nil {
 		logger.Errorf("cannot determine security groups to delete: %v", err)
 		return
@@ -2030,7 +2048,7 @@ func (e *environ) deleteSecurityGroupsForInstances(ctx context.ProviderCallConte
 			// In this case, our failure to delete security group is reasonable: it's still in use.
 			// 2. Some security groups may be shared by multiple instances,
 			// for example, global firewalling. We should not delete these.
-			logger.Errorf("provider failure: %v", err)
+			logger.Warningf("%v", err)
 		}
 	}
 }
@@ -2065,7 +2083,7 @@ var deleteSecurityGroupInsistently = func(inst SecurityGroupCleaner, ctx context
 		},
 	})
 	if err != nil {
-		return errors.Annotatef(err, "cannot delete security group %q: consider deleting it manually", group.Name)
+		return errors.Annotatef(err, "cannot delete security group %q (%q): consider deleting it manually", group.Name, group.Id)
 	}
 	return nil
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -53,7 +53,15 @@ func AllModelVolumes(e environs.Environ, ctx context.ProviderCallContext) ([]str
 }
 
 func AllModelGroups(e environs.Environ, ctx context.ProviderCallContext) ([]string, error) {
-	return e.(*environ).modelSecurityGroupIDs(ctx)
+	groups, err := e.(*environ).modelSecurityGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+	groupIds := make([]string, len(groups))
+	for i, g := range groups {
+		groupIds[i] = g.Id
+	}
+	return groupIds, nil
 }
 
 var (

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -628,7 +628,7 @@ func (t *localServerSuite) TestDestroyControllerModelDeleteSecurityGroupInsisten
 		return errors.New(msg)
 	})
 	err := env.DestroyController(t.callCtx, t.ControllerUUID)
-	c.Assert(err, gc.ErrorMatches, "destroying managed environs: cannot delete security group .*: "+msg)
+	c.Assert(err, gc.ErrorMatches, "destroying managed models: "+msg)
 }
 
 func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyError(c *gc.C) {
@@ -646,13 +646,13 @@ func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyE
 		return errors.New(msg)
 	})
 	err = hostedEnv.Destroy(t.callCtx)
-	c.Assert(err, gc.ErrorMatches, "cannot delete environment security groups: cannot delete default security group: "+msg)
+	c.Assert(err, gc.ErrorMatches, "cannot delete model security groups: "+msg)
 }
 
 func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *gc.C) {
 	controllerEnv := t.prepareAndBootstrap(c)
 
-	// Create a hosted model environment with an instance and a volume.
+	// Create a hosted model with an instance and a volume.
 	hostedModelUUID := "7e386e08-cba7-44a4-a76e-7c1633584210"
 	t.srv.ec2srv.SetInitialInstanceState(ec2test.Running)
 	cfg, err := controllerEnv.Config().Apply(map[string]interface{}{
@@ -724,7 +724,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 	)
 
 	// Destroy the controller resources. This should destroy the hosted
-	// environment too.
+	// model too.
 	err = controllerEnv.DestroyController(t.callCtx, t.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1923,7 +1923,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	controllerGroups, err := ec2.AllModelGroups(controllerEnv, s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Create a hosted model environment with an instance and a volume.
+	// Create a hosted model with an instance and a volume.
 	hostedModelUUID := "7e386e08-cba7-44a4-a76e-7c1633584210"
 	s.srv.ec2srv.SetInitialInstanceState(ec2test.Running)
 	cfg, err := controllerEnv.Config().Apply(map[string]interface{}{


### PR DESCRIPTION
Forward port https://github.com/juju/juju/pull/12677

Earlier version of Juju did not always delete all EC2 security groups when destroying a model.
This has since been fixed, but there's a possibility orphaned security groups can still occur, according to the bug report below.

This PR add 2 enhancements to EC2 to make things more robust:
- on destroy model, query all security groups tagged against the model and delete them (not just the model group, also include any others that may have been orphaned when the corresponding instance was deleted)
- log warnings if an instance is terminated but does not appear in the expected state (this is a possible reason why subsequent deletion of the security group may be skipped)

Also do little error message cleanup to remove some stuttering.

## QA steps

deploy an EC2 model with a few charms
remove an app and verify that the instance security groups are deleted
destroy the model and verify that all model tagged security groups are deleted
destroy the controller and ensure all remaining security groups are deleted

## Bug reference

https://bugs.launchpad.net/juju/+bug/1720571
