### PR TITLE
Find with options

### DIFF
--- a/api/charmhub/client.go
+++ b/api/charmhub/client.go
@@ -35,10 +35,15 @@ func newClientFromFacade(frontend base.ClientFacade, backend base.FacadeCaller) 
 }
 
 // Info queries the CharmHub API for information for a given name.
-func (c *Client) Info(name, channel string) (InfoResponse, error) {
+func (c *Client) Info(name string, options ...InfoOption) (InfoResponse, error) {
+	opts := newInfoOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
 	args := params.Info{
 		Tag:     names.NewApplicationTag(name).String(),
-		Channel: channel,
+		Channel: opts.channel,
 	}
 	var result params.CharmHubEntityInfoResult
 	if err := c.facade.FacadeCall("Info", args, &result); err != nil {
@@ -50,12 +55,113 @@ func (c *Client) Info(name, channel string) (InfoResponse, error) {
 
 // Find queries the CharmHub API finding potential charms or bundles for the
 // given query.
-func (c *Client) Find(query string) ([]FindResponse, error) {
-	args := params.Query{Query: query}
+func (c *Client) Find(query string, options ...FindOption) ([]FindResponse, error) {
+	opts := newFindOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	args := params.Query{
+		Query:            query,
+		Category:         opts.category,
+		Channel:          opts.channel,
+		CharmType:        opts.charmType,
+		Platforms:        opts.platforms,
+		Publisher:        opts.publisher,
+		RelationRequires: opts.relationRequires,
+		RelationProvides: opts.relationProvides,
+	}
+
 	var result params.CharmHubEntityFindResult
 	if err := c.facade.FacadeCall("Find", args, &result); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return convertCharmFindResults(result.Results), nil
+}
+
+// InfoOption to be passed to Info to customize the resulting request.
+type InfoOption func(*infoOptions)
+
+type infoOptions struct {
+	channel string
+}
+
+// WithInfoChannel sets the channel on the option.
+func WithInfoChannel(ch string) InfoOption {
+	return func(infoOptions *infoOptions) {
+		infoOptions.channel = ch
+	}
+}
+
+// Create a infoOptions instance with default values.
+func newInfoOptions() *infoOptions {
+	return &infoOptions{}
+}
+
+// FindOption to be passed to Find to customize the resulting request.
+type FindOption func(*findOptions)
+
+type findOptions struct {
+	category         string
+	channel          string
+	charmType        string
+	platforms        string
+	publisher        string
+	relationRequires string
+	relationProvides string
+}
+
+// WithFindCategory sets the category on the option.
+func WithFindCategory(category string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.category = category
+	}
+}
+
+// WithFindChannel sets the channel on the option.
+func WithFindChannel(channel string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.channel = channel
+	}
+}
+
+// WithFindType sets the charmType on the option.
+func WithFindType(charmType string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.charmType = charmType
+	}
+}
+
+// WithFindPlatforms sets the charmPlatforms on the option.
+func WithFindPlatforms(platforms string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.platforms = platforms
+	}
+}
+
+// WithFindPublisher sets the publisher on the option.
+func WithFindPublisher(publisher string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.publisher = publisher
+	}
+}
+
+// WithFindRelationRequires sets the relationRequires on the option.
+func WithFindRelationRequires(relationRequires string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.relationRequires = relationRequires
+	}
+}
+
+// WithFindRelationProvides sets the relationProvides on the option.
+func WithFindRelationProvides(relationProvides string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.relationProvides = relationProvides
+	}
+}
+
+// Create a findOptions instance with default values.
+func newFindOptions() *findOptions {
+	return &findOptions{}
 }

--- a/api/charmhub/client_test.go
+++ b/api/charmhub/client_test.go
@@ -30,7 +30,24 @@ func (s charmHubSuite) TestInfo(c *gc.C) {
 	}
 	s.facade.EXPECT().FacadeCall("Info", arg, gomock.Any()).SetArg(2, resultSource)
 
-	obtained, err := s.newClientFromFacadeForTest().Info("wordpress", "")
+	obtained, err := s.newClientFromFacadeForTest().Info("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	assertInfoResponseSameContents(c, obtained, getInfoResponse())
+}
+
+func (s charmHubSuite) TestInfoWithOptions(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	arg := params.Info{
+		Tag:     names.NewApplicationTag("wordpress").String(),
+		Channel: "stable",
+	}
+	resultSource := params.CharmHubEntityInfoResult{
+		Result: getParamsInfoResponse(),
+	}
+	s.facade.EXPECT().FacadeCall("Info", arg, gomock.Any()).SetArg(2, resultSource)
+
+	obtained, err := s.newClientFromFacadeForTest().Info("wordpress", WithInfoChannel("stable"))
 	c.Assert(err, jc.ErrorIsNil)
 	assertInfoResponseSameContents(c, obtained, getInfoResponse())
 }
@@ -45,6 +62,24 @@ func (s charmHubSuite) TestFind(c *gc.C) {
 	s.facade.EXPECT().FacadeCall("Find", arg, gomock.Any()).SetArg(2, resultSource)
 
 	obtained, err := s.newClientFromFacadeForTest().Find("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	assertFindResponsesSameContents(c, obtained, getFindResponses())
+}
+
+func (s charmHubSuite) TestFindWithOptions(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	arg := params.Query{
+		Query:     "wordpress",
+		Channel:   "stable",
+		Platforms: "platforms",
+	}
+	resultSource := params.CharmHubEntityFindResult{
+		Results: getParamsFindResponses(),
+	}
+	s.facade.EXPECT().FacadeCall("Find", arg, gomock.Any()).SetArg(2, resultSource)
+
+	obtained, err := s.newClientFromFacadeForTest().Find("wordpress", WithFindChannel("stable"), WithFindPlatforms("platforms"))
 	c.Assert(err, jc.ErrorIsNil)
 	assertFindResponsesSameContents(c, obtained, getFindResponses())
 }

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -85,7 +85,7 @@ func newCharmHubAPI(backend Backend, authorizer facade.Authorizer, clientFactory
 }
 
 // Info queries the CharmHub API with a given entity ID.
-func (api *CharmHubAPI) Info(arg params.Info) (params.CharmHubEntityInfoResult, error) {
+func (api *CharmHubAPI) Info(ctx context.Context, arg params.Info) (params.CharmHubEntityInfoResult, error) {
 	logger.Tracef("Info(%v)", arg.Tag)
 
 	tag, err := names.ParseApplicationTag(arg.Tag)
@@ -102,7 +102,8 @@ func (api *CharmHubAPI) Info(arg params.Info) (params.CharmHubEntityInfoResult, 
 		options = append(options, charmhub.WithInfoChannel(ch.String()))
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), TimeoutDuration)
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, TimeoutDuration)
 	defer cancel()
 
 	info, err := api.client.Info(ctx, tag.Id(), options...)
@@ -113,10 +114,11 @@ func (api *CharmHubAPI) Info(arg params.Info) (params.CharmHubEntityInfoResult, 
 }
 
 // Find queries the CharmHub API with a given entity ID.
-func (api *CharmHubAPI) Find(arg params.Query) (params.CharmHubEntityFindResult, error) {
+func (api *CharmHubAPI) Find(ctx context.Context, arg params.Query) (params.CharmHubEntityFindResult, error) {
 	logger.Tracef("Find(%v)", arg.Query)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), TimeoutDuration)
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, TimeoutDuration)
 	defer cancel()
 
 	results, err := api.client.Find(ctx, arg.Query, populateFindOptions(arg)...)

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -56,6 +56,17 @@ func (s *charmHubAPISuite) TestFind(c *gc.C) {
 	assertFindResponseSameContents(c, obtained.Results[0], getParamsFindResponse())
 }
 
+func (s *charmHubAPISuite) TestFindWithOptions(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectFind()
+	arg := params.Query{Query: "wordpress", Channel: "stable", Category: "k8s"}
+	obtained, err := s.newCharmHubAPIForTest(c).Find(arg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(obtained.Results, gc.HasLen, 1)
+	assertFindResponseSameContents(c, obtained.Results[0], getParamsFindResponse())
+}
+
 func (s *charmHubAPISuite) newCharmHubAPIForTest(c *gc.C) *CharmHubAPI {
 	s.expectModelConfig(c)
 	s.expectAuth()
@@ -98,7 +109,7 @@ func (s *charmHubAPISuite) expectInfo() {
 }
 
 func (s *charmHubAPISuite) expectFind() {
-	s.client.EXPECT().Find(gomock.Any(), "wordpress").Return(getCharmHubFindResponses(), nil)
+	s.client.EXPECT().Find(gomock.Any(), "wordpress", gomock.Any()).Return(getCharmHubFindResponses(), nil)
 }
 
 func assertInfoResponseSameContents(c *gc.C, obtained, expected params.InfoResponse) {

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -4,6 +4,8 @@
 package charmhub
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -29,7 +31,7 @@ func (s *charmHubAPISuite) TestInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectInfo()
 	arg := params.Info{Tag: names.NewApplicationTag("wordpress").String()}
-	obtained, err := s.newCharmHubAPIForTest(c).Info(arg)
+	obtained, err := s.newCharmHubAPIForTest(c).Info(context.TODO(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertInfoResponseSameContents(c, obtained.Result, getParamsInfoResponse())
@@ -39,7 +41,7 @@ func (s *charmHubAPISuite) TestInfoWithChannel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectInfo()
 	arg := params.Info{Tag: names.NewApplicationTag("wordpress").String(), Channel: "stable"}
-	obtained, err := s.newCharmHubAPIForTest(c).Info(arg)
+	obtained, err := s.newCharmHubAPIForTest(c).Info(context.TODO(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertInfoResponseSameContents(c, obtained.Result, getParamsInfoResponse())
@@ -49,7 +51,7 @@ func (s *charmHubAPISuite) TestFind(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectFind()
 	arg := params.Query{Query: "wordpress"}
-	obtained, err := s.newCharmHubAPIForTest(c).Find(arg)
+	obtained, err := s.newCharmHubAPIForTest(c).Find(context.TODO(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(obtained.Results, gc.HasLen, 1)
@@ -60,7 +62,7 @@ func (s *charmHubAPISuite) TestFindWithOptions(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectFind()
 	arg := params.Query{Query: "wordpress", Channel: "stable", Category: "k8s"}
-	obtained, err := s.newCharmHubAPIForTest(c).Find(arg)
+	obtained, err := s.newCharmHubAPIForTest(c).Find(context.TODO(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(obtained.Results, gc.HasLen, 1)

--- a/apiserver/facades/client/charmhub/package_mock_test.go
+++ b/apiserver/facades/client/charmhub/package_mock_test.go
@@ -113,18 +113,23 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Find mocks base method
-func (m *MockClient) Find(arg0 context.Context, arg1 string) ([]transport.FindResponse, error) {
+func (m *MockClient) Find(arg0 context.Context, arg1 string, arg2 ...charmhub0.FindOption) ([]transport.FindResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Find", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Find", varargs...)
 	ret0, _ := ret[0].([]transport.FindResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Find indicates an expected call of Find
-func (mr *MockClientMockRecorder) Find(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Find(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockClient)(nil).Find), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockClient)(nil).Find), varargs...)
 }
 
 // Info mocks base method

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12691,7 +12691,28 @@
                 "Query": {
                     "type": "object",
                     "properties": {
+                        "category": {
+                            "type": "string"
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "platforms": {
+                            "type": "string"
+                        },
+                        "publisher": {
+                            "type": "string"
+                        },
                         "query": {
+                            "type": "string"
+                        },
+                        "relation-provides": {
+                            "type": "string"
+                        },
+                        "relation-requires": {
+                            "type": "string"
+                        },
+                        "type": {
                             "type": "string"
                         }
                     },

--- a/apiserver/params/charmhub.go
+++ b/apiserver/params/charmhub.go
@@ -6,7 +6,14 @@ package params
 // Query holds the query information when attempting to find possible charms or
 // bundles for searching the CharmHub.
 type Query struct {
-	Query string `json:"query"`
+	Query            string `json:"query"`
+	Category         string `json:"category,omitempty"`
+	Channel          string `json:"channel,omitempty"`
+	CharmType        string `json:"type,omitempty"`
+	Platforms        string `json:"platforms,omitempty"`
+	Publisher        string `json:"publisher,omitempty"`
+	RelationRequires string `json:"relation-requires,omitempty"`
+	RelationProvides string `json:"relation-provides,omitempty"`
 }
 
 // Info tag represents a info query for a given tag and channel.

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -243,8 +243,8 @@ func (c *Client) Info(ctx context.Context, name string, options ...InfoOption) (
 }
 
 // Find searches for a given charm for a given name from CharmHub API.
-func (c *Client) Find(ctx context.Context, name string) ([]transport.FindResponse, error) {
-	return c.findClient.Find(ctx, name)
+func (c *Client) Find(ctx context.Context, name string, options ...FindOption) ([]transport.FindResponse, error) {
+	return c.findClient.Find(ctx, name, options...)
 }
 
 // Refresh defines a client for making refresh API calls, that allow for

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -43,6 +43,30 @@ func (s *FindSuite) TestFind(c *gc.C) {
 	c.Assert(responses[0].Name, gc.Equals, name)
 }
 
+func (s *FindSuite) TestFindWithOptions(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	name := "meshuggah"
+	path := path.MakePath(baseURL)
+
+	expect, err := path.Query("channel", "1.0/stable")
+	c.Assert(err, jc.ErrorIsNil)
+	expect, err = expect.Query("type", "bundle")
+	c.Assert(err, jc.ErrorIsNil)
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, expect, name)
+
+	client := NewFindClient(path, restClient, &FakeLogger{})
+	responses, err := client.Find(context.TODO(), name, WithFindChannel("1.0/stable"), WithFindType("bundle"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(responses), gc.Equals, 1)
+	c.Assert(responses[0].Name, gc.Equals, name)
+}
+
 func (s *FindSuite) TestFindFailure(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -22,8 +22,8 @@ type infoOptions struct {
 	channel *string
 }
 
-// WithChannel sets the channel on the option.
-func WithChannel(ch string) InfoOption {
+// WithInfoChannel sets the channel on the option.
+func WithInfoChannel(ch string) InfoOption {
 	return func(infoOptions *infoOptions) {
 		infoOptions.channel = &ch
 	}

--- a/charmhub/path/path_test.go
+++ b/charmhub/path/path_test.go
@@ -93,3 +93,21 @@ func (s *PathSuite) TestMultipleQueries(c *gc.C) {
 	c.Assert(path.String(), gc.Equals, "http://foobar/v1/path")
 	c.Assert(newPath.String(), gc.Equals, "http://foobar/v1/path?q=foo1&q=foo2&x=bar")
 }
+
+func (s *PathSuite) TestQueries(c *gc.C) {
+	rawURL := MustParseURL(c, "http://foobar/v1/path")
+
+	path := MakePath(rawURL)
+
+	newPath0, err := path.Query("a", "foo1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newPath0.String(), gc.Equals, "http://foobar/v1/path?a=foo1")
+
+	newPath1, err := newPath0.Query("b", "foo2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newPath1.String(), gc.Equals, "http://foobar/v1/path?a=foo1&b=foo2")
+
+	newPath1, err = newPath1.Query("c", "foo3")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newPath1.String(), gc.Equals, "http://foobar/v1/path?a=foo1&b=foo2&c=foo3")
+}

--- a/cmd/juju/charmhub/find.go
+++ b/cmd/juju/charmhub/find.go
@@ -34,24 +34,33 @@ See also:
 
 // NewFindCommand wraps findCommand with sane model settings.
 func NewFindCommand() cmd.Command {
-	return modelcmd.Wrap(&findCommand{
-		charmHubCommand: newCharmHubCommand(),
+	cmd := &findCommand{
 		CharmHubClientFunc: func(api base.APICallCloser) FindCommandAPI {
 			return charmhub.NewClient(api)
 		},
-	})
+	}
+	cmd.APIRootFunc = func() (base.APICallCloser, error) {
+		return cmd.NewAPIRoot()
+	}
+	return modelcmd.Wrap(cmd)
 }
 
 // findCommand supplies the "find" CLI command used to display find information.
 type findCommand struct {
-	*charmHubCommand
+	modelcmd.ModelCommandBase
 
+	APIRootFunc        func() (base.APICallCloser, error)
 	CharmHubClientFunc func(base.APICallCloser) FindCommandAPI
 
 	out        cmd.Output
 	warningLog Log
 
-	query   string
+	query     string
+	category  string
+	channel   string
+	charmType string
+	publisher string
+
 	columns string
 }
 
@@ -70,13 +79,19 @@ func (c *findCommand) Info() *cmd.Info {
 // SetFlags defines flags which can be used with the find command.
 // It implements part of the cmd.Command interface.
 func (c *findCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.charmHubCommand.SetFlags(f)
+	c.ModelCommandBase.SetFlags(f)
 
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"yaml":    cmd.FormatYaml,
 		"json":    cmd.FormatJson,
 		"tabular": c.formatter,
 	})
+
+	f.StringVar(&c.category, "category", "", `filter by a category name`)
+	f.StringVar(&c.channel, "channel", "", `filter by channel. "latest" can be omitted, so "stable" also matches "latest/stable"`)
+	f.StringVar(&c.charmType, "type", "", `search by a given type <charm|bundle>`)
+	f.StringVar(&c.publisher, "publisher", "", `search by a given publisher`)
+
 	f.StringVar(&c.columns, "columns", "nbvps", `display the columns associated with a find search.
 
     The following columns are supported:
@@ -96,14 +111,14 @@ func (c *findCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init initializes the find command, including validating the provided
 // flags. It implements part of the cmd.Command interface.
 func (c *findCommand) Init(args []string) error {
-	if err := c.charmHubCommand.Init(args); err != nil {
-		return errors.Trace(err)
-	}
-
 	// We allow searching of empty queries, which will return a list of
 	// "interesting charms".
 	if len(args) > 0 {
 		c.query = args[0]
+	}
+
+	if c.charmType != "" && (c.charmType != "charm" && c.charmType != "bundle") {
+		return errors.Errorf("expected type to be charm or bundle")
 	}
 
 	if c.columns == "" {
@@ -123,10 +138,6 @@ func (c *findCommand) Init(args []string) error {
 // Run is the business logic of the find command.  It implements the meaty
 // part of the cmd.Command interface.
 func (c *findCommand) Run(ctx *cmd.Context) error {
-	if err := c.charmHubCommand.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
-
 	apiRoot, err := c.APIRootFunc()
 	if err != nil {
 		return errors.Trace(err)
@@ -139,7 +150,7 @@ func (c *findCommand) Run(ctx *cmd.Context) error {
 
 	charmHubClient := c.CharmHubClientFunc(apiRoot)
 
-	results, err := charmHubClient.Find(c.query)
+	results, err := charmHubClient.Find(c.query, populateFindOptions(c)...)
 	if params.IsCodeNotFound(err) {
 		return errors.Wrap(err, errors.Errorf("Nothing found for query %q.", c.query))
 	} else if err != nil {
@@ -151,8 +162,6 @@ func (c *findCommand) Run(ctx *cmd.Context) error {
 	// We store it on the command before attempting to output, so we can pick
 	// it up later.
 	c.warningLog = ctx.Warningf
-
-	results = filterFindResults(results, c.arch, c.series)
 
 	return c.output(ctx, results)
 }
@@ -202,4 +211,23 @@ func (c *findCommand) formatter(writer io.Writer, value interface{}) error {
 	}
 
 	return nil
+}
+
+func populateFindOptions(cmd *findCommand) []charmhub.FindOption {
+	var options []charmhub.FindOption
+
+	if cmd.category != "" {
+		options = append(options, charmhub.WithFindCategory(cmd.category))
+	}
+	if cmd.channel != "" {
+		options = append(options, charmhub.WithFindChannel(cmd.channel))
+	}
+	if cmd.charmType != "" {
+		options = append(options, charmhub.WithFindType(cmd.charmType))
+	}
+	if cmd.publisher != "" {
+		options = append(options, charmhub.WithFindPublisher(cmd.publisher))
+	}
+
+	return options
 }

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -157,7 +157,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 		channel = charmChannel.String()
 	}
 
-	info, err := charmHubClient.Info(c.charmOrBundle, channel)
+	info, err := charmHubClient.Info(c.charmOrBundle, charmhub.WithInfoChannel(channel))
 	if params.IsCodeNotFound(err) {
 		return errors.Wrap(err, errors.Errorf("No information found for charm or bundle with the name %q", c.charmOrBundle))
 	} else if err != nil {

--- a/cmd/juju/charmhub/interface.go
+++ b/cmd/juju/charmhub/interface.go
@@ -22,13 +22,13 @@ type Log = func(format string, params ...interface{})
 
 // InfoCommandAPI describes API methods required to execute the info command.
 type InfoCommandAPI interface {
-	Info(string, string) (apicharmhub.InfoResponse, error)
+	Info(string, ...apicharmhub.InfoOption) (apicharmhub.InfoResponse, error)
 	Close() error
 }
 
 // FindCommandAPI describes API methods required to execute the find command.
 type FindCommandAPI interface {
-	Find(string) ([]apicharmhub.FindResponse, error)
+	Find(string, ...apicharmhub.FindOption) ([]apicharmhub.FindResponse, error)
 	Close() error
 }
 

--- a/cmd/juju/charmhub/mocks/api_mock.go
+++ b/cmd/juju/charmhub/mocks/api_mock.go
@@ -129,18 +129,23 @@ func (mr *MockInfoCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // Info mocks base method
-func (m *MockInfoCommandAPI) Info(arg0, arg1 string) (charmhub.InfoResponse, error) {
+func (m *MockInfoCommandAPI) Info(arg0 string, arg1 ...charmhub.InfoOption) (charmhub.InfoResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Info", arg0, arg1)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Info", varargs...)
 	ret0, _ := ret[0].(charmhub.InfoResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Info indicates an expected call of Info
-func (mr *MockInfoCommandAPIMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInfoCommandAPIMockRecorder) Info(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockInfoCommandAPI)(nil).Info), arg0, arg1)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockInfoCommandAPI)(nil).Info), varargs...)
 }
 
 // MockFindCommandAPI is a mock of FindCommandAPI interface
@@ -181,18 +186,23 @@ func (mr *MockFindCommandAPIMockRecorder) Close() *gomock.Call {
 }
 
 // Find mocks base method
-func (m *MockFindCommandAPI) Find(arg0 string) ([]charmhub.FindResponse, error) {
+func (m *MockFindCommandAPI) Find(arg0 string, arg1 ...charmhub.FindOption) ([]charmhub.FindResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Find", arg0)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Find", varargs...)
 	ret0, _ := ret[0].([]charmhub.FindResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Find indicates an expected call of Find
-func (mr *MockFindCommandAPIMockRecorder) Find(arg0 interface{}) *gomock.Call {
+func (mr *MockFindCommandAPIMockRecorder) Find(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockFindCommandAPI)(nil).Find), arg0)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockFindCommandAPI)(nil).Find), varargs...)
 }
 
 // MockModelConfigClient is a mock of ModelConfigClient interface


### PR DESCRIPTION
Update the find command to take into consideration the filter logic.
Unfortunately, there are some filtering logic that is present in the api
doc that isn't currently supported, although they will be added and
some are only available on staging API.

The following will be added, but are still being implemented

 - platforms
 - relation-requires
 - relation-provides

The following is in staging

 - publisher

I'm going to leave the ones to be implemented on the server, but hide
them in the cmd, so we can just add them when they become available.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju find --type=charm juju
$ juju find --type=bundle kube
$ juju find --channel=stable juju
$ juju find juju
```
