### PR TITLE
[2.9] Ensure openstack unit tests pass on non amd64 hosts

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -513,7 +513,7 @@ func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	env := s.ensureAMDImages(c)
 	err := bootstrapEnv(c, env)
 	c.Assert(err, jc.ErrorIsNil)
-	_, hc := testing.AssertStartInstanceWithConstraints(c, env, s.callCtx, s.ControllerUUID, "100", constraints.MustParse("mem=1024"))
+	_, hc := testing.AssertStartInstanceWithConstraints(c, env, s.callCtx, s.ControllerUUID, "100", constraints.MustParse("mem=1024 arch=amd64"))
 	c.Check(*hc.Arch, gc.Equals, "amd64")
 	c.Check(*hc.Mem, gc.Equals, uint64(2048))
 	c.Check(*hc.CpuCores, gc.Equals, uint64(1))
@@ -2988,10 +2988,10 @@ func (s *localServerSuite) ensureAMDImages(c *gc.C) environs.Environ {
 		Number: jujuversion.Current,
 		Arch:   arch.AMD64,
 	}
-	workloadSeries, err := series.WorkloadSeries(time.Now(), "", "")
+	workloadOSList, err := series.AllWorkloadOSTypes("", "")
 	c.Assert(err, jc.ErrorIsNil)
-	for _, supSeries := range workloadSeries.Values() {
-		amd64Version.Release = supSeries
+	for _, workloadOS := range workloadOSList.Values() {
+		amd64Version.Release = workloadOS
 		envtesting.AssertUploadFakeToolsVersions(
 			c, s.toolsMetadataStorage, s.env.Config().AgentStream(), s.env.Config().AgentStream(), amd64Version)
 	}


### PR DESCRIPTION
This PR fixes two issues with the openstack unit tests:
- The `ensureAMDImages` method used by several tests in the localServerSuite used to iterate the supported series when uploading fake tool binaries. Since 2.9, tool binaries include the OS instead of the series thus causing the fake tool upload step to fail due to validation errors. It has been updated to use OS instead of series.
- When no bootstrap constraint is specified, juju uses the arch of the host running the client. As a result, the expectation in TestStartInstanceHardwareCharacteristics (as written, the test seems to be meant to test that an amd64 instance would be spinned up) would fail on non-amd64 machines. This was easily fixed by specifying an arch constraint

## QA steps

```console
# Run the openstack unit tests on a non-amd64 box
$ cd provider/openstack
$ go test
```