### PR TITLE
Scaffolding for charmhub charm resources command

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -554,7 +554,7 @@ func registerCommands(r commandRegistry) {
 			return resourceadapters.NewAPIClient(apiRoot)
 		},
 	}))
-	r.Register(resource.NewCharmResourcesCommand(nil))
+	r.Register(resource.NewCharmResourcesCommand())
 
 	// CharmHub related commands
 	r.Register(charmhub.NewInfoCommand())

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -61,6 +61,19 @@ func NewCharmResourcesCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&c)
 }
 
+// NewCharmResourcesCommandWithClient returns a new command that lists resources
+// defined by a charm.
+func NewCharmResourcesCommandWithClient(client ResourceLister) modelcmd.ModelCommand {
+	c := CharmResourcesCommand{
+		baseCharmResourcesCommand{
+			CreateResourceListerFn: func(schema string, deps ResourceListerDependencies) (ResourceLister, error) {
+				return client, nil
+			},
+		},
+	}
+	return modelcmd.Wrap(&c)
+}
+
 // Info implements cmd.Command.
 func (c *CharmResourcesCommand) Info() *cmd.Info {
 	i := c.baseInfo()

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -10,13 +10,40 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/controller"
 	"github.com/juju/juju/charmstore"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	corecharm "github.com/juju/juju/core/charm"
 )
+
+// ResourceLister lists resources for the given charm ids.
+type ResourceLister interface {
+	ListResources(ids []CharmID) ([][]charmresource.Resource, error)
+}
+
+// CharmID represents the charm identifier.
+type CharmID struct {
+	// URL is the url of the charm.
+	URL *charm.URL
+
+	// Channel is the channel in which the charm was published.
+	Channel corecharm.Channel
+}
+
+// ResourceListerDependencies defines the dependencies to create a store
+// dependant resource listener.
+type ResourceListerDependencies interface {
+	BakeryClient() (*httpbakery.Client, error)
+	NewControllerAPIRoot() (api.Connection, error)
+}
+
+// CreateResourceListener defines a factory function to create a resource
+// listener.
+type CreateResourceListener = func(string, ResourceListerDependencies) (ResourceLister, error)
 
 // CharmResourcesCommand implements the "juju charm-resources" command.
 type CharmResourcesCommand struct {
@@ -25,9 +52,12 @@ type CharmResourcesCommand struct {
 
 // NewCharmResourcesCommand returns a new command that lists resources defined
 // by a charm.
-func NewCharmResourcesCommand(resourceLister ResourceLister) modelcmd.ModelCommand {
-	var c CharmResourcesCommand
-	c.setResourceLister(resourceLister)
+func NewCharmResourcesCommand() modelcmd.ModelCommand {
+	c := CharmResourcesCommand{
+		baseCharmResourcesCommand{
+			CreateResourceListerFn: defaultResourceLister,
+		},
+	}
 	return modelcmd.Wrap(&c)
 }
 
@@ -54,28 +84,14 @@ func (c *CharmResourcesCommand) Run(ctx *cmd.Context) error {
 	return c.baseRun(ctx)
 }
 
-// CharmResourceLister lists resources for the given charm ids.
-type ResourceLister interface {
-	ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error)
-}
-
 type baseCharmResourcesCommand struct {
 	modelcmd.ModelCommandBase
 
-	// resourceLister is called by Run to list charm resources and
-	// uses juju/juju/charmstore.Client.
-	resourceLister ResourceLister
+	CreateResourceListerFn CreateResourceListener
 
 	out     cmd.Output
 	channel string
 	charm   string
-}
-
-func (b *baseCharmResourcesCommand) setResourceLister(resourceLister ResourceLister) {
-	if resourceLister == nil {
-		resourceLister = b
-	}
-	b.resourceLister = resourceLister
 }
 
 func (c *baseCharmResourcesCommand) baseInfo() *cmd.Info {
@@ -110,15 +126,34 @@ func (c *baseCharmResourcesCommand) baseInit(args []string) error {
 }
 
 func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
-	// TODO(ericsnow) Adjust this to the charm store.
-
 	charmURL, err := resolveCharm(c.charm)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	charm := charmstore.CharmID{URL: charmURL, Channel: csparams.Channel(c.channel)}
 
-	resources, err := c.resourceLister.ListResources([]charmstore.CharmID{charm})
+	var channel corecharm.Channel
+	if charm.CharmHub.Matches(charmURL.Schema) {
+		channel, err = corecharm.ParseChannelNormalize(c.channel)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		channel = corecharm.MakePermissiveChannel("", c.channel, "")
+	}
+
+	resourceLister, err := c.CreateResourceListerFn(charmURL.Schema, c)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	charm := CharmID{
+		URL:     charmURL,
+		Channel: channel,
+	}
+
+	resources, err := resourceLister.ListResources([]CharmID{
+		charm,
+	})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -139,7 +174,7 @@ func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
 	return c.out.Write(ctx, formatted)
 }
 
-var charmResourcesDoc = `
+const charmResourcesDoc = `
 This command will report the resources for a charm in the charm store.
 
 <charm> can be a charm URL, or an unambiguously condensed form of it,
@@ -156,18 +191,53 @@ Where the series is not supplied, the series from your local host is used.
 Thus the above examples imply that the local series is trusty.
 `
 
-// ListCharmResources implements CharmResourceLister by getting the charmstore client
-// from the command's ModelCommandBase.
-func (c *baseCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][]charmresource.Resource, error) {
-	bakeryClient, err := c.BakeryClient()
+func resolveCharm(raw string) (*charm.URL, error) {
+	charmURL, err := charm.ParseURL(raw)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	conAPIRoot, err := c.NewControllerAPIRoot()
+
+	if charmURL.Series == "bundle" {
+		return nil, errors.Errorf("charm bundles are not supported")
+	}
+
+	return charmURL, nil
+}
+
+func defaultResourceLister(schema string, deps ResourceListerDependencies) (ResourceLister, error) {
+	if charm.CharmHub.Matches(schema) {
+		return nil, errors.Errorf("charmhub charms are currently not supported")
+	}
+
+	return &CharmStoreResourceListener{
+		BakeryClientFn:      deps.BakeryClient,
+		ControllerAPIRootFn: deps.NewControllerAPIRoot,
+	}, nil
+}
+
+// BakeryClient defines a way to create a bakery client.
+type BakeryClient = func() (*httpbakery.Client, error)
+
+// ControllerAPIRoot defines a way to create a new controller API root.
+type ControllerAPIRoot = func() (api.Connection, error)
+
+// CharmStoreResourceListener defines a charm store resource listener.
+type CharmStoreResourceListener struct {
+	BakeryClientFn      BakeryClient
+	ControllerAPIRootFn ControllerAPIRoot
+}
+
+// ListResources implements CharmResourceLister.
+func (c *CharmStoreResourceListener) ListResources(ids []CharmID) ([][]charmresource.Resource, error) {
+	bakeryClient, err := c.BakeryClientFn()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	csURL, err := getCharmStoreAPIURL(conAPIRoot)
+	conAPIRoot, err := c.ControllerAPIRootFn()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	csURL, err := c.getCharmStoreAPIURL(conAPIRoot)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -175,24 +245,20 @@ func (c *baseCharmResourcesCommand) ListResources(ids []charmstore.CharmID) ([][
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return client.ListResources(ids)
-}
 
-func resolveCharm(raw string) (*charm.URL, error) {
-	charmURL, err := charm.ParseURL(raw)
-	if err != nil {
-		return charmURL, errors.Trace(err)
+	charmIDs := make([]charmstore.CharmID, len(ids))
+	for i, id := range ids {
+		charmIDs[i] = charmstore.CharmID{
+			URL:     id.URL,
+			Channel: csparams.Channel(id.Channel.Risk),
+		}
 	}
 
-	if charmURL.Series == "bundle" {
-		return charmURL, errors.Errorf("charm bundles are not supported")
-	}
-
-	return charmURL, nil
+	return client.ListResources(charmIDs)
 }
 
 // getCharmStoreAPIURL consults the controller config for the charmstore api url to use.
-var getCharmStoreAPIURL = func(conAPIRoot api.Connection) (string, error) {
+func (c *CharmStoreResourceListener) getCharmStoreAPIURL(conAPIRoot api.Connection) (string, error) {
 	controllerAPI := controller.NewClient(conAPIRoot)
 	controllerCfg, err := controllerAPI.ControllerConfig()
 	if err != nil {

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -140,6 +140,13 @@ func (c *baseCharmResourcesCommand) baseInit(args []string) error {
 
 func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
 	charmURL, err := resolveCharm(c.charm)
+	if errors.IsNotSupported(err) {
+		if c.out.Name() == "tabular" {
+			ctx.Infof("Bundles have no resources to display.")
+			return nil
+		}
+		return c.out.Write(ctx, struct{}{})
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -211,7 +218,7 @@ func resolveCharm(raw string) (*charm.URL, error) {
 	}
 
 	if charmURL.Series == "bundle" {
-		return nil, errors.Errorf("charm bundles are not supported")
+		return nil, errors.NotSupportedf("charm bundles")
 	}
 
 	return charmURL, nil

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	jujucmd "github.com/juju/cmd"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/charmstore"
+	jujuresource "github.com/juju/juju/cmd/juju/resource"
 	resourcecmd "github.com/juju/juju/cmd/juju/resource"
+	corecharm "github.com/juju/juju/core/charm"
 )
 
 var _ = gc.Suite(&CharmResourcesSuite{})
@@ -85,12 +87,22 @@ website   2
 	s.stub.CheckCallNames(c,
 		"ListResources",
 	)
-	s.stub.CheckCall(c, 0, "ListResources", []charmstore.CharmID{
+	s.stub.CheckCall(c, 0, "ListResources", []jujuresource.CharmID{
 		{
 			URL:     charm.MustParseURL("cs:a-charm"),
-			Channel: "stable",
+			Channel: corecharm.MustParseChannel("stable"),
 		},
 	})
+}
+
+func (s *CharmResourcesSuite) TestCharmhub(c *gc.C) {
+	s.client.stub.SetErrors(errors.Errorf("charmhub charms are currently not supported"))
+
+	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
+	code, stdout, stderr := runCmd(c, command, "a-charm")
+	c.Check(code, gc.Equals, 1)
+	c.Check(stdout, gc.Equals, "")
+	c.Check(stderr, gc.Equals, "ERROR charmhub charms are currently not supported\n")
 }
 
 func (s *CharmResourcesSuite) TestNoResources(c *gc.C) {

--- a/cmd/juju/resource/export_test.go
+++ b/cmd/juju/resource/export_test.go
@@ -33,15 +33,25 @@ func UploadCommandApplication(c *UploadCommand) string {
 var FormatApplicationResources = formatApplicationResources
 
 func NewCharmResourcesCommandForTest(resourceLister ResourceLister) modelcmd.ModelCommand {
-	var c CharmResourcesCommand
-	c.setResourceLister(resourceLister)
+	c := CharmResourcesCommand{
+		baseCharmResourcesCommand{
+			CreateResourceListerFn: func(schema string, deps ResourceListerDependencies) (ResourceLister, error) {
+				return resourceLister, nil
+			},
+		},
+	}
 	c.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(&c)
 }
 
 func NewListCharmResourcesCommandForTest(resourceLister ResourceLister) modelcmd.ModelCommand {
-	var c ListCharmResourcesCommand
-	c.setResourceLister(resourceLister)
+	c := ListCharmResourcesCommand{
+		baseCharmResourcesCommand{
+			CreateResourceListerFn: func(schema string, deps ResourceListerDependencies) (ResourceLister, error) {
+				return resourceLister, nil
+			},
+		},
+	}
 	c.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(&c)
 }

--- a/cmd/juju/resource/list_charm_resources.go
+++ b/cmd/juju/resource/list_charm_resources.go
@@ -24,8 +24,11 @@ type ListCharmResourcesCommand struct {
 // NewListCharmResourcesCommand returns a new command that lists resources defined
 // by a charm.
 func NewListCharmResourcesCommand(resourceLister ResourceLister) modelcmd.ModelCommand {
-	var c ListCharmResourcesCommand
-	c.setResourceLister(resourceLister)
+	c := ListCharmResourcesCommand{
+		baseCharmResourcesCommand{
+			CreateResourceListerFn: defaultResourceLister,
+		},
+	}
 	return modelcmd.Wrap(&c)
 }
 

--- a/cmd/juju/resource/stub_test.go
+++ b/cmd/juju/resource/stub_test.go
@@ -8,10 +8,9 @@ import (
 
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
+	jujuresource "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/resource"
 	"github.com/juju/testing"
-
-	"github.com/juju/juju/charmstore"
 )
 
 type stubCharmStore struct {
@@ -20,7 +19,7 @@ type stubCharmStore struct {
 	ReturnListResources [][]charmresource.Resource
 }
 
-func (s *stubCharmStore) ListResources(charms []charmstore.CharmID) ([][]charmresource.Resource, error) {
+func (s *stubCharmStore) ListResources(charms []jujuresource.CharmID) ([][]charmresource.Resource, error) {
 	s.stub.AddCall("ListResources", charms)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -4,6 +4,7 @@
 package featuretests
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/cmd/juju/resource"
 	coretesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -108,7 +108,8 @@ upload-resource   -
 }
 
 func (s *ResourcesCmdSuite) runCharmResourcesCommand(c *gc.C) {
-	context, err := cmdtesting.RunCommand(c, resource.NewCharmResourcesCommand(s.client), s.charmName)
+	charmName := fmt.Sprintf("cs:%s", s.charmName)
+	context, err := cmdtesting.RunCommand(c, resource.NewCharmResourcesCommandWithClient(s.client), charmName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
@@ -127,7 +128,7 @@ type stubCharmStore struct {
 	listResources func() [][]charmresource.Resource
 }
 
-func (s *stubCharmStore) ListResources(charms []charmstore.CharmID) ([][]charmresource.Resource, error) {
+func (s *stubCharmStore) ListResources(charms []resource.CharmID) ([][]charmresource.Resource, error) {
 	s.stub.AddCall("ListResources", charms)
 	return s.listResources(), s.stub.NextErr()
 }


### PR DESCRIPTION
The following starts to plan out adding charmhub queries for getting
charm resources. The code in here is old and weird. I've updated it to
allow us to perform different requests based on the charm schema.

## QA steps

Existing tests pass

```sh
$ juju bootstrap lxd test
$ juju charm-resources cs:postgresql
$ juju charm-resources mysql
ERROR charmhub charms are currently not supported
```

## Bug reference

Addresses, but doesn't complete: https://bugs.launchpad.net/juju/+bug/1913754