### PR TITLE
fix data race with callers of seriesForTypes with SeriesVersion.

### DIFF
--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -71,6 +71,8 @@ func seriesForTypes(path string, now time.Time, requestedSeries, imageStream str
 	// after reading the `/usr/share/distro-info/ubuntu.csv` on the Ubuntu distro
 	// the non-LTS should disappear if they're not in the release window for that
 	// series.
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
 	composeSeriesVersions()
 	if requestedSeries != "" && imageStream == Daily {
 		setSupported(allSeriesVersions, requestedSeries)


### PR DESCRIPTION
There is a data race, found by CI unit tests, using allSeriesVersions in the core series package.  Found by upgrader worker unit tests.  AllWorkloadSeries was trying to refresh the data at the same time as SeriesVersions was trying to use it. Use the lock in seriesForTypes.  

## QA steps

(cd worker/upgrader  ; go test -gocheck.v -race ./...)

