### PR TITLE
[2.8] Record hostname when machine agent starts

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -66,7 +66,7 @@ var facadeVersions = map[string]int{
 	"MachineActions":               1,
 	"MachineManager":               6,
 	"MachineUndertaker":            1,
-	"Machiner":                     4,
+	"Machiner":                     5,
 	"MeterStatus":                  2,
 	"MetricsAdder":                 2,
 	"MetricsDebug":                 2,

--- a/api/machiner/machiner_test.go
+++ b/api/machiner/machiner_test.go
@@ -208,7 +208,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	wc.AssertOneChange()
 }
 
-func (s *machinerSuite) TestRecordAgentStartTime(c *gc.C) {
+func (s *machinerSuite) TestRecordAgentStartInformation(c *gc.C) {
 	mTag := names.NewMachineTag("1")
 	stMachine, err := s.State.Machine(mTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
@@ -217,11 +217,12 @@ func (s *machinerSuite) TestRecordAgentStartTime(c *gc.C) {
 	machine, err := s.machiner.Machine(mTag)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = machine.RecordAgentStartTime()
+	err = machine.RecordAgentStartInformation("thundering-herds")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = stMachine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(stMachine.AgentStartTime(), gc.Not(gc.Equals), oldStartedAt, gc.Commentf("expected the agent start time to be updated"))
+	c.Assert(stMachine.Hostname(), gc.Equals, "thundering-herds", gc.Commentf("expected for the recorded machine hostname to be updated"))
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -245,7 +245,8 @@ func AllFacades() *facade.Registry {
 	reg("Machiner", 1, machine.NewMachinerAPIV1)
 	reg("Machiner", 2, machine.NewMachinerAPIV2) // Adds RecordAgentStartTime.
 	reg("Machiner", 3, machine.NewMachinerAPIV3) // Relies on agent-set origin in SetObservedNetworkConfig.
-	reg("Machiner", 4, machine.NewMachinerAPI)   // Removes SetProviderNetworkConfig.
+	reg("Machiner", 4, machine.NewMachinerAPIV4) // Removes SetProviderNetworkConfig.
+	reg("Machiner", 5, machine.NewMachinerAPI)   // Adds RecordAgentHostAndStartTime.
 
 	reg("MeterStatus", 1, meterstatus.NewMeterStatusFacadeV1)
 	reg("MeterStatus", 2, meterstatus.NewMeterStatusFacade)

--- a/apiserver/facades/agent/machine/machiner_test.go
+++ b/apiserver/facades/agent/machine/machiner_test.go
@@ -288,3 +288,25 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	wc := statetesting.NewNotifyWatcherC(c, s.State, resource.(state.NotifyWatcher))
 	wc.AssertNoChange()
 }
+
+func (s *machinerSuite) TestRecordAgentStartInformation(c *gc.C) {
+	args := params.RecordAgentStartInformationArgs{Args: []params.RecordAgentStartInformationArg{
+		{Tag: "machine-1", Hostname: "thundering-herds"},
+		{Tag: "machine-0", Hostname: "eldritch-octopii"},
+		{Tag: "machine-42", Hostname: "missing-gem"},
+	}}
+
+	result, err := s.machiner.RecordAgentStartInformation(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{nil},
+			{apiservertesting.ErrUnauthorized},
+			{apiservertesting.ErrUnauthorized},
+		},
+	})
+
+	err = s.machine1.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine1.Hostname(), gc.Equals, "thundering-herds", gc.Commentf("expected the machine hostname to be updated"))
+}

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1010,6 +1010,7 @@ func (c *statusContext) makeMachineStatus(machine *state.Machine, appStatusInfo 
 			logger.Debugf("error fetching public address: %q", err)
 		}
 		status.DNSName = addr.Value
+		status.Hostname = machine.Hostname()
 		mAddrs := machine.Addresses()
 		if len(mAddrs) == 0 {
 			logger.Debugf("no IP addresses fetched for machine %q", instid)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -11549,6 +11549,9 @@
                         "has-vote": {
                             "type": "boolean"
                         },
+                        "hostname": {
+                            "type": "string"
+                        },
                         "id": {
                             "type": "string"
                         },
@@ -22609,7 +22612,7 @@
     {
         "Name": "Machiner",
         "Description": "MachinerAPI implements the API used by the machiner worker.",
-        "Version": 4,
+        "Version": 5,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent"
@@ -22679,6 +22682,18 @@
                         }
                     },
                     "description": "ModelUUID returns the model UUID to connect to the model\nthat the current connection is for."
+                },
+                "RecordAgentStartInformation": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RecordAgentStartInformationArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RecordAgentStartInformation syncs the machine model with information\nreported by a machine agent when it starts."
                 },
                 "RecordAgentStartTime": {
                     "type": "object",
@@ -23189,6 +23204,36 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "RecordAgentStartInformationArg": {
+                    "type": "object",
+                    "properties": {
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "RecordAgentStartInformationArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RecordAgentStartInformationArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
                     ]
                 },
                 "SetMachineNetworkConfig": {

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -266,6 +266,19 @@ type DestroyMachinesParams struct {
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
+// RecordAgentStartInformationArgs holds the parameters for updating the
+// information reported by one or more machine agents when they start.
+type RecordAgentStartInformationArgs struct {
+	Args []RecordAgentStartInformationArg `json:"args"`
+}
+
+// RecordAgentStartInformationArg holds the information reported by a machine
+// agnet to the controller when it starts.
+type RecordAgentStartInformationArg struct {
+	Tag      string `json:"tag"`
+	Hostname string `json:"hostname,omitempty"`
+}
+
 // UpdateSeriesArg holds the parameters for updating the series for the
 // specified application or machine. For Application, only known by facade
 // version 5 and greater. For MachineManger, only known by facade version

--- a/apiserver/params/status.go
+++ b/apiserver/params/status.go
@@ -80,7 +80,8 @@ type MachineStatus struct {
 	InstanceStatus     DetailedStatus `json:"instance-status"`
 	ModificationStatus DetailedStatus `json:"modification-status"`
 
-	DNSName string `json:"dns-name"`
+	Hostname string `json:"hostname,omitempty"`
+	DNSName  string `json:"dns-name"`
 
 	// IPAddresses holds the IP addresses known for this machine. It is
 	// here for backwards compatibility. It should be similar to its

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -63,6 +63,7 @@ type networkInterface struct {
 type machineStatus struct {
 	Err                error                         `json:"-" yaml:",omitempty"`
 	JujuStatus         statusInfoContents            `json:"juju-status,omitempty" yaml:"juju-status,omitempty"`
+	Hostname           string                        `json:"hostname,omitempty" yaml:"hostname,omitempty"`
 	DNSName            string                        `json:"dns-name,omitempty" yaml:"dns-name,omitempty"`
 	IPAddresses        []string                      `json:"ip-addresses,omitempty" yaml:"ip-addresses,omitempty"`
 	InstanceId         instance.Id                   `json:"instance-id,omitempty" yaml:"instance-id,omitempty"`

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -177,6 +177,7 @@ func (sf *statusFormatter) formatMachine(machine params.MachineStatus) machineSt
 
 	out = machineStatus{
 		JujuStatus:         sf.getStatusInfoContents(machine.AgentStatus),
+		Hostname:           machine.Hostname,
 		DNSName:            machine.DNSName,
 		IPAddresses:        machine.IPAddresses,
 		InstanceId:         machine.InstanceId,

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -180,6 +180,9 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		// In this scenario machine0 runs an older agent version that
+		// does not support reporting of host names. Since the hostname
+		// is blank it will be skipped.
 		"dns-name":     "10.0.0.1",
 		"ip-addresses": []string{"10.0.0.1"},
 		"instance-id":  "controller-0",
@@ -207,6 +210,7 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		"hostname":     "eldritch-octopii",
 		"dns-name":     "10.0.1.1",
 		"ip-addresses": []string{"10.0.1.1"},
 		"instance-id":  "controller-1",
@@ -233,6 +237,7 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		"hostname":     "eldritch-octopii",
 		"dns-name":     "10.0.1.1",
 		"ip-addresses": []string{"10.0.1.1"},
 		"instance-id":  "controller-1",
@@ -288,6 +293,7 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		"hostname":     "titanium-shoelace",
 		"dns-name":     "10.0.2.1",
 		"ip-addresses": []string{"10.0.2.1"},
 		"instance-id":  "controller-2",
@@ -314,6 +320,7 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		"hostname":     "loud-silence",
 		"dns-name":     "10.0.3.1",
 		"ip-addresses": []string{"10.0.3.1"},
 		"instance-id":  "controller-3",
@@ -341,6 +348,7 @@ var (
 			"current": "started",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
+		"hostname":     "antediluvian-furniture",
 		"dns-name":     "10.0.4.1",
 		"ip-addresses": []string{"10.0.4.1"},
 		"instance-id":  "controller-4",
@@ -437,6 +445,7 @@ var (
 				"series": "quantal",
 			},
 		},
+		"hostname":     "eldritch-octopii",
 		"dns-name":     "10.0.1.1",
 		"ip-addresses": []string{"10.0.1.1"},
 		"instance-id":  "controller-1",
@@ -907,10 +916,12 @@ var statusTests = []testCase{
 
 		// step 10
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 		addMachine{machineId: "2", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "2", hostname: "titanium-shoelace"},
 		setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")},
 		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
@@ -1017,10 +1028,12 @@ var statusTests = []testCase{
 		// step 29
 		addMachine{machineId: "3", job: state.JobHostUnits},
 		startMachine{"3"},
+		recordAgentStartInformation{machineId: "3", hostname: "loud-silence"},
 		// Simulate some status with info, while the agent is down.
 		setAddresses{"3", network.NewSpaceAddresses("10.0.3.1")},
 		setMachineStatus{"3", status.Stopped, "Really?"},
 		addMachine{machineId: "4", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "4", hostname: "antediluvian-furniture"},
 		setAddresses{"4", network.NewSpaceAddresses("10.0.4.1")},
 		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Error, "Beware the red toys"},
@@ -1036,6 +1049,7 @@ var statusTests = []testCase{
 					"1": machine1,
 					"2": machine2,
 					"3": M{
+						"hostname":     "loud-silence",
 						"dns-name":     "10.0.3.1",
 						"ip-addresses": []string{"10.0.3.1"},
 						"instance-id":  "controller-3",
@@ -1063,6 +1077,7 @@ var statusTests = []testCase{
 						"hardware": "arch=amd64 cores=1 mem=1024M root-disk=8192M",
 					},
 					"4": M{
+						"hostname":     "antediluvian-furniture",
 						"dns-name":     "10.0.4.1",
 						"ip-addresses": []string{"10.0.4.1"},
 						"instance-id":  "controller-4",
@@ -1391,6 +1406,7 @@ var statusTests = []testCase{
 		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -1501,6 +1517,7 @@ var statusTests = []testCase{
 		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -1740,6 +1757,7 @@ var statusTests = []testCase{
 		addApplication{name: "project", charm: "wordpress"},
 		setApplicationExposed{"project", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -1750,6 +1768,7 @@ var statusTests = []testCase{
 		addApplication{name: "mysql", charm: "mysql"},
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "2", hostname: "titanium-shoelace"},
 		setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")},
 		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
@@ -1760,6 +1779,7 @@ var statusTests = []testCase{
 		addApplication{name: "varnish", charm: "varnish"},
 		setApplicationExposed{"varnish", true},
 		addMachine{machineId: "3", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "3", hostname: "loud-silence"},
 		setAddresses{"3", network.NewSpaceAddresses("10.0.3.1")},
 		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
@@ -1769,6 +1789,7 @@ var statusTests = []testCase{
 		addApplication{name: "private", charm: "wordpress"},
 		setApplicationExposed{"private", true},
 		addMachine{machineId: "4", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "4", hostname: "antediluvian-furniture"},
 		setAddresses{"4", network.NewSpaceAddresses("10.0.4.1")},
 		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Started, ""},
@@ -1949,6 +1970,7 @@ var statusTests = []testCase{
 		addApplication{name: "riak", charm: "riak"},
 		setApplicationExposed{"riak", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -1956,6 +1978,7 @@ var statusTests = []testCase{
 		setAgentStatus{"riak/0", status.Idle, "", nil},
 		setUnitStatus{"riak/0", status.Active, "", nil},
 		addMachine{machineId: "2", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "2", hostname: "titanium-shoelace"},
 		setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")},
 		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
@@ -1963,6 +1986,7 @@ var statusTests = []testCase{
 		setAgentStatus{"riak/1", status.Idle, "", nil},
 		setUnitStatus{"riak/1", status.Active, "", nil},
 		addMachine{machineId: "3", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "3", hostname: "loud-silence"},
 		setAddresses{"3", network.NewSpaceAddresses("10.0.3.1")},
 		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
@@ -2066,6 +2090,7 @@ var statusTests = []testCase{
 		addApplication{name: "wordpress", charm: "wordpress"},
 		setApplicationExposed{"wordpress", true},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -2076,6 +2101,7 @@ var statusTests = []testCase{
 		addApplication{name: "mysql", charm: "mysql"},
 		setApplicationExposed{"mysql", true},
 		addMachine{machineId: "2", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "2", hostname: "titanium-shoelace"},
 		setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")},
 		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
@@ -2452,6 +2478,7 @@ var statusTests = []testCase{
 
 		// step 7
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -2570,6 +2597,7 @@ var statusTests = []testCase{
 								},
 							},
 						},
+						"hostname":     "eldritch-octopii",
 						"dns-name":     "10.0.1.1",
 						"ip-addresses": []string{"10.0.1.1"},
 						"instance-id":  "controller-1",
@@ -2635,6 +2663,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -2698,6 +2727,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -2763,6 +2793,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -2830,6 +2861,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -2897,16 +2929,19 @@ var statusTests = []testCase{
 		setMachineStatus{"0", status.Started, ""},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "2", hostname: "titanium-shoelace"},
 		setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")},
 		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
 
 		addMachine{machineId: "3", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "3", hostname: "loud-silence"},
 		setAddresses{"3", network.NewSpaceAddresses("10.0.3.1")},
 		startAliveMachine{"3", ""},
 		setMachineStatus{"3", status.Started, ""},
@@ -2914,6 +2949,7 @@ var statusTests = []testCase{
 
 		addMachine{machineId: "4", job: state.JobHostUnits},
 		setAddresses{"4", network.NewSpaceAddresses("10.0.4.1")},
+		recordAgentStartInformation{machineId: "4", hostname: "antediluvian-furniture"},
 		startAliveMachine{"4", ""},
 		setMachineStatus{"4", status.Started, ""},
 
@@ -3084,6 +3120,7 @@ var statusTests = []testCase{
 		addApplication{name: "mysql", charm: "mysql"},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -3147,6 +3184,7 @@ var statusTests = []testCase{
 		addApplication{name: "mysql", charm: "mysql"},
 
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -3154,6 +3192,7 @@ var statusTests = []testCase{
 		setUnitWorkloadVersion{"mysql/0", "the best!"},
 
 		addMachine{machineId: "2", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "2", hostname: "titanium-shoelace"},
 		setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")},
 		startAliveMachine{"2", ""},
 		setMachineStatus{"2", status.Started, ""},
@@ -3309,6 +3348,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -3462,6 +3502,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -3497,6 +3538,7 @@ var statusTests = []testCase{
 							"current": "started",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
+						"hostname":     "eldritch-octopii",
 						"dns-name":     "10.0.1.1",
 						"ip-addresses": []string{"10.0.1.1"},
 						"instance-id":  "controller-1",
@@ -3602,6 +3644,7 @@ var statusTests = []testCase{
 		startAliveMachine{"0", ""},
 		setMachineStatus{"0", status.Started, ""},
 		addMachine{machineId: "1", job: state.JobHostUnits},
+		recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 		setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 		startAliveMachine{"1", ""},
 		setMachineStatus{"1", status.Started, ""},
@@ -3822,6 +3865,19 @@ func (am addMachine) step(c *gc.C, ctx *context) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, am.machineId)
+}
+
+type recordAgentStartInformation struct {
+	machineId string
+	hostname  string
+}
+
+func (ri recordAgentStartInformation) step(c *gc.C, ctx *context) {
+	m, err := ctx.st.Machine(ri.machineId)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = m.RecordAgentStartInformation(ri.hostname)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 type addContainer struct {
@@ -5822,6 +5878,7 @@ var statusTimeTest = test(
 	addApplication{name: "dummy-application", charm: "dummy"},
 
 	addMachine{machineId: "1", job: state.JobHostUnits},
+	recordAgentStartInformation{machineId: "1", hostname: "eldritch-octopii"},
 	startAliveMachine{"1", ""},
 	setAddresses{"1", network.NewSpaceAddresses("10.0.1.1")},
 	setMachineStatus{"1", status.Started, ""},

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -102,6 +102,7 @@ var (
 	// person! Juju Needs You.
 	useMultipleCPUs   = utils.UseMultipleCPUs
 	reportOpenedState = func(*state.State) {}
+	getHostname       = os.Hostname
 
 	caasModelManifolds   = model.CAASManifolds
 	iaasModelManifolds   = model.IAASManifolds
@@ -711,12 +712,16 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 		return nil, errors.Annotate(err, "setting up container support")
 	}
 
-	// Record the agent start time in the machine document. This ensures
-	// that whenever a machine restarts, the instancepoller gets a chance
-	// to immediately refresh the provider address (inc. shadow IP)
+	// Report the machine host name and record the agent start time. This
+	// ensures that whenever a machine restarts, the instancepoller gets a
+	// chance to immediately refresh the provider address (inc. shadow IP)
 	// information which can change between reboots.
-	if err := a.recordAgentStartTime(apiConn); err != nil {
-		return nil, errors.Annotate(err, "recording agent start time")
+	hostname, err := getHostname()
+	if err != nil {
+		return nil, errors.Annotate(err, "getting machine hostname")
+	}
+	if err := a.recordAgentStartInformation(apiConn, hostname); err != nil {
+		return nil, errors.Annotate(err, "recording agent start information")
 	}
 
 	var isController bool
@@ -773,7 +778,7 @@ func (a *MachineAgent) machine(apiConn api.Connection) (*apimachiner.Machine, er
 	return machinerAPI.Machine(tag)
 }
 
-func (a *MachineAgent) recordAgentStartTime(apiConn api.Connection) error {
+func (a *MachineAgent) recordAgentStartInformation(apiConn api.Connection, hostname string) error {
 	m, err := a.machine(apiConn)
 	if errors.IsNotFound(err) || err == nil && m.Life() == life.Dead {
 		return jworker.ErrTerminateAgent
@@ -782,8 +787,8 @@ func (a *MachineAgent) recordAgentStartTime(apiConn api.Connection) error {
 		return errors.Annotatef(err, "cannot load machine %s from state", a.CurrentConfig().Tag())
 	}
 
-	if err := m.RecordAgentStartTime(); err != nil {
-		return errors.Annotate(err, "cannot record agent start time")
+	if err := m.RecordAgentStartInformation(hostname); err != nil {
+		return errors.Annotate(err, "cannot record agent start information")
 	}
 	return nil
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -126,14 +126,23 @@ func (s *MachineSuite) TestSetUnsetRebootFlag(c *gc.C) {
 	c.Assert(rebootFlag, jc.IsFalse)
 }
 
-func (s *MachineSuite) TestRecordAgentStartTime(c *gc.C) {
+func (s *MachineSuite) TestRecordAgentStartInformation(c *gc.C) {
 	now := s.Clock.Now().Truncate(time.Millisecond)
-	err := s.machine.RecordAgentStartTime()
+	err := s.machine.RecordAgentStartInformation("thundering-herds")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.machine.AgentStartTime(), gc.Equals, now)
+	c.Assert(s.machine.Hostname(), gc.Equals, "thundering-herds")
+
+	// Passing an empty hostname should be ignored
+	err = s.machine.RecordAgentStartInformation("")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.machine.AgentStartTime(), gc.Equals, now)
+	c.Assert(s.machine.Hostname(), gc.Equals, "thundering-herds", gc.Commentf("expected the host name not be changed"))
 }
 
 func (s *MachineSuite) TestSetKeepInstance(c *gc.C) {
@@ -1570,14 +1579,14 @@ func (s *MachineSuite) TestWatchMachineStartTimes(c *gc.C) {
 
 	// Update the agent start time for the new machine and wait for quiesceInterval
 	// so the change gets processed and added to a new changeset.
-	err = s.machine.RecordAgentStartTime()
+	err = s.machine.RecordAgentStartInformation("machine-1")
 	c.Assert(err, jc.ErrorIsNil)
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	s.Clock.Advance(quiesceInterval)
 
 	// Update the agent start time for machine 0 and wait for quiesceInterval
 	// so the change gets processed and appended to the current changeset.
-	err = s.machine0.RecordAgentStartTime()
+	err = s.machine0.RecordAgentStartInformation("machine-0")
 	c.Assert(err, jc.ErrorIsNil)
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 	s.Clock.Advance(quiesceInterval)

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -326,8 +326,9 @@ func (s *MigrationSuite) TestMachineDocFields(c *gc.C) {
 		// Ignored at this stage, could be an issue if mongo 3.0 isn't
 		// available.
 		"StopMongoUntilVersion",
-		// Ignored; it gets populated on demand when the agent restarts
+		// Ignored; they get populated on demand when the agent restarts
 		"AgentStartedAt",
+		"Hostname",
 	)
 	migrated := set.NewStrings(
 		"Addresses",


### PR DESCRIPTION
This PR provides a solution for scenarios such us the one described in the referenced bug. More specifically, given that (provider) instance IDs are typically not related to the machine's host name and that some providers do not let us query the machine host name, `juju show-machine` output will include an IP address in the `dns-name` field.

The PR introduces a consistent cross-provider way of recording and reporting the machine host names. To achieve this, the machine agents will now query the machine host name and report it at the same time that they request from the controller to record the agent start time. While the machiner facade already had a `RecordAgentStartTime` method (added in 2.8), it accepted a slice of `params.Entity` values which meant that we could not push additional information to the controller.

To this end, the PR adds a new API call named `RecordAgentStartInformation` which supersedes `RecordAgentStartTime` and bumps the machiner facade version to **5**. Given that the machiner facade versions have not diverged in the 2.9 branch, this change can easily be forward ported. The machiner API client utilizes facade version checks to select the appropriate method to call.

In a similar fashion to the `AgentStartTime` field, the `Hostname` field will always get populated after the agent restart. As a result there is no need to modify the `juju/description` package or worry about migrations.

To report back the recorded machine hostname, the payload for the client/status (MachineStatus in FullStatus) had to be augmented with an extra field. In this case, the status API has already diverged in 2.9 so I opted to simply add the extra (it's optional anyway) field to the status response **without bumping the facade version** so we can merge the changes forward. 

Finally, the CLI has been tweaked to include the host name (if not empty) in `juju show-machine` output.

## QA steps

```console
# Bootstrap with the current 2.8 juju snap
$ /snap/bin/juju bootstrap lxd test --no-gui

$ juju switch controller
$ juju show-machine 0
model: controller
machines:
  "0":
    juju-status:
      current: started
      since: 11 Mar 2021 12:52:21Z
      version: 2.8.9
    dns-name: 10.232.217.231
    ip-addresses:
    - 10.232.217.231
    instance-id: juju-1ee6f9-0
    machine-status:
      current: running
      message: Running
      since: 11 Mar 2021 12:52:31Z
    modification-status:
      current: idle
      since: 11 Mar 2021 12:52:08Z
    series: bionic
    network-interfaces:
      eth0:
        ip-addresses:
        - 10.232.217.231
        mac-address: 00:16:3e:24:20:9e
        gateway: 10.232.217.1
        is-up: true
    hardware: arch=amd64 cores=0 mem=0M
    controller-member-status: has-vote

# Upgrade
$ juju upgrade-controller --build-agent

# The host name should magically now appear in show-machine output
$ juju show-machine 0
model: controller
machines:
  "0":
    juju-status:
      current: started
      since: 11 Mar 2021 12:53:43Z
      version: 2.8.10.1
    hostname: juju-1ee6f9-0    <----- you are looking for this
    dns-name: 10.232.217.231
    ip-addresses:
    - 10.232.217.231
    instance-id: juju-1ee6f9-0
    machine-status:
      current: running
      message: Running
      since: 11 Mar 2021 12:52:31Z
    modification-status:
      current: idle
      since: 11 Mar 2021 12:52:08Z
    series: bionic
    network-interfaces:
      eth0:
        ip-addresses:
        - 10.232.217.231
        mac-address: 00:16:3e:24:20:9e
        gateway: 10.232.217.1
        is-up: true
    hardware: arch=amd64 cores=0 mem=0M
    controller-member-status: has-vote
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1918204
