### PR TITLE
RBAC label id moved 

### DIFF
--- a/caas/kubernetes/cloud/credential.go
+++ b/caas/kubernetes/cloud/credential.go
@@ -50,6 +50,13 @@ var SupportedCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
 				Hidden:      true,
 			},
 		},
+		{
+			Name: RBACLabelKeyName,
+			CredentialAttr: cloud.CredentialAttr{
+				Optional:    true,
+				Description: "the unique ID key name of the rbac resources",
+			},
+		},
 	},
 	cloud.CertificateAuthType: {
 		{


### PR DESCRIPTION
The rbac label field was wrongly place on the credential schema in k8s.
This change adds it to the OAuth2 credential type

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap to a GKE cluster
