### PR TITLE
Charmhub bundle upload and test

### DIFF
--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/.jujuignore
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/.jujuignore
@@ -1,0 +1,4 @@
+/venv
+*.py[cod]
+*.charm
+charmcraft.yaml

--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/README.md
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/README.md
@@ -1,0 +1,11 @@
+# juju-qa-bundle-test
+
+## Description
+
+A bundle to use in testing juju.
+
+## Usage
+
+Basic deploy: <br>
+<code>juju deploy juju-qa-bundle-test</code>
+

--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/bundle.yaml
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/bundle.yaml
@@ -1,0 +1,74 @@
+name: juju-qa-bundle-test
+series: bionic
+applications:
+  easyrsa:
+    charm: containers-easyrsa
+    channel: stable
+    num_units: 1
+    to:
+    - lxd:0
+    annotations:
+      gui-x: "450"
+      gui-y: "550"
+  etcd:
+    charm: etcd
+    channel: stable
+    num_units: 1
+    to:
+    - "0"
+    options:
+      channel: 3.2/stable
+    annotations:
+      gui-x: "800"
+      gui-y: "550"
+  flannel:
+    charm: containers-flannel
+    channel: stable
+  juju-qa-test:
+    charm: juju-qa-test
+    channel: 2.0/stable
+  kubernetes-master:
+    charm: containers-kubernetes-master
+    channel: stable
+    num_units: 1
+    to:
+    - "0"
+    expose: true
+    options:
+      channel: 1.12/stable
+  kubernetes-worker:
+    charm: containers-kubernetes-worker
+    channel: stable
+    num_units: 1
+    to:
+    - "1"
+    expose: true
+    options:
+      channel: 1.12/stable
+      proxy-extra-args: proxy-mode=userspace
+machines:
+  "0":
+    constraints: arch=amd64 cores=2 mem=4G root-disk=16G
+    series: bionic
+  "1":
+    constraints: arch=amd64 cores=4 mem=8G root-disk=20G
+    series: bionic
+relations:
+- - flannel:cni
+  - kubernetes-worker:cni
+- - flannel:cni
+  - kubernetes-master:cni
+- - kubernetes-worker:certificates
+  - easyrsa:client
+- - etcd:certificates
+  - easyrsa:client
+- - kubernetes-master:certificates
+  - easyrsa:client
+- - kubernetes-master:kube-control
+  - kubernetes-worker:kube-control
+- - kubernetes-master:kube-api-endpoint
+  - kubernetes-worker:kube-api-endpoint
+- - flannel:etcd
+  - etcd:db
+- - kubernetes-master:etcd
+  - etcd:db

--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/charmcraft.yaml
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/charmcraft.yaml
@@ -1,4 +1,7 @@
 type: bundle
+parts:
+    bundle:
+        prime: ["bundle.yaml", "README.md"]
 charmhub:
     api_url: https://api.charmhub.io
     storage_url: https://storage.snapcraftcontent.com

--- a/testcharms/charm-hub/bundles/juju-qa-bundle-test/charmcraft.yaml
+++ b/testcharms/charm-hub/bundles/juju-qa-bundle-test/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: bundle
+charmhub:
+    api_url: https://api.charmhub.io
+    storage_url: https://storage.snapcraftcontent.com

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -73,6 +73,27 @@ run_deploy_trusted_bundle() {
 	destroy_model "test-trusted-bundles-deploy"
 }
 
+run_deploy_charmhub_bundle() {
+    echo
+
+    model_name="test-charmhub-bundle-deploy"
+    file="${TEST_DIR}/${model_name}.log"
+
+    ensure "${model_name}" "${file}"
+
+    bundle=juju-qa-bundle-test
+    juju deploy "${bundle}"
+
+    wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
+    wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "candidate")"
+    wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+    wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal" 1)"
+    wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
+    wait_for "ntp-focal" "$(idle_subordinate_condition "ntp-focal" "juju-qa-test-focal")"
+
+    destroy_model "${model_name}"
+}
+
 # run_deploy_lxd_profile_bundle_openstack is to test a more
 # real world scenario of a minimal openstack bundle with a
 # charm using an lxd profile.
@@ -155,6 +176,7 @@ test_deploy_bundles() {
 		run "run_deploy_cmr_bundle"
 		run "run_deploy_exported_bundle"
 		run "run_deploy_trusted_bundle"
+		run "run_deploy_charmhub_bundle"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")


### PR DESCRIPTION
Add a bundle that has been uploaded to charmhub.  Add an integration test which uses the bundle.

## QA steps

```console
$ juju info juju-qa-bundle-test
name: juju-qa-bundle-test
bundle-id: CmaAdYBqmiXJfzAVNMAocW87mIhIrafa
publisher: Canonical Juju QA Bot
channels: |
  latest/stable:     1  2021-03-22  (1)  345B
  latest/candidate:  ↑
  latest/beta:       ↑
  latest/edge:       ↑

# Verify juju can find the bundle.   At PR time, the bundle was not visible, in the process of being made visible.
$ juju find juju-qa-bundle-test

$ (cd tests; ./main.sh deploy test_deploy_bundles )
```

