### PR TITLE
Replace systems with bases for metadata v2

### DIFF
--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -76,7 +76,7 @@ func convertCharmMeta(meta *params.CharmMeta) (*charm.Meta, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	systems, err := convertCharmSystems(meta.Systems)
+	bases, err := convertCharmBases(meta.Bases)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -103,10 +103,9 @@ func convertCharmMeta(meta *params.CharmMeta) (*charm.Meta, error) {
 		Resources:      resources,
 		Terms:          meta.Terms,
 		MinJujuVersion: minVersion,
-		Systems:        systems,
-		Platforms:      convertCharmPlatforms(meta.Platforms),
-		Architectures:  convertCharmArchitectures(meta.Architectures),
+		Bases:          bases,
 		Containers:     containers,
+		Assumes:        meta.Assumes,
 	}
 	return result, nil
 }
@@ -359,9 +358,9 @@ func (c *charmImpl) Revision() int {
 	return c.info.Revision
 }
 
-func convertCharmSystems(input []params.CharmSystem) ([]systems.System, error) {
+func convertCharmBases(input []params.CharmBase) ([]systems.Base, error) {
 	var err error
-	res := []systems.System(nil)
+	res := []systems.Base(nil)
 	for _, v := range input {
 		ch := channel.Channel{}
 		if v.Channel != "" {
@@ -370,41 +369,20 @@ func convertCharmSystems(input []params.CharmSystem) ([]systems.System, error) {
 				return nil, errors.Trace(err)
 			}
 		}
-		res = append(res, systems.System{
-			OS:       v.OS,
-			Channel:  ch,
-			Resource: v.Resource,
+		res = append(res, systems.Base{
+			Name:    v.Name,
+			Channel: ch,
 		})
 	}
 	return res, nil
 }
 
-func convertCharmPlatforms(input []string) []charm.Platform {
-	platforms := []charm.Platform(nil)
-	for _, v := range input {
-		platforms = append(platforms, charm.Platform(v))
-	}
-	return platforms
-}
-
-func convertCharmArchitectures(input []string) []charm.Architecture {
-	architectures := []charm.Architecture(nil)
-	for _, v := range input {
-		architectures = append(architectures, charm.Architecture(v))
-	}
-	return architectures
-}
-
 func convertCharmContainers(input map[string]params.CharmContainer) (map[string]charm.Container, error) {
 	containers := map[string]charm.Container{}
 	for k, v := range input {
-		systems, err := convertCharmSystems(v.Systems)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		containers[k] = charm.Container{
-			Systems: systems,
-			Mounts:  convertCharmMounts(v.Mounts),
+			Resource: v.Resource,
+			Mounts:   convertCharmMounts(v.Mounts),
 		}
 	}
 	if len(containers) == 0 {

--- a/api/common/charms/common_test.go
+++ b/api/common/charms/common_test.go
@@ -63,19 +63,15 @@ func (s *charmsMockSuite) TestCharmInfo(c *gc.C) {
 					Description: "OCI image used for cockroachdb",
 				},
 			},
-			Systems: []params.CharmSystem{
+			Bases: []params.CharmBase{
 				{
-					OS:      "ubuntu",
+					Name:    "ubuntu",
 					Channel: "20.04/stable",
 				},
 			},
 			Containers: map[string]params.CharmContainer{
 				"cockroachdb": {
-					Systems: []params.CharmSystem{
-						{
-							Resource: "cockroachdb-image",
-						},
-					},
+					Resource: "cockroachdb-image",
 					Mounts: []params.CharmMount{
 						{
 							Storage:  "database",
@@ -84,13 +80,12 @@ func (s *charmsMockSuite) TestCharmInfo(c *gc.C) {
 					},
 				},
 			},
-			Platforms:     []string{"kubernetes"},
-			Architectures: []string{"amd64"},
 			Storage: map[string]params.CharmStorage{
 				"database": {
 					Type: "filesystem",
 				},
 			},
+			Assumes: []string{"kubernetes"},
 		},
 	}
 
@@ -131,9 +126,9 @@ func (s *charmsMockSuite) TestCharmInfo(c *gc.C) {
 					Description: "OCI image used for cockroachdb",
 				},
 			},
-			Systems: []systems.System{
+			Bases: []systems.Base{
 				{
-					OS: "ubuntu",
+					Name: "ubuntu",
 					Channel: channel.Channel{
 						Name:  "20.04/stable",
 						Risk:  "stable",
@@ -143,11 +138,7 @@ func (s *charmsMockSuite) TestCharmInfo(c *gc.C) {
 			},
 			Containers: map[string]charm.Container{
 				"cockroachdb": {
-					Systems: []systems.System{
-						{
-							Resource: "cockroachdb-image",
-						},
-					},
+					Resource: "cockroachdb-image",
 					Mounts: []charm.Mount{
 						{
 							Storage:  "database",
@@ -156,13 +147,12 @@ func (s *charmsMockSuite) TestCharmInfo(c *gc.C) {
 					},
 				},
 			},
-			Platforms:     []charm.Platform{"kubernetes"},
-			Architectures: []charm.Architecture{"amd64"},
 			Storage: map[string]charm.Storage{
 				"database": {
 					Type: "filesystem",
 				},
 			},
+			Assumes: []string{"kubernetes"},
 		},
 	}
 	c.Assert(got, gc.DeepEquals, want)

--- a/apiserver/common/applicationwatcher_test.go
+++ b/apiserver/common/applicationwatcher_test.go
@@ -27,9 +27,9 @@ func (s *applicationWatcherSuite) TestEmbeddedFilter(c *gc.C) {
 		charm: mockAppWatcherCharm{
 			meta: &charm.Meta{
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -77,9 +77,9 @@ func (s *applicationWatcherSuite) TestLegacyFilter(c *gc.C) {
 		charm: mockAppWatcherCharm{
 			meta: &charm.Meta{
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -127,9 +127,9 @@ func (s *applicationWatcherSuite) TestNoFilter(c *gc.C) {
 		charm: mockAppWatcherCharm{
 			meta: &charm.Meta{
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -128,10 +128,9 @@ func convertCharmMeta(meta *charm.Meta) *params.CharmMeta {
 		Resources:      convertCharmResourceMetaMap(meta.Resources),
 		Terms:          meta.Terms,
 		MinJujuVersion: meta.MinJujuVersion.String(),
-		Systems:        convertCharmSystems(meta.Systems),
-		Platforms:      convertCharmPlatforms(meta.Platforms),
-		Architectures:  convertCharmArchitectures(meta.Architectures),
+		Bases:          convertCharmBases(meta.Bases),
 		Containers:     convertCharmContainers(meta.Containers),
+		Assumes:        meta.Assumes,
 	}
 }
 
@@ -353,40 +352,23 @@ func convertCharmDevices(devices map[string]charm.Device) map[string]params.Char
 	return results
 }
 
-func convertCharmSystems(input []systems.System) []params.CharmSystem {
-	systems := []params.CharmSystem(nil)
+func convertCharmBases(input []systems.Base) []params.CharmBase {
+	systems := []params.CharmBase(nil)
 	for _, v := range input {
-		systems = append(systems, params.CharmSystem{
-			OS:       v.OS,
-			Channel:  v.Channel.String(),
-			Resource: v.Resource,
+		systems = append(systems, params.CharmBase{
+			Name:    v.Name,
+			Channel: v.Channel.String(),
 		})
 	}
 	return systems
-}
-
-func convertCharmPlatforms(input []charm.Platform) []string {
-	platforms := []string(nil)
-	for _, v := range input {
-		platforms = append(platforms, string(v))
-	}
-	return platforms
-}
-
-func convertCharmArchitectures(input []charm.Architecture) []string {
-	architectures := []string(nil)
-	for _, v := range input {
-		architectures = append(architectures, string(v))
-	}
-	return architectures
 }
 
 func convertCharmContainers(input map[string]charm.Container) map[string]params.CharmContainer {
 	containers := map[string]params.CharmContainer{}
 	for k, v := range input {
 		containers[k] = params.CharmContainer{
-			Systems: convertCharmSystems(v.Systems),
-			Mounts:  convertCharmMounts(v.Mounts),
+			Resource: v.Resource,
+			Mounts:   convertCharmMounts(v.Mounts),
 		}
 	}
 	if len(containers) == 0 {

--- a/apiserver/common/charms/common_test.go
+++ b/apiserver/common/charms/common_test.go
@@ -245,24 +245,18 @@ func (s *charmsSuite) TestClientCharmInfo(c *gc.C) {
 				URL:      "local:focal/cockroachdb-0",
 				Config:   map[string]params.CharmOption{},
 				Meta: &params.CharmMeta{
-					Name:          "cockroachdb",
-					Summary:       "cockroachdb",
-					Description:   "cockroachdb",
-					Platforms:     []string{"kubernetes"},
-					Architectures: []string{"amd64"},
-					Systems: []params.CharmSystem{
+					Name:        "cockroachdb",
+					Summary:     "cockroachdb",
+					Description: "cockroachdb",
+					Bases: []params.CharmBase{
 						{
-							OS:      "ubuntu",
+							Name:    "ubuntu",
 							Channel: "20.04/stable",
 						},
 					},
 					Containers: map[string]params.CharmContainer{
 						"cockroachdb": {
-							Systems: []params.CharmSystem{
-								{
-									Resource: "cockroachdb-image",
-								},
-							},
+							Resource: "cockroachdb-image",
 							Mounts: []params.CharmMount{
 								{
 									Storage:  "database",

--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -50,9 +50,9 @@ func newMockState() *mockState {
 				sha256: "fake-sha256",
 				meta: &charm.Meta{
 					// charm.FormatV2.
-					Systems: []systems.System{
+					Bases: []systems.Base{
 						{
-							OS: "ubuntu",
+							Name: "ubuntu",
 							Channel: channel.Channel{
 								Name:  "20.04/stable",
 								Risk:  "stable",

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -184,9 +184,9 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectStateful(c *gc.C) {
 					DeploymentType: charm.DeploymentStateful,
 				},
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -257,9 +257,9 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectDeployment(c *gc.C) 
 					DeploymentType: charm.DeploymentStateless,
 				},
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -330,9 +330,9 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectDaemon(c *gc.C) {
 					DeploymentType: charm.DeploymentDaemon,
 				},
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -405,9 +405,9 @@ func (s *CAASApplicationProvisionerSuite) TestGarbageCollectForced(c *gc.C) {
 					DeploymentType: charm.DeploymentDaemon,
 				},
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -552,9 +552,9 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithStorage
 					DeploymentType: charm.DeploymentStateful,
 				},
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",
@@ -735,9 +735,9 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStor
 					DeploymentType: charm.DeploymentStateful,
 				},
 				// charm.FormatV2.
-				Systems: []systems.System{
+				Bases: []systems.Base{
 					{
-						OS: "ubuntu",
+						Name: "ubuntu",
 						Channel: channel.Channel{
 							Name:  "20.04/stable",
 							Risk:  "stable",

--- a/apiserver/facades/controller/caasfirewaller/firewaller_test.go
+++ b/apiserver/facades/controller/caasfirewaller/firewaller_test.go
@@ -96,9 +96,9 @@ func (s *firewallerEmbeddedSuite) SetUpTest(c *gc.C) {
 	s.firewallerBaseSuite.SetUpTest(c)
 
 	// charm.FormatV2.
-	s.st.application.charm.meta.Systems = []systems.System{
+	s.st.application.charm.meta.Bases = []systems.Base{
 		{
-			OS: "ubuntu",
+			Name: "ubuntu",
 			Channel: channel.Channel{
 				Name:  "20.04/stable",
 				Risk:  "stable",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7064,6 +7064,18 @@
                     },
                     "additionalProperties": false
                 },
+                "CharmBase": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
@@ -7073,11 +7085,8 @@
                                 "$ref": "#/definitions/CharmMount"
                             }
                         },
-                        "systems": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmSystem"
-                            }
+                        "resource": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -7172,10 +7181,16 @@
                 "CharmMeta": {
                     "type": "object",
                     "properties": {
-                        "architectures": {
+                        "assumes": {
                             "type": "array",
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "bases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmBase"
                             }
                         },
                         "categories": {
@@ -7236,12 +7251,6 @@
                                 }
                             }
                         },
-                        "platforms": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "provides": {
                             "type": "object",
                             "patternProperties": {
@@ -7285,12 +7294,6 @@
                         },
                         "summary": {
                             "type": "string"
-                        },
-                        "systems": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmSystem"
-                            }
                         },
                         "tags": {
                             "type": "array",
@@ -7513,21 +7516,6 @@
                         "count-max",
                         "minimum-size"
                     ]
-                },
-                "CharmSystem": {
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string"
-                        },
-                        "os": {
-                            "type": "string"
-                        },
-                        "resource": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
                 },
                 "CharmURL": {
                     "type": "object",
@@ -8781,6 +8769,18 @@
                     },
                     "additionalProperties": false
                 },
+                "CharmBase": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
@@ -8790,11 +8790,8 @@
                                 "$ref": "#/definitions/CharmMount"
                             }
                         },
-                        "systems": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmSystem"
-                            }
+                        "resource": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -8889,10 +8886,16 @@
                 "CharmMeta": {
                     "type": "object",
                     "properties": {
-                        "architectures": {
+                        "assumes": {
                             "type": "array",
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "bases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmBase"
                             }
                         },
                         "categories": {
@@ -8953,12 +8956,6 @@
                                 }
                             }
                         },
-                        "platforms": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "provides": {
                             "type": "object",
                             "patternProperties": {
@@ -9002,12 +8999,6 @@
                         },
                         "summary": {
                             "type": "string"
-                        },
-                        "systems": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmSystem"
-                            }
                         },
                         "tags": {
                             "type": "array",
@@ -9230,21 +9221,6 @@
                         "count-max",
                         "minimum-size"
                     ]
-                },
-                "CharmSystem": {
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string"
-                        },
-                        "os": {
-                            "type": "string"
-                        },
-                        "resource": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
                 },
                 "CharmURL": {
                     "type": "object",
@@ -13085,6 +13061,18 @@
                     },
                     "additionalProperties": false
                 },
+                "CharmBase": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "CharmContainer": {
                     "type": "object",
                     "properties": {
@@ -13094,11 +13082,8 @@
                                 "$ref": "#/definitions/CharmMount"
                             }
                         },
-                        "systems": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmSystem"
-                            }
+                        "resource": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -13193,10 +13178,16 @@
                 "CharmMeta": {
                     "type": "object",
                     "properties": {
-                        "architectures": {
+                        "assumes": {
                             "type": "array",
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "bases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmBase"
                             }
                         },
                         "categories": {
@@ -13257,12 +13248,6 @@
                                 }
                             }
                         },
-                        "platforms": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "provides": {
                             "type": "object",
                             "patternProperties": {
@@ -13306,12 +13291,6 @@
                         },
                         "summary": {
                             "type": "string"
-                        },
-                        "systems": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/CharmSystem"
-                            }
                         },
                         "tags": {
                             "type": "array",
@@ -13703,21 +13682,6 @@
                         "count-max",
                         "minimum-size"
                     ]
-                },
-                "CharmSystem": {
-                    "type": "object",
-                    "properties": {
-                        "channel": {
-                            "type": "string"
-                        },
-                        "os": {
-                            "type": "string"
-                        },
-                        "resource": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
                 },
                 "CharmURL": {
                     "type": "object",

--- a/apiserver/params/charms.go
+++ b/apiserver/params/charms.go
@@ -128,10 +128,9 @@ type CharmMeta struct {
 	Terms          []string                     `json:"terms,omitempty"`
 	MinJujuVersion string                       `json:"min-juju-version,omitempty"`
 
-	Systems       []CharmSystem             `json:"systems,omitempty"`
-	Platforms     []string                  `json:"platforms,omitempty"`
-	Architectures []string                  `json:"architectures,omitempty"`
-	Containers    map[string]CharmContainer `json:"containers,omitempty"`
+	Bases      []CharmBase               `json:"bases,omitempty"`
+	Containers map[string]CharmContainer `json:"containers,omitempty"`
+	Assumes    []string                  `json:"assumes,omitempty"`
 }
 
 // Charm holds all the charm data that the client needs.
@@ -182,17 +181,16 @@ type CharmDeployment struct {
 	MinVersion     string `json:"min-version"`
 }
 
-// CharmSystem mirrors charm.System
-type CharmSystem struct {
-	OS       string `json:"os,omitempty"`
-	Channel  string `json:"channel,omitempty"`
-	Resource string `json:"resource,omitempty"`
+// CharmBase mirrors systems.Base
+type CharmBase struct {
+	Name    string `json:"name,omitempty"`
+	Channel string `json:"channel,omitempty"`
 }
 
 // CharmContainer mirrors charm.Container
 type CharmContainer struct {
-	Systems []CharmSystem `json:"systems,omitempty"`
-	Mounts  []CharmMount  `json:"mounts,omitempty"`
+	Resource string       `json:"resource,omitempty"`
+	Mounts   []CharmMount `json:"mounts,omitempty"`
 }
 
 // CharmMount mirrors charm.Mount

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -88,25 +88,22 @@ func imageRepoToPath(imageRepo string, ver version.Number) string {
 	return tagImagePath(path, ver)
 }
 
-// ImageForSystem returns the OCI image path for a generic system.
-// NOTE: resource referenced systems are not resolved via ImageForSystem.
-func ImageForSystem(imageRepo string, system systems.System) (string, error) {
-	if system.Resource != "" {
-		return "", errors.NotValidf("system can't reference a resource")
-	}
-	if system.OS == "" {
-		return "", errors.NotValidf("system must specify os")
+// ImageForBase returns the OCI image path for a generic base.
+// NOTE: resource referenced bases are not resolved via ImageForBase.
+func ImageForBase(imageRepo string, base systems.Base) (string, error) {
+	if base.Name == "" {
+		return "", errors.NotValidf("base name")
 	}
 	if imageRepo == "" {
 		imageRepo = JujudOCINamespace
 	}
-	if len(system.Channel.Track) == 0 || len(system.Channel.Risk) == 0 {
-		return "", errors.NotValidf("channel %q", system.Channel)
+	if len(base.Channel.Track) == 0 || len(base.Channel.Risk) == 0 {
+		return "", errors.NotValidf("channel %q", base.Channel)
 	}
-	tag := system.Channel.Track
-	if system.Channel.Risk != channel.Stable {
-		tag = fmt.Sprintf("%s-%s", tag, system.Channel.Risk)
+	tag := base.Channel.Track
+	if base.Channel.Risk != channel.Stable {
+		tag = fmt.Sprintf("%s-%s", tag, base.Channel.Risk)
 	}
-	image := fmt.Sprintf("%s/%s:%s", imageRepo, system.OS, tag)
+	image := fmt.Sprintf("%s/%s:%s", imageRepo, base.Name, tag)
 	return image, nil
 }

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -34,28 +34,25 @@ func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
 	c.Assert(path, jc.DeepEquals, "testing-old-repo/jujud-old-operator:2.6-beta3")
 }
 
-func (*imageSuite) TestImageForSystem(c *gc.C) {
-	_, err := podcfg.ImageForSystem("", systems.System{Resource: "resource 1"})
-	c.Assert(err, gc.ErrorMatches, `system can't reference a resource not valid`)
+func (*imageSuite) TestImageForBase(c *gc.C) {
+	_, err := podcfg.ImageForBase("", systems.Base{})
+	c.Assert(err, gc.ErrorMatches, `base name not valid`)
 
-	_, err = podcfg.ImageForSystem("", systems.System{})
-	c.Assert(err, gc.ErrorMatches, `system must specify os not valid`)
-
-	_, err = podcfg.ImageForSystem("", systems.System{OS: "ubuntu"})
+	_, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu"})
 	c.Assert(err, gc.ErrorMatches, `channel "" not valid`)
 
-	_, err = podcfg.ImageForSystem("", systems.System{OS: "ubuntu", Channel: channel.Channel{
+	_, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
 		Track: "20.04",
 	}})
 	c.Assert(err, gc.ErrorMatches, `channel "" not valid`)
 
-	path, err := podcfg.ImageForSystem("", systems.System{OS: "ubuntu", Channel: channel.Channel{
+	path, err := podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
 		Track: "20.04", Risk: channel.Stable,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, gc.DeepEquals, `jujusolutions/ubuntu:20.04`)
 
-	path, err = podcfg.ImageForSystem("", systems.System{OS: "ubuntu", Channel: channel.Channel{
+	path, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
 		Track: "20.04", Risk: channel.Edge,
 	}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -46,18 +46,9 @@ var caasOS = set.NewStrings(os.Kubernetes.String())
 // ValidateSeries ensures the charm series is valid for the model type.
 func ValidateSeries(modelType ModelType, charmSeries string, charmFormat charm.Format) error {
 	if charmFormat >= charm.FormatV2 {
-		system, err := systems.ParseSystemFromSeries(charmSeries)
+		_, err := systems.ParseBaseFromSeries(charmSeries)
 		if err != nil {
 			return errors.Trace(err)
-		}
-		if system.Resource != "" {
-			switch modelType {
-			case CAAS:
-				// CAAS models support using a resource as the system.
-				return nil
-			case IAAS:
-				return errors.NotValidf("IAAS models don't support systems referencing a resource")
-			}
 		}
 	} else {
 		os, err := series.GetOSFromSeries(charmSeries)

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b
+	github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f
 	github.com/juju/charmrepo/v6 v6.0.0-20210309083204-29c3dbf03675
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
@@ -68,7 +68,7 @@ require (
 	github.com/juju/romulus v0.0.0-20210309074704-4fa3bbd32568
 	github.com/juju/rpcreflect v0.0.0-20200416001309-bb46e9ba1476
 	github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989
-	github.com/juju/systems v0.0.0-20200925032749-8c613192c759
+	github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca
 	github.com/juju/terms-client/v2 v2.0.0-20210309081804-aed8368405f6
 	github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07
 	github.com/juju/txn v0.0.0-20210302043154-251cea9e140a

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b h1:+KrXxt1oLLINuFv0Dmi9TOkIjVJhbXONA5jCfOV0J00=
-github.com/juju/charm/v8 v8.0.0-20210305131337-93c70ae08c0b/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
+github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f h1:cAmcDXpeI44jQ5ccZs6FF/eTmjJKCGmxnA1erbMtjlI=
+github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f/go.mod h1:AttoXjf7BuW3tQJxUyvDGtPZ+QgZwYLXztWBgIAMW4U=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
@@ -426,7 +426,6 @@ github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611 h1:qYMzwsKsEBtgdS
 github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611/go.mod h1:Xyly79yyEtbs4CizvwlQkdV9XLBqytrJm6Pz579cCSA=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d h1:c93kUJDtVAXFEhsCh5jSxyOJmFHuzcihnslQiX8Urwo=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
-github.com/juju/go-oracle-cloud v0.0.0-20170421134547-932a8cea00a1 h1:prQSgzU8eKdTD+Po4DIYviutE8GMpGp3zkoY0ggVqgY=
 github.com/juju/go-oracle-cloud v0.0.0-20170421134547-932a8cea00a1/go.mod h1:aC7I7BnFXPTr0ruRe6OlLYu5wmuk8/mJGhBCD5TQ49g=
 github.com/juju/go4 v0.0.0-20160222163258-40d72ab9641a h1:45JtCyuNYE+QN9aPuR1ID9++BQU+NMTMudHSuaK0Las=
 github.com/juju/go4 v0.0.0-20160222163258-40d72ab9641a/go.mod h1:RVHtZuvrpETIepiNUrNlih2OynoFf1eM6DGC6dloXzk=
@@ -531,8 +530,9 @@ github.com/juju/schema v0.0.0-20180109041850-e4f08199aa80/go.mod h1:7dL+43wADDfx
 github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989 h1:qx1Zh1bnHHVIMmRxq0fehYk7npCG50GhUwEkYeUg/t4=
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
-github.com/juju/systems v0.0.0-20200925032749-8c613192c759 h1:JhhlHeV1sXWIrtrr2IVKcWAD3819eUsRqw+001LjqMQ=
 github.com/juju/systems v0.0.0-20200925032749-8c613192c759/go.mod h1:FcXkVf5o+mosxneWzQsHQ7h9sU3lD2GDOttJClqgnuA=
+github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca h1:KmPR6hTiZ8kDALV8YgFagYlRvyJCfJVvihwDvXgma6I=
+github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca/go.mod h1:FcXkVf5o+mosxneWzQsHQ7h9sU3lD2GDOttJClqgnuA=
 github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae h1:wGk/zIPORICWlu4giN7CLGlP0PNvY/oZCRwfVLgjOZw=
 github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae/go.mod h1:oGYNRVtU+5D99X5rPRaSwzKCc0mqF8A/L2a2UZycbQg=
 github.com/juju/terms-client/v2 v2.0.0-20210309081804-aed8368405f6 h1:kyXBAn5zttmD328DUaqUGyF7aB26B3GvwbVfCE2w71o=

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -4995,12 +4995,8 @@ func (s *ApplicationSuite) TestCAASEmbeddedCharm(c *gc.C) {
 name: cockroachdb
 description: foo
 summary: foo
-platforms:
-  - kubernetes
-architectures:
-  - amd64
-systems:
-  - os: ubuntu
+bases:
+  - name: ubuntu
     channel: 20.04/stable
 `
 	ch := state.AddCustomCharmForSeries(c, st, "cockroach", "metadata.yaml", charmDef, "focal", 1)

--- a/testcharms/charm-repo/focal/cockroach/metadata.yaml
+++ b/testcharms/charm-repo/focal/cockroach/metadata.yaml
@@ -2,17 +2,12 @@ name: cockroachdb
 summary: cockroachdb
 maintainers: ["Harry Pidcock <harry.pidcock@canonical.com>"]
 description: cockroachdb
-platforms:
-  - kubernetes
-architectures:
-  - amd64
-systems:
-  - os: ubuntu
+bases:
+  - name: ubuntu
     channel: 20.04/stable
 containers:
   cockroachdb:
-    systems:
-      - resource: cockroachdb-image
+    resource: cockroachdb-image
     mounts:
       - storage: database
         location: /cockroach/cockroach-data

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -63,18 +63,13 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 	appCharmInfo := &charmscommon.CharmInfo{
 		Meta: &charm.Meta{
 			Name: "test",
-			Platforms: []charm.Platform{
-				charm.PlatformKubernetes,
-			},
-			Systems: []systems.System{{
-				OS:      systems.Ubuntu,
+			Bases: []systems.Base{{
+				Name:    systems.Ubuntu,
 				Channel: channel.MustParse("20.04/stable"),
 			}},
 			Containers: map[string]charm.Container{
 				"test": {
-					Systems: []systems.System{{
-						Resource: "test-oci",
-					}},
+					Resource: "test-oci",
 				},
 			},
 			Resources: map[string]charmresource.Meta{

--- a/worker/caasfirewallerembedded/applicationworker_test.go
+++ b/worker/caasfirewallerembedded/applicationworker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
+	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/systems"
 	"github.com/juju/systems/channel"
 	jc "github.com/juju/testing/checkers"
@@ -92,19 +93,18 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 	appCharmInfo := &charmscommon.CharmInfo{
 		Meta: &charm.Meta{
 			Name: "test",
-			Platforms: []charm.Platform{
-				charm.PlatformKubernetes,
-			},
-			Systems: []systems.System{{
-				OS:      systems.Ubuntu,
+			Bases: []systems.Base{{
+				Name:    systems.Ubuntu,
 				Channel: channel.MustParse("20.04/stable"),
 			}},
 			Containers: map[string]charm.Container{
 				"test": {
-					Systems: []systems.System{{
-						OS:      systems.Ubuntu,
-						Channel: channel.MustParse("20.04/stable"),
-					}},
+					Resource: "test-oci",
+				},
+			},
+			Resources: map[string]charmresource.Meta{
+				"test-oci": {
+					Type: charmresource.TypeContainerImage,
 				},
 			},
 		},

--- a/worker/uniter/container/workload.go
+++ b/worker/uniter/container/workload.go
@@ -139,7 +139,7 @@ func (r *workloadHookResolver) NextOp(
 	noOp := func() (operation.Operation, error) {
 		if localState.Kind == operation.RunHook &&
 			localState.Hook != nil &&
-			localState.Hook.Kind == hooks.WorkloadReady {
+			localState.Hook.Kind == hooks.PebbleReady {
 			// If we are resuming from an unexpected state, skip hook.
 			return opFactory.NewSkipHook(*localState.Hook)
 		}
@@ -149,7 +149,7 @@ func (r *workloadHookResolver) NextOp(
 	case operation.RunHook:
 		if localState.Step != operation.Pending ||
 			localState.Hook == nil ||
-			localState.Hook.Kind != hooks.WorkloadReady {
+			localState.Hook.Kind != hooks.PebbleReady {
 			break
 		}
 		fallthrough
@@ -172,7 +172,7 @@ func (r *workloadHookResolver) NextOp(
 				}
 			}
 			op, err := opFactory.NewRunHook(hook.Info{
-				Kind:         hooks.WorkloadReady,
+				Kind:         hooks.PebbleReady,
 				WorkloadName: evt.WorkloadName,
 			})
 			if err != nil {

--- a/worker/uniter/container/workload_test.go
+++ b/worker/uniter/container/workload_test.go
@@ -83,7 +83,7 @@ func (s *workloadSuite) TestWorkloadReadyHook(c *gc.C) {
 	hookOp, ok := op.(*mockRunHookOp)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(hookOp.hookInfo, gc.DeepEquals, hook.Info{
-		Kind:         "workload-ready",
+		Kind:         "pebble-ready",
 		WorkloadName: "test",
 	})
 }

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -70,7 +70,7 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook has a remote unit but no application", hi.Kind)
 		}
 		return nil
-	case hooks.WorkloadReady:
+	case hooks.PebbleReady:
 		if hi.WorkloadName == "" {
 			return fmt.Errorf("%q hook requires a workload name", hi.Kind)
 		}

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -44,8 +44,8 @@ var validateTests = []struct {
 		hook.Info{Kind: hooks.Kind("grok")},
 		`unknown hook kind "grok"`,
 	}, {
-		hook.Info{Kind: hooks.WorkloadReady},
-		`"workload-ready" hook requires a workload name`,
+		hook.Info{Kind: hooks.PebbleReady},
+		`"pebble-ready" hook requires a workload name`,
 	},
 	{hook.Info{Kind: hooks.Install}, ""},
 	{hook.Info{Kind: hooks.Start}, ""},
@@ -64,7 +64,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.StorageAttached}, `invalid storage ID ""`},
 	{hook.Info{Kind: hooks.StorageAttached, StorageId: "data/0"}, ""},
 	{hook.Info{Kind: hooks.StorageDetaching, StorageId: "data/0"}, ""},
-	{hook.Info{Kind: hooks.WorkloadReady, WorkloadName: "gitlab"}, ""},
+	{hook.Info{Kind: hooks.PebbleReady, WorkloadName: "gitlab"}, ""},
 }
 
 func (s *InfoSuite) TestValidate(c *gc.C) {

--- a/worker/uniter/pebblepoller.go
+++ b/worker/uniter/pebblepoller.go
@@ -21,6 +21,7 @@ import (
 // need for the PebblePoller.
 type PebbleClient interface {
 	SysInfo() (*client.SysInfo, error)
+	CloseIdleConnections()
 }
 
 // NewPebbleClientFunc is the function type used to create a PebbleClient.
@@ -106,6 +107,7 @@ func (p *pebblePoller) poll(containerName string) error {
 		Socket: path.Join("/charm/containers", containerName, "pebble.socket"),
 	}
 	pc := p.newPebbleClient(config)
+	defer pc.CloseIdleConnections()
 	info, err := pc.SysInfo()
 	if err != nil {
 		return errors.Annotatef(err, "failed to get pebble info")

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -208,7 +208,7 @@ func (s *ContextFactorySuite) TestRelationHookContext(c *gc.C) {
 
 func (s *ContextFactorySuite) TestWorkloadHookContext(c *gc.C) {
 	hi := hook.Info{
-		Kind:         hooks.WorkloadReady,
+		Kind:         hooks.PebbleReady,
 		WorkloadName: "test",
 	}
 	ctx, err := s.factory.HookContext(hi)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -399,7 +399,7 @@ func (s *UniterSuite) TestUniterWorkloadReadyHook(c *gc.C) {
 			waitHooks(startupHooks(false)),
 			waitUnitAgent{status: status.Idle},
 			activateTestContainer{"test"},
-			waitHooks{"test-workload-ready"},
+			waitHooks{"test-pebble-ready"},
 		),
 	})
 }


### PR DESCRIPTION
Updates charm/v8 to latest and applies refactors to use bases/assumes and remove systems/platforms/architectures etc.

Fixes closing pebble connections.

## QA steps

You can use the testing charms from [hpidcock/testing-charms](https://github.com/hpidcock/testing-charms)

`juju deploy cockroachdb.charm --resource cockroachdb-image=cockroachdb/cockroach:v20.1.4 --storage database=1G`

## Documentation changes

N/A

## Bug reference

Also fixes https://github.com/canonical/pebble/issues/15

## Related

https://github.com/canonical/operator/pull/490