### PR TITLE
Verify charmhub subordinates

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -575,14 +575,6 @@ func (mm *MachineManagerAPI) completeUpgradeSeries(arg params.UpdateSeriesArg) e
 	return machine.CompleteUpgradeSeries()
 }
 
-func (mm *MachineManagerAPI) removeUpgradeSeriesLock(arg params.UpdateSeriesArg) error {
-	machine, err := mm.machineFromTag(arg.Entity.Tag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return machine.RemoveUpgradeSeriesLock()
-}
-
 // WatchUpgradeSeriesNotifications returns a watcher that fires on upgrade series events.
 func (mm *MachineManagerAPI) WatchUpgradeSeriesNotifications(args params.Entities) (params.NotifyWatchResults, error) {
 	err := mm.authorizer.CanRead()

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -21,10 +21,8 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/series"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
@@ -666,42 +664,6 @@ func (mm *MachineManagerAPI) machineFromTag(tag string) (Machine, error) {
 	return machine, nil
 }
 
-// verifiedUnits verifies that the machine units and their tree of subordinates
-// all support the input series. If not, an error is returned.
-// If they do, the agent statuses are checked to ensure that they are all in
-// the idle state i.e. not installing, running hooks, or needing intervention.
-// the final check is that the unit itself is not in an error state.
-func (mm *MachineManagerAPI) verifiedUnits(machine Machine, series string, force bool) ([]string, error) {
-	principals := machine.Principals()
-	units, err := machine.VerifyUnitsSeries(principals, series, force)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	unitNames := make([]string, len(units))
-	for i, u := range units {
-		agentStatus, err := u.AgentStatus()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if agentStatus.Status != status.Idle {
-			return nil, errors.Errorf("unit %s is not ready to start a series upgrade; its agent status is: %q %s",
-				u.Name(), agentStatus.Status, agentStatus.Message)
-		}
-		unitStatus, err := u.Status()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if unitStatus.Status == status.Error {
-			return nil, errors.Errorf("unit %s is not ready to start a series upgrade; its status is: \"error\" %s",
-				u.Name(), unitStatus.Message)
-		}
-
-		unitNames[i] = u.UnitTag().Id()
-	}
-	return unitNames, nil
-}
-
 // isSeriesLessThan returns a bool indicating whether the first argument's
 // version is lexicographically less than the second argument's, thus indicating
 // that the series represents an older version of the operating system. The
@@ -732,51 +694,6 @@ func (mm *MachineManagerAPIV4) UpdateMachineSeries(_ params.UpdateSeriesArgs) (p
 			Error: apiservererrors.ServerError(errors.New("UpdateMachineSeries is no longer supported")),
 		}},
 	}, nil
-}
-
-func validateSeries(requestedSeries, machineSeries, machineTag string) error {
-	if requestedSeries == "" {
-		return &params.Error{
-			Message: "series missing from args",
-			Code:    params.CodeBadRequest,
-		}
-	}
-
-	opSys, err := series.GetOSFromSeries(requestedSeries)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if opSys != os.Ubuntu {
-		return errors.Errorf("series %q is from OS %q and is not a valid upgrade target",
-			requestedSeries, opSys.String())
-	}
-
-	opSys, err = series.GetOSFromSeries(machineSeries)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if opSys != os.Ubuntu {
-		return errors.Errorf("%s is running %s and is not valid for Ubuntu series upgrade",
-			machineTag, opSys.String())
-	}
-
-	if requestedSeries == machineSeries {
-		return errors.Errorf("%s is already running series %s", machineTag, requestedSeries)
-	}
-
-	// TODO (Check the charmhub API for all applications running on this) machine
-	// to see if it's possible to run a charm on this machine.
-
-	isOlderSeries, err := isSeriesLessThan(requestedSeries, machineSeries)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if isOlderSeries {
-		return errors.Errorf("machine %s is running %s which is a newer series than %s.",
-			machineTag, machineSeries, requestedSeries)
-	}
-
-	return nil
 }
 
 // ModelAuthorizer defines if a given operation can be performed based on a

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -63,7 +63,6 @@ type Machine interface {
 	CreateUpgradeSeriesLock([]string, string) error
 	RemoveUpgradeSeriesLock() error
 	CompleteUpgradeSeries() error
-	VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error)
 	Principals() []string
 	WatchUpgradeSeriesNotifications() (state.NotifyWatcher, error)
 	GetUpgradeSeriesMessages() ([]string, bool, error)
@@ -191,18 +190,6 @@ type Unit interface {
 	Name() string
 	AgentStatus() (status.StatusInfo, error)
 	Status() (status.StatusInfo, error)
-}
-
-func (m machineShim) VerifyUnitsSeries(unitNames []string, series string, force bool) ([]Unit, error) {
-	units, err := m.Machine.VerifyUnitsSeries(unitNames, series, force)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]Unit, len(units))
-	for i, u := range units {
-		out[i] = u
-	}
-	return out, nil
 }
 
 type storageInterface interface {

--- a/apiserver/facades/client/machinemanager/types_mock_test.go
+++ b/apiserver/facades/client/machinemanager/types_mock_test.go
@@ -7,13 +7,13 @@ package machinemanager
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	v8 "github.com/juju/charm/v8"
+	charm "github.com/juju/charm/v8"
 	charmhub "github.com/juju/juju/charmhub"
 	transport "github.com/juju/juju/charmhub/transport"
 	model "github.com/juju/juju/core/model"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
-	v4 "github.com/juju/names/v4"
+	names "github.com/juju/names/v4"
 	reflect "reflect"
 	time "time"
 )
@@ -242,10 +242,10 @@ func (mr *MockMachineMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 interface{}
 }
 
 // Tag mocks base method
-func (m *MockMachine) Tag() v4.Tag {
+func (m *MockMachine) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
-	ret0, _ := ret[0].(v4.Tag)
+	ret0, _ := ret[0].(names.Tag)
 	return ret0
 }
 
@@ -283,21 +283,6 @@ func (m *MockMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 func (mr *MockMachineMockRecorder) UpgradeSeriesStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockMachine)(nil).UpgradeSeriesStatus))
-}
-
-// VerifyUnitsSeries mocks base method
-func (m *MockMachine) VerifyUnitsSeries(arg0 []string, arg1 string, arg2 bool) ([]Unit, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyUnitsSeries", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]Unit)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// VerifyUnitsSeries indicates an expected call of VerifyUnitsSeries
-func (mr *MockMachineMockRecorder) VerifyUnitsSeries(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnitsSeries", reflect.TypeOf((*MockMachine)(nil).VerifyUnitsSeries), arg0, arg1, arg2)
 }
 
 // WatchUpgradeSeriesNotifications mocks base method
@@ -450,10 +435,10 @@ func (mr *MockUnitMockRecorder) Status() *gomock.Call {
 }
 
 // UnitTag mocks base method
-func (m *MockUnit) UnitTag() v4.UnitTag {
+func (m *MockUnit) UnitTag() names.UnitTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitTag")
-	ret0, _ := ret[0].(v4.UnitTag)
+	ret0, _ := ret[0].(names.UnitTag)
 	return ret0
 }
 
@@ -515,10 +500,10 @@ func (mr *MockCharmMockRecorder) String() *gomock.Call {
 }
 
 // URL mocks base method
-func (m *MockCharm) URL() *v8.URL {
+func (m *MockCharm) URL() *charm.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "URL")
-	ret0, _ := ret[0].(*v8.URL)
+	ret0, _ := ret[0].(*charm.URL)
 	return ret0
 }
 

--- a/apiserver/facades/client/machinemanager/upgrade_series_mock_test.go
+++ b/apiserver/facades/client/machinemanager/upgrade_series_mock_test.go
@@ -216,6 +216,20 @@ func (mr *MockUpgradeSeriesValidatorMockRecorder) ValidateApplications(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateApplications", reflect.TypeOf((*MockUpgradeSeriesValidator)(nil).ValidateApplications), arg0, arg1, arg2)
 }
 
+// ValidateMachine mocks base method
+func (m *MockUpgradeSeriesValidator) ValidateMachine(arg0 Machine) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateMachine", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateMachine indicates an expected call of ValidateMachine
+func (mr *MockUpgradeSeriesValidatorMockRecorder) ValidateMachine(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateMachine", reflect.TypeOf((*MockUpgradeSeriesValidator)(nil).ValidateMachine), arg0)
+}
+
 // ValidateSeries mocks base method
 func (m *MockUpgradeSeriesValidator) ValidateSeries(arg0, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -5,6 +5,7 @@ package machine
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -290,8 +291,16 @@ func (c *upgradeSeriesCommand) retrieveUnits() ([]string, error) {
 			if unit.Machine == machine.Id {
 				units = append(units, name)
 			}
+			for subName, subordinate := range unit.Subordinates {
+				if subordinate.Machine != "" && subordinate.Machine != machine.Id {
+					return nil, errors.Errorf("subordinate %q machine has unexpected machine id %s", subName, machine.Id)
+				}
+				units = append(units, subName)
+			}
 		}
 	}
+
+	sort.Strings(units)
 
 	return units, nil
 }


### PR DESCRIPTION
<strike>Requires https://github.com/juju/juju/pull/12776 to land first, will rebase once it's landed.</strike>

Upgrade series should work with subordinates. The work here was to
verify that and remove duplicated code.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --series=bionic
$ juju deploy nrpe
$ juju add-relation ubuntu nrpe
$ juju upgrade-series 0 prepare focal
WARNING: This command will mark machine "0" as being upgraded to series "focal".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  ubuntu

Continue [y/N]?y
machine-0 validation of upgrade series from "bionic" to "focal"
machine-0 started upgrade series from "bionic" to "focal"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
nrpe/0 pre-series-upgrade hook running
nrpe/0 pre-series-upgrade hook not found, skipping
machine-0 binaries and service files written

Juju is now ready for the series to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade series process:

juju upgrade-series 0 complete
```
