### PR TITLE
Fix panic when using juju find --columns

### DIFF
--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -163,7 +163,7 @@ func summaryColumnIndex(columns Columns) int {
 			return v.Index
 		}
 	}
-	return -1
+	return 0
 }
 
 func oneLine(line string, inset int) (string, error) {


### PR DESCRIPTION
```juju find --columns [nbvpaoS]```, caused a panic, "panic: strings: negative Repeat count". Using 's' did not.

summaryColumnIndex should return 0 if not found.  Returning -1 there, causes a deliberate panic in strings.Repeat,
called in wordWrapLine.

More work is needed for ```juju find admission-webhook --columns nsS```, where a column displays after the Summary.

## QA steps

```console
$ juju bootstrap localhost testme

$ juju find admission-webhook --columns ns
Name               Summary
admission-webhook  Injects common data (e.g. env vars, volumes)
                   to pods (e.g. notebooks)

$ juju find  juju --columns n
Name
juju-lint
juju-gui
charmscaler
.... 
```
