### PR TITLE
Fixes a permission issue in 2.9 with modeloperator

### DIFF
--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -555,7 +555,7 @@ func ensureModelOperatorRBAC(
 			{
 				APIGroups: []string{""},
 				Resources: []string{"namespaces"},
-				Verbs:     []string{"get"},
+				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{"admissionregistration.k8s.io"},

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -46,7 +46,7 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 			c.Assert(cr.Name, gc.Equals, modelOperatorName)
 			c.Assert(cr.Rules[0].APIGroups, jc.DeepEquals, []string{""})
 			c.Assert(cr.Rules[0].Resources, jc.DeepEquals, []string{"namespaces"})
-			c.Assert(cr.Rules[0].Verbs, jc.DeepEquals, []string{"get"})
+			c.Assert(cr.Rules[0].Verbs, jc.DeepEquals, []string{"get", "list"})
 			c.Assert(cr.Rules[1].APIGroups, jc.DeepEquals, []string{"admissionregistration.k8s.io"})
 			c.Assert(cr.Rules[1].Resources, jc.DeepEquals, []string{"mutatingwebhookconfigurations"})
 			c.Assert(cr.Rules[1].Verbs, jc.DeepEquals, []string{


### PR DESCRIPTION
In 2.9 we introduced changes to the permission set that model operator
uses. This this change we are missing a list namespaces permission that
is required by the caas broker.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap a Juju controller and watch the logs of the Model Operator pod in the controller namespace

## Bug reference

https://bugs.launchpad.net/juju/+bug/1919442
