### PR TITLE
[2.8] Add link-local field to netplan.Interface

### DIFF
--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -44,6 +44,10 @@ type Interface struct {
 	RoutingPolicy  []RoutePolicy `yaml:"routing-policy,omitempty"`
 	// Optional doesn't have to be *bool because it is only used if True
 	Optional bool `yaml:"optional,omitempty"`
+
+	// Configure the link-local addresses to bring up. Valid options are
+	// "ipv4" and "ipv6".
+	LinkLocal []string `yaml:"link-local,omitempty"`
 }
 
 // Ethernet defines fields for just Ethernet devices

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -106,6 +106,21 @@ network:
 `)
 }
 
+func (s *NetplanSuite) TestParseEthernetDeviceWithLinkLocalField(c *gc.C) {
+	MustNetplanFromYaml(c, `
+network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    eth0:
+      match:
+        macaddress: "00:11:22:33:44:55"
+      link-local: [ipv4, ipv6]
+      wakeonlan: true
+      set-name: main-if
+`)
+}
+
 func (s *NetplanSuite) TestBasicBond(c *gc.C) {
 	checkNetplanRoundTrips(c, `
 network:


### PR DESCRIPTION
When juju parses an existing netplan configuration, it uses string YAML unmarshaling (i.e. unmarshaling fails if we encounter a field that is not present in the struct we unmarshal to) to ensure that we don't accidentally drop an entry when we write the netplan configuration back.

This PR adds `link-local` to the list of supported fields (see https://netplan.io/reference/) to allow the bridge operations to work as expected in the scenario described in the following bug report.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1919144