### PR TITLE
fix data race in ActionSuite TestLastActionFinishCompletesOperationMany

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -421,7 +421,7 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperationMany(c *gc.C) {
 				c.Assert(operation.Status(), gc.Not(gc.Equals), state.ActionCompleted)
 			}
 
-			_, err = actions[a].Finish(state.ActionResults{
+			_, err := actions[a].Finish(state.ActionResults{
 				Status: state.ActionCompleted,
 			})
 			c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Avoid data race, use new err var in go routine.

## QA steps

 (cd state  ; go test -gocheck.v -race -gocheck.f ActionSuite.TestLastActionFinishCompletesOperationMany)