### PR TITLE
Use charm-base as the repository for charm oci base images.

### DIFF
--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -100,10 +100,10 @@ func ImageForBase(imageRepo string, base systems.Base) (string, error) {
 	if len(base.Channel.Track) == 0 || len(base.Channel.Risk) == 0 {
 		return "", errors.NotValidf("channel %q", base.Channel)
 	}
-	tag := base.Channel.Track
+	tag := fmt.Sprintf("%s-%s", base.Name, base.Channel.Track)
 	if base.Channel.Risk != channel.Stable {
 		tag = fmt.Sprintf("%s-%s", tag, base.Channel.Risk)
 	}
-	image := fmt.Sprintf("%s/%s:%s", imageRepo, base.Name, tag)
+	image := fmt.Sprintf("%s/charm-base:%s", imageRepo, tag)
 	return image, nil
 }

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -50,11 +50,11 @@ func (*imageSuite) TestImageForBase(c *gc.C) {
 		Track: "20.04", Risk: channel.Stable,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.DeepEquals, `jujusolutions/ubuntu:20.04`)
+	c.Assert(path, gc.DeepEquals, `jujusolutions/charm-base:ubuntu-20.04`)
 
 	path, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
 		Track: "20.04", Risk: channel.Edge,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.DeepEquals, `jujusolutions/ubuntu:20.04-edge`)
+	c.Assert(path, gc.DeepEquals, `jujusolutions/charm-base:ubuntu-20.04-edge`)
 }

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -143,7 +143,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 			mc.AddExpr(`_.Charm`, gc.NotNil)
 			c.Check(config, mc, caas.ApplicationConfig{
 				CharmBaseImage: resources.DockerImageDetails{
-					RegistryPath: "jujusolutions/ubuntu:20.04",
+					RegistryPath: "jujusolutions/charm-base:ubuntu-20.04",
 				},
 				Containers: map[string]caas.ContainerConfig{
 					"test": {


### PR DESCRIPTION
Uses jujusolutions/charm-base:ubuntu-20.04-edge as the format for the charm base oci image path.

## QA steps

Run unit tests, test deploying sidecar charm.

## Documentation changes

N/A

## Bug reference

N/A
