### PR TITLE
Ensure non nil context after refreshMany Build.

### DIFF
--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -380,10 +380,13 @@ func RefreshMany(configs ...RefreshConfig) RefreshConfig {
 
 // Build a refresh request that can be past to the API.
 func (c refreshMany) Build() (transport.RefreshRequest, Headers, error) {
-	var (
-		result          transport.RefreshRequest
-		composedHeaders Headers
-	)
+	var composedHeaders Headers
+	// Not all configs built here have a context, start out with an empty
+	// slice, so we do not call Refresh with a nil context.
+	// See executeOne.Build().
+	result := transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{},
+	}
 	for _, config := range c.Configs {
 		req, headers, err := config.Build()
 		if err != nil {

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -503,6 +503,31 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelEnsure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *RefreshConfigSuite) TestRefreshManyBuildContextNotNil(c *gc.C) {
+	id1 := "foo"
+	config1, err := DownloadOneFromRevision(id1, 1, RefreshPlatform{
+		OS:           "ubuntu",
+		Series:       "focal",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	config1 = DefineInstanceKey(c, config1, "foo-bar")
+
+	id2 := "bar"
+	config2, err := DownloadOneFromChannel(id2, "latest/edge", RefreshPlatform{
+		OS:           "ubuntu",
+		Series:       "trusty",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	config2 = DefineInstanceKey(c, config2, "foo-baz")
+	config := RefreshMany(config1, config2)
+
+	req, _, err := config.Build()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(req.Context, gc.NotNil)
+}
+
 func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	id1 := "foo"
 	config1, err := RefreshOne(id1, 1, "latest/stable", RefreshPlatform{


### PR DESCRIPTION
Appending an empty slice to a nil slice, yields a nil slice.  Download
actions do not have a context, therefore ensure we have an empty slice
of contexts in the resulting RefreshRequest from RefreshMany.  A nil
context results in an api-error otherwise.

## QA steps

Use the bundle described here:
```code
series: bionic
applications:
  etcd:
    charm: etcd
    num_units: 1
    options:
      channel: 3.2/stable
  flannel:
    charm: containers-flannel
    resources:
      flannel-amd64: 3
      flannel-arm64: 1
      flannel-s390x: 3
relations:
- - flannel:etcd
  - etcd:db
```

```console
$ juju bootstrap localhost

# this will error, but not the original api error.
$ juju deploy ./bundle-test.yaml
Located charm "etcd" in charm-hub
Located charm "containers-flannel" in charm-hub
Executing changes:
- upload charm etcd from charm-hub for series bionic
- deploy application etcd from charm-hub on bionic
  added resource core
  added resource etcd
  added resource snapshot
- upload charm containers-flannel from charm-hub for series bionic
- upload charm containers-flannel from charm-hub for series bionic
- deploy application flannel from charm-hub on bionic using containers-flannel
ERROR cannot deploy bundle: charm resource "flannel-arm64" at revision 1 not found
```
