### PR TITLE
Feature/upgrade crd to v1

### DIFF
--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -42,7 +42,7 @@ func (k *kubernetesClient) getAPIExtensionLabelsNamespaced(appName string) map[s
 	return utils.LabelsForApp(appName, k.IsLegacyLabels())
 }
 
-func (k *kubernetesClient) getCRLabels(appName string, scope apiextensionsv1beta1.ResourceScope) map[string]string {
+func (k *kubernetesClient) getCRLabels(appName string, scope apiextensionsv1.ResourceScope) map[string]string {
 	if isCRDScopeNamespaced(scope) {
 		return k.getAPIExtensionLabelsNamespaced(appName)
 	}
@@ -139,8 +139,8 @@ func (k *kubernetesClient) ensureCustomResourceDefinitionV1(
 	return out, cleanUps, errors.Trace(err)
 }
 
-func (k *kubernetesClient) getCustomResourceDefinition(name string) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	crd, err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
+func (k *kubernetesClient) getCustomResourceDefinition(name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	crd, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("custom resource definition %q", name)
 	}
@@ -182,7 +182,7 @@ func (k *kubernetesClient) deleteCustomResourceDefinitions(selector k8slabels.Se
 }
 
 func (k *kubernetesClient) deleteCustomResourcesForApp(appName string) error {
-	selectorGetter := func(crd apiextensionsv1beta1.CustomResourceDefinition) k8slabels.Selector {
+	selectorGetter := func(crd apiextensionsv1.CustomResourceDefinition) k8slabels.Selector {
 		return mergeSelectors(
 			utils.LabelsToSelector(k.getCRLabels(appName, crd.Spec.Scope)),
 			lifecycleApplicationRemovalSelector,
@@ -191,8 +191,8 @@ func (k *kubernetesClient) deleteCustomResourcesForApp(appName string) error {
 	return k.deleteCustomResources(selectorGetter)
 }
 
-func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensionsv1beta1.CustomResourceDefinition) k8slabels.Selector) error {
-	crds, err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
+func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensionsv1.CustomResourceDefinition) k8slabels.Selector) error {
+	crds, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
 		// CRDs might be provisioned by another application/charm from a different model.
 	})
 	if err != nil {
@@ -221,8 +221,8 @@ func (k *kubernetesClient) deleteCustomResources(selectorGetter func(apiextensio
 	return nil
 }
 
-func (k *kubernetesClient) listCustomResources(selectorGetter func(apiextensionsv1beta1.CustomResourceDefinition) k8slabels.Selector) (out []unstructured.Unstructured, err error) {
-	crds, err := k.extendedClient().ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
+func (k *kubernetesClient) listCustomResources(selectorGetter func(apiextensionsv1.CustomResourceDefinition) k8slabels.Selector) (out []unstructured.Unstructured, err error) {
+	crds, err := k.extendedClient().ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
 		// CRDs might be provisioned by another application/charm from a different model.
 	})
 	if err != nil {
@@ -336,25 +336,22 @@ func deleteCustomResourceDefinition(api dynamic.ResourceInterface, name string, 
 }
 
 type CRDGetterInterface interface {
-	Get(string) (*apiextensionsv1beta1.CustomResourceDefinition, error)
+	Get(string) (*apiextensionsv1.CustomResourceDefinition, error)
 }
 
 type crdGetter struct {
 	Broker *kubernetesClient
 }
 
-func (cg *crdGetter) Get(name string) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+func (cg *crdGetter) Get(name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	crd, err := cg.Broker.getCustomResourceDefinition(name)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting custom resource definition %q", name)
 	}
-	version := crd.Spec.Version
-	if version == "" {
-		if len(crd.Spec.Versions) == 0 {
-			return nil, errors.NotValidf("custom resource definition %q without version", crd.GetName())
-		}
-		version = crd.Spec.Versions[0].Name
+	if len(crd.Spec.Versions) == 0 {
+		return nil, errors.NotValidf("custom resource definition %q without version", crd.GetName())
 	}
+	version := crd.Spec.Versions[0].Name
 	crClient, err := cg.Broker.getCustomResourceDefinitionClient(crd, version)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting custom resource definition client %q", name)
@@ -372,20 +369,20 @@ func (cg *crdGetter) Get(name string) (*apiextensionsv1beta1.CustomResourceDefin
 func (k *kubernetesClient) getCRDsForCRs(
 	crs map[string][]unstructured.Unstructured,
 	getter CRDGetterInterface,
-) (out map[string]*apiextensionsv1beta1.CustomResourceDefinition, err error) {
+) (out map[string]*apiextensionsv1.CustomResourceDefinition, err error) {
 	n := len(crs)
 	if n == 0 {
 		return
 	}
 
-	out = make(map[string]*apiextensionsv1beta1.CustomResourceDefinition)
-	crdChan := make(chan *apiextensionsv1beta1.CustomResourceDefinition, n)
+	out = make(map[string]*apiextensionsv1.CustomResourceDefinition)
+	crdChan := make(chan *apiextensionsv1.CustomResourceDefinition, n)
 
 	getCRD := func(
 		ctx context.Context,
 		name string,
 		getter CRDGetterInterface,
-		resultChan chan<- *apiextensionsv1beta1.CustomResourceDefinition,
+		resultChan chan<- *apiextensionsv1.CustomResourceDefinition,
 		clk jujuclock.Clock,
 	) error {
 		return retry.Call(retry.CallArgs{
@@ -438,19 +435,16 @@ func (k *kubernetesClient) getCRDsForCRs(
 	return out, nil
 }
 
-func isCRDScopeNamespaced(scope apiextensionsv1beta1.ResourceScope) bool {
-	return scope == apiextensionsv1beta1.NamespaceScoped
+func isCRDScopeNamespaced(scope apiextensionsv1.ResourceScope) bool {
+	return scope == apiextensionsv1.NamespaceScoped
 }
 
-func (k *kubernetesClient) getCustomResourceDefinitionClient(crd *apiextensionsv1beta1.CustomResourceDefinition, version string) (dynamic.ResourceInterface, error) {
+func (k *kubernetesClient) getCustomResourceDefinitionClient(crd *apiextensionsv1.CustomResourceDefinition, version string) (dynamic.ResourceInterface, error) {
 	if version == "" {
 		return nil, errors.NotValidf("empty version for custom resource definition %q", crd.GetName())
 	}
 
 	checkVersion := func() error {
-		if crd.Spec.Version == version {
-			return nil
-		}
 		for _, v := range crd.Spec.Versions {
 			if !v.Served {
 				continue

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
+	"golang.org/x/sync/errgroup"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -343,9 +343,7 @@ type crdGetter struct {
 	Broker *kubernetesClient
 }
 
-func (cg *crdGetter) Get(
-	name string,
-) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+func (cg *crdGetter) Get(name string) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	crd, err := cg.Broker.getCustomResourceDefinition(name)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting custom resource definition %q", name)
@@ -361,8 +359,8 @@ func (cg *crdGetter) Get(
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting custom resource definition client %q", name)
 	}
-	if _, err := crClient.List(context.TODO(), metav1.ListOptions{}); err != nil {
-		if k8serrors.IsNotFound(err) {
+	if resources, err := crClient.List(context.TODO(), metav1.ListOptions{}); err != nil {
+		if k8serrors.IsNotFound(err) || len(resources.Items) == 0 {
 			// CRD already exists, but the resource type does not exist yet.
 			return nil, errors.NewNotFound(err, fmt.Sprintf("custom resource definition %q resource type", crd.GetName()))
 		}
@@ -375,38 +373,37 @@ func (k *kubernetesClient) getCRDsForCRs(
 	crs map[string][]unstructured.Unstructured,
 	getter CRDGetterInterface,
 ) (out map[string]*apiextensionsv1beta1.CustomResourceDefinition, err error) {
-
-	out = make(map[string]*apiextensionsv1beta1.CustomResourceDefinition)
-	crdChan := make(chan *apiextensionsv1beta1.CustomResourceDefinition, 1)
-	errChan := make(chan error, 1)
-
 	n := len(crs)
 	if n == 0 {
 		return
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(n)
-	defer wg.Wait()
+	out = make(map[string]*apiextensionsv1beta1.CustomResourceDefinition)
+	crdChan := make(chan *apiextensionsv1beta1.CustomResourceDefinition, n)
 
 	getCRD := func(
 		ctx context.Context,
 		name string,
 		getter CRDGetterInterface,
 		resultChan chan<- *apiextensionsv1beta1.CustomResourceDefinition,
-		errChan chan<- error,
 		clk jujuclock.Clock,
-	) {
-		var crd *apiextensionsv1beta1.CustomResourceDefinition
-		var err error
-		err = retry.Call(retry.CallArgs{
+	) error {
+		return retry.Call(retry.CallArgs{
 			Attempts: 8,
 			Delay:    1 * time.Second,
 			Clock:    clk,
 			Stop:     ctx.Done(),
 			Func: func() error {
-				crd, err = getter.Get(name)
-				return errors.Trace(err)
+				if crd, err := getter.Get(name); err != nil {
+					return err
+				} else {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case resultChan <- crd:
+					}
+					return nil
+				}
 			},
 			IsFatalError: func(err error) bool {
 				return err != nil && !errors.IsNotFound(err)
@@ -415,38 +412,28 @@ func (k *kubernetesClient) getCRDsForCRs(
 				logger.Debugf("fetching custom resource definition %q, err %#v, attempt %v", name, err, attempt)
 			},
 		})
-		if err == nil {
-			select {
-			case resultChan <- crd:
-			}
-		} else {
-			select {
-			case errChan <- err:
-			}
-		}
-		wg.Done()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	g, ctx := errgroup.WithContext(ctx)
 	for name := range crs {
-		go getCRD(ctx, name, getter, crdChan, errChan, k.clock)
+		n := name
+		g.Go(func() error {
+			return getCRD(ctx, n, getter, crdChan, k.clock)
+		})
 	}
-
-	for range crs {
-		select {
-		case crd := <-crdChan:
-			if crd == nil {
-				continue
-			}
-			name := crd.GetName()
-			out[name] = crd
-			logger.Debugf("custom resource definition %q is ready", name)
-		case err := <-errChan:
-			if err != nil {
-				return nil, errors.Annotatef(err, "getting custom resources")
-			}
+	if err := g.Wait(); err != nil {
+		return nil, errors.Annotatef(err, "getting custom resources")
+	}
+	close(crdChan)
+	for crd := range crdChan {
+		if crd == nil {
+			continue
 		}
+		name := crd.GetName()
+		out[name] = crd
+		logger.Debugf("custom resource definition %q is ready", name)
 	}
 	return out, nil
 }

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -635,7 +635,7 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 				},
 				Spec: podSpec,
 			},
-			PodManagementPolicy: apps.ParallelPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			ServiceName:         "app-name-endpoints",
 		},
 	}
@@ -1034,7 +1034,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 				Resource: crd.Spec.Names.Plural,
 			},
 		).Times(1).Return(s.mockNamespaceableResourceClient),
-		s.mockResourceClient.EXPECT().List(gomock.Any(), v1.ListOptions{}).Times(1).Return(&unstructured.UnstructuredList{}, nil),
+		s.mockResourceClient.EXPECT().List(gomock.Any(), v1.ListOptions{}).Times(1).Return(
+			&unstructured.UnstructuredList{Items: []unstructured.Unstructured{{Object: map[string]interface{}{}}}}, nil,
+		),
 
 		// ensuring cr1.
 		s.mockDynamicClient.EXPECT().Resource(
@@ -1330,10 +1332,10 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 		resultChan <- result
 	}(s.broker)
 
-	err := s.clock.WaitAdvance(time.Second, testing.LongWait, 2)
+	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 2)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.clock.WaitAdvance(time.Second, testing.LongWait, 1)
+	err = s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
@@ -1371,7 +1373,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsFailEarly(c *gc.C) {
 		resultChan <- result
 	}(s.broker)
 
-	err := s.clock.WaitAdvance(time.Second, testing.LongWait, 1)
+	err := s.clock.WaitAdvance(time.Second, testing.ShortWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
@@ -130,7 +130,7 @@ func NewProviderCredentials(
 	}
 }
 
-func (k *kubernetesClient) GetCRDsForCRs(crs map[string][]unstructured.Unstructured, getter CRDGetterInterface) (out map[string]*apiextensionsv1beta1.CustomResourceDefinition, err error) {
+func (k *kubernetesClient) GetCRDsForCRs(crs map[string][]unstructured.Unstructured, getter CRDGetterInterface) (out map[string]*apiextensionsv1.CustomResourceDefinition, err error) {
 	return k.getCRDsForCRs(crs, getter)
 }
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -17,14 +17,12 @@ import (
 	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	apps "k8s.io/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1446,51 +1444,46 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 	defer ctrl.Finish()
 
 	// CRs of this Cluster scope CRD will get deleted.
-	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdClusterScope := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfjobs.kubeflow.org",
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: apiextensionsv1beta1.ClusterScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name: "v1alpha2", Served: true, Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -1498,55 +1491,56 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 						},
 					},
 				},
+			},
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
 	// CRs of this namespaced scope CRD will be skipped.
-	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdNamespacedScope := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfjobs.kubeflow.org",
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.juju.is/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name: "v1alpha2", Served: true, Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -1554,6 +1548,12 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 						},
 					},
 				},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
@@ -1611,8 +1611,8 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 		).Return(s.mockNamespaceableResourceClient),
 	).After(
 		// list cluster wide all custom resource definitions for listing custom resources.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
-			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+		s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1.CustomResourceDefinitionList{Items: []apiextensionsv1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
 	).After(
 		// delete all custom resources for crd "v1alpha2".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(gomock.Any(),
@@ -1643,8 +1643,8 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 		).Return(s.mockNamespaceableResourceClient),
 	).After(
 		// list cluster wide all custom resource definitions for deleting custom resources.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
-			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+		s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1.CustomResourceDefinitionList{Items: []apiextensionsv1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
 	)
 
 	// timer +1.
@@ -1831,7 +1831,7 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 					},
 				},
 			}},
-			PodManagementPolicy: apps.ParallelPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			ServiceName:         "app-name-endpoints",
 		},
 	}
@@ -1841,51 +1841,46 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "tfjobs.kubeflow.org",
 			Namespace: "test",
 			Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.kubernetes.io/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: "Namespaced",
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name: "v1alpha2", Served: true, Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -1893,6 +1888,12 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 						},
 					},
 				},
+			},
+			Scope: "Namespaced",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
@@ -1958,8 +1959,8 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 		).Return(nil),
 
 		// list cluster wide all custom resource definitions for deleting custom resources.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crd}}, nil),
+		s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{}).
+			Return(&apiextensionsv1.CustomResourceDefinitionList{Items: []apiextensionsv1.CustomResourceDefinition{*crd}}, nil),
 		// delete all custom resources for crd "v1".
 		s.mockDynamicClient.EXPECT().Resource(
 			schema.GroupVersionResource{
@@ -2025,7 +2026,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoUnits(c *gc.C) {
 	defer ctrl.Finish()
 
 	two := int32(2)
-	dc := &apps.Deployment{ObjectMeta: v1.ObjectMeta{Name: "juju-unit-storage"}, Spec: apps.DeploymentSpec{Replicas: &two}}
+	dc := &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "juju-unit-storage"}, Spec: appsv1.DeploymentSpec{Replicas: &two}}
 	zero := int32(0)
 	emptyDc := dc
 	emptyDc.Spec.Replicas = &zero
@@ -2206,9 +2207,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 				},
 				Spec: podSpec,
 			},
-			Strategy: apps.DeploymentStrategy{
-				Type: apps.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &apps.RollingUpdateDeployment{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
 					MaxUnavailable: &intstr.IntOrString{IntVal: 10},
 					MaxSurge:       &intstr.IntOrString{IntVal: 20},
 				},
@@ -2980,7 +2981,7 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 				},
 				Spec: podSpec,
 			},
-			PodManagementPolicy: apps.PodManagementPolicyType("OrderedReady"),
+			PodManagementPolicy: appsv1.PodManagementPolicyType("OrderedReady"),
 			ServiceName:         "app-name-endpoints",
 		},
 	}
@@ -3221,7 +3222,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 				},
 				Spec: podSpec,
 			},
-			PodManagementPolicy: apps.PodManagementPolicyType("OrderedReady"),
+			PodManagementPolicy: appsv1.PodManagementPolicyType("OrderedReady"),
 			ServiceName:         "app-name-endpoints",
 		},
 	}
@@ -3305,7 +3306,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 				},
 				Spec: podSpec,
 			},
-			PodManagementPolicy: apps.ParallelPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			ServiceName:         "app-name-endpoints",
 		},
 	}
@@ -5086,9 +5087,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 		}},
 	})
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
-	statefulSetArg.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
-		Type: apps.RollingUpdateStatefulSetStrategyType,
-		RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+	statefulSetArg.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
 			Partition: int32Ptr(10),
 		},
 	}
@@ -5834,9 +5835,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 				},
 				Spec: podSpec,
 			},
-			UpdateStrategy: apps.DaemonSetUpdateStrategy{
-				Type: apps.RollingUpdateDaemonSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateDaemonSet{
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 					MaxUnavailable: &intstr.IntOrString{IntVal: 10},
 				},
 			},
@@ -7306,8 +7307,8 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 		Type: "RollingUpdate",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DaemonSetUpdateStrategy{
-		Type: apps.RollingUpdateDaemonSetStrategyType,
+	c.Assert(o, jc.DeepEquals, appsv1.DaemonSetUpdateStrategy{
+		Type: appsv1.RollingUpdateDaemonSetStrategyType,
 	})
 
 	_, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
@@ -7339,9 +7340,9 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DaemonSetUpdateStrategy{
-		Type: apps.RollingUpdateDaemonSetStrategyType,
-		RollingUpdate: &apps.RollingUpdateDaemonSet{
+	c.Assert(o, jc.DeepEquals, appsv1.DaemonSetUpdateStrategy{
+		Type: appsv1.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 			MaxUnavailable: &intstr.IntOrString{IntVal: 10},
 		},
 	})
@@ -7350,8 +7351,8 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 		Type: "OnDelete",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DaemonSetUpdateStrategy{
-		Type: apps.OnDeleteDaemonSetStrategyType,
+	c.Assert(o, jc.DeepEquals, appsv1.DaemonSetUpdateStrategy{
+		Type: appsv1.OnDeleteDaemonSetStrategyType,
 	})
 
 	_, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
@@ -7374,8 +7375,8 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
 		Type: "RollingUpdate",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DeploymentStrategy{
-		Type: apps.RollingUpdateDeploymentStrategyType,
+	c.Assert(o, jc.DeepEquals, appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
 	})
 
 	_, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
@@ -7397,8 +7398,8 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
 		Type: "Recreate",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DeploymentStrategy{
-		Type: apps.RecreateDeploymentStrategyType,
+	c.Assert(o, jc.DeepEquals, appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
 	})
 
 	_, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
@@ -7418,9 +7419,9 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.DeploymentStrategy{
-		Type: apps.RollingUpdateDeploymentStrategyType,
-		RollingUpdate: &apps.RollingUpdateDeployment{
+	c.Assert(o, jc.DeepEquals, appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
 			MaxUnavailable: &intstr.IntOrString{IntVal: 10},
 			MaxSurge:       &intstr.IntOrString{IntVal: 20},
 		},
@@ -7438,8 +7439,8 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 		Type: "RollingUpdate",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.StatefulSetUpdateStrategy{
-		Type: apps.RollingUpdateStatefulSetStrategyType,
+	c.Assert(o, jc.DeepEquals, appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.RollingUpdateStatefulSetStrategyType,
 	})
 
 	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
@@ -7470,8 +7471,8 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 		Type: "OnDelete",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.StatefulSetUpdateStrategy{
-		Type: apps.OnDeleteStatefulSetStrategyType,
+	c.Assert(o, jc.DeepEquals, appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.OnDeleteStatefulSetStrategyType,
 	})
 
 	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
@@ -7489,9 +7490,9 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(o, jc.DeepEquals, apps.StatefulSetUpdateStrategy{
-		Type: apps.RollingUpdateStatefulSetStrategyType,
-		RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{
+	c.Assert(o, jc.DeepEquals, appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
 			Partition: int32Ptr(10),
 		},
 	})

--- a/caas/kubernetes/provider/mocks/crd_getter_mock.go
+++ b/caas/kubernetes/provider/mocks/crd_getter_mock.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	reflect "reflect"
 )
 
@@ -34,10 +34,10 @@ func (m *MockCRDGetterInterface) EXPECT() *MockCRDGetterInterfaceMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockCRDGetterInterface) Get(arg0 string) (*v1beta1.CustomResourceDefinition, error) {
+func (m *MockCRDGetterInterface) Get(arg0 string) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
-	ret0, _ := ret[0].(*v1beta1.CustomResourceDefinition)
+	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -10,7 +10,7 @@ import (
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
@@ -107,7 +107,7 @@ func (k *kubernetesClient) deleteClusterScopeCustomResourcesModelTeardown(
 	wg *sync.WaitGroup,
 	errChan chan<- error,
 ) {
-	getSelector := func(crd apiextensionsv1beta1.CustomResourceDefinition) k8slabels.Selector {
+	getSelector := func(crd apiextensionsv1.CustomResourceDefinition) k8slabels.Selector {
 		if !isCRDScopeNamespaced(crd.Spec.Scope) {
 			// We only delete cluster scope CRs here, namespaced CRs are deleted by namespace destroy process.
 			return selector

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -18,7 +18,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,50 +31,47 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 	defer ctrl.Finish()
 
 	// CRs of this Cluster scope CRD will get deleted.
-	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdClusterScope := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "tfjobs.kubeflow.org",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.kubernetes.io/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: apiextensionsv1beta1.ClusterScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -83,54 +79,57 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 						},
 					},
 				},
+			},
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
 	// CRs of this namespaced scope CRD will be skipped.
-	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdNamespacedScope := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "tfjobs.kubeflow.org",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.kubernetes.io/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -138,6 +137,12 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 						},
 					},
 				},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
@@ -189,8 +194,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 		).Return(s.mockNamespaceableResourceClient),
 	).After(
 		// list cluster wide all custom resource definitions for listing custom resources.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
-			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+		s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1.CustomResourceDefinitionList{Items: []apiextensionsv1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
 	).After(
 		// delete all custom resources for crd "v1alpha2".
 		s.mockNamespaceableResourceClient.EXPECT().DeleteCollection(gomock.Any(),
@@ -221,8 +226,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 		).Return(s.mockNamespaceableResourceClient),
 	).After(
 		// list cluster wide all custom resource definitions for deleting custom resources.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
-			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+		s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1.CustomResourceDefinitionList{Items: []apiextensionsv1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
 	)
 
 	// timer +1.
@@ -296,50 +301,45 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 	defer ctrl.Finish()
 
 	// CRs of this Cluster scope CRD will get deleted.
-	crdClusterScope := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdClusterScope := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "tfjobs.kubeflow.org",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.kubernetes.io/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: apiextensionsv1beta1.ClusterScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name: "v1alpha2", Served: true, Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -347,54 +347,55 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 						},
 					},
 				},
+			},
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
 	// CRs of this namespaced scope CRD will be skipped.
-	crdNamespacedScope := &apiextensionsv1beta1.CustomResourceDefinition{
+	crdNamespacedScope := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   "tfjobs.kubeflow.org",
 			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name", "model.kubernetes.io/name": "test"},
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "kubeflow.org",
-			Version: "v1alpha2",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "kubeflow.org",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
-				{Name: "v1alpha2", Served: true, Storage: false},
-			},
-			Scope: apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:   "tfjobs",
-				Kind:     "TFJob",
-				Singular: "tfjob",
-			},
-			Validation: &apiextensionsv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"tfReplicaSpecs": {
-							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-								"Worker": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
+				{
+					Name: "v1alpha2", Served: true, Storage: false,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"tfReplicaSpecs": {
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"Worker": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"PS": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+										"PS": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type: "integer", Minimum: float64Ptr(1),
+												},
+											},
 										},
-									},
-								},
-								"Chief": {
-									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-										"replicas": {
-											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+										"Chief": {
+											Properties: map[string]apiextensionsv1.JSONSchemaProps{
+												"replicas": {
+													Type:    "integer",
+													Minimum: float64Ptr(1),
+													Maximum: float64Ptr(1),
+												},
+											},
 										},
 									},
 								},
@@ -402,6 +403,12 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 						},
 					},
 				},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "tfjobs",
+				Kind:     "TFJob",
+				Singular: "tfjob",
 			},
 		},
 	}
@@ -444,8 +451,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 		).Return(s.mockNamespaceableResourceClient),
 	).After(
 		// list cluster wide all custom resource definitions for deleting custom resources.
-		s.mockCustomResourceDefinitionV1Beta1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
-			Return(&apiextensionsv1beta1.CustomResourceDefinitionList{Items: []apiextensionsv1beta1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
+		s.mockCustomResourceDefinitionV1.EXPECT().List(gomock.Any(), v1.ListOptions{}).AnyTimes().
+			Return(&apiextensionsv1.CustomResourceDefinitionList{Items: []apiextensionsv1.CustomResourceDefinition{*crdClusterScope, *crdNamespacedScope}}, nil),
 	)
 
 	s.mockCustomResourceDefinitionV1.EXPECT().DeleteCollection(gomock.Any(),


### PR DESCRIPTION
*Upgrade crd API from v1beta1 to v1 for getting CR and CRD removal;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ yml2json /tmp/charm-builds/mariadb-k8s/reactive/k8s_resources.yaml | jq '.kubernetesResources.customResourceDefinitions[].name'

"certificates.networking.internal.knative.dev"
"tfjobs.kubeflow.org"
"tfjob1s.kubeflow.org1"
"tfjob2s.kubeflow.org2"

$ mkubectl get crds -l app.kubernetes.io/name=mariadb-k8s -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "certificates.networking.internal.knative.dev"
}
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjobs.kubeflow.org"
}
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjob1s.kubeflow.org1"
}
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjob2s.kubeflow.org2"
}

$ juju debug-log -m k1:controller --color --replay --include-module=juju.kubernetes.provider
controller-0: 15:25:53 INFO juju.kubernetes.provider ensuring custom resource definition "certificates.networking.internal.knative.dev" with version "v1"
controller-0: 15:25:53 INFO juju.kubernetes.provider ensuring custom resource definition "tfjobs.kubeflow.org" with version "v1beta1"
controller-0: 15:25:53 INFO juju.kubernetes.provider ensuring custom resource definition "tfjob1s.kubeflow.org1" with version "v1beta1"
controller-0: 15:25:53 INFO juju.kubernetes.provider ensuring custom resource definition "tfjob2s.kubeflow.org2" with version "v1beta1"

$ yml2json /tmp/charm-builds/mariadb-k8s/reactive/k8s_resources.yaml | jq '.kubernetesResources.customResources["tfjobs.kubeflow.org"][].metadata.name'
"dist-mnist-for-e2e-test"

$ mkubectl get tfjobs.kubeflow.org -l app.kubernetes.io/name=mariadb-k8s -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
{
  "apiVersion": "kubeflow.org/v1",
  "name": "dist-mnist-for-e2e-test"
}

$ juju remove-application mariadb-k8s -m k1:t1 --destroy-storage --force
removing application mariadb-k8s
- will remove storage database/0

$ mkubectl get tfjobs.kubeflow.org -l app.kubernetes.io/name=mariadb-k8s -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
error: the server doesn't have a resource type "tfjobs"

$ mkubectl get crds -l 'app.kubernetes.io/name=mariadb-k8s' -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjob1s.kubeflow.org1"
}
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjob2s.kubeflow.org2"
}

$ mkubectl get crds -l 'app.kubernetes.io/name=mariadb-k8s,juju-resource-lifecycle=persistent' -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjob1s.kubeflow.org1"
}
{
  "apiVersion": "apiextensions.k8s.io/v1",
  "name": "tfjob2s.kubeflow.org2"
}

$ mkubectl get crds -l 'app.kubernetes.io/name=mariadb-k8s,!juju-resource-lifecycle' -o json | jq '.items[] | {apiVersion: .apiVersion, name: .metadata.name}'

```

## Documentation changes

No

## Bug reference

No
