### PR TITLE
openstack provider credentials should consider project domain id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,3 +139,5 @@ replace (
 	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.19.6
 	k8s.io/client-go v0.0.0 => k8s.io/client-go v0.19.6
 )
+
+replace gopkg.in/goose.v2 v2.0.1 => github.com/hemanthnakkina/goose issue88

--- a/provider/openstack/credentials.go
+++ b/provider/openstack/credentials.go
@@ -26,6 +26,7 @@ const (
 	CredAttrPassword          = "password"
 	CredAttrDomainName        = "domain-name"
 	CredAttrProjectDomainName = "project-domain-name"
+	CredAttrProjectDomainID   = "project-domain-id"
 	CredAttrUserDomainName    = "user-domain-name"
 	CredAttrAccessKey         = "access-key"
 	CredAttrSecretKey         = "secret-key"
@@ -70,6 +71,11 @@ func (OpenstackCredentials) CredentialSchemas() map[cloud.AuthType]cloud.Credent
 					Description: "The OpenStack project domain name.",
 					Optional:    true,
 				},
+                        }, {
+                                CredAttrProjectDomainID, cloud.CredentialAttr{
+                                        Description: "The OpenStack project domain ID.",
+                                        Optional:    true,
+                                },
 			}, {
 				CredAttrUserDomainName, cloud.CredentialAttr{
 					Description: "The OpenStack user domain name.",
@@ -185,6 +191,7 @@ func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, str
 				CredAttrTenantID:          creds.TenantID,
 				CredAttrUserDomainName:    creds.UserDomain,
 				CredAttrProjectDomainName: creds.ProjectDomain,
+				CredAttrProjectDomainID:   creds.ProjectDomainID,
 				CredAttrDomainName:        creds.Domain,
 				CredAttrVersion:           version,
 			},

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -841,6 +841,7 @@ func newCredentials(spec environscloudspec.CloudSpec) (identity.Credentials, ide
 		cred.User = credAttrs[CredAttrUserName]
 		cred.Secrets = credAttrs[CredAttrPassword]
 		cred.ProjectDomain = credAttrs[CredAttrProjectDomainName]
+		cred.ProjectDomainID = credAttrs[CredAttrProjectDomainID]
 		cred.UserDomain = credAttrs[CredAttrUserDomainName]
 		cred.Domain = credAttrs[CredAttrDomainName]
 		if credAttrs[CredAttrVersion] != "" {


### PR DESCRIPTION
juju autoload-credentials ignores the OS_PROJECT_DOMAIN_ID if set
and looks for only OS_PROJECT_DOMAIN_NAME. However there are cases
where openrc downloaded from OpenStack Dashboard for non-admin user
sets only OS_PROJECT_DOMAIN_ID. In these cases juju bootstrap fails
with authentication error since juju is not aware of project domain
id and project domain name is empty.
This change reads OS_PROJECT_DOMAIN_ID and sets in CredentialsAttribute
map. The same have been passed to the client for authentication
purpose.

## Checklist

-  Requires a go-goose change 
   https://github.com/go-goose/goose/pull/89

## QA steps

```sh
$ #Download openrc from OpenStack Horizon for a non-admin user
$ source openrc
$ # Add openstack cloud to juju using juju add-cloud
$ juju autoload-credentials
$ juju show-credentials # Check project-domain-id is set and project-domain-name is empty
$ juju bootstrap <cloud> <controller>
```

## Documentation changes
NA

## Bug reference
https://bugs.launchpad.net/juju/+bug/1772649