### PR TITLE
[2.9] Support spaces on lxd

### DIFF
--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -80,6 +80,7 @@ type Server interface {
 	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
 	Name() string
 	GetNetworkNames() ([]string, error)
+	GetNetwork(name string) (*lxdapi.Network, string, error)
 	GetNetworkState(name string) (*lxdapi.NetworkState, error)
 	GetContainer(name string) (*lxdapi.Container, string, error)
 	GetContainerState(name string) (*lxdapi.ContainerState, string, error)

--- a/provider/lxd/server_mock_test.go
+++ b/provider/lxd/server_mock_test.go
@@ -10,7 +10,7 @@ import (
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
 	cloudspec "github.com/juju/juju/environs/cloudspec"
-	lxd1 "github.com/lxc/lxd/client"
+	client "github.com/lxc/lxd/client"
 	api "github.com/lxc/lxd/shared/api"
 	reflect "reflect"
 )
@@ -304,10 +304,10 @@ func (mr *MockServerMockRecorder) GetClusterMembers() *gomock.Call {
 }
 
 // GetConnectionInfo mocks base method
-func (m *MockServer) GetConnectionInfo() (*lxd1.ConnectionInfo, error) {
+func (m *MockServer) GetConnectionInfo() (*client.ConnectionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionInfo")
-	ret0, _ := ret[0].(*lxd1.ConnectionInfo)
+	ret0, _ := ret[0].(*client.ConnectionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -378,6 +378,22 @@ func (m *MockServer) GetNICsFromProfile(arg0 string) (map[string]map[string]stri
 func (mr *MockServerMockRecorder) GetNICsFromProfile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNICsFromProfile", reflect.TypeOf((*MockServer)(nil).GetNICsFromProfile), arg0)
+}
+
+// GetNetwork mocks base method
+func (m *MockServer) GetNetwork(arg0 string) (*api.Network, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetwork", arg0)
+	ret0, _ := ret[0].(*api.Network)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetNetwork indicates an expected call of GetNetwork
+func (mr *MockServerMockRecorder) GetNetwork(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockServer)(nil).GetNetwork), arg0)
 }
 
 // GetNetworkNames mocks base method

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -436,6 +436,10 @@ type StubClient struct {
 	NetworkState       map[string]api.NetworkState
 }
 
+func (conn *StubClient) GetNetwork(string) (*api.Network, string, error) {
+	return nil, "", errors.NotImplementedf("GetNetwork")
+}
+
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
 	conn.AddCall("FilterContainers", prefix, statuses)
 	if err := conn.NextErr(); err != nil {


### PR DESCRIPTION
This PR adds the last remaining bits to ensure that spaces are properly supported when using lxd as the substrate.

First, the PR corrects an issue with the lxd-specific subnet discovery logic that got introduced via a set of prior PRs (#11788, #11831, #11831). Note that this work is a 2.9 feature and has not been yet released. More specifically:

When we use lxd as a substrate (vs deploying an lxd workload on a machine managed by another substrate), Subnets() output should only include networks that are able to be bridged.

Given that an lxd server may be either local or remote, we cannot guarantee that we will be able to create bridges for regular NICs (as we do in the containerizer's bridge policy logic). Therefore, by ensuring that all reported subnets can be bridged, we allow users to define spaces and guarantee that the lxd provider will always be able to use the bridge NICs as parents of devices that get injected into the container specs constructed by StartInstance.

The second half of this PR completes the work for supporting spaces on lxd by:
1) ensuring that we populate the `AvailabilityZones` field with the lxd server's name when discovering subnets. This is a prerequisite for the provisioner to be able to resolve space constraints into a set of (provider) subnet IDs prior to invoking the provider's `StartInstance` method.
2) ensuring that we add any extra required NICs to container to satisfy the subnet requirements passed to `StartInstance`. The implementation includes de-dupping logic to avoid creating NICs that are bridged to the same host bridge. 

## QA steps

NOTE: Subnet discovery is disabled on lxd < 3.0 (xenial) so none of this code is invoked. However, the subnet discovery logic is slightly different on bionic and focal so they must **both** be tested. While testing I used a bionic instance on MAAS as a remote lxd cloud.

Example for focal:

```sh
$ juju bootstrap lxd test --no-gui

# YMMV based on what bridges are visible to lxd. You will need to adjust the following steps accordingly.
$ juju subnets
 juju subnets
subnets:
  10.0.0.0/24:
    type: ipv4
    provider-id: subnet-virmaasbr0-10.0.0.0/24
    provider-network-id: net-virmaasbr0
    status: in-use
    space: alpha
    zones:
    - mars
  10.42.0.0/24:
    type: ipv4
    provider-id: subnet-virmaasbr1-10.42.0.0/24
    provider-network-id: net-virmaasbr1
    status: in-use
    space: alpha
    zones:
    - mars
  10.232.217.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.232.217.0/24
    provider-network-id: net-lxdbr0
    status: in-use
    space: alpha
    zones:
    - mars
  172.17.0.0/16:
    type: ipv4
    provider-id: subnet-docker0-172.17.0.0/16
    provider-network-id: net-docker0
    status: in-use
    space: alpha
    zones:
    - mars
  192.168.122.0/24:
    type: ipv4
    provider-id: subnet-virbr0-192.168.122.0/24
    provider-network-id: net-virbr0
    status: in-use
    space: alpha
    zones:
    - mars
 
$ juju add-space space1  10.0.0.0/24 10.42.0.0/24

$ juju spaces
Name    Space ID  Subnets
alpha   0         10.232.217.0/24
                  172.17.0.0/16
                  192.168.122.0/24
space1  2         10.0.0.0/24
                  10.42.0.0/24


# Add a machine to that space
$ juju add-machine --constraints spaces=space1
$  juju show-machine 0
model: default
machines:
  "0":
    ....
     network-interfaces:
      eth0:
        ip-addresses:
        - 10.232.217.253   <---- this is bridged to lxdbr0 on my host
        mac-address: 00:16:3e:b0:4a:f4
        gateway: 10.232.217.1
        space: alpha
        is-up: true
      eth1:
        ip-addresses:
        - 10.42.0.194
        mac-address: 00:16:3e:61:48:df
        space: space1
        is-up: true
      eth2:
        ip-addresses:
        - 10.0.0.199
        mac-address: 00:16:3e:9e:a3:49
        space: space1
        is-up: true
    ...
    constraints: spaces=space1
    
# Try to deploy with --bind
$ juju deploy cs:wordpress --bind space1

# Wait for machine to start...
$ juju ssh wordpress/0 'ip a | grep eth.*@'
51: eth0@if52: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
53: eth1@if54: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
55: eth2@if56: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
```

## Documentation changes

We should tick the supports spaces box (with a on 2.9+ )