### PR TITLE
Use charm url name when migrating charms.

### DIFF
--- a/api/migrationtarget/client.go
+++ b/api/migrationtarget/client.go
@@ -75,12 +75,17 @@ func (c *Client) Activate(modelUUID string) error {
 // to add the charm binary to the model specified.
 func (c *Client) UploadCharm(modelUUID string, curl *charm.URL, content io.ReadSeeker) (*charm.URL, error) {
 	args := url.Values{}
+	args.Add("name", curl.Name)
 	args.Add("schema", curl.Schema)
 	args.Add("arch", curl.Architecture)
 	args.Add("user", curl.User)
 	args.Add("series", curl.Series)
 	args.Add("revision", strconv.Itoa(curl.Revision))
-	apiURI := url.URL{Path: "/migrate/charms", RawQuery: args.Encode()}
+
+	apiURI := url.URL{
+		Path:     "/migrate/charms",
+		RawQuery: args.Encode(),
+	}
 
 	contentType := "application/zip"
 	var resp params.CharmsResponse

--- a/api/migrationtarget/client_test.go
+++ b/api/migrationtarget/client_test.go
@@ -74,7 +74,7 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 		ControllerAgentVersion: controllerVers,
 	}
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationTarget.Prechecks", []interface{}{"", expectedArg}},
+		{FuncName: "MigrationTarget.Prechecks", Args: []interface{}{"", expectedArg}},
 	})
 }
 
@@ -85,7 +85,7 @@ func (s *ClientSuite) TestImport(c *gc.C) {
 
 	expectedArg := params.SerializedModel{Bytes: []byte("foo")}
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationTarget.Import", []interface{}{"", expectedArg}},
+		{FuncName: "MigrationTarget.Import", Args: []interface{}{"", expectedArg}},
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
@@ -189,7 +189,7 @@ func (s *ClientSuite) TestUploadCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outCurl, gc.DeepEquals, curl)
 	c.Assert(doer.method, gc.Equals, "POST")
-	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=&revision=2&schema=cs&series=&user=user")
+	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=&name=foo&revision=2&schema=cs&series=&user=user")
 	c.Assert(doer.body, gc.Equals, charmBody)
 }
 
@@ -207,7 +207,7 @@ func (s *ClientSuite) TestUploadCharmHubCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outCurl, gc.DeepEquals, curl)
 	c.Assert(doer.method, gc.Equals, "POST")
-	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=s390x&revision=15&schema=ch&series=bionic&user=")
+	c.Assert(doer.url, gc.Equals, "/migrate/charms?arch=s390x&name=juju-qa-test&revision=15&schema=ch&series=bionic&user=")
 	c.Assert(doer.body, gc.Equals, charmBody)
 }
 
@@ -310,7 +310,7 @@ func (s *ClientSuite) TestCACert(c *gc.C) {
 func (s *ClientSuite) AssertModelCall(c *gc.C, stub *jujutesting.Stub, tag names.ModelTag, call string, err error, expectError bool) {
 	expectedArg := params.ModelArgs{ModelTag: tag.String()}
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationTarget." + call, []interface{}{"", expectedArg}},
+		{FuncName: "MigrationTarget." + call, Args: []interface{}{"", expectedArg}},
 	})
 	if expectError {
 		c.Assert(err, gc.ErrorMatches, "boom")


### PR DESCRIPTION
During a migration it is expected that a charm name in the metadata is
the same one in the URL. This isn't always the case. In-fact it might
never be the case for CharmHub charms, as the charmhub store does a lot
of charm url re-writing.

To this end, we allow the passing in of the charm name during a
migration and fallback to the one in metadata if it's empty.

---

The code is TERRIBLE in this file. There is no logical separation, just
massive freaking function of code. It's impossible to test at a unit
level and as kat-co pointed out years ago this handler setup should be
broken up.

I've added my 2-cents to the "fixme" at the top of the file and we could
use something like a Middleware pattern for this, so we can test the
various pathways to have a better and more secure API server.

---

Fixes: LP#1921722

## QA steps

```sh
$ juju bootstrap lxd src
$ juju bootstrap lxd dst
$ juju switch src
$ juju add-model src-model
$ juju deploy ubuntu
$ juju deploy cs:~logrotate-charmers/logrotate-charm-5
$ juju add-relation ubuntu logrotated # notice this isn't logrotate, but logrotated!
$ juju migrate src-model dst
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1921722
