### PR TITLE
[2.8] Release openstack machine before attempting to start a new instance after a timeout

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -793,6 +793,11 @@ func (s *localServerSuite) TestStartInstanceWaitForActiveDetails(c *gc.C) {
 	inst, _, _, err := testing.StartInstance(env, s.callCtx, s.ControllerUUID, "100")
 	c.Check(inst, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "cannot run instance: max duration exceeded: instance .* has status BUILD")
+
+	// Ensure that the started instance got terminated.
+	insts, err := env.AllInstances(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(insts, gc.HasLen, 0, gc.Commentf("expected launched instance to be terminated if stuck in BUILD state"))
 }
 
 func assertSecurityGroups(c *gc.C, env environs.Environ, expected []string) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1236,8 +1236,9 @@ func (e *Environ) startInstance(
 				// If we got an error back (eg. StillBuilding)
 				// we need to terminate the instance before
 				// retrying to avoid leaking resources.
+				logger.Warningf("Unable to retrieve details for created instance %q: %v; attempting to terminate it", server.Id, err)
 				if termErr := e.terminateInstances(ctx, []instance.Id{instance.Id(server.Id)}); termErr != nil {
-					logger.Debugf("Failed to delete instance in BUILD state, %q", termErr)
+					logger.Errorf("Failed to delete instance %q: %v; manual cleanup required", server.Id, termErr)
 				}
 				server = nil
 				break
@@ -1254,7 +1255,7 @@ func (e *Environ) startInstance(
 				}
 				logger.Infof("Deleting instance %q in ERROR state%v", server.Id, faultMsg)
 				if err = e.terminateInstances(ctx, []instance.Id{instance.Id(server.Id)}); err != nil {
-					logger.Debugf("Failed to delete instance in ERROR state, %q", err)
+					logger.Errorf("Failed to delete instance in ERROR state %q: %v; manual cleanup required", server.Id, err)
 				}
 				server = nil
 				err = errors.New(faultMsg)


### PR DESCRIPTION
Prior to this change, if the openstack provider got a timeout while waiting for a machine to finish building it would not terminate the instance before retrying the StartInstance attempt.

This PR ensures that those machines get terminated before `StartInstance` returns with an error.

## QA steps
As this issue manifests under high load you will need to try deploying something to a loaded openstack instance.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1914829