### PR TITLE
Merge 2.9

### DIFF
--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -1008,9 +1009,10 @@ func blockDeviceNamer(numbers bool) func() (requestName, actualName string, err 
 		if letter > deviceLetterMax {
 			return "", "", errTooManyVolumes
 		}
-		deviceName := devicePrefix + string(rune(letter))
+		deviceName := devicePrefix + fmt.Sprintf("%c", letter)
 		if numbers {
-			deviceName += string(rune('1' + (n % deviceNumMax)))
+			// Suffix is a digit from [1, deviceNumMax)
+			deviceName += fmt.Sprintf("%d", 1+(n%deviceNumMax))
 		}
 		n++
 		realDeviceName := renamedDevicePrefix + deviceName[len(devicePrefix):]

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1010,13 +1010,20 @@ func tagRootDisk(e *amzec2.EC2, ctx context.ProviderCallContext, tags map[string
 	for a := waitRootDiskAttempt.Start(); volumeID == "" && a.Next(); {
 		resp, err := e.Instances([]string{inst.InstanceId}, nil)
 		if err != nil {
-			err = errors.Annotate(maybeConvertCredentialError(err, ctx), "cannot fetch instance information")
-			logger.Warningf("%v", err)
-			if a.HasNext() == false {
-				return err
+			// EC2 calls are eventually consistent; if we get a
+			// NotFound error when looking up the instance we
+			// should retry until it appears or we run out of
+			// attempts.
+			if strings.HasSuffix(ec2ErrCode(err), ".NotFound") {
+				logger.Debugf("instance %v is not available yet; retrying fetch of instance information", inst.InstanceId)
+				continue
 			}
-			logger.Infof("retrying fetch of instances")
-			continue
+
+			// No need to retry for other error types.
+			return errors.Annotate(
+				maybeConvertCredentialError(err, ctx),
+				"cannot fetch instance information",
+			)
 		}
 		if len(resp.Reservations) > 0 && len(resp.Reservations[0].Instances) > 0 {
 			inst = &resp.Reservations[0].Instances[0]
@@ -2181,19 +2188,39 @@ var zeroGroup amzec2.SecurityGroup
 // groupName or with filter by vpc-id and group-name, depending on whether
 // vpc-id is empty or not.
 func (e *environ) securityGroupsByNameOrID(groupName string) (*amzec2.SecurityGroupsResp, error) {
+	var (
+		groups []amzec2.SecurityGroup
+		filter *amzec2.Filter
+	)
+
 	if chosenVPCID := e.ecfg().vpcID(); isVPCIDSet(chosenVPCID) {
 		// AWS VPC API requires both of these filters (and no
 		// group names/ids set) for non-default EC2-VPC groups:
-		filter := amzec2.NewFilter()
+		filter = amzec2.NewFilter()
 		filter.Add("vpc-id", chosenVPCID)
 		filter.Add("group-name", groupName)
-		return e.ec2.SecurityGroups(nil, filter)
+	} else {
+		// EC2-Classic or EC2-VPC with implicit default VPC need to use
+		// the GroupName.X arguments instead of the filters.
+		groups = amzec2.SecurityGroupNames(groupName)
 	}
 
-	// EC2-Classic or EC2-VPC with implicit default VPC need to use the
-	// GroupName.X arguments instead of the filters.
-	groups := amzec2.SecurityGroupNames(groupName)
-	return e.ec2.SecurityGroups(groups, nil)
+	// If the security group was just created, it might not be available
+	// yet as EC2 resources are eventually consistent. If we get a NotFound
+	// error from EC2 we will retry the request using the shortAttempt
+	// strategy before giving up.
+	for a := shortAttempt.Start(); ; a.Next() {
+		resp, err := e.ec2.SecurityGroups(groups, filter)
+		if err == nil {
+			return resp, err
+		}
+
+		// If we run out of attempts or we got an error other than NotFound
+		// immediately return the error back.
+		if !a.HasNext() || !strings.HasSuffix(ec2ErrCode(err), ".NotFound") {
+			return nil, err
+		}
+	}
 }
 
 // ensureGroup returns the security group with name and perms.


### PR DESCRIPTION
Merge 2.8 with these PRs:

#12681 Retry ec2 security group lookups and improve instance lookup warning message

There was a conflict in ebs.go due to a slightly different approach to set up device names. I just went with the 2.8 approach.

## QA steps

See PRs

