### PR TITLE
Fixes facade method used for migration-minion report timeout

### DIFF
--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -285,7 +285,7 @@ func (c *Client) MinionReportTimeout() (time.Duration, error) {
 	var timeout time.Duration
 
 	var res params.StringResult
-	err := c.caller.FacadeCall("MinionReports", nil, &res)
+	err := c.caller.FacadeCall("MinionReportTimeout", nil, &res)
 	if err != nil {
 		return timeout, errors.Trace(err)
 	}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -553,7 +553,10 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 }
 
 func (s *ClientSuite) TestMinionReportTimeout(c *gc.C) {
-	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(facade string, _ int, _, method string, _ interface{}, result interface{}) error {
+		c.Assert(facade, gc.Equals, "MigrationMaster")
+		c.Assert(method, gc.Equals, "MinionReportTimeout")
+
 		out := result.(*params.StringResult)
 		*out = params.StringResult{
 			Result: "30s",


### PR DESCRIPTION
Applies a fix that I definitely made while working on https://github.com/juju/juju/pull/12767, but somehow did not push.

Calling the wrong method name causes migrations to hang at the starting phase, unable to progress because the worker always errors out.

## QA steps

Same as for https://github.com/juju/juju/pull/12767.

## Documentation changes

None.

## Bug reference

N/A
