### PR TITLE
Remove more obsolete facade apis

### DIFF
--- a/api/provisioner/machine.go
+++ b/api/provisioner/machine.go
@@ -45,7 +45,7 @@ type MachineProvisioner interface {
 	Refresh() error
 
 	// ProvisioningInfo returns the information required to provision a machine.
-	ProvisioningInfo() (*params.ProvisioningInfoV10, error)
+	ProvisioningInfo() (*params.ProvisioningInfo, error)
 
 	// SetInstanceStatus sets the status for the provider instance.
 	SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error
@@ -182,8 +182,8 @@ func (m *Machine) Refresh() error {
 }
 
 // ProvisioningInfo implements MachineProvisioner.ProvisioningInfo.
-func (m *Machine) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
-	var results params.ProvisioningInfoResultsV10
+func (m *Machine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
+	var results params.ProvisioningInfoResults
 	args := params.Entities{Entities: []params.Entity{{m.tag.String()}}}
 	err := m.st.facade.FacadeCall("ProvisioningInfo", args, &results)
 	if err != nil {

--- a/api/provisioner/mocks/machine_mock.go
+++ b/api/provisioner/mocks/machine_mock.go
@@ -201,10 +201,10 @@ func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
 }
 
 // ProvisioningInfo mocks base method
-func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
+func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo")
-	ret0, _ := ret[0].(*params.ProvisioningInfoV10)
+	ret0, _ := ret[0].(*params.ProvisioningInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -147,31 +147,8 @@ func (st *State) ContainerManagerConfig(args params.ContainerManagerConfigParams
 // ContainerConfig returns information from the model config that is
 // needed for container cloud-init.
 func (st *State) ContainerConfig() (result params.ContainerConfig, err error) {
-	if st.facade.BestAPIVersion() < 6 {
-		return st.containerConfigV5()
-	}
 	err = st.facade.FacadeCall("ContainerConfig", nil, &result)
 	return result, err
-}
-
-func (st *State) containerConfigV5() (params.ContainerConfig, error) {
-	var result params.ContainerConfigV5
-	if err := st.facade.FacadeCall("ContainerConfig", nil, &result); err != nil {
-		return params.ContainerConfig{}, err
-	}
-	return params.ContainerConfig{
-		ProviderType:            result.ProviderType,
-		AuthorizedKeys:          result.AuthorizedKeys,
-		SSLHostnameVerification: result.SSLHostnameVerification,
-		LegacyProxy:             result.Proxy,
-		AptProxy:                result.AptProxy,
-		// JujuProxy is zero value.
-		// SnapProxy is zero value,
-		AptMirror:                  result.AptMirror,
-		CloudInitUserData:          result.CloudInitUserData,
-		ContainerInheritProperties: result.ContainerInheritProperties,
-		UpdateBehavior:             result.UpdateBehavior,
-	}, nil
 }
 
 // MachinesWithTransientErrors returns a slice of machines and corresponding status information

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/juju/juju/api"
 	apimocks "github.com/juju/juju/api/base/mocks"
-	apibasetesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/provisioner"
 	apitesting "github.com/juju/juju/api/testing"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -697,21 +696,6 @@ func (s *provisionerSuite) TestContainerManagerConfigPermissive(c *gc.C) {
 
 func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 	result, err := s.provisioner.ContainerConfig()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.ProviderType, gc.Equals, "dummy")
-	c.Assert(result.AuthorizedKeys, gc.Equals, s.Environ.Config().AuthorizedKeys())
-	c.Assert(result.SSLHostnameVerification, jc.IsTrue)
-}
-
-func (s *provisionerSuite) TestContainerConfigV5(c *gc.C) {
-	caller := apibasetesting.BestVersionCaller{
-		APICallerFunc: s.st.APICall,
-		BestVersion:   5,
-	}
-
-	provAPI := provisioner.NewState(caller)
-
-	result, err := provAPI.ContainerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.ProviderType, gc.Equals, "dummy")
 	c.Assert(result.AuthorizedKeys, gc.Equals, s.Environ.Config().AuthorizedKeys())

--- a/api/storageprovisioner/provisioner.go
+++ b/api/storageprovisioner/provisioner.go
@@ -88,7 +88,7 @@ func (st *State) WatchVolumes(scope names.Tag) (watcher.StringsWatcher, error) {
 	return st.watchStorageEntities("WatchVolumes", scope)
 }
 
-// WatchVolumes watches for lifecycle changes to volumes scoped to the
+// WatchFilesystems watches for lifecycle changes to volumes scoped to the
 // entity with the specified tag.
 func (st *State) WatchFilesystems(scope names.Tag) (watcher.StringsWatcher, error) {
 	return st.watchStorageEntities("WatchFilesystems", scope)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -304,7 +304,6 @@ func AllFacades() *facade.Registry {
 	reg("Storage", 5, storage.NewStorageAPIV5) // Update and Delete storage pools and CreatePool bulk calls.
 	reg("Storage", 6, storage.NewStorageAPI)   // modify Remove to support force and maxWait; add DetachStorage to support force and maxWait.
 
-	reg("StorageProvisioner", 3, storageprovisioner.NewFacadeV3)
 	reg("StorageProvisioner", 4, storageprovisioner.NewFacadeV4)
 	reg("Subnets", 2, subnets.NewAPIv2)
 	reg("Subnets", 3, subnets.NewAPIv3)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -275,14 +275,6 @@ func AllFacades() *facade.Registry {
 	)
 
 	reg("Pinger", 1, NewPinger)
-	reg("Provisioner", 3, provisioner.NewProvisionerAPIV4) // Yes this is weird.
-	reg("Provisioner", 4, provisioner.NewProvisionerAPIV4)
-	reg("Provisioner", 5, provisioner.NewProvisionerAPIV5)   // Adds DistributionGroupByMachineId()
-	reg("Provisioner", 6, provisioner.NewProvisionerAPIV6)   // Adds more proxy settings
-	reg("Provisioner", 7, provisioner.NewProvisionerAPIV7)   // Adds charm profile watcher
-	reg("Provisioner", 8, provisioner.NewProvisionerAPIV8)   // Adds changes charm profile and modification status
-	reg("Provisioner", 9, provisioner.NewProvisionerAPIV9)   // Adds supported containers
-	reg("Provisioner", 10, provisioner.NewProvisionerAPIV10) // Adds support for multiple space constraints.
 	reg("Provisioner", 11, provisioner.NewProvisionerAPIV11) // Relies on agent-set origin in SetHostMachineNetworkConfig.
 
 	reg("ProxyUpdater", 1, proxyupdater.NewFacadeV1)

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -234,9 +234,6 @@ func AllFacades() *facade.Registry {
 	reg("MachineManager", 6, machinemanager.NewFacadeV6) // DestroyMachinesWithParams gains maxWait.
 
 	reg("MachineUndertaker", 1, machineundertaker.NewFacade)
-	reg("Machiner", 1, machine.NewMachinerAPIV1)
-	reg("Machiner", 2, machine.NewMachinerAPIV2) // Adds RecordAgentStartTime.
-	reg("Machiner", 3, machine.NewMachinerAPIV3) // Relies on agent-set origin in SetObservedNetworkConfig.
 	reg("Machiner", 4, machine.NewMachinerAPI)   // Removes SetProviderNetworkConfig.
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacadeV1)

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -18,9 +18,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// TODO (manadart 2020-10-21): Remove the ModelUUID method
-// from the next version of this facade.
-
 // MachinerAPI implements the API used by the machiner worker.
 type MachinerAPI struct {
 	*common.LifeGetter
@@ -165,87 +162,3 @@ func (api *MachinerAPI) RecordAgentStartTime(args params.Entities) (params.Error
 	}
 	return results, nil
 }
-
-// ModelUUID returns the model UUID that this machine resides in.
-// It is implemented here directly as a result of removing it from
-// embedded APIAddresser *without* bumping the facade version.
-// It should be blanked when this facade version is next incremented.
-func (api *MachinerAPI) ModelUUID() params.StringResult {
-	return params.StringResult{Result: api.st.ModelUUID()}
-}
-
-// MachinerAPIV1 implements the V1 API used by the machiner worker.
-type MachinerAPIV1 struct {
-	*MachinerAPIV2
-}
-
-// MachinerAPIV2 implements the V2 API used by the machiner worker.
-// It adds RecordAgentStartTime and back-fills the missing origin in
-// NetworkConfig.
-type MachinerAPIV2 struct {
-	*MachinerAPIV3
-}
-
-// MachinerAPIV3 implements the V3 API used by the machiner worker.
-// It removes SetProviderNetworkConfig.
-type MachinerAPIV3 struct {
-	*MachinerAPI
-}
-
-// NewMachinerAPIV1 creates a new instance of the V1 Machiner API.
-func NewMachinerAPIV1(
-	ctx facade.Context,
-) (*MachinerAPIV1, error) {
-	api, err := NewMachinerAPIV2(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &MachinerAPIV1{api}, nil
-}
-
-// NewMachinerAPIV2 creates a new instance of the V2 Machiner API.
-func NewMachinerAPIV2(
-	ctx facade.Context,
-) (*MachinerAPIV2, error) {
-	api, err := NewMachinerAPIV3(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &MachinerAPIV2{api}, nil
-}
-
-// SetObservedNetworkConfig back-fills machine origin before calling through to
-// the networking common method of the same name.
-// Older agents do not set the origin, so we must do it for them.
-func (api *MachinerAPIV2) SetObservedNetworkConfig(args params.SetMachineNetworkConfig) error {
-	args.BackFillMachineOrigin()
-	return api.NetworkConfigAPI.SetObservedNetworkConfig(args)
-}
-
-// NewMachinerAPIV3 creates a new instance of the V3 Machiner API.
-func NewMachinerAPIV3(
-	ctx facade.Context,
-) (*MachinerAPIV3, error) {
-	api, err := NewMachinerAPI(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &MachinerAPIV3{api}, nil
-}
-
-// SetProviderNetworkConfig is no-op.
-// This method stub is here, because the method was removed from the common
-// networking API.
-// It was only ever called by controller machine agents during start-up.
-// Not only was this unnecessary, it duplicated link-layer devices on AWS.
-func (api *MachinerAPIV3) SetProviderNetworkConfig(args params.Entities) (params.ErrorResults, error) {
-	return params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.Entities)),
-	}, nil
-}
-
-// RecordAgentStartTime is not available in V1.
-func (api *MachinerAPIV1) RecordAgentStartTime(_, _ struct{}) {}

--- a/apiserver/facades/agent/provisioner/imagemetadata_test.go
+++ b/apiserver/facades/agent/provisioner/imagemetadata_test.go
@@ -149,7 +149,7 @@ func (s *ImageMetadataSuite) expectedDataSoureImageMetadata() [][]params.CloudIm
 }
 
 func (s *ImageMetadataSuite) assertImageMetadataResults(
-	c *gc.C, obtained params.ProvisioningInfoResultsV10, expected ...[]params.CloudImageMetadata,
+	c *gc.C, obtained params.ProvisioningInfoResults, expected ...[]params.CloudImageMetadata,
 ) {
 	c.Assert(obtained.Results, gc.HasLen, len(expected))
 	for i, one := range obtained.Results {

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -173,112 +173,10 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 	return api, nil
 }
 
-// ProvisionerAPIV4 provides v4 (and v3 for some reason) of the provisioner facade.
-type ProvisionerAPIV4 struct {
-	*ProvisionerAPIV5
-}
-
-// ProvisionerAPIV5 provides v5 of the provisioner facade.
-type ProvisionerAPIV5 struct {
-	*ProvisionerAPIV6
-}
-
-// ProvisionerAPIV6 provides v6 of the provisioner facade.
-type ProvisionerAPIV6 struct {
-	*ProvisionerAPIV7
-}
-
-// ProvisionerAPIV7 provides v7 of the provisioner facade.
-type ProvisionerAPIV7 struct {
-	*ProvisionerAPIV8
-}
-
-// ProvisionerAPIV8 provides v8 of the provisioner facade.
-// Added ModificationStatus and SetModificationStatus
-type ProvisionerAPIV8 struct {
-	*ProvisionerAPIV9
-}
-
-// ProvisionerAPIV9 provides v9 of the provisioner facade.
-// Added SupportedContainers
-type ProvisionerAPIV9 struct {
-	*ProvisionerAPIV10
-}
-
-// ProvisionerAPIV10 provides v10 of the provisioner facade.
-// It returns a new form of ProvisioningInfo that
-// supports multiple space constraints.
-type ProvisionerAPIV10 struct {
-	*ProvisionerAPIV11
-}
-
 // ProvisionerAPIV11 provides v10 of the provisioner facade.
 // It relies on agent-set origin when calling SetHostMachineNetworkConfig.
 type ProvisionerAPIV11 struct {
 	*ProvisionerAPI
-}
-
-// NewProvisionerAPIV4 creates a new server-side version 4 Provisioner API facade.
-func NewProvisionerAPIV4(ctx facade.Context) (*ProvisionerAPIV4, error) {
-	provisionerAPI, err := NewProvisionerAPIV5(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV4{provisionerAPI}, nil
-}
-
-// NewProvisionerAPIV5 creates a new server-side Provisioner API facade.
-func NewProvisionerAPIV5(ctx facade.Context) (*ProvisionerAPIV5, error) {
-	provisionerAPI, err := NewProvisionerAPIV6(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV5{provisionerAPI}, nil
-}
-
-// NewProvisionerAPIV6 creates a new server-side Provisioner API facade.
-func NewProvisionerAPIV6(ctx facade.Context) (*ProvisionerAPIV6, error) {
-	provisionerAPI, err := NewProvisionerAPIV7(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV6{provisionerAPI}, nil
-}
-
-// NewProvisionerAPIV7 creates a new server-side Provisioner API facade.
-func NewProvisionerAPIV7(ctx facade.Context) (*ProvisionerAPIV7, error) {
-	provisionerAPI, err := NewProvisionerAPIV8(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV7{provisionerAPI}, nil
-}
-
-// NewProvisionerAPIV8 creates a new server-side Provisioner API facade.
-func NewProvisionerAPIV8(ctx facade.Context) (*ProvisionerAPIV8, error) {
-	provisionerAPI, err := NewProvisionerAPIV9(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV8{provisionerAPI}, nil
-}
-
-// NewProvisionerAPIV9 creates a new server-side Provisioner API facade.
-func NewProvisionerAPIV9(ctx facade.Context) (*ProvisionerAPIV9, error) {
-	provisionerAPI, err := NewProvisionerAPIV10(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV9{provisionerAPI}, nil
-}
-
-// NewProvisionerAPIV10 creates a new server-side Provisioner API facade.
-func NewProvisionerAPIV10(ctx facade.Context) (*ProvisionerAPIV10, error) {
-	provisionerAPI, err := NewProvisionerAPIV11(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &ProvisionerAPIV10{provisionerAPI}, nil
 }
 
 // NewProvisionerAPIV11 creates a new server-side Provisioner API facade.
@@ -356,19 +254,6 @@ func (api *ProvisionerAPI) WatchAllContainers(args params.WatchContainers) (para
 	return api.WatchContainers(args)
 }
 
-// WatchContainersCharmProfiles starts a StringsWatcher to  notifies when
-// the provisioner should update the charm profiles used by a container on
-// the given machine.
-//
-// Remove in juju 3, this is for compatibility of provisioner using
-// APIV7 or APIV8. It is required for the worker to start, and for
-// the former processProfileChanges, which will no longer be used in APIv9.
-// Code in apiserver application SetCharm() will prevent APIv8
-// models from upgrading charm with profiles and causing issues.
-func (p *ProvisionerAPIV8) WatchContainersCharmProfiles(args params.WatchContainers) (params.StringsWatchResults, error) {
-	return p.WatchContainers(args)
-}
-
 // SetSupportedContainers updates the list of containers supported by the machines passed in args.
 func (api *ProvisionerAPI) SetSupportedContainers(args params.MachineContainersParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
@@ -401,10 +286,6 @@ func (api *ProvisionerAPI) SetSupportedContainers(args params.MachineContainersP
 		}
 	}
 	return result, nil
-}
-
-func (p *ProvisionerAPIV8) SupportedContainers(_, _ struct{}) (params.MachineContainerResults, error) {
-	return params.MachineContainerResults{}, nil
 }
 
 // SupportedContainers returns the list of containers supported by the machines passed in args.
@@ -490,28 +371,6 @@ func (api *ProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
 	result.CloudInitUserData = cfg.CloudInitUserData()
 	result.ContainerInheritProperties = cfg.ContainerInheritProperties()
 	return result, nil
-}
-
-// ContainerConfig returns information from the model config that is
-// needed for container cloud-init.
-func (p *ProvisionerAPIV5) ContainerConfig() (params.ContainerConfigV5, error) {
-	var empty params.ContainerConfigV5
-	cfg, err := p.ProvisionerAPI.ContainerConfig()
-	if err != nil {
-		return empty, err
-	}
-
-	return params.ContainerConfigV5{
-		ProviderType:               cfg.ProviderType,
-		AuthorizedKeys:             cfg.AuthorizedKeys,
-		SSLHostnameVerification:    cfg.SSLHostnameVerification,
-		Proxy:                      cfg.LegacyProxy,
-		AptProxy:                   cfg.AptProxy,
-		AptMirror:                  cfg.AptMirror,
-		CloudInitUserData:          cfg.CloudInitUserData,
-		ContainerInheritProperties: cfg.ContainerInheritProperties,
-		UpdateBehavior:             cfg.UpdateBehavior,
-	}, nil
 }
 
 // MachinesWithTransientErrors returns status data for machines with provisioning
@@ -726,9 +585,6 @@ func commonServiceInstances(st *state.State, m *state.Machine) ([]instance.Id, e
 	return instanceIds, nil
 }
 
-// DistributionGroupByMachineId isn't on the v4 API.
-func (p *ProvisionerAPIV4) DistributionGroupByMachineId(_, _ struct{}) {}
-
 // DistributionGroupByMachineId returns, for each given machine entity,
 // a slice of machine.Ids that belong to the same distribution
 // group as that machine. This information may be used to
@@ -883,18 +739,6 @@ func (api *ProvisionerAPI) WatchMachineErrorRetry() (params.NotifyWatchResult, e
 		return result, watcher.EnsureErr(watch)
 	}
 	return result, nil
-}
-
-// WatchModelMachinesCharmProfiles returns a StringsWatcher that notifies when
-// the provisioner should update the charm profiles used by a machine.
-//
-// Remove in juju 3, this is for compatibility of provisioner using
-// APIV7 or APIV8. It is required for the worker to start, and for
-// the former processProfileChanges, which will no longer be used in APIv9.
-// Code in apiserver application SetCharm() will prevent APIv8
-// models from upgrading charm with profiles and causing issues.
-func (p *ProvisionerAPIV8) WatchModelMachinesCharmProfiles() (params.StringsWatchResult, error) {
-	return p.WatchModelMachines()
 }
 
 // ReleaseContainerAddresses finds addresses allocated to a container and marks
@@ -1378,9 +1222,6 @@ func (api *ProvisionerAPI) SetInstanceStatus(args params.SetStatus) (params.Erro
 	return result, nil
 }
 
-// SetModificationStatus isn't on the v7 or lower API.
-func (p *ProvisionerAPIV7) SetModificationStatus(_, _ struct{}) {}
-
 // SetModificationStatus updates the instance whilst changes are occurring. This
 // is different from SetStatus and SetInstanceStatus, by the fact this holds
 // information about the ongoing changes that are happening to instances.
@@ -1462,13 +1303,6 @@ func (api *ProvisionerAPI) markOneMachineForRemoval(machineTag string, canAccess
 	return machine.MarkForRemoval()
 }
 
-// SetHostMachineNetworkConfig on versions prior to 11 will not receive args
-// with origin set by the calling agent. We back-fill for them.
-func (api *ProvisionerAPIV10) SetHostMachineNetworkConfig(args params.SetMachineNetworkConfig) error {
-	args.BackFillMachineOrigin()
-	return api.SetObservedNetworkConfig(args)
-}
-
 func (api *ProvisionerAPI) SetHostMachineNetworkConfig(args params.SetMachineNetworkConfig) error {
 	return api.SetObservedNetworkConfig(args)
 }
@@ -1481,18 +1315,6 @@ func (api *ProvisionerAPI) CACert() (params.BytesResult, error) {
 	}
 	caCert, _ := cfg.CACert()
 	return params.BytesResult{Result: []byte(caCert)}, nil
-}
-
-// CharmProfileChangeInfo retrieves the info necessary to change a charm
-// profile used by a machine.
-//
-// Remove in juju 3, this is for compatibility of provisioner using
-// APIV7 or APIV8. It is required for the worker to start, and for
-// the former processProfileChanges, which will no longer be used in APIv9.
-// Code in apiserver application SetCharm() will prevent APIv8
-// models from upgrading charm with profiles and causing issues.
-func (p *ProvisionerAPIV8) CharmProfileChangeInfo(args params.ProfileArgs) (params.ProfileChangeResults, error) {
-	return params.ProfileChangeResults{}, errors.NewNotSupported(nil, "CharmProfileChangeInfo")
 }
 
 // SetCharmProfiles records the given slice of charm profile names.
@@ -1524,30 +1346,4 @@ func (api *ProvisionerAPI) setOneMachineCharmProfiles(machineTag string, profile
 // ModelUUID returns the model UUID that the current connection is for.
 func (api *ProvisionerAPI) ModelUUID() params.StringResult {
 	return params.StringResult{Result: api.st.ModelUUID()}
-}
-
-// SetUpgradeCharmProfileComplete recorded that the result of updating
-// the machine's charm profile(s)
-//
-// Remove in juju 3. Upgrading existing charm profiles is now handled
-// in the instance mutater worker.  This is for compatibility only with
-// older provisioners.
-func (p *ProvisionerAPIV8) SetUpgradeCharmProfileComplete(args params.SetProfileUpgradeCompleteArgs) (params.ErrorResults, error) {
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.Args)),
-	}
-	return results, nil
-}
-
-// RemoveUpgradeCharmProfileData completely removes the instance charm profile
-// data for a machine, even if the machine is dead.
-//
-// Remove in juju 3. Upgrading existing charm profiles is now handled
-// in the instance mutater worker.  This is for compatibility only with
-// older provisioners.
-func (p *ProvisionerAPIV8) RemoveUpgradeCharmProfileData(args params.Entities) (params.ErrorResults, error) {
-	results := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(args.Entities)),
-	}
-	return results, nil
 }

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -24,8 +24,9 @@ import (
 // to change any part of it so that it were no longer *obviously* and
 // *trivially* correct, you would be Doing It Wrong.
 
-// NewFacadeV3 provides the signature required for facade registration.
-func NewFacadeV3(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*StorageProvisionerAPIv3, error) {
+// NewFacadeV4 provides the signature required for facade registration.
+func NewFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
+	st := ctx.State()
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -41,19 +42,7 @@ func NewFacadeV3(st *state.State, resources facade.Resources, authorizer facade.
 	pm := poolmanager.New(state.NewStateSettings(st), registry)
 
 	backend, storageBackend, err := NewStateBackends(st)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting backend")
-	}
-	return NewStorageProvisionerAPIv3(backend, storageBackend, resources, authorizer, registry, pm)
-}
-
-// NewFacadeV4 provides the signature required for facade registration.
-func NewFacadeV4(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*StorageProvisionerAPIv4, error) {
-	v3, err := NewFacadeV3(st, resources, authorizer)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return NewStorageProvisionerAPIv4(v3), nil
+	return NewStorageProvisionerAPIv4(backend, storageBackend, ctx.Resources(), ctx.Auth(), registry, pm)
 }
 
 type Backend interface {

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -87,9 +87,8 @@ func (s *iaasProvisionerSuite) SetUpTest(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
-	v3, err := storageprovisioner.NewStorageProvisionerAPIv3(backend, storageBackend, s.resources, s.authorizer, registry, pm)
+	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = storageprovisioner.NewStorageProvisionerAPIv4(v3)
 }
 
 func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
@@ -120,9 +119,8 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.State)
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
-	v3, err := storageprovisioner.NewStorageProvisionerAPIv3(backend, storageBackend, s.resources, s.authorizer, registry, pm)
+	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, s.resources, s.authorizer, registry, pm)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = storageprovisioner.NewStorageProvisionerAPIv4(v3)
 }
 
 func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
@@ -130,7 +128,7 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.State)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = storageprovisioner.NewStorageProvisionerAPIv3(backend, storageBackend, common.NewResources(), authorizer, nil, nil)
+	_, err = storageprovisioner.NewStorageProvisionerAPIv4(backend, storageBackend, common.NewResources(), authorizer, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -32108,7 +32108,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/ProvisioningInfoResultsV10"
+                            "$ref": "#/definitions/ProvisioningInfoResults"
                         }
                     },
                     "description": "ProvisioningInfo returns the provisioning information for each given machine entity.\nIt supports all positive space constraints."
@@ -33560,130 +33560,9 @@
                         "Build"
                     ]
                 },
-                "ProvisioningInfoBase": {
+                "ProvisioningInfo": {
                     "type": "object",
                     "properties": {
-                        "charm-lxd-profiles": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "cloudinit-userdata": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        },
-                        "constraints": {
-                            "$ref": "#/definitions/Value"
-                        },
-                        "controller-config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        },
-                        "endpoint-bindings": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "image-metadata": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CloudImageMetadata"
-                            }
-                        },
-                        "jobs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "placement": {
-                            "type": "string"
-                        },
-                        "root-disk": {
-                            "$ref": "#/definitions/VolumeParams"
-                        },
-                        "series": {
-                            "type": "string"
-                        },
-                        "tags": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "volume-attachments": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/VolumeAttachmentParams"
-                            }
-                        },
-                        "volumes": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/VolumeParams"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "constraints",
-                        "series",
-                        "placement",
-                        "jobs"
-                    ]
-                },
-                "ProvisioningInfoResultV10": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "result": {
-                            "$ref": "#/definitions/ProvisioningInfoV10"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "result"
-                    ]
-                },
-                "ProvisioningInfoResultsV10": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ProvisioningInfoResultV10"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
-                    ]
-                },
-                "ProvisioningInfoV10": {
-                    "type": "object",
-                    "properties": {
-                        "ProvisioningInfoBase": {
-                            "$ref": "#/definitions/ProvisioningInfoBase"
-                        },
                         "ProvisioningNetworkTopology": {
                             "$ref": "#/definitions/ProvisioningNetworkTopology"
                         },
@@ -33792,10 +33671,39 @@
                         "series",
                         "placement",
                         "jobs",
-                        "ProvisioningInfoBase",
                         "subnet-zones",
                         "space-subnets",
                         "ProvisioningNetworkTopology"
+                    ]
+                },
+                "ProvisioningInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ProvisioningInfo"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "ProvisioningInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ProvisioningInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "ProvisioningNetworkTopology": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -26362,15 +26362,6 @@
                     },
                     "description": "Life returns the life status of every supplied entity, where available."
                 },
-                "ModelUUID": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/StringResult"
-                        }
-                    },
-                    "description": "ModelUUID returns the model UUID that this machine resides in.\nIt is implemented here directly as a result of removing it from\nembedded APIAddresser *without* bumping the facade version.\nIt should be blanked when this facade version is next incremented."
-                },
                 "RecordAgentStartTime": {
                     "type": "object",
                     "properties": {
@@ -26932,21 +26923,6 @@
                     "additionalProperties": false,
                     "required": [
                         "entities"
-                    ]
-                },
-                "StringResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "result": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "result"
                     ]
                 },
                 "StringsResult": {
@@ -39071,7 +39047,7 @@
                             "$ref": "#/definitions/ErrorResults"
                         }
                     },
-                    "description": "RemoveAttachments removes the specified machine storage attachments\nfrom state."
+                    "description": "RemoveAttachment removes the specified machine storage attachments\nfrom state."
                 },
                 "RemoveFilesystemParams": {
                     "type": "object",

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -769,44 +769,6 @@ type AgentVersionResult struct {
 	Version version.Number `json:"version"`
 }
 
-// ProvisioningInfoBase holds machine provisioning info common
-// across different versions of the provisioner API facade.
-type ProvisioningInfoBase struct {
-	Constraints       constraints.Value        `json:"constraints"`
-	Series            string                   `json:"series"`
-	Placement         string                   `json:"placement"`
-	Jobs              []model.MachineJob       `json:"jobs"`
-	RootDisk          *VolumeParams            `json:"root-disk,omitempty"`
-	Volumes           []VolumeParams           `json:"volumes,omitempty"`
-	VolumeAttachments []VolumeAttachmentParams `json:"volume-attachments,omitempty"`
-	Tags              map[string]string        `json:"tags,omitempty"`
-	ImageMetadata     []CloudImageMetadata     `json:"image-metadata,omitempty"`
-	EndpointBindings  map[string]string        `json:"endpoint-bindings,omitempty"`
-	ControllerConfig  map[string]interface{}   `json:"controller-config,omitempty"`
-	CloudInitUserData map[string]interface{}   `json:"cloudinit-userdata,omitempty"`
-	CharmLXDProfiles  []string                 `json:"charm-lxd-profiles,omitempty"`
-}
-
-// ProvisioningInfo holds machine provisioning info returned by
-// versions 9 and lower of the provisioner API facade.
-type ProvisioningInfo struct {
-	ProvisioningInfoBase
-	SubnetsToZones map[string][]string `json:"subnets-to-zones,omitempty"`
-}
-
-// ProvisioningInfoResult holds machine provisioning info or an error
-// for versions 9 and lower of the provisioner API facade.
-type ProvisioningInfoResult struct {
-	Result *ProvisioningInfo `json:"result"`
-	Error  *Error            `json:"error,omitempty"`
-}
-
-// ProvisioningInfoResults holds multiple machine provisioning info results
-// for versions 9 and lower of the provisioner API facade.
-type ProvisioningInfoResults struct {
-	Results []ProvisioningInfoResult `json:"results"`
-}
-
 // ProvisioningNetworkTopology holds a network topology that is based on
 // positive machine space constraints.
 // This is used for creating NICs on instances where the provider is not space
@@ -824,24 +786,34 @@ type ProvisioningNetworkTopology struct {
 	SpaceSubnets map[string][]string `json:"space-subnets"`
 }
 
-// ProvisioningInfoV10 holds machine provisioning info returned by
-// versions 10 and above of the provisioner API facade.
-type ProvisioningInfoV10 struct {
-	ProvisioningInfoBase
+// ProvisioningInfo holds machine provisioning info.
+type ProvisioningInfo struct {
+	Constraints       constraints.Value        `json:"constraints"`
+	Series            string                   `json:"series"`
+	Placement         string                   `json:"placement"`
+	Jobs              []model.MachineJob       `json:"jobs"`
+	RootDisk          *VolumeParams            `json:"root-disk,omitempty"`
+	Volumes           []VolumeParams           `json:"volumes,omitempty"`
+	VolumeAttachments []VolumeAttachmentParams `json:"volume-attachments,omitempty"`
+	Tags              map[string]string        `json:"tags,omitempty"`
+	ImageMetadata     []CloudImageMetadata     `json:"image-metadata,omitempty"`
+	EndpointBindings  map[string]string        `json:"endpoint-bindings,omitempty"`
+	ControllerConfig  map[string]interface{}   `json:"controller-config,omitempty"`
+	CloudInitUserData map[string]interface{}   `json:"cloudinit-userdata,omitempty"`
+	CharmLXDProfiles  []string                 `json:"charm-lxd-profiles,omitempty"`
+
 	ProvisioningNetworkTopology
 }
 
-// ProvisioningInfoResultV10 holds machine provisioning info or an error
-// for versions 10 and above of the provisioner API facade.
-type ProvisioningInfoResultV10 struct {
-	Result *ProvisioningInfoV10 `json:"result"`
-	Error  *Error               `json:"error,omitempty"`
+// ProvisioningInfoResult holds machine provisioning info or an error.
+type ProvisioningInfoResult struct {
+	Result *ProvisioningInfo `json:"result"`
+	Error  *Error            `json:"error,omitempty"`
 }
 
-// ProvisioningInfoResultsV10 holds multiple machine provisioning info results
-// for versions 10 and above of the provisioner API facade.
-type ProvisioningInfoResultsV10 struct {
-	Results []ProvisioningInfoResultV10 `json:"results"`
+// ProvisioningInfoResults holds multiple machine provisioning info results.
+type ProvisioningInfoResults struct {
+	Results []ProvisioningInfoResult `json:"results"`
 }
 
 // Metric holds a single metric.

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -744,20 +744,6 @@ type ContainerConfig struct {
 	*UpdateBehavior
 }
 
-// ContainerConfigV5 contains information from the model config that is
-// needed for container cloud-init for version 5 provisioner api calls.
-type ContainerConfigV5 struct {
-	ProviderType               string                 `json:"provider-type"`
-	AuthorizedKeys             string                 `json:"authorized-keys"`
-	SSLHostnameVerification    bool                   `json:"ssl-hostname-verification"`
-	Proxy                      proxy.Settings         `json:"proxy"`
-	AptProxy                   proxy.Settings         `json:"apt-proxy"`
-	AptMirror                  string                 `json:"apt-mirror"`
-	CloudInitUserData          map[string]interface{} `json:"cloudinit-userdata,omitempty"`
-	ContainerInheritProperties string                 `json:"container-inherit-properties,omitempty"`
-	*UpdateBehavior
-}
-
 // ProvisioningScriptParams contains the parameters for the
 // ProvisioningScript client API call.
 type ProvisioningScriptParams struct {

--- a/worker/containerbroker/mocks/machine_mock.go
+++ b/worker/containerbroker/mocks/machine_mock.go
@@ -201,10 +201,10 @@ func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *gomock.Call {
 }
 
 // ProvisioningInfo mocks base method
-func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
+func (m *MockMachineProvisioner) ProvisioningInfo() (*params.ProvisioningInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo")
-	ret0, _ := ret[0].(*params.ProvisioningInfoV10)
+	ret0, _ := ret[0].(*params.ProvisioningInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -556,7 +556,7 @@ func (task *provisionerTask) stopInstances(instances []instances.Instance) error
 func (task *provisionerTask) constructInstanceConfig(
 	machine apiprovisioner.MachineProvisioner,
 	auth authentication.AuthenticationProvider,
-	pInfo *params.ProvisioningInfoV10,
+	pInfo *params.ProvisioningInfo,
 ) (*instancecfg.InstanceConfig, error) {
 
 	apiInfo, err := auth.SetupAuthentication(machine)
@@ -613,7 +613,7 @@ func (task *provisionerTask) constructStartInstanceParams(
 	controllerUUID string,
 	machine apiprovisioner.MachineProvisioner,
 	instanceConfig *instancecfg.InstanceConfig,
-	provisioningInfo *params.ProvisioningInfoV10,
+	provisioningInfo *params.ProvisioningInfo,
 	possibleTools coretools.List,
 ) (environs.StartInstanceParams, error) {
 

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/core/network"
 	"github.com/juju/names/v4"
 
 	"github.com/golang/mock/gomock"
@@ -29,6 +28,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -854,13 +854,11 @@ func (m *testMachine) SetInstanceInfo(
 	return nil
 }
 
-func (m *testMachine) ProvisioningInfo() (*params.ProvisioningInfoV10, error) {
-	return &params.ProvisioningInfoV10{
-		ProvisioningInfoBase: params.ProvisioningInfoBase{
-			ControllerConfig: coretesting.FakeControllerConfig(),
-			Series:           jujuversion.DefaultSupportedLTS(),
-			Constraints:      constraints.MustParse(m.constraints),
-		},
+func (m *testMachine) ProvisioningInfo() (*params.ProvisioningInfo, error) {
+	return &params.ProvisioningInfo{
+		ControllerConfig:            coretesting.FakeControllerConfig(),
+		Series:                      jujuversion.DefaultSupportedLTS(),
+		Constraints:                 constraints.MustParse(m.constraints),
 		ProvisioningNetworkTopology: m.topology,
 	}, nil
 }


### PR DESCRIPTION
Remove v10 and earlier of the provisioner facade.
Also remove storage provisioner v1 and machiner v3 and earlier.

## QA steps

bootstrap
deploy a charm with storage