### PR TITLE
Merge 2.8

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -261,6 +261,7 @@ def dump_env_logs(client, bootstrap_host, artifacts_dir, runtime_config=None):
     dump_env_logs_known_hosts(client, artifacts_dir, runtime_config,
                               known_hosts)
 
+
 def dump_env_logs_known_hosts(client, artifacts_dir, runtime_config=None,
                               known_hosts=None):
     if known_hosts is None:
@@ -284,11 +285,13 @@ def dump_env_logs_known_hosts(client, artifacts_dir, runtime_config=None,
     archive_logs(artifacts_dir)
     retain_config(runtime_config, artifacts_dir)
 
+
 def maybe_inject_ssh_keys(remote, env):
     use_ssh_key = getattr(remote, "use_ssh_key", None)
     if callable(use_ssh_key):
         identity_file = os.path.join(env.juju_home, "ssh", "juju_id_rsa")
         use_ssh_key(identity_file)
+
 
 def retain_config(runtime_config, log_directory):
     if not runtime_config:
@@ -627,8 +630,7 @@ class CreateController:
     def get_hosts(self):
         """Provide the controller host."""
         hosts = {}
-        host_0 = get_machine_dns_name(
-            self.client.get_controller_client(), '0')
+        host_0 = get_machine_dns_name(self.client.get_controller_client(), '0')
         if host_0 is not None:
             # Only IaaS controller has machine now.
             hosts['0'] = host_0
@@ -683,8 +685,7 @@ class ExistingController:
 
     def get_hosts(self):
         """Provide the controller host."""
-        host = get_machine_dns_name(
-            self.client.get_controller_client(), '0')
+        host = get_machine_dns_name(self.client.get_controller_client(), '0')
         if host is None:
             raise ValueError('Could not get machine 0 host')
         return {'0': host}
@@ -773,6 +774,7 @@ class BootstrapManager:
     # cleanup_hook allows injecting cleanup steps that are
     # not applicable for config's substrate account.
     cleanup_hook = None
+    k8s_controller = False
 
     def __init__(self, temp_env_name, client, tear_down_client, bootstrap_host,
                  machines, series, arch, agent_url, agent_stream, region,
@@ -876,7 +878,9 @@ class BootstrapManager:
                 client.env.bootstrap_to = args.to
             if args.logging_config is not None:
                 client.env.logging_config = args.logging_config
-        return cls.from_client(args, client)
+        bm = cls.from_client(args, client)
+        bm.k8s_controller = getattr(args, 'k8s_controller', False)
+        return bm
 
     @classmethod
     def _for_existing_controller(cls, args):
@@ -1063,9 +1067,10 @@ class BootstrapManager:
         """
         try:
             with logged_exception(logging):
-                if len(self.known_hosts) == 0:
+                if len(self.known_hosts) == 0 and not self.k8s_controller:
                     self.known_hosts.update(
-                        self.controller_strategy.get_hosts())
+                        self.controller_strategy.get_hosts(),
+                    )
                 if addable_machines is not None:
                     self.client.add_ssh_machines(addable_machines)
                 yield

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -563,6 +563,7 @@ def describe_substrate(env):
 def get_stripped_version_number(version_string):
     return get_version_string_parts(version_string)[0]
 
+
 def get_version_string_parts(version_string):
     # strip the series and arch from the built version.
     # Note:
@@ -1536,7 +1537,7 @@ class ModelClient:
         with self.check_timeouts():
             with self.ignore_soft_deadline():
                 yield self.get_status()
-                for remaining in until_timeout(timeout, start=start):
+                for _ in until_timeout(timeout, start=start):
                     yield self.get_status()
 
     def _wait_for_status(self, reporter, translate, exc_type=StatusNotMet,

--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 )
 
@@ -65,7 +66,11 @@ func canBeLost(agent, workload status.StatusInfo) bool {
 	case status.Allocating, status.Running:
 		return false
 	case status.Executing:
-		return agent.Message != operation.RunningHookMessage(string(hooks.Install))
+		installMsg := operation.RunningHookMessage(
+			string(hooks.Install),
+			hook.Info{Kind: hooks.Install},
+		)
+		return agent.Message != installMsg
 	}
 
 	// TODO(fwereade/wallyworld): we should have an explicit place in the model

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -295,7 +295,7 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, gc.ErrorMatches, `
-these models must first be upgraded to at least 2.9.0 before upgrading the controller:
+these models must first be upgraded to at least 2.8.9 before upgrading the controller:
  -admin/controller`[1:])
 }
 

--- a/cmd/jujud/agent/caasunitinit_test.go
+++ b/cmd/jujud/agent/caasunitinit_test.go
@@ -5,12 +5,12 @@ package agent
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"net"
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"sync"
 	"time"
 
@@ -133,7 +133,7 @@ func (s *CAASUnitInitSuite) TestInitUnit(c *gc.C) {
 }
 
 func (s *CAASUnitInitSuite) TestInitUnitWaitSend(c *gc.C) {
-	socketName := "@" + strconv.FormatInt(rand.Int63(), 10)
+	socketName := fmt.Sprintf("@%d", rand.Int63())
 	listening := make(chan struct{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -448,9 +448,9 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
 	err := s.runPrecheck(backend)
 	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.0 before being migrated to a controller with version 3.0.0`)
+		`model must be upgraded to at least version 2.8.9 before being migrated to a controller with version 3.0.0`)
 
-	s.modelInfo.AgentVersion = version.MustParse("2.9.0")
+	s.modelInfo.AgentVersion = version.MustParse("2.8.9")
 	err = s.runPrecheck(backend)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/upgrades/model.go
+++ b/upgrades/model.go
@@ -11,7 +11,7 @@ import (
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	3: version.MustParse("2.9.0"),
+	3: version.MustParse("2.8.9"),
 }
 
 // UpgradeAllowed returns true if a major version upgrade is allowed

--- a/upgrades/model_test.go
+++ b/upgrades/model_test.go
@@ -30,22 +30,22 @@ func (s *ModelSuite) TestUpgradeAllowed(c *gc.C) {
 			from:    "2.8.0",
 			to:      "3.0.0",
 			allowed: false,
-			minVers: "2.9.0",
+			minVers: "2.8.9",
 		}, {
 			from:    "2.9-rc1",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.0",
+			minVers: "2.8.9",
 		}, {
 			from:    "2.9.0",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.0",
+			minVers: "2.8.9",
 		}, {
 			from:    "2.9.1",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.0",
+			minVers: "2.8.9",
 		}, {
 			from:    "2.9.0",
 			to:      "4.0.0",

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -94,14 +94,17 @@ func (rh *runHook) Prepare(state State) (*State, error) {
 }
 
 // RunningHookMessage returns the info message to print when running a hook.
-func RunningHookMessage(hookName string) string {
+func RunningHookMessage(hookName string, info hook.Info) string {
+	if info.Kind.IsRelation() && info.RemoteUnit != "" {
+		return fmt.Sprintf("running %s hook for %s", hookName, info.RemoteUnit)
+	}
 	return fmt.Sprintf("running %s hook", hookName)
 }
 
 // Execute runs the hook.
 // Execute is part of the Operation interface.
 func (rh *runHook) Execute(state State) (*State, error) {
-	message := RunningHookMessage(rh.name)
+	message := RunningHookMessage(rh.name, rh.info)
 	if err := rh.beforeHook(state); err != nil {
 		return nil, err
 	}

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -842,3 +842,23 @@ func (s *RunHookSuite) TestNeedsGlobalMachineLock_Run(c *gc.C) {
 func (s *RunHookSuite) TestNeedsGlobalMachineLock_Skip(c *gc.C) {
 	s.testNeedsGlobalMachineLock(c, operation.Factory.NewSkipHook, false)
 }
+
+func (s *RunHookSuite) TestRunningHookMessageForRelationHooks(c *gc.C) {
+	msg := operation.RunningHookMessage(
+		"host-relation-created",
+		hook.Info{
+			Kind:       hooks.RelationCreated,
+			RemoteUnit: "alien/0",
+		},
+	)
+	c.Assert(msg, gc.Equals, "running host-relation-created hook for alien/0", gc.Commentf("expected remote unit to be included for a relation hook with a populated remote unit"))
+
+	msg = operation.RunningHookMessage(
+		"install",
+		hook.Info{
+			Kind:       hooks.Install,
+			RemoteUnit: "bogus",
+		},
+	)
+	c.Assert(msg, gc.Equals, "running install hook", gc.Commentf("expected remote unit not to be included for a non-relation hook"))
+}


### PR DESCRIPTION
Merge 2.8 with these PRs:

#12692 Fix internal microk8s patch
#12693 Augment running hook msg for relations
#12696 Extend retry timeout for patching role/istio-ingressgateway-operator;
#12697 Allow upgrading from 2.8.9 to 3

```
# Conflicts:
(accepted the 2.9 version in most cases)
#       cmd/juju/machine/add_test.go
#       cmd/jujud/agent/caasunitinit_test.go
#       container/kvm/libvirt/domainxml.go
#       controller/config_test.go


```

## QA steps

See PRs