### PR TITLE
Verify charmhub finish series

### DIFF
--- a/apiserver/common/mocks/upgradeseries.go
+++ b/apiserver/common/mocks/upgradeseries.go
@@ -176,17 +176,17 @@ func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
 }
 
 // UpdateMachineSeries mocks base method
-func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string, arg1 bool) error {
+func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMachineSeries", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateMachineSeries", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMachineSeries indicates an expected call of UpdateMachineSeries
-func (mr *MockUpgradeSeriesMachineMockRecorder) UpdateMachineSeries(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockUpgradeSeriesMachineMockRecorder) UpdateMachineSeries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMachineSeries", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpdateMachineSeries), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMachineSeries", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpdateMachineSeries), arg0)
 }
 
 // UpgradeSeriesStatus mocks base method

--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -35,7 +35,7 @@ type UpgradeSeriesMachine interface {
 	RemoveUpgradeSeriesLock() error
 	UpgradeSeriesTarget() (string, error)
 	Series() string
-	UpdateMachineSeries(series string, force bool) error
+	UpdateMachineSeries(series string) error
 	SetInstanceStatus(status.StatusInfo) error
 }
 

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -46,19 +46,13 @@ func (s *upgradeSeriesSuite) assertBackendApi(c *gc.C, tag names.Tag) (*common.U
 
 	unitAuthFunc := func() (common.AuthFunc, error) {
 		return func(tag names.Tag) bool {
-			if tag.Id() == s.unitTag1.Id() {
-				return true
-			}
-			return false
+			return tag.Id() == s.unitTag1.Id()
 		}, nil
 	}
 
 	machineAuthFunc := func() (common.AuthFunc, error) {
 		return func(tag names.Tag) bool {
-			if tag.Id() == s.machineTag1.Id() {
-				return true
-			}
-			return false
+			return tag.Id() == s.machineTag1.Id()
 		}, nil
 	}
 

--- a/apiserver/facades/agent/upgradeseries/upgradeseries.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries.go
@@ -230,7 +230,7 @@ func (a *API) FinishUpgradeSeries(args params.UpdateSeriesArgs) (params.ErrorRes
 		if arg.Series == ms {
 			logger.Debugf("%q series is unchanged from %q", arg.Entity.Tag, ms)
 		} else {
-			if err := machine.UpdateMachineSeries(arg.Series, true); err != nil {
+			if err := machine.UpdateMachineSeries(arg.Series); err != nil {
 				result.Results[i].Error = apiservererrors.ServerError(err)
 				continue
 			}

--- a/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
+++ b/apiserver/facades/agent/upgradeseries/upgradeseries_test.go
@@ -157,7 +157,7 @@ func (s *upgradeSeriesSuite) TestFinishUpgradeSeriesUpgraded(c *gc.C) {
 
 	exp := s.machine.EXPECT()
 	exp.Series().Return("trusty")
-	exp.UpdateMachineSeries("xenial", true).Return(nil)
+	exp.UpdateMachineSeries("xenial").Return(nil)
 	exp.RemoveUpgradeSeriesLock().Return(nil)
 
 	entity := params.Entity{Tag: s.machineTag.String()}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
-	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
 	coretesting "github.com/juju/juju/testing"
@@ -1842,26 +1841,6 @@ func (s *ApplicationSuite) TestApplicationUpdateSeriesOfSubordinate(c *gc.C) {
 
 	app := s.backend.applications["postgresql-subordinate"]
 	app.CheckCall(c, 0, "IsPrincipal")
-}
-
-func (s *ApplicationSuite) TestApplicationUpdateSeriesIncompatibleSeries(c *gc.C) {
-	app := s.backend.applications["postgresql"]
-	app.SetErrors(nil, nil, stateerrors.NewErrIncompatibleSeries([]string{"yakkety", "zesty"}, "xenial", "testCharm"))
-	results, err := s.api.UpdateApplicationSeries(
-		params.UpdateSeriesArgs{
-			Args: []params.UpdateSeriesArg{{
-				Entity: params.Entity{Tag: names.NewApplicationTag("postgresql").String()},
-				Series: "xenial",
-			}},
-		})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(results.Results), gc.Equals, 1)
-	c.Assert(results.Results[0], jc.DeepEquals, params.ErrorResult{
-		Error: &params.Error{
-			Code:    params.CodeIncompatibleSeries,
-			Message: "series \"xenial\" not supported by charm \"testCharm\", supported series are: yakkety, zesty",
-		},
-	})
 }
 
 func (s *ApplicationSuite) TestApplicationUpdateSeriesPermissionDenied(c *gc.C) {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
-	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -853,7 +852,7 @@ func (s *MachineManagerSuite) TestUpgradeSeriesPrepareIncompatibleSeries(c *gc.C
 	defer s.setup(c).Finish()
 
 	s.setupUpgradeSeries(c)
-	s.st.machines["0"].SetErrors(stateerrors.NewErrIncompatibleSeries([]string{"yakkety", "zesty"}, "xenial", "TestCharm"))
+	s.st.machines["0"].SetErrors(apiservererrors.NewErrIncompatibleSeries([]string{"yakkety", "zesty"}, "xenial", "TestCharm"))
 	apiV5 := s.apiV5()
 	result, err := apiV5.UpgradeSeriesPrepare(
 		params.UpdateSeriesArg{

--- a/apiserver/facades/client/machinemanager/upgrade_series.go
+++ b/apiserver/facades/client/machinemanager/upgrade_series.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
-	stateerrors "github.com/juju/juju/state/errors"
 )
 
 // UpgradeSeries defines an interface for interacting with upgrading a series.
@@ -438,7 +437,7 @@ func (s stateSeriesValidator) verifySupportedSeries(application Application, ser
 	if seriesSupportedErr != nil && !force {
 		// TODO (stickupkid): Once all commands are placed in this API, we
 		// should relocate these to the API server.
-		return stateerrors.NewErrIncompatibleSeries(supportedSeries, series, ch.String())
+		return apiservererrors.NewErrIncompatibleSeries(supportedSeries, series, ch.String())
 	}
 	return nil
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2633,28 +2633,14 @@ func (s *MachineSuite) assertMachineAndUnitSeriesChanged(c *gc.C, mach *state.Ma
 
 func (s *MachineSuite) TestUpdateMachineSeries(c *gc.C) {
 	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.UpdateMachineSeries("trusty", false)
+	err := mach.UpdateMachineSeries("trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertMachineAndUnitSeriesChanged(c, mach, "trusty")
 }
 
-func (s *MachineSuite) TestUpdateMachineSeriesFail(c *gc.C) {
-	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.UpdateMachineSeries("xenial", false)
-	c.Assert(err, jc.Satisfies, state.IsIncompatibleSeriesError)
-	s.assertMachineAndUnitSeriesChanged(c, mach, "precise")
-}
-
-func (s *MachineSuite) TestUpdateMachineSeriesForce(c *gc.C) {
-	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.UpdateMachineSeries("xenial", true)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertMachineAndUnitSeriesChanged(c, mach, "xenial")
-}
-
 func (s *MachineSuite) TestUpdateMachineSeriesSameSeriesToStart(c *gc.C) {
 	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.UpdateMachineSeries("precise", false)
+	err := mach.UpdateMachineSeries("precise")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertMachineAndUnitSeriesChanged(c, mach, "precise")
 }
@@ -2680,34 +2666,11 @@ func (s *MachineSuite) TestUpdateMachineSeriesSameSeriesAfterStart(c *gc.C) {
 		},
 	).Check()
 
-	err := mach.UpdateMachineSeries("trusty", false)
+	err := mach.UpdateMachineSeries("trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	err = mach.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mach.Series(), gc.Equals, "trusty")
-}
-
-func (s *MachineSuite) TestUpdateMachineSeriesCharmURLChangedSeriesFail(c *gc.C) {
-	mach := s.setupTestUpdateMachineSeries(c)
-
-	defer state.SetTestHooks(c, s.State,
-		jujutxn.TestHook{
-			Before: func() {
-				v2 := state.AddTestingCharmMultiSeries(c, s.State, "multi-seriesv2")
-				cfg := state.SetCharmConfig{Charm: v2}
-				app, err := s.State.Application("multi-series")
-				c.Assert(err, jc.ErrorIsNil)
-				err = app.SetCharm(cfg)
-				c.Assert(err, jc.ErrorIsNil)
-			},
-		},
-	).Check()
-
-	// Trusty is listed in only version 1 of the charm.
-	err := mach.UpdateMachineSeries("trusty", false)
-	c.Assert(err, gc.ErrorMatches,
-		"updating series for machine \"2\": series \"trusty\" not supported by charm \"cs:multi-series-2\", "+
-			"supported series are: precise, xenial")
 }
 
 func (s *MachineSuite) TestUpdateMachineSeriesPrincipalsListChange(c *gc.C) {
@@ -2729,46 +2692,10 @@ func (s *MachineSuite) TestUpdateMachineSeriesPrincipalsListChange(c *gc.C) {
 		},
 	).Check()
 
-	err = mach.UpdateMachineSeries("trusty", false)
+	err = mach.UpdateMachineSeries("trusty")
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertMachineAndUnitSeriesChanged(c, mach, "trusty")
 	c.Assert(len(mach.Principals()), gc.Equals, 2)
-}
-
-func (s *MachineSuite) TestUpdateMachineSeriesSubordinateListChangeIncompatibleSeries(c *gc.C) {
-	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-
-	unit, err := s.State.Unit("multi-series/0")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unit.SubordinateNames(), gc.DeepEquals, []string{"multi-series-subordinate/0"})
-
-	defer state.SetTestHooks(c, s.State,
-		jujutxn.TestHook{
-			Before: func() {
-				subCh2 := state.AddTestingCharmMultiSeries(c, s.State, "multi-series-subordinate2")
-				subApp2 := state.AddTestingApplicationForSeries(c, s.State, "precise", "multi-series-subordinate2", subCh2)
-				c.Assert(subApp2.Series(), gc.Equals, "precise")
-
-				eps, err := s.State.InferEndpoints("multi-series", "multi-series-subordinate2")
-				c.Assert(err, jc.ErrorIsNil)
-				rel, err := s.State.AddRelation(eps...)
-				c.Assert(err, jc.ErrorIsNil)
-
-				err = unit.Refresh()
-				c.Assert(err, jc.ErrorIsNil)
-				relUnit, err := rel.Unit(unit)
-				c.Assert(err, jc.ErrorIsNil)
-				err = relUnit.EnterScope(nil)
-				c.Assert(err, jc.ErrorIsNil)
-			},
-		},
-	).Check()
-
-	err = mach.UpdateMachineSeries("yakkety", false)
-	c.Assert(err, jc.Satisfies, state.IsIncompatibleSeriesError)
-	s.assertMachineAndUnitSeriesChanged(c, mach, "precise")
 }
 
 func (s *MachineSuite) addMachineUnit(c *gc.C, mach *state.Machine) *state.Unit {
@@ -2791,18 +2718,6 @@ func (s *MachineSuite) addMachineUnit(c *gc.C, mach *state.Machine) *state.Unit 
 	err = unit.AssignToMachine(mach)
 	c.Assert(err, jc.ErrorIsNil)
 	return unit
-}
-
-// VerifyUnitsSeries is also tested via TestUpdateMachineSeries*
-func (s *MachineSuite) TestVerifyUnitsSeries(c *gc.C) {
-	mach := s.setupTestUpdateMachineSeries(c)
-	err := mach.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	expectedUnits, err := mach.Units()
-	c.Assert(err, jc.ErrorIsNil)
-	obtainedUnits, err := mach.VerifyUnitsSeries([]string{"multi-series/0"}, "trusty", false)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitNames(obtainedUnits), jc.SameContents, unitNames(expectedUnits))
 }
 
 func unitNames(units []*state.Unit) []string {


### PR DESCRIPTION
<strike>Requires #12786 to land first, will rebase after.</strike>

-----

During a finish upgrade series, we ensure again that the applications are
valid, but this is superfluous. The machine lock was created and
validated up front and we know for certain that the application supports
the given series. We, therefore, don't need to perform the request again.

The following code starts to extract the mess and performing a
FinishUpgradeSeries will just use the machine units, which include
subordinates before setting the series.

Interestingly performing a complete on an upgrade series doesn't
actually, require you to do an upgrade, instead, it will just finish with
the hostSeries, essentially providing a MASSIVE no-op.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --series=bionic
$ juju deploy nrpe
$ juju deploy nagios
$ juju add-relation nrpe ubuntu
$ juju add-relation nrpe:monitors nagios:monitors
$ juju upgrade-series 0 prepare focal
$ juju upgrade-series 0 complete
```

