### PR TITLE
Merge pull request #12090 from benhoyt/bug-1893844

### DIFF
--- a/state/backups/create.go
+++ b/state/backups/create.go
@@ -134,7 +134,7 @@ func newBuilder(backupDir string, filesToBackUp []string, db DBDumper) (b *build
 		}
 	}()
 
-	// Create all the direcories we need.  We go with user-only
+	// Create all the directories we need.  We go with user-only
 	// permissions on principle; the directories are short-lived so in
 	// practice it shouldn't matter much.
 	err = os.MkdirAll(b.archivePaths.DBDumpDir, 0700)

--- a/state/backups/exec.go
+++ b/state/backups/exec.go
@@ -13,11 +13,14 @@ import (
 // runCommand execs the provided command. It exists
 // here so it can be overridden in export_test.go
 func runCommand(cmd string, args ...string) error {
+	logger.Tracef("runCommand cmd=%s, args=%s", cmd, args)
 	command := exec.Command(cmd, args...)
 	out, err := command.CombinedOutput()
 	if err == nil {
+		logger.Tracef("runCommand succeeded, output is:\n%s", out)
 		return nil
 	}
+	logger.Tracef("runCommand error %v; output is:\n%s", out)
 	if _, ok := err.(*exec.ExitError); ok && len(out) > 0 {
 		return errors.Errorf(
 			"error executing %q: %s",


### PR DESCRIPTION
Backport https://github.com/juju/juju/pull/12090

Currently "juju create-backup" fails if the controller is on Focal, because on Focal Mongo is installed using the juju-db Snap, which adds a "juju-db." prefix to the binary names, and puts the shared-secret file in a different directory. Relevant paths (before and after Focal):

* `$MONGOD_PATH/mongodump` -> `$MONGOD_PATH/juju-db.mongodump`
* `/var/lib/juju/shared-secret` -> `/var/snap/juju-db/common/shared-secret`

Additionally, the Snap `juju-db.mongodump` binary dumps to `/tmp/snap.juju-db/tmp/foobarz` instead of `/tmp/foobarz` (due to Snap confinement), so move the dump directory after calling it. Before this fix, the backup appeared to have succeeded, but didn't have any Mongo dump files in -- this was obviously very problematic, so I've added a check to ensure there are *some* files in the dump dir.

## Checklist

 - [ ] Checked if it requires a [pylibjuju](https://github.com/juju/python-libjuju) change?
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR?
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed?
 - [x] Do comments answer the question of why design decisions were made?

## QA steps

To repro, bootstrap a controller on Focal and then create a backup:

```sh
juju bootstrap localhost backuptest --bootstrap-series=focal
juju switch controller
juju create-backup
```

That will spit out the "mongodump not available" error before the fix, but work fine after.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1893844

