### PR TITLE
[2.9] Revert back to summarized "juju help" output

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -63,41 +63,41 @@ func init() {
 //  Main
 
 var jujuDoc = `
-Juju provides easy, intelligent application orchestration on top of cloud
-infrastructure providers such as Amazon EC2, MaaS, OpenStack, Windows, Azure,
-or your local machine.
+Juju provides easy, intelligent application orchestration on top of Kubernetes,
+cloud infrastructure providers such as Amazon, Google, Microsoft, Openstack,
+MAAS (and more!), or even on your local machine via LXD.
 
-See https://discourse.jujucharms.com/ for ideas, documentation and FAQ.
+See https://juju.is for getting started tutorials and additional documentation.
 `
 
 var usageHelp = `
-Usage: juju [help] <command>
+Juju provides easy, intelligent application orchestration on top of Kubernetes,
+cloud infrastructure providers such as Amazon, Google, Microsoft, Openstack,
+MAAS (and more!), or even your local machine via LXD.
 
-Summary:
-Juju is model & application management software designed to leverage the power
-of existing resource pools, particularly cloud-based ones. It has built-in
-support for cloud providers such as Amazon EC2, Google GCE, Microsoft
-Azure, OpenStack, and Rackspace. It also works very well with MAAS and
-LXD. Juju allows for easy installation and management of workloads on a
-chosen resource pool.
+See https://juju.is for getting started tutorials and additional documentation.
 
-See https://jujucharms.com/docs/stable/help for documentation.
+Starter commands:
 
-Common commands:
-
-    add-cloud           Adds a user-defined cloud to Juju.
-    add-credential      Adds or replaces credentials for a cloud.
-    add-model           Adds a hosted model.
-    add-relation        Adds a relation between two applications.
-    add-unit            Adds extra units of a deployed application.
-    add-user            Adds a Juju user to a controller.
+    add-k8s             Adds a k8s endpoint and credential to Juju.
     bootstrap           Initializes a cloud environment.
-    controllers         Lists all controllers.
+    add-model           Adds a hosted model.
     deploy              Deploys a new application.
+    status              Displays the current status of Juju, applications, and units.
+    add-unit            Adds extra units of a deployed application.
+    relate              Adds a relation between two applications.
     expose              Makes an application publicly available over the network.
     models              Lists models a user can access on a controller.
-    status              Displays the current status of Juju, applications, and units.
+    controllers         Lists all controllers.
+    whoami              Display the current controller, model and logged in user name. 
     switch              Selects or identifies the current controller and model.
+    add-cloud           Adds a user-defined cloud to Juju.
+    add-credential      Adds or replaces credentials for a cloud.
+
+REPL mode:
+
+When run without arguments, Juju will enter an interactive shell which can be
+used to run any Juju command directly.
 
 Help commands:
     

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -70,6 +70,44 @@ or your local machine.
 See https://discourse.jujucharms.com/ for ideas, documentation and FAQ.
 `
 
+var usageHelp = `
+Usage: juju [help] <command>
+
+Summary:
+Juju is model & application management software designed to leverage the power
+of existing resource pools, particularly cloud-based ones. It has built-in
+support for cloud providers such as Amazon EC2, Google GCE, Microsoft
+Azure, OpenStack, and Rackspace. It also works very well with MAAS and
+LXD. Juju allows for easy installation and management of workloads on a
+chosen resource pool.
+
+See https://jujucharms.com/docs/stable/help for documentation.
+
+Common commands:
+
+    add-cloud           Adds a user-defined cloud to Juju.
+    add-credential      Adds or replaces credentials for a cloud.
+    add-model           Adds a hosted model.
+    add-relation        Adds a relation between two applications.
+    add-unit            Adds extra units of a deployed application.
+    add-user            Adds a Juju user to a controller.
+    bootstrap           Initializes a cloud environment.
+    controllers         Lists all controllers.
+    deploy              Deploys a new application.
+    expose              Makes an application publicly available over the network.
+    models              Lists models a user can access on a controller.
+    status              Displays the current status of Juju, applications, and units.
+    switch              Selects or identifies the current controller and model.
+
+Help commands:
+    
+    juju help           This help page.
+    juju help <command> Show help for the specified command.
+
+For the full list of supported commands run: 
+    
+    juju help commands`[1:]
+
 const (
 	cliHelpHint = `See "juju --help"`
 )
@@ -221,6 +259,8 @@ func NewJujuCommandWithStore(
 			}
 		},
 	})
+	jcmd.AddHelpTopic("basics", "Basic Help Summary", usageHelp)
+
 	jujuRegistry = &jujuCommandRegistry{
 		store:           store,
 		commandRegistry: jcmd,

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -79,7 +79,6 @@ See https://juju.is for getting started tutorials and additional documentation.
 
 Starter commands:
 
-    add-k8s             Adds a k8s endpoint and credential to Juju.
     bootstrap           Initializes a cloud environment.
     add-model           Adds a hosted model.
     deploy              Deploys a new application.
@@ -91,10 +90,11 @@ Starter commands:
     controllers         Lists all controllers.
     whoami              Display the current controller, model and logged in user name. 
     switch              Selects or identifies the current controller and model.
+    add-k8s             Adds a k8s endpoint and credential to Juju.
     add-cloud           Adds a user-defined cloud to Juju.
     add-credential      Adds or replaces credentials for a cloud.
 
-REPL mode:
+Interactive mode:
 
 When run without arguments, Juju will enter an interactive shell which can be
 used to run any Juju command directly.

--- a/cmd/juju/commands/repl.go
+++ b/cmd/juju/commands/repl.go
@@ -55,7 +55,7 @@ Type "q" or ^D or ^C to quit.
 
 var (
 	quitCommands         = set.NewStrings("q", "quit", "exit")
-	noControllerCommands = set.NewStrings("bootstrap", "register")
+	noControllerCommands = set.NewStrings("help", "bootstrap", "register")
 )
 
 const (

--- a/cmd/juju/commands/repl.go
+++ b/cmd/juju/commands/repl.go
@@ -39,12 +39,11 @@ func newReplCommand(showHelp bool) cmd.Command {
 }
 
 const replDoc = `
-When run without arguments, enter an interactive shell which can be
+When run without arguments, Juju will enter an interactive shell which can be
 used to run any Juju command directly. When in the shell:
-  type "help" to see a list of available commands.
-  type "q" or ^D or ^C to quit.
 
-Otherwise, the supported command usage is described below.
+  type "help" to see the full list of available commands.
+  type "q" or ^D or ^C to quit.
 `
 
 var firstPrompt = `
@@ -97,8 +96,12 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 		if err := jujuCmd.Init([]string{"help"}); err != nil {
 			return errors.Trace(err)
 		}
+
+		if err := jujuCmd.Run(ctx); err != nil {
+			return err
+		}
 		fmt.Fprintln(ctx.Stdout, replDoc)
-		return jujuCmd.Run(ctx)
+		return nil
 	}
 
 	history, err := ioutil.TempFile("", "juju-repl")
@@ -184,7 +187,11 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 		if noCurrentController && !noControllerCommands.Contains(args[0]) {
 			fmt.Fprintln(ctx.Stderr, noControllersMessage)
 			continue
+		} else if args[0] == "help" {
+			// Show command list
+			args = append(args, "commands")
 		}
+
 		c.execJujuCommand(jujuCmd, ctx, args)
 	}
 	return nil

--- a/cmd/juju/commands/repl.go
+++ b/cmd/juju/commands/repl.go
@@ -38,14 +38,6 @@ func newReplCommand(showHelp bool) cmd.Command {
 	}
 }
 
-const replDoc = `
-When run without arguments, Juju will enter an interactive shell which can be
-used to run any Juju command directly. When in the shell:
-
-  type "help" to see the full list of available commands.
-  type "q" or ^D or ^C to quit.
-`
-
 var firstPrompt = `
 Welcome to the Juju interactive shell.
 Type "help" to see a list of available commands.
@@ -100,7 +92,6 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 		if err := jujuCmd.Run(ctx); err != nil {
 			return err
 		}
-		fmt.Fprintln(ctx.Stdout, replDoc)
 		return nil
 	}
 
@@ -146,7 +137,6 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 			if err := jujuCmd.Init([]string{"help"}); err != nil {
 				return errors.Trace(err)
 			}
-			fmt.Fprintln(ctx.Stderr, replDoc)
 			return jujuCmd.Run(ctx)
 		}
 		// Get the prompt based on the current controller/model/user.

--- a/cmd/juju/commands/repl_test.go
+++ b/cmd/juju/commands/repl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -124,6 +125,13 @@ func (s *ReplSuite) TestHelp(c *gc.C) {
 
 func (s *ReplSuite) assertHelp(c *gc.C, helpArg string) {
 	f := func() {
+		// The jujuMain command is not designed to be run multiple times
+		// in a loop as it attempts to register the same writer thus
+		// causing an error to be returned and the actual command not
+		// to execute.
+		//
+		// This is needed for testing only.
+		_, _ = loggo.RemoveWriter("warning")
 		jujuMain{
 			execCommand: func(command string, args ...string) *exec.Cmd {
 				c.Fail()
@@ -134,7 +142,7 @@ func (s *ReplSuite) assertHelp(c *gc.C, helpArg string) {
 
 	stdout, _ := jujutesting.CaptureOutput(c, f)
 	s.assertOutMatches(c, stdout,
-		"When run without arguments, enter an interactive shell.*")
+		".*When run without arguments, Juju will enter an interactive shell.*")
 }
 
 func (s *ReplSuite) TestJujuCommandHelp(c *gc.C) {


### PR DESCRIPTION
At some point, the `juju help` command would output the basic juju commands and prompt the user to run `juju help commands` to get the full list of commands. At some point this functionality was removed in favor of listing the _full_ set of commands when running `juju help`.

This PR:
- switches back to a short help text variant
- revises the help text (put k8s front and center, clean up provider list and reference juju.is for docs) 
- re-arranges the start command list so the order reflects the flow of commands that a new Juju user would execute when getting started with Juju. 

Additionally, the help text for the REPL has been embedded into each own section (the how to use the REPL details have been omitted as they will be rendered when entering REPL-mode) and the show-full-command-list instructions have also been moved into their own dedicated section (at the end) to make them clearly visible.

Finally, the PR fixes a small bug in the REPL implementation as a drive-by.

## QA steps

```console
# Try "juju help", "juju -h", "juju --help"
$ juju help
Juju provides easy, intelligent application orchestration on top of Kubernetes,
cloud infrastructure providers such as Amazon, Google, Microsoft, Openstack,
MAAS (and more!), or even your local machine via LXD.

See https://juju.is for getting started tutorials and additional documentation.

Starter commands:

    bootstrap           Initializes a cloud environment.
    add-model           Adds a hosted model.
    deploy              Deploys a new application.
    status              Displays the current status of Juju, applications, and units.
    add-unit            Adds extra units of a deployed application.
    relate              Adds a relation between two applications.
    expose              Makes an application publicly available over the network.
    models              Lists models a user can access on a controller.
    controllers         Lists all controllers.
    whoami              Display the current controller, model and logged in user name.
    switch              Selects or identifies the current controller and model.
    add-k8s             Adds a k8s endpoint and credential to Juju.
    add-cloud           Adds a user-defined cloud to Juju.
    add-credential      Adds or replaces credentials for a cloud.

Interactive mode:

When run without arguments, Juju will enter an interactive shell which can be
used to run any Juju command directly.

Help commands:

    juju help           This help page.
    juju help <command> Show help for the specified command.

For the full list of supported commands run:

    juju help commands

$ juju help commands
....
1 billion lines of output
...

# List commands in REPL
$ juju
Welcome to the Juju interactive shell.
Type "help" to see a list of available commands.
Type "q" or ^D or ^C to quit.

no controllers registered$ help
...
1 billion lines of output
....
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1912760