### PR TITLE
Enable ha integration test

### DIFF
--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -1,9 +1,9 @@
 wait_for_controller_machines() {
-    ammount=${1}
+    amount=${1}
 
     attempt=0
     # shellcheck disable=SC2143
-    until [[ "$(juju machines -m controller --format=json | jq -r ".machines | .[] | .[\"juju-status\"] | select(.current == \"started\") | .current" | wc -l | grep "${ammount}")" ]]; do
+    until [[ "$(juju machines -m controller --format=json | jq -r ".machines | .[] | .[\"juju-status\"] | select(.current == \"started\") | .current" | wc -l | grep "${amount}")" ]]; do
         echo "[+] (attempt ${attempt}) polling machines"
         juju machines -m controller 2>&1 | sed 's/^/    | /g'
         sleep "${SHORT_TIMEOUT}"

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -1,0 +1,71 @@
+run_enable_ha() {
+    echo
+
+    file="${TEST_DIR}/enable_ha.log"
+
+    ensure "enable-ha" "${file}"
+
+    juju deploy "cs:~jameinel/ubuntu-lite-7"
+
+    juju enable-ha
+
+    attempt=0
+    until [[ "$(juju machines -m controller --format=json | jq -r ".machines | .[] | .[\"juju-status\"] | select(.current == \"started\") | .current" | wc -l | grep "3")" ]]; do
+        echo "[+] (attempt ${attempt}) polling machines"
+        juju machines -m controller 2>&1 | sed 's/^/    | /g'
+        sleep "${SHORT_TIMEOUT}"
+        attempt=$((attempt+1))
+        if [[ "${attempt}" -gt 50 ]]; then
+            echo "enable-ha failed waiting for machines to start"
+            exit 1
+        fi
+    done
+
+    if [ "${attempt}" -gt 0 ]; then
+        echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
+        juju machines -m controller 2>&1 | sed 's/^/    | /g'
+        # Although juju reports as an idle condition, some charms require a
+        # breathe period to ensure things have actually settled.
+        sleep "${SHORT_TIMEOUT}"
+    fi
+
+    juju remove-machine -m controller 1
+    juju remove-machine -m controller 2
+
+    attempt=0
+    until [[ "$(juju machines -m controller --format=json | jq -r ".machines | .[] | .[\"juju-status\"] | select(.current == \"started\") | .current" | wc -l | grep "1")" ]]; do
+        echo "[+] (attempt ${attempt}) polling machines"
+        juju machines -m controller 2>&1 | sed 's/^/    | /g'
+        sleep "${SHORT_TIMEOUT}"
+        attempt=$((attempt+1))
+        if [[ "${attempt}" -gt 50 ]]; then
+            echo "removing ha failed waiting for machines to be destroyed"
+            exit 1
+        fi
+    done
+
+    if [ "${attempt}" -gt 0 ]; then
+        echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
+        juju machines -m controller 2>&1 | sed 's/^/    | /g'
+        # Although juju reports as an idle condition, some charms require a
+        # breathe period to ensure things have actually settled.
+        sleep "${SHORT_TIMEOUT}"
+    fi
+
+    destroy_model "enable-ha"
+}
+
+test_enable_ha() {
+    if [ -n "$(skip 'test_enable_ha')" ]; then
+        echo "==> SKIP: Asked to skip controller enable-ha tests"
+        return
+    fi
+
+    (
+        set_verbosity
+
+        cd .. || exit
+
+        run "run_enable_ha"
+    )
+}

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -20,8 +20,34 @@ wait_for_controller_machines() {
     if [[ "${attempt}" -gt 0 ]]; then
         echo "[+] $(green 'Completed polling machines')"
         juju machines -m controller 2>&1 | sed 's/^/    | /g'
-        # Although juju reports as an idle condition, some charms require a
-        # breathe period to ensure things have actually settled.
+
+        sleep "${SHORT_TIMEOUT}"
+    fi
+}
+
+wait_for_ha() {
+    amount=${1}
+
+    attempt=0
+    # shellcheck disable=SC2143
+    until [[ "$(juju show-controller --format=json | jq -r ".[] | .[\"controller-machines\"] | .[] | select(.[\"ha-status\"] == \"ha-enabled\") | .[\"instance-id\"]" | wc -l | grep "${amount}")" ]]; do
+        echo "[+] (attempt ${attempt}) polling ha"
+        juju show-controller 2>&1 | sed 's/^/    | /g'
+        sleep "${SHORT_TIMEOUT}"
+        attempt=$((attempt+1))
+
+        # Wait for roughly 16 minutes for a enable-ha. In the field it's know
+        # that enable-ha can take this long.
+        if [[ "${attempt}" -gt 100 ]]; then
+            echo "enable-ha failed waiting for machines to start"
+            exit 1
+        fi
+    done
+
+    if [[ "${attempt}" -gt 0 ]]; then
+        echo "[+] $(green 'Completed polling ha')"
+        juju show-controller 2>&1 | sed 's/^/    | /g'
+
         sleep "${SHORT_TIMEOUT}"
     fi
 }
@@ -38,11 +64,15 @@ run_enable_ha() {
     juju enable-ha
 
     wait_for_controller_machines 3
+    wait_for_ha 3
 
     juju remove-machine -m controller 1
     juju remove-machine -m controller 2
 
     wait_for_controller_machines 1
+
+    # Ensure that we have no ha enabled machines.
+    juju show-controller --format=json | jq -r ".[] | .[\"controller-machines\"] |  reduce(.[] | select(.[\"instance-id\"] == null)) as \$i (0;.+=1)" | grep 0
 
     destroy_model "enable-ha"
 }

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -2,6 +2,7 @@ wait_for_controller_machines() {
     ammount=${1}
 
     attempt=0
+    # shellcheck disable=SC2143
     until [[ "$(juju machines -m controller --format=json | jq -r ".machines | .[] | .[\"juju-status\"] | select(.current == \"started\") | .current" | wc -l | grep "${ammount}")" ]]; do
         echo "[+] (attempt ${attempt}) polling machines"
         juju machines -m controller 2>&1 | sed 's/^/    | /g'
@@ -17,7 +18,7 @@ wait_for_controller_machines() {
     done
 
     if [[ "${attempt}" -gt 0 ]]; then
-        echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
+        echo "[+] $(green 'Completed polling machines')"
         juju machines -m controller 2>&1 | sed 's/^/    | /g'
         # Although juju reports as an idle condition, some charms require a
         # breathe period to ensure things have actually settled.

--- a/tests/suites/controller/task.sh
+++ b/tests/suites/controller/task.sh
@@ -14,6 +14,7 @@ test_controller() {
     bootstrap "test-controller" "${file}"
 
     test_mongo_memory_profile
+    test_enable_ha
 
     destroy_controller "test-controller"
 }

--- a/tests/suites/controller/task.sh
+++ b/tests/suites/controller/task.sh
@@ -13,8 +13,9 @@ test_controller() {
 
     bootstrap "test-controller" "${file}"
 
-    test_mongo_memory_profile
     test_enable_ha
+    # Leave this one last, as it can cause mongo to slowdown to a snails pace.
+    test_mongo_memory_profile
 
     destroy_controller "test-controller"
 }


### PR DESCRIPTION
The following adds a generic enable-ha integration test, along with
removing ha to ensure that we are correctly going back from ha as 
well.

The code is actually simple and not that hard to follow, just waiting
for the machines to appear is most of the code.

## QA steps

*Please replace with how we can verify that the change works.*

```sh
(cd tests && ./main.sh controller)
```
