### PR TITLE
[2.8] No panic missing bundle app body

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges v1.0.1-0.20210209114844-acd700ed48fe
-	github.com/juju/charm/v7 v7.0.3
+	github.com/juju/charm/v7 v7.0.4-0.20210312103909-46ac1f0b2db4
 	github.com/juju/charmrepo/v5 v5.0.0-20210309073708-d0dc3a75f085
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/juju/bundlechanges v1.0.1-0.20210209114844-acd700ed48fe/go.mod h1:nsB
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596/go.mod h1:/Hb24f6NaHMuxV/XeKR9v1QY8qCc0NanWAXQuv6+Ob0=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
 github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
-github.com/juju/charm/v7 v7.0.3 h1:plWkQdziV/BUlGPcc4a4/S6F8dmjPMQR05+tvTuEUHc=
-github.com/juju/charm/v7 v7.0.3/go.mod h1:gSJopNd1QJBmICiXxAKXS9XqIpFyFfVtJEvXGWCHe4I=
+github.com/juju/charm/v7 v7.0.4-0.20210312103909-46ac1f0b2db4 h1:c1SyhKxMGvDhRyzaDky4SSYjyuYIf/8VCN48zcnquak=
+github.com/juju/charm/v7 v7.0.4-0.20210312103909-46ac1f0b2db4/go.mod h1:gSJopNd1QJBmICiXxAKXS9XqIpFyFfVtJEvXGWCHe4I=
 github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI/PZPnS5feY4/7Ue2v1zm1YtT8rsXHeWCg=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=


### PR DESCRIPTION
The change prevents a panic if the body of a base bundle 
application is missing and used in conjunction with overlay. 
The fix is to error out early to prevent panic out when attempting
to merge the overlays.


## QA steps

Create a bundle.yaml

```yaml
series: focal
applications:
  apache2:
--- # overlay 1
applications:
  apache2:
    num_units: 2
```

```sh
$ juju bootstrap lxd test
$ juju deploy ./bundle.yaml
ERROR cannot deploy bundle: base application "apache2" has no body
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1918742
