### PR TITLE
Better help message for existing applications

### DIFF
--- a/api/application/client_test.go
+++ b/api/application/client_test.go
@@ -140,6 +140,51 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 }
 
+func (s *applicationSuite) TestDeployAlreadyExists(c *gc.C) {
+	var called bool
+	client := application.NewClient(basetesting.BestVersionCaller{
+		APICallerFunc: basetesting.APICallerFunc(
+			func(objType string, version int, id, request string, a, response interface{}) error {
+				called = true
+				c.Assert(request, gc.Equals, "Deploy")
+
+				result := response.(*params.ErrorResults)
+				result.Results = []params.ErrorResult{
+					{Error: &params.Error{
+						Message: "application already exists",
+						Code:    params.CodeAlreadyExists,
+					}},
+				}
+				return nil
+			},
+		),
+		BestVersion: 5,
+	})
+
+	args := application.DeployArgs{
+		CharmID: application.CharmID{
+			URL: charm.MustParseURL("cs:trusty/a-charm-1"),
+		},
+		CharmOrigin: apicharm.Origin{
+			Source: apicharm.OriginCharmStore,
+		},
+		ApplicationName:  "applicationA",
+		Series:           "series",
+		NumUnits:         1,
+		ConfigYAML:       "configYAML",
+		Config:           map[string]string{"foo": "bar"},
+		Cons:             constraints.MustParse("mem=4G"),
+		Placement:        []*instance.Placement{{"scope", "directive"}},
+		Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+		AttachStorage:    []string{"data/0"},
+		Resources:        map[string]string{"foo": "bar"},
+		EndpointBindings: map[string]string{"foo": "bar"},
+	}
+	err := client.Deploy(args)
+	c.Assert(err, gc.ErrorMatches, `application already exists`)
+	c.Assert(called, jc.IsTrue)
+}
+
 func (s *applicationSuite) TestDeployAttachStorageV4(c *gc.C) {
 	var called bool
 	client := application.NewClient(basetesting.BestVersionCaller{

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -22,7 +22,6 @@ import (
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/api/resources/client"
 	app "github.com/juju/juju/apiserver/facades/client/application"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
@@ -259,11 +258,8 @@ func (d *deployCharm) deploy(
 		return nil
 	}
 
-	if pErr, ok := errors.Cause(err).(*params.Error); ok {
-		switch pErr.Code {
-		case params.CodeAlreadyExists:
-			return errors.Wrapf(err, errors.Errorf("\ndeploy application using an alias name, or use remove-application to remove the existing one and try again"), err.Error())
-		}
+	if errors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, errors.Errorf("\ndeploy application using an alias name, or use remove-application to remove the existing one and try again"), err.Error())
 	}
 	return errors.Trace(err)
 

--- a/state/state.go
+++ b/state/state.go
@@ -1073,7 +1073,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	if exists, err := isNotDead(st, applicationsC, args.Name); err != nil {
 		return nil, errors.Trace(err)
 	} else if exists {
-		return nil, errors.Errorf("application already exists")
+		return nil, errors.AlreadyExistsf("application")
 	}
 	if err := checkModelActive(st); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
When deploying an existing application again via `juju deploy` the help
message is a bit sad, as it doesn't explain how you get out of that
position and move forward.

The following aim so to do that by using an error type all the way from
state and catching that error code in the charm deployer.

Interestingly the state tests don't change as we're backwards compatible
with the old error message (nice!) and the charm one isn't exactly easy
to trigger.

## QA steps


```sh
$ juju bootstrap lxd test
$ juju deploy mysql
$ juju deploy mysql
Located charm "mysql" in charm-hub, revision 58
Deploying "mysql" from charm-hub charm "mysql", revision 58 in channel stable
ERROR cannot add application "mysql": application already exists:
deploy application using an alias name, or use remove-application to remove the existing one and try again
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1915223
