### PR TITLE
Correct default bootstrap-timeout value displayed in help.

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -93,7 +93,7 @@ You can change the default timeout and retry delays used during the
 bootstrap by changing the following settings in your configuration
 (all values represent number of seconds):
     # How long to wait for a connection to the controller
-    bootstrap-timeout: 600 # default: 10 minutes
+    bootstrap-timeout: 1200 # default: 20 minutes
     # How long to wait between connection attempts to a controller
 address.
     bootstrap-retry-delay: 5 # default: 5 seconds


### PR DESCRIPTION
A quick usability fix. Correct default bootstrap-timeout value displayed in help. DefaultBootstrapSSHTimeout is defined as 1200.

## QA steps
```console
$ juju help bootstrap | grep bootstrap-timeout
    bootstrap-timeout: 1200 # default: 20 minutes                <- here is the change.
bootstrap-timeout:
    juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
```


