### PR TITLE
[2.8] Augment running hook msg for relations

### DIFF
--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 )
 
@@ -64,7 +65,11 @@ func canBeLost(agent, workload status.StatusInfo) bool {
 	case status.Allocating, status.Running:
 		return false
 	case status.Executing:
-		return agent.Message != operation.RunningHookMessage(string(hooks.Install))
+		installMsg := operation.RunningHookMessage(
+			string(hooks.Install),
+			hook.Info{Kind: hooks.Install},
+		)
+		return agent.Message != installMsg
 	}
 
 	// TODO(fwereade/wallyworld): we should have an explicit place in the model

--- a/cmd/juju/action/showoutput_test.go
+++ b/cmd/juju/action/showoutput_test.go
@@ -84,7 +84,7 @@ func (s *ShowOutputSuite) TestRun(c *gc.C) {
 	}{{
 		should:         "handle wait-time formatting errors",
 		withClientWait: "not-a-duration-at-all",
-		expectedErr:    `time: invalid duration not-a-duration-at-all`,
+		expectedErr:    `time: invalid duration "?not-a-duration-at-all"?`,
 	}, {
 		should:            "timeout if result never comes",
 		withClientWait:    "2s",

--- a/cmd/juju/commands/exec_test.go
+++ b/cmd/juju/commands/exec_test.go
@@ -218,7 +218,7 @@ func (*ExecSuite) TestTimeoutArgParsing(c *gc.C) {
 	}, {
 		message:  "invalid time",
 		args:     []string{"--timeout=foo", "--all", "sudo reboot"},
-		errMatch: `invalid value "foo" for option --timeout: time: invalid duration foo`,
+		errMatch: `invalid value "foo" for option --timeout: time: invalid duration "?foo"?`,
 		modeType: model.IAAS,
 	}, {
 		message:  "two hours",

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -4,6 +4,7 @@
 package machine_test
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -242,7 +243,7 @@ func (f *fakeAddMachineAPI) AddMachines(args []params.AddMachineParams) ([]param
 			})
 		} else {
 			results = append(results, params.AddMachinesResult{
-				Machine: string(i),
+				Machine: fmt.Sprint(i),
 				Error:   &params.Error{Message: "something went wrong", Code: "1"},
 			})
 		}

--- a/cmd/jujud/agent/caasunitinit_test.go
+++ b/cmd/jujud/agent/caasunitinit_test.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"net"
 	"os"
@@ -132,7 +133,7 @@ func (s *CAASUnitInitSuite) TestInitUnit(c *gc.C) {
 }
 
 func (s *CAASUnitInitSuite) TestInitUnitWaitSend(c *gc.C) {
-	socketName := "@" + string(rand.Int63())
+	socketName := fmt.Sprintf("@%d", rand.Int63())
 	listening := make(chan struct{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -186,7 +186,7 @@ func deviceID(i int) (string, error) {
 	if i < 0 || i > 25 {
 		return "", errors.Errorf("got %d but only support devices 0-25", i)
 	}
-	return fmt.Sprintf("vd%s", string('a'+i)), nil
+	return fmt.Sprintf("vd%c", 'a'+i), nil
 }
 
 // Domain describes a libvirt domain. A domain is an instance of an operating

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -235,7 +235,7 @@ var newConfigTests = []struct {
 	config: controller.Config{
 		controller.PruneTxnSleepTime: "15",
 	},
-	expectError: `prune-txn-sleep-time must be a valid duration \(eg "10ms"\): time: missing unit in duration 15`,
+	expectError: `prune-txn-sleep-time must be a valid duration \(eg "10ms"\): time: missing unit in duration "?15"?`,
 }, {
 	about: "mongo-memory-profile not valid",
 	config: controller.Config{
@@ -277,7 +277,7 @@ var newConfigTests = []struct {
 	config: controller.Config{
 		controller.AgentRateLimitRate: "150",
 	},
-	expectError: `agent-ratelimit-rate: conversion to duration: time: missing unit in duration 150`,
+	expectError: `agent-ratelimit-rate: conversion to duration: time: missing unit in duration "?150"?`,
 }, {
 	about: "agent-ratelimit-rate bad type, int",
 	config: controller.Config{
@@ -669,7 +669,7 @@ func (s *ConfigSuite) TestMaxDebugLogDurationSchemaCoerce(c *gc.C) {
 			"max-debug-log-duration": "12",
 		},
 	)
-	c.Assert(err.Error(), gc.Equals, "max-debug-log-duration: conversion to duration: time: missing unit in duration 12")
+	c.Assert(err.Error(), gc.Matches, `max-debug-log-duration: conversion to duration: time: missing unit in duration "?12"?`)
 }
 
 func (s *ConfigSuite) TestDefaults(c *gc.C) {

--- a/provider/oracle/storage_volumes.go
+++ b/provider/oracle/storage_volumes.go
@@ -389,7 +389,7 @@ func (s *oracleVolumeSource) updateVolume(volumeId string, details ociResponse.S
 			Imagelist_entry:  details.Imagelist_entry,
 			Name:             details.Name,
 			Properties:       details.Properties,
-			Size:             ociCommon.StorageSize(details.Size),
+			Size:             ociCommon.StorageSize(fmt.Sprint(details.Size)),
 			Snapshot:         derefString(details.Snapshot),
 			Snapshot_account: details.Snapshot_account,
 			Snapshot_id:      details.Snapshot_id,

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -94,14 +94,17 @@ func (rh *runHook) Prepare(state State) (*State, error) {
 }
 
 // RunningHookMessage returns the info message to print when running a hook.
-func RunningHookMessage(hookName string) string {
+func RunningHookMessage(hookName string, info hook.Info) string {
+	if info.Kind.IsRelation() && info.RemoteUnit != "" {
+		return fmt.Sprintf("running %s hook for %s", hookName, info.RemoteUnit)
+	}
 	return fmt.Sprintf("running %s hook", hookName)
 }
 
 // Execute runs the hook.
 // Execute is part of the Operation interface.
 func (rh *runHook) Execute(state State) (*State, error) {
-	message := RunningHookMessage(rh.name)
+	message := RunningHookMessage(rh.name, rh.info)
 	if err := rh.beforeHook(state); err != nil {
 		return nil, err
 	}

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -842,3 +842,23 @@ func (s *RunHookSuite) TestNeedsGlobalMachineLock_Run(c *gc.C) {
 func (s *RunHookSuite) TestNeedsGlobalMachineLock_Skip(c *gc.C) {
 	s.testNeedsGlobalMachineLock(c, operation.Factory.NewSkipHook, false)
 }
+
+func (s *RunHookSuite) TestRunningHookMessageForRelationHooks(c *gc.C) {
+	msg := operation.RunningHookMessage(
+		"host-relation-created",
+		hook.Info{
+			Kind:       hooks.RelationCreated,
+			RemoteUnit: "alien/0",
+		},
+	)
+	c.Assert(msg, gc.Equals, "running host-relation-created hook for alien/0", gc.Commentf("expected remote unit to be included for a relation hook with a populated remote unit"))
+
+	msg = operation.RunningHookMessage(
+		"install",
+		hook.Info{
+			Kind:       hooks.Install,
+			RemoteUnit: "bogus",
+		},
+	)
+	c.Assert(msg, gc.Equals, "running install hook", gc.Commentf("expected remote unit not to be included for a non-relation hook"))
+}


### PR DESCRIPTION
When juju appends an entry in a unit's status history, it de-dups entries with the same message and simply updates the tracked status timestamp. This makes debugging harder when working with relation hooks (e.g. relation-departed) as the hook runs for the different units get coalesced together.

This PR, augments the emitted message when running a hook to include the remote unit for relation hooks only (if defined, i.e. this is not a relation-broken hook).

## QA steps

```console
$ juju bootstrap lxd test --no-gui
$ juju deploy cs:~containers/easyrsa-345
$ juju deploy cs:~nats-charmers/nats-9 -n3
$ juju relate nats easyrsa

# Wait for units to settle

$ juju debug-hook nats/2 cluster-relation-departed

# In another terminal
$ juju remove-unit nats/2

# Wait for the *first* debug hook to trigger and press ctrl+d
# Once you get to the prompt for the *second* debug hook
# switch to another terminal and run:
$ juju show-status-log nats/2
...
running cluster-relation-departed hook for nats/0
running cluster-relation-departed hook for nats/1
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1916746