### PR TITLE
Fix CI upgrade tests and non amd64 unit tests

### DIFF
--- a/acceptancetests/assess_upgrade.py
+++ b/acceptancetests/assess_upgrade.py
@@ -72,7 +72,7 @@ def assess_upgrade_from_stable_to_develop(args, stable_bsm, devel_client):
             stable_client, base_dir, 'released')
         setup_agent_metadata(
             stream_server, args.devel_juju_agent,
-            devel_client, base_dir, 'develop')
+            devel_client, base_dir, 'devel')
         with stream_server.server() as url:
             stable_client.env.update_config({
                 'agent-metadata-url': url,
@@ -177,6 +177,19 @@ def setup_agent_metadata(
         version_parts.version,
         version_parts.arch,
         agent_details)
+
+    try:
+        major, minor, patch = version_parts.version.split('.')
+    except ValueError:
+        major, minor_patch = version_parts.version.split('.')
+        minor, patch = minor_patch.split('-')
+    if int(major) == 2 and int(minor) <= 9:
+        stream_server.add_product(
+            stream,
+            version_parts.version,
+            version_parts.arch,
+            agent_details,
+            client.env.get_option('default-series'))
 
 
 def get_version_parts(version_string):

--- a/acceptancetests/jujupy/stream_server.py
+++ b/acceptancetests/jujupy/stream_server.py
@@ -65,7 +65,7 @@ class _JujuStreamData:
 
         os.makedirs(self._agent_path)
 
-    def add_product(self, content_id, version, arch, agent_tgz_path):
+    def add_product(self, content_id, version, arch, agent_tgz_path, series=None):
         """Add a new product to generate stream data for.
 
         :param content_id: String ID (e.g.'proposed', 'release')
@@ -74,10 +74,12 @@ class _JujuStreamData:
         :param agent_tgz_path: String full path to agent tarball file to use.
           This file is copied into the JujuStreamData working dir to be served
           up at a later date.
+        :param series: Series string that appears in item_name
+          (e.g. 'bionic', 'xenial', 'centos')
         """
         shutil.copy(agent_tgz_path, self._agent_path)
         product_dict = _generate_product_json(
-            content_id, version, arch, agent_tgz_path)
+            content_id, version, arch, agent_tgz_path, series)
         self.products.append(product_dict)
 
     def generate_stream_data(self):
@@ -106,7 +108,7 @@ class StreamServer:
         self.base_dir = base_dir
         self.stream_data = stream_data_type(base_dir)
 
-    def add_product(self, content_id, version, arch, agent_tgz_path):
+    def add_product(self, content_id, version, arch, agent_tgz_path, series=None):
         """Add a new product to generate stream data for.
 
         :param content_id: String ID (e.g.'proposed', 'released')
@@ -115,9 +117,11 @@ class StreamServer:
         :param agent_tgz_path: String full path to agent tarball file to use.
           This file is copied into the JujuStreamData working dir to be served
           up at a later date.
+        :param series: Series string that appears in item_name
+          (e.g. 'bionic', 'xenial', 'centos')
         """
         self.stream_data.add_product(
-            content_id, version, arch, agent_tgz_path)
+            content_id, version, arch, agent_tgz_path, series)
         # Re-generate when adding a product allows updating the server while
         # running.
         # Can be noisey in the logs, if a lot of products need to be added can
@@ -208,29 +212,54 @@ def agent_tgz_from_juju_binary(
     return tgz_path
 
 
-def _generate_product_json(content_id, version, arch, agent_tgz_path):
+def _generate_product_json(content_id, version, arch, agent_tgz_path, series=None):
     """Return dict containing product metadata from provided args."""
     tgz_name = os.path.basename(agent_tgz_path)
     file_details = _get_tgz_file_details(agent_tgz_path)
-    item_name = '{version}-ubuntu-{arch}'.format(
+    index_part = 'agents'
+    product_part = 'ubuntu'
+    release = 'ubuntu'
+    # If series is supplied we need to generate old style metadata.
+    if series is not None:
+        release = series
+        product_part = _get_series_code(series)
+        index_part = 'tools'
+    item_name = '{version}-{release}-{arch}'.format(
         version=version,
+        release=release,
         arch=arch)
     return dict(
         arch=arch,
-        content_id='com.ubuntu.juju:{}:agents'.format(content_id),
+        content_id='com.ubuntu.juju:{}:{}'.format(content_id, index_part),
         format='products:1.0',
         ftype='tar.gz',
         item_name=item_name,
         md5=file_details['md5'],
         path=os.path.join('agent', tgz_name),
-        product_name='com.ubuntu.juju:ubuntu:{arch}'.format(
+        product_name='com.ubuntu.juju:{product_part}:{arch}'.format(
+            product_part=product_part,
             arch=arch),
-        release='ubuntu',
+        release=release,
         sha256=file_details['sha256'],
         size=file_details['size'],
         version=version,
         version_name=datetime.utcnow().strftime('%Y%m%d')
     )
+
+
+def _get_series_code(series):
+    # Ubuntu agents use series and a code (i.e. trusty:14.04), others don't.
+    _series_lookup = dict(
+        trusty=14.04,
+        xenial=16.04,
+        bionic=18.04,
+        focal=20.04,
+    )
+    try:
+        series_code = _series_lookup[series]
+    except KeyError:
+        return series
+    return series_code
 
 
 def _get_tgz_file_details(agent_tgz_path):

--- a/api/agent/machine_test.go
+++ b/api/agent/machine_test.go
@@ -167,7 +167,7 @@ func (s *machineSuite) TestEntitySetPassword(c *gc.C) {
 	// Check that we cannot log in to mongo with the correct password.
 	// This is because there's no mongo password set for s.machine,
 	// which has JobHostUnits
-	info := s.MongoInfo(c)
+	info := s.MongoInfo()
 	// TODO(dfc) this entity.Tag should return a Tag
 	tag, err := names.ParseTag(entity.Tag())
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1106,7 +1106,7 @@ func (api *APIBase) setConfig(app Application, generation, settingsYAML string, 
 	return nil
 }
 
-// UpdateApplicationSeries updates the application series. Release for
+// UpdateApplicationSeries updates the application series. Series for
 // subordinates updated too.
 func (api *APIBase) UpdateApplicationSeries(args params.UpdateSeriesArgs) (params.ErrorResults, error) {
 	if err := api.checkCanWrite(); err != nil {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2388,7 +2388,7 @@
                             "$ref": "#/definitions/ErrorResults"
                         }
                     },
-                    "description": "UpdateApplicationSeries updates the application series. Release for\nsubordinates updated too."
+                    "description": "UpdateApplicationSeries updates the application series. Series for\nsubordinates updated too."
                 }
             },
             "definitions": {

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -135,7 +135,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tools1, gc.DeepEquals, agentTools)
 
-	stateInfo := s.MongoInfo(c)
+	stateInfo := s.MongoInfo()
 	apiInfo := s.APIInfo(c)
 	paths := agent.DefaultPaths
 	paths.DataDir = s.DataDir()
@@ -198,7 +198,7 @@ func (s *AgentSuite) WriteStateAgentConfig(
 	vers version.Binary,
 	modelTag names.ModelTag,
 ) agent.ConfigSetterWriter {
-	stateInfo := s.MongoInfo(c)
+	stateInfo := s.MongoInfo()
 	apiPort := gitjujutesting.FindTCPPort()
 	s.SetControllerConfigAPIPort(c, apiPort)
 	apiAddr := []string{fmt.Sprintf("localhost:%d", apiPort)}


### PR DESCRIPTION
The CI upgrade tests have been fixed to generate the necessary series based metadata so 2.8 can be upgraded.

Also fix some unit tests on non amd64.

And fix a s/Series/Release typo.

And some lint cleanup.

## QA steps

`./assess --substrate lxd upgrade --stable-juju-bin /snap/juju/current/bin/juju`

