### PR TITLE
Add run_resource_attach_large to resource tests.

### DIFF
--- a/tests/suites/resources/upgrade.sh
+++ b/tests/suites/resources/upgrade.sh
@@ -56,7 +56,8 @@ run_resource_attach_large() {
 
     # .txt suffix required for attach.
     FILE=$(mktemp /tmp/resource-XXXXX.txt)
-    < /dev/urandom tr -dc "\n [:alnum:]" | head -c 100M > "${FILE}"
+    # Use urandom to add alpha numeric characters with new lines added to the file
+    cat /dev/urandom | base64 | head -c 100M > "${FILE}"
     line=$(head -n 1 "${FILE}")
     juju attach juju-qa-test foo-file="${FILE}"
 

--- a/tests/suites/resources/upgrade.sh
+++ b/tests/suites/resources/upgrade.sh
@@ -43,6 +43,32 @@ run_resource_attach() {
     destroy_model "test-${name}"
 }
 
+run_resource_attach_large() {
+    echo
+    name="resource-attach-large"
+
+    file="${TEST_DIR}/test-${name}.log"
+
+    ensure "test-${name}" "${file}"
+
+    juju deploy juju-qa-test
+    wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+    # .txt suffix required for attach.
+    FILE=$(mktemp /tmp/resource-XXXXX.txt)
+    < /dev/urandom tr -dc "\n [:alnum:]" | head -c 100M > "${FILE}"
+    line=$(head -n 1 "${FILE}")
+    juju attach juju-qa-test foo-file="${FILE}"
+
+    juju config juju-qa-test foo-file=true
+    # wait for config-changed, the charm will update the status
+    # to include the contents of foo-file.txt
+    wait_for "resource line one: ${line}" "$(workload_status juju-qa-test 0).message"
+
+    rm "${FILE}"
+    destroy_model "test-${name}"
+}
+
 test_upgrade_resources() {
     if [ "$(skip 'test_upgrade_resources')" ]; then
         echo "==> TEST SKIPPED: Resource upgrades"
@@ -56,5 +82,6 @@ test_upgrade_resources() {
 
         run "run_resource_upgrade"
         run "run_resource_attach"
+        run "run_resource_attach_large"
     )
 }


### PR DESCRIPTION
Add run_resource_attach_large to resource integration tests to eventually replace nw-charm-resources-large.  The old test ran with files of size 10M, 100M and 200M, with no note as to why.  Only running with a file of 100M here.

## QA steps
```console
$ (cd tests ; ./main.sh  -r -s test_basic_resources resources)
```
