### PR TITLE
Remove the force when destroying models

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -111,7 +111,7 @@ bootstrap() {
         if [ -n "${OUT}" ]; then
             echo "${model} already exists. Use the following to clean up the environment:"
             echo "    juju switch ${bootstrapped_name}"
-            echo "    juju destroy-model --force -y ${model}"
+            echo "    juju destroy-model -y ${model}"
             exit 1
         fi
 
@@ -208,7 +208,7 @@ destroy_model() {
     output="${TEST_DIR}/${name}-destroy.log"
 
     echo "====> Destroying juju model ${name}"
-    echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
+    echo "${name}" | xargs -I % juju destroy-model -y % >"${output}" 2>&1 || true
     CHK=$(cat "${output}" | grep -i "ERROR" || true)
     if [ -n "${CHK}" ]; then
         printf "\\nFound some issues\\n"
@@ -242,7 +242,7 @@ destroy_controller() {
         echo "====> Destroying model ($(green "${name}"))"
 
         output="${TEST_DIR}/${name}-destroy-model.log"
-        echo "${name}" | xargs -I % juju destroy-model --force -y % >"${output}" 2>&1
+        echo "${name}" | xargs -I % juju destroy-model -y % >"${output}" 2>&1 || true
 
         echo "====> Destroyed model ($(green "${name}"))"
         return


### PR DESCRIPTION
The idea is to test the model teardown as an implicit step. Although
it's annoying to see your test failing because of a tear down issue.
It's important for juju to not fail in real life because of tear down
issue and should be solved.

## QA steps

Run some of the integration tests to see the damage.

```sh
(cd tests && ./main.sh model)
```
