### PR TITLE
Support older agent upgrades

### DIFF
--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -60,7 +60,7 @@ __metaclass__ = type
 log = logging.getLogger("assess_upgrade")
 
 
-VersionParts = namedtuple('VersionParts', ['version', 'series', 'arch'])
+VersionParts = namedtuple('VersionParts', ['version', 'release', 'arch'])
 
 
 def assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client):
@@ -88,9 +88,9 @@ def assess_upgrade_passing_agent_stream(args, devel_client):
     stable_client = stable_bsm.client
     devel_version_parts = get_version_parts(devel_client.version)
     forced_devel_client = devel_client.clone(
-        version='{vers}-{series}-{arch}'.format(
+        version='{vers}-{release}-{arch}'.format(
             vers=increment_version(devel_client.version),
-            series=devel_version_parts.series,
+            release=devel_version_parts.release,
             arch=devel_version_parts.arch))
     with temp_dir() as base_dir:
         stream_server = StreamServer(base_dir)

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -150,7 +150,7 @@ class StreamServer:
 
 
 def agent_tgz_from_juju_binary(
-        juju_bin_path, tmp_dir, series=None, force_version=None):
+        juju_bin_path, tmp_dir, release=None, force_version=None):
     """
     Create agent tarball with jujud found with provided juju binary.
 
@@ -159,19 +159,10 @@ def agent_tgz_from_juju_binary(
 
     :param juju_bin_path: The path to the juju bin in use.
     :param tmp_dir: Location to store the generated agent file.
-    :param series: String series to use instead of that of the passed binary.
-      Allows one to overwrite the series of the juju client.
+    :param release: String release (os name) to use instead of that of the passed binary.
+      Allows one to overwrite the os name of the juju client.
     :returns: String path to generated
     """
-    def _series_lookup(series):
-        # Handle the inconsistencies with agent series names.
-        if series is None:
-            return None
-        if series.startswith('centos'):
-            return series
-        if series.startswith('win'):
-            return 'win2012'
-        return 'ubuntu'
 
     bin_dir = os.path.dirname(juju_bin_path)
     try:
@@ -184,8 +175,7 @@ def agent_tgz_from_juju_binary(
     try:
         version_output = subprocess.check_output(
             [jujud_path, 'version']).rstrip(str.encode('\n'))
-        version, bin_series, arch = get_version_string_parts(version_output)
-        bin_agent_series = _series_lookup(bin_series)
+        version, bin_agent_release, arch = get_version_string_parts(version_output)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(
             'Unable to query jujud for version details: {}'.format(e))
@@ -195,9 +185,9 @@ def agent_tgz_from_juju_binary(
             'string: {}'.format(version_output))
 
     version = force_version or version
-    agent_tgz_name = 'juju-{version}-{series}-{arch}.tgz'.format(
+    agent_tgz_name = 'juju-{version}-{release}-{arch}.tgz'.format(
         version=version,
-        series=series if series else bin_agent_series,
+        release=release if release else bin_agent_release,
         arch=arch
     )
 

--- a/api/client.go
+++ b/api/client.go
@@ -559,8 +559,8 @@ func NewCharmDownloader(apiCaller base.APICaller) *downloader.Downloader {
 }
 
 // UploadTools uploads tools at the specified location to the API server over HTTPS.
-func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary) (tools.List, error) {
-	endpoint := fmt.Sprintf("/tools?binaryVersion=%s", vers)
+func (c *Client) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (tools.List, error) {
+	endpoint := fmt.Sprintf("/tools?binaryVersion=%s&series=%s", vers, strings.Join(additionalSeries, ","))
 	contentType := "application/x-tar-gz"
 	var resp params.ToolsResult
 	if err := c.httpPost(r, endpoint, contentType, &resp); err != nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -83,6 +83,7 @@ func (s *clientSuite) TestUploadToolsOtherModel(c *gc.C) {
 
 			c.Assert(r.URL.Query(), gc.DeepEquals, url.Values{
 				"binaryVersion": []string{"5.4.3-ubuntu-amd64"},
+				"series":        []string{""},
 			})
 			defer r.Body.Close()
 			obtainedTools, err := ioutil.ReadAll(r.Body)

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -110,7 +110,7 @@ func (t *ToolsGetter) Tools(args params.Entities) (params.ToolsResults, error) {
 }
 
 func (t *ToolsGetter) getGlobalAgentVersion() (version.Number, error) {
-	// Get the Agent Version requested in the Environment Config
+	// Get the Agent Version requested in the Model Config
 	nothing := version.Number{}
 	cfg, err := t.configGetter.ModelConfig()
 	if err != nil {

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/state/stateenvirons"
 )
 
-// InstanceConfig returns information from the environment config that
+// InstanceConfig returns information from the model config that
 // is needed for machine cloud-init (for non-controllers only). It
 // is exposed for testing purposes.
 // TODO(rog) fix environs/manual tests so they do not need to call this, or move this elsewhere.

--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -111,7 +111,7 @@ func (c *syncToolsCommand) Init(args []string) error {
 // api.Client API. This exists to enable mocking.
 type syncToolsAPI interface {
 	FindTools(majorVersion, minorVersion int, osType, arch, agentStream string) (params.FindToolsResult, error)
-	UploadTools(r io.ReadSeeker, v version.Binary) (coretools.List, error)
+	UploadTools(r io.ReadSeeker, v version.Binary, _ ...string) (coretools.List, error)
 	Close() error
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -263,7 +263,7 @@ func (s *syncToolsSuite) TestAPIAdapterUploadTools(c *gc.C) {
 	uploadToolsErr := errors.New("uh oh")
 	current := coretesting.CurrentVersion(c)
 	fake := fakeSyncToolsAPI{
-		uploadTools: func(r io.Reader, v version.Binary) (coretools.List, error) {
+		uploadTools: func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error) {
 			data, err := ioutil.ReadAll(r)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(string(data), gc.Equals, "abc")
@@ -287,15 +287,15 @@ func (s *syncToolsSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
 
 type fakeSyncToolsAPI struct {
 	findTools   func(majorVersion, minorVersion int, osType, arch, stream string) (params.FindToolsResult, error)
-	uploadTools func(r io.Reader, v version.Binary) (coretools.List, error)
+	uploadTools func(r io.Reader, v version.Binary, additionalSeries ...string) (coretools.List, error)
 }
 
 func (f *fakeSyncToolsAPI) FindTools(majorVersion, minorVersion int, osType, arch, stream string) (params.FindToolsResult, error) {
 	return f.findTools(majorVersion, minorVersion, osType, arch, stream)
 }
 
-func (f *fakeSyncToolsAPI) UploadTools(r io.ReadSeeker, v version.Binary) (coretools.List, error) {
-	return f.uploadTools(r, v)
+func (f *fakeSyncToolsAPI) UploadTools(r io.ReadSeeker, v version.Binary, additionalSeries ...string) (coretools.List, error) {
+	return f.uploadTools(r, v, additionalSeries...)
 }
 
 func (f *fakeSyncToolsAPI) Close() error {

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -288,7 +288,7 @@ func formatVersions(agents coretools.Versions) string {
 
 type toolsAPI interface {
 	FindTools(majorVersion, minorVersion int, osType, arch, agentStream string) (result params.FindToolsResult, err error)
-	UploadTools(r io.ReadSeeker, vers version.Binary) (coretools.List, error)
+	UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error)
 }
 
 type upgradeJujuAPI interface {
@@ -297,9 +297,14 @@ type upgradeJujuAPI interface {
 	Close() error
 }
 
+type statusAPI interface {
+	Status(patterns []string) (*params.FullStatus, error)
+}
+
 type jujuClientAPI interface {
 	toolsAPI
 	upgradeJujuAPI
+	statusAPI
 }
 
 type modelConfigAPI interface {
@@ -824,7 +829,7 @@ type upgradeContext struct {
 // than that of any otherwise-matching available envtools.
 // uploadTools resets the chosen version and replaces the available tools
 // with the ones just uploaded.
-func (context *upgradeContext) uploadTools(client toolsAPI, buildAgent bool, agentVersion version.Number, dryRun bool) (err error) {
+func (context *upgradeContext) uploadTools(client jujuClientAPI, buildAgent bool, agentVersion version.Number, dryRun bool) (err error) {
 	// TODO(fwereade): this is kinda crack: we should not assume that
 	// jujuversion.Current matches whatever source happens to be built. The
 	// ideal would be:
@@ -877,7 +882,21 @@ func (context *upgradeContext) uploadTools(client toolsAPI, buildAgent bool, age
 		return errors.Trace(err)
 	}
 	defer f.Close()
-	uploaded, err := client.UploadTools(f, uploadToolsVersion)
+
+	// Older 2.8 agents still look for tools based on series.
+	// Look at the model and get all series for all machines
+	// and use those to create additional tools.
+	additionalSeries := set.NewStrings()
+	if agentVersion.Major == 2 && agentVersion.Minor <= 8 {
+		fullStatus, err := client.Status(nil)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for _, m := range fullStatus.Machines {
+			additionalSeries.Add(m.Series)
+		}
+	}
+	uploaded, err := client.UploadTools(f, uploadToolsVersion, additionalSeries.Values()...)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -503,7 +503,16 @@ func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowe
 	// or the user has asked for a new agent to be built, upload a local
 	// jujud binary if possible.
 	if !warnCompat && (uploadLocalBinary || c.BuildAgent) {
-		if err := upgradeCtx.uploadTools(client, c.BuildAgent, agentVersion, c.DryRun); err != nil {
+		controllerAgentCfg, err := config.New(config.NoDefaults, controllerModelConfig)
+		if err != nil {
+			return err
+		}
+		controllerAgentVersion, ok := controllerAgentCfg.AgentVersion()
+		if !ok {
+			// Can't happen. In theory.
+			return errors.New("incomplete controller model configuration")
+		}
+		if err := upgradeCtx.uploadTools(client, c.BuildAgent, agentVersion, controllerAgentVersion, c.DryRun); err != nil {
 			return block.ProcessBlockedError(err, block.BlockChange)
 		}
 		builtMsg := ""
@@ -829,7 +838,9 @@ type upgradeContext struct {
 // than that of any otherwise-matching available envtools.
 // uploadTools resets the chosen version and replaces the available tools
 // with the ones just uploaded.
-func (context *upgradeContext) uploadTools(client jujuClientAPI, buildAgent bool, agentVersion version.Number, dryRun bool) (err error) {
+func (context *upgradeContext) uploadTools(
+	client jujuClientAPI, buildAgent bool, agentVersion version.Number, controllerAgentVersion version.Number, dryRun bool,
+) (err error) {
 	// TODO(fwereade): this is kinda crack: we should not assume that
 	// jujuversion.Current matches whatever source happens to be built. The
 	// ideal would be:
@@ -884,10 +895,11 @@ func (context *upgradeContext) uploadTools(client jujuClientAPI, buildAgent bool
 	defer f.Close()
 
 	// Older 2.8 agents still look for tools based on series.
+	// Newer 2.9+ controllers can deal with this but not older controllers.
 	// Look at the model and get all series for all machines
 	// and use those to create additional tools.
 	additionalSeries := set.NewStrings()
-	if agentVersion.Major == 2 && agentVersion.Minor <= 8 {
+	if controllerAgentVersion.Major == 2 && controllerAgentVersion.Minor <= 8 {
 		fullStatus, err := client.Status(nil)
 		if err != nil {
 			return errors.Trace(err)

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -461,7 +461,6 @@ func (s *UpgradeBaseSuite) assertUpgradeTests(c *gc.C, tests []upgradeTest, upgr
 		c.Check(agentVersion, gc.Equals, version.MustParse(test.expectVersion))
 
 		for _, uploaded := range test.expectUploaded {
-			// Substitute latest LTS for placeholder in expected series for uploaded tools
 			vers := version.MustParseBinary(uploaded)
 			s.checkToolsUploaded(c, vers, agentVersion)
 		}
@@ -620,6 +619,40 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent", "-m", "dummy-model")
 	c.Assert(err, gc.ErrorMatches, "--build-agent can only be used with the controller model")
+}
+
+func (s *UpgradeJujuSuite) TestUpgradeOld28Agent(c *gc.C) {
+	s.Reset(c)
+	fakeAPI := &fakeUpgradeJujuAPINoState{
+		name:           "dummy-model",
+		uuid:           "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		controllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+		agentVersion:   "2.8.0",
+	}
+	s.PatchValue(&jujuversion.Current, version.MustParse("2.9.0"))
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
+	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fakeAPI.tools, gc.HasLen, 2)
+	vers := coretesting.CurrentVersion(c)
+	vers.Number = version.MustParse("2.9.0.1")
+	vers.Release = "focal"
+	c.Assert(fakeAPI.tools[1].Version.String(), gc.Equals, vers.String())
+}
+
+func (s *UpgradeJujuSuite) TestUpgradeNewerThan28Agent(c *gc.C) {
+	s.Reset(c)
+	fakeAPI := &fakeUpgradeJujuAPINoState{
+		name:           "dummy-model",
+		uuid:           "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		controllerUUID: "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+		agentVersion:   "2.9.0",
+	}
+	s.PatchValue(&jujuversion.Current, version.MustParse("2.9.1"))
+	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
+	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fakeAPI.tools, gc.HasLen, 1)
 }
 
 func (s *UpgradeJujuSuite) TestFailUploadNoControllerModelPermission(c *gc.C) {
@@ -1078,8 +1111,12 @@ func (a *fakeUpgradeJujuAPI) FindTools(majorVersion, minorVersion int, osType, a
 	}, nil
 }
 
-func (a *fakeUpgradeJujuAPI) UploadTools(r io.ReadSeeker, vers version.Binary) (coretools.List, error) {
-	panic("not implemented")
+func (a *fakeUpgradeJujuAPI) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *fakeUpgradeJujuAPI) Status(patterns []string) (*params.FullStatus, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (a *fakeUpgradeJujuAPI) AbortCurrentUpgrade() error {
@@ -1127,9 +1164,22 @@ func (a *fakeUpgradeJujuAPINoState) FindTools(majorVersion, minorVersion int, os
 	return result, nil
 }
 
-func (a *fakeUpgradeJujuAPINoState) UploadTools(r io.ReadSeeker, vers version.Binary) (coretools.List, error) {
+func (a *fakeUpgradeJujuAPINoState) UploadTools(r io.ReadSeeker, vers version.Binary, additionalSeries ...string) (coretools.List, error) {
 	a.tools = coretools.List{&coretools.Tools{Version: vers}}
+	for _, s := range additionalSeries {
+		v := vers
+		v.Release = s
+		a.tools = append(a.tools, &coretools.Tools{Version: v})
+	}
 	return a.tools, nil
+}
+
+func (a *fakeUpgradeJujuAPINoState) Status(patterns []string) (*params.FullStatus, error) {
+	return &params.FullStatus{
+		Machines: map[string]params.MachineStatus{
+			"0": {Series: "focal"},
+		},
+	}, nil
 }
 
 func (a *fakeUpgradeJujuAPINoState) SetModelAgentVersion(version version.Number, ignoreAgentVersions bool) error {

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -623,6 +623,8 @@ func (s *UpgradeJujuSuite) TestFailUploadOnNonController(c *gc.C) {
 
 func (s *UpgradeJujuSuite) TestUpgradeOld28Agent(c *gc.C) {
 	s.Reset(c)
+	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), true)
+	c.Assert(err, jc.ErrorIsNil)
 	fakeAPI := &fakeUpgradeJujuAPINoState{
 		name:           "dummy-model",
 		uuid:           "deadbeef-0bad-400d-8000-4b1d0d06f00d",
@@ -631,7 +633,7 @@ func (s *UpgradeJujuSuite) TestUpgradeOld28Agent(c *gc.C) {
 	}
 	s.PatchValue(&jujuversion.Current, version.MustParse("2.9.0"))
 	command := s.upgradeJujuCommand(fakeAPI, fakeAPI, fakeAPI, nil)
-	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
+	_, err = cmdtesting.RunCommand(c, command, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(fakeAPI.tools, gc.HasLen, 2)
 	vers := coretesting.CurrentVersion(c)

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -4,7 +4,6 @@
 package series
 
 import (
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -98,25 +97,6 @@ func seriesForTypes(path string, now time.Time, requestedSeries, imageStream str
 	}
 
 	return supported, nil
-}
-
-// OSAllSeries returns the series (supported or not) of the
-// specified OS on which we can run Juju workloads.
-func OSAllSeries(os coreos.OSType) ([]string, error) {
-	var osSeries []string
-	workloadSeries, err := AllWorkloadSeries("", "")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, ser := range workloadSeries.Values() {
-		seriesOS, err := GetOSFromSeries(ser)
-		if err != nil || seriesOS != os {
-			continue
-		}
-		osSeries = append(osSeries, ser)
-	}
-	sort.Strings(osSeries)
-	return osSeries, nil
 }
 
 // GetOSFromSeries will return the operating system based
@@ -469,12 +449,6 @@ type unknownSeriesVersionError string
 
 func (e unknownSeriesVersionError) Error() string {
 	return `unknown version for series: "` + string(e) + `"`
-}
-
-// IsUnknownSeriesVersionError returns true if err is of type unknownSeriesVersionError.
-func IsUnknownSeriesVersionError(err error) bool {
-	_, ok := errors.Cause(err).(unknownSeriesVersionError)
-	return ok
 }
 
 type unknownVersionSeriesError string

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -143,33 +143,6 @@ func (s *SupportedSeriesSuite) TestUnknownOSFromSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown OS for series: "Xuanhuaceratops"`)
 }
 
-func (s *SupportedSeriesSuite) TestOSSupportedSeries(c *gc.C) {
-	tmpFile, close := makeTempFile(c, distroInfoContents)
-	defer close()
-
-	s.PatchValue(&UbuntuDistroInfo, tmpFile.Name())
-	supported, err := OSAllSeries(coreos.Ubuntu)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(supported, jc.SameContents, []string{
-		"artful", "bionic", "cosmic", "disco", "eoan", "focal", "groovy", "hairy",
-		"hirsute", "precise", "quantal", "raring", "saucy", "trusty", "utopic", "vivid",
-		"wily", "xenial", "yakkety", "zesty"})
-	supported, err = OSAllSeries(coreos.Windows)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(supported, jc.SameContents, []string{
-		"win7", "win2016nano", "win10", "win2016", "win8", "win2012r2",
-		"win2012hvr2", "win81", "win2019", "win2012", "win2016hv", "win2012hv", "win2008r2"})
-	supported, err = OSAllSeries(coreos.CentOS)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(supported, jc.SameContents, []string{"centos7", "centos8"})
-	supported, err = OSAllSeries(coreos.OpenSUSE)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(supported, jc.SameContents, []string{"opensuseleap"})
-	supported, err = OSAllSeries(coreos.GenericLinux)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(supported, jc.SameContents, []string{"genericlinux"})
-}
-
 func (s *SupportedSeriesSuite) TestVersionSeriesValid(c *gc.C) {
 	seriesResult, err := VersionSeries("14.04")
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/series/testing.go
+++ b/core/series/testing.go
@@ -54,22 +54,6 @@ func ESMSupportedJujuSeries() []string {
 	return series
 }
 
-// SupportedJujuControllerSeries returns a slice of juju supported series that
-// target a controller (bootstrapping).
-func SupportedJujuControllerSeries() []string {
-	seriesVersionsMutex.Lock()
-	defer seriesVersionsMutex.Unlock()
-	updateSeriesVersionsOnce()
-	var series []string
-	for s, version := range ubuntuSeries {
-		if !version.Supported {
-			continue
-		}
-		series = append(series, string(s))
-	}
-	return series
-}
-
 // SupportedJujuWorkloadSeries returns a slice of juju supported series that
 // target a workload (deploying a charm).
 func SupportedJujuWorkloadSeries() []string {

--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -3,7 +3,7 @@ start_server() {
 
     path=${1}
 
-    python3 -m http.server --directory "${path}" 8000 >"${TEST_DIR}/server.log" 2>&1 &
+    python3 -m http.server --directory "${path}" 8666 >"${TEST_DIR}/server.log" 2>&1 &
     SERVER_PID=$!
 
     echo "${SERVER_PID}" > "${TEST_DIR}/server.pid"

--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -21,7 +21,7 @@ run_simplestream_metadata() {
 
     file="${TEST_DIR}/test-bootstrap-stream.log"
     juju bootstrap "lxd" "${name}" \
-        --config agent-metadata-url="http://${ip_address}:8000/" \
+        --config agent-metadata-url="http://${ip_address}:8666/" \
         --config test-mode=true \
         --agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
     echo "${name}" >> "${TEST_DIR}/jujus"

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -18,7 +18,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	jujuos "github.com/juju/juju/core/os"
-	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -205,10 +204,8 @@ func (s *EnvSuite) TestEnvUbuntu(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.Ubuntu })
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 
-	// As TERM is series-specific we need to make sure all supported versions are covered.
-	supported, err := series.OSAllSeries(jujuos.Ubuntu)
-	c.Assert(err, jc.ErrorIsNil)
-	for _, testSeries := range supported {
+	// TERM is different for trusty.
+	for _, testSeries := range []string{"trusty", "focal"} {
 		s.PatchValue(&osseries.HostSeries, func() (string, error) { return testSeries, nil })
 		ubuntuVars := []string{
 			"APT_LISTCHANGES_FRONTEND=none",
@@ -256,10 +253,8 @@ func (s *EnvSuite) TestEnvCentos(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.CentOS })
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 
-	// As TERM is series-specific we need to make sure all supported versions are covered.
-	supported, err := series.OSAllSeries(jujuos.CentOS)
-	c.Assert(err, jc.ErrorIsNil)
-	for _, testSeries := range supported {
+	// TERM is different for centos7.
+	for _, testSeries := range []string{"centos7", "centos8"} {
 		s.PatchValue(&osseries.HostSeries, func() (string, error) { return testSeries, nil })
 		centosVars := []string{
 			"LANG=C.UTF-8",
@@ -305,10 +300,8 @@ func (s *EnvSuite) TestEnvOpenSUSE(c *gc.C) {
 	s.PatchValue(&jujuos.HostOS, func() jujuos.OSType { return jujuos.OpenSUSE })
 	s.PatchValue(&jujuversion.Current, version.MustParse("1.2.3"))
 
-	// As TERM is series-specific we need to make sure all supported versions are covered.
-	supported, err := series.OSAllSeries(jujuos.OpenSUSE)
-	c.Assert(err, jc.ErrorIsNil)
-	for _, testSeries := range supported {
+	// TERM is different for opensuseleap.
+	for _, testSeries := range []string{"opensuseleap", "opensuse"} {
 		s.PatchValue(&osseries.HostSeries, func() (string, error) { return testSeries, nil })
 		openSUSEVars := []string{
 			"LANG=C.UTF-8",


### PR DESCRIPTION
Juju 2.8 or earlier agents still look for series based agent metadata.
Restore some deleted "additional series" functionality and add a version check so that if the agent being upgraded is 2.8 or earlier, supply the extra upload tools args to cause the tools to be cloned for those series.

Also delete some unused code from core/series and refactor a couple of tests to allow more code deletion.

## QA steps

bootstrap a 2.8 bionic controller
add a focal machine
juju upgrade-controller --build-agent

check the upgrade completes
juju dump-db on controller model and check the toolsMetadata collection has info for focal and bionic

./main.sh upgrade

