### PR TITLE
Pull resources for app from store

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -672,7 +672,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			opener, err := resourceadapters.NewResourceOpener(st.State, tag.Id())
+			opener, err := resourceadapters.NewResourceOpener(resourceadapters.NewResourceOpenerState(st.State), tag.Id())
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -568,3 +568,19 @@ func (v *mockVolume) SetStatus(statusInfo status.StatusInfo) error {
 func (v *mockVolume) Info() (state.VolumeInfo, error) {
 	return state.VolumeInfo{}, errors.NotProvisionedf("volume")
 }
+
+type mockResourceOpener struct {
+	testing.Stub
+
+	appName   string
+	resources *mockResources
+}
+
+func (ro *mockResourceOpener) OpenResource(name string) (resource.Opened, error) {
+	ro.MethodCall(ro, "OpenResource", name)
+	r, rio, err := ro.resources.OpenResource(ro.appName, name)
+	if err != nil {
+		return resource.Opened{}, err
+	}
+	return resource.Opened{Resource: r, ReadCloser: rio}, nil
+}

--- a/resource/resourceadapters/export_test.go
+++ b/resource/resourceadapters/export_test.go
@@ -34,6 +34,7 @@ func NewResourceOpenerForTest(
 	res Resources,
 	tag names.Tag,
 	unit Unit,
+	application Application,
 	fn func(st ResourceOpenerState) ResourceRetryClientGetter,
 ) *ResourceOpener {
 	return &ResourceOpener{
@@ -41,6 +42,7 @@ func NewResourceOpenerForTest(
 		res:               res,
 		userID:            tag,
 		unit:              unit,
+		application:       application,
 		newResourceOpener: fn,
 	}
 }

--- a/resource/resourceadapters/interfaces.go
+++ b/resource/resourceadapters/interfaces.go
@@ -35,6 +35,7 @@ type ResourceOpenerState interface {
 	// required for NewResourceOpener and OpenResource
 	Resources() (Resources, error)
 	Unit(string) (Unit, error)
+	Application(string) (Application, error)
 }
 
 // Model represents model methods required to open a resource.
@@ -53,12 +54,17 @@ type Unit interface {
 // Application represents application methods required to open a resource.
 type Application interface {
 	CharmOrigin() *corestate.CharmOrigin
+	CharmURL() (*charm.URL, bool)
+	Name() string
+	Tag() names.Tag
 }
 
 // Resources represents the methods used by resourceCache from state.Resources .
 type Resources interface {
 	// GetResource returns the identified resource.
 	GetResource(applicationID, name string) (resource.Resource, error)
+	// OpenResource returns the metadata for a resource and a reader for the resource.
+	OpenResource(applicationID, name string) (resource.Resource, io.ReadCloser, error)
 	// OpenResourceForUniter returns the metadata for a resource and a reader for the resource.
 	OpenResourceForUniter(unit resource.Unit, name string) (resource.Resource, io.ReadCloser, error)
 	// SetResource adds the resource to blob storage and updates the metadata.

--- a/resource/resourceadapters/mocks/opener_mock.go
+++ b/resource/resourceadapters/mocks/opener_mock.go
@@ -40,6 +40,21 @@ func (m *MockResourceOpenerState) EXPECT() *MockResourceOpenerStateMockRecorder 
 	return m.recorder
 }
 
+// Application mocks base method
+func (m *MockResourceOpenerState) Application(arg0 string) (resourceadapters.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Application", arg0)
+	ret0, _ := ret[0].(resourceadapters.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Application indicates an expected call of Application
+func (mr *MockResourceOpenerStateMockRecorder) Application(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockResourceOpenerState)(nil).Application), arg0)
+}
+
 // Charm mocks base method
 func (m *MockResourceOpenerState) Charm(arg0 *charm.URL) (*state.Charm, error) {
 	m.ctrl.T.Helper()
@@ -150,6 +165,49 @@ func (m *MockApplication) CharmOrigin() *state.CharmOrigin {
 func (mr *MockApplicationMockRecorder) CharmOrigin() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmOrigin", reflect.TypeOf((*MockApplication)(nil).CharmOrigin))
+}
+
+// CharmURL mocks base method
+func (m *MockApplication) CharmURL() (*charm.URL, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CharmURL")
+	ret0, _ := ret[0].(*charm.URL)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// CharmURL indicates an expected call of CharmURL
+func (mr *MockApplicationMockRecorder) CharmURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL))
+}
+
+// Name mocks base method
+func (m *MockApplication) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockApplicationMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockApplication)(nil).Name))
+}
+
+// Tag mocks base method
+func (m *MockApplication) Tag() names.Tag {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Tag")
+	ret0, _ := ret[0].(names.Tag)
+	return ret0
+}
+
+// Tag indicates an expected call of Tag
+func (mr *MockApplicationMockRecorder) Tag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockApplication)(nil).Tag))
 }
 
 // MockUnit is a mock of Unit interface
@@ -283,6 +341,22 @@ func (m *MockResources) GetResource(arg0, arg1 string) (resource0.Resource, erro
 func (mr *MockResourcesMockRecorder) GetResource(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResource", reflect.TypeOf((*MockResources)(nil).GetResource), arg0, arg1)
+}
+
+// OpenResource mocks base method
+func (m *MockResources) OpenResource(arg0, arg1 string) (resource0.Resource, io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenResource", arg0, arg1)
+	ret0, _ := ret[0].(resource0.Resource)
+	ret1, _ := ret[1].(io.ReadCloser)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// OpenResource indicates an expected call of OpenResource
+func (mr *MockResourcesMockRecorder) OpenResource(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenResource", reflect.TypeOf((*MockResources)(nil).OpenResource), arg0, arg1)
 }
 
 // OpenResourceForUniter mocks base method

--- a/resource/resourceadapters/opener.go
+++ b/resource/resourceadapters/opener.go
@@ -21,14 +21,41 @@ import (
 //
 // The caller owns the State provided. It is the caller's
 // responsibility to close it.
-func NewResourceOpener(st *corestate.State, unitName string) (opener resource.Opener, err error) {
-	return newInternalResourceOpener(&stateShim{st}, unitName)
+func NewResourceOpener(st ResourceOpenerState, unitName string) (opener resource.Opener, err error) {
+	return newInternalResourceOpener(st, unitName, "")
 }
 
-func newInternalResourceOpener(st ResourceOpenerState, unitName string) (opener resource.Opener, err error) {
-	unit, err := st.Unit(unitName)
+// NewResourceOpenerForApplication returns a new resource.Opener for the given app.
+//
+// The caller owns the State provided. It is the caller's
+// responsibility to close it.
+func NewResourceOpenerForApplication(st ResourceOpenerState, applicationName string) (opener resource.Opener, err error) {
+	return newInternalResourceOpener(st, "", applicationName)
+}
+
+// NewResourceOpenerState wraps a State pointer for passing into NewResourceOpener/NewResourceOpenerForApplication.
+func NewResourceOpenerState(st *corestate.State) ResourceOpenerState {
+	return &stateShim{st}
+}
+
+func newInternalResourceOpener(st ResourceOpenerState, unitName string, applicationName string) (opener resource.Opener, err error) {
+	unit := Unit(nil)
+	if unitName != "" {
+		unit, err = st.Unit(unitName)
+		if err != nil {
+			return nil, errors.Annotate(err, "loading unit")
+		}
+	}
+
+	if applicationName == "" {
+		if unit == nil {
+			return nil, errors.Errorf("missing both unit and application")
+		}
+		applicationName = unit.ApplicationName()
+	}
+	application, err := st.Application(applicationName)
 	if err != nil {
-		return nil, errors.Annotate(err, "loading unit")
+		return nil, errors.Trace(err)
 	}
 
 	resources, err := st.Resources()
@@ -38,13 +65,18 @@ func newInternalResourceOpener(st ResourceOpenerState, unitName string) (opener 
 
 	var resourceClient ResourceRetryClientGetterFn
 
-	curl, _ := unit.CharmURL()
+	charmURL := (*charm.URL)(nil)
+	if unit != nil {
+		charmURL, _ = unit.CharmURL()
+	} else {
+		charmURL, _ = application.CharmURL()
+	}
 	switch {
-	case charm.CharmHub.Matches(curl.Schema):
+	case charm.CharmHub.Matches(charmURL.Schema):
 		resourceClient = func(st ResourceOpenerState) ResourceRetryClientGetter {
 			return newCharmHubOpener(st)
 		}
-	case charm.CharmStore.Matches(curl.Schema):
+	case charm.CharmStore.Matches(charmURL.Schema):
 		resourceClient = func(st ResourceOpenerState) ResourceRetryClientGetter {
 			return newCharmStoreOpener(st)
 		}
@@ -56,37 +88,51 @@ func newInternalResourceOpener(st ResourceOpenerState, unitName string) (opener 
 			return newNopOpener()
 		}
 	}
+
+	userID := names.Tag(nil)
+	if unit != nil {
+		userID = unit.Tag()
+	} else {
+		userID = application.Tag()
+	}
+
 	return &ResourceOpener{
 		st:                st,
 		res:               resources,
-		userID:            unit.Tag(),
+		userID:            userID,
 		unit:              unit,
+		application:       application,
 		newResourceOpener: resourceClient,
 	}, nil
 }
 
 // ResourceOpener is a ResourceOpener for the charm store.
 type ResourceOpener struct {
-	st                ResourceOpenerState
-	res               Resources
-	userID            names.Tag
-	unit              Unit
+	st          ResourceOpenerState
+	res         Resources
+	userID      names.Tag
+	unit        Unit
+	application Application
+
 	newResourceOpener func(st ResourceOpenerState) ResourceRetryClientGetter
 }
 
 // OpenResource implements server.ResourceOpener.
 func (ro *ResourceOpener) OpenResource(name string) (o resource.Opened, err error) {
-	if ro.unit == nil {
-		return resource.Opened{}, errors.Errorf("missing unit")
+	if ro.application == nil {
+		return resource.Opened{}, errors.Errorf("missing application")
 	}
-	app, err := ro.unit.Application()
-	if err != nil {
-		return resource.Opened{}, errors.Trace(err)
+
+	charmURL := (*charm.URL)(nil)
+	if ro.unit != nil {
+		charmURL, _ = ro.unit.CharmURL()
+	} else {
+		charmURL, _ = ro.application.CharmURL()
 	}
-	cURL, _ := ro.unit.CharmURL()
+
 	id := repositories.CharmID{
-		URL:    cURL,
-		Origin: *app.CharmOrigin(),
+		URL:    charmURL,
+		Origin: *ro.application.CharmOrigin(),
 	}
 
 	client, err := ro.newResourceOpener(ro.st).NewClient()
@@ -95,10 +141,10 @@ func (ro *ResourceOpener) OpenResource(name string) (o resource.Opened, err erro
 	}
 
 	st := &resourceState{
-		st:      ro.res,
-		userID:  ro.userID,
-		unit:    ro.unit,
-		appName: ro.unit.ApplicationName(),
+		st:          ro.res,
+		userID:      ro.userID,
+		unit:        ro.unit,
+		application: ro.application,
 	}
 
 	res, reader, err := repositories.GetResource(repositories.GetResourceArgs{
@@ -120,26 +166,26 @@ func (ro *ResourceOpener) OpenResource(name string) (o resource.Opened, err erro
 
 // resourceState adapts between resource state and charmstore.EntityCache.
 type resourceState struct {
-	st      Resources
-	userID  names.Tag
-	unit    resource.Unit
-	appName string
+	st          Resources
+	userID      names.Tag
+	unit        resource.Unit
+	application Application
 }
 
 // GetResource implements charmstore.EntityCache.
 func (s *resourceState) GetResource(name string) (resource.Resource, error) {
-	return s.st.GetResource(s.appName, name)
+	return s.st.GetResource(s.application.Name(), name)
 }
 
 // SetResource implements charmstore.EntityCache.
 func (s *resourceState) SetResource(chRes charmresource.Resource, reader io.Reader) (resource.Resource, error) {
-	return s.st.SetResource(s.appName, s.userID.Id(), chRes, reader)
+	return s.st.SetResource(s.application.Name(), s.userID.Id(), chRes, reader)
 }
 
 // OpenResource implements charmstore.EntityCache.
 func (s *resourceState) OpenResource(name string) (resource.Resource, io.ReadCloser, error) {
 	if s.unit == nil {
-		return resource.Resource{}, nil, errors.NotImplementedf("")
+		return s.st.OpenResource(s.application.Name(), name)
 	}
 	return s.st.OpenResourceForUniter(s.unit, name)
 }
@@ -190,6 +236,10 @@ func (s *stateShim) Unit(name string) (Unit, error) {
 
 func (s *stateShim) Resources() (Resources, error) {
 	return s.State.Resources()
+}
+
+func (s *stateShim) Application(applicationName string) (Application, error) {
+	return s.State.Application(applicationName)
 }
 
 type unitShim struct {

--- a/resource/resourceadapters/opener_test.go
+++ b/resource/resourceadapters/opener_test.go
@@ -33,7 +33,7 @@ type OpenerSuite struct {
 var _ = gc.Suite(&OpenerSuite{})
 
 func (s *OpenerSuite) TestOpenResource(c *gc.C) {
-	defer s.setupMocks(c).Finish()
+	defer s.setupMocks(c, true).Finish()
 	fp, _ := charmresource.ParseFingerprint("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b")
 	res := resource.Resource{
 		Resource: charmresource.Resource{
@@ -59,18 +59,54 @@ func (s *OpenerSuite) TestOpenResource(c *gc.C) {
 	c.Assert(opened.Resource, gc.DeepEquals, res)
 }
 
-func (s *OpenerSuite) setupMocks(c *gc.C) *gomock.Controller {
+func (s *OpenerSuite) TestOpenResourceApplication(c *gc.C) {
+	defer s.setupMocks(c, false).Finish()
+	fp, _ := charmresource.ParseFingerprint("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b")
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "wal-e",
+				Type: 1,
+			},
+			Origin:      2,
+			Revision:    0,
+			Fingerprint: fp,
+			Size:        0,
+		},
+		ApplicationID: "postgreql",
+	}
+	s.expectCacheMethods(res)
+	s.resourceGetter.EXPECT().GetResource(gomock.Any()).Return(charmstore.ResourceData{
+		ReadCloser: nil,
+		Resource:   res.Resource,
+	}, nil)
+
+	opened, err := s.newOpener().OpenResource("wal-e")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(opened.Resource, gc.DeepEquals, res)
+}
+
+func (s *OpenerSuite) setupMocks(c *gc.C, includeUnit bool) *gomock.Controller {
 	ctrl := gomock.NewController(c)
-	s.unit = mocks.NewMockUnit(ctrl)
+	if includeUnit {
+		s.unit = mocks.NewMockUnit(ctrl)
+	} else {
+		s.unit = nil
+	}
 	s.app = mocks.NewMockApplication(ctrl)
 	s.resourceGetter = mocks.NewMockResourceGetter(ctrl)
 	s.resources = mocks.NewMockResources(ctrl)
 	s.resourceOpenerState = mocks.NewMockResourceOpenerState(ctrl)
 
-	s.unit.EXPECT().ApplicationName().Return("postgresql")
-	s.unit.EXPECT().Application().Return(s.app, nil)
 	curl, _ := charm.ParseURL("postgresql")
-	s.unit.EXPECT().CharmURL().Return(curl, false)
+	if s.unit != nil {
+		s.unit.EXPECT().ApplicationName().Return("postgresql").AnyTimes()
+		s.unit.EXPECT().Application().Return(s.app, nil).AnyTimes()
+		s.unit.EXPECT().CharmURL().Return(curl, false).AnyTimes()
+	} else {
+		s.app.EXPECT().CharmURL().Return(curl, false).AnyTimes()
+	}
+	s.app.EXPECT().Name().Return("postgresql").AnyTimes()
 	s.expectCharmOrigin()
 
 	return ctrl
@@ -92,22 +128,36 @@ func (s *OpenerSuite) expectCharmOrigin() {
 }
 
 func (s *OpenerSuite) expectCacheMethods(res resource.Resource) {
-	s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(resource.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
+	if s.unit != nil {
+		s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(resource.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
+	} else {
+		s.resources.EXPECT().OpenResource(gomock.Any(), gomock.Any()).Return(resource.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
+	}
 	s.resources.EXPECT().GetResource("postgresql", "wal-e").Return(res, nil)
 	s.resources.EXPECT().SetResource("postgresql", "", res.Resource, gomock.Any()).Return(res, nil)
 
 	other := res
 	other.ApplicationID = "postgreql"
-	s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+	if s.unit != nil {
+		s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+	} else {
+		s.resources.EXPECT().OpenResource(gomock.Any(), gomock.Any()).Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+	}
 }
 
 func (s *OpenerSuite) newOpener() *resourceadapters.ResourceOpener {
 	tag, _ := names.ParseUnitTag("postgresql/0")
+	// preserve nil
+	unit := resourceadapters.Unit(nil)
+	if s.unit != nil {
+		unit = s.unit
+	}
 	return resourceadapters.NewResourceOpenerForTest(
 		s.resourceOpenerState,
 		s.resources,
 		tag,
-		s.unit,
+		unit,
+		s.app,
 		func(st resourceadapters.ResourceOpenerState) resourceadapters.ResourceRetryClientGetter {
 			return &testNewClient{
 				resourceGetter: s.resourceGetter,


### PR DESCRIPTION
Uses the resource opener from resource/resourceadapters to pull the resource if not available.

## QA steps

You'll need to apply the patch from the [first comment](https://github.com/juju/juju/pull/12773#issuecomment-800783793)

Then you can `juju deploy snappass-test --series=focal --channel=edge`

## Documentation changes

N/A

## Bug reference

N/A