### PR TITLE
Allow upgrading from 2.8.9 to 3

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -294,7 +294,7 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, gc.ErrorMatches, `
-these models must first be upgraded to at least 2.9.0 before upgrading the controller:
+these models must first be upgraded to at least 2.8.9 before upgrading the controller:
  -admin/controller`[1:])
 }
 

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -448,9 +448,9 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
 	err := s.runPrecheck(backend)
 	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.0 before being migrated to a controller with version 3.0.0`)
+		`model must be upgraded to at least version 2.8.9 before being migrated to a controller with version 3.0.0`)
 
-	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
+	s.modelInfo.AgentVersion = version.MustParse("2.8.9")
 	err = s.runPrecheck(backend)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/upgrades/model.go
+++ b/upgrades/model.go
@@ -11,7 +11,7 @@ import (
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	3: version.MustParse("2.9.0"),
+	3: version.MustParse("2.8.9"),
 }
 
 // UpgradeAllowed returns true if a major version upgrade is allowed


### PR DESCRIPTION
Juju 2.8 and 3.0 use the same agent facade versions except for uniter which is 16 in 2.8 and 17 in 3.0.

We'll retain uniter 16 in 3.0 to allow upgrades and migrations from 2.8 -> 3.x.

## QA steps

bootstrap a 2.8.9 controller
checkout develop branch
juju upgrade-controller --build-agent
