### PR TITLE
Support Go 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,10 @@ jobs:
            - { os: darwin, arch: amd64 }
 
     steps:
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: "1.14"
+        go-version: "1.16"
       id: go
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.14
+        go-version: 1.16
       id: go
 
     - name: Checkout

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,10 +7,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.14
+        go-version: 1.16
       id: go
 
     - name: Install Dependencies
@@ -52,10 +52,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.14
+        go-version: 1.16
       id: go
 
     - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ concurrent language.
 
 ### via snap
 
-    snap install go --channel=1.14/stable --classic
+    snap install go --channel=1.16/stable --classic
 
 [Snap](https://snapcraft.io/go) is the recommended way to install Go on Linux.
 

--- a/Makefile
+++ b/Makefile
@@ -169,15 +169,14 @@ else
 		./apiserver/facades/schema.json
 endif
 
-# Install packages required to develop Juju and run tests. The stable
-# PPA includes the required mongodb-server binaries.
+# Install packages required to develop Juju and run tests.
 install-snap-dependencies:
 ## install-snap-dependencies: Install the supported snap dependencies
-ifeq ($(shell go version | grep -o "go1.14" || true),go1.14)
-	@echo Using installed go-1.14
+ifeq ($(shell go version | grep -o "go1.16" || true),go1.16)
+	@echo Using installed go-1.16
 else
-	@echo Installing go-1.14 snap
-	@sudo snap install go --channel=1.14/stable --classic
+	@echo Installing go-1.16 snap
+	@sudo snap install go --channel=1.16/stable --classic
 endif
 
 install-mongo-dependencies:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.14
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go v46.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -180,7 +180,6 @@ github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gabriel-samfira/sys v0.0.0-20150608132119-9ddc60d56b51/go.mod h1:j3qx7fgMceeChTk5ItmRVrWR2ZOTHI9ymSVsxolzC/g=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/logfwd/syslog/client_test.go
+++ b/logfwd/syslog/client_test.go
@@ -65,7 +65,13 @@ func (s *ClientSuite) TestOpen(c *gc.C) {
 		RootCAs:      rootCAs,
 	}
 
-	s.stub.CheckCall(c, 0, "DialFunc", tlsConfig, time.Duration(0))
+	call := s.stub.Calls()[0]
+	c.Assert(call.Args, gc.HasLen, 2)
+	c.Assert(call.Args[1], gc.Equals, time.Duration(0))
+	tlsCfg, ok := call.Args[0].(*tls.Config)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(tlsCfg.Certificates, jc.DeepEquals, tlsConfig.Certificates)
+	c.Assert(call.Args[1], gc.Equals, time.Duration(0))
 	c.Check(client.Sender, gc.Equals, s.sender)
 }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
   juju:
     # TODO(hpidcock): move to upstream go plugin when it has the features we need.
     plugin: juju-go
-    go-channel: 1.14/stable
+    go-channel: 1.16/stable
     # The source can be your local tree or github
     # source: https://github.com/juju/juju.git
     # If you pull a remote, set source-depth to 1 to make the fetch shorter


### PR DESCRIPTION
Change the version of Go to 1.16

This is simply the first step - the Jenkins infrastructure also needs to be updated since the merge check tests etc still use 1.14

## QA steps

Unit tests