### PR TITLE
[2.9] Fix space/expose-related bash tests

### DIFF
--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -16,7 +16,7 @@ run_juju_bind() {
     juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 
     # Deploy test charm to dual-nic machine
-    juju deploy cs:~juju-qa/bionic/space-defender-1 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+    juju deploy cs:~juju-qa/focal/space-defender-3 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
     unit_index=$(get_unit_index "space-defender")
     wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -17,7 +17,7 @@ run_upgrade_charm_with_bind() {
     juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 
     # Deploy test charm to dual-nic machine
-    juju deploy cs:~juju-qa/bionic/space-defender-0 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+    juju deploy cs:~juju-qa/focal/space-defender-2 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}" --force
     unit_index=$(get_unit_index "space-defender")
     wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -25,7 +25,9 @@ add_multi_nic_machine() {
   # Add an entry to netplan and apply it so the second interface comes online
   echo "[+] updating netplan and restarting machine agent"
   # shellcheck disable=SC2086,SC2016
-  juju ssh ${juju_machine_id} 'sudo sh -c "echo \"            gateway4: `ip route | grep default | cut -d\" \" -f3`\n        ens6:\n            dhcp4: true\n\" >> /etc/netplan/50-cloud-init.yaml"'
+  juju ssh ${juju_machine_id} 'sudo sh -c "sed -i \"/version:/d\" /etc/netplan/50-cloud-init.yaml"'
+  # shellcheck disable=SC2086,SC2016
+  juju ssh ${juju_machine_id} 'sudo sh -c "echo \"            gateway4: `ip route | grep default | cut -d\" \" -f3`\n        ens6:\n            dhcp4: true\n    version: 2\n\" >> /etc/netplan/50-cloud-init.yaml"'
   # shellcheck disable=SC2086,SC2016
   juju ssh ${juju_machine_id} 'sudo netplan apply'
   # shellcheck disable=SC2086,SC2016


### PR DESCRIPTION
This PR revises the EC2 expose/space tests to work on focal (default 2.9 bootstrap series) as well as the changes (version field) in netplan's config files.

## QA steps

```sh
$ cd tests
$  ./main.sh -v -p aws expose_ec2
$ ./main.sh -v -p aws spaces_ec2
```