### PR TITLE
Fix python exception in unregister acceptance test.

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -117,7 +117,7 @@ def wait_until_model_disappears(client, model_name, timeout=600):
             # it's being removed.
             # We can't consider the model gone yet until we don't get this
             # error and the model is no longer in the output.
-            if 'cannot get model details' not in e.stderr:
+            if 'cannot get model details' not in str(e.stderr):
                 raise
 
     try:

--- a/acceptancetests/assess_unregister.py
+++ b/acceptancetests/assess_unregister.py
@@ -67,7 +67,7 @@ def assert_switch_raises_error(client):
     try:
         client.get_raw_juju_output('switch', None, include_e=False)
     except subprocess.CalledProcessError as e:
-        if 'no model name was passed' not in e.stderr:
+        if 'no model name was passed' not in str(e.stderr):
             raise JujuAssertionError(
                 '"juju switch" command failed for an unexpected reason: '
                 '{}'.format(e.stderr))


### PR DESCRIPTION
Fix python exception in unregister acceptance test.   Found with the unregister test which looks for an expected failure.  The same type of check was used in 1 other tests, though not hit as true exception handling looking for errors.

## QA steps

```console 
# Should now succeed
(cd acceptancetests/; ./assess unregister)

# No change expected to 
(cd acceptancetests/;  ./assess model_migration)
```
