### PR TITLE
Make errors from API2Resource users friendly by include relevent

### DIFF
--- a/charmstore/client.go
+++ b/charmstore/client.go
@@ -277,7 +277,7 @@ func (c Client) listResources(ch CharmID) ([]resource.Resource, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return api2resources(resources)
+	return api2resources(ch.URL.String(), resources)
 }
 
 // csWrapper is a type that abstracts away the low-level implementation details
@@ -333,13 +333,17 @@ func (c csclientImpl) ResourceMeta(channel csparams.Channel, id *charm.URL, name
 	return client.ResourceMeta(id, name, revision)
 }
 
-func api2resources(res []csparams.Resource) ([]resource.Resource, error) {
+func api2resources(name string, res []csparams.Resource) ([]resource.Resource, error) {
 	result := make([]resource.Resource, len(res))
 	for i, r := range res {
 		var err error
 		result[i], err = csparams.API2Resource(r)
 		if err != nil {
-			return nil, errors.Trace(err)
+			msg := name
+			if r.Name != "" {
+				msg = fmt.Sprintf("%s resource %q", msg, r.Name)
+			}
+			return nil, errors.Trace(errors.Annotatef(err, "%s", msg))
 		}
 	}
 	return result, nil

--- a/charmstore/client_test.go
+++ b/charmstore/client_test.go
@@ -4,6 +4,7 @@
 package charmstore
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -166,6 +167,23 @@ func (s *ClientSuite) TestListResourcesError(c *gc.C) {
 		Channel: params.StableChannel,
 	}})
 	c.Assert(err, gc.ErrorMatches, `another error not found`)
+	c.Assert(ret, gc.IsNil)
+}
+
+func (s *ClientSuite) TestListResourcesAPI2ResourcesFailure(c *gc.C) {
+	dev := params.Resource{
+		Name: "name2",
+	}
+	s.wrapper.ReturnListResourcesStable = []resourceResult{oneResourceResult(dev)}
+	client, err := newCachingClient(s.cache, "", s.wrapper.makeWrapper)
+	c.Assert(err, jc.ErrorIsNil)
+
+	curl := charm.MustParseURL("cs:quantal/foo-1")
+	ret, err := client.ListResources([]CharmID{{
+		URL:     curl,
+		Channel: params.StableChannel,
+	}})
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("%s resource %q: .*", curl.String(), dev.Name))
 	c.Assert(ret, gc.IsNil)
 }
 


### PR DESCRIPTION
Found during test of a new charmstore compatibility API endpoint.  The error message seen when juju gets empty resource data is unhelpful, especially when deploying a bundle:

ERROR cannot deploy bundle: bad metadata: resource missing filename

Annotate the error message to include the charm and resource name, if available:

ERROR cannot deploy bundle: cs:openstack-dashboard-507 resource "theme": bad metadata: resource missing filename