### PR TITLE
[2.8] Retry ec2 security group lookups and improve instance lookup warning message

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -1008,9 +1009,10 @@ func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err 
 		if letter > deviceLetterMax {
 			return "", "", errTooManyVolumes
 		}
-		deviceName := devicePrefix + string(letter)
+		deviceName := devicePrefix + fmt.Sprintf("%c", letter)
 		if numbers {
-			deviceName += string('1' + (n % deviceNumMax))
+			// Suffix is a digit from [1, deviceNumMax)
+			deviceName += fmt.Sprintf("%d", 1+(n%deviceNumMax))
 		}
 		n++
 		realDeviceName := renamedDevicePrefix + deviceName[len(devicePrefix):]

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2124,19 +2124,39 @@ var zeroGroup ec2.SecurityGroup
 // groupName or with filter by vpc-id and group-name, depending on whether
 // vpc-id is empty or not.
 func (e *environ) securityGroupsByNameOrID(groupName string) (*ec2.SecurityGroupsResp, error) {
+	var (
+		groups []ec2.SecurityGroup
+		filter *ec2.Filter
+	)
+
 	if chosenVPCID := e.ecfg().vpcID(); isVPCIDSet(chosenVPCID) {
 		// AWS VPC API requires both of these filters (and no
 		// group names/ids set) for non-default EC2-VPC groups:
-		filter := ec2.NewFilter()
+		filter = ec2.NewFilter()
 		filter.Add("vpc-id", chosenVPCID)
 		filter.Add("group-name", groupName)
-		return e.ec2.SecurityGroups(nil, filter)
+	} else {
+		// EC2-Classic or EC2-VPC with implicit default VPC need to use
+		// the GroupName.X arguments instead of the filters.
+		groups = ec2.SecurityGroupNames(groupName)
 	}
 
-	// EC2-Classic or EC2-VPC with implicit default VPC need to use the
-	// GroupName.X arguments instead of the filters.
-	groups := ec2.SecurityGroupNames(groupName)
-	return e.ec2.SecurityGroups(groups, nil)
+	// If the security group was just created, it might not be available
+	// yet as EC2 resources are eventually consistent. If we get a NotFound
+	// error from EC2 we will retry the request using the shortAttempt
+	// strategy before giving up.
+	for a := shortAttempt.Start(); ; a.Next() {
+		resp, err := e.ec2.SecurityGroups(groups, filter)
+		if err == nil {
+			return resp, err
+		}
+
+		// If we run out of attempts or we got an error other than NotFound
+		// immediately return the error back.
+		if !a.HasNext() || !strings.HasSuffix(ec2ErrCode(err), ".NotFound") {
+			return nil, err
+		}
+	}
 }
 
 // ensureGroup returns the security group with name and perms.


### PR DESCRIPTION
This PR wraps the security group lookup code in a retry loop so that we can work around the eventual consistency model that applies to most/all EC2 resources.

In addition, the PR rephrases the warning message emitted while attempting to look up the instance information for an instance that was just created (so we can grab the volume ID of the root disk) as EC2 eventual consistency can cause the EC2 API to initially return a `NotFound` error. To avoid user confusion, the message is now logged at DEBUG level and the retry loop gets **immediately** aborted if any **other** error type is reported.

Finally, the PR addresses a go 1.15 compilation warning wrt. rune concatenation.

For more information on EC2 eventual consistency see: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency

## QA steps

```sh
$ juju bootstrap aws test --debug --no-gui
# Look for a message like:
DEBUG: instance i-0e043391f669e3b18 is not available yet; retrying fetch of instance information
$ juju add-machine

# Watch status until the machine is ready
$ watch juju status
```

## Bug reference
- https://bugs.launchpad.net/juju/+bug/1915057
- https://bugs.launchpad.net/juju/+bug/1914098