### PR TITLE
Prevent charm series and systems (bases)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716
+	github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b
 	github.com/juju/charmrepo/v6 v6.0.0-20210304024300-06897423a416
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716 h1:pDJjQQHQi5hKnGbk7H6AA1UGLSG3iYMDWHFT7kukEBI=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
+github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b h1:+KrXxt1oLLINuFv0Dmi9TOkIjVJhbXONA5jCfOV0J00=
+github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=


### PR DESCRIPTION
The following brings in the charm change that prevents series and
systems from being used at the same time. We should aim for 
conceptual purity within the modeling of our systems and having 
series and systems prevent that.

So that `series: [focal]` could deviate from `bases: {name: ubuntu,
channel: "16.04/stable"}`. 
This could cause chaos in the future and we should prevent it from 
ever happening.

----

Hyrum's Law states:

> With a sufficient number of users of an API,
> it does not matter what you promise in the contract:
> all observable behaviors of your system
> will be depended on by somebody.

----

See spec: https://discourse.charmhub.io/t/charm-metadata-v2/3674/12
And following google spec doc.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy mysql
$ juju deploy snappass-test --series=focal --channel edge
ERROR storing charm "snappass-test": charm "snappass-test" declares both series and systems
```
