### PR TITLE
[2.8] Include hostname in multi-watcher machine deltas

### DIFF
--- a/apiserver/params/multiwatcher.go
+++ b/apiserver/params/multiwatcher.go
@@ -136,6 +136,7 @@ type MachineInfo struct {
 	Addresses                []Address                         `json:"addresses"`
 	HasVote                  bool                              `json:"has-vote"`
 	WantsVote                bool                              `json:"wants-vote"`
+	Hostname                 string                            `json:"hostname,omitempty"`
 }
 
 // EntityId returns a unique identifier for a machine across

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -231,6 +231,7 @@ func (aw *SrvAllWatcher) translateMachine(info multiwatcher.EntityInfo) params.E
 		Addresses:                aw.translateAddresses(orig.Addresses),
 		HasVote:                  orig.HasVote,
 		WantsVote:                orig.WantsVote,
+		Hostname:                 orig.Hostname,
 	}
 }
 

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -99,6 +99,9 @@ type MachineInfo struct {
 	// only stored on the machine info to populate the unit info.
 	PreferredPublicAddress  network.SpaceAddress
 	PreferredPrivateAddress network.SpaceAddress
+
+	// The machine's hostname reported by the machine agent when it started.
+	Hostname string
 }
 
 // EntityID returns a unique identifier for a machine across

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -355,6 +355,7 @@ func (m *backingMachine) updated(ctx *allWatcherContext) error {
 		WantsVote:                wantsVote,
 		PreferredPublicAddress:   m.PreferredPublicAddress.networkAddress(),
 		PreferredPrivateAddress:  m.PreferredPrivateAddress.networkAddress(),
+		Hostname:                 m.Hostname,
 	}
 	addresses := network.MergedAddresses(networkAddresses(m.MachineAddresses), networkAddresses(m.Addresses))
 	for _, addr := range addresses {


### PR DESCRIPTION
This is a followup PR to #12754 to ensure that the agent-reported machine host name is included in the deltas produced by the multi-watcher/all-watcher API calls so this information can be made available via pylibjuju.

Similar to the client/status facade changes in the linked PR, the watcher facade has not been bumped as hostname is an optional field.

No further QA required; the changes will be tested as part of an upcoming PR against pylibjuju.