### PR TITLE
Add support for mem, cpu and arch to k8s.

### DIFF
--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -12,7 +12,6 @@ var unsupportedConstraints = []string{
 	constraints.Cores,
 	constraints.VirtType,
 	constraints.Container,
-	constraints.Arch,
 	constraints.InstanceType,
 	constraints.Spaces,
 	constraints.AllocatePublicIP,

--- a/caas/kubernetes/provider/constraints_test.go
+++ b/caas/kubernetes/provider/constraints_test.go
@@ -78,7 +78,6 @@ func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	expected := []string{
 		"cores",
 		"virt-type",
-		"arch",
 		"instance-type",
 		"spaces",
 		"container",

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -6425,6 +6425,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		Name:      "database-appuuid",
 		MountPath: "path/to/here",
 	})
+	podSpec.NodeSelector = map[string]string{
+		"kubernetes.io/arch": "amd64",
+	}
 	for i := range podSpec.Containers {
 		podSpec.Containers[i].Resources = core.ResourceRequirements{
 			Limits: core.ResourceList{
@@ -6478,7 +6481,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
-		Constraints: constraints.MustParse("mem=64 cpu-power=500"),
+		Constraints: constraints.MustParse("mem=64 cpu-power=500 arch=amd64"),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",


### PR DESCRIPTION
Adds support for arch constraint support to kubernetes and cpu/mem requests to kubernetes sidecar charms.

## QA steps

Deploy charm to k8s (both sidecar & legacy) with `--constraints="arch=amd64 cpu-power=100 mem=1G"`
Check Pod yaml applied to k8s.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1919975
