### PR TITLE
[2.9] Additional cross platform test fixes

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -98,7 +98,7 @@ func (s *toolsSuite) TestSeriesTools(c *gc.C) {
 
 	current := coretesting.CurrentVersion(c)
 	currentCopy := current
-	currentCopy.Release = coretesting.HostSeries(c)
+	currentCopy.Release = "focal"
 	err := s.machine0.SetAgentVersion(currentCopy)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -301,7 +301,7 @@ func (s *toolsSuite) TestFindToolsOldAgent(c *gc.C) {
 			stateenvirons.EnvironConfigGetter{Model: s.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"), newEnviron,
 		)
 		result, err := toolsFinder.FindTools(params.FindToolsParams{
-			Number: version.MustParse("2.8.9"),
+			Number:       version.MustParse("2.8.9"),
 			MajorVersion: 2,
 			MinorVersion: 8,
 			OSType:       "ubuntu",

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
+	coreos "github.com/juju/juju/core/os"
 	jujuos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
@@ -80,6 +81,9 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 			HelpHint: `See "juju --help"`,
 		}.Error())
 	}
+
+	curVersion := testing.CurrentVersion(c)
+	curVersion.Release = coreos.HostOSTypeName()
 
 	// The test array structure needs to be inline here as some of the
 	// expected values below use deployHelpText().  This constructs the deploy
@@ -156,12 +160,12 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "check version command returns a fully qualified version string",
 		args:    []string{"version"},
 		code:    0,
-		out:     testing.CurrentVersion(c).String() + "\n",
+		out:     curVersion.String() + "\n",
 	}, {
 		summary: "check --version command returns a fully qualified version string",
 		args:    []string{"--version"},
 		code:    0,
-		out:     testing.CurrentVersion(c).String() + "\n",
+		out:     curVersion.String() + "\n",
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		out := badrun(c, t.code, t.args...)

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -479,9 +479,14 @@ func (s *UpgradeBaseSuite) checkToolsUploaded(c *gc.C, vers version.Binary, agen
 	r.Close()
 	c.Check(err, jc.ErrorIsNil)
 	expectContent := version.Binary{
-		Number:  agentVersion,
-		Arch:    arch.HostArch(),
-		Release: coreos.HostOSTypeName(),
+		Number: agentVersion,
+		Arch:   arch.HostArch(),
+		// All tests that upload fake agent tool binaries assume that
+		// we are always running on ubuntu. Unfortunately, this
+		// assumption breaks tests when running the suites on non-ubuntu
+		// platform (e.g. centos). Instead of trying to auto-detect the
+		// current OS, we force the release to "ubuntu".
+		Release: strings.ToLower(coreos.Ubuntu.String()),
 	}
 	checkToolsContent(c, data, "jujud contents "+expectContent.String())
 }

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -123,7 +123,16 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.makeTestModel(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
+	//
+	// CurrentVersion() currently hardcodes Release to "ubuntu" to match
+	// the expectations of other test suites wrt. the underlying host where
+	// the tests are running. However, this test is an exception as we
+	// are testing the bootstrap flow which uses the actual OS type to
+	// select agent binaries. Therefore, we need to specify the appropriate
+	// release value here.
 	current := testing.CurrentVersion(c)
+	current.Release = coreos.HostOSTypeName()
+
 	toolsDir := filepath.FromSlash(agenttools.SharedToolsDir(s.dataDir, current))
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
@@ -672,9 +681,18 @@ func (s *BootstrapSuite) TestDownloadedToolsMetadata(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
+	// CurrentVersion() currently hardcodes Release to "ubuntu" to match
+	// the expectations of other test suites wrt. the underlying host where
+	// the tests are running. However, this test is an exception as we
+	// are testing the bootstrap flow which uses the actual OS type to
+	// select agent binaries. Therefore, we need to specify the appropriate
+	// release value here.
+	vers := testing.CurrentVersion(c)
+	vers.Release = coreos.HostOSTypeName()
+
 	// Tools uploaded over ssh.
 	s.writeDownloadedTools(c, &tools.Tools{
-		Version: testing.CurrentVersion(c),
+		Version: vers,
 		URL:     "file:///does/not/matter",
 	})
 	s.testToolsMetadata(c)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/raftlease"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
@@ -77,6 +78,7 @@ import (
 	"github.com/juju/juju/worker/migrationmaster"
 	raftworker "github.com/juju/juju/worker/raft"
 	"github.com/juju/juju/worker/storageprovisioner"
+	"github.com/juju/juju/worker/upgrader"
 )
 
 const (
@@ -104,6 +106,10 @@ func (s *MachineSuite) SetUpTest(c *gc.C) {
 
 	// Restart failed workers much faster for the tests.
 	s.PatchValue(&engine.EngineErrorDelay, 100*time.Millisecond)
+
+	s.PatchValue(&upgrader.HostOSTypeName, func() string {
+		return strings.ToLower(coreos.Ubuntu.String())
+	})
 
 	// Most of these tests normally finish sub-second on a fast machine.
 	// If any given test hits a minute, we have almost certainly become

--- a/cmd/jujud/agent/unit_test.go
+++ b/cmd/jujud/agent/unit_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
 	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
 	"github.com/juju/juju/core/network"
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/status"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/state"
@@ -31,6 +33,7 @@ import (
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/upgrader"
 )
 
 type UnitSuite struct {
@@ -38,6 +41,13 @@ type UnitSuite struct {
 }
 
 var _ = gc.Suite(&UnitSuite{})
+
+func (s *UnitSuite) SetUpTest(c *gc.C) {
+	s.AgentSuite.SetUpTest(c)
+	s.PatchValue(&upgrader.HostOSTypeName, func() string {
+		return strings.ToLower(coreos.Ubuntu.String())
+	})
+}
 
 // primeAgent creates a unit, and sets up the unit agent's directory.
 // It returns the assigned machine, new unit and the agent's configuration.

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -261,8 +261,7 @@ func (s *uploadSuite) TestUpload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertEqualsCurrentVersion(c, t.Version)
 	c.Assert(t.URL, gc.Not(gc.Equals), "")
-	hostOSType := coreos.HostOSTypeName()
-	s.assertUploadedTools(c, t, []string{hostOSType}, "released")
+	s.assertUploadedTools(c, t, []string{t.Version.Release}, "released")
 }
 
 func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -7,6 +7,7 @@
 package featuretests
 
 import (
+	"strings"
 	"time"
 
 	"github.com/juju/cmd/cmdtesting"
@@ -32,6 +33,7 @@ import (
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/state/watcher"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -39,6 +41,7 @@ import (
 	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
+	"github.com/juju/juju/worker/upgrader"
 	"github.com/juju/juju/worker/upgradesteps"
 )
 
@@ -80,6 +83,11 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 
 	// Ensure we don't fail disk space check.
 	s.PatchValue(&upgrades.MinDiskSpaceMib, uint64(0))
+
+	// Ensure tests run on non-ubuntu hosts.
+	s.PatchValue(&upgrader.HostOSTypeName, func() string {
+		return strings.ToLower(coreos.Ubuntu.String())
+	})
 
 	// Consume apt-get commands that get run before upgrades.
 	aptCmds := s.AgentSuite.HookCommandOutput(&pacman.CommandOutput, nil, nil)

--- a/state/pool.go
+++ b/state/pool.go
@@ -113,7 +113,8 @@ type StatePool struct {
 	// hub is used to pass the transaction changes from the TxnWatcher
 	// to the various HubWatchers that are used in each state object created
 	// by the state pool.
-	hub *pubsub.SimpleHub
+	hub        *pubsub.SimpleHub
+	hubUnsubFn func()
 
 	// watcherRunner makes sure the TxnWatcher stays running.
 	watcherRunner *worker.Runner
@@ -180,7 +181,7 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 		RestartDelay: time.Second,
 		Clock:        args.Clock,
 	})
-	pool.hub.Subscribe(watcher.TxnWatcherStarting, func(string, interface{}) {
+	pool.hubUnsubFn = pool.hub.Subscribe(watcher.TxnWatcherStarting, func(string, interface{}) {
 		close(pool.watcherStarted)
 	})
 	pool.txnWatcherSession = args.MongoSession.Copy()
@@ -428,6 +429,10 @@ func (p *StatePool) Close() error {
 	if p.watcherRunner != nil {
 		_ = worker.Stop(p.watcherRunner)
 		p.txnWatcherSession.Close()
+	}
+	if p.hubUnsubFn != nil {
+		p.hubUnsubFn()
+		p.hubUnsubFn = nil
 	}
 	p.mu.Unlock()
 	// As with above and the other watchers. Unlock while releas

--- a/testing/base.go
+++ b/testing/base.go
@@ -332,9 +332,14 @@ func GetExportedFields(arg interface{}) set.Strings {
 // CurrentVersion returns the current Juju version, asserting on error.
 func CurrentVersion(c *gc.C) version.Binary {
 	return version.Binary{
-		Number:  jujuversion.Current,
-		Arch:    arch.HostArch(),
-		Release: coreos.HostOSTypeName(),
+		Number: jujuversion.Current,
+		Arch:   arch.HostArch(),
+		// All tests that upload fake agent tool binaries assume that
+		// we are always running on ubuntu. Unfortunately, this
+		// assumption breaks tests when running the suites on non-ubuntu
+		// platform (e.g. centos). Instead of trying to auto-detect the
+		// current OS, we force the release to "ubuntu".
+		Release: strings.ToLower(coreos.Ubuntu.String()),
 	}
 }
 

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -59,6 +59,9 @@ var (
 		jujuDumpLogs,
 		jujuIntrospect,
 	}
+
+	// Overridden by tests.
+	HostOSTypeName = coreos.HostOSTypeName
 )
 
 // caasOperator implements the capabilities of the caasoperator agent. It is not intended to
@@ -412,7 +415,7 @@ func (op *caasOperator) loop() (err error) {
 	logger.Infof("operator %q started", op.config.Application)
 
 	// Start by reporting current tools (which includes arch/ostype).
-	hostOSType := coreos.HostOSTypeName()
+	hostOSType := HostOSTypeName()
 	if err := op.config.VersionSetter.SetVersion(
 		op.config.Application, toBinaryVersion(jujuversion.Current, hostOSType)); err != nil {
 		return errors.Annotate(err, "cannot set agent version")

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -29,6 +30,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/exec"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -145,6 +147,10 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = ioutil.WriteFile(filepath.Join(s.config.DataDir, "tools", "jujud"), []byte("jujud"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
+
+	s.PatchValue(&caasoperator.HostOSTypeName, func() string {
+		return strings.ToLower(coreos.Ubuntu.String())
+	})
 }
 
 func (s *WorkerSuite) TestValidateConfig(c *gc.C) {

--- a/worker/caasupgrader/upgrader_test.go
+++ b/worker/caasupgrader/upgrader_test.go
@@ -4,6 +4,8 @@
 package caasupgrader_test
 
 import (
+	"fmt"
+
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
@@ -12,6 +14,7 @@ import (
 	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
 
+	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/watcher/watchertest"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -77,7 +80,8 @@ func (s *UpgraderSuite) TestUpgraderSetsVersion(c *gc.C) {
 }
 
 func (s *UpgraderSuite) TestUpgraderController(c *gc.C) {
-	vers := version.MustParseBinary("6.6.6-ubuntu-amd64")
+	hostType := coreos.HostOSTypeName()
+	vers := version.MustParseBinary(fmt.Sprintf("6.6.6-%s-amd64", hostType))
 	s.patchVersion(vers)
 	s.upgraderClient.desired = version.MustParse("6.6.7")
 
@@ -93,7 +97,8 @@ func (s *UpgraderSuite) TestUpgraderController(c *gc.C) {
 }
 
 func (s *UpgraderSuite) TestUpgraderApplication(c *gc.C) {
-	vers := version.MustParseBinary("6.6.6-ubuntu-amd64")
+	hostType := coreos.HostOSTypeName()
+	vers := version.MustParseBinary(fmt.Sprintf("6.6.6-%s-amd64", hostType))
 	s.patchVersion(vers)
 	s.upgraderClient.desired = version.MustParse("6.6.7")
 

--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -4,6 +4,7 @@
 package deployer_test
 
 import (
+	"strings"
 	"time"
 
 	"github.com/juju/clock"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	coreos "github.com/juju/juju/core/os"
 	message "github.com/juju/juju/pubsub/agent"
 	jt "github.com/juju/juju/testing"
 	jv "github.com/juju/juju/version"
@@ -87,6 +89,10 @@ func (s *NestedContextSuite) SetUpTest(c *gc.C) {
 		},
 		UnitManifolds: s.workers.Manifolds,
 	}
+
+	s.PatchValue(&deployer.HostOSTypeName, func() string {
+		return strings.ToLower(coreos.Ubuntu.String())
+	})
 }
 
 func (s *NestedContextSuite) TestConfigMissingAgentConfig(c *gc.C) {

--- a/worker/deployer/unit_agent.go
+++ b/worker/deployer/unit_agent.go
@@ -29,6 +29,11 @@ import (
 	"github.com/juju/juju/worker/logsender"
 )
 
+var (
+	// Overridden by tests
+	HostOSTypeName = coreos.HostOSTypeName
+)
+
 // UnitAgent wraps the agent config for this unit.
 type UnitAgent struct {
 	tag    names.UnitTag
@@ -105,7 +110,7 @@ func NewUnitAgent(config UnitAgentConfig) (*UnitAgent, error) {
 	current := version.Binary{
 		Number:  jujuversion.Current,
 		Arch:    arch.HostArch(),
-		Release: coreos.HostOSTypeName(),
+		Release: HostOSTypeName(),
 	}
 	tag := names.NewUnitTag(config.Name)
 	toolsDir := tools.ToolsDir(config.DataDir, tag.String())

--- a/worker/deployer/unit_agent_test.go
+++ b/worker/deployer/unit_agent_test.go
@@ -4,6 +4,8 @@
 package deployer_test
 
 import (
+	"strings"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
+	coreos "github.com/juju/juju/core/os"
 	jt "github.com/juju/juju/testing"
 	jv "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/deployer"
@@ -50,6 +53,10 @@ func (s *UnitAgentSuite) SetUpTest(c *gc.C) {
 		UnitEngineConfig: engine.DependencyEngineConfig,
 		UnitManifolds:    s.workers.Manifolds,
 	}
+
+	s.PatchValue(&deployer.HostOSTypeName, func() string {
+		return strings.ToLower(coreos.Ubuntu.String())
+	})
 }
 
 func (s *UnitAgentSuite) TestConfigMissingName(c *gc.C) {

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -46,7 +46,13 @@ const (
 // Don't do this, instead pass one through as config to the worker.
 type logger interface{}
 
-var _ logger = struct{}{}
+var (
+	_ logger = struct{}{}
+
+	// Used by tests to override host OS detection when running in
+	// non-ubuntu hosts.
+	HostOSTypeName = coreos.HostOSTypeName
+)
 
 // Upgrader represents a worker that watches the state for upgrade
 // requests.
@@ -120,7 +126,7 @@ func (u *Upgrader) loop() error {
 	logger := u.config.Logger
 	// Start by reporting current tools (which includes arch/os type, and is
 	// used by the controller in communicating the desired version below).
-	hostOSType := coreos.HostOSTypeName()
+	hostOSType := HostOSTypeName()
 	if err := u.st.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostOSType)); err != nil {
 		return errors.Annotate(err, "cannot set agent version")
 	}


### PR DESCRIPTION
This PR includes a series of fixes that ensure that none of our unit tests depends on the OS that the tests are running on. 

More specifically, the changes in this PR hardcode the `Release` field of the `testing.CurrentVersion` helper to `ubuntu` instead of populating it with the value that corresponds to the host OS where the tests are running on. This is required as the vast majority of our test expectations (pretty much anything that uploads fake tools) assumes that we are running on an ubuntu host.

In addition, the PR updates some of the workers (e.g. upgrade, caasoperator etc.) to include hooks for allowing tests to patch the result of `os.HostOSTypeName` calls and therefore ensure that tests are not OS-dependent.

Finally, the PR includes a forward port of #12827 to avoid leaking goroutines when closing the StatePool during testing.

NOTE: these tests are failing on 2.9 because of the switch in versioning which now uses the OS type instead of a specific release type.

## QA steps

Run `make test` in a centos environment. I used an lxd instance for my tests but spinning up a centos box on ec2 and running the tests there (+ the typical CI boilerplate to setup the box) should do the trick.