### PR TITLE
Add architecuture to url for UploadCharm during migration.

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -76,6 +76,7 @@ func (c *Client) Activate(modelUUID string) error {
 func (c *Client) UploadCharm(modelUUID string, curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
 	args := url.Values{}
 	args.Add("schema", curl.Schema)
+	args.Add("arch", curl.Architecture)
 	args.Add("user", curl.User)
 	args.Add("series", curl.Series)
 	args.Add("revision", strconv.Itoa(curl.Revision))
@@ -87,11 +88,11 @@ func (c *Client) UploadCharm(modelUUID string, curl *charm.URL, content io.ReadS
 		return nil, errors.Trace(err)
 	}
 
-	curl, err := charm.ParseURL(resp.CharmURL)
+	respCurl, err := charm.ParseURL(resp.CharmURL)
 	if err != nil {
 		return nil, errors.Annotatef(err, "bad charm URL in response")
 	}
-	return curl, nil
+	return respCurl, nil
 }
 
 // UploadTools uploads tools at the specified location to the API server over HTTPS

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -189,7 +189,25 @@ func (s *ClientSuite) TestUploadCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outCurl, gc.DeepEquals, curl)
 	c.Assert(doer.method, gc.Equals, "POST")
-	c.Assert(doer.url, gc.Equals, "/migrate/charms?revision=2&schema=cs&series=&user=user")
+	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=&revision=2&schema=cs&series=&user=user")
+	c.Assert(doer.body, gc.Equals, charmBody)
+}
+
+func (s *ClientSuite) TestUploadCharmHubCharm(c *gc.C) {
+	const charmBody = "charming"
+	curl := charm.MustParseURL("ch:s390x/bionic/juju-qa-test-15")
+	doer := newFakeDoer(c, params.CharmsResponse{
+		CharmURL: curl.String(),
+	})
+	caller := &fakeHTTPCaller{
+		httpClient: &httprequest.Client{Doer: doer},
+	}
+	client := migrationtarget.NewClient(caller)
+	outCurl, err := client.UploadCharm("uuid", curl, strings.NewReader(charmBody))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(outCurl, gc.DeepEquals, curl)
+	c.Assert(doer.method, gc.Equals, "POST")
+	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=s390x&revision=15&schema=ch&series=bionic&user=")
 	c.Assert(doer.body, gc.Equals, charmBody)
 }
 

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -247,10 +247,11 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 
 	// We got it, now let's reserve a charm URL for it in state.
 	curl := &charm.URL{
-		Schema:   schema,
-		Name:     archive.Meta().Name,
-		Revision: archive.Revision(),
-		Series:   series,
+		Schema:       schema,
+		Architecture: query.Get("arch"),
+		Name:         archive.Meta().Name,
+		Revision:     archive.Revision(),
+		Series:       series,
 	}
 	switch charm.Schema(schema) {
 	case charm.Local:


### PR DESCRIPTION

charmhub urls are more complex than charmstore or local ones.  When requesting to upload a charm during migration, include the architecture to ensure that the correct charm is found and the correct charm url is returned for verification.

## QA steps

```console
# 
# Test 2.9 to 2.9 migration
# 
$ juju bootstrap localhost to
$ juju bootstrap localhost from
$ juju add-model move-me
$ juju deploy cs:ubuntu
$ juju deploy juju-qa-test

# migrate the model
$ juju migrate move-me to

# verify model in working order 
$ juju switch to:move-me
$ juju add-unit ubuntu
$ juju add-unit juju-qa-test

# 
# Test 2.8 to 2.9 migration
# 
$ juju bootstrap localhost to
$ juju-2.8 bootstrap localhost from
$ juju-2.8 add-model move-me
$ juju-2.8 deploy cs:ubuntu

# migrate the model
$ juju migrate move-me to

# verify model in working order 
$ juju switch to:move-me
$ juju add-unit ubuntu
$ juju add-unit juju-qa-test

# 
# the units added above will fail as work is on going with #12790 continuations.
# ERROR juju.worker.dependency "unit-agent-deployer" manifold worker returned unexpected error: cannot read agent 
# metadata in directory /var/lib/juju/tools/2.8.9-bionic-amd64: open 
# /var/lib/juju/tools/2.8.9-bionic-amd64/downloaded-tools.txt: no such file or directory
```

## Bug reference

Found during QA of #12790: migration failed with:

migrating: aborted, removing model from target controller: model data transfer failed, failed to migrate binaries: charm ch:amd64/focal/ubuntu-19 unexpectedly assigned ch:focal/ubuntu-19
