### PR TITLE
Fix errant relative timeout for migration minion reports

### DIFF
--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -716,12 +716,11 @@ func (w *Worker) waitForMinions(
 	infoPrefix string,
 ) (success bool, err error) {
 	clk := w.config.Clock
-	maxWait := maxMinionWait - clk.Now().Sub(status.PhaseChangedTime)
-	timeout := clk.After(maxWait)
+	timeout := clk.After(maxMinionWait)
 
 	w.setInfoStatus("%s, waiting for agents to report back", infoPrefix)
 	w.logger.Infof("waiting for agents to report back for migration phase %s (will wait up to %s)",
-		status.Phase, truncDuration(maxWait))
+		status.Phase, truncDuration(maxMinionWait))
 
 	watch, err := w.config.Facade.WatchMinionReports()
 	if err != nil {


### PR DESCRIPTION
At a customer site we had multiple occurrences of a model migration aborting due to a time-out waiting for minion reports for the _VALIDATION_ phase.

This turns out to be because the time-out is set to be at 15 minutes from the **phase change time in the migration status**. This status is only retrieved from the API upon migration commencement and is not updated when the phase transitions, so it imposes an effective 15 minute time-out for the **whole migration**.

Here, we simply allow the time-out to be an absolute 15 minutes from the current time as we commence waiting for reports.

First commit is linter fixes. Reviewers will be best served by considering the second commit in isolation.

## QA steps

It is hard to contrive a real test here, because we need a model of sufficient size to exceed 15 minutes for the _IMPORT_ phase.

The unit test change here is red/green for the change.

## Documentation changes

None.

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
