### PR TITLE
Change 'dialled' to 'dialed'.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -550,7 +550,7 @@ func tagToString(tag names.Tag) string {
 	return tag.String()
 }
 
-// dialResult holds a dialled connection, the URL
+// dialResult holds a dialed connection, the URL
 // and TLS configuration used to connect to it.
 type dialResult struct {
 	conn      jsoncodec.JSONConn

--- a/mongo/open.go
+++ b/mongo/open.go
@@ -171,7 +171,7 @@ func DialInfo(info Info, opts DialOpts) (*mgo.DialInfo, error) {
 			}
 			c = cc
 		}
-		logger.Debugf("dialled mongodb server at %q", addr)
+		logger.Debugf("dialed mongodb server at %q", addr)
 		return c, nil
 	}
 


### PR DESCRIPTION
While 'dialled' is valid UK spelling, most of our code is using
'dialed', and right now the output of our debug log is split, which
makes it hard to find what time everything is connected.

## QA steps

```sh
$ juju bootstrap lxd --debug
$ juju debug-log
```
You should see things like:
```
2021-03-09 22:02:17 DEBUG juju.mongo open.go:174 dialed mongodb server at "127.0.0.1:37017"
```
Which match lines like:
```
2021-03-09 22:02:21 DEBUG juju.api apiclient.go:1107 successfully dialed "wss://localhost:17070/model/6794f411-792a-483a-8645-a2c63c7db4ea/api"
```

Instead of
```
2021-03-09 22:02:21 DEBUG juju.mongo open.go:174 dialled mongodb server at "10.244.41.11:37017"
```

Which don't match.

## Documentation changes

None.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1920040