### PR TITLE
Add IsSecondary to Address network params

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -894,6 +894,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -972,6 +975,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -9544,6 +9550,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -9652,6 +9661,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -9969,6 +9981,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -10243,6 +10258,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -10653,6 +10671,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -10788,6 +10809,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -11359,6 +11383,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -14504,6 +14531,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -15290,6 +15320,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -20034,6 +20067,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -20214,6 +20250,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -23737,6 +23776,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -25961,6 +26003,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -26909,6 +26954,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -27043,6 +27091,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -32828,6 +32879,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -33562,6 +33616,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"
@@ -43212,6 +43269,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
                         "scope": {
                             "type": "string"
                         },
@@ -43906,6 +43966,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
                         },
                         "port": {
                             "type": "integer"

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -434,15 +434,17 @@ type Address struct {
 	Scope           string `json:"scope"`
 	SpaceName       string `json:"space-name,omitempty"`
 	ProviderSpaceID string `json:"space-id,omitempty"`
+	IsSecondary     bool   `json:"is-secondary,omitempty"`
 }
 
 // MachineAddress transforms the Address to a MachineAddress,
 // effectively ignoring the space fields.
 func (addr Address) MachineAddress() network.MachineAddress {
 	return network.MachineAddress{
-		Value: addr.Value,
-		Type:  network.AddressType(addr.Type),
-		Scope: network.Scope(addr.Scope),
+		Value:       addr.Value,
+		Type:        network.AddressType(addr.Type),
+		Scope:       network.Scope(addr.Scope),
+		IsSecondary: addr.IsSecondary,
 	}
 }
 
@@ -483,6 +485,7 @@ func FromProviderAddress(addr network.ProviderAddress) Address {
 		Scope:           string(addr.Scope),
 		SpaceName:       string(addr.SpaceName),
 		ProviderSpaceID: string(addr.ProviderSpaceID),
+		IsSecondary:     addr.IsSecondary,
 	}
 }
 
@@ -499,9 +502,10 @@ func FromMachineAddresses(mAddrs ...network.MachineAddress) []Address {
 // FromMachineAddress returns an Address for the input MachineAddress.
 func FromMachineAddress(addr network.MachineAddress) Address {
 	return Address{
-		Value: addr.Value,
-		Type:  string(addr.Type),
-		Scope: string(addr.Scope),
+		Value:       addr.Value,
+		Type:        string(addr.Type),
+		Scope:       string(addr.Scope),
+		IsSecondary: addr.IsSecondary,
 	}
 }
 

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -261,6 +261,7 @@ func (s *NetworkSuite) TestPortRangeConvenience(c *gc.C) {
 func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 	pAddrs := network.ProviderAddresses{
 		network.NewProviderAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewProviderAddress("1.2.3.5", network.WithScope(network.ScopeCloudLocal), network.WithSecondary()),
 		network.NewProviderAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	}
 	pAddrs[0].SpaceName = "test-space"
@@ -273,11 +274,13 @@ func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 func (s *NetworkSuite) TestMachineAddressConversion(c *gc.C) {
 	mAddrs := []network.MachineAddress{
 		network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewMachineAddress("1.2.3.5", network.WithScope(network.ScopeCloudLocal), network.WithSecondary()),
 		network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	}
 
 	exp := []params.Address{
 		{Value: "1.2.3.4", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address)},
+		{Value: "1.2.3.5", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address), IsSecondary: true},
 		{Value: "2.3.4.5", Scope: string(network.ScopePublic), Type: string(network.IPv4Address)},
 	}
 	c.Assert(params.FromMachineAddresses(mAddrs...), jc.DeepEquals, exp)


### PR DESCRIPTION
Simple patch to add `IsSecondary` to the wire type for `Address`.

Helper methods for converting between `MachineAddress` and `ProviderAddress` are updated to reflect it.

## QA steps

Tests verify this change. It is not yet recruited by operational logic.

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1863916
