### PR TITLE
Migration-master worker uses configured minion report timeout

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -279,6 +279,25 @@ func (c *Client) MinionReports() (migration.MinionReports, error) {
 	return out, nil
 }
 
+// MinionReportTimeout returns the maximum duration that the migration master
+// worker should wait for minions to report on a migration phase.
+func (c *Client) MinionReportTimeout() (time.Duration, error) {
+	var timeout time.Duration
+
+	var res params.StringResult
+	err := c.caller.FacadeCall("MinionReports", nil, &res)
+	if err != nil {
+		return timeout, errors.Trace(err)
+	}
+
+	if res.Error != nil {
+		return timeout, res.Error
+	}
+
+	timeout, err = time.ParseDuration(res.Result)
+	return timeout, errors.Trace(err)
+}
+
 // StreamModelLog takes a starting time and returns a channel that
 // will yield the logs on or after that time - these are the logs that
 // need to be transferred to the target after the migration is

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -552,6 +552,20 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `processing failed agents: "dave" is not a valid tag`)
 }
 
+func (s *ClientSuite) TestMinionReportTimeout(c *gc.C) {
+	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
+		out := result.(*params.StringResult)
+		*out = params.StringResult{
+			Result: "30s",
+		}
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller, nil)
+	timeout, err := client.MinionReportTimeout()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(timeout, gc.Equals, 30*time.Second)
+}
+
 func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
 	caller := fakeConnector{path: new(string), attrs: &url.Values{}}
 	client := migrationmaster.NewClient(caller, nil)

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -216,6 +216,9 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		// Wait for migration to start.
 		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
+		},
 
 		// QUIESCE
 		prechecksCalls,
@@ -288,6 +291,7 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
@@ -403,6 +407,9 @@ func (s *Suite) TestQUIESCEFailedAgent(c *gc.C) {
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
+		},
 		prechecksCalls,
 		[]jujutesting.StubCall{
 			{"facade.WatchMinionReports", nil},
@@ -420,6 +427,7 @@ func (s *Suite) TestQUIESCEWrongController(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.Prechecks", nil},
 			{"facade.ModelInfo", nil},
 			apiOpenControllerCall,
@@ -436,7 +444,10 @@ func (s *Suite) TestQUIESCESourceChecksFail(c *gc.C) {
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
-		[]jujutesting.StubCall{{"facade.Prechecks", nil}},
+		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
+			{"facade.Prechecks", nil},
+		},
 		abortCalls,
 	))
 }
@@ -449,6 +460,7 @@ func (s *Suite) TestQUIESCEModelInfoFail(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.Prechecks", nil},
 			{"facade.ModelInfo", nil},
 		},
@@ -463,6 +475,9 @@ func (s *Suite) TestQUIESCETargetChecksFail(c *gc.C) {
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
+		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
+		},
 		prechecksCalls,
 		abortCalls,
 	))
@@ -476,6 +491,7 @@ func (s *Suite) TestProcessRelationsFailure(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.ProcessRelations", []interface{}{""}},
 		},
 		abortCalls,
@@ -490,6 +506,7 @@ func (s *Suite) TestExportFailure(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.Export", nil},
 		},
 		abortCalls,
@@ -504,6 +521,7 @@ func (s *Suite) TestAPIOpenFailure(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.Export", nil},
 			apiOpenControllerCall,
 			{"facade.SetPhase", []interface{}{coremigration.ABORT}},
@@ -521,6 +539,7 @@ func (s *Suite) TestImportFailure(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.Export", nil},
 			apiOpenControllerCall,
 			importCall,
@@ -562,6 +581,7 @@ func (s *Suite) TestVALIDATIONFailedAgent(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 		},
@@ -578,6 +598,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
@@ -601,6 +622,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
@@ -625,6 +647,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesOtherError(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
@@ -656,6 +679,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
@@ -687,6 +711,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			{"facade.MinionReports", nil},
 			apiOpenControllerCall,
@@ -729,6 +754,7 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{"facade.WatchMinionReports", nil},
 			apiOpenControllerCall,
 			adoptResourcesCall,
@@ -790,6 +816,7 @@ func (s *Suite) TestAPIConnectWithMacaroon(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			{
 				"apiOpen",
 				[]interface{}{
@@ -817,6 +844,7 @@ func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 		},
 	))
@@ -830,6 +858,7 @@ func (s *Suite) TestLogTransferErrorGettingStartTime(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 		},
@@ -844,6 +873,7 @@ func (s *Suite) TestLogTransferErrorOpeningLogSource(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
@@ -859,6 +889,7 @@ func (s *Suite) TestLogTransferErrorOpeningLogDest(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
@@ -877,6 +908,7 @@ func (s *Suite) TestLogTransferErrorWriting(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
@@ -912,6 +944,7 @@ func (s *Suite) TestLogTransferSendsRecords(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
@@ -978,6 +1011,7 @@ func (s *Suite) TestLogTransfer_ChecksLatestTime(c *gc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]jujutesting.StubCall{
+			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{t}},
@@ -1078,6 +1112,7 @@ func newStubMasterFacade(stub *jujutesting.Stub) *stubMasterFacade {
 		// Give minionReportsChanges a larger-than-required buffer to
 		// support waits at a number of phases.
 		minionReportsChanges: make(chan struct{}, 999),
+		minionReportTimeout:  15 * time.Minute,
 	}
 }
 
@@ -1103,6 +1138,7 @@ type stubMasterFacade struct {
 	minionReportsWatchErr error
 	minionReports         []coremigration.MinionReports
 	minionReportsErr      error
+	minionReportTimeout   time.Duration
 
 	exportedResources []coremigration.SerializedModelResource
 
@@ -1176,6 +1212,11 @@ func (f *stubMasterFacade) MinionReports() (coremigration.MinionReports, error) 
 	r := f.minionReports[0]
 	f.minionReports = f.minionReports[1:]
 	return r, nil
+}
+
+func (f *stubMasterFacade) MinionReportTimeout() (time.Duration, error) {
+	f.stub.AddCall("facade.MinionReportTimeout")
+	return f.minionReportTimeout, nil
 }
 
 func (f *stubMasterFacade) Prechecks() error {


### PR DESCRIPTION
Adds `MinionReportTimeout` to the migration-master API client.

The worker calls this method before settling into the state-machine loop, to get the time-out that will be used when waiting for minion reports at various stages of the migration.

## QA steps

- Bootstrap 2 controllers, _src_ and _dst_.
- Delete the default model from _dst_.
- Deploy postgresql into the _src_ default model.
- Execute `juju controller-config migration-agent-wait-time="1ms"` against _src_.
- `Juju migrate default dst` should hit the time-out and return an error (see `juju status`).
-  Lengthen the time-out: `juju controller-config migration-agent-wait-time="15m"`.
- Migration should now succeed.

## Documentation changes

The new configuration item needs recording.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1918695
