### PR TITLE
Ensure we use the same user-agent version

### DIFF
--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -222,8 +222,9 @@ func openCSClient(args OpenCSRepoParams) (*csclient.Client, error) {
 		return nil, err
 	}
 	csParams := csclient.Params{
-		URL:          csURL.String(),
-		BakeryClient: httpbakery.NewClient(),
+		URL:            csURL.String(),
+		BakeryClient:   httpbakery.NewClient(),
+		UserAgentValue: jujuversion.UserAgentVersion,
 	}
 
 	if args.CharmStoreMacaroon != nil {

--- a/apiserver/facades/client/charms/charmstorerepo.go
+++ b/apiserver/facades/client/charms/charmstorerepo.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/version"
 )
 
 type csRepo struct {
@@ -92,8 +93,9 @@ func openCSClient(args ResolverGetterParams) (*csclient.Client, error) {
 		return nil, errors.Trace(err)
 	}
 	csParams := csclient.Params{
-		URL:          csURL.String(),
-		BakeryClient: httpbakery.NewClient(),
+		URL:            csURL.String(),
+		BakeryClient:   httpbakery.NewClient(),
+		UserAgentValue: version.UserAgentVersion,
 	}
 
 	if args.CharmStoreMacaroon != nil {

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	userAgentKey   = "User-Agent"
-	userAgentValue = "Juju/" + version.Current.String()
+	userAgentValue = version.UserAgentVersion
 )
 
 // Logger is a in place interface to represent a logger for consuming.

--- a/charmstore/client.go
+++ b/charmstore/client.go
@@ -19,6 +19,8 @@ import (
 	"github.com/juju/loggo"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	"gopkg.in/macaroon.v2"
+
+	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.charmstore")
@@ -100,8 +102,9 @@ func makeWrapper(bakeryClient *httpbakery.Client, server string) (csWrapper, err
 		return csclientImpl{}, errors.NotValidf("empty charmstore URL")
 	}
 	p := csclient.Params{
-		BakeryClient: bakeryClient,
-		URL:          server,
+		BakeryClient:   bakeryClient,
+		URL:            server,
+		UserAgentValue: version.UserAgentVersion,
 	}
 	return csclientImpl{csclient.New(p)}, nil
 }

--- a/cmd/juju/application/store/store.go
+++ b/cmd/juju/application/store/store.go
@@ -16,6 +16,7 @@ import (
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/version"
 )
 
 // AddCharmFromURL calls the appropriate client API calls to add the
@@ -58,8 +59,9 @@ func AddCharmWithAuthorizationFromURL(client CharmAdder, cs MacaroonGetter, curl
 // It is defined as a variable so it can be changed for testing purposes.
 var NewCharmStoreClient = func(client *httpbakery.Client, csURL string) *csclient.Client {
 	return csclient.New(csclient.Params{
-		URL:          csURL,
-		BakeryClient: client,
+		URL:            csURL,
+		BakeryClient:   client,
+		UserAgentValue: version.UserAgentVersion,
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
 	github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e
-	github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f
+	github.com/juju/charmrepo/v6 v6.0.0-20210224160253-14d76381037d
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
@@ -106,10 +106,10 @@ require (
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
-	golang.org/x/net v0.0.0-20210222171744-9060382bd457
+	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20210223095934-7937bea0104d
+	golang.org/x/sys v0.0.0-20210223212115-eede4237b368
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/tools v0.0.0-20200725200936-102e7d357031
 	google.golang.org/api v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,8 @@ github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e h1:qIK2VhlqGdlQyp3kI
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f h1:esltimJsCcUSaC9ahxBpC70Gumqnnmgm0Ah+BLVQBTY=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
+github.com/juju/charmrepo/v6 v6.0.0-20210224160253-14d76381037d h1:42OeuoFgQht+ddnFb0FyBVWDPoKaQbFqZr39HsECBZE=
+github.com/juju/charmrepo/v6 v6.0.0-20210224160253-14d76381037d/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=
@@ -832,8 +834,8 @@ golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210222171744-9060382bd457 h1:hMm9lBjyNLe/c9C6bElQxp4wsrleaJn1vXMZIQkNN44=
-golang.org/x/net v0.0.0-20210222171744-9060382bd457/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 h1:OgUuv8lsRpBibGNbSizVwKWlysjaNzmC9gYMhPVfqFM=
+golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -890,8 +892,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210223095934-7937bea0104d h1:u0GOGnBJ3EKE/tNqREhhGiCzE9jFXydDo2lf7hOwGuc=
-golang.org/x/sys v0.0.0-20210223095934-7937bea0104d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368 h1:fDE3p0qf2V1co1vfj3/o87Ps8Hq6QTGNxJ5Xe7xSp80=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/version/version.go
+++ b/version/version.go
@@ -23,6 +23,10 @@ import (
 // number of the release package.
 const version = "2.9-rc6"
 
+// UserAgentVersion defines a user agent version used for communication for
+// outside resources.
+const UserAgentVersion = "Juju/" + version
+
 const (
 	// TreeStateDirty when the build was made with a dirty checkout.
 	TreeStateDirty = "dirty"


### PR DESCRIPTION
The user-agent we send from Juju differs from client to client. The
following starts a trend to change that so that we're consistent with
how we're querying the APIs.

This becomes apparent when the charmstore shim API has a different
User-Agent version from the same Juju version. This is a bit weird and
inconsistent.

## QA steps

To really ensure that we're hitting the API with the right User-Agent, you
can either use Wireshark, but certs become an issue, or you can use this
very simple hack for now.

```sh
$ juju bootstrap lxd test --config="charmstore-url=http://0.0.0.0:8080"
$ juju status -m controller
$ lxc exec <name> bash
$ cat > server.py
#!/usr/bin/env python3
import http.server as SimpleHTTPServer
import socketserver as SocketServer
import logging

PORT = 8080

class GetHandler(
        SimpleHTTPServer.SimpleHTTPRequestHandler
        ):

    def do_GET(self):
        logging.error(self.headers)
        SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)


Handler = GetHandler
httpd = SocketServer.TCPServer(("", PORT), Handler)

httpd.serve_forever()
$ chmod +x server.py
$ ./server.py
$ juju deploy cs:mysql
ERROR:root:Host: 0.0.0.0:8080
User-Agent: Juju/2.9-rc6
Bakery-Protocol-Version: 3
Cookie:
Accept-Encoding: gzip
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1913754
