### PR TITLE
List charm resources

### DIFF
--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -232,7 +232,7 @@ func (c *Client) ListCharmResources(curl *charm.URL, origin apicharm.Origin) ([]
 
 		chRes, err := api.API2CharmResource(res.CharmResource)
 		if err != nil {
-			return nil, errors.Annotate(err, "got bad data from server")
+			return nil, errors.Annotate(err, "unexpected charm resource")
 		}
 		resources[i] = chRes
 	}

--- a/api/charms/client_test.go
+++ b/api/charms/client_test.go
@@ -6,6 +6,7 @@ package charms_test
 import (
 	"github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
+	charmresource "github.com/juju/charm/v8/resource"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -304,4 +305,71 @@ func (s charmsMockSuite) TestCheckCharmPlacementError(c *gc.C) {
 	client := charms.NewClientWithFacade(mockFacadeCaller)
 	err := client.CheckCharmPlacement("winnie", charm.MustParseURL("poo"))
 	c.Assert(err, gc.ErrorMatches, "trap")
+}
+
+func (s *charmsMockSuite) TestListCharmResourcesIsNotSupported(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().BestAPIVersion().Return(2)
+
+	client := charms.NewClientWithFacade(mockFacadeCaller)
+
+	curl := charm.MustParseURL("a-charm")
+	origin := apicharm.Origin{}
+
+	_, err := client.ListCharmResources(curl, origin)
+	c.Assert(errors.IsNotSupported(err), jc.IsTrue)
+}
+
+func (s *charmsMockSuite) TestListCharmResources(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	curl := charm.MustParseURL("a-charm")
+	noChannelParamsOrigin := params.CharmOrigin{Source: "charm-hub"}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+
+	facadeArgs := params.CharmURLAndOrigins{
+		Entities: []params.CharmURLAndOrigin{
+			{CharmURL: curl.String(), Origin: noChannelParamsOrigin},
+		},
+	}
+
+	var resolve params.CharmResourcesResults
+
+	p := params.CharmResourcesResults{
+		Results: [][]params.CharmResourceResult{{{
+			CharmResource: params.CharmResource{
+				Type:     "oci-image",
+				Origin:   "upload",
+				Name:     "a-charm-res-1",
+				Path:     "res.txt",
+				Revision: 2,
+				Size:     1024,
+			},
+		}}},
+	}
+
+	mockFacadeCaller.EXPECT().BestAPIVersion().Return(3)
+	mockFacadeCaller.EXPECT().FacadeCall("ListCharmResources", facadeArgs, &resolve).SetArg(2, p).Return(nil)
+
+	client := charms.NewClientWithFacade(mockFacadeCaller)
+	got, err := client.ListCharmResources(curl, apicharm.APICharmOrigin(noChannelParamsOrigin))
+	c.Assert(err, gc.IsNil)
+
+	want := []charmresource.Resource{{
+		Meta: charmresource.Meta{
+			Type: charmresource.TypeContainerImage,
+			Name: "a-charm-res-1",
+			Path: "res.txt",
+		},
+		Origin:   charmresource.OriginUpload,
+		Revision: 2,
+		Size:     1024,
+	}}
+
+	c.Assert(got, gc.DeepEquals, want)
 }

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -204,7 +204,7 @@ func (c *chRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url
 
 // ListResources returns the resources for a given charm and origin.
 func (c *chRepo) ListResources(curl *charm.URL, origin corecharm.Origin) ([]charmresource.Resource, error) {
-	logger.Tracef("CharmStore ListResources %q", curl)
+	logger.Tracef("CharmHub ListResources %q", curl)
 	var err error
 	curl, origin, _, err = c.ResolveWithPreferredChannel(curl, origin)
 	if err != nil {

--- a/apiserver/facades/client/charms/charmstorerepo.go
+++ b/apiserver/facades/client/charms/charmstorerepo.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/juju/charm/v8"
+	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/charmrepo/v6"
 	"github.com/juju/charmrepo/v6/csclient"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"
@@ -14,7 +15,6 @@ import (
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/version"
@@ -27,12 +27,12 @@ type csRepo struct {
 // ResolveWithPreferredChannel calls the CharmStore version of
 // ResolveWithPreferredChannel. Convert CharmStore channel to
 // and from the charm Origin.
-func (c *csRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.CharmOrigin) (*charm.URL, params.CharmOrigin, []string, error) {
-	logger.Tracef("Resolving CharmStore charm %q with channel %q", curl, origin.Risk)
+func (c *csRepo) ResolveWithPreferredChannel(curl *charm.URL, origin corecharm.Origin) (*charm.URL, corecharm.Origin, []string, error) {
+	logger.Tracef("Resolving CharmStore charm %q with channel %q", curl, origin.Channel.Risk)
 	// A charm origin risk is equivalent to a charm store channel
-	newCurl, newRisk, supportedSeries, err := c.repo.ResolveWithPreferredChannel(curl, csparams.Channel(origin.Risk))
+	newCurl, newRisk, supportedSeries, err := c.repo.ResolveWithPreferredChannel(curl, csparams.Channel(origin.Channel.Risk))
 	if err != nil {
-		return nil, params.CharmOrigin{}, nil, errors.Trace(err)
+		return nil, corecharm.Origin{}, nil, errors.Trace(err)
 	}
 
 	var t string
@@ -45,7 +45,7 @@ func (c *csRepo) ResolveWithPreferredChannel(curl *charm.URL, origin params.Char
 
 	newOrigin := origin
 	newOrigin.Type = t
-	newOrigin.Risk = string(newRisk)
+	newOrigin.Channel.Risk = corecharm.Risk(newRisk)
 	return newCurl, newOrigin, supportedSeries, err
 }
 
@@ -61,6 +61,11 @@ func (c *csRepo) DownloadCharm(resourceURL string, archivePath string) (*charm.C
 func (c *csRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url.URL, corecharm.Origin, error) {
 	logger.Tracef("CharmStore FindDownloadURL %q", curl)
 	return nil, origin, nil
+}
+
+func (c *csRepo) ListResources(curl *charm.URL, origin corecharm.Origin) ([]charmresource.Resource, error) {
+	logger.Tracef("CharmStore ListResources %q", curl)
+	return nil, nil
 }
 
 type CSResolverGetterFunc func(args ResolverGetterParams) (CSRepository, error)

--- a/apiserver/facades/client/charms/repositories_test.go
+++ b/apiserver/facades/client/charms/repositories_test.go
@@ -9,8 +9,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/facades/client/charms/mocks"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/arch"
+	corecharm "github.com/juju/juju/core/charm"
 )
 
 type charmStoreResolversSuite struct {
@@ -30,121 +30,157 @@ type sanitizeCharmOriginSuite struct{}
 var _ = gc.Suite(&sanitizeCharmOriginSuite{})
 
 func (s *sanitizeCharmOriginSuite) TestSanitize(c *gc.C) {
-	received := params.CharmOrigin{
-		Architecture: "all",
-		OS:           "all",
-		Series:       "all",
+	received := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "all",
+			OS:           "all",
+			Series:       "all",
+		},
 	}
-	requested := params.CharmOrigin{
-		Architecture: arch.DefaultArchitecture,
-		OS:           "Ubuntu",
-		Series:       "focal",
+	requested := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "Ubuntu",
+			Series:       "focal",
+		},
 	}
 	got, err := sanitizeCharmOrigin(received, requested)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
-		Architecture: arch.DefaultArchitecture,
-		OS:           "ubuntu",
-		Series:       "focal",
+	c.Assert(got, gc.DeepEquals, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "ubuntu",
+			Series:       "focal",
+		},
 	})
 }
 
 func (s *sanitizeCharmOriginSuite) TestSanitizeWithValues(c *gc.C) {
-	received := params.CharmOrigin{
-		Architecture: "arm64",
-		OS:           "windows",
-		Series:       "win8",
+	received := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "arm64",
+			OS:           "windows",
+			Series:       "win8",
+		},
 	}
-	requested := params.CharmOrigin{
-		Architecture: arch.DefaultArchitecture,
-		OS:           "Ubuntu",
-		Series:       "focal",
+	requested := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "Ubuntu",
+			Series:       "focal",
+		},
 	}
 	got, err := sanitizeCharmOrigin(received, requested)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
-		Architecture: "arm64",
-		OS:           "windows",
-		Series:       "win8",
+	c.Assert(got, gc.DeepEquals, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "arm64",
+			OS:           "windows",
+			Series:       "win8",
+		},
 	})
 }
 
 func (s *sanitizeCharmOriginSuite) TestSanitizeWithEmptyValues(c *gc.C) {
-	received := params.CharmOrigin{
-		Architecture: "",
-		OS:           "",
-		Series:       "",
+	received := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "",
+			Series:       "",
+		},
 	}
-	requested := params.CharmOrigin{
-		Architecture: arch.DefaultArchitecture,
-		OS:           "Ubuntu",
-		Series:       "focal",
+	requested := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "Ubuntu",
+			Series:       "focal",
+		},
 	}
 	got, err := sanitizeCharmOrigin(received, requested)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
-		Architecture: "",
-		OS:           "",
-		Series:       "",
+	c.Assert(got, gc.DeepEquals, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "",
+			Series:       "",
+		},
 	})
 }
 
 func (s *sanitizeCharmOriginSuite) TestSanitizeWithRequestedEmptyValues(c *gc.C) {
-	received := params.CharmOrigin{
-		Architecture: "all",
-		OS:           "all",
-		Series:       "all",
+	received := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "all",
+			OS:           "all",
+			Series:       "all",
+		},
 	}
-	requested := params.CharmOrigin{
-		Architecture: "",
-		OS:           "",
-		Series:       "",
+	requested := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "",
+			Series:       "",
+		},
 	}
 	got, err := sanitizeCharmOrigin(received, requested)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
-		Architecture: "",
-		OS:           "",
-		Series:       "",
+	c.Assert(got, gc.DeepEquals, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "",
+			Series:       "",
+		},
 	})
 }
 
 func (s *sanitizeCharmOriginSuite) TestSanitizeWithRequestedEmptyValuesAlt(c *gc.C) {
-	received := params.CharmOrigin{
-		Architecture: "all",
-		OS:           "all",
-		Series:       "focal",
+	received := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "all",
+			OS:           "all",
+			Series:       "focal",
+		},
 	}
-	requested := params.CharmOrigin{
-		Architecture: "",
-		OS:           "",
-		Series:       "",
+	requested := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "",
+			Series:       "",
+		},
 	}
 	got, err := sanitizeCharmOrigin(received, requested)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
-		Architecture: "",
-		OS:           "ubuntu",
-		Series:       "focal",
+	c.Assert(got, gc.DeepEquals, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "ubuntu",
+			Series:       "focal",
+		},
 	})
 }
 
 func (s *sanitizeCharmOriginSuite) TestSanitizeWithRequestedEmptyValuesOSVersusSeries(c *gc.C) {
-	received := params.CharmOrigin{
-		Architecture: "all",
-		OS:           "ubuntu",
-		Series:       "all",
+	received := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "all",
+			OS:           "ubuntu",
+			Series:       "all",
+		},
 	}
-	requested := params.CharmOrigin{
-		Architecture: "",
-		OS:           "",
-		Series:       "",
+	requested := corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "",
+			Series:       "",
+		},
 	}
 	got, err := sanitizeCharmOrigin(received, requested)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(got, gc.DeepEquals, params.CharmOrigin{
-		Architecture: "",
-		OS:           "ubuntu",
-		Series:       "",
+	c.Assert(got, gc.DeepEquals, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "",
+			OS:           "ubuntu",
+			Series:       "",
+		},
 	})
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12855,6 +12855,18 @@
                     },
                     "description": "List returns a list of charm URLs currently in the state.\nIf supplied parameter contains any names, the result will\nbe filtered to return only the charms with supplied names."
                 },
+                "ListCharmResources": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURLAndOrigins"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmResourcesResults"
+                        }
+                    },
+                    "description": "ListCharmResources returns a series of resources for a given charm."
+                },
                 "ResolveCharms": {
                     "type": "object",
                     "properties": {
@@ -13458,6 +13470,48 @@
                         "scope"
                     ]
                 },
+                "CharmResource": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size"
+                    ]
+                },
                 "CharmResourceMeta": {
                     "type": "object",
                     "properties": {
@@ -13480,6 +13534,77 @@
                         "type",
                         "path",
                         "description"
+                    ]
+                },
+                "CharmResourceResult": {
+                    "type": "object",
+                    "properties": {
+                        "CharmResource": {
+                            "$ref": "#/definitions/CharmResource"
+                        },
+                        "ErrorResult": {
+                            "$ref": "#/definitions/ErrorResult"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ErrorResult",
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size",
+                        "CharmResource"
+                    ]
+                },
+                "CharmResourcesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/CharmResourceResult"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "CharmStorage": {

--- a/apiserver/params/resources.go
+++ b/apiserver/params/resources.go
@@ -140,3 +140,14 @@ type CharmResource struct {
 	// Size is the size of the resource, in bytes.
 	Size int64 `json:"size"`
 }
+
+// CharmResourcesResults returns a list of charm resource results.
+type CharmResourcesResults struct {
+	Results [][]CharmResourceResult `json:"results"`
+}
+
+// CharmResourceResult returns a charm resource result.
+type CharmResourceResult struct {
+	ErrorResult
+	CharmResource
+}

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -281,7 +281,7 @@ func (c *CharmhubResourceLister) ListResources(ids []CharmID) ([][]charmresource
 		Risk:   string(id.Channel.Risk),
 	})
 	if errors.IsNotSupported(err) {
-		return nil, nil
+		return nil, errors.Errorf("charmhub charms are not supported with the current controller, try upgrading the controller to a newer version")
 	} else if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/juju/charm/v8"
-	"github.com/juju/juju/apiserver/params"
+	charmresource "github.com/juju/charm/v8/resource"
 )
 
 // Repository represents the necessary methods to resolve and download
@@ -16,7 +16,7 @@ type Repository interface {
 	// FindDownloadURL returns a url from which a charm can be downloaded
 	// based on the given charm url and charm origin.  A charm origin
 	// updated with the ID and hash for the download is also returned.
-	FindDownloadURL(curl *charm.URL, origin Origin) (*url.URL, Origin, error)
+	FindDownloadURL(*charm.URL, Origin) (*url.URL, Origin, error)
 
 	// DownloadCharm reads the charm referenced the resource URL or downloads
 	// into a file with the given path, which will be created if needed.
@@ -29,5 +29,8 @@ type Repository interface {
 	// is used. It returns a charm URL which includes the most current revision,
 	// if none was provided, a charm origin, and a slice of series supported by
 	// this charm.
-	ResolveWithPreferredChannel(*charm.URL, params.CharmOrigin) (*charm.URL, params.CharmOrigin, []string, error)
+	ResolveWithPreferredChannel(*charm.URL, Origin) (*charm.URL, Origin, []string, error)
+
+	// ListResources returns a list of resources associated with a given charm.
+	ListResources(*charm.URL, Origin) ([]charmresource.Resource, error)
 }


### PR DESCRIPTION
The following adds the ability to list a charms resources from a
charmhub perspective. The facade implementation is rather easy as we can
reuse a lot of existing functionality.

I did spot an issue with the implementation, the core/charm repository
interface was importing params, which is a massive no-no. I fixed that
to have a much cleaner implementation and removed a ton of code as well.

With that fixed, the list charm resources works as designed.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju charm-resources postgresql
Resource  Revision
wal-e     0
```
