### PR TITLE
Integration fixes

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -301,7 +301,7 @@ func (s *toolsSuite) TestFindToolsOldAgent(c *gc.C) {
 			stateenvirons.EnvironConfigGetter{Model: s.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"), newEnviron,
 		)
 		result, err := toolsFinder.FindTools(params.FindToolsParams{
-			Number: version.MustParse("2.8.9"),
+			Number:       version.MustParse("2.8.9"),
 			MajorVersion: 2,
 			MinorVersion: 8,
 			OSType:       "ubuntu",

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -42,7 +42,7 @@ check_not_contains() {
 	shift
 
 	chk=$(echo "${input}" | grep "${value}" || true)
-	if [[ -n "${chk}" ]]; then
+	if [[ -n ${chk} ]]; then
 		printf "Unexpected \"${value}\" found\n\n%s\n" "${input}" >&2
 		exit 1
 	else
@@ -60,7 +60,7 @@ check_contains() {
 	shift
 
 	chk=$(echo "${input}" | grep "${value}" || true)
-	if [[ -z "${chk}" ]]; then
+	if [[ -z ${chk} ]]; then
 		printf "Expected \"%s\" not found\n\n%s\n" "${value}" "${input}" >&2
 		exit 1
 	else
@@ -100,7 +100,7 @@ check() {
 	done
 
 	OUT=$(echo "${got}" | grep -E "${want}" || echo "(NOT FOUND)")
-	if [[ "${OUT}" == "(NOT FOUND)" ]]; then
+	if [[ ${OUT} == "(NOT FOUND)" ]]; then
 		echo "" >&2
 		# shellcheck disable=SC2059
 		printf "$(red \"Expected\"): ${want}\n" >&2

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -42,7 +42,7 @@ check_not_contains() {
 	shift
 
 	chk=$(echo "${input}" | grep "${value}" || true)
-	if [ -n "${chk}" ]; then
+	if [[ -n "${chk}" ]]; then
 		printf "Unexpected \"${value}\" found\n\n%s\n" "${input}" >&2
 		exit 1
 	else
@@ -60,7 +60,7 @@ check_contains() {
 	shift
 
 	chk=$(echo "${input}" | grep "${value}" || true)
-	if [ -z "${chk}" ]; then
+	if [[ -z "${chk}" ]]; then
 		printf "Expected \"%s\" not found\n\n%s\n" "${value}" "${input}" >&2
 		exit 1
 	else
@@ -100,7 +100,7 @@ check() {
 	done
 
 	OUT=$(echo "${got}" | grep -E "${want}" || echo "(NOT FOUND)")
-	if [ "${OUT}" == "(NOT FOUND)" ]; then
+	if [[ "${OUT}" == "(NOT FOUND)" ]]; then
 		echo "" >&2
 		# shellcheck disable=SC2059
 		printf "$(red \"Expected\"): ${want}\n" >&2

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -4,11 +4,11 @@ check_dependencies() {
 
 	for dep in "$@"; do
 		if ! which "$dep" >/dev/null 2>&1; then
-			[ "$missing" ] && missing="$missing $dep" || missing="$dep"
+			[[ "$missing" ]] && missing="$missing, $dep" || missing="$dep"
 		fi
 	done
 
-	if [ "$missing" ]; then
+	if [[ "$missing" ]]; then
 		echo "Missing dependencies: $missing" >&2
 		echo ""
 		exit 1
@@ -21,12 +21,12 @@ check_juju_dependencies() {
 
 	for dep in "$@"; do
 		if ! juju "$dep" >/dev/null 2>&1; then
-			[ "$missing" ] && missing="$missing $dep" || missing="$dep"
+			[[ "$missing" ]] && missing="$missing, juju $dep" || missing="juju $dep"
 		fi
 	done
 
-	if [ "$missing" ]; then
-		echo "Missing dependencies: $missing" >&2
+	if [[ "$missing" ]]; then
+		echo "Missing juju commands: $missing" >&2
 		echo ""
 		exit 1
 	fi

--- a/tests/includes/check.sh
+++ b/tests/includes/check.sh
@@ -78,7 +78,7 @@ check_gt() {
 	shift
 
 	if [[ ${input} > ${value} ]]; then
-		echo 'Success: "%s" > "%s"' "${input}" "${value}" >&2
+		printf "Success: \"%s\" > \"%s\"\n" "${input}" "${value}" >&2
 	else
 		printf "Expected \"%s\" > \"%s\"\n" "${input}" "${value}" >&2
 		exit 1

--- a/tests/includes/cleanup.sh
+++ b/tests/includes/cleanup.sh
@@ -8,7 +8,7 @@ add_clean_func() {
 
 # cleanup_funcs attempts to clean up with functions.
 cleanup_funcs() {
-	if [ -f "${TEST_DIR}/cleanup" ]; then
+	if [[ -f "${TEST_DIR}/cleanup" ]]; then
 		while read -r CMD; do
 			echo "====> Running clean up func: ${CMD}"
 			$CMD

--- a/tests/includes/colors.sh
+++ b/tests/includes/colors.sh
@@ -14,7 +14,7 @@ supports_colors() {
 }
 
 red() {
-	if [ "$(supports_colors)" = "YES" ]; then
+	if [[ "$(supports_colors)" = "YES" ]]; then
 		tput sgr0
 		echo "$(tput setaf 1)${1}$(tput sgr0)"
 		return
@@ -23,7 +23,7 @@ red() {
 }
 
 green() {
-	if [ "$(supports_colors)" = "YES" ]; then
+	if [[ "$(supports_colors)" = "YES" ]]; then
 		tput sgr0
 		echo "$(tput setaf 2)${1}$(tput sgr0)"
 		return

--- a/tests/includes/colors.sh
+++ b/tests/includes/colors.sh
@@ -1,5 +1,5 @@
 supports_colors() {
-	if [[ -z "${TERM}" ]] || [[ "${TERM}" = "" ]] || [[ "${TERM}" = "dumb" ]]; then
+	if [[ -z ${TERM} ]] || [[ ${TERM} == "" ]] || [[ ${TERM} == "dumb" ]]; then
 		echo "NO"
 		return
 	fi
@@ -14,7 +14,7 @@ supports_colors() {
 }
 
 red() {
-	if [[ "$(supports_colors)" = "YES" ]]; then
+	if [[ "$(supports_colors)" == "YES" ]]; then
 		tput sgr0
 		echo "$(tput setaf 1)${1}$(tput sgr0)"
 		return
@@ -23,7 +23,7 @@ red() {
 }
 
 green() {
-	if [[ "$(supports_colors)" = "YES" ]]; then
+	if [[ "$(supports_colors)" == "YES" ]]; then
 		tput sgr0
 		echo "$(tput setaf 2)${1}$(tput sgr0)"
 		return

--- a/tests/includes/colors.sh
+++ b/tests/includes/colors.sh
@@ -1,5 +1,5 @@
 supports_colors() {
-	if [ -z "${TERM}" ] || [ "${TERM}" = "" ] || [ "${TERM}" = "dumb" ]; then
+	if [[ -z "${TERM}" ]] || [[ "${TERM}" = "" ]] || [[ "${TERM}" = "dumb" ]]; then
 		echo "NO"
 		return
 	fi

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -214,7 +214,7 @@ destroy_model() {
 	# shellcheck disable=SC2034
 	OUT=$(juju models --format=json | jq '.models | .[] | .["short-name"]' | grep "${name}" || true)
 	# shellcheck disable=SC2181
-	if [ -z "${OUT}" ]; then
+	if [[ -z "${OUT}" ]]; then
 		return
 	fi
 
@@ -223,7 +223,7 @@ destroy_model() {
 	echo "====> Destroying juju model ${name}"
 	echo "${name}" | xargs -I % juju destroy-model -y % >"${output}" 2>&1 || true
 	CHK=$(cat "${output}" | grep -i "ERROR" || true)
-	if [ -n "${CHK}" ]; then
+	if [[ -n "${CHK}" ]]; then
 		printf '\nFound some issues\n'
 		cat "${output}"
 		exit 1
@@ -315,7 +315,7 @@ introspect_controller() {
 	name=${1}
 
 	idents=$(juju machines -m "${name}:controller" --format=json | jq ".machines | keys | .[]")
-	if [ -z "${idents}" ]; then
+	if [[ -z "${idents}" ]]; then
 		return
 	fi
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -87,13 +87,13 @@ bootstrap() {
 	rnd=$(rnd_str)
 	name="ctrl-${rnd}"
 
-	if [ ! -f "${TEST_DIR}/jujus" ]; then
+	if [[ ! -f "${TEST_DIR}/jujus" ]]; then
 		touch "${TEST_DIR}/jujus"
 	fi
-	bootstrapped_name=$(grep "." "${TEST_DIR}/jujus" | tail -n 1)
-	if [ -z "${bootstrapped_name}" ]; then
+	bootstrapped_name=$({ grep "." "${TEST_DIR}/jujus" || echo ""; } | tail -n 1)
+	if [[ -z "${bootstrapped_name}" ]]; then
 		# shellcheck disable=SC2236
-		if [ ! -z "${BOOTSTRAP_REUSE_LOCAL}" ]; then
+		if [[ ! -z "${BOOTSTRAP_REUSE_LOCAL}" ]]; then
 			bootstrapped_name="${BOOTSTRAP_REUSE_LOCAL}"
 			export BOOTSTRAP_REUSE="true"
 		else
@@ -102,11 +102,11 @@ bootstrap() {
 			export BOOTSTRAP_REUSE="false"
 		fi
 	fi
-	if [ "${BOOTSTRAP_REUSE}" = "true" ]; then
+	if [[ "${BOOTSTRAP_REUSE}" = "true" ]]; then
 		OUT=$(juju show-machine -m "${bootstrapped_name}":controller --format=json | jq -r ".machines | .[] | .series")
-		if [ -n "${OUT}" ]; then
+		if [[ -n "${OUT}" ]]; then
 			OUT=$(echo "${OUT}" | grep -oh "${BOOTSTRAP_SERIES}" || true)
-			if [ "${OUT}" != "${BOOTSTRAP_SERIES}" ]; then
+			if [[ "${OUT}" != "${BOOTSTRAP_SERIES}" ]]; then
 				echo "====> Unable to reuse bootstrapped juju"
 				export BOOTSTRAP_REUSE="false"
 			fi
@@ -116,11 +116,11 @@ bootstrap() {
 	version=$(juju_version)
 
 	START_TIME=$(date +%s)
-	if [ "${BOOTSTRAP_REUSE}" = "true" ]; then
+	if [[ "${BOOTSTRAP_REUSE}" = "true" ]]; then
 		echo "====> Reusing bootstrapped juju ($(green "${version}:${provider}"))"
 
 		OUT=$(juju models -c "${bootstrapped_name}" --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
-		if [ -n "${OUT}" ]; then
+		if [[ -n "${OUT}" ]]; then
 			echo "${model} already exists. Use the following to clean up the environment:"
 			echo "    juju switch ${bootstrapped_name}"
 			echo "    juju destroy-model -y ${model}"
@@ -151,7 +151,7 @@ add_model() {
 	output=${4}
 
 	OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${provider}" || true)
-	if [ -n "${OUT}" ]; then
+	if [[ -n "${OUT}" ]]; then
 		juju add-model -c "${controller}" "${model}" "${provider}" 2>&1 | OUTPUT "${output}"
 	else
 		juju add-model -c "${controller}" "${model}" 2>&1 | OUTPUT "${output}"
@@ -181,8 +181,8 @@ juju_bootstrap() {
 	"${CURRENT_LTS}")
 		series="--bootstrap-series=${BOOTSTRAP_SERIES} --config image-stream=daily --force"
 		;;
-	"") ;;
-
+	"")
+		;;
 	*)
 		series="--bootstrap-series=${BOOTSTRAP_SERIES}"
 		;;
@@ -246,9 +246,9 @@ destroy_controller() {
 	# shellcheck disable=SC2034
 	OUT=$(juju controllers --format=json | jq '.controllers | keys[]' | grep "${name}" || true)
 	# shellcheck disable=SC2181
-	if [ -z "${OUT}" ]; then
+	if [[ -z "${OUT}" ]]; then
 		OUT=$(juju models --format=json | jq -r '.models | .[] | .["short-name"]' | grep "^${name}$" || true)
-		if [ -z "${OUT}" ]; then
+		if [[ -z "${OUT}" ]]; then
 			echo "====> ERROR Destroy controller/model. Unable to locate $(red "${name}")"
 			exit 1
 		fi
@@ -283,7 +283,7 @@ destroy_controller() {
 
 	set +e
 	CHK=$(cat "${output}" | grep -i "ERROR" || true)
-	if [ -n "${CHK}" ]; then
+	if [[ -n "${CHK}" ]]; then
 		printf '\nFound some issues\n'
 		cat "${output}"
 		exit 1
@@ -298,7 +298,7 @@ destroy_controller() {
 # knows about. This is for internal use only and shouldn't be used by any of the
 # tests directly.
 cleanup_jujus() {
-	if [ -f "${TEST_DIR}/jujus" ]; then
+	if [[ -f "${TEST_DIR}/jujus" ]]; then
 		echo "====> Cleaning up jujus"
 
 		while read -r juju_name; do
@@ -329,11 +329,11 @@ remove_controller_offers() {
 	name=${1}
 
 	OUT=$(juju models -c "${name}" --format=json | jq -r '.["models"] | .[] | select(.["is-controller"] == false) | .name' || true)
-	if [ -n "${OUT}" ]; then
+	if [[ -n "${OUT}" ]]; then
 		echo "${OUT}" | while read -r model; do
 			OUT=$(juju offers -m "${name}:${model}" --format=json | jq -r '.[] | .["offer-url"]' || true)
 			echo "${OUT}" | while read -r offer; do
-				if [ -n "${offer}" ]; then
+				if [[ -n "${offer}" ]]; then
 					juju remove-offer --force -y -c "${name}" "${offer}"
 					echo "${offer}" >>"${TEST_DIR}/${name}-juju_removed_offers.log"
 				fi

--- a/tests/includes/output.sh
+++ b/tests/includes/output.sh
@@ -4,18 +4,18 @@ OUTPUT() {
 	output=${1}
 	shift
 
-	if [ -z "${output}" ] || [ "${VERBOSE}" -gt 1 ]; then
+	if [[ -z "${output}" ]] || [[ "${VERBOSE}" -gt 1 ]]; then
 		echo
 	fi
 
 	# shellcheck disable=SC2162
 	while read data; do
 		# If there is no output, just dump straight to stdout.
-		if [ -z "${output}" ]; then
+		if [[ -z "${output}" ]]; then
 			echo "${data}"
 		# If there is an output, but we're not in verbose mode, just append to
 		# the output.
-		elif [ "${VERBOSE}" -le 1 ]; then
+		elif [[ "${VERBOSE}" -le 1 ]]; then
 			echo "${data}" >>"${output}"
 		# If we are in verbose mode, but we're an empty line, send to stdout
 		# and also tee it to the output.
@@ -28,7 +28,7 @@ OUTPUT() {
 		fi
 	done
 
-	if [ -z "${output}" ] || [ "${VERBOSE}" -gt 1 ]; then
+	if [[ -z "${output}" ]] || [[ "${VERBOSE}" -gt 1 ]]; then
 		echo
 	fi
 }

--- a/tests/includes/output.sh
+++ b/tests/includes/output.sh
@@ -4,18 +4,18 @@ OUTPUT() {
 	output=${1}
 	shift
 
-	if [[ -z "${output}" ]] || [[ "${VERBOSE}" -gt 1 ]]; then
+	if [[ -z ${output} ]] || [[ ${VERBOSE} -gt 1 ]]; then
 		echo
 	fi
 
 	# shellcheck disable=SC2162
 	while read data; do
 		# If there is no output, just dump straight to stdout.
-		if [[ -z "${output}" ]]; then
+		if [[ -z ${output} ]]; then
 			echo "${data}"
 		# If there is an output, but we're not in verbose mode, just append to
 		# the output.
-		elif [[ "${VERBOSE}" -le 1 ]]; then
+		elif [[ ${VERBOSE} -le 1 ]]; then
 			echo "${data}" >>"${output}"
 		# If we are in verbose mode, but we're an empty line, send to stdout
 		# and also tee it to the output.
@@ -28,7 +28,7 @@ OUTPUT() {
 		fi
 	done
 
-	if [[ -z "${output}" ]] || [[ "${VERBOSE}" -gt 1 ]]; then
+	if [[ -z ${output} ]] || [[ ${VERBOSE} -gt 1 ]]; then
 		echo
 	fi
 }

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -16,30 +16,12 @@ run() {
 
 	START_TIME=$(date +%s)
 
-	# Prevent the sub-shell from killing our script if that sub-shell fails on an
-	# error. We need this so that we can capture the full output and collect the
-	# exit code when it does fail.
-	# Do not remove or none of the tests will report correctly!
-	set +e
-
-	cmd_output=$(run_error_early "${CMD}" "$@" 2>&1)
-	cmd_status=$?
-
+	"${CMD}" "$@" 2>&1
 	set_verbosity
-
-	# Only output if it's not empty.
-	if [ -n "${cmd_output}" ]; then
-		echo -e "${cmd_output}" | OUTPUT "${TEST_DIR}/${TEST_CURRENT}.log"
-	fi
 
 	END_TIME=$(date +%s)
 
-	if [ "${cmd_status}" -eq 0 ]; then
-		echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
-	else
-		echo -e "\r===> [ $(red "x") ] Fail: ${DESC} ($((END_TIME - START_TIME))s)"
-		exit 1
-	fi
+	echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
 }
 
 run_error_early() {

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -29,8 +29,8 @@ run() {
 
 	"${CMD}" "$@" >"${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
 	if [[ ${VERBOSE} -gt 1 ]]; then
-		# SIGINT because it should be safe to do so.
-		kill -2 "${pid}" >/dev/null 2>&1 || true
+		# SIGKILL because it should be safe to do so.
+		kill -9 "${pid}" >/dev/null 2>&1 || true
 	fi
 
 	END_TIME=$(date +%s)

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -2,7 +2,7 @@
 run() {
 	CMD="${1}"
 
-	if [[ -n "${RUN_SUBTEST}" ]]; then
+	if [[ -n ${RUN_SUBTEST} ]]; then
 		# shellcheck disable=SC2143
 		if [[ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]]; then
 			echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
@@ -18,17 +18,19 @@ run() {
 
 	set_verbosity
 
-	if [[ "${VERBOSE}" -gt 1 ]]; then
+	if [[ ${VERBOSE} -gt 1 ]]; then
 		touch "${TEST_DIR}/${TEST_CURRENT}.log"
 		tail -f "${TEST_DIR}/${TEST_CURRENT}.log" 2>/dev/null &
 		pid=$!
 
-		trap "kill -9 ${pid} >/dev/null || true" EXIT
+		# SIGKILL it with fire, as we don't know what state we're in.
+		trap 'kill -9 "${pid}" >/dev/null 2>&1 || true' EXIT
 	fi
 
-	"${CMD}" "$@" 2>&1 >"${TEST_DIR}/${TEST_CURRENT}.log"
-	if [[ "${VERBOSE}" -gt 1 ]]; then
-		kill -9 ${pid} >/dev/null || true
+	"${CMD}" "$@" >"${TEST_DIR}/${TEST_CURRENT}.log" 2>&1
+	if [[ ${VERBOSE} -gt 1 ]]; then
+		# SIGINT because it should be safe to do so.
+		kill -2 "${pid}" >/dev/null 2>&1 || true
 	fi
 
 	END_TIME=$(date +%s)
@@ -41,7 +43,7 @@ run() {
 run_linter() {
 	CMD="${1}"
 
-	if [[ -n "${RUN_SUBTEST}" ]]; then
+	if [[ -n ${RUN_SUBTEST} ]]; then
 		# shellcheck disable=SC2143
 		if [[ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]]; then
 			echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
@@ -69,13 +71,13 @@ run_linter() {
 	set +o pipefail
 
 	# Only output if it's not empty.
-	if [[ -n "${cmd_output}" ]]; then
+	if [[ -n ${cmd_output} ]]; then
 		echo -e "${cmd_output}" | OUTPUT "${TEST_DIR}/${TEST_CURRENT}.log"
 	fi
 
 	END_TIME=$(date +%s)
 
-	if [[ "${cmd_status}" -eq 0 ]]; then
+	if [[ ${cmd_status} -eq 0 ]]; then
 		echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
 	else
 		echo -e "\r===> [ $(red "x") ] Fail: ${DESC} ($((END_TIME - START_TIME))s)"

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -2,9 +2,9 @@
 run() {
 	CMD="${1}"
 
-	if [ -n "${RUN_SUBTEST}" ]; then
+	if [[ -n "${RUN_SUBTEST}" ]]; then
 		# shellcheck disable=SC2143
-		if [ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]; then
+		if [[ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]]; then
 			echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
 			exit 0
 		fi
@@ -36,9 +36,9 @@ run_error_early() {
 run_linter() {
 	CMD="${1}"
 
-	if [ -n "${RUN_SUBTEST}" ]; then
+	if [[ -n "${RUN_SUBTEST}" ]]; then
 		# shellcheck disable=SC2143
-		if [ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]; then
+		if [[ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]]; then
 			echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
 			exit 0
 		fi
@@ -64,13 +64,13 @@ run_linter() {
 	set +o pipefail
 
 	# Only output if it's not empty.
-	if [ -n "${cmd_output}" ]; then
+	if [[ -n "${cmd_output}" ]]; then
 		echo -e "${cmd_output}" | OUTPUT "${TEST_DIR}/${TEST_CURRENT}.log"
 	fi
 
 	END_TIME=$(date +%s)
 
-	if [ "${cmd_status}" -eq 0 ]; then
+	if [[ "${cmd_status}" -eq 0 ]]; then
 		echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
 	else
 		echo -e "\r===> [ $(red "x") ] Fail: ${DESC} ($((END_TIME - START_TIME))s)"
@@ -81,7 +81,7 @@ run_linter() {
 skip() {
 	CMD="${1}"
 	# shellcheck disable=SC2143,SC2046
-	if [ $(echo "${SKIP_LIST:-}" | grep -w "${CMD}") ]; then
+	if [[ $(echo "${SKIP_LIST:-}" | grep -w "${CMD}") ]]; then
 		echo "SKIP"
 		exit 1
 	fi

--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -16,19 +16,24 @@ run() {
 
 	START_TIME=$(date +%s)
 
-	"${CMD}" "$@" 2>&1
 	set_verbosity
+
+	if [[ "${VERBOSE}" -gt 1 ]]; then
+		touch "${TEST_DIR}/${TEST_CURRENT}.log"
+		tail -f "${TEST_DIR}/${TEST_CURRENT}.log" 2>/dev/null &
+		pid=$!
+
+		trap "kill -9 ${pid} >/dev/null || true" EXIT
+	fi
+
+	"${CMD}" "$@" 2>&1 >"${TEST_DIR}/${TEST_CURRENT}.log"
+	if [[ "${VERBOSE}" -gt 1 ]]; then
+		kill -9 ${pid} >/dev/null || true
+	fi
 
 	END_TIME=$(date +%s)
 
 	echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
-}
-
-run_error_early() {
-	set -e
-	shift
-
-	"${1}" "$@"
 }
 
 # run_linter will run until the end of a pipeline even if there is a failure.

--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -15,7 +15,7 @@ kill_server() {
 	fi
 
 	pid=$(cat "${TEST_DIR}/server.pid" | head -n 1 || echo "NOT FOUND")
-	if [[ "${pid}" == "NOT FOUND" ]]; then
+	if [[ ${pid} == "NOT FOUND" ]]; then
 		return
 	fi
 

--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -10,12 +10,12 @@ start_server() {
 }
 
 kill_server() {
-	if [ ! -f "${TEST_DIR}/server.pid" ]; then
+	if [[ ! -f "${TEST_DIR}/server.pid" ]]; then
 		return
 	fi
 
 	pid=$(cat "${TEST_DIR}/server.pid" | head -n 1 || echo "NOT FOUND")
-	if [ "${pid}" == "NOT FOUND" ]; then
+	if [[ "${pid}" == "NOT FOUND" ]]; then
 		return
 	fi
 

--- a/tests/includes/verbose.sh
+++ b/tests/includes/verbose.sh
@@ -11,11 +11,6 @@ set_verbosity() {
 		set -eu
 		set -o pipefail
 		;;
-	11)
-		# You asked for it!
-		set -eux
-		set -o pipefail
-		;;
 	*)
 		echo "Unexpected verbose level" >&2
 		exit 1

--- a/tests/includes/verbose.sh
+++ b/tests/includes/verbose.sh
@@ -5,13 +5,16 @@ set_verbosity() {
 	case "${VERBOSE}" in
 	1)
 		set -eu
+		set -o pipefail
 		;;
 	2)
 		set -eu
+		set -o pipefail
 		;;
 	11)
 		# You asked for it!
 		set -eux
+		set -o pipefail
 		;;
 	*)
 		echo "Unexpected verbose level" >&2

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -24,7 +24,7 @@ wait_for() {
 		attempt=$((attempt + 1))
 	done
 
-	if [ "${attempt}" -gt 0 ]; then
+	if [[ "${attempt}" -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
 		juju status --relations 2>&1 | sed 's/^/    | /g'
 		# Although juju reports as an idle condition, some charms require a
@@ -136,7 +136,7 @@ wait_for_machine_agent_status() {
 		attempt=$((attempt + 1))
 	done
 
-	if [ "${attempt}" -gt 0 ]; then
+	if [[ "${attempt}" -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling machines')"
 		juju machines | grep "$inst_id" 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
@@ -195,7 +195,7 @@ wait_for_subordinate_count() {
 		attempt=$((attempt + 1))
 	done
 
-	if [ "${attempt}" -gt 0 ]; then
+	if [[ "${attempt}" -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling status')"
 		juju status 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
@@ -226,7 +226,7 @@ wait_for_model() {
 		attempt=$((attempt + 1))
 	done
 
-	if [ "${attempt}" -gt 0 ]; then
+	if [[ "${attempt}" -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling models')"
 		juju models | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
@@ -255,7 +255,7 @@ wait_for_systemd_service_files_to_appear() {
 		echo "[+] (attempt ${attempt}) waiting for the systemd unit files for ${unit} to appear"
 
 		svc_present=$(juju ssh "${unit}" "ls ${svc_file_path} 2>/dev/null || echo -n 'missing'")
-		if [ "${svc_present}" != "missing" ]; then
+		if [[ "${svc_present}" != "missing" ]]; then
 			echo "[+] systemd unit files for ${unit} are now available"
 			return
 		fi

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -24,7 +24,7 @@ wait_for() {
 		attempt=$((attempt + 1))
 	done
 
-	if [[ "${attempt}" -gt 0 ]]; then
+	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
 		juju status --relations 2>&1 | sed 's/^/    | /g'
 		# Although juju reports as an idle condition, some charms require a
@@ -136,7 +136,7 @@ wait_for_machine_agent_status() {
 		attempt=$((attempt + 1))
 	done
 
-	if [[ "${attempt}" -gt 0 ]]; then
+	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling machines')"
 		juju machines | grep "$inst_id" 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
@@ -195,7 +195,7 @@ wait_for_subordinate_count() {
 		attempt=$((attempt + 1))
 	done
 
-	if [[ "${attempt}" -gt 0 ]]; then
+	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling status')"
 		juju status 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
@@ -226,7 +226,7 @@ wait_for_model() {
 		attempt=$((attempt + 1))
 	done
 
-	if [[ "${attempt}" -gt 0 ]]; then
+	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling models')"
 		juju models | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
@@ -255,7 +255,7 @@ wait_for_systemd_service_files_to_appear() {
 		echo "[+] (attempt ${attempt}) waiting for the systemd unit files for ${unit} to appear"
 
 		svc_present=$(juju ssh "${unit}" "ls ${svc_file_path} 2>/dev/null || echo -n 'missing'")
-		if [[ "${svc_present}" != "missing" ]]; then
+		if [[ ${svc_present} != "missing" ]]; then
 			echo "[+] systemd unit files for ${unit} are now available"
 			return
 		fi

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -168,7 +168,7 @@ while getopts "hH?vAs:a:x:rl:p:S:" opt; do
 		export BOOTSTRAP_REUSE="true"
 		CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
 		PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}' | head -n 1)
-		if [ -z "${PROVIDER}" ]; then
+		if [[ -z "${PROVIDER}" ]]; then
 			PROVIDER="${CLOUD}"
 		fi
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
@@ -187,13 +187,13 @@ while getopts "hH?vAs:a:x:rl:p:S:" opt; do
 done
 
 shift $((OPTIND - 1))
-[ "${1:-}" = "--" ] && shift
+[[ "${1:-}" = "--" ]] && shift
 
 export VERBOSE="${VERBOSE}"
 export SKIP_LIST="${SKIP_LIST}"
 
-if [ "$#" -eq 0 ]; then
-	if [ "${RUN_ALL}" != "true" ]; then
+if [[ "$#" -eq 0 ]]; then
+	if [[ "${RUN_ALL}" != "true" ]]; then
 		echo "$(red '---------------------------------------')"
 		echo "$(red 'Run with -A to run all the test suites.')"
 		echo "$(red '---------------------------------------')"
@@ -208,7 +208,7 @@ echo ""
 echo "==> Checking for dependencies"
 check_dependencies curl jq shellcheck
 
-if [ "${USER:-'root'}" = "root" ]; then
+if [[ "${USER:-'root'}" = "root" ]]; then
 	echo "The testsuite must not be run as root." >&2
 	exit 1
 fi
@@ -218,8 +218,8 @@ cleanup() {
 	set +ex
 
 	# Allow for inspection
-	if [ -n "${TEST_INSPECT:-}" ]; then
-		if [ "${TEST_RESULT}" != "success" ]; then
+	if [[ -n "${TEST_INSPECT:-}" ]]; then
+		if [[ "${TEST_RESULT}" != "success" ]]; then
 			echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION}"
 		fi
 		echo "==> Test result: ${TEST_RESULT}"
@@ -235,9 +235,9 @@ cleanup() {
 	cleanup_funcs
 
 	echo ""
-	if [ "${TEST_RESULT}" != "success" ]; then
+	if [[ "${TEST_RESULT}" != "success" ]]; then
 		echo "==> TESTS DONE: ${TEST_CURRENT_DESCRIPTION}"
-		if [ -f "${TEST_DIR}/${TEST_CURRENT}.log" ]; then
+		if [[ -f "${TEST_DIR}/${TEST_CURRENT}.log" ]]; then
 			echo "==> RUN OUTPUT: ${TEST_CURRENT}"
 			cat "${TEST_DIR}/${TEST_CURRENT}.log" | sed 's/^/    | /g'
 			echo ""
@@ -246,14 +246,14 @@ cleanup() {
 	echo "==> Test result: ${TEST_RESULT}"
 
 	# Move any artifacts to the choosen location
-	if [ -n "${ARITFACT_FILE}" ]; then
+	if [[ -n "${ARITFACT_FILE}" ]]; then
 		echo "==> Test artifact: ${ARITFACT_FILE}"
-		if [ -f "${OUTPUT_FILE}" ]; then
+		if [[ -f "${OUTPUT_FILE}" ]]; then
 			cp "${OUTPUT_FILE}" "${TEST_DIR}"
 		fi
 		TAR_OUTPUT=$(tar -C "${TEST_DIR}" --transform s/./artifacts/ -zcvf "${ARITFACT_FILE}" ./ 2>&1)
 		# shellcheck disable=SC2181
-		if [ $? -ne 0 ]; then
+		if [[ $? -ne 0 ]]; then
 			echo "${TAR_OUTPUT}"
 			exit 1
 		fi
@@ -280,7 +280,7 @@ run_test() {
 	TEST_CURRENT_DESCRIPTION=${2:-${1}}
 	TEST_CURRENT_NAME=${TEST_CURRENT#"test_"}
 
-	if [ -n "${4}" ]; then
+	if [[ -n "${4}" ]]; then
 		TEST_CURRENT=${4}
 	fi
 
@@ -296,11 +296,11 @@ run_test() {
 }
 
 # allow for running a specific set of tests
-if [ "$#" -gt 0 ]; then
+if [[ "$#" -gt 0 ]]; then
 	# shellcheck disable=SC2143
-	if [ "$(echo "${2}" | grep -E "^run_")" ]; then
+	if [[ "$(echo "${2}" | grep -E "^run_")" ]]; then
 		TEST="$(grep -lr "run \"${2}\"" "suites/${1}" | xargs sed -rn 's/.*(test_\w+)\s+?\(\)\s+?\{/\1/p')"
-		if [ -z "${TEST}" ]; then
+		if [[ -z "${TEST}" ]]; then
 			echo "==> Unable to find parent test for ${2}."
 			echo "    Try and run the parent test directly."
 			exit 1

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -168,7 +168,7 @@ while getopts "hH?vAs:a:x:rl:p:S:" opt; do
 		export BOOTSTRAP_REUSE="true"
 		CLOUD=$(juju show-controller "${OPTARG}" --format=json | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
 		PROVIDER=$(juju clouds --client 2>/dev/null | grep "${CLOUD}" | awk '{print $4}' | head -n 1)
-		if [[ -z "${PROVIDER}" ]]; then
+		if [[ -z ${PROVIDER} ]]; then
 			PROVIDER="${CLOUD}"
 		fi
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
@@ -187,13 +187,13 @@ while getopts "hH?vAs:a:x:rl:p:S:" opt; do
 done
 
 shift $((OPTIND - 1))
-[[ "${1:-}" = "--" ]] && shift
+[[ ${1:-} == "--" ]] && shift
 
 export VERBOSE="${VERBOSE}"
 export SKIP_LIST="${SKIP_LIST}"
 
-if [[ "$#" -eq 0 ]]; then
-	if [[ "${RUN_ALL}" != "true" ]]; then
+if [[ $# -eq 0 ]]; then
+	if [[ ${RUN_ALL} != "true" ]]; then
 		echo "$(red '---------------------------------------')"
 		echo "$(red 'Run with -A to run all the test suites.')"
 		echo "$(red '---------------------------------------')"
@@ -208,7 +208,7 @@ echo ""
 echo "==> Checking for dependencies"
 check_dependencies curl jq shellcheck
 
-if [[ "${USER:-'root'}" = "root" ]]; then
+if [[ ${USER:-'root'} == "root" ]]; then
 	echo "The testsuite must not be run as root." >&2
 	exit 1
 fi
@@ -218,8 +218,8 @@ cleanup() {
 	set +ex
 
 	# Allow for inspection
-	if [[ -n "${TEST_INSPECT:-}" ]]; then
-		if [[ "${TEST_RESULT}" != "success" ]]; then
+	if [[ -n ${TEST_INSPECT:-} ]]; then
+		if [[ ${TEST_RESULT} != "success" ]]; then
 			echo "==> TEST DONE: ${TEST_CURRENT_DESCRIPTION}"
 		fi
 		echo "==> Test result: ${TEST_RESULT}"
@@ -235,7 +235,7 @@ cleanup() {
 	cleanup_funcs
 
 	echo ""
-	if [[ "${TEST_RESULT}" != "success" ]]; then
+	if [[ ${TEST_RESULT} != "success" ]]; then
 		echo "==> TESTS DONE: ${TEST_CURRENT_DESCRIPTION}"
 		if [[ -f "${TEST_DIR}/${TEST_CURRENT}.log" ]]; then
 			echo "==> RUN OUTPUT: ${TEST_CURRENT}"
@@ -246,9 +246,9 @@ cleanup() {
 	echo "==> Test result: ${TEST_RESULT}"
 
 	# Move any artifacts to the choosen location
-	if [[ -n "${ARITFACT_FILE}" ]]; then
+	if [[ -n ${ARITFACT_FILE} ]]; then
 		echo "==> Test artifact: ${ARITFACT_FILE}"
-		if [[ -f "${OUTPUT_FILE}" ]]; then
+		if [[ -f ${OUTPUT_FILE} ]]; then
 			cp "${OUTPUT_FILE}" "${TEST_DIR}"
 		fi
 		TAR_OUTPUT=$(tar -C "${TEST_DIR}" --transform s/./artifacts/ -zcvf "${ARITFACT_FILE}" ./ 2>&1)
@@ -280,7 +280,7 @@ run_test() {
 	TEST_CURRENT_DESCRIPTION=${2:-${1}}
 	TEST_CURRENT_NAME=${TEST_CURRENT#"test_"}
 
-	if [[ -n "${4}" ]]; then
+	if [[ -n ${4} ]]; then
 		TEST_CURRENT=${4}
 	fi
 
@@ -296,11 +296,11 @@ run_test() {
 }
 
 # allow for running a specific set of tests
-if [[ "$#" -gt 0 ]]; then
+if [[ $# -gt 0 ]]; then
 	# shellcheck disable=SC2143
 	if [[ "$(echo "${2}" | grep -E "^run_")" ]]; then
 		TEST="$(grep -lr "run \"${2}\"" "suites/${1}" | xargs sed -rn 's/.*(test_\w+)\s+?\(\)\s+?\{/\1/p')"
-		if [[ -z "${TEST}" ]]; then
+		if [[ -z ${TEST} ]]; then
 			echo "==> Unable to find parent test for ${2}."
 			echo "    Try and run the parent test directly."
 			exit 1

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -74,24 +74,24 @@ run_deploy_trusted_bundle() {
 }
 
 run_deploy_charmhub_bundle() {
-    echo
+	echo
 
-    model_name="test-charmhub-bundle-deploy"
-    file="${TEST_DIR}/${model_name}.log"
+	model_name="test-charmhub-bundle-deploy"
+	file="${TEST_DIR}/${model_name}.log"
 
-    ensure "${model_name}" "${file}"
+	ensure "${model_name}" "${file}"
 
-    bundle=juju-qa-bundle-test
-    juju deploy "${bundle}"
+	bundle=juju-qa-bundle-test
+	juju deploy "${bundle}"
 
-    wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
-    wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "candidate")"
-    wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-    wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal" 1)"
-    wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
-    wait_for "ntp-focal" "$(idle_subordinate_condition "ntp-focal" "juju-qa-test-focal")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
+	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "candidate")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+	wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal" 1)"
+	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
+	wait_for "ntp-focal" "$(idle_subordinate_condition "ntp-focal" "juju-qa-test-focal")"
 
-    destroy_model "${model_name}"
+	destroy_model "${model_name}"
 }
 
 # run_deploy_lxd_profile_bundle_openstack is to test a more

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -1,7 +1,3 @@
-test_bash() {
-	echo "focal" | check "bionic"
-}
-
 test_static_analysis() {
 	if [ "$(skip 'test_static_analysis')" ]; then
 		echo "==> TEST SKIPPED: skip static analysis"
@@ -10,10 +6,9 @@ test_static_analysis() {
 
 	set_verbosity
 
-	run "test_bash"
-	#test_copyright
-	#test_static_analysis_go
-	#test_static_analysis_shell
-	#test_static_analysis_python
-	#test_schema
+	test_copyright
+	test_static_analysis_go
+	test_static_analysis_shell
+	test_static_analysis_python
+	test_schema
 }

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -1,3 +1,7 @@
+test_bash() {
+	echo "focal" | check "bionic"
+}
+
 test_static_analysis() {
 	if [ "$(skip 'test_static_analysis')" ]; then
 		echo "==> TEST SKIPPED: skip static analysis"
@@ -6,9 +10,10 @@ test_static_analysis() {
 
 	set_verbosity
 
-	test_copyright
-	test_static_analysis_go
-	test_static_analysis_shell
-	test_static_analysis_python
-	test_schema
+	run "test_bash"
+	#test_copyright
+	#test_static_analysis_go
+	#test_static_analysis_shell
+	#test_static_analysis_python
+	#test_schema
 }


### PR DESCRIPTION
The following changes ensure that the verbose setting when running
the integration tests to allow the real-time viewing of what's being currently 
run. Previously this was hidden until the very end of the test, which made
it really hard to develop against it locally when you have long integration
tests.

The code is simple, send the logs to a file and then using a background
process, just tail the log file. Although simple, it wasn't easy to get right
as first, as we had to ensure backward compatibility and ensure that
pipefail worked as designed.

As a driveby I fixed the inconsistency issue of one bracket vs two, now
that we're using bash.

## QA steps

Without verbose, this should be rather quiet:

```sh
(cd tests && ./main.sh smoke)
```

With verbose this should be really chatty:

```sh
(cd tests && ./main.sh -v smoke)
```
