### PR TITLE
[2.9] No panic missing bundle app body

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b
+	github.com/juju/charm/v8 v8.0.0-20210312121826-31723b67c6d4
 	github.com/juju/charmrepo/v6 v6.0.0-20210309083204-29c3dbf03675
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,7 @@ github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b h1:+KrXxt1oLLINuFv0Dmi9TOkIjVJhbXONA5jCfOV0J00=
-github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
+github.com/juju/charm/v8 v8.0.0-20210312121826-31723b67c6d4/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=


### PR DESCRIPTION
This is a merge forward of #12758

The change prevents a panic if the body of a base bundle 
application is missing and used in conjunction with overlay. 
The fix is to error out early to prevent panic out when attempting
to merge the overlays.


## QA steps

Create a bundle.yaml

```yaml
series: focal
applications:
  apache2:
--- # overlay 1
applications:
  apache2:
    num_units: 2
```

```sh
$ juju bootstrap lxd test
$ juju deploy ./bundle.yaml
ERROR cannot deploy bundle: base application "apache2" has no body
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1918742
