### PR TITLE
A few hack-fixes for the Pebble / sidecar charm demo:

### DIFF
--- a/caas/kubernetes/provider/klog.go
+++ b/caas/kubernetes/provider/klog.go
@@ -34,7 +34,8 @@ func (k *klogAdapter) Error(err error, msg string, keysAndValues ...interface{})
 		return
 	}
 	if strings.HasPrefix(msg, "an error occurred forwarding") ||
-		strings.HasPrefix(msg, "error copying from remote stream to local connection") {
+		strings.HasPrefix(msg, "error copying from remote stream to local connection") ||
+		strings.HasPrefix(msg, "error copying from local connection to remote stream") {
 		k.Logger.Debugf(msg, keysAndValues...)
 		return
 	}

--- a/caas/kubernetes/provider/klog.go
+++ b/caas/kubernetes/provider/klog.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"github.com/go-logr/logr"
 	"github.com/juju/loggo"
+	"strings"
 )
 
 // klogAdapter is an adapter for Kubernetes logger onto juju loggo. We use this
@@ -30,9 +31,14 @@ func (k *klogAdapter) Enabled() bool {
 func (k *klogAdapter) Error(err error, msg string, keysAndValues ...interface{}) {
 	if err != nil {
 		k.Logger.Errorf(msg+": "+err.Error(), keysAndValues...)
-	} else {
-		k.Logger.Errorf(msg, keysAndValues...)
+		return
 	}
+	if strings.HasPrefix(msg, "an error occurred forwarding") ||
+		strings.HasPrefix(msg, "error copying from remote stream to local connection") {
+		k.Logger.Debugf(msg, keysAndValues...)
+		return
+	}
+	k.Logger.Errorf(msg, keysAndValues...)
 }
 
 // Info see https://pkg.go.dev/github.com/go-logr/logr#Logger

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -116,7 +116,19 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 		return nil, errors.Trace(err)
 	}
 
-	c.logger.Tracef("Refresh() unmarshalled: %s", pretty.Sprint(resp.Results))
+	// TODO(benhoyt) - total hack for demo, remove
+	// The Charmhub API seems to be returning type="file" incorrectly
+	for _, result := range resp.Results {
+		if result.Entity.Name != "snappass-test" {
+			continue
+		}
+		for i, res := range result.Entity.Resources {
+			c.logger.Errorf("Refresh(): replacing type %q with \"oci-image\"", res.Type)
+			result.Entity.Resources[i].Type = "oci-image"
+		}
+	}
+
+	c.logger.Errorf("Refresh() unmarshalled: %s", pretty.Sprint(resp.Results))
 	return resp.Results, config.Ensure(resp.Results)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b
+	github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716
 	github.com/juju/charmrepo/v6 v6.0.0-20210309083204-29c3dbf03675
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -394,9 +394,8 @@ github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815/go.mod h1:gcqIN/pHfz
 github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI/PZPnS5feY4/7Ue2v1zm1YtT8rsXHeWCg=
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
+github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716 h1:pDJjQQHQi5hKnGbk7H6AA1UGLSG3iYMDWHFT7kukEBI=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b h1:+KrXxt1oLLINuFv0Dmi9TOkIjVJhbXONA5jCfOV0J00=
-github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=


### PR DESCRIPTION
* Revert juju/charm version to allow both "series" and "systems" in
  metadata.yaml (this is the go.mod change)
* Hack charmhub/refresh.go: if charm is "snappass-test", replace
  resource type "file" with "oci-image" as Charmhub isn't sending the
  correct value (or charmcraft is not uploading the correct value)
* Filter out K8s "error copying from remote stream" log messages;
  see also https://github.com/juju/juju/pull/12735
