### PR TITLE
Fix agent lookup on upgraded 2.8 controllers

### DIFF
--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -72,7 +72,7 @@ def assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client):
             stable_client, base_dir, 'released')
         setup_agent_metadata(
             stream_server, args.devel_juju_agent,
-            devel_client, base_dir, 'released')
+            devel_client, base_dir, 'develop')
         with stream_server.server() as url:
             stable_client.env.update_config({
                 'agent-metadata-url': url,
@@ -172,12 +172,6 @@ def setup_agent_metadata(
     else:
         agent_details = agent
 
-    stream_server.add_product(
-        stream,
-        version_parts.version,
-        version_parts.arch,
-        agent_details)
-    # Trusty needed for wikimedia charm.
     stream_server.add_product(
         stream,
         version_parts.version,

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -208,7 +208,7 @@ def agent_tgz_from_juju_binary(
     return tgz_path
 
 
-def _generate_product_json(content_id, version, arch, series, agent_tgz_path):
+def _generate_product_json(content_id, version, arch, agent_tgz_path):
     """Return dict containing product metadata from provided args."""
     tgz_name = os.path.basename(agent_tgz_path)
     file_details = _get_tgz_file_details(agent_tgz_path)
@@ -231,21 +231,6 @@ def _generate_product_json(content_id, version, arch, series, agent_tgz_path):
         version=version,
         version_name=datetime.utcnow().strftime('%Y%m%d')
     )
-
-
-def _get_series_details(series):
-    # Ubuntu agents use series and a code (i.e. trusty:14.04), others don't.
-    _series_lookup = dict(
-        trusty=14.04,
-        xenial=16.04,
-        artful=17.10,
-        bionic=18.04,
-    )
-    try:
-        series_code = _series_lookup[series]
-    except KeyError:
-        return series, series
-    return series, series_code
 
 
 def _get_tgz_file_details(agent_tgz_path):

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -385,6 +385,24 @@ func (s *toolsSuite) TestDownloadModelUUIDPath(c *gc.C) {
 	s.testDownload(c, tools, s.State.ModelUUID())
 }
 
+// TODO(juju4) - remove
+func (s *toolsSuite) TestDownloadOldAgent(c *gc.C) {
+	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
+		Version: "2.8.9-focal-amd64",
+		Size:    3,
+		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	})
+	resp := s.downloadRequest(c, version.MustParseBinary("2.8.9-ubuntu-amd64"), s.State.ModelUUID())
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.HasLen, int(tools.Size))
+
+	hash := sha256.New()
+	hash.Write(data)
+	c.Assert(fmt.Sprintf("%x", hash.Sum(nil)), gc.Equals, tools.SHA256)
+}
+
 func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 	newSt := s.Factory.MakeModel(c, nil)
 	defer newSt.Close()

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -898,6 +898,7 @@ func (context *upgradeContext) uploadTools(
 	// Newer 2.9+ controllers can deal with this but not older controllers.
 	// Look at the model and get all series for all machines
 	// and use those to create additional tools.
+	// TODO(juju4) - remove this logic
 	additionalSeries := set.NewStrings()
 	if controllerAgentVersion.Major == 2 && controllerAgentVersion.Minor <= 8 {
 		fullStatus, err := client.Status(nil)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -721,11 +721,8 @@ func (i *importer) makeTools(t description.AgentTools) (*tools.Tools, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	for _, ser := range allSeries.SortedValues() {
-		if result.Version.Release == ser {
-			result.Version.Release = coreseries.DefaultOSTypeNameFromSeries(ser)
-			break
-		}
+	if allSeries.Contains(result.Version.Release) {
+		result.Version.Release = coreseries.DefaultOSTypeNameFromSeries(result.Version.Release)
 	}
 	return result, nil
 }


### PR DESCRIPTION
When upgrading a 2.8 controller to 2.9, existing 2.8 models on that controller would try to ask for agents with version `2.8.9-ubuntu-amd64`. However, Juju only knows about series agents for 2.8. So in the metadata lookup and agent binary download, a compatibility step is added to look for any agent with a matching series and use that.

## QA steps

On 2.8.9
juju bootstrap
juju switch default
juju add-machine --series=bionic

WIth 2.9 client
juju upgrade-controller --build-agent
juju add-machine --series=xenial
^^^^ this would fail previously
check the machine gets provisioned and is shown as started
