### PR TITLE
Add MinionReportTimeout to migration-master API

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -72,7 +72,7 @@ var facadeVersions = map[string]int{
 	"MetricsDebug":                 2,
 	"MetricsManager":               1,
 	"MigrationFlag":                1,
-	"MigrationMaster":              2,
+	"MigrationMaster":              3,
 	"MigrationMinion":              1,
 	"MigrationStatusWatcher":       1,
 	"MigrationTarget":              1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -255,8 +255,9 @@ func AllFacades() *facade.Registry {
 	reg("MetricsManager", 1, metricsmanager.NewFacade)
 
 	reg("MigrationFlag", 1, migrationflag.NewFacade)
-	reg("MigrationMaster", 1, migrationmaster.NewMigrationMasterFacade)
+	reg("MigrationMaster", 1, migrationmaster.NewMigrationMasterFacadeV1)
 	reg("MigrationMaster", 2, migrationmaster.NewMigrationMasterFacadeV2)
+	reg("MigrationMaster", 3, migrationmaster.NewMigrationMasterFacade) // Adds MinionReportTimeout.
 	reg("MigrationMinion", 1, migrationminion.NewFacade)
 	reg("MigrationTarget", 1, migrationtarget.NewFacade)
 

--- a/apiserver/facades/controller/migrationmaster/backend.go
+++ b/apiserver/facades/controller/migrationmaster/backend.go
@@ -7,13 +7,10 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/version"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
 )
-
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/backend.go github.com/juju/juju/apiserver/facades/controller/migrationmaster Backend,OfferConnection
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/precheckbackend.go github.com/juju/juju/migration PrecheckBackend
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/state.go github.com/juju/juju/state ModelMigration,NotifyWatcher,ExternalController
 
 // Backend defines the state functionality required by the
 // migrationmaster facade.
@@ -27,6 +24,7 @@ type Backend interface {
 	ModelOwner() (names.UserTag, error)
 	AgentVersion() (version.Number, error)
 	RemoveExportingModelDocs() error
+	ControllerConfig() (controller.Config, error)
 }
 
 // OfferConnection describes methods offer connection methods

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/juju/controller"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/description/v2"
 	"github.com/juju/errors"
@@ -517,6 +519,22 @@ func (s *Suite) TestMinionReports(c *gc.C) {
 			u1.String(),
 		},
 	})
+}
+
+func (s *Suite) TestMinionReportTimeout(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	timeout := "30s"
+
+	s.backend.EXPECT().ControllerConfig().Return(controller.Config{
+		controller.MigrationMinionWaitMax: timeout,
+	}, nil)
+
+	res, err := s.mustMakeAPI(c).MinionReportTimeout()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res.Error, gc.IsNil)
+	c.Check(res.Result, gc.Equals, timeout)
 }
 
 func (s *Suite) setupMocks(c *gc.C) *gomock.Controller {

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -5,13 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description/v2"
+	controller "github.com/juju/juju/controller"
 	state "github.com/juju/juju/state"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockBackend is a mock of Backend interface
@@ -50,6 +50,21 @@ func (m *MockBackend) AgentVersion() (version.Number, error) {
 func (mr *MockBackendMockRecorder) AgentVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentVersion", reflect.TypeOf((*MockBackend)(nil).AgentVersion))
+}
+
+// ControllerConfig mocks base method
+func (m *MockBackend) ControllerConfig() (controller.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret0, _ := ret[0].(controller.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerConfig indicates an expected call of ControllerConfig
+func (mr *MockBackendMockRecorder) ControllerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockBackend)(nil).ControllerConfig))
 }
 
 // Export mocks base method
@@ -98,10 +113,10 @@ func (mr *MockBackendMockRecorder) ModelName() *gomock.Call {
 }
 
 // ModelOwner mocks base method
-func (m *MockBackend) ModelOwner() (names_v3.UserTag, error) {
+func (m *MockBackend) ModelOwner() (names.UserTag, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelOwner")
-	ret0, _ := ret[0].(names_v3.UserTag)
+	ret0, _ := ret[0].(names.UserTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
@@ -5,14 +5,13 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	migration "github.com/juju/juju/migration"
 	resource "github.com/juju/juju/resource"
 	state "github.com/juju/juju/state"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	version "github.com/juju/version"
+	reflect "reflect"
 )
 
 // MockPrecheckBackend is a mock of PrecheckBackend interface
@@ -114,7 +113,7 @@ func (mr *MockPrecheckBackendMockRecorder) AllRelations() *gomock.Call {
 }
 
 // CloudCredential mocks base method
-func (m *MockPrecheckBackend) CloudCredential(arg0 names_v3.CloudCredentialTag) (state.Credential, error) {
+func (m *MockPrecheckBackend) CloudCredential(arg0 names.CloudCredentialTag) (state.Credential, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudCredential", arg0)
 	ret0, _ := ret[0].(state.Credential)

--- a/apiserver/facades/controller/migrationmaster/mocks/state.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/state.go
@@ -5,15 +5,14 @@
 package mocks
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	crossmodel "github.com/juju/juju/core/crossmodel"
 	migration "github.com/juju/juju/core/migration"
 	permission "github.com/juju/juju/core/permission"
 	state "github.com/juju/juju/state"
-	names_v3 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
+	reflect "reflect"
+	time "time"
 )
 
 // MockModelMigration is a mock of ModelMigration interface
@@ -125,7 +124,7 @@ func (mr *MockModelMigrationMockRecorder) ModelUUID() *gomock.Call {
 }
 
 // ModelUserAccess mocks base method
-func (m *MockModelMigration) ModelUserAccess(arg0 names_v3.Tag) permission.Access {
+func (m *MockModelMigration) ModelUserAccess(arg0 names.Tag) permission.Access {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelUserAccess", arg0)
 	ret0, _ := ret[0].(permission.Access)
@@ -238,7 +237,7 @@ func (mr *MockModelMigrationMockRecorder) StatusMessage() *gomock.Call {
 }
 
 // SubmitMinionReport mocks base method
-func (m *MockModelMigration) SubmitMinionReport(arg0 names_v3.Tag, arg1 migration.Phase, arg2 bool) error {
+func (m *MockModelMigration) SubmitMinionReport(arg0 names.Tag, arg1 migration.Phase, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitMinionReport", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/apiserver/facades/controller/migrationmaster/package_test.go
+++ b/apiserver/facades/controller/migrationmaster/package_test.go
@@ -1,6 +1,10 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/backend.go github.com/juju/juju/apiserver/facades/controller/migrationmaster Backend,OfferConnection
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/precheckbackend.go github.com/juju/juju/migration PrecheckBackend
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/state.go github.com/juju/juju/state ModelMigration,NotifyWatcher,ExternalController
+
 package migrationmaster_test
 
 import (

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -24277,7 +24277,7 @@
     {
         "Name": "MigrationMaster",
         "Description": "API implements the API required for the model migration\nmaster worker.",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -24304,6 +24304,15 @@
                         }
                     },
                     "description": "MigrationStatus returns the details and progress of the latest\nmodel migration."
+                },
+                "MinionReportTimeout": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "MinionReportTimeout returns the configuration value for this controller that\nindicates how long the migration master worker should wait for minions to\nreported on phases of a migration."
                 },
                 "MinionReports": {
                     "type": "object",
@@ -24752,6 +24761,21 @@
                     "additionalProperties": false,
                     "required": [
                         "message"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
                     ]
                 }
             }


### PR DESCRIPTION
Adds a new version of the migration master API that includes a new method `MinionReportTimeoiut`.

This method returns the configured controller setting added under #12761.

## QA steps

Integration verification to follow with the next patch. Unit test verifies this addition.

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1918695
