### PR TITLE
Add disk provisioning customization

### DIFF
--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -38,7 +38,7 @@ var (
 		cfgPrimaryNetwork:         schema.Omit,
 		cfgForceVMHardwareVersion: int(0),
 		cfgEnableDiskUUID:         true,
-		cfgDiskProvisioningType:   string(vsphereclient.DiskTypeThickEagerZero),
+		cfgDiskProvisioningType:   string(vsphereclient.DiskTypeThick),
 	}
 
 	configRequiredFields  = []string{}

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -28,6 +28,7 @@ func fakeConfigAttrs(attrs ...testing.Attrs) testing.Attrs {
 		"external-network":          "",
 		"enable-disk-uuid":          true,
 		"force-vm-hardware-version": 0,
+		"disk-provisioning-type":    "thin",
 	})
 	for _, attrs := range attrs {
 		merged = merged.Merge(attrs)
@@ -121,11 +122,23 @@ func (ts configTestSpec) newConfig(c *gc.C) *config.Config {
 	return cfg
 }
 
-var newConfigTests = []configTestSpec{{
-	info:   "unknown field is not touched",
-	insert: testing.Attrs{"unknown-field": "12345"},
-	expect: testing.Attrs{"unknown-field": "12345"},
-}}
+var newConfigTests = []configTestSpec{
+	{
+		info:   "unknown field is not touched",
+		insert: testing.Attrs{"unknown-field": "12345"},
+		expect: testing.Attrs{"unknown-field": "12345"},
+	},
+	{
+		info:   "use thick disk provisioning",
+		insert: testing.Attrs{"disk-provisioning-type": "thick"},
+		expect: testing.Attrs{"disk-provisioning-type": "thick"},
+	},
+	{
+		info:   "set invalid disk provisioning",
+		insert: testing.Attrs{"disk-provisioning-type": "eroneous"},
+		err:    "\"disk-provisioning-type\" must be one of.*",
+	},
+}
 
 func (*ConfigSuite) TestNewModelConfig(c *gc.C) {
 	for i, test := range newConfigTests {
@@ -185,7 +198,7 @@ func (s *ConfigSuite) TestValidateOldConfig(c *gc.C) {
 				continue
 			}
 
-			c.Check(err, jc.ErrorIsNil)
+			c.Assert(err, jc.ErrorIsNil)
 			// We verify that Validate filled in the defaults
 			// appropriately.
 			c.Check(validatedConfig, gc.NotNil)

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -28,7 +28,7 @@ func fakeConfigAttrs(attrs ...testing.Attrs) testing.Attrs {
 		"external-network":          "",
 		"enable-disk-uuid":          true,
 		"force-vm-hardware-version": 0,
-		"disk-provisioning-type":    "thin",
+		"disk-provisioning-type":    "",
 	})
 	for _, attrs := range attrs {
 		merged = merged.Merge(attrs)

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -231,6 +231,7 @@ func (env *sessionEnviron) newRawInstance(
 		EnableDiskUUID:         env.ecfg.enableDiskUUID(),
 		ForceVMHardwareVersion: env.ecfg.forceVMHardwareVersion(),
 		IsBootstrap:            args.InstanceConfig.Bootstrap != nil,
+		DiskProvisioningType:   env.ecfg.diskProvisioningType(),
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -268,7 +268,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickEagerZe
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url":     s.imageServer.URL,
-			"disk-provisioning-type": "thickEagerZero",
+			"disk-provisioning-type": "thick",
 		}),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -279,7 +279,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickEagerZe
 
 	call := s.client.Calls()[4]
 	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
-	c.Assert(createVMArgs.DiskProvisioningType, gc.Equals, vsphereclient.DiskTypeThickEagerZero)
+	c.Assert(createVMArgs.DiskProvisioningType, gc.Equals, vsphereclient.DiskTypeThick)
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -151,6 +151,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstance(c *gc.C) {
 		UpdateProgressInterval: 5 * time.Second,
 		EnableDiskUUID:         true,
 		IsBootstrap:            true,
+		DiskProvisioningType:   vsphereclient.DiskTypeThin,
 	})
 
 	ovaLocation, ovaReadCloser, err := readOVA()

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -48,11 +48,12 @@ const (
 	//   * Before new data will be written to a disk area, the hypervisor
 	//     will first zero out the disk area before writing to it. This adds
 	//     latency to disk writes in that area.
-	DiskTypeThickLazyZero DiskProvisioningType = "thickLazyZero"
+	DiskTypeThickLazyZero DiskProvisioningType = "thick-lazy-zero"
 	// DiskTypeThick sets the provisioning type for disks to
 	// "Thick Provision Eagerly Zeroed". The entire size of the virtual
 	// disk will be deducted from the underlying datastore. Any unwritten
-	// disk areas will be zeroed out during cloning.
+	// disk areas will be zeroed out during cloning. This is the default
+	// disk provisioning type.
 	DiskTypeThick DiskProvisioningType = "thick"
 )
 

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -52,7 +52,7 @@ const (
 	// DiskTypeThickEagerZero sets the provisioning type for disks to
 	// "thick eager zeroed". The entire size of the virtual disk will be
 	// deducted from the underlying datastore. Any unwritten disk areas
-	// will be zeroed out during cloning. This is the default setting.
+	// will be zeroed out during cloning.
 	DiskTypeThickEagerZero DiskProvisioningType = "thickEagerZero"
 )
 
@@ -63,6 +63,9 @@ var (
 		DiskTypeThick,
 		DiskTypeThickEagerZero,
 	}
+	// DefaultDiskProvisioningType is the default disk provisioning type
+	// if none is selected in the model config.
+	DefaultDiskProvisioningType = DiskTypeThickEagerZero
 )
 
 // ErrExtendDisk is returned if we timed out trying to extend the root

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -122,6 +122,10 @@ type CreateVirtualMachineParams struct {
 	// IsBootstrap indicates whether the requested instance will be a
 	// newly bootstrapped controller.
 	IsBootstrap bool
+
+	// DiskProvisioningType specifies how disks should be provisioned when
+	// cloning a template.
+	DiskProvisioningType DiskProvisioningType
 }
 
 // vmTemplateName returns the well-known name to
@@ -414,10 +418,15 @@ func (c *Client) extendVMRootDisk(
 	sizeMB uint64,
 	taskWaiter *taskWaiter,
 ) error {
-	disk, err := c.getDisk(ctx, vm)
+	disks, err := c.getDisks(ctx, vm)
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	if len(disks) == 0 {
+		return errors.NotFoundf("root disk")
+	}
+	disk := disks[0]
 	newCapacityInKB := int64(megabytesToKiB(sizeMB))
 	if disk.CapacityInKB >= newCapacityInKB {
 		// The root disk is already bigger than the

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -231,7 +231,7 @@ func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
 
 func (s *clientSuite) TestCreateVirtualMachineThickDiskProvisioning(c *gc.C) {
 	args := baseCreateVirtualMachineParams(c)
-	args.DiskProvisioningType = DiskTypeThick
+	args.DiskProvisioningType = DiskTypeThickLazyZero
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -271,7 +271,7 @@ func (s *clientSuite) TestCreateVirtualMachineThickDiskProvisioning(c *gc.C) {
 
 func (s *clientSuite) TestCreateVirtualMachineThickEagerZeroDiskProvisioning(c *gc.C) {
 	args := baseCreateVirtualMachineParams(c)
-	args.DiskProvisioningType = DiskTypeThickEagerZero
+	args.DiskProvisioningType = DiskTypeThick
 
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	_, err := client.CreateVirtualMachine(context.Background(), args)

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -183,12 +183,12 @@ func (s *clientSuite) TestCreateVirtualMachineForceHWVersion(c *gc.C) {
 	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.roundTripper.CheckCall(c, 41, "RetrieveProperties", "FakeVm1")
-	s.roundTripper.CheckCall(c, 42, "QueryConfigOption", "FakeEnvironmentBrowser")
+	s.roundTripper.CheckCall(c, 42, "RetrieveProperties", "FakeVm1")
+	s.roundTripper.CheckCall(c, 43, "QueryConfigOption", "FakeEnvironmentBrowser")
 	// Mock server max version is vmx-13
 	// Mock template VM version is vmx-10
 	// We requested vmx-11. This should match the call to UpgradeVM_Task.
-	s.roundTripper.CheckCall(c, 43, "UpgradeVM_Task", "vmx-11")
+	s.roundTripper.CheckCall(c, 44, "UpgradeVM_Task", "vmx-11")
 }
 
 func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -75,6 +75,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "FakeVmdkContent")
 
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
 	templateCisp := baseCisp()
 	templateCisp.EntityName = vmTemplateName(args)
 	s.roundTripper.CheckCalls(c, []testing.StubCall{
@@ -125,6 +126,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		retrievePropertiesStubCall("onetwork-0"),
 		retrievePropertiesStubCall("dvportgroup-0"),
 		retrievePropertiesStubCall("FakeVm0"),
+		retrievePropertiesStubCall("FakeVm0"),
 		{"CloneVM_Task", []interface{}{
 			"vm-0",
 			&types.VirtualMachineConfigSpec{
@@ -146,7 +148,17 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 			},
 			types.VirtualMachineRelocateSpec{
 				Pool:      &args.ResourcePool,
-				Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
+				Datastore: &datastore,
+				Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+					{
+						DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+							EagerlyScrub:    newBool(false),
+							ThinProvisioned: newBool(true),
+						},
+						DiskId:    0,
+						Datastore: datastore,
+					},
+				},
 			},
 		}},
 		{"CreatePropertyCollector", nil},
@@ -186,7 +198,8 @@ func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
 	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.roundTripper.CheckCall(c, 37, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
+	s.roundTripper.CheckCall(c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
 		ExtraConfig: []types.BaseOptionValue{
 			&types.OptionValue{Key: "k", Value: "v"},
 		},
@@ -202,7 +215,139 @@ func (s *clientSuite) TestCreateVirtualMachineNoDiskUUID(c *gc.C) {
 		},
 	}, types.VirtualMachineRelocateSpec{
 		Pool:      &args.ResourcePool,
-		Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
+		Datastore: &datastore,
+		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+			{
+				DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+					EagerlyScrub:    newBool(false),
+					ThinProvisioned: newBool(true),
+				},
+				DiskId:    0,
+				Datastore: datastore,
+			},
+		},
+	})
+}
+
+func (s *clientSuite) TestCreateVirtualMachineThickDiskProvisioning(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.DiskProvisioningType = DiskTypeThick
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
+
+	s.roundTripper.CheckCall(c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{Key: "k", Value: "v"},
+		},
+		Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
+		VAppConfig: &types.VmConfigSpec{
+			Property: []types.VAppPropertySpec{{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+				Info:            &types.VAppPropertyInfo{Key: 1, Value: "vm-0"},
+			}, {
+				ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+				Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
+			}},
+		},
+	}, types.VirtualMachineRelocateSpec{
+		Pool:      &args.ResourcePool,
+		Datastore: &datastore,
+		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+			{
+				DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+					// Thick disk provisioning, lazy zeros
+					EagerlyScrub:    newBool(false),
+					ThinProvisioned: newBool(false),
+				},
+				DiskId:    0,
+				Datastore: datastore,
+			},
+		},
+	})
+}
+
+func (s *clientSuite) TestCreateVirtualMachineThickEagerZeroDiskProvisioning(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.DiskProvisioningType = DiskTypeThickEagerZero
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
+
+	s.roundTripper.CheckCall(c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{Key: "k", Value: "v"},
+		},
+		Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
+		VAppConfig: &types.VmConfigSpec{
+			Property: []types.VAppPropertySpec{{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+				Info:            &types.VAppPropertyInfo{Key: 1, Value: "vm-0"},
+			}, {
+				ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+				Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
+			}},
+		},
+	}, types.VirtualMachineRelocateSpec{
+		Pool:      &args.ResourcePool,
+		Datastore: &datastore,
+		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+			{
+				DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+					// Thick disk provisioning, eager zeros
+					EagerlyScrub:    newBool(true),
+					ThinProvisioned: newBool(false),
+				},
+				DiskId:    0,
+				Datastore: datastore,
+			},
+		},
+	})
+}
+
+func (s *clientSuite) TestCreateVirtualMachineThinDiskProvisioning(c *gc.C) {
+	args := baseCreateVirtualMachineParams(c)
+	args.DiskProvisioningType = DiskTypeThin
+
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	_, err := client.CreateVirtualMachine(context.Background(), args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
+
+	s.roundTripper.CheckCall(c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{Key: "k", Value: "v"},
+		},
+		Flags: &types.VirtualMachineFlagInfo{DiskUuidEnabled: newBool(true)},
+		VAppConfig: &types.VmConfigSpec{
+			Property: []types.VAppPropertySpec{{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+				Info:            &types.VAppPropertyInfo{Key: 1, Value: "vm-0"},
+			}, {
+				ArrayUpdateSpec: types.ArrayUpdateSpec{Operation: "edit"},
+				Info:            &types.VAppPropertyInfo{Key: 4, Value: "baz"},
+			}},
+		},
+	}, types.VirtualMachineRelocateSpec{
+		Pool:      &args.ResourcePool,
+		Datastore: &datastore,
+		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+			{
+				DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+					// Thin disk provisioning
+					EagerlyScrub:    newBool(false),
+					ThinProvisioned: newBool(true),
+				},
+				DiskId:    0,
+				Datastore: datastore,
+			},
+		},
 	})
 }
 
@@ -229,9 +374,9 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreSpecified(c *gc.C) {
 		types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"},
 		cisp,
 	)
-
+	datastoreLocation := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"}
 	s.roundTripper.CheckCall(
-		c, 37, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+		c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
 			ExtraConfig: []types.BaseOptionValue{
 				&types.OptionValue{Key: "k", Value: "v"},
 			},
@@ -247,7 +392,17 @@ func (s *clientSuite) TestCreateVirtualMachineDatastoreSpecified(c *gc.C) {
 			},
 		}, types.VirtualMachineRelocateSpec{
 			Pool:      &args.ResourcePool,
-			Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"},
+			Datastore: &datastoreLocation,
+			Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+				{
+					DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+						EagerlyScrub:    newBool(false),
+						ThinProvisioned: newBool(true),
+					},
+					DiskId:    0,
+					Datastore: datastoreLocation,
+				},
+			},
 		})
 }
 
@@ -355,13 +510,13 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 			DeviceName: "arpa",
 		},
 	}
-
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
 	s.roundTripper.CheckCall(c, 27, "ImportVApp", &types.VirtualMachineImportSpec{
 		ConfigSpec: types.VirtualMachineConfigSpec{
 			Name: "vm-name",
 		},
 	})
-	s.roundTripper.CheckCall(c, 37, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+	s.roundTripper.CheckCall(c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
 		ExtraConfig: []types.BaseOptionValue{
 			&types.OptionValue{Key: "k", Value: "v"},
 		},
@@ -387,7 +542,17 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 		},
 	}, types.VirtualMachineRelocateSpec{
 		Pool:      &args.ResourcePool,
-		Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
+		Datastore: &datastore,
+		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+			{
+				DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+					EagerlyScrub:    newBool(false),
+					ThinProvisioned: newBool(true),
+				},
+				DiskId:    0,
+				Datastore: datastore,
+			},
+		},
 	})
 }
 
@@ -418,10 +583,11 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 	retrieveDVSCall := retrievePropertiesStubCall("dvs-0")
 	s.roundTripper.CheckCall(c, 36, retrieveDVSCall.FuncName, retrieveDVSCall.Args...)
 
+	datastore := types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"}
 	// When the external network is a distributed virtual portgroup,
 	// we must make an additional RetrieveProperties call to fetch
 	// the DVS's UUID. This bumps the ImportVApp position by one.
-	s.roundTripper.CheckCall(c, 38, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
+	s.roundTripper.CheckCall(c, 39, "CloneVM_Task", "vm-0", &types.VirtualMachineConfigSpec{
 		ExtraConfig: []types.BaseOptionValue{
 			&types.OptionValue{Key: "k", Value: "v"},
 		},
@@ -443,7 +609,17 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 		},
 	}, types.VirtualMachineRelocateSpec{
 		Pool:      &args.ResourcePool,
-		Datastore: &types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore2"},
+		Datastore: &datastore,
+		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+			{
+				DiskBackingInfo: &types.VirtualDiskFlatVer2BackingInfo{
+					EagerlyScrub:    newBool(false),
+					ThinProvisioned: newBool(true),
+				},
+				DiskId:    0,
+				Datastore: datastore,
+			},
+		},
 	})
 }
 
@@ -478,7 +654,7 @@ func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {
 	_, err := client.CreateVirtualMachine(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.roundTripper.CheckCall(c, 42, "ReconfigVM_Task", types.VirtualMachineConfigSpec{
+	s.roundTripper.CheckCall(c, 43, "ReconfigVM_Task", types.VirtualMachineConfigSpec{
 		DeviceChange: []types.BaseVirtualDeviceConfigSpec{
 			&types.VirtualDeviceConfigSpec{
 				Operation:     types.VirtualDeviceConfigSpecOperationEdit,
@@ -618,6 +794,7 @@ func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 		Clock:                  testclock.NewClock(time.Time{}),
 		EnableDiskUUID:         true,
 		IsBootstrap:            false,
+		DiskProvisioningType:   DiskTypeThin,
 	}
 }
 

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -36,7 +36,7 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 		Cloud:  fakeCloudSpec(),
 		Config: config,
 	})
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()
 	c.Assert(envConfig.Name(), gc.Equals, "testmodel")
@@ -81,7 +81,7 @@ func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 func (s *providerSuite) TestValidate(c *gc.C) {
 	config := fakeConfig(c)
 	validCfg, err := s.provider.Validate(config, nil)
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	validAttrs := validCfg.AllAttrs()
 	c.Assert(config.AllAttrs(), gc.DeepEquals, validAttrs)


### PR DESCRIPTION
This change allows operators to set a new model-level config option which dictates how template VM disks should be cloned when creating a new machine. Current values are:

  * thin - Sparse provisioning, only written blocks will take up disk space on the datastore
  * thick - The entire size of the virtual disk will be deducted from the datastore, but unwritten blocks will not be zeroed out. This adds 2 potential pitfalls. See comments in ```provider/vsphere/internal/vsphereclient/client.go``` regarding ```DiskProvisioningType```.
  * thickEagerZero  (default) - The entire size of the virtual disk is deducted from the datastore, and unwritten blocks are zeroed out. Improves latency when committing to disk, as no extra step needs to be taken before writing data.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```bash
juju bootstrap
juju model-config disk-provisioning-type=thin
juju add-machine
```

Verify your vsphere deployment that the root disk of the newly provisioned VM is thinly provisioned.

NOTE: The VM template used must *not* have disks provisioned as "flat". Disks of the source template must be "thin" or "thick". Flat disks cannot be cloned as "thin" or "thick".

## Documentation changes

No changes required to CLI or API.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1807957
