### PR TITLE
Allow setting of VM hardware version

### DIFF
--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -23,10 +23,11 @@ func fakeConfig(c *gc.C, attrs ...testing.Attrs) *config.Config {
 
 func fakeConfigAttrs(attrs ...testing.Attrs) testing.Attrs {
 	merged := testing.FakeConfig().Merge(testing.Attrs{
-		"type":             "vsphere",
-		"uuid":             "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
-		"external-network": "",
-		"enable-disk-uuid": true,
+		"type":                      "vsphere",
+		"uuid":                      "2d02eeac-9dbb-11e4-89d3-123b93f75cba",
+		"external-network":          "",
+		"enable-disk-uuid":          true,
+		"force-vm-hardware-version": 0,
 	})
 	for _, attrs := range attrs {
 		merged = merged.Merge(attrs)

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -229,6 +229,7 @@ func (env *sessionEnviron) newRawInstance(
 		UpdateProgressInterval: updateProgressInterval,
 		Clock:                  clock.WallClock,
 		EnableDiskUUID:         env.ecfg.enableDiskUUID(),
+		ForceVMHardwareVersion: env.ecfg.forceVMHardwareVersion(),
 		IsBootstrap:            args.InstanceConfig.Bootstrap != nil,
 	}
 

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -614,9 +614,7 @@ func (c *Client) maybeUpgradeVMHardware(
 	}
 
 	if vmVersion > args.ForceVMHardwareVersion {
-		// Not downgrading VM.
-		c.logger.Warningf("selected HW version is lower than VM hardware. Not downgrading.")
-		return nil
+		return errors.Errorf("selected HW (%d) version is lower than VM hardware", args.ForceVMHardwareVersion)
 	}
 
 	supportedMaxVersion, err := c.getMaxSuportedVersion(ctx, args.ComputeResource)
@@ -626,8 +624,8 @@ func (c *Client) maybeUpgradeVMHardware(
 	if supportedMaxVersion < args.ForceVMHardwareVersion {
 		// Requested HW version is newer than what the destination supports
 		// Not upgrading VM hardware.
-		c.logger.Warningf("target does not support selected hardware version: %d", args.ForceVMHardwareVersion)
-		return nil
+		return errors.Errorf(
+			"hardware version %d not supported by target (max version %d)", args.ForceVMHardwareVersion, supportedMaxVersion)
 	}
 
 	version := fmt.Sprintf("vmx-%d", args.ForceVMHardwareVersion)

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -550,7 +550,7 @@ func (c *Client) getMaxSuportedVersion(ctx context.Context, cr *mo.ComputeResour
 	}
 	opt, err := methods.QueryConfigOption(ctx, c.client, &req)
 	if err != nil {
-		return 0, err
+		return 0, errors.Trace(err)
 	}
 
 	if opt.Returnval == nil {
@@ -571,7 +571,7 @@ func (c *Client) getVMHardwareVersion(ctx context.Context, srcVM *object.Virtual
 	var templateVM mo.VirtualMachine
 	err := srcVM.Properties(ctx, srcVM.Reference(), []string{"config.version"}, &templateVM)
 	if err != nil {
-		return 0, err
+		return 0, errors.Trace(err)
 	}
 
 	if templateVM.Config == nil {
@@ -587,7 +587,7 @@ func (c *Client) getVMHardwareVersion(ctx context.Context, srcVM *object.Virtual
 func (c *Client) parseVMXVersion(version string) (int64, error) {
 	fields := strings.Split(version, "-")
 	if len(fields) != 2 {
-		return 0, fmt.Errorf("invalid VMX version: %s", version)
+		return 0, errors.Errorf("invalid VMX version: %s", version)
 	}
 
 	parsed, err := strconv.ParseInt(fields[1], 10, 64)

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -292,6 +293,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 			PropSet: []types.DynamicProperty{
 				{Name: "name", Val: "juju-vm-0"},
 				{Name: "runtime.powerState", Val: "poweredOff"},
+				{Name: "config.version", Val: "vmx-10"},
 				{
 					Name: "config.hardware.device",
 					Val: []types.BaseVirtualDevice{
@@ -384,6 +386,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 			PropSet: []types.DynamicProperty{
 				{Name: "name", Val: "juju-vm-1"},
 				{Name: "runtime.powerState", Val: "poweredOn"},
+				{Name: "config.version", Val: "vmx-10"},
 				{
 					Name: "config.hardware.device",
 					Val: []types.BaseVirtualDevice{
@@ -416,6 +419,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 			PropSet: []types.DynamicProperty{
 				{Name: "name", Val: "juju-vm-template"},
 				{Name: "runtime.powerState", Val: "poweredOff"},
+				{Name: "config.version", Val: "vmx-10"},
 				{
 					Name: "config.hardware.device",
 					Val: []types.BaseVirtualDevice{
@@ -808,6 +812,147 @@ func (s *clientSuite) TestRemoveVirtualMachinesDestroyRace(c *gc.C) {
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	err := client.RemoveVirtualMachines(context.Background(), "foo/bar/*")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *clientSuite) TestMaybeUpgradeVMVersionNotSet(c *gc.C) {
+	args := CreateVirtualMachineParams{
+		ForceVMHardwareVersion: 0,
+	}
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	var vm mo.VirtualMachine
+	vm.Self = types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: "FakeVm0",
+	}
+
+	vmObj := object.NewVirtualMachine(client.client.Client, vm.Reference())
+	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// No calls should be made. ForceVMHardwareVersion was not set.
+	s.roundTripper.CheckCalls(c, []testing.StubCall{})
+}
+
+func (s *clientSuite) TestMaybeUpgradeVMVersionLowerThanSourceVM(c *gc.C) {
+	args := CreateVirtualMachineParams{
+		ForceVMHardwareVersion: 9,
+	}
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	var vm mo.VirtualMachine
+	vm.Self = types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: "FakeVm0",
+	}
+
+	vmObj := object.NewVirtualMachine(client.client.Client, vm.Reference())
+	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// ForceVMHardwareVersion was set, but is lower than the VM version (vmx-10).
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeVm0"),
+	})
+}
+
+func (s *clientSuite) TestMaybeUpgradeVMVersionNotSupportedByEnv(c *gc.C) {
+	// Version is mocked at vmx-13. Set a version larger than what env supports.
+	args := CreateVirtualMachineParams{
+		ForceVMHardwareVersion: 14,
+		ComputeResource: &mo.ComputeResource{
+			EnvironmentBrowser: &types.ManagedObjectReference{
+				Type:  "EnvironmentBrowser",
+				Value: "FakeEnvironmentBrowser",
+			},
+		},
+	}
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	var vm mo.VirtualMachine
+	vm.Self = types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: "FakeVm0",
+	}
+
+	vmObj := object.NewVirtualMachine(client.client.Client, vm.Reference())
+	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{})
+
+	// We ignore the request and log the event.
+	c.Assert(err, jc.ErrorIsNil)
+
+	// No calls should be made. ForceVMHardwareVersion was not set.
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		// Gets VM version
+		retrievePropertiesStubCall("FakeVm0"),
+		// Gets environment max version.
+		{
+			FuncName: "QueryConfigOption",
+			Args: []interface{}{
+				"FakeEnvironmentBrowser",
+			},
+		},
+	})
+}
+
+func (s *clientSuite) TestMaybeUpgradeVMVersion(c *gc.C) {
+	// Version is mocked at vmx-13. Set a version larger than what env supports.
+	args := CreateVirtualMachineParams{
+		// set the version to 11. This should prompt the upgrade.
+		ForceVMHardwareVersion: 11,
+		ComputeResource: &mo.ComputeResource{
+			EnvironmentBrowser: &types.ManagedObjectReference{
+				Type:  "EnvironmentBrowser",
+				Value: "FakeEnvironmentBrowser",
+			},
+		},
+		Clock:                  testclock.NewClock(time.Time{}),
+		UpdateProgress:         func(status string) {},
+		UpdateProgressInterval: time.Second,
+	}
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	var vm mo.VirtualMachine
+	vm.Self = types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: "FakeVm0",
+	}
+
+	vmObj := object.NewVirtualMachine(client.client.Client, vm.Reference())
+	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{
+		clock:                  args.Clock,
+		updateProgress:         args.UpdateProgress,
+		updateProgressInterval: args.UpdateProgressInterval,
+	})
+
+	// We ignore the request and log the event.
+	c.Assert(err, jc.ErrorIsNil)
+
+	// No calls should be made. ForceVMHardwareVersion was not set.
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeVm0"),
+		{
+			FuncName: "QueryConfigOption",
+			Args: []interface{}{
+				"FakeEnvironmentBrowser",
+			},
+		},
+		{
+			FuncName: "UpgradeVM_Task",
+			Args: []interface{}{
+				// must match the version we set in the model, if supported.
+				"vmx-11",
+			},
+		},
+		{
+			FuncName: "CreatePropertyCollector",
+			Args:     nil,
+		},
+		{
+			FuncName: "CreateFilter",
+			Args:     nil,
+		},
+		{
+			FuncName: "WaitForUpdatesEx",
+			Args:     nil,
+		},
+	})
 }
 
 func (s *clientSuite) TestUpdateVirtualMachineExtraConfig(c *gc.C) {

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -846,7 +846,7 @@ func (s *clientSuite) TestMaybeUpgradeVMVersionLowerThanSourceVM(c *gc.C) {
 
 	vmObj := object.NewVirtualMachine(client.client.Client, vm.Reference())
 	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{})
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, `selected HW \(9\) version is lower than VM hardware`)
 
 	// ForceVMHardwareVersion was set, but is lower than the VM version (vmx-10).
 	s.roundTripper.CheckCalls(c, []testing.StubCall{
@@ -876,7 +876,7 @@ func (s *clientSuite) TestMaybeUpgradeVMVersionNotSupportedByEnv(c *gc.C) {
 	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{})
 
 	// We ignore the request and log the event.
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.ErrorMatches, `hardware version 14 not supported by target \(max version 13\)`)
 
 	// No calls should be made. ForceVMHardwareVersion was not set.
 	s.roundTripper.CheckCalls(c, []testing.StubCall{

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -358,6 +358,7 @@ func (c *Client) CreateVirtualMachine(
 	}()
 
 	if err := c.maybeUpgradeVMHardware(ctx, args, vm, taskWaiter); err != nil {
+		args.UpdateProgress(fmt.Sprintf("VM upgrade failed: %s", err))
 		return nil, errors.Annotate(err, "upgrading VM hardware")
 	}
 

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -84,6 +84,11 @@ type CreateVirtualMachineParams struct {
 	// to create the VM.
 	ComputeResource *mo.ComputeResource
 
+	// ForceVMHardwareVersion if set, will attempt to upgrade the VM to the
+	// specified hardware version. If not supported by the deployment of VSphere,
+	// this option will be ignored.
+	ForceVMHardwareVersion int64
+
 	// ResourcePool is a reference to the pool the VM should be
 	// created in.
 	ResourcePool types.ManagedObjectReference
@@ -351,6 +356,10 @@ func (c *Client) CreateVirtualMachine(
 			c.logger.Warningf("cleaning up cloned VM %q failed: %s", vm.InventoryPath, err)
 		}
 	}()
+
+	if err := c.maybeUpgradeVMHardware(ctx, args, vm, taskWaiter); err != nil {
+		return nil, errors.Annotate(err, "upgrading VM hardware")
+	}
 
 	if args.Constraints.RootDisk != nil {
 		// The user specified a root disk, so extend the VM's

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -287,7 +287,23 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 				}},
 			}},
 		}
-
+	case *methods.QueryConfigOptionBody:
+		req := req.(*methods.QueryConfigOptionBody).Req
+		r.MethodCall(r, "QueryConfigOption", req.This.Value)
+		res.Res = &types.QueryConfigOptionResponse{
+			Returnval: &types.VirtualMachineConfigOption{
+				Version: "vmx-13",
+			},
+		}
+	case *methods.UpgradeVM_TaskBody:
+		req := req.(*methods.UpgradeVM_TaskBody).Req
+		r.MethodCall(r, "UpgradeVM_Task", req.Version)
+		res.Res = &types.UpgradeVM_TaskResponse{
+			Returnval: types.ManagedObjectReference{
+				Type:  "Task",
+				Value: "UpgradeVM_Task",
+			},
+		}
 	default:
 		logger.Debugf("mockRoundTripper: unknown res type %T", res)
 		panic(fmt.Sprintf("unknown type %T", res))


### PR DESCRIPTION
This change adds a new model level flag, that allows operators to
set a newer compatibility version for the instances that get spawned
by juju.

The version set via model config must be of equal or higher version
than that of the source template, and it must be supported by the
remote compute resource it will be spawned on. Attempting to set a
version that does not conform to the mentioned rules, will be ignored,
and the VM will use the same HW compatibility version as the source
template.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
juju model-config force-vm-hardware-version=12
juju add-machine
```
Check if the VM compatibility version is set to 12 in your vsphere deployment, for the newly spawned VM.

## Documentation changes

No changes required to CLI or API. This change adds a single model config option.
