### PR TITLE
[dev] Revise bash acceptance tests

### DIFF
--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -1,11 +1,11 @@
 cat_mongo_service() {
-    if juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service'; then
+    if juju exec -m controller --machine 0 'cat /etc/systemd/system/juju-db.service'; then
         # shellcheck disable=SC2046
-        echo $(juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service' | grep "^ExecStart")
+        echo $(juju exec -m controller --machine 0 'cat /etc/systemd/system/juju-db.service' | grep "^ExecStart")
     else
         # On focal and beyond we install Mongo via a snap
         # shellcheck disable=SC2046
-        echo $(juju run -m controller --machine 0 'sudo cat /var/snap/juju-db/common/juju-db.config' | grep "wiredTigerCacheSizeGB")
+        echo $(juju exec -m controller --machine 0 'sudo cat /var/snap/juju-db/common/juju-db.config' | grep "wiredTigerCacheSizeGB")
     fi
 }
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -173,7 +173,7 @@ run_deploy_lxd_to_container() {
 
     wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 
-    OUT=$(juju run --machine 0 -- sh -c "sudo lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-0\"")
+    OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-0\"")
     echo "${OUT}" | grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
     juju upgrade-charm "lxd-profile-alt" --path "${charm}"
@@ -185,7 +185,7 @@ run_deploy_lxd_to_container() {
 
     attempt=0
     while true; do
-        OUT=$(juju run --machine 0 -- sh -c "sudo lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-1\"" || echo 'NOT FOUND')
+        OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile show \"juju-test-deploy-lxd-container-lxd-profile-alt-1\"" || echo 'NOT FOUND')
         if echo "${OUT}" | grep -E -q "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"; then
             break
         fi
@@ -201,7 +201,7 @@ run_deploy_lxd_to_container() {
     # Ensure that the old one is removed
     attempt=0
     while true; do
-        OUT=$(juju run --machine 0 -- sh -c "sudo lxc profile list" || echo 'NOT FOUND')
+        OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile list" || echo 'NOT FOUND')
         if echo "${OUT}" | grep -v "juju-test-deploy-lxd-container-lxd-profile-alt-0"; then
             break
         fi

--- a/tests/suites/expose_ec2/expose_app.sh
+++ b/tests/suites/expose_ec2/expose_app.sh
@@ -24,15 +24,15 @@ run_expose_app_ec2() {
 assert_opened_ports_output() {
     echo "==> Checking open/opened-ports hook tools work as expected"
 
-    juju run --unit ubuntu-lite/0 "open-port 1337-1339/tcp"
-    juju run --unit ubuntu-lite/0 "open-port 1234/tcp --endpoints ubuntu"
+    juju exec --unit ubuntu-lite/0 "open-port 1337-1339/tcp"
+    juju exec --unit ubuntu-lite/0 "open-port 1234/tcp --endpoints ubuntu"
 
     # Test the backwards-compatible version of opened-ports where the output
     # includes the unique set of opened ports for all endpoints.
-    # Note that 'juju run' injects a trailing line-feed tot he command output
+    # Note that 'juju exec' injects a trailing line-feed tot he command output
     # so we need to use echo to generate our expectation string.
     exp=$(echo "1234/tcp 1337-1339/tcp" | tr '\n' ' ')
-    got=$(juju run --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ')
+    got=$(juju exec --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ')
     if [ "$got" != "$exp" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected opened-ports output to be:\n${exp}\nGOT:\n${got}")
@@ -40,10 +40,10 @@ assert_opened_ports_output() {
     fi
 
     # Try the new version where we group by endpoint.
-    # Note that 'juju run' injects a trailing line-feed tot he command output
+    # Note that 'juju exec' injects a trailing line-feed tot he command output
     # so we need to use echo to generate our expectation string.
     exp=$(echo "1234/tcp (ubuntu) 1337-1339/tcp (*)" | tr '\n' ' ')
-    got=$(juju run --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ')
+    got=$(juju exec --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ')
     if [ "$got" != "$exp" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected opened-ports output when using --endpoints to be:\n${exp}\nGOT:\n${got}")

--- a/tests/suites/hooks/dispatch.sh
+++ b/tests/suites/hooks/dispatch.sh
@@ -20,7 +20,7 @@ run_hook_dispatching_script() {
     # awk, change the separator to " and get the 2nd value.
     # e.g Action queued with id: "2"
     # yields: 2
-    action_id=$(juju run ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
+    action_id=$(juju exec ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
     juju show-task "${action_id}" | grep -q completed || true
 
     # wait for update-status

--- a/tests/suites/hooktools/state_tools.sh
+++ b/tests/suites/hooktools/state_tools.sh
@@ -9,15 +9,15 @@ run_state_delete_get_set() {
     juju deploy cs:~jameinel/ubuntu-lite-7
     wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-    juju run --unit ubuntu-lite/0 'state-get | grep -q "{}"'
-    juju run --unit ubuntu-lite/0 'state-set one=two'
-    juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
-    juju run --unit ubuntu-lite/0 'state-set three=four'
-    juju run --unit ubuntu-lite/0 'state-get three | grep -q "four"'
-    juju run --unit ubuntu-lite/0 'state-delete one'
-    juju run --unit ubuntu-lite/0 'state-get | grep -q "three: four"'
-    juju run --unit ubuntu-lite/0 'state-get one --strict | grep -q "ERROR \"one\" not found" || true'
-    juju run --unit ubuntu-lite/0 'state-get one'
+    juju exec --unit ubuntu-lite/0 'state-get | grep -q "{}"'
+    juju exec --unit ubuntu-lite/0 'state-set one=two'
+    juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+    juju exec --unit ubuntu-lite/0 'state-set three=four'
+    juju exec --unit ubuntu-lite/0 'state-get three | grep -q "four"'
+    juju exec --unit ubuntu-lite/0 'state-delete one'
+    juju exec --unit ubuntu-lite/0 'state-get | grep -q "three: four"'
+    juju exec --unit ubuntu-lite/0 'state-get one --strict | grep -q "ERROR \"one\" not found" || true'
+    juju exec --unit ubuntu-lite/0 'state-get one'
 
     destroy_model "${model_name}"
 }
@@ -37,15 +37,15 @@ run_state_set_clash_uniter_state() {
     juju deploy cs:~jameinel/ubuntu-lite-7
     wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-    juju run --unit ubuntu-lite/0 'state-get | grep -q "{}"'
-    juju run --unit ubuntu-lite/0 'state-set one=two'
-    juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+    juju exec --unit ubuntu-lite/0 'state-get | grep -q "{}"'
+    juju exec --unit ubuntu-lite/0 'state-set one=two'
+    juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
 
     # force a hook
-    juju run --unit ubuntu-lite/0 hooks/update-status
+    juju exec --unit ubuntu-lite/0 hooks/update-status
 
     # verify charm set values
-    juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+    juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
 
     destroy_model "${model_name}"
 }

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -35,7 +35,7 @@ check_default_routes() {
     echo "[+] checking default routes"
 
     for machine in $(juju machines --format=json | jq -r ".machines | keys | .[]"); do
-        default=$(juju run --machine "$machine" -- ip route show | grep default)
+        default=$(juju exec --machine "$machine" -- ip route show | grep default)
         if [ -z "$default" ]; then
             echo "No default route detected for machine ${machine}"
             exit 1
@@ -53,7 +53,7 @@ check_accessibility() {
 
         # Check that each of the principles can access the subordinate.
         for principle_unit in "mongodb/0" "ubuntu-bionic/0" "ubuntu-focal/0"; do
-            check_contains "$(juju run --unit $principle_unit "$curl_cmd")" "pass"
+            check_contains "$(juju exec --unit $principle_unit "$curl_cmd")" "pass"
         done
 
         # Check that the exposed subordinate is accessible externally.

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -20,7 +20,7 @@ run_relation_data_exchange() {
     # below will fail
     attempt=0
     while true; do
-       got=$(juju run --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress' || echo 'NOT FOUND')
+       got=$(juju exec --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress' || echo 'NOT FOUND')
        if [ "${got}" != "NOT FOUND" ]; then
          break
        fi
@@ -34,7 +34,7 @@ run_relation_data_exchange() {
     done
     attempt=0
     while true; do
-       got=$(juju run --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql' || echo 'NOT FOUND')
+       got=$(juju exec --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql' || echo 'NOT FOUND')
        if [ "${got}" != "NOT FOUND" ]; then
          break
        fi
@@ -47,25 +47,25 @@ run_relation_data_exchange() {
        sleep 1
     done
 
-    juju run --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
+    juju exec --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
 
     # As the leader units, set some *application* data for both sides of a
     # non-peer relation
-    juju run --unit 'wordpress/0' 'relation-set --app -r db:2 origin=wordpress'
-    juju run --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
+    juju exec --unit 'wordpress/0' 'relation-set --app -r db:2 origin=wordpress'
+    juju exec --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
 
     # As the leader wordpress unit, also set *application* data for a peer relation
-    juju run --unit 'wordpress/0' 'relation-set --app -r loadbalancer:0 visible=to-peers'
+    juju exec --unit 'wordpress/0' 'relation-set --app -r loadbalancer:0 visible=to-peers'
 
     # Check 1: ensure that leaders can read the application databag for their
     # own application (LP1854348)
-    got=$(juju run --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress')
+    got=$(juju exec --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress')
     if [ "${got}" != "wordpress" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected wordpress leader to read its own databag for non-peer relation")
       exit 1
     fi
-    got=$(juju run --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql')
+    got=$(juju exec --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql')
     if [ "${got}" != "mysql" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected mysql leader to read its own databag for non-peer relation")
@@ -74,13 +74,13 @@ run_relation_data_exchange() {
 
     # Check 2: ensure that any unit can read its own application databag for
     # *peer* relations LP1865229)
-    got=$(juju run --unit 'wordpress/0' 'relation-get --app -r loadbalancer:0 visible wordpress')
+    got=$(juju exec --unit 'wordpress/0' 'relation-get --app -r loadbalancer:0 visible wordpress')
     if [ "${got}" != "to-peers" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected wordpress leader to read its own databag for a peer relation")
       exit 1
     fi
-    got=$(juju run --unit 'wordpress/1' 'relation-get --app -r loadbalancer:0 visible wordpress')
+    got=$(juju exec --unit 'wordpress/1' 'relation-get --app -r loadbalancer:0 visible wordpress')
     if [ "${got}" != "to-peers" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected wordpress non-leader to read its own databag for a peer relation")
@@ -89,7 +89,7 @@ run_relation_data_exchange() {
 
     # Check 3: ensure that non-leader units are not allowed to read their own
     # application databag for non-peer relations
-    got=$(juju run --unit 'wordpress/1' 'relation-get --app -r db:2 origin wordpress' || echo 'PERMISSION DENIED')
+    got=$(juju exec --unit 'wordpress/1' 'relation-get --app -r db:2 origin wordpress' || echo 'PERMISSION DENIED')
     if [ "${got}" != "PERMISSION DENIED" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected wordpress non-leader not to be allowed to read the databag for a non-peer relation")

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -14,22 +14,22 @@ run_relation_list_app() {
     wait_for "mysql" "$(idle_condition "mysql" 0 0)"
 
     # Figure out the right relation IDs to use for our hook tool invocations
-    db_rel_id=$(juju run --unit mysql/0 "relation-ids db" | cut -d':' -f2)
-    peer_rel_id=$(juju run --unit mysql/0 "relation-ids cluster" | cut -d':' -f2)
+    db_rel_id=$(juju exec --unit mysql/0 "relation-ids db" | cut -d':' -f2)
+    peer_rel_id=$(juju exec --unit mysql/0 "relation-ids cluster" | cut -d':' -f2)
 
     # Remove wordpress unit; the wordpress-mysql relation is still established
     # but there are no units present in the wordpress side
     juju remove-unit wordpress/0
     sleep 5
 
-    got=$(juju run --unit mysql/0 "relation-list --app -r ${db_rel_id}")
+    got=$(juju exec --unit mysql/0 "relation-list --app -r ${db_rel_id}")
     if [ "${got}" != "wordpress" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected running 'relation-list --app' on mysql unit for non-peer relation to return 'wordpress'; got ${got}")
       exit 1
     fi
 
-    got=$(juju run --unit mysql/0 "relation-list --app -r ${peer_rel_id}")
+    got=$(juju exec --unit mysql/0 "relation-list --app -r ${peer_rel_id}")
     if [ "${got}" != "mysql" ]; then
       # shellcheck disable=SC2046
       echo $(red "expected running 'relation-list --app' on mysql unit for peer relation to return 'mysql'; got ${got}")

--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -16,7 +16,7 @@ run_juju_bind() {
     juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 
     # Deploy test charm to dual-nic machine
-    juju deploy cs:~juju-qa/bionic/space-defender-1 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+    juju deploy cs:~juju-qa/focal/space-defender-3 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
     unit_index=$(get_unit_index "space-defender")
     wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -17,7 +17,7 @@ run_upgrade_charm_with_bind() {
     juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 
     # Deploy test charm to dual-nic machine
-    juju deploy cs:~juju-qa/bionic/space-defender-0 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+    juju deploy cs:~juju-qa/focal/space-defender-2 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}" --force
     unit_index=$(get_unit_index "space-defender")
     wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -25,7 +25,9 @@ add_multi_nic_machine() {
   # Add an entry to netplan and apply it so the second interface comes online
   echo "[+] updating netplan and restarting machine agent"
   # shellcheck disable=SC2086,SC2016
-  juju ssh ${juju_machine_id} 'sudo sh -c "echo \"            gateway4: `ip route | grep default | cut -d\" \" -f3`\n        ens6:\n            dhcp4: true\n\" >> /etc/netplan/50-cloud-init.yaml"'
+  juju ssh ${juju_machine_id} 'sudo sh -c "sed -i \"/version:/d\" /etc/netplan/50-cloud-init.yaml"'
+  # shellcheck disable=SC2086,SC2016
+  juju ssh ${juju_machine_id} 'sudo sh -c "echo \"            gateway4: `ip route | grep default | cut -d\" \" -f3`\n        ens6:\n            dhcp4: true\n    version: 2\n\" >> /etc/netplan/50-cloud-init.yaml"'
   # shellcheck disable=SC2086,SC2016
   juju ssh ${juju_machine_id} 'sudo netplan apply'
   # shellcheck disable=SC2086,SC2016

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -50,7 +50,7 @@ assert_net_iface_for_endpoint_matches() {
     exp_if_name=${3}
 
     # shellcheck disable=SC2086,SC2016
-    got_if=$(juju run -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
+    got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
     if [ "$got_if" != "$exp_if_name" ]; then
         # shellcheck disable=SC2086,SC2016,SC2046
         echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")


### PR DESCRIPTION
This PR forward-ports the changes from #12730 and in addition, replaces all instances of `juju run` to `juju exec` for all bash-based acceptance tests so that they can run on the develop branch.

## QA steps

Run **all** bash-based acceptance tests