### PR TITLE
Fixes bug where model operator perms overwrite

### DIFF
--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -65,6 +65,10 @@ type ModelOperatorBroker interface {
 	// exists in the targets cluster.
 	EnsureServiceAccount(*core.ServiceAccount) ([]func(), error)
 
+	// Model returns the name of the current model being deployed to for the
+	// broker
+	Model() string
+
 	// Namespace returns the current default namespace targeted by this broker.
 	Namespace() string
 
@@ -83,6 +87,7 @@ type modelOperatorBrokerBridge struct {
 	ensureRoleBinding        func(*rbac.RoleBinding) ([]func(), error)
 	ensureService            func(*core.Service) ([]func(), error)
 	ensureServiceAccount     func(*core.ServiceAccount) ([]func(), error)
+	model                    func() string
 	namespace                func() string
 	isLegacyLabels           func() bool
 }
@@ -167,6 +172,14 @@ func (m *modelOperatorBrokerBridge) EnsureServiceAccount(s *core.ServiceAccount)
 	return m.ensureServiceAccount(s)
 }
 
+// Model implements ModelOperatorBroker
+func (m *modelOperatorBrokerBridge) Model() string {
+	if m.model == nil {
+		return ""
+	}
+	return m.model()
+}
+
 // Namespace implements ModelOperatorBroker
 func (m *modelOperatorBrokerBridge) Namespace() string {
 	if m.namespace == nil {
@@ -244,7 +257,6 @@ func ensureModelOperator(
 	saName, c, err := ensureModelOperatorRBAC(
 		broker,
 		operatorName,
-		broker.Namespace(),
 		labels,
 	)
 	cleanUpFuncs = append(cleanUpFuncs, c...)
@@ -326,6 +338,7 @@ func (k *kubernetesClient) EnsureModelOperator(
 			return c, err
 		},
 		namespace:      func() string { return k.namespace },
+		model:          func() string { return k.CurrentModel() },
 		isLegacyLabels: k.IsLegacyLabels,
 	}
 
@@ -523,18 +536,26 @@ func modelOperatorService(
 	}
 }
 
+func modelOperatorGlobalScopedName(model, operatorName string) string {
+	if model == "" {
+		return operatorName
+	}
+	return fmt.Sprintf("%s-%s", model, operatorName)
+}
+
 func ensureModelOperatorRBAC(
 	broker ModelOperatorBroker,
-	operatorName,
-	namespace string,
+	operatorName string,
 	labels map[string]string,
 ) (string, []func(), error) {
 	cleanUpFuncs := []func(){}
 
+	globalName := modelOperatorGlobalScopedName(broker.Model(), operatorName)
+
 	sa := &core.ServiceAccount{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
-			Namespace: namespace,
+			Namespace: broker.Namespace(),
 			Labels:    labels,
 		},
 		AutomountServiceAccountToken: boolPtr(true),
@@ -548,7 +569,7 @@ func ensureModelOperatorRBAC(
 
 	clusterRole := &rbac.ClusterRole{
 		ObjectMeta: meta.ObjectMeta{
-			Name:   operatorName,
+			Name:   globalName,
 			Labels: labels,
 		},
 		Rules: []rbac.PolicyRule{
@@ -579,7 +600,7 @@ func ensureModelOperatorRBAC(
 
 	clusterRoleBinding := &rbac.ClusterRoleBinding{
 		ObjectMeta: meta.ObjectMeta{
-			Name:   operatorName,
+			Name:   globalName,
 			Labels: labels,
 		},
 		RoleRef: rbac.RoleRef{
@@ -605,7 +626,7 @@ func ensureModelOperatorRBAC(
 	role := &rbac.Role{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
-			Namespace: namespace,
+			Namespace: broker.Namespace(),
 			Labels:    labels,
 		},
 		Rules: []rbac.PolicyRule{
@@ -630,7 +651,7 @@ func ensureModelOperatorRBAC(
 	roleBinding := &rbac.RoleBinding{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      operatorName,
-			Namespace: namespace,
+			Namespace: broker.Namespace(),
 			Labels:    labels,
 		},
 		RoleRef: rbac.RoleRef{

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -31,6 +31,7 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 		namespaceCalled                = false
 		modelUUID                      = "abcd-efff-face"
 		agentPath                      = "/var/app/juju"
+		model                          = "test-model"
 		namespace                      = "test-namespace"
 	)
 
@@ -43,7 +44,7 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 	bridge := &modelOperatorBrokerBridge{
 		ensureClusterRole: func(cr *rbac.ClusterRole) ([]func(), error) {
 			ensureClusterRoleCalled = true
-			c.Assert(cr.Name, gc.Equals, modelOperatorName)
+			c.Assert(cr.Name, gc.Equals, "test-model-modeloperator")
 			c.Assert(cr.Rules[0].APIGroups, jc.DeepEquals, []string{""})
 			c.Assert(cr.Rules[0].Resources, jc.DeepEquals, []string{"namespaces"})
 			c.Assert(cr.Rules[0].Verbs, jc.DeepEquals, []string{"get", "list"})
@@ -60,10 +61,10 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 		},
 		ensureClusterRoleBinding: func(crb *rbac.ClusterRoleBinding) ([]func(), error) {
 			ensureClusterRoleBindingCalled = true
-			c.Assert(crb.Name, gc.Equals, modelOperatorName)
+			c.Assert(crb.Name, gc.Equals, "test-model-modeloperator")
 			c.Assert(crb.RoleRef.APIGroup, gc.Equals, "rbac.authorization.k8s.io")
 			c.Assert(crb.RoleRef.Kind, gc.Equals, "ClusterRole")
-			c.Assert(crb.RoleRef.Name, gc.Equals, modelOperatorName)
+			c.Assert(crb.RoleRef.Name, gc.Equals, "test-model-modeloperator")
 			return nil, nil
 		},
 		ensureConfigMap: func(cm *core.ConfigMap) ([]func(), error) {
@@ -120,6 +121,9 @@ func (m *ModelOperatorSuite) Test(c *gc.C) {
 			c.Assert(s.Namespace, gc.Equals, namespace)
 			c.Assert(s.Spec.Ports[0].Port, gc.Equals, config.Port)
 			return nil, nil
+		},
+		model: func() string {
+			return model
 		},
 		namespace: func() string {
 			namespaceCalled = true


### PR DESCRIPTION
A bug was introduced where model operator cluster role and role binding
permissions would overwrite each other because they shared the same
name. This change makes it so they have unique names now.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap Juju to a kubernetes cluster. Add two or models. On the first model added remove the model operator pod. Check the new pod coming up does not have any errors in the logs.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1921667
