### PR TITLE
Disregard refcount for blobstore cleanup

### DIFF
--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,7 +64,10 @@ func main() {
 	}
 	checkErr(loggo.ConfigureLoggers(*loggingConfig), "logging config")
 
-	cleaner := NewBlobstoreCleaner()
+	cleaner, err := NewBlobstoreCleaner()
+	if err != nil {
+		log.Fatal(err)
+	}
 	cleaner.findModellessManagedResources()
 	cleaner.cleanupManagedResources()
 	cleaner.findUnmanagedResources()
@@ -161,8 +165,11 @@ func lengthToSize(length uint64) string {
 	return fmt.Sprintf("%d", length)
 }
 
-func NewBlobstoreCleaner() *BlobstoreCleaner {
+func NewBlobstoreCleaner() (*BlobstoreCleaner, error) {
 	statePool, session, err := getState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	// Some of the chunks queries take a long time
 	session.SetSocketTimeout(10 * time.Minute)
 	checkErr(err, "getting state connection")
@@ -185,7 +192,7 @@ func NewBlobstoreCleaner() *BlobstoreCleaner {
 		foundResourceIDs:    set.NewStrings(),
 		foundBlobstorePaths: set.NewStrings(),
 		foundBlobstoreIDs:   set.NewStrings(),
-	}
+	}, nil
 }
 
 type ManagedResource struct {

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -376,7 +376,6 @@ func removeStoredResourceOps(docID string) []txn.Op {
 	return []txn.Op{{
 		C:      resourceCatalogC,
 		Id:     docID,
-		Assert: bson.D{{"refcount", 1}},
 		Remove: true,
 	}}
 }


### PR DESCRIPTION
Makes a slight correction to the blob-store clean-up script.

This removes an assertion from the operation to delete entries from `storedResources` that are unreferenced by documents in `managedStoredResources`.

We don't care about the `refcount` for this operation, because if it is greater than zero, it is incorrect anyway and we're performing an operation out-of-band from Juju-proper to reacquire space.

It also addresses contradiction of the comment on the parent method that explicitly states we are ignoring `refcount`.

## QA steps

- Bootstrap with `--agent-version 2.8.7`
- `juju deploy redis` (Trusty).
- `juju deploy ubuntu` (Bionic).
- Upgrade controller and model with `--agent-version 2.8.8`
- Connect to Mongo and delete the 2.8.7 agent records from `managedStoredResources`. There should be 2; one each for Trusty and Bionic, pointing to the same resource ID. This in turn implies a `refcount` of 2 on the resource doc, which can be verified directly.
- SCP the built binary for this "script" to the controller.
- Run it with `--dry-run=false` and see it inform of resource deletion.

## Documentation changes

None.

## Bug reference

N/A
