### PR TITLE
[2.9] Improve remove cloud output

### DIFF
--- a/cmd/juju/cloud/remove.go
+++ b/cmd/juju/cloud/remove.go
@@ -105,8 +105,12 @@ func (c *removeCloudCommand) Run(ctxt *cmd.Context) error {
 	}
 	if c.ControllerName != "" {
 		if err := c.removeControllerCloud(ctxt); err != nil {
-			ctxt.Infof("ERROR %v", err)
-			returnErr = cmd.ErrSilent
+			if errors.IsNotFound(err) {
+				ctxt.Infof("No cloud called %q exists on controller %q", c.Cloud, c.ControllerName)
+			} else {
+				ctxt.Infof("ERROR %v", err)
+				returnErr = cmd.ErrSilent
+			}
 		}
 	}
 	return returnErr


### PR DESCRIPTION
When attempting to remove a cloud, juju would treat unknown clouds differently for the client and the controller. More specifically, if the cloud is unknown to the **client**, an INFO message is displayed and no error is reported. On the other hand, if the cloud is unknown to the **controller**, we get a NotFound error back which the client emits and subsequently proceeds to exit the command with a **1** status code.

This can be quite confusing for users in the case where the cloud is only known by the client and not the controller where the juju CLI would emit both a success and an error message (see bug details).

This PR attempts to fix this by checking the error type returned by the controller and ensuring that the client emits a suitable INFO message when the cloud is not known to the controller.

## QA steps

```console
$ juju bootstrap lxd test --no-gui

$ juju remove-cloud bogus --client --controller test
No cloud called "bogus" exists on this client
No cloud called "bogus" exists on controller "test"

# Add an lxd cloud to the client, controller and both (just point to your lxd's endpoint)
$ juju add-cloud client-only --client
$ juju add-cloud controller-only --controller test
$ juju add-cloud both --client --controller test

# Remove each one of the clouds and ensure that the output makes sense
$ juju remove-cloud client-only --client --controller test
$ juju remove-cloud controller-only --client --controller test 
$ juju remove-cloud both --client --controller test
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

## Bug reference
https://bugs.launchpad.net/juju/+bug/1914027