### PR TITLE
Fixes broken kubeconfig loading tests.

### DIFF
--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -66,7 +66,7 @@ func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEn
 }
 
 func (s *detectCloudSuite) TestDetectCloudsWithoutKubeConfig(c *gc.C) {
-	err := os.Setenv("KUBECONFIG", "")
+	err := os.Setenv("KUBECONFIG", "/tmp/doesnotexistkubeconfig.yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	k8sCloud := jujucloud.Cloud{
 		Name: "testingMicrok8s",
@@ -81,7 +81,7 @@ func (s *detectCloudSuite) TestDetectCloudsWithoutKubeConfig(c *gc.C) {
 }
 
 func (s *detectCloudSuite) TestDetectCloudsMicroK8sNotFoundWithoutKubeConfig(c *gc.C) {
-	err := os.Setenv("KUBECONFIG", "")
+	err := os.Setenv("KUBECONFIG", "/tmp/doesnotexistkubeconfig.yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	p := s.getProvider(builtinCloudRet{err: errors.NotFoundf("")})
 	cloudDetector := p.(environs.CloudDetector)


### PR DESCRIPTION
Juju has tests that require no kube config present. In this test we
where setting the kubeconfig variable to nil which forced the default
loading of ~/.kube/config. This is not the behaviour wanted. We now set
this value to a file that doesn't exist.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Create a valid Kubernetes config file at ~/.kube/config and run the caas/kubernetes/provider tests
