### PR TITLE
Remove InterfaceInfo.CIDR; use Address.CIDR instead

### DIFF
--- a/api/instancepoller/machine_test.go
+++ b/api/instancepoller/machine_test.go
@@ -228,9 +228,8 @@ func (s *MachineSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 func (s *MachineSuite) TestSetProviderNetworkConfigSuccess(c *gc.C) {
 	cfg := network.InterfaceInfos{{
 		DeviceIndex: 0,
-		CIDR:        "10.0.0.0/24",
 		Addresses: []network.ProviderAddress{
-			network.NewProviderAddress("10.0.0.42"),
+			network.NewProviderAddress("10.0.0.42", network.WithCIDR("10.0.0.0/24")),
 		},
 	}}
 	expectArgs := params.SetProviderNetworkConfig{

--- a/api/provisioner/provisioner.go
+++ b/api/provisioner/provisioner.go
@@ -251,44 +251,8 @@ func (st *State) PrepareContainerInterfaceInfo(containerTag names.MachineTag) (c
 	if err := result.Results[0].Error; err != nil {
 		return nil, err
 	}
-	machineConf := result.Results[0]
-	ifaceInfo := make(corenetwork.InterfaceInfos, len(machineConf.Config))
-	for i, cfg := range machineConf.Config {
-		routes := make([]corenetwork.Route, len(cfg.Routes))
-		for j, route := range cfg.Routes {
-			routes[j] = corenetwork.Route{
-				DestinationCIDR: route.DestinationCIDR,
-				GatewayIP:       route.GatewayIP,
-				Metric:          route.Metric,
-			}
-		}
-		// TODO(achilleasa): do we need to define interfaces for the
-		// non-primary private addresses (if present)?
-		ifaceInfo[i] = corenetwork.InterfaceInfo{
-			DeviceIndex:         cfg.DeviceIndex,
-			MACAddress:          cfg.MACAddress,
-			CIDR:                cfg.CIDR,
-			MTU:                 cfg.MTU,
-			ProviderId:          corenetwork.Id(cfg.ProviderId),
-			ProviderSubnetId:    corenetwork.Id(cfg.ProviderSubnetId),
-			ProviderSpaceId:     corenetwork.Id(cfg.ProviderSpaceId),
-			ProviderVLANId:      corenetwork.Id(cfg.ProviderVLANId),
-			ProviderAddressId:   corenetwork.Id(cfg.ProviderAddressId),
-			VLANTag:             cfg.VLANTag,
-			InterfaceName:       cfg.InterfaceName,
-			ParentInterfaceName: cfg.ParentInterfaceName,
-			InterfaceType:       corenetwork.InterfaceType(cfg.InterfaceType),
-			Disabled:            cfg.Disabled,
-			NoAutoStart:         cfg.NoAutoStart,
-			ConfigType:          corenetwork.AddressConfigType(cfg.ConfigType),
-			Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(cfg.Address)},
-			DNSServers:          corenetwork.NewProviderAddresses(cfg.DNSServers...),
-			DNSSearchDomains:    cfg.DNSSearchDomains,
-			GatewayAddress:      corenetwork.NewProviderAddress(cfg.GatewayAddress),
-			Routes:              routes,
-		}
-	}
-	return ifaceInfo, nil
+
+	return params.InterfaceInfoFromNetworkConfig(result.Results[0].Config), nil
 }
 
 // SetHostMachineNetworkConfig sets the network configuration of the

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -941,7 +941,6 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoSingleNIC(c
 	c.Check(networkInfo, jc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:         1,
 		MACAddress:          "de:ad:be:ff:11:22",
-		CIDR:                "192.168.0.5/24",
 		MTU:                 9000,
 		ProviderId:          "prov-id",
 		ProviderSubnetId:    "prov-sub-id",
@@ -955,10 +954,12 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoSingleNIC(c
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("192.168.0.6")},
-		DNSServers:          corenetwork.NewProviderAddresses("8.8.8.8"),
-		DNSSearchDomains:    []string{"mydomain"},
-		GatewayAddress:      corenetwork.NewProviderAddress("192.168.0.1"),
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("192.168.0.6", corenetwork.WithCIDR("192.168.0.5/24")),
+		},
+		DNSServers:       corenetwork.NewProviderAddresses("8.8.8.8"),
+		DNSSearchDomains: []string{"mydomain"},
+		GatewayAddress:   corenetwork.NewProviderAddress("192.168.0.1"),
 		Routes: []corenetwork.Route{{
 			DestinationCIDR: "10.0.0.0/16",
 			GatewayIP:       "192.168.0.1",

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -397,8 +397,7 @@ func (o *updateMachineLinkLayerOp) processSubnets(name string) ([]txn.Op, error)
 	cidrSet := set.NewStrings()
 	var isVLAN bool
 	for _, matching := range o.Incoming().GetByName(name) {
-		cidr := matching.CIDR
-		if cidr == "" || matching.InterfaceType == network.LoopbackInterface {
+		if matching.InterfaceType == network.LoopbackInterface {
 			continue
 		}
 
@@ -406,7 +405,11 @@ func (o *updateMachineLinkLayerOp) processSubnets(name string) ([]txn.Op, error)
 			isVLAN = true
 		}
 
-		cidrSet.Add(cidr)
+		for _, addr := range matching.Addresses {
+			if addr.CIDR != "" {
+				cidrSet.Add(addr.CIDR)
+			}
+		}
 	}
 	cidrs := cidrSet.SortedValues()
 

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -105,25 +105,28 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfigCallsApplyOperation(c *
 		{
 			InterfaceName: "lo",
 			InterfaceType: "loopback",
-			CIDR:          "127.0.0.0/8",
-			Addresses:     network.NewProviderAddresses("127.0.0.1"),
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("127.0.0.1", network.WithCIDR("127.0.0.0/8")),
+			},
 			// This is a quirk of the transformation.
 			// Due to the way address type is derived, this is not equivalent
 			// to the provider address zero-value.
 			GatewayAddress: network.NewProviderAddress(""),
 		}, {
-			InterfaceName:  "eth0",
-			InterfaceType:  "ethernet",
-			MACAddress:     "aa:bb:cc:dd:ee:f0",
-			CIDR:           "0.10.0.0/24",
-			Addresses:      network.NewProviderAddresses("0.10.0.2"),
+			InterfaceName: "eth0",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:f0",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.10.0.2", network.WithCIDR("0.10.0.0/24")),
+			},
 			GatewayAddress: network.NewProviderAddress(""),
 		}, {
-			InterfaceName:  "eth1",
-			InterfaceType:  "ethernet",
-			MACAddress:     "aa:bb:cc:dd:ee:f1",
-			CIDR:           "0.20.0.0/24",
-			Addresses:      network.NewProviderAddresses("0.20.0.2"),
+			InterfaceName: "eth1",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:f1",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.20.0.2", network.WithCIDR("0.20.0.0/24")),
+			},
 			GatewayAddress: network.NewProviderAddress(""),
 		},
 	})
@@ -163,8 +166,9 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfigFixesFanSubs(c *gc.C) {
 			InterfaceType: "ethernet",
 			MACAddress:    "aa:bb:cc:dd:ee:f0",
 			// Gets the CIDR from the Fan segment.
-			CIDR:           "0.10.0.0/16",
-			Addresses:      network.NewProviderAddresses("0.10.0.2"),
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.10.0.2", network.WithCIDR("0.10.0.0/16")),
+			},
 			GatewayAddress: network.NewProviderAddress(""),
 		},
 	})
@@ -258,32 +262,36 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpMultipleAddressSuccess(
 			// Existing device and address.
 			InterfaceName: "lo",
 			InterfaceType: "loopback",
-			CIDR:          "127.0.0.0/8",
-			Addresses:     network.NewProviderAddresses("127.0.0.1"),
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("127.0.0.1", network.WithCIDR("127.0.0.0/8")),
+			},
 		}, {
 			// Existing device with new address.
-			InterfaceName:    "eth0",
-			InterfaceType:    "ethernet",
-			MACAddress:       ethMAC,
-			CIDR:             "0.10.0.0/24",
-			Addresses:        network.NewProviderAddresses("0.10.0.2"),
+			InterfaceName: "eth0",
+			InterfaceType: "ethernet",
+			MACAddress:    ethMAC,
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.10.0.2", network.WithCIDR("0.10.0.0/24")),
+			},
 			GatewayAddress:   network.NewProviderAddress("0.10.0.1"),
 			IsDefaultGateway: true,
 		}, {
 			// New device and addresses for eth1.
-			InterfaceName:  "eth1",
-			InterfaceType:  "ethernet",
-			MACAddress:     "aa:bb:cc:dd:ee:f1",
-			CIDR:           "0.20.0.0/24",
-			Addresses:      network.NewProviderAddresses("0.20.0.2"),
+			InterfaceName: "eth1",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:f1",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.20.0.2", network.WithCIDR("0.20.0.0/24")),
+			},
 			GatewayAddress: network.NewProviderAddress("0.20.0.1"),
 		}, {
 			// A duplicate is effectively ignored.
-			InterfaceName:  "eth1",
-			InterfaceType:  "ethernet",
-			MACAddress:     "aa:bb:cc:dd:ee:f1",
-			CIDR:           "0.20.0.0/24",
-			Addresses:      network.NewProviderAddresses("0.20.0.2"),
+			InterfaceName: "eth1",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:f1",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.20.0.2", network.WithCIDR("0.20.0.0/24")),
+			},
 			GatewayAddress: network.NewProviderAddress("0.20.0.1"),
 		},
 	}, false, s.state)
@@ -347,11 +355,12 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpUnobservedParentNotRemo
 	op := s.NewUpdateMachineLinkLayerOp(s.machine, network.InterfaceInfos{
 		{
 			// New device and addresses for eth1 with eth99 as the parent.
-			InterfaceName:       "eth1",
-			InterfaceType:       "ethernet",
-			MACAddress:          "aa:bb:cc:dd:ee:f1",
-			CIDR:                "0.20.0.0/24",
-			Addresses:           network.NewProviderAddresses("0.20.0.2"),
+			InterfaceName: "eth1",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:f1",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.20.0.2", network.WithCIDR("0.20.0.0/24")),
+			},
 			GatewayAddress:      network.NewProviderAddress("0.20.0.1"),
 			ParentInterfaceName: "eth99",
 			Origin:              network.OriginMachine,
@@ -384,22 +393,25 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpNewSubnetsAdded(c *gc.C
 		{
 			InterfaceName: "lo",
 			InterfaceType: "loopback",
-			CIDR:          "127.0.0.0/8",
-			Addresses:     network.NewProviderAddresses("127.0.0.1"),
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("127.0.0.1", network.WithCIDR("127.0.0.0/8")),
+			},
 		}, {
-			InterfaceName:    "eth0",
-			InterfaceType:    "ethernet",
-			MACAddress:       "aa:bb:cc:dd:ee:ff",
-			CIDR:             "0.10.0.0/24",
-			Addresses:        network.NewProviderAddresses("0.10.0.2"),
+			InterfaceName: "eth0",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:ff",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.10.0.2", network.WithCIDR("0.10.0.0/24")),
+			},
 			GatewayAddress:   network.NewProviderAddress("0.10.0.1"),
 			IsDefaultGateway: true,
 		}, {
-			InterfaceName:  "eth1",
-			InterfaceType:  "ethernet",
-			MACAddress:     "aa:bb:cc:dd:ee:f1",
-			CIDR:           "0.20.0.0/24",
-			Addresses:      network.NewProviderAddresses("0.20.0.2"),
+			InterfaceName: "eth1",
+			InterfaceType: "ethernet",
+			MACAddress:    "aa:bb:cc:dd:ee:f1",
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("0.20.0.2", network.WithCIDR("0.20.0.0/24")),
+			},
 			GatewayAddress: network.NewProviderAddress("0.20.0.1"),
 		},
 	}, true, s.state)
@@ -476,11 +488,12 @@ func (s *networkConfigSuite) TestUpdateMachineLinkLayerOpBridgedDeviceMovesAddre
 			Origin:              network.OriginMachine,
 		},
 		{
-			InterfaceName:  "br-eth0",
-			InterfaceType:  "bridge",
-			MACAddress:     hwAddr,
-			CIDR:           "10.0.0.0/24",
-			Addresses:      network.NewProviderAddresses("10.0.0.6"),
+			InterfaceName: "br-eth0",
+			InterfaceType: "bridge",
+			MACAddress:    hwAddr,
+			Addresses: network.ProviderAddresses{
+				network.NewProviderAddress("10.0.0.6", network.WithCIDR("10.0.0.0/24")),
+			},
 			GatewayAddress: network.NewProviderAddress("10.0.0.1"),
 			Origin:         network.OriginMachine,
 		},

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -234,7 +234,7 @@ func networkAddressStateArgsForDevice(devs network.InterfaceInfos, name string) 
 func networkAddressToStateArgs(
 	dev network.InterfaceInfo, addr network.ProviderAddress,
 ) (state.LinkLayerDeviceAddress, error) {
-	cidrAddress, err := addr.ValueForCIDR(dev.CIDR)
+	cidrAddress, err := addr.ValueWithMask()
 	if err != nil {
 		return state.LinkLayerDeviceAddress{}, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -894,6 +894,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -975,6 +978,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -9526,6 +9532,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -9637,6 +9646,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -9957,6 +9969,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -10234,6 +10249,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -10647,6 +10665,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -10785,6 +10806,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -11359,6 +11383,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -14495,6 +14522,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -15288,6 +15318,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -20038,6 +20071,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -20221,6 +20257,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -23747,6 +23786,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -25974,6 +26016,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -26937,6 +26982,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -27074,6 +27122,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -32916,6 +32967,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -33657,6 +33711,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"
@@ -43310,6 +43367,9 @@
                 "Address": {
                     "type": "object",
                     "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -44007,6 +44067,9 @@
                     "properties": {
                         "Address": {
                             "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
                         },
                         "is-secondary": {
                             "type": "boolean"

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -260,7 +260,7 @@ func (s *NetworkSuite) TestPortRangeConvenience(c *gc.C) {
 
 func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 	pAddrs := network.ProviderAddresses{
-		network.NewProviderAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewProviderAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal), network.WithCIDR("1.2.3.0/24")),
 		network.NewProviderAddress("1.2.3.5", network.WithScope(network.ScopeCloudLocal), network.WithSecondary()),
 		network.NewProviderAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	}
@@ -273,7 +273,7 @@ func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 
 func (s *NetworkSuite) TestMachineAddressConversion(c *gc.C) {
 	mAddrs := []network.MachineAddress{
-		network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal)),
+		network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal), network.WithCIDR("1.2.3.0/24")),
 		network.NewMachineAddress("1.2.3.5", network.WithScope(network.ScopeCloudLocal), network.WithSecondary()),
 		network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
 	}

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -150,7 +150,7 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 	netPlan.Network.Version = 2
 	for _, info := range interfaces {
 		var iface netplan.Ethernet
-		cidr, err := info.CIDRAddress()
+		cidr, err := info.PrimaryAddress().ValueWithMask()
 		if err != nil && !errors.IsNotFound(err) {
 			return "", errors.Trace(err)
 		}
@@ -254,7 +254,7 @@ func PrepareNetworkConfigFromInterfaces(interfaces corenetwork.InterfaceInfos) (
 			autoStarted.Add(ifaceName)
 		}
 
-		cidr, err := info.CIDRAddress()
+		cidr, err := info.PrimaryAddress().ValueWithMask()
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, errors.Trace(err)
 		}

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -67,22 +67,22 @@ func (s *NetworkUbuntuSuite) SetUpTest(c *gc.C) {
 	s.jujuNetplanFile = filepath.Join(netplanFolder, "79-juju.yaml")
 
 	s.fakeInterfaces = corenetwork.InterfaceInfos{{
-		InterfaceName:    "any0",
-		CIDR:             "0.1.2.0/24",
-		ConfigType:       corenetwork.ConfigStatic,
-		NoAutoStart:      false,
-		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.1.2.3")},
+		InterfaceName: "any0",
+		ConfigType:    corenetwork.ConfigStatic,
+		NoAutoStart:   false,
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("0.1.2.3", corenetwork.WithCIDR("0.1.2.0/24"))},
 		DNSServers:       corenetwork.NewProviderAddresses("ns1.invalid", "ns2.invalid"),
 		DNSSearchDomains: []string{"foo", "bar"},
 		GatewayAddress:   corenetwork.NewProviderAddress("0.1.2.1"),
 		MACAddress:       "aa:bb:cc:dd:ee:f0",
 		MTU:              8317,
 	}, {
-		InterfaceName:    "any1",
-		CIDR:             "0.2.2.0/24",
-		ConfigType:       corenetwork.ConfigStatic,
-		NoAutoStart:      false,
-		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.2.2.4")},
+		InterfaceName: "any1",
+		ConfigType:    corenetwork.ConfigStatic,
+		NoAutoStart:   false,
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("0.2.2.4", corenetwork.WithCIDR("0.2.2.0/24"))},
 		DNSServers:       corenetwork.NewProviderAddresses("ns1.invalid", "ns2.invalid"),
 		DNSSearchDomains: []string{"foo", "bar"},
 		GatewayAddress:   corenetwork.NewProviderAddress("0.2.2.1"),
@@ -108,12 +108,12 @@ func (s *NetworkUbuntuSuite) SetUpTest(c *gc.C) {
 		MACAddress:    "aa:bb:cc:dd:ee:f4",
 		NoAutoStart:   true,
 	}, {
-		InterfaceName:  "any5",
-		ConfigType:     corenetwork.ConfigStatic,
-		MACAddress:     "aa:bb:cc:dd:ee:f5",
-		NoAutoStart:    false,
-		CIDR:           "2001:db8::/64",
-		Addresses:      corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("2001:db8::dead:beef")},
+		InterfaceName: "any5",
+		ConfigType:    corenetwork.ConfigStatic,
+		MACAddress:    "aa:bb:cc:dd:ee:f5",
+		NoAutoStart:   false,
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("2001:db8::dead:beef", corenetwork.WithCIDR("2001:db8::/64"))},
 		GatewayAddress: corenetwork.NewProviderAddress("2001:db8::dead:f00"),
 	}}
 
@@ -555,7 +555,7 @@ func (s *NetworkUbuntuSuite) TestENIScriptHotplug(c *gc.C) {
 }
 
 func (s *NetworkUbuntuSuite) TestPrepareNetworkConfigFromInterfacesBadCIDRError(c *gc.C) {
-	s.fakeInterfaces[0].CIDR = "invalid"
+	s.fakeInterfaces[0].Addresses[0].CIDR = "invalid"
 	_, err := cloudinit.PrepareNetworkConfigFromInterfaces(s.fakeInterfaces)
 	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
 }

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -100,11 +100,12 @@ type fakeAPI struct {
 var _ broker.APICalls = (*fakeAPI)(nil)
 
 var fakeInterfaceInfo = corenetwork.InterfaceInfo{
-	DeviceIndex:    0,
-	MACAddress:     "aa:bb:cc:dd:ee:ff",
-	CIDR:           "0.1.2.0/24",
-	InterfaceName:  "dummy0",
-	Addresses:      corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.1.2.3")},
+	DeviceIndex:   0,
+	MACAddress:    "aa:bb:cc:dd:ee:ff",
+	InterfaceName: "dummy0",
+	Addresses: corenetwork.ProviderAddresses{
+		corenetwork.NewProviderAddress("0.1.2.3", corenetwork.WithCIDR("0.1.2.0/24")),
+	},
 	GatewayAddress: corenetwork.NewProviderAddress("0.1.2.1"),
 	// Explicitly set only DNSServers, but not DNSSearchDomains to test this is
 	// detected and the latter populated by parsing the fake resolv.conf created

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -368,8 +368,10 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 		ParentInterfaceName: "br-eth0",
 		InterfaceName:       "eth0",
 		InterfaceType:       "ethernet",
-		CIDR:                "10.10.0.0/24",
 		MACAddress:          "aa:bb:cc:dd:ee:f0",
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("", corenetwork.WithCIDR("10.10.0.0/24")),
+		},
 	}}
 
 	expected := map[string]map[string]string{

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -485,7 +485,7 @@ func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID s
 		if v.ParentInterfaceName == "" {
 			return nil, nil, errors.Errorf("parent interface name is empty")
 		}
-		if v.CIDR == "" {
+		if v.PrimaryAddress().CIDR == "" {
 			unknown = append(unknown, v.ParentInterfaceName)
 		}
 		hostIfaceName := makeHostInterfaceName(machineID, nicCount)

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -189,12 +189,18 @@ func (a MachineAddress) IP() net.IP {
 	return net.ParseIP(a.Value)
 }
 
-// ValueForCIDR returns the value of the address combined with a subnet mask
-// indicated by the input CIDR.
-// TODO (manadart 2020-07-10): This should evolve to use the address CIDR
-// directly instead of receiving a value, once we clean up InterfaceInfo.
-func (a MachineAddress) ValueForCIDR(cidr string) (string, error) {
-	_, ipNet, err := net.ParseCIDR(cidr)
+// ValueWithMask returns the value of the address combined
+// with the subnet mask indicated by its CIDR.
+func (a MachineAddress) ValueWithMask() (string, error) {
+	// Returning a NotFound error preserves prior behaviour from when
+	// CIDRAddress was a method on InterfaceInfo.
+	// TODO (manadart 2021-03-16): Rethink this as we clean up InterfaceInfos
+	// and its corresponding wire type.
+	if a.Value == "" || a.CIDR == "" {
+		return "", errors.NotFoundf("address and CIDR pair (%q, %q)", a.Value, a.CIDR)
+	}
+
+	_, ipNet, err := net.ParseCIDR(a.CIDR)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/core/network/address_options.go
+++ b/core/network/address_options.go
@@ -14,6 +14,9 @@ type AddressMutator interface {
 	// SetSecondary indicates that this address is not the
 	// primary address of the device it is associated with.
 	SetSecondary()
+
+	// SetConfigType indicates how this address was configured.
+	SetConfigType(AddressConfigType)
 }
 
 // SetScope (AddressMutator) sets the input
@@ -34,6 +37,12 @@ func (a *MachineAddress) SetSecondary() {
 	a.IsSecondary = true
 }
 
+// SetConfigType (AddressMutator) sets the input
+// AddressConfigType on the address receiver.
+func (a *MachineAddress) SetConfigType(configType AddressConfigType) {
+	a.ConfigType = configType
+}
+
 // WithScope returns a functional option that can
 // be used to set the input scope on an address.
 func WithScope(scope Scope) func(AddressMutator) {
@@ -52,8 +61,14 @@ func WithCIDR(cidr string) func(AddressMutator) {
 
 // WithSecondary returns a functional option that can be used to
 // indicate that an address is not the primary for its NIC.
-func WithSecondary() func(mutator AddressMutator) {
+func WithSecondary() func(AddressMutator) {
 	return func(a AddressMutator) {
 		a.SetSecondary()
+	}
+}
+
+func WithConfigType(configType AddressConfigType) func(AddressMutator) {
+	return func(a AddressMutator) {
+		a.SetConfigType(configType)
 	}
 }

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -859,28 +859,15 @@ func (s *AddressSuite) TestSpaceAddressesValues(c *gc.C) {
 }
 
 func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
-	type test struct {
-		IP   string
-		CIDR string
-		exp  string
-	}
+	_, err := network.NewMachineAddress("172.31.37.53").ValueWithMask()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	tests := []test{{
-		IP:   "172.31.37.53",
-		CIDR: "172.31.32.0/20",
-		exp:  "172.31.37.53/20",
-	}, {
-		IP:   "192.168.0.1",
-		CIDR: "192.168.0.0/31",
-		exp:  "192.168.0.1/31",
-	}}
+	_, err = network.NewMachineAddress("", network.WithCIDR("172.31.37.0/20")).ValueWithMask()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	for i, t := range tests {
-		c.Logf("test %d: ValueForCIDR(%q, %q)", i, t.IP, t.CIDR)
-		got, err := network.NewMachineAddress(t.IP).ValueForCIDR(t.CIDR)
-		c.Check(err, jc.ErrorIsNil)
-		c.Check(got, gc.Equals, t.exp)
-	}
+	val, err := network.NewMachineAddress("172.31.37.53", network.WithCIDR("172.31.37.0/20")).ValueWithMask()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(val, gc.Equals, "172.31.37.53/20")
 }
 
 func (s *AddressSuite) TestCIDRAddressType(c *gc.C) {

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -238,20 +238,6 @@ func (i *InterfaceInfo) Validate() error {
 	return nil
 }
 
-// CIDRAddress returns Address.Value combined with subnet mask.
-// TODO (manadart 2020-07-02): Usage of this method should be phased out
-// in favour of calling ValueForCIDR on each member of the addresses slice.
-func (i *InterfaceInfo) CIDRAddress() (string, error) {
-	primaryAddr := i.PrimaryAddress()
-
-	if i.CIDR == "" || primaryAddr.Value == "" {
-		return "", errors.NotFoundf("address and CIDR pair (%q, %q)", primaryAddr.Value, i.CIDR)
-	}
-
-	withMask, err := primaryAddr.ValueForCIDR(i.CIDR)
-	return withMask, errors.Trace(err)
-}
-
 // PrimaryAddress returns the primary address for the interface.
 func (i *InterfaceInfo) PrimaryAddress() ProviderAddress {
 	if len(i.Addresses) == 0 {

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -82,9 +82,6 @@ type InterfaceInfo struct {
 	// (e.g. "aa:bb:cc:dd:ee:ff").
 	MACAddress string
 
-	// CIDR of the network, in 123.45.67.89/24 format.
-	CIDR string
-
 	// ProviderId is a provider-specific NIC id.
 	ProviderId Id
 

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -71,44 +71,6 @@ func (s *nicSuite) TestAdditionalFields(c *gc.C) {
 	}})
 }
 
-func (*nicSuite) TestCIDRAddress(c *gc.C) {
-	dev := network.InterfaceInfo{
-		Addresses: network.NewProviderAddresses("10.0.0.10"),
-		CIDR:      "10.0.0.0/24",
-	}
-	addr, err := dev.CIDRAddress()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(addr, gc.Equals, "10.0.0.10/24")
-
-	dev = network.InterfaceInfo{
-		Addresses: network.NewProviderAddresses("10.0.0.10"),
-	}
-	addr, err = dev.CIDRAddress()
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Check(addr, gc.Equals, "")
-
-	dev = network.InterfaceInfo{
-		CIDR: "10.0.0.0/24",
-	}
-	addr, err = dev.CIDRAddress()
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Check(addr, gc.Equals, "")
-
-	dev = network.InterfaceInfo{
-		Addresses: network.NewProviderAddresses("invalid"),
-		CIDR:      "10.0.0.0/24",
-	}
-	_, err = dev.CIDRAddress()
-	c.Assert(err, gc.ErrorMatches, `cannot parse IP address "invalid"`)
-
-	dev = network.InterfaceInfo{
-		Addresses: network.NewProviderAddresses("10.0.0.10"),
-		CIDR:      "invalid",
-	}
-	_, err = dev.CIDRAddress()
-	c.Assert(err, gc.ErrorMatches, `invalid CIDR address: invalid`)
-}
-
 func (*nicSuite) TestInterfaceInfoValidate(c *gc.C) {
 	dev := network.InterfaceInfo{InterfaceName: ""}
 	c.Check(dev.Validate(), jc.Satisfies, errors.IsNotValid)

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1464,7 +1464,6 @@ func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []ins
 				ProviderId:       corenetwork.Id(fmt.Sprintf("dummy-eth%d", i)),
 				ProviderSubnetId: corenetwork.Id("dummy-" + netName),
 				InterfaceType:    corenetwork.EthernetInterface,
-				CIDR:             fmt.Sprintf("0.%d.0.0/24", (i+1)*10),
 				InterfaceName:    fmt.Sprintf("eth%d", i),
 				VLANTag:          i,
 				MACAddress:       fmt.Sprintf("aa:bb:cc:dd:ee:f%d", i),
@@ -1474,6 +1473,7 @@ func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []ins
 				Addresses: corenetwork.ProviderAddresses{
 					corenetwork.NewProviderAddress(
 						fmt.Sprintf("0.%d.0.%d", (i+1)*10+idIndex, estate.maxAddr+2),
+						corenetwork.WithCIDR(fmt.Sprintf("0.%d.0.0/24", (i+1)*10)),
 					),
 				},
 				DNSServers: corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -241,7 +241,6 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 	expectInfo := corenetwork.InterfaceInfos{{
 		ProviderId:       "dummy-eth0",
 		ProviderSubnetId: "dummy-private",
-		CIDR:             "0.10.0.0/24",
 		DeviceIndex:      0,
 		InterfaceName:    "eth0",
 		InterfaceType:    "ethernet",
@@ -250,14 +249,15 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:         false,
 		NoAutoStart:      false,
 		ConfigType:       corenetwork.ConfigDHCP,
-		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.10.0.2")},
-		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress:   corenetwork.NewProviderAddress("0.10.0.1"),
-		Origin:           corenetwork.OriginProvider,
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("0.10.0.2", corenetwork.WithCIDR("0.10.0.0/24")),
+		},
+		DNSServers:     corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
+		GatewayAddress: corenetwork.NewProviderAddress("0.10.0.1"),
+		Origin:         corenetwork.OriginProvider,
 	}, {
 		ProviderId:       "dummy-eth1",
 		ProviderSubnetId: "dummy-public",
-		CIDR:             "0.20.0.0/24",
 		DeviceIndex:      1,
 		InterfaceName:    "eth1",
 		InterfaceType:    "ethernet",
@@ -266,14 +266,15 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:         false,
 		NoAutoStart:      true,
 		ConfigType:       corenetwork.ConfigDHCP,
-		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.20.0.2")},
-		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress:   corenetwork.NewProviderAddress("0.20.0.1"),
-		Origin:           corenetwork.OriginProvider,
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("0.20.0.2", corenetwork.WithCIDR("0.20.0.0/24")),
+		},
+		DNSServers:     corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
+		GatewayAddress: corenetwork.NewProviderAddress("0.20.0.1"),
+		Origin:         corenetwork.OriginProvider,
 	}, {
 		ProviderId:       "dummy-eth2",
 		ProviderSubnetId: "dummy-disabled",
-		CIDR:             "0.30.0.0/24",
 		DeviceIndex:      2,
 		InterfaceName:    "eth2",
 		InterfaceType:    "ethernet",
@@ -282,10 +283,12 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		Disabled:         true,
 		NoAutoStart:      false,
 		ConfigType:       corenetwork.ConfigDHCP,
-		Addresses:        corenetwork.ProviderAddresses{corenetwork.NewProviderAddress("0.30.0.2")},
-		DNSServers:       corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
-		GatewayAddress:   corenetwork.NewProviderAddress("0.30.0.1"),
-		Origin:           corenetwork.OriginProvider,
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewProviderAddress("0.30.0.2", corenetwork.WithCIDR("0.30.0.0/24")),
+		},
+		DNSServers:     corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
+		GatewayAddress: corenetwork.NewProviderAddress("0.30.0.1"),
+		Origin:         corenetwork.OriginProvider,
 	}}
 	infoList, err := e.NetworkInterfaces(s.callCtx, []instance.Id{instance.Id("i-42")})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -129,7 +129,7 @@ func (e *environ) getInstanceSubnets(
 			results = append(results, makeSubnetInfo(
 				iface.ProviderSubnetId,
 				iface.ProviderNetworkId,
-				iface.CIDR,
+				iface.PrimaryAddress().CIDR,
 				zones,
 			))
 		}
@@ -206,7 +206,6 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 
 			infos[idx] = append(infos[idx], corenetwork.InterfaceInfo{
 				DeviceIndex: i,
-				CIDR:        details.cidr,
 				// The network interface has no id in GCE so it's
 				// identified by the machine's id + its name.
 				ProviderId:        corenetwork.Id(fmt.Sprintf("%s/%s", ids[idx], iface.Name)),
@@ -214,9 +213,11 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 				ProviderNetworkId: details.network,
 				AvailabilityZones: copyStrings(zones),
 				InterfaceName:     iface.Name,
-				Addresses: corenetwork.ProviderAddresses{
-					corenetwork.NewProviderAddress(iface.NetworkIP, corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-				},
+				Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+					iface.NetworkIP,
+					corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+					corenetwork.WithCIDR(details.cidr),
+				)},
 				ShadowAddresses: shadowAddrs,
 				InterfaceType:   corenetwork.EthernetInterface,
 				Disabled:        false,

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -204,7 +204,6 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/somenetif",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -214,9 +213,11 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.3",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		Origin: corenetwork.OriginProvider,
 	}})
 }
@@ -290,7 +291,6 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 	infos := infoLists[0]
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "i-1/somenetif",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -300,9 +300,11 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.3",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		Origin: corenetwork.OriginProvider,
 	}})
 
@@ -310,7 +312,6 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 	infos = infoLists[1]
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "i-2/netif-0",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -320,16 +321,17 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.42", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.42",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
 		Origin: corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
-		CIDR:              "10.0.20.0/24",
 		ProviderId:        "i-2/netif-1",
 		ProviderSubnetId:  "shellac",
 		ProviderNetworkId: "albini",
@@ -339,9 +341,11 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.20.42", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.20.42",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.20.0/24"),
+		)},
 		Origin: corenetwork.OriginProvider,
 	}})
 }
@@ -359,7 +363,6 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 	infos := infoLists[0]
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "i-1/somenetif",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -369,9 +372,11 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.3",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		Origin: corenetwork.OriginProvider,
 	}})
 
@@ -405,7 +410,6 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/somenetif",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -415,13 +419,14 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.3",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		Origin: corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
-		CIDR:              "10.0.20.0/24",
 		ProviderId:        "moana/othernetif",
 		ProviderSubnetId:  "shellac",
 		ProviderNetworkId: "albini",
@@ -431,9 +436,11 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.20.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.20.3",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.20.0/24"),
+		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
@@ -466,7 +473,6 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.240.0.0/16",
 		ProviderId:        "moana/somenetif",
 		ProviderSubnetId:  "",
 		ProviderNetworkId: "legacy",
@@ -476,9 +482,11 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.240.0.2", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.240.0.2",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.240.0.0/16"),
+		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},
@@ -505,14 +513,13 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 	})
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{"moana"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:       0,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/somenetif",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -522,13 +529,14 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.3", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.3",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		Origin: corenetwork.OriginProvider,
 	}, {
 		DeviceIndex:       1,
-		CIDR:              "10.0.10.0/24",
 		ProviderId:        "moana/othernetif",
 		ProviderSubnetId:  "go-team",
 		ProviderNetworkId: "go-team1",
@@ -538,9 +546,11 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("10.0.10.4", corenetwork.WithScope(corenetwork.ScopeCloudLocal)),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"10.0.10.4",
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR("10.0.10.0/24"),
+		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
 		},

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -385,11 +385,12 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 				InterfaceType:       network.EthernetInterface,
 				Origin:              network.OriginProvider,
 				ConfigType:          network.ConfigStatic,
-				CIDR:                "10.55.158.0/24",
 				ProviderId:          "nic-00:16:3e:19:29:cb",
 				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
 				ProviderNetworkId:   "net-lxdbr0",
-				Addresses:           network.NewProviderAddresses("10.55.158.99"),
+				Addresses: network.ProviderAddresses{
+					network.NewProviderAddress("10.55.158.99", network.WithCIDR("10.55.158.0/24")),
+				},
 			},
 			{
 				DeviceIndex:         1,
@@ -400,11 +401,12 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 				InterfaceType:       network.EthernetInterface,
 				Origin:              network.OriginProvider,
 				ConfigType:          network.ConfigStatic,
-				CIDR:                "10.42.42.0/24",
 				ProviderId:          "nic-00:16:3e:fe:fe:fe",
 				ProviderSubnetId:    "subnet-ovsbr0-10.42.42.0/24",
 				ProviderNetworkId:   "net-ovsbr0",
-				Addresses:           network.NewProviderAddresses("10.42.42.99"),
+				Addresses: network.ProviderAddresses{
+					network.NewProviderAddress("10.42.42.99", network.WithCIDR("10.42.42.0/24")),
+				},
 			},
 		},
 	}
@@ -461,11 +463,12 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 				InterfaceType:       network.EthernetInterface,
 				Origin:              network.OriginProvider,
 				ConfigType:          network.ConfigStatic,
-				CIDR:                "10.55.158.0/24",
 				ProviderId:          "nic-00:16:3e:19:29:cb",
 				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
 				ProviderNetworkId:   "net-lxdbr0",
-				Addresses:           network.NewProviderAddresses("10.55.158.99"),
+				Addresses: network.ProviderAddresses{
+					network.NewProviderAddress("10.55.158.99", network.WithCIDR("10.55.158.0/24")),
+				},
 			},
 		},
 		nil, // slot for second instance is nil as the container was not found

--- a/provider/maas/instance_test.go
+++ b/provider/maas/instance_test.go
@@ -169,10 +169,10 @@ func (s *instanceTest) TestAddressesViaInterfaces(c *gc.C) {
 		return network.Id(fmt.Sprintf("%d", u))
 	}
 	expected := network.ProviderAddresses{
-		newAddressOnSpaceWithId("bar", idFromUint(barSpace.ID), "8.7.6.5"),
-		newAddressOnSpaceWithId("bar", idFromUint(barSpace.ID), "8.7.6.6"),
-		newAddressOnSpaceWithId("storage", idFromUint(storageSpace.ID), "10.0.1.1"),
-		newAddressOnSpaceWithId("db", idFromUint(dbSpace.ID), "fc00::123"),
+		newAddressOnSpaceWithId("bar", idFromUint(barSpace.ID), "8.7.6.5", network.WithCIDR("8.7.6.0/24")),
+		newAddressOnSpaceWithId("bar", idFromUint(barSpace.ID), "8.7.6.6", network.WithCIDR("8.7.6.0/24")),
+		newAddressOnSpaceWithId("storage", idFromUint(storageSpace.ID), "10.0.1.1", network.WithCIDR("10.0.1.1/24")),
+		newAddressOnSpaceWithId("db", idFromUint(dbSpace.ID), "fc00::123", network.WithCIDR("fc00::/64")),
 	}
 
 	addr, err := inst.Addresses(s.callCtx)

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -271,7 +271,6 @@ func maasObjectNetworkInterfaces(
 				continue
 			}
 
-			nicInfo.CIDR = sub.CIDR
 			nicInfo.ProviderSubnetId = corenetwork.Id(fmt.Sprintf("%v", sub.ID))
 			nicInfo.ProviderVLANId = corenetwork.Id(fmt.Sprintf("%v", sub.VLAN.ID))
 
@@ -281,7 +280,9 @@ func maasObjectNetworkInterfaces(
 
 			// Now we know the subnet and space, we can update the address to
 			// store the space with it.
-			nicInfo.Addresses[0] = corenetwork.NewProviderAddressInSpace(space, link.IPAddress)
+			nicInfo.Addresses[0] = corenetwork.NewProviderAddressInSpace(
+				space, link.IPAddress, corenetwork.WithCIDR(sub.CIDR))
+
 			spaceId, ok := subnetsMap[sub.CIDR]
 			if !ok {
 				// The space we found is not recognised.
@@ -391,7 +392,6 @@ func maas2NetworkInterfaces(
 				continue
 			}
 
-			nicInfo.CIDR = sub.CIDR()
 			nicInfo.ProviderSubnetId = corenetwork.Id(fmt.Sprintf("%v", sub.ID()))
 			nicInfo.ProviderVLANId = corenetwork.Id(fmt.Sprintf("%v", sub.VLAN().ID()))
 
@@ -401,7 +401,9 @@ func maas2NetworkInterfaces(
 
 			// Now we know the subnet and space, we can update the address to
 			// store the space with it.
-			nicInfo.Addresses[0] = corenetwork.NewProviderAddressInSpace(space, link.IPAddress())
+			nicInfo.Addresses[0] = corenetwork.NewProviderAddressInSpace(
+				space, link.IPAddress(), corenetwork.WithCIDR(sub.CIDR()))
+
 			spaceId, ok := subnetsMap[sub.CIDR()]
 			if !ok {
 				// The space we found is not recognised.

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	corenetwork "github.com/juju/juju/core/network"
+	network "github.com/juju/juju/core/network"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -22,8 +22,10 @@ type interfacesSuite struct {
 
 var _ = gc.Suite(&interfacesSuite{})
 
-func newAddressOnSpaceWithId(space string, id corenetwork.Id, address string) corenetwork.ProviderAddress {
-	newAddress := corenetwork.NewProviderAddressInSpace(space, address)
+func newAddressOnSpaceWithId(
+	space string, id network.Id, address string, options ...func(network.AddressMutator),
+) network.ProviderAddress {
+	newAddress := network.NewProviderAddressInSpace(space, address, options...)
 	newAddress.ProviderSpaceID = id
 	return newAddress
 }
@@ -416,10 +418,9 @@ const exampleInterfaceSetJSON = `
         }
 ]`
 
-var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
+var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	DeviceIndex:       0,
 	MACAddress:        "52:54:00:70:9b:fe",
-	CIDR:              "10.20.19.0/24",
 	ProviderId:        "91",
 	ProviderSubnetId:  "3",
 	AvailabilityZones: nil,
@@ -431,16 +432,17 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	Disabled:          false,
 	NoAutoStart:       false,
 	ConfigType:        "static",
-	Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.103")},
-	DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-	DNSSearchDomains:  nil,
-	MTU:               1500,
-	GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-	Origin:            corenetwork.OriginProvider,
+	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+		"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+	)},
+	DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+	DNSSearchDomains: nil,
+	MTU:              1500,
+	GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+	Origin:           network.OriginProvider,
 }, {
 	DeviceIndex:       0,
 	MACAddress:        "52:54:00:70:9b:fe",
-	CIDR:              "10.20.19.0/24",
 	ProviderId:        "91",
 	ProviderSubnetId:  "3",
 	AvailabilityZones: nil,
@@ -452,16 +454,17 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	Disabled:          false,
 	NoAutoStart:       false,
 	ConfigType:        "static",
-	Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.104")},
-	DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-	DNSSearchDomains:  nil,
-	MTU:               1500,
-	GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-	Origin:            corenetwork.OriginProvider,
+	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+		"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+	)},
+	DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+	DNSSearchDomains: nil,
+	MTU:              1500,
+	GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+	Origin:           network.OriginProvider,
 }, {
 	DeviceIndex:         1,
 	MACAddress:          "52:54:00:70:9b:fe",
-	CIDR:                "10.50.19.0/24",
 	ProviderId:          "150",
 	ProviderSubnetId:    "5",
 	AvailabilityZones:   nil,
@@ -474,16 +477,17 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	Disabled:            false,
 	NoAutoStart:         false,
 	ConfigType:          "static",
-	Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("admin", "10.50.19.103")},
-	DNSServers:          nil,
-	DNSSearchDomains:    nil,
-	MTU:                 1500,
-	GatewayAddress:      corenetwork.NewProviderAddressInSpace("admin", "10.50.19.2"),
-	Origin:              corenetwork.OriginProvider,
+	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+		"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"),
+	)},
+	DNSServers:       nil,
+	DNSSearchDomains: nil,
+	MTU:              1500,
+	GatewayAddress:   network.NewProviderAddressInSpace("admin", "10.50.19.2"),
+	Origin:           network.OriginProvider,
 }, {
 	DeviceIndex:         2,
 	MACAddress:          "52:54:00:70:9b:fe",
-	CIDR:                "10.100.19.0/24",
 	ProviderId:          "151",
 	ProviderSubnetId:    "6",
 	AvailabilityZones:   nil,
@@ -496,16 +500,17 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	Disabled:            false,
 	NoAutoStart:         false,
 	ConfigType:          "static",
-	Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("public", "10.100.19.103")},
-	DNSServers:          nil,
-	DNSSearchDomains:    nil,
-	MTU:                 1500,
-	GatewayAddress:      corenetwork.NewProviderAddressInSpace("public", "10.100.19.2"),
-	Origin:              corenetwork.OriginProvider,
+	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+		"public", "10.100.19.103", network.WithCIDR("10.100.19.0/24"),
+	)},
+	DNSServers:       nil,
+	DNSSearchDomains: nil,
+	MTU:              1500,
+	GatewayAddress:   network.NewProviderAddressInSpace("public", "10.100.19.2"),
+	Origin:           network.OriginProvider,
 }, {
 	DeviceIndex:         3,
 	MACAddress:          "52:54:00:70:9b:fe",
-	CIDR:                "10.250.19.0/24",
 	ProviderId:          "152",
 	ProviderSubnetId:    "8",
 	AvailabilityZones:   nil,
@@ -519,16 +524,17 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	Disabled:            false,
 	NoAutoStart:         false,
 	ConfigType:          "static",
-	Addresses:           corenetwork.ProviderAddresses{newAddressOnSpaceWithId("storage", "3", "10.250.19.103")},
-	DNSServers:          nil,
-	DNSSearchDomains:    nil,
-	MTU:                 1500,
-	GatewayAddress:      newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
-	Origin:              corenetwork.OriginProvider,
+	Addresses: network.ProviderAddresses{newAddressOnSpaceWithId(
+		"storage", "3", "10.250.19.103", network.WithCIDR("10.250.19.0/24"),
+	)},
+	DNSServers:       nil,
+	DNSSearchDomains: nil,
+	MTU:              1500,
+	GatewayAddress:   newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
+	Origin:           network.OriginProvider,
 }, {
 	DeviceIndex:         4,
 	MACAddress:          "52:54:00:08:24:2d",
-	CIDR:                "",
 	ProviderId:          "10",
 	ProviderSubnetId:    "",
 	AvailabilityZones:   nil,
@@ -544,11 +550,10 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	DNSServers:          nil,
 	DNSSearchDomains:    nil,
 	MTU:                 0,
-	Origin:              corenetwork.OriginProvider,
+	Origin:              network.OriginProvider,
 }, {
 	DeviceIndex:         5,
 	MACAddress:          "52:54:00:08:24:2d",
-	CIDR:                "192.168.20.0/24",
 	ProviderId:          "30",
 	ProviderSubnetId:    "4",
 	AvailabilityZones:   nil,
@@ -562,12 +567,14 @@ var exampleParsedInterfaceSetJSON = corenetwork.InterfaceInfos{{
 	Disabled:            false,
 	NoAutoStart:         false,
 	ConfigType:          "dhcp",
-	Addresses:           corenetwork.ProviderAddresses{newAddressOnSpaceWithId("space-0", "4", "192.168.20.192")},
-	DNSServers:          nil,
-	DNSSearchDomains:    nil,
-	MTU:                 1500,
-	GatewayAddress:      newAddressOnSpaceWithId("space-0", "4", "192.168.20.2"),
-	Origin:              corenetwork.OriginProvider,
+	Addresses: network.ProviderAddresses{newAddressOnSpaceWithId(
+		"space-0", "4", "192.168.20.192", network.WithCIDR("192.168.20.0/24"),
+	)},
+	DNSServers:       nil,
+	DNSSearchDomains: nil,
+	MTU:              1500,
+	GatewayAddress:   newAddressOnSpaceWithId("space-0", "4", "192.168.20.2"),
+	Origin:           network.OriginProvider,
 }}
 
 func (s *interfacesSuite) TestParseInterfacesNoJSON(c *gc.C) {
@@ -791,7 +798,7 @@ func (s *interfacesSuite) TestMAASObjectNetworkInterfaces(c *gc.C) {
         "interface_set": %s
     }`, exampleInterfaceSetJSON)
 	obj := s.testMAASObject.TestServer.NewNode(nodeJSON)
-	subnetsMap := make(map[string]corenetwork.Id)
+	subnetsMap := make(map[string]network.Id)
 	subnetsMap["10.250.19.0/24"] = "3"
 	subnetsMap["192.168.1.0/24"] = "0"
 	subnetsMap["192.168.20.0/24"] = "4"
@@ -937,14 +944,13 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		},
 	}
 
-	subnetsMap := make(map[string]corenetwork.Id)
+	subnetsMap := make(map[string]network.Id)
 	subnetsMap["10.250.19.0/24"] = "3"
 	subnetsMap["192.168.1.0/24"] = "0"
 
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",
 		ProviderSubnetId:  "3",
 		AvailabilityZones: nil,
@@ -956,16 +962,17 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.103")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            corenetwork.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:           network.OriginProvider,
 	}, {
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",
 		ProviderSubnetId:  "3",
 		AvailabilityZones: nil,
@@ -977,16 +984,17 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.104")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            corenetwork.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:           network.OriginProvider,
 	}, {
 		DeviceIndex:         1,
 		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.50.19.0/24",
 		ProviderId:          "150",
 		ProviderSubnetId:    "5",
 		AvailabilityZones:   nil,
@@ -999,16 +1007,17 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("admin", "10.50.19.103")},
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      corenetwork.NewProviderAddressInSpace("admin", "10.50.19.2"),
-		Origin:              corenetwork.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"),
+		)},
+		DNSServers:       nil,
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("admin", "10.50.19.2"),
+		Origin:           network.OriginProvider,
 	}, {
 		DeviceIndex:         2,
 		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.100.19.0/24",
 		ProviderId:          "151",
 		ProviderSubnetId:    "6",
 		AvailabilityZones:   nil,
@@ -1021,16 +1030,17 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses:           corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("public", "10.100.19.103")},
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      corenetwork.NewProviderAddressInSpace("public", "10.100.19.2"),
-		Origin:              corenetwork.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"public", "10.100.19.103", network.WithCIDR("10.100.19.0/24"),
+		)},
+		DNSServers:       nil,
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("public", "10.100.19.2"),
+		Origin:           network.OriginProvider,
 	}, {
 		DeviceIndex:         3,
 		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.250.19.0/24",
 		ProviderId:          "152",
 		ProviderSubnetId:    "8",
 		AvailabilityZones:   nil,
@@ -1044,12 +1054,14 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses:           corenetwork.ProviderAddresses{newAddressOnSpaceWithId("storage", "3", "10.250.19.103")},
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
-		Origin:              corenetwork.OriginProvider,
+		Addresses: network.ProviderAddresses{newAddressOnSpaceWithId(
+			"storage", "3", "10.250.19.103", network.WithCIDR("10.250.19.0/24"),
+		)},
+		DNSServers:       nil,
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   newAddressOnSpaceWithId("storage", "3", "10.250.19.2"),
+		Origin:           network.OriginProvider,
 	}}
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
 	instance := &maas2Instance{machine: machine}
@@ -1096,10 +1108,9 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 	machine := &fakeMachine{interfaceSet: exampleInterfaces}
 	instance := &maas2Instance{machine: machine}
 
-	expected := corenetwork.InterfaceInfos{{
+	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",
 		ProviderSubnetId:  "3",
 		AvailabilityZones: nil,
@@ -1111,15 +1122,17 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace("default", "10.20.19.103")},
-		DNSServers:        corenetwork.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    corenetwork.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            corenetwork.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:           network.OriginProvider,
 	}}
 
-	infos, err := maas2NetworkInterfaces(s.callCtx, instance, map[string]corenetwork.Id{})
+	infos, err := maas2NetworkInterfaces(s.callCtx, instance, map[string]network.Id{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(infos, jc.DeepEquals, expected)
 }

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -910,7 +910,6 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",
 		ProviderSubnetId:  "3",
 		AvailabilityZones: nil,
@@ -922,16 +921,17 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("default", "10.20.19.103")},
-		DNSServers:        network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:           network.OriginProvider,
 	}, {
 		DeviceIndex:       0,
 		MACAddress:        "52:54:00:70:9b:fe",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "91",
 		ProviderSubnetId:  "3",
 		AvailabilityZones: nil,
@@ -943,16 +943,17 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		Disabled:          false,
 		NoAutoStart:       false,
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("default", "10.20.19.104")},
-		DNSServers:        network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
-		DNSSearchDomains:  nil,
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("default", "10.20.19.2"),
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("default", "10.20.19.2"),
+		Origin:           network.OriginProvider,
 	}, {
 		DeviceIndex:         1,
 		MACAddress:          "52:54:00:70:9b:fe",
-		CIDR:                "10.50.19.0/24",
 		ProviderId:          "150",
 		ProviderSubnetId:    "5",
 		AvailabilityZones:   nil,
@@ -965,12 +966,14 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses:           network.ProviderAddresses{network.NewProviderAddressInSpace("admin", "10.50.19.103")},
-		DNSServers:          nil,
-		DNSSearchDomains:    nil,
-		MTU:                 1500,
-		GatewayAddress:      network.NewProviderAddressInSpace("admin", "10.50.19.2"),
-		Origin:              network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"),
+		)},
+		DNSServers:       nil,
+		DNSSearchDomains: nil,
+		MTU:              1500,
+		GatewayAddress:   network.NewProviderAddressInSpace("admin", "10.50.19.2"),
+		Origin:           network.OriginProvider,
 	}}
 	c.Assert(result.NetworkInfo, jc.DeepEquals, expected)
 }
@@ -1078,16 +1081,15 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 
 	prepared := network.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
-		CIDR:          "10.20.19.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
 		InterfaceName: "eth0",
 	}}
 	ignored := names.NewMachineTag("1/lxd/0")
-	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
+	result, err := env.AllocateContainerAddresses(suite.callCtx, "1", ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
-		CIDR:              "192.168.1.0/24",
 		ProviderId:        "93",
 		ProviderSubnetId:  "4",
 		VLANTag:           0,
@@ -1096,10 +1098,12 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "192.168.1.127")},
-		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"freckles", "192.168.1.127", network.WithCIDR("192.168.1.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
 		Routes: []network.Route{{
 			DestinationCIDR: subnet1.CIDR(),
 			GatewayIP:       "192.168.1.1",
@@ -1208,7 +1212,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 
 	prepared := network.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
-		CIDR:          "10.20.19.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
 		InterfaceName: "eth0",
 	}}
 	ignored := names.NewMachineTag("1/lxd/0")
@@ -1217,7 +1221,6 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "93",
 		ProviderSubnetId:  "3",
 		VLANTag:           0,
@@ -1226,12 +1229,14 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "10.20.19.104")},
-		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
-		Routes:            []network.Route{},
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"freckles", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Routes:         []network.Route{},
+		Origin:         network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -1303,11 +1308,11 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesStaticRoutesDenied
 
 	prepared := network.InterfaceInfos{{
 		MACAddress:    "52:54:00:70:9b:fe",
-		CIDR:          "10.20.19.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
 		InterfaceName: "eth0",
 	}}
 	ignored := names.NewMachineTag("1/lxd/0")
-	_, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
+	_, err := env.AllocateContainerAddresses(suite.callCtx, "1", ignored, prepared)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, gc.ErrorMatches, ".*ServerError: 500 \\(I have failed you\\).*")
 }
@@ -1449,17 +1454,16 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 
 	prepared := network.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:9b:ff",
-		CIDR:          "10.20.19.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
 		InterfaceName: "eth0",
 	}, {
 		MACAddress:    "52:54:00:70:9b:f4",
-		CIDR:          "192.168.1.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("192.168.1.0/24"))},
 		InterfaceName: "eth1",
 	}}
 	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "93",
 		ProviderSubnetId:  "3",
 		ProviderVLANId:    "5001",
@@ -1467,15 +1471,16 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "10.20.19.127")},
-		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"freckles", "10.20.19.127", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Origin:         network.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		MACAddress:        "52:54:00:70:9b:f4",
-		CIDR:              "192.168.1.0/24",
 		ProviderId:        "94",
 		ProviderSubnetId:  "4",
 		ProviderVLANId:    "5002",
@@ -1483,10 +1488,12 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "192.168.1.127")},
-		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"freckles", "192.168.1.127", network.WithCIDR("192.168.1.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
 		Routes: []network.Route{{
 			DestinationCIDR: "10.20.19.0/24",
 			GatewayIP:       "192.168.1.1",
@@ -1565,9 +1572,10 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesMachinesError(c *g
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := network.InterfaceInfos{
-		{InterfaceName: "eth0", CIDR: "10.20.19.0/24"},
-	}
+	prepared := network.InterfaceInfos{{
+		InterfaceName: "eth0",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
+	}}
 	ignored := names.NewMachineTag("1/lxd/0")
 	_, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, gc.ErrorMatches, "boom")
@@ -1600,9 +1608,11 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateDeviceError(
 	}
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
-	prepared := network.InterfaceInfos{
-		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
-	}
+	prepared := network.InterfaceInfos{{
+		InterfaceName: "eth0",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
+		MACAddress:    "DEADBEEF",
+	}}
 	ignored := names.NewMachineTag("1/lxd/0")
 	_, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
 	c.Assert(err, gc.ErrorMatches, `failed to create MAAS device for "juju-06f00d-1-lxd-0": bad device call`)
@@ -1680,8 +1690,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
 	prepared := network.InterfaceInfos{
-		{InterfaceName: "eth0", CIDR: "", MACAddress: "DEADBEEF"},
-		{InterfaceName: "eth1", CIDR: "", MACAddress: "DEADBEEE"},
+		{InterfaceName: "eth0", MACAddress: "DEADBEEF"},
+		{InterfaceName: "eth1", MACAddress: "DEADBEEE"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
 	allocated, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
@@ -1744,8 +1754,16 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesCreateInterfaceErr
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
 	prepared := network.InterfaceInfos{
-		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
-		{InterfaceName: "eth1", CIDR: "10.20.20.0/24", MACAddress: "DEADBEEE"},
+		{
+			InterfaceName: "eth0",
+			Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
+			MACAddress:    "DEADBEEF",
+		},
+		{
+			InterfaceName: "eth1",
+			Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.20.0/24"))},
+			MACAddress:    "DEADBEEE",
+		},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
 	_, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
@@ -1794,11 +1812,19 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesLinkSubnetError(c 
 	suite.injectController(controller)
 	env = suite.makeEnviron(c, nil)
 	prepared := network.InterfaceInfos{
-		{InterfaceName: "eth0", CIDR: "10.20.19.0/24", MACAddress: "DEADBEEF"},
-		{InterfaceName: "eth1", CIDR: "10.20.20.0/24", MACAddress: "DEADBEEE"},
+		{
+			InterfaceName: "eth0",
+			Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
+			MACAddress:    "DEADBEEF",
+		},
+		{
+			InterfaceName: "eth1",
+			Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.20.0/24"))},
+			MACAddress:    "DEADBEEE",
+		},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
-	_, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
+	_, err := env.AllocateContainerAddresses(suite.callCtx, "1", ignored, prepared)
 	c.Assert(err, gc.ErrorMatches, "failed to create MAAS device.*boom")
 	args := getArgs(c, interface_.Calls(), 0, 0)
 	maasArgs, ok := args.(gomaasapi.LinkSubnetArgs)
@@ -1909,16 +1935,15 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 
 	prepared := network.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:9b:ff",
-		CIDR:          "10.20.19.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
 		InterfaceName: "eth0",
 	}}
 	containerTag := names.NewMachineTag("1/lxd/0")
-	result, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), containerTag, prepared)
+	result, err := env.AllocateContainerAddresses(suite.callCtx, "1", containerTag, prepared)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:9b:ff",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "93",
 		ProviderSubnetId:  "3",
 		VLANTag:           0,
@@ -1927,12 +1952,14 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("space-1", "10.20.19.105")},
-		DNSServers:        network.NewProviderAddressesInSpace("space-1", "10.20.19.2", "10.20.19.3"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("space-1", "10.20.19.2"),
-		Routes:            []network.Route{},
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"space-1", "10.20.19.105", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("space-1", "10.20.19.2", "10.20.19.3"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("space-1", "10.20.19.2"),
+		Routes:         []network.Route{},
+		Origin:         network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }
@@ -2105,11 +2132,11 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 
 	prepared := network.InterfaceInfos{{
 		MACAddress:    "53:54:00:70:88:aa",
-		CIDR:          "10.20.19.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("10.20.19.0/24"))},
 		InterfaceName: "eth0",
 	}, {
 		MACAddress:    "53:54:00:70:88:bb",
-		CIDR:          "192.168.1.0/24",
+		Addresses:     network.ProviderAddresses{network.NewProviderAddress("", network.WithCIDR("192.168.1.0/24"))},
 		InterfaceName: "eth1",
 	}}
 	containerTag := names.NewMachineTag("1/lxd/0")
@@ -2118,7 +2145,6 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 	expected := network.InterfaceInfos{{
 		DeviceIndex:       0,
 		MACAddress:        "53:54:00:70:88:aa",
-		CIDR:              "10.20.19.0/24",
 		ProviderId:        "93",
 		ProviderSubnetId:  "3",
 		VLANTag:           0,
@@ -2127,16 +2153,17 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "10.20.19.105")},
-		DNSServers:        network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
-		Routes:            []network.Route{},
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"freckles", "10.20.19.105", network.WithCIDR("10.20.19.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("freckles", "10.20.19.2"),
+		Routes:         []network.Route{},
+		Origin:         network.OriginProvider,
 	}, {
 		DeviceIndex:       1,
 		MACAddress:        "53:54:00:70:88:bb",
-		CIDR:              "192.168.1.0/24",
 		ProviderId:        "94",
 		ProviderSubnetId:  "4",
 		VLANTag:           0,
@@ -2145,12 +2172,14 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
 		ConfigType:        "static",
-		Addresses:         network.ProviderAddresses{network.NewProviderAddressInSpace("freckles", "192.168.1.101")},
-		DNSServers:        network.NewProviderAddressesInSpace("freckles", "192.168.1.2"),
-		MTU:               1500,
-		GatewayAddress:    network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
-		Routes:            []network.Route{},
-		Origin:            network.OriginProvider,
+		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
+			"freckles", "192.168.1.101", network.WithCIDR("192.168.1.0/24"),
+		)},
+		DNSServers:     network.NewProviderAddressesInSpace("freckles", "192.168.1.2"),
+		MTU:            1500,
+		GatewayAddress: network.NewProviderAddressInSpace("freckles", "192.168.1.1"),
+		Routes:         []network.Route{},
+		Origin:         network.OriginProvider,
 	}}
 	c.Assert(result, jc.DeepEquals, expected)
 }

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -76,7 +76,7 @@ func (s *maas2InstanceSuite) TestAddresses(c *gc.C) {
 	addresses, err := instance.Addresses(s.callCtx)
 
 	expectedAddresses := network.ProviderAddresses{
-		newAddressOnSpaceWithId("freckles", "4567", "192.168.10.1"),
+		newAddressOnSpaceWithId("freckles", "4567", "192.168.10.1", network.WithCIDR(subnet.cidr)),
 	}
 
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -35,7 +35,6 @@ const (
 
 	VcnNamePrefix         = "juju-vcn"
 	SecListNamePrefix     = "juju-seclist"
-	SubnetNamePrefix      = "juju-subnet"
 	InternetGatewayPrefix = "juju-ig"
 	RouteTablePrefix      = "juju-rt"
 )
@@ -1093,11 +1092,11 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 				network.NewProviderAddress(
 					*iface.Vnic.PrivateIp,
 					network.WithScope(network.ScopeCloudLocal),
+					network.WithCIDR(*subnet.CidrBlock),
 				),
 			},
 			InterfaceType:    network.EthernetInterface,
 			ProviderSubnetId: network.Id(*iface.Vnic.SubnetId),
-			CIDR:             *subnet.CidrBlock,
 			Origin:           network.OriginProvider,
 		}
 		if iface.Vnic.PublicIp != nil {

--- a/provider/oci/networking_test.go
+++ b/provider/oci/networking_test.go
@@ -244,7 +244,8 @@ func (n *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 
 	c.Assert(info, gc.HasLen, 1)
 	c.Assert(info[0].Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{
-		corenetwork.NewProviderAddress("1.1.1.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal))})
+		corenetwork.NewProviderAddress(
+			"1.1.1.1", corenetwork.WithScope(corenetwork.ScopeCloudLocal), corenetwork.WithCIDR("1.0.0.0/8"))})
 	c.Assert(info[0].ShadowAddresses, gc.DeepEquals, corenetwork.ProviderAddresses{
 		corenetwork.NewProviderAddress("2.2.2.2", corenetwork.WithScope(corenetwork.ScopePublic))})
 	c.Assert(info[0].DeviceIndex, gc.Equals, 0)
@@ -252,7 +253,6 @@ func (n *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 	c.Assert(info[0].MACAddress, gc.Equals, "aa:aa:aa:aa:aa:aa")
 	c.Assert(info[0].InterfaceType, gc.Equals, corenetwork.EthernetInterface)
 	c.Assert(info[0].ProviderSubnetId, gc.Equals, corenetwork.Id("fakeSubnetId"))
-	c.Assert(info[0].CIDR, gc.Equals, "1.0.0.0/8")
 }
 
 func (n *networkingSuite) TestSubnets(c *gc.C) {

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -588,6 +588,8 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(
 		VirtualPortType:     dev.VirtualPortType(),
 	}
 
+	// Include a single address without an IP, but with a CIDR
+	// to indicate that we know the subnet for this bridge.
 	if len(addrs) > 0 {
 		addr := addrs[0]
 		if askProviderForAddress {
@@ -599,12 +601,14 @@ func (dev *LinkLayerDevice) EthernetDeviceForBridge(
 				)
 			}
 			newDev.ConfigType = network.ConfigStatic
-			newDev.CIDR = sub.CIDR()
 			newDev.ProviderSubnetId = sub.ProviderId()
 			newDev.VLANTag = sub.VLANTag()
 			newDev.IsDefaultGateway = addr.IsDefaultGateway()
+			newDev.Addresses = network.ProviderAddresses{
+				network.NewProviderAddress("", network.WithCIDR(sub.CIDR()))}
 		} else {
-			newDev.CIDR = addr.SubnetCIDR()
+			newDev.Addresses = network.ProviderAddresses{
+				network.NewProviderAddress("", network.WithCIDR(addr.SubnetCIDR()))}
 		}
 	}
 

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -637,7 +637,7 @@ func (s *linkLayerDevicesStateSuite) TestEthernetDeviceForBridge(c *gc.C) {
 	c.Check(child.InterfaceName, gc.Equals, "eth0")
 	c.Check(child.ConfigType, gc.Equals, corenetwork.ConfigStatic)
 	c.Check(child.ParentInterfaceName, gc.Equals, "br0")
-	c.Check(child.CIDR, gc.Equals, "10.0.0.0/24")
+	c.Check(child.PrimaryAddress().CIDR, gc.Equals, "10.0.0.0/24")
 	c.Check(child.ProviderSubnetId, gc.Equals, corenetwork.Id("ps-01"))
 
 	child, err = dev.EthernetDeviceForBridge("eth0", false)

--- a/worker/containerbroker/broker_test.go
+++ b/worker/containerbroker/broker_test.go
@@ -4,6 +4,10 @@ package containerbroker_test
 
 import (
 	"github.com/golang/mock/gomock"
+	"github.com/juju/names/v4"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/provisioner"
@@ -15,9 +19,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/worker/containerbroker"
 	"github.com/juju/juju/worker/containerbroker/mocks"
-	"github.com/juju/names/v4"
-	"github.com/juju/testing"
-	gc "gopkg.in/check.v1"
 )
 
 type brokerConfigSuite struct {
@@ -145,9 +146,9 @@ func (s *trackerSuite) TestNewTracker(c *gc.C) {
 		&broker.Config{
 			Name:          "instance-broker",
 			ContainerType: instance.LXD,
-			ManagerConfig: container.ManagerConfig(map[string]string{
+			ManagerConfig: map[string]string{
 				container.ConfigAvailabilityZone: "0",
-			}),
+			},
 			APICaller:    s.state,
 			AgentConfig:  s.agentConfig,
 			MachineTag:   s.machineTag,

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -505,8 +505,6 @@ func fakeInterfacesFromInstanceAddrs(addrs []network.ProviderAddress) network.In
 		default:
 			instIfaceList[i].Addresses = append(instIfaceList[i].Addresses, addr)
 		}
-
-		instIfaceList[i].CIDR = addr.CIDR
 	}
 
 	return instIfaceList

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -47,7 +47,6 @@ var (
 			DeviceIndex:   0,
 			InterfaceName: "eth0",
 			MACAddress:    "de:ad:be:ef:00:00",
-			CIDR:          "10.0.0.0/24",
 			Addresses: network.ProviderAddresses{
 				network.NewProviderAddress(
 					"10.0.0.1", network.WithCIDR("10.0.0.0/24"), network.WithScope(network.ScopeCloudLocal)),
@@ -62,7 +61,6 @@ var (
 	testCoercedNetIfs = network.InterfaceInfos{
 		{
 			DeviceIndex: 0,
-			CIDR:        "10.0.0.0/24",
 			Addresses: network.ProviderAddresses{
 				network.NewProviderAddress(
 					"10.0.0.1", network.WithCIDR("10.0.0.0/24"), network.WithScope(network.ScopeCloudLocal)),
@@ -70,7 +68,6 @@ var (
 		},
 		{
 			DeviceIndex: 1,
-			CIDR:        "1.1.1.0/24",
 			ShadowAddresses: network.ProviderAddresses{
 				network.NewProviderAddress(
 					"1.1.1.42", network.WithCIDR("1.1.1.0/24"), network.WithScope(network.ScopePublic)),


### PR DESCRIPTION
This change moves towards a sane cardinality for the `InterfaceInfo` type in `core/network`.

Historically this type and it's wire analogue, `params.NetworkConfig` were repeated for each address on a network interface.

At some point more recently, the `Address` string was superseded by `Addresses` and `ShadowAddresses`, which are collections of `ProviderAddress`. At this time the presence of members such as `CIDR`, `ConfigType` et al, were made incorrect as properties of the interface.

Over time the intention is to push usage of all such properties down into the addresses collection so that we model the device/address relationship properly.

In this patch we deal with the CIDR member; specifically:
- `Address.ValueForCIDR` is replaced with `ValueWithMask`, which uses the member CIDR instead of accepting it as an argument.
- `CIDR` is removed from `InterfaceInfo` as is the `CIDRAddress` method, which called through to `ValueForCIDR` removed above.
- The `params.NetworkConfig` type is preserved, but with altered conversion logic for the new `InterfaceInfo` form. Thus we preserve backward compatibility.
- All previous usages of `InterfaceInfo.CIDR` are removed and replaced with logic that deals with CIDR as a characteristic of members in the `Addresses` collection.

## QA steps

### MAAS (container-networking-method=provider)

- Bootstrap to a MAAS configured with multiple spaces.
- `juju model-config default-space=<space-x>`
- Add a machine that is connected to multiple spaces.
- `juju deploy ubuntu --to lxd:0 --constraints "spaces=<space-x>`.
- Once settled, `juju show-machine 0` should indicate `network-interfaces` entries for both machine and container in the correct subnet/space.
- Connect to Mongo and run `db.ip.addresses.find().pretty()`. All documents should have a populated `subnet-cidr`.

### AWS (container-networking-method=fan)

- Bootstrap.
- `juju add-space space-1 172.31.80.0/20`.
- `juju add-machine --constraints "spaces=space-1"`.
- `juju deploy ubuntu --to lxd:0 --constraints "spaces=space-1"`.
- Satisfy the same checks as for MAAS, above.

## Documentation changes

None.

## Bug reference

More foundation work in service of https://bugs.launchpad.net/juju/+bug/1863916
