### PR TITLE
Add coverage to make file

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -98,6 +98,10 @@ jobs:
       if: (matrix.os == 'ubuntu-latest')
       run: |
         # Jenkins can perform the full jujud testing.
-        go test -v ./cmd/juju/... -check.v
+        go test -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic
         go test -v ./cmd/plugins/... -check.v
       shell: bash
+
+    - name: Upload coverage to Codecov
+      if: (matrix.os == 'ubuntu-latest')
+      run: bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,14 @@ else
 	TEST_ARGS :=
 endif
 
+# Enable coverage testing.
+ifeq ($(COVERAGE_CHECK), 1)
+	TEST_ARGS += -cover
+endif
+
 # Enable verbose testing for reporting.
 ifeq ($(VERBOSE_CHECK), 1)
-	CHECK_ARGS = -v $(TEST_ARGS)
-else
-	CHECK_ARGS = $(TEST_ARGS)
+	CHECK_ARGS = -v
 endif
 
 GIT_COMMIT ?= $(shell git -C $(PROJECT_DIR) rev-parse HEAD 2>/dev/null)
@@ -120,8 +123,8 @@ run-tests:
 ## run-tests: Run the unit tests
 	$(eval TMP := $(shell mktemp -d $${TMPDIR:-/tmp}/jj-XXX))
 	$(eval TEST_PACKAGES := $(shell go list $(PROJECT)/... | grep -v $(PROJECT)$$ | grep -v $(PROJECT)/vendor/ | grep -v $(PROJECT)/acceptancetests/ | grep -v $(PROJECT)/generate/ | grep -v mocks))
-	@echo 'go test -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES -check.v'
-	@TMPDIR=$(TMP) go test -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES) -check.v
+	@echo 'go test -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES -check.v'
+	@TMPDIR=$(TMP) go test -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES) -check.v
 	@rm -r $(TMP)
 
 install: rebuild-schema go-install

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 
 # Enable coverage testing.
 ifeq ($(COVERAGE_CHECK), 1)
-	TEST_ARGS += -cover
+	TEST_ARGS += -coverprofile=coverage.txt -covermode=atomic
 endif
 
 # Enable verbose testing for reporting.


### PR DESCRIPTION
The following introduces code coverage to the tests, this should allow
us to see what's missing and what we can remove in terms of tests
without loss to the project.
## QA steps

```sh
COVERAGE_CHECK=1 make run-tests
```