### PR TITLE
Non-ubuntu tools tests

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -806,7 +806,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	})
 
 	s.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
-	envtesting.MustUploadFakeTools(s.toolsStorage, cfg.AgentStream(), cfg.AgentStream())
+	envtesting.UploadFakeTools(c, s.toolsStorage, cfg.AgentStream(), cfg.AgentStream())
 	inst, _, _, err := jujutesting.StartInstance(env, callCtx, testing.FakeControllerConfig().ControllerUUID(), "0")
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -17,10 +17,8 @@ import (
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/os/v2/series"
 	"github.com/juju/pubsub"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -429,10 +427,7 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 		agentVersion = jujuversion.Current
 	}
 	osTypes := set.NewStrings("ubuntu")
-	hostSeries, err := series.HostSeries()
-	if err != nil {
-		osTypes.Add(coreseries.DefaultOSTypeNameFromSeries(hostSeries))
-	}
+	osTypes.Add(coreos.HostOSTypeName())
 	var versions []version.Binary
 	for _, osType := range osTypes.Values() {
 		versions = append(versions, version.Binary{


### PR DESCRIPTION
Fix unit test failures on non-Ubuntu hosts.

Tweak the fake agent metadata generation in test setup.

## QA steps

run unit tests on centos8

