### PR TITLE
Merge 2.9

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import logging
 import os
 from pprint import pformat
+from datetime import datetime, timezone
 
 import yaml
 from azure.identity import ClientSecretCredential
@@ -129,7 +130,6 @@ class AKS(Base):
         linux_profile = m.ContainerServiceLinuxProfile(
             admin_username='azureuser', ssh=ssh_,
         )
-
         return m.ManagedCluster(
             location=location,
             dns_prefix=self.cluster_name,  # use cluster name as dns prefix.
@@ -138,6 +138,7 @@ class AKS(Base):
             agent_pool_profiles=[agentpool_default],
             linux_profile=linux_profile,
             enable_rbac=True,
+            tags={'createdAt': datetime.now(tz=timezone.utc).isoformat()},
         )
 
     def list_clusters(self, resource_group):

--- a/caas/kubernetes/cloud/credential.go
+++ b/caas/kubernetes/cloud/credential.go
@@ -50,6 +50,13 @@ var SupportedCredentialSchemas = map[cloud.AuthType]cloud.CredentialSchema{
 				Hidden:      true,
 			},
 		},
+		{
+			Name: RBACLabelKeyName,
+			CredentialAttr: cloud.CredentialAttr{
+				Optional:    true,
+				Description: "the unique ID key name of the rbac resources",
+			},
+		},
 	},
 	cloud.CertificateAuthType: {
 		{

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -4,6 +4,7 @@
 package proxyupdater_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	jujuos "github.com/juju/os/v2"
 	"github.com/juju/packaging/commands"
 	pacconfig "github.com/juju/packaging/config"
 	"github.com/juju/proxy"
@@ -405,8 +407,8 @@ func nextCall(c *gc.C, calls <-chan []string) []string {
 }
 
 func (s *ProxyUpdaterSuite) TestSnapProxySetNoneSet(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("snap settings not handled on windows")
+	if host := jujuos.HostOS(); host == jujuos.Windows || host == jujuos.CentOS {
+		c.Skip(fmt.Sprintf("snap settings not handled on %s", host.String()))
 	}
 
 	logger := s.config.Logger
@@ -468,8 +470,8 @@ func (s *ProxyUpdaterSuite) TestSnapProxySet(c *gc.C) {
 }
 
 func (s *ProxyUpdaterSuite) TestSnapStoreProxy(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("snap settings not handled on windows")
+	if host := jujuos.HostOS(); host == jujuos.Windows || host == jujuos.CentOS {
+		c.Skip(fmt.Sprintf("snap settings not handled on %s", host.String()))
 	}
 
 	logger := s.config.Logger


### PR DESCRIPTION
Merge 2.9 with these PRs:

- https://github.com/juju/juju/pull/12747 Use UTC time for aks creation time;
- https://github.com/juju/juju/pull/12746 [2.9] Fix broken centos proxy tests 
- https://github.com/juju/juju/pull/12745 Convert createdAt timestamp to isoformat string for AKS tag;
- https://github.com/juju/juju/pull/12743 Tag creation timestamp to AKS cluster because this is not accessible via AKS API later;
- https://github.com/juju/juju/pull/12740 RBAC label id moved

no conflicts.

