### PR TITLE
Upgrade series graph/FSM

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -757,9 +757,9 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	mach := s.st.machines["0"]
-	c.Assert(len(mach.Calls()), gc.Equals, 3)
-	mach.CheckCallNames(c, "Principals", "VerifyUnitsSeries", "CreateUpgradeSeriesLock")
-	mach.CheckCall(c, 2, "CreateUpgradeSeriesLock", []string{"foo/0", "test/0"}, "xenial")
+	c.Assert(len(mach.Calls()), gc.Equals, 2)
+	mach.CheckCallNames(c, "Units", "CreateUpgradeSeriesLock")
+	mach.CheckCall(c, 1, "CreateUpgradeSeriesLock", []string{"foo/0", "foo/1", "foo/2"}, "xenial")
 }
 
 func (s *MachineManagerSuite) TestUpgradeSeriesPrepareMachineNotFound(c *gc.C) {

--- a/apiserver/facades/client/machinemanager/upgrade_series.go
+++ b/apiserver/facades/client/machinemanager/upgrade_series.go
@@ -184,7 +184,7 @@ func (a *UpgradeSeriesAPI) Validate(entities []ValidationEntity) ([]ValidationRe
 
 func (a *UpgradeSeriesAPI) Prepare(tag, series string, force bool) error {
 	if series == "" {
-		return errors.BadRequestf("series")
+		return errors.BadRequestf("series missing from args")
 	}
 
 	machine, err := a.state.MachineFromTag(tag)

--- a/apiserver/facades/client/machinemanager/upgrade_series.go
+++ b/apiserver/facades/client/machinemanager/upgrade_series.go
@@ -26,6 +26,11 @@ type UpgradeSeries interface {
 	// If they do, a list of the machine's current units is returned for use in
 	// soliciting user confirmation of the command.
 	Validate([]ValidationEntity) ([]ValidationResult, error)
+
+	// Prepare attempts to prepare a machine for a OS series upgrade.
+	// It is expected that a validate call has been performed before the prepare
+	// step.
+	Prepare(string, string, bool) error
 }
 
 // UpgradeSeriesState defines a common set of functions for retrieving state
@@ -175,6 +180,31 @@ func (a *UpgradeSeriesAPI) Validate(entities []ValidationEntity) ([]ValidationRe
 	}
 
 	return results, nil
+}
+
+func (a *UpgradeSeriesAPI) Prepare(tag, series string, force bool) error {
+	if series == "" {
+		return errors.BadRequestf("series")
+	}
+
+	machine, err := a.state.MachineFromTag(tag)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	units, err := machine.Units()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	unitNames := make([]string, len(units))
+	for i, unit := range units {
+		unitNames[i] = unit.UnitTag().Id()
+	}
+
+	// TODO 2018-06-28 managed series upgrade
+	// improve error handling based on error type, there will be cases where retrying
+	// the hooks is needed etc.
+	return machine.CreateUpgradeSeriesLock(unitNames, series)
 }
 
 func verifyUnits(units []Unit) ([]string, error) {

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -435,18 +435,18 @@ func (m *Machine) SetUpgradeSeriesUnitStatus(unitName string, status model.Upgra
 func (m *Machine) verifyUnitUpgradeSeriesStatus(unitName string, status model.UpgradeSeriesStatus) (bool, error) {
 	lock, err := m.getUpgradeSeriesLock()
 	if err != nil {
-		return false, err
+		return false, errors.Trace(err)
 	}
 	us, ok := lock.UnitStatuses[unitName]
 	if !ok {
 		return false, errors.NotFoundf(unitName)
 	}
 
-	comp, err := model.CompareUpgradeSeriesStatus(us.Status, status)
+	fsm, err := model.NewUpgradeSeriesFSM(model.UpgradeSeriesGraph(), us.Status)
 	if err != nil {
-		return false, err
+		return false, errors.Trace(err)
 	}
-	return comp == -1, nil
+	return fsm.TransitionTo(status), nil
 }
 
 // [TODO](externalreality): move some/all of these parameters into an argument structure.

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -721,13 +721,17 @@ func (w *RemoteStateWatcher) upgradeSeriesStatusChanged() error {
 }
 
 func (w *RemoteStateWatcher) upgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	rawStatus, err := w.unit.UpgradeSeriesStatus()
+	status, err := w.unit.UpgradeSeriesStatus()
 	if err != nil {
-		return "", err
+		return "", errors.Trace(err)
 	}
-	status, err := model.ValidateUpgradeSeriesStatus(rawStatus)
-	if err != nil {
-		return "", err
+
+	graph := model.UpgradeSeriesGraph()
+	if err := graph.Validate(); err != nil {
+		return "", errors.Trace(err)
+	}
+	if !graph.ValidState(status) {
+		return "", errors.NotValidf("upgrade series %q is", status)
 	}
 	return status, nil
 }


### PR DESCRIPTION
<strike>Requires #12763 to land, will rebase after landing.</strike>

The previous logic for upgrade series was really bad, essentially it
allowed you to jump up the order to reach the error state without
actually ensuring that you could access all the states.

The following code changes that and introduces an FSM. The FSM ensures
that you can go to only the states that are supplied in the child
states.

The FSM is modeled as a DAG with each state show how it can move along
the edges to each vertex. This tightens up a lot of the logic around a
upgrade series and ensures that you have to move to each state
correctly.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --series=bionic
$ juju upgrade-series 0 prepare focal
$ juju upgrade-series 0 complete
```
