### PR TITLE
Fix wrong mount volume for init containers;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1329,7 +1329,7 @@ func (k *kubernetesClient) configurePodFiles(
 	containers []specs.ContainerSpec,
 	cfgMapName configMapNameFunc,
 ) error {
-	for i, container := range containers {
+	for _, container := range containers {
 		for _, fileSet := range container.VolumeConfig {
 			vol, err := k.fileSetToVolume(appName, annotations, workloadSpec, fileSet, cfgMapName)
 			if err != nil {
@@ -1338,14 +1338,38 @@ func (k *kubernetesClient) configurePodFiles(
 			if err = pushUniqueVolume(&workloadSpec.Pod.PodSpec, vol, false); err != nil {
 				return errors.Trace(err)
 			}
-			workloadSpec.Pod.Containers[i].VolumeMounts = append(workloadSpec.Pod.Containers[i].VolumeMounts, core.VolumeMount{
-				// TODO(caas): add more config fields support(SubPath, ReadOnly, etc).
-				Name:      vol.Name,
-				MountPath: fileSet.MountPath,
-			})
+			if err := configVolumeMount(
+				container, workloadSpec,
+				core.VolumeMount{
+					// TODO(caas): add more config fields support(SubPath, ReadOnly, etc).
+					Name:      vol.Name,
+					MountPath: fileSet.MountPath,
+				},
+			); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 	return nil
+}
+
+func configVolumeMount(container specs.ContainerSpec, workloadSpec *workloadSpec, volMount core.VolumeMount) error {
+	if container.Init {
+		for i, c := range workloadSpec.Pod.InitContainers {
+			if c.Name == container.Name {
+				workloadSpec.Pod.InitContainers[i].VolumeMounts = append(workloadSpec.Pod.InitContainers[i].VolumeMounts, volMount)
+				return nil
+			}
+		}
+		return errors.Annotatef(errors.NotFoundf("init container %q", container.Name), "configuring volume mount %q", volMount.Name)
+	}
+	for i, c := range workloadSpec.Pod.Containers {
+		if c.Name == container.Name {
+			workloadSpec.Pod.Containers[i].VolumeMounts = append(workloadSpec.Pod.Containers[i].VolumeMounts, volMount)
+			return nil
+		}
+	}
+	return errors.Annotatef(errors.NotFoundf("container %q", container.Name), "configuring volume mount %q", volMount.Name)
 }
 
 func (k *kubernetesClient) configureStorage(

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1158,6 +1158,7 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 	}, {
 		Name:  "test2",
 		Ports: []specs.ContainerPort{{ContainerPort: 8080, Protocol: "TCP", Name: "fred"}},
+		Init:  true,
 		Image: "juju/image2",
 		VolumeConfig: []specs.FileSet{
 			{
@@ -1205,7 +1206,10 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 				Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
 			},
 			VolumeMounts: dataVolumeMounts(),
-		}, {
+		},
+	}
+	workloadSpec.Pod.InitContainers = []core.Container{
+		{
 			Name:  "test2",
 			Image: "juju/image2",
 			Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
@@ -1271,7 +1275,10 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 				{Name: "cache-volume", MountPath: "/empty-dir"},
 				{Name: "cache-volume", MountPath: "/another-empty-dir"},
 			}...),
-		}, {
+		},
+	})
+	c.Assert(workloadSpec.Pod.InitContainers, gc.DeepEquals, []core.Container{
+		{
 			Name:  "test2",
 			Image: "juju/image2",
 			Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},


### PR DESCRIPTION
*Fix wrong mount volume for init containers*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# deploy podspec has init containers
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ juju run --unit mariadb-k8s/0  pod-spec-get | yml2json | jq '.containers[] | {name: .name, init: .init, image: .image, imageDetails: .imageDetails.imagePath}'
{
  "name": "init-myservice",
  "init": true,
  "image": "busybox:1.28",
  "imageDetails": null
}
{
  "name": "mariadb-k8s",
  "init": null,
  "image": null,
  "imageDetails": "mariadb"
}

$ mkubectl -nt1 get pod/mariadb-k8s-7f5f486c8b-r4g8k -o json | jq '.spec.initContainers[] | {name: .name, image: .image}'
{
  "name": "init-myservice",
  "image": "busybox:1.28"
}
{
  "name": "juju-pod-init",
  "image": "ycliuhw/jujud-operator:2.8.10"
}

$ mkubectl -nt1 get pod/mariadb-k8s-7f5f486c8b-r4g8k -o json | jq '.spec.containers[] | {name: .name, image: .image}'
{
  "name": "mariadb-k8s",
  "image": "mariadb"
}

$ mkubectl -nt1 get pod/mariadb-k8s-7f5f486c8b-r4g8k -o json | jq '{initContainerStatuses: .status.initContainerStatuses, containerStatuses: .status.containerStatuses}'
{
  "initContainerStatuses": [
    {
      "containerID": "containerd://d29774f76fb3607c2b7c5775b79e7e3b62a7340270c13c92eb7fcecb39fba5bf",
      "image": "docker.io/library/busybox:1.28",
      "imageID": "docker.io/library/busybox@sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
      "lastState": {},
      "name": "init-myservice",
      "ready": true,
      "restartCount": 0,
      "state": {
        "terminated": {
          "containerID": "containerd://d29774f76fb3607c2b7c5775b79e7e3b62a7340270c13c92eb7fcecb39fba5bf",
          "exitCode": 0,
          "finishedAt": "2021-03-22T23:40:38Z",
          "reason": "Completed",
          "startedAt": "2021-03-22T23:40:20Z"
        }
      }
    },
    {
      "containerID": "containerd://db4352d8ea9c6267d2b17fdc3f5b77de19d469ef10bf412a7a773250b7b36df7",
      "image": "docker.io/ycliuhw/jujud-operator:2.8.10",
      "imageID": "sha256:167d4c4100177404bbb03a6630f77c488232e467b029057448f8db7c9dfc1f24",
      "lastState": {},
      "name": "juju-pod-init",
      "ready": true,
      "restartCount": 0,
      "state": {
        "terminated": {
          "containerID": "containerd://db4352d8ea9c6267d2b17fdc3f5b77de19d469ef10bf412a7a773250b7b36df7",
          "exitCode": 0,
          "finishedAt": "2021-03-22T23:40:43Z",
          "reason": "Completed",
          "startedAt": "2021-03-22T23:40:39Z"
        }
      }
    }
  ],
  "containerStatuses": [
    {
      "containerID": "containerd://9fe6f4807c4e7ab98d30bafb9d68add486aa7da252bf4766a8625e33c95e9283",
      "image": "docker.io/library/mariadb:latest",
      "imageID": "docker.io/library/mariadb@sha256:54b817feea3022688e49aeb70b27d4cc6aa08de0b114bd664b9194b549a1d277",
      "lastState": {},
      "name": "mariadb-k8s",
      "ready": true,
      "restartCount": 0,
      "started": true,
      "state": {
        "running": {
          "startedAt": "2021-03-22T23:40:47Z"
        }
      }
    }
  ]
}

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1920711
