### PR TITLE
Fix/enable rbac

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 
 import logging
 import os
-from pprint import pformat
 from datetime import datetime, timezone
+from pprint import pformat
 
 import yaml
 from azure.identity import ClientSecretCredential
@@ -46,8 +46,8 @@ class AKS(Base):
     driver = None
     parameters = None
 
-    def __init__(self, bs_manager, cluster_name=None, timeout=1800):
-        super().__init__(bs_manager, cluster_name, timeout)
+    def __init__(self, bs_manager, cluster_name=None, enable_rbac=False, timeout=1800):
+        super().__init__(bs_manager, cluster_name, enable_rbac, timeout)
 
         self.default_storage_class_name = ''
         self.__init_client(bs_manager.client.env)

--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -137,7 +137,7 @@ class AKS(Base):
             service_principal_profile=service_principal_profile,
             agent_pool_profiles=[agentpool_default],
             linux_profile=linux_profile,
-            enable_rbac=True,
+            enable_rbac=self.enable_rbac,
             tags={'createdAt': datetime.now(tz=timezone.utc).isoformat()},
         )
 

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -33,6 +33,7 @@ from time import sleep
 from jujupy.client import temp_bootstrap_env
 from jujupy.utility import ensure_dir, until_timeout
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -211,11 +212,12 @@ class Base(object):
             raise Exception("RBAC is unexpectedly enabled in the cluster")
 
     def check_rbac_enable(self):
-        cmd = ['/bin/sh', '-c', f'{" ".join(self._kubectl_bin)} run tmp-shell --restart=Never --rm -i --tty --image bitnami/kubectl:latest -- auth can-i create pods; exit 0']
-        o = self.sh(*cmd, timeout=60)
+        timeout = 180
+        cmd = ['/bin/sh', '-c', f'{" ".join(self._kubectl_bin)} run --timeout={timeout}s tmp-shell --restart=Never --rm -i --tty --image bitnami/kubectl:latest -- auth can-i create pods; exit 0']
+        o = self.sh(*cmd, timeout=timeout)
         logger.info('checking RBAC by run "%s" -> %s', ' '.join(cmd), o)
         # The default SA in the default namespace does NOT have permission to create pods when RBAC is enabled.
-        return o.split('\n')[0] == 'no'
+        return 'no' in o.split()
 
     def kubectl(self, *args):
         return self.sh(*(self._kubectl_bin + args))

--- a/acceptancetests/jujupy/k8s_provider/eks.py
+++ b/acceptancetests/jujupy/k8s_provider/eks.py
@@ -43,8 +43,8 @@ class EKS(Base):
     location = None
     parameters = None
 
-    def __init__(self, bs_manager, cluster_name=None, timeout=1800):
-        super().__init__(bs_manager, cluster_name, timeout)
+    def __init__(self, bs_manager, cluster_name=None, enable_rbac=False, timeout=1800):
+        super().__init__(bs_manager, cluster_name, enable_rbac, timeout)
 
         self._eksctl_bin = os.path.join(self.juju_home, 'eksctl')
         self._ensure_eksctl_bin()

--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -48,8 +48,8 @@ class GKE(Base):
     driver = None
     default_params = None
 
-    def __init__(self, bs_manager, cluster_name=None, timeout=1800):
-        super().__init__(bs_manager, cluster_name, timeout)
+    def __init__(self, bs_manager, cluster_name=None, enable_rbac=False, timeout=1800):
+        super().__init__(bs_manager, cluster_name, enable_rbac, timeout)
 
         self.default_storage_class_name = ''
         self.__init_driver(bs_manager.client.env)

--- a/acceptancetests/jujupy/k8s_provider/kubernetes_core.py
+++ b/acceptancetests/jujupy/k8s_provider/kubernetes_core.py
@@ -20,15 +20,11 @@
 from __future__ import print_function
 
 import logging
-import tempfile
 import subprocess
+import tempfile
 
-from .base import (
-    Base,
-    K8sProviderType,
-)
+from .base import Base, K8sProviderType
 from .factory import register_provider
-
 
 logger = logging.getLogger(__name__)
 
@@ -182,8 +178,8 @@ class KubernetesCore(Base):
 
     name = K8sProviderType.K8S_CORE
 
-    def __init__(self, bs_manager, cluster_name=None, timeout=1800):
-        super().__init__(bs_manager, cluster_name, timeout)
+    def __init__(self, bs_manager, cluster_name=None, enable_rbac=False, timeout=1800):
+        super().__init__(bs_manager, cluster_name, enable_rbac, timeout)
         self.default_storage_class_name = "juju-storageclass"
 
     def _ensure_kube_dir(self):

--- a/acceptancetests/jujupy/k8s_provider/microk8s.py
+++ b/acceptancetests/jujupy/k8s_provider/microk8s.py
@@ -43,8 +43,8 @@ class MicroK8s(Base):
     name = K8sProviderType.MICROK8S
     cloud_name = 'microk8s'  # built-in cloud name
 
-    def __init__(self, bs_manager, cluster_name=None, timeout=1800):
-        super().__init__(bs_manager, cluster_name, timeout)
+    def __init__(self, bs_manager, cluster_name=None, enable_rbac=False, timeout=1800):
+        super().__init__(bs_manager, cluster_name, enable_rbac, timeout)
         self.default_storage_class_name = 'microk8s-hostpath'
 
     def _ensure_cluster_stack(self):


### PR DESCRIPTION
This PR ensures RBAC enabled for `microk8s`, `GKE`, `AKS` and `EKS` for k8s CI tests when the `enable_rbac` sets to `True`;