### PR TITLE
update bundles for deploy bundle test

### DIFF
--- a/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
@@ -1,4 +1,4 @@
-series: focal
+series: bionic
 saas:
   mysql:
     url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.mysql

--- a/tests/suites/deploy/bundles/lxd-profile-bundle.yaml
+++ b/tests/suites/deploy/bundles/lxd-profile-bundle.yaml
@@ -1,4 +1,4 @@
-series: focal
+series: bionic
 machines:
   '0': {}
   '1': {}

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -1,17 +1,22 @@
-series: focal
+series: bionic
 applications:
   influxdb:
     charm: cs:influxdb-22
+    channel: stable
     num_units: 1
     to:
     - "0"
+    constraints: arch=amd64
   telegraf:
     charm: cs:telegraf-29
+    channel: stable
   ubuntu:
     charm: cs:ubuntu-12
+    channel: stable
     num_units: 1
     to:
     - "1"
+    constraints: arch=amd64
 machines:
   "0": {}
   "1": {}


### PR DESCRIPTION
Update bundles used as appropriate to update series, channel, and constraints related to recently changes to juju related to same.

## QA steps

```sh
(cd tests ; ./main.sh -v  -r -l wednesday  deploy test_deploy_bundles  )
```

