### PR TITLE
Update charm dependency

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -42,6 +42,9 @@ func NewFacadeV4(ctx facade.Context) (*StorageProvisionerAPIv4, error) {
 	pm := poolmanager.New(state.NewStateSettings(st), registry)
 
 	backend, storageBackend, err := NewStateBackends(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return NewStorageProvisionerAPIv4(backend, storageBackend, ctx.Resources(), ctx.Auth(), registry, pm)
 }
 

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -6,7 +6,6 @@ package action_test
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"testing"
 	"time"
 
@@ -228,18 +227,6 @@ func (s *actionSuite) TestEnqueueOperation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(operations, gc.HasLen, 1)
 	c.Assert(operations[0].Summary(), gc.Equals, "multiple actions run on unit-wordpress-0,application-wordpress,unit-mysql-0,wordpress/leader")
-}
-
-type testCaseAction struct {
-	Name       string
-	Parameters map[string]interface{}
-	Execute    bool
-}
-
-type receiverGroup struct {
-	ExpectedError *params.Error
-	Receiver      names.Tag
-	Actions       []testCaseAction
 }
 
 func (s *actionSuite) TestCancel(c *gc.C) {
@@ -475,31 +462,6 @@ func assertReadyToTest(c *gc.C, receiver state.ActionReceiver) {
 	actions, err = receiver.CompletedActions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actions, gc.HasLen, 0)
-}
-
-func toStrings(items []params.ActionResult) []string {
-	ret := make([]string, len(items))
-	for i, a := range items {
-		ret[i] = stringify(a)
-	}
-	return ret
-}
-
-func stringify(r params.ActionResult) string {
-	a := r.Action
-	if a == nil {
-		a = &params.Action{}
-	}
-	// Convert action output map to ordered result.
-	var keys, orderedOut []string
-	for k := range r.Output {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		orderedOut = append(orderedOut, fmt.Sprintf("%v=%v", k, r.Output[k]))
-	}
-	return fmt.Sprintf("%s-%s-%#v-%s-%s-%v", a.Tag, a.Name, a.Parameters, r.Status, r.Message, orderedOut)
 }
 
 func (s *actionSuite) TestWatchActionProgress(c *gc.C) {

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v5 v5.0.0-20210224113052-f5fb3bbb6c25
-	github.com/juju/charm/v9 v9.0.0-20210304052111-31c24cedd783
+	github.com/juju/charm/v9 v9.0.0-20210309091641-7e600f16b30f
 	github.com/juju/charmrepo/v7 v7.0.0-20210304053701-83fffdb11c56
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,7 @@ github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gabriel-samfira/sys v0.0.0-20150608132119-9ddc60d56b51/go.mod h1:j3qx7fgMceeChTk5ItmRVrWR2ZOTHI9ymSVsxolzC/g=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -400,6 +401,8 @@ github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI
 github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
 github.com/juju/charm/v9 v9.0.0-20210304052111-31c24cedd783 h1:Q5YaOwMkhY7qapH7Thd2M3N52aNXeAYmymFjmPrwr1k=
 github.com/juju/charm/v9 v9.0.0-20210304052111-31c24cedd783/go.mod h1:82L0Bk5mPMnoGOtP9hsxDumxYWKvjsrFjKiYvte6gP8=
+github.com/juju/charm/v9 v9.0.0-20210309091641-7e600f16b30f h1:zHUKNECfsOIRmQlAYwxj/Rvealq8Jkypy316V4cTag0=
+github.com/juju/charm/v9 v9.0.0-20210309091641-7e600f16b30f/go.mod h1:82L0Bk5mPMnoGOtP9hsxDumxYWKvjsrFjKiYvte6gP8=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v7 v7.0.0-20210125112315-0c95be42cafc/go.mod h1:R9PTZ6VsweDsg/J2skiWj5ulVpxYPj7JW5IyQxBA4UU=

--- a/go.sum
+++ b/go.sum
@@ -180,7 +180,6 @@ github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gabriel-samfira/sys v0.0.0-20150608132119-9ddc60d56b51/go.mod h1:j3qx7fgMceeChTk5ItmRVrWR2ZOTHI9ymSVsxolzC/g=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -399,7 +398,6 @@ github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85/go.mod h1:gcqIN/pHfz
 github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
 github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI/PZPnS5feY4/7Ue2v1zm1YtT8rsXHeWCg=
 github.com/juju/charm/v9 v9.0.0-20210125110411-23fabd67cb4c/go.mod h1:ffLfwuA4E426HlTtqgMvKZdBAWXOwbgeeHye/1ITTLc=
-github.com/juju/charm/v9 v9.0.0-20210304052111-31c24cedd783 h1:Q5YaOwMkhY7qapH7Thd2M3N52aNXeAYmymFjmPrwr1k=
 github.com/juju/charm/v9 v9.0.0-20210304052111-31c24cedd783/go.mod h1:82L0Bk5mPMnoGOtP9hsxDumxYWKvjsrFjKiYvte6gP8=
 github.com/juju/charm/v9 v9.0.0-20210309091641-7e600f16b30f h1:zHUKNECfsOIRmQlAYwxj/Rvealq8Jkypy316V4cTag0=
 github.com/juju/charm/v9 v9.0.0-20210309091641-7e600f16b30f/go.mod h1:82L0Bk5mPMnoGOtP9hsxDumxYWKvjsrFjKiYvte6gP8=


### PR DESCRIPTION
This brings in the latest charm dependency to reflect the new error
message.

This brings in this PR https://github.com/juju/juju/pull/12722 to develop.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy mysql
$ juju deploy snappass-test --series=focal --channel edge
ERROR storing charm "snappass-test": charm "snappass-test" declares both series and systems
```
