### PR TITLE
Merge 2.8

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -83,6 +83,8 @@ jobs:
           set -eux
           git clone https://github.com/juju-solutions/bundle-kubeflow.git
           cd bundle-kubeflow
+          # TODO: tmp fix, remove me later once current kubeflow master branch published.
+          git reset --hard 5e0b6fcb
           git clone git://git.launchpad.net/canonical-osm
           cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
 

--- a/acceptancetests/assess_caas_deploy_kubeflow.py
+++ b/acceptancetests/assess_caas_deploy_kubeflow.py
@@ -10,25 +10,24 @@
 from __future__ import print_function
 
 import argparse
+import contextlib
 import json
 import logging
-import contextlib
 import os
 import shutil
-import time
+import subprocess
 import sys
 import textwrap
-import subprocess
+import time
 from pprint import pformat
 from time import sleep
 
 from deploy_stack import BootstrapManager
+from jujupy.k8s_provider import K8sProviderType, providers
+from jujupy.utility import until_timeout
 from utility import (
     JujuAssertionError, add_basic_testing_arguments, configure_logging,
 )
-from jujupy.k8s_provider import K8sProviderType, providers
-from jujupy.utility import until_timeout
-
 
 __metaclass__ = type
 log = logging.getLogger("assess_caas_kubeflow_deployment")
@@ -295,6 +294,16 @@ def get_pub_addr(caas_client, model_name):
 
 
 def prepare(caas_client, caas_provider, build):
+
+    for dep in [
+        "charm",
+        "juju-helpers",
+        "juju-wait",
+    ]:
+        if shutil.which(dep):
+            continue
+        caas_client.sh('sudo', 'snap', 'install', dep, '--classic')
+
     if caas_provider == K8sProviderType.MICROK8S.name:
         caas_client.enable_microk8s_addons(
             [
@@ -306,15 +315,6 @@ def prepare(caas_client, caas_provider, build):
             "wait", "--for=condition=available",
             "-nkube-system", "deployment/coredns", "deployment/hostpath-provisioner", "--timeout=10m",
         )
-
-    for dep in [
-        "charm",
-        "juju-helpers",
-        "juju-wait",
-    ]:
-        if shutil.which(dep):
-            continue
-        caas_client.sh('sudo', 'snap', 'install', dep, '--classic')
 
     caas_client.sh('sudo', 'apt', 'update')
     caas_client.sh('sudo', 'apt', 'install', '-y', 'libssl-dev', 'python3-setuptools')
@@ -340,7 +340,7 @@ def prepare(caas_client, caas_provider, build):
         )
 
 
-def run_test(caas_provider, k8s_model, bundle, build):
+def run_test(caas_provider, caas_client, k8s_model, bundle, build):
     if caas_provider != K8sProviderType.MICROK8S.name:
         # tests/run.sh only works for microk8s.
         log.info("%s/tests/run.sh is skipped for %s k8s provider", KUBEFLOW_DIR, caas_provider)
@@ -352,6 +352,10 @@ def run_test(caas_provider, k8s_model, bundle, build):
     os.environ['JUJU_DATA'] = k8s_model.env.juju_home
 
     with jump_dir(KUBEFLOW_DIR):
+        if not build:
+            # TODO: tmp fix, remove me later once current kubeflow master branch published.
+            caas_client.sh('git', 'reset', '--hard', '5e0b6fcb')
+
         run("sg", "microk8s", "-c", f"{KUBEFLOW_DIR}/tests/run.sh -m {bundle}")
 
 
@@ -416,7 +420,7 @@ def assess_caas_kubeflow_deployment(caas_client, caas_provider, bundle, build=Fa
         log.info("sleeping for 30 seconds to let everything start up")
         sleep(30)
 
-        run_test(caas_provider, k8s_model, bundle, build)
+        run_test(caas_provider, caas_client, k8s_model, bundle, build)
         k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
         success_hook()
     except:  # noqa: E722

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -285,7 +285,7 @@ func (c *Client) MinionReportTimeout() (time.Duration, error) {
 	var timeout time.Duration
 
 	var res params.StringResult
-	err := c.caller.FacadeCall("MinionReports", nil, &res)
+	err := c.caller.FacadeCall("MinionReportTimeout", nil, &res)
 	if err != nil {
 		return timeout, errors.Trace(err)
 	}

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -553,7 +553,10 @@ func (s *ClientSuite) TestMinionReportsBadFailedTag(c *gc.C) {
 }
 
 func (s *ClientSuite) TestMinionReportTimeout(c *gc.C) {
-	apiCaller := apitesting.APICallerFunc(func(_ string, _ int, _ string, _ string, _ interface{}, result interface{}) error {
+	apiCaller := apitesting.APICallerFunc(func(facade string, _ int, _, method string, _ interface{}, result interface{}) error {
+		c.Assert(facade, gc.Equals, "MigrationMaster")
+		c.Assert(method, gc.Equals, "MinionReportTimeout")
+
 		out := result.(*params.StringResult)
 		*out = params.StringResult{
 			Result: "30s",

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -71,6 +71,8 @@ func seriesForTypes(path string, now time.Time, requestedSeries, imageStream str
 	// after reading the `/usr/share/distro-info/ubuntu.csv` on the Ubuntu distro
 	// the non-LTS should disappear if they're not in the release window for that
 	// series.
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
 	composeSeriesVersions()
 	if requestedSeries != "" && imageStream == Daily {
 		setSupported(allSeriesVersions, requestedSeries)

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http"
 	"github.com/juju/os/v2/series"
@@ -269,12 +270,14 @@ func (s *uploadSuite) TestUpload(c *gc.C) {
 func (s *uploadSuite) TestUploadFakeSeries(c *gc.C) {
 	s.patchBundleTools(c, nil)
 	seriesToUpload := "xenial"
-	if seriesToUpload == coretesting.HostSeries(c) {
+	hostSeries := coretesting.HostSeries(c)
+	if seriesToUpload == hostSeries {
 		seriesToUpload = "raring"
 	}
 	t, err := sync.Upload(s.targetStorage, "released", nil, "bionic", seriesToUpload)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUploadedTools(c, t, []string{seriesToUpload, "bionic", coretesting.HostSeries(c)}, "released")
+	expectedSeries := set.NewStrings(seriesToUpload, "bionic", hostSeries)
+	s.assertUploadedTools(c, t, expectedSeries.Values(), "released")
 }
 
 func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
@@ -299,7 +302,8 @@ func (s *uploadSuite) TestSyncTools(c *gc.C) {
 func (s *uploadSuite) TestSyncToolsFakeSeries(c *gc.C) {
 	s.patchBundleTools(c, nil)
 	seriesToUpload := "xenial"
-	if seriesToUpload == coretesting.HostSeries(c) {
+	hostSeries := coretesting.HostSeries(c)
+	if seriesToUpload == hostSeries {
 		seriesToUpload = "raring"
 	}
 	builtTools, err := sync.BuildAgentTarball(true, nil, "testing")
@@ -307,7 +311,8 @@ func (s *uploadSuite) TestSyncToolsFakeSeries(c *gc.C) {
 
 	t, err := sync.SyncBuiltTools(s.targetStorage, "testing", builtTools, "bionic", seriesToUpload)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUploadedTools(c, t, []string{seriesToUpload, "bionic", coretesting.HostSeries(c)}, "testing")
+	expectedSeries := set.NewStrings(seriesToUpload, "bionic", hostSeries)
+	s.assertUploadedTools(c, t, expectedSeries.Values(), "testing")
 }
 
 func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {


### PR DESCRIPTION
This PR is a forward merge of the following PRs:

- Fixes facade method used for migration-minion report timeout #12777
- Fix TestSyncToolsFakeSeries and TestUploadFakeSeries. #12778
- fix data race with callers of seriesForTypes with SeriesVersion. #12779
- fix data race in ActionSuite TestLastActionFinishCompletesOperationMany #12780
- Add tmp fix to pass kubeflow pre-commit action; #12781

no conflicts