### PR TITLE
[2.8] Support merging of netplan configs

### DIFF
--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -290,87 +291,9 @@ func (np *Netplan) createBridgeFromInterface(bridgeName, deviceId string, intf *
 	*intf = Interface{MTU: intf.MTU}
 }
 
-func (np *Netplan) merge(other *Netplan) {
-	// Only copy attributes that would be unmarshalled from yaml.
-	// This blithely replaces keys in the maps (eg. Ethernets or
-	// Wifis) if they're set in both np and other - it's not clear
-	// from the reference whether this is the right thing to do.
-	// See https://bugs.launchpad.net/juju/+bug/1701429 and
-	// https://netplan.io/reference#general-structure
-	np.Network.Version = other.Network.Version
-	np.Network.Renderer = other.Network.Renderer
-	np.Network.Routes = other.Network.Routes
-	if np.Network.Ethernets == nil {
-		np.Network.Ethernets = other.Network.Ethernets
-	} else {
-		for key, val := range other.Network.Ethernets {
-			np.Network.Ethernets[key] = val
-		}
-	}
-	if np.Network.Wifis == nil {
-		np.Network.Wifis = other.Network.Wifis
-	} else {
-		for key, val := range other.Network.Wifis {
-			np.Network.Wifis[key] = val
-		}
-	}
-	if np.Network.Bridges == nil {
-		np.Network.Bridges = other.Network.Bridges
-	} else {
-		for key, val := range other.Network.Bridges {
-			np.Network.Bridges[key] = val
-		}
-	}
-	if np.Network.Bonds == nil {
-		np.Network.Bonds = other.Network.Bonds
-	} else {
-		for key, val := range other.Network.Bonds {
-			np.Network.Bonds[key] = val
-		}
-	}
-	if np.Network.VLANs == nil {
-		np.Network.VLANs = other.Network.VLANs
-	} else {
-		for key, val := range other.Network.VLANs {
-			np.Network.VLANs[key] = val
-		}
-	}
-}
-
-func Unmarshal(in []byte, out *Netplan) error {
-	if out == nil {
-		return errors.NotValidf("nil out Netplan")
-	}
-	// Use UnmarshalStrict because we want errors for unknown
-	// attributes. This also refuses to overwrite keys (which we need)
-	// so unmarshal locally and copy across.
-	var local Netplan
-	if err := goyaml.UnmarshalStrict(in, &local); err != nil {
-		return errors.Trace(err)
-	}
-	out.merge(&local)
-	return nil
-}
-
+// Marshal a Netplan instance into YAML.
 func Marshal(in *Netplan) (out []byte, err error) {
 	return goyaml.Marshal(in)
-}
-
-// readYamlFile reads netplan yaml into existing netplan structure
-// TODO(wpk) 2017-06-14 When reading files sequentially netplan replaces single
-// keys with new values, we have to simulate this behaviour.
-// https://bugs.launchpad.net/juju/+bug/1701429
-func (np *Netplan) readYamlFile(path string) (err error) {
-	contents, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	err = Unmarshal(contents, np)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 type sortableFileInfos []os.FileInfo
@@ -397,18 +320,157 @@ func ReadDirectory(dirPath string) (np Netplan, err error) {
 	np.sourceDirectory = dirPath
 	sortedFileInfos := sortableFileInfos(fileInfos)
 	sort.Sort(sortedFileInfos)
+
+	// First, unmarshal all configuration files into maps and merge them.
+	// Since the file list is pre-sorted, the first unmarshalled file
+	// serves as the base configuration; subsequent configuration maps are
+	// merged into it.
+	var mergedConfig map[interface{}]interface{}
 	for _, fileInfo := range sortedFileInfos {
 		if !fileInfo.IsDir() && strings.HasSuffix(fileInfo.Name(), ".yaml") {
 			np.sourceFiles = append(np.sourceFiles, fileInfo.Name())
+
+			pathToConfig := path.Join(np.sourceDirectory, fileInfo.Name())
+			configContents, err := ioutil.ReadFile(pathToConfig)
+			if err != nil {
+				return Netplan{}, errors.Annotatef(err, "reading netplan configuration from %q", pathToConfig)
+			}
+
+			var unmarshaledContents map[interface{}]interface{}
+			if err := goyaml.Unmarshal(configContents, &unmarshaledContents); err != nil {
+				return Netplan{}, errors.Annotatef(err, "unmarshaling netplan configuration from %q", pathToConfig)
+
+			}
+
+			if mergedConfig == nil {
+				mergedConfig = unmarshaledContents
+			} else {
+				mergedResult, err := mergeNetplanConfigs(mergedConfig, unmarshaledContents)
+				if err != nil {
+					return Netplan{}, errors.Annotatef(err, "merging netplan configuration from %s", pathToConfig)
+				}
+
+				// mergeNetplanConfigs should return back the
+				// value we passed in. However, lets be extra
+				// paranoid and double check that a malicious
+				// file did not mutate the type of the returned
+				// value.
+				mergedConfigMap, ok := mergedResult.(map[interface{}]interface{})
+				if !ok {
+					return Netplan{}, errors.Errorf("merging netplan configuration from %s caused the original configuration to become corrupted", pathToConfig)
+				}
+				mergedConfig = mergedConfigMap
+			}
 		}
 	}
-	for _, fileName := range np.sourceFiles {
-		err := np.readYamlFile(path.Join(np.sourceDirectory, fileName))
-		if err != nil {
-			return np, err
-		}
+
+	// Serialize the merged config back into yaml and unmarshal it using
+	// strict mode it to ensure that the presence of any unknown field
+	// triggers an error.
+	//
+	// As juju mutates the unmashaled Netplan struct and writes it back to
+	// disk, using strict mode guarantees that we will never accidentally
+	// drop netplan config values just because they were not defined in
+	// our structs.
+	mergedYAML, err := goyaml.Marshal(mergedConfig)
+	if err != nil {
+		return Netplan{}, errors.Trace(err)
+	} else if err := goyaml.UnmarshalStrict(mergedYAML, &np); err != nil {
+		return Netplan{}, errors.Trace(err)
 	}
 	return np, nil
+}
+
+// mergeNetplanConfigs recursively merges two netplan configurations where
+// values is src will overwrite values in dst based on the rules described in
+// http://manpages.ubuntu.com/manpages/groovy/man8/netplan-generate.8.html:
+//
+// - If  the  values are YAML boolean or scalar values (numbers and strings)
+// the old value is overwritten by the new value.
+//
+// - If the values are sequences, the sequences are concatenated - the new
+// values are appended to the old list.
+//
+// - If the values are mappings, netplan will examine the elements of the
+// mappings in turn using these rules.
+//
+// The function returns back the merged destination object which *may* be
+// different than the one that was passed into the function (e.g. if dst was
+// a map or slice that got resized).
+func mergeNetplanConfigs(dst, src interface{}) (interface{}, error) {
+	if dst == nil {
+		return src, nil
+	}
+
+	var err error
+	switch dstVal := dst.(type) {
+	case map[interface{}]interface{}:
+		srcVal, ok := src.(map[interface{}]interface{})
+		if !ok {
+			return nil, errors.Errorf("configuration values have different types (destination: %T, src: %T)", dst, src)
+		}
+
+		// Overwrite values in dst for keys that are present in both
+		// dst and src.
+		for dstMapKey, dstMapVal := range dstVal {
+			srcMapVal, exists := srcVal[dstMapKey]
+			if !exists {
+				continue
+			}
+
+			// Merge recursively (if non-scalar values)
+			dstVal[dstMapKey], err = mergeNetplanConfigs(dstMapVal, srcMapVal)
+			if err != nil {
+				return nil, errors.Annotatef(err, "merging configuration key %q", dstMapKey)
+			}
+		}
+
+		// Now append values from src for keys that are not present in
+		// the dst map. However, if the dstVal is nil, just use the
+		// srcVal as-is.
+		if dstVal == nil {
+			return srcVal, nil
+		}
+
+		for srcMapKey, srcMapVal := range srcVal {
+			_, exists := dstVal[srcMapKey]
+			if exists {
+				continue
+			}
+
+			// Insert new value into the destination.
+			dstVal[srcMapKey] = srcMapVal
+		}
+
+		return dstVal, nil
+	case []interface{}:
+		srcVal, ok := src.([]interface{})
+		if !ok {
+			return nil, errors.Errorf("configuration values have different types (destination: %T, src: %T)", dst, src)
+		}
+
+		// Only append missing values to the slice
+		dstLen := len(dstVal)
+	nextSrcSliceVal:
+		for _, srcSliceVal := range srcVal {
+			// If the srcSliceVal is not present in any of the
+			// original dstVal entries then append it. Note that we
+			// don't care about the values that may get potentially
+			// appended, hence the pre-calculation of the dstVal
+			// length.
+			for i := 0; i < dstLen; i++ {
+				if reflect.DeepEqual(dstVal[i], srcSliceVal) {
+					continue nextSrcSliceVal // value already present
+				}
+			}
+
+			dstVal = append(dstVal, srcSliceVal)
+		}
+		return dstVal, nil
+	default:
+		// Assume a scalar value and overwrite with src
+		return src, nil
+	}
 }
 
 // MoveYamlsToBak moves source .yaml files in a directory to .yaml.bak.(timestamp), except

--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -47,8 +47,12 @@ type Interface struct {
 	Optional bool `yaml:"optional,omitempty"`
 
 	// Configure the link-local addresses to bring up. Valid options are
-	// "ipv4" and "ipv6".
-	LinkLocal []string `yaml:"link-local,omitempty"`
+	// "ipv4" and "ipv6". According to the netplan reference, netplan will
+	// only bring up ipv6 addresses if *no* link-local attribute is
+	// specified. On the other hand, if an empty link-local attribute is
+	// specified, this instructs netplan not to bring any ipv4/ipv6 address
+	// up.
+	LinkLocal *[]string `yaml:"link-local,omitempty"`
 }
 
 // Ethernet defines fields for just Ethernet devices

--- a/network/netplan/netplan_internal_test.go
+++ b/network/netplan/netplan_internal_test.go
@@ -1,0 +1,234 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package netplan
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	goyaml "gopkg.in/yaml.v2"
+)
+
+type NetplanConfigurationMergeSuite struct {
+}
+
+var _ = gc.Suite(&NetplanConfigurationMergeSuite{})
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsWithEmptyBaseFile(c *gc.C) {
+	base := ``
+
+	src := `
+network:
+  version: 314
+  renderer: whateverd
+  ethernets:
+    enp5s0:
+      dhcp4: false
+`[1:]
+
+	s.assertMergeResult(c, base, src, src)
+}
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsWithEmptySourceFile(c *gc.C) {
+	base := `
+network:
+  renderer: networkd
+  version: 2
+  ethernets:
+    enp5s0:
+      dhcp4: true
+      optional: true
+`[1:]
+
+	src := ``
+
+	s.assertMergeResult(c, base, src, base)
+}
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsScalarValuOverwrite(c *gc.C) {
+	base := `
+network:
+  renderer: networkd
+  version: 2
+  ethernets:
+    enp5s0:
+      dhcp4: true
+      optional: true
+`[1:]
+
+	src := `
+network:
+  version: 314        # Overwrite numeric value
+  renderer: whateverd # Overwrite string value
+  ethernets:
+    enp5s0:
+      dhcp4: false    # Overwrite bool value
+`[1:]
+
+	exp := `
+network:
+  version: 314
+  renderer: whateverd
+  ethernets:
+    enp5s0:
+      dhcp4: false
+      optional: true
+`[1:]
+
+	s.assertMergeResult(c, base, src, exp)
+}
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsMergeMapValues(c *gc.C) {
+	base := `
+network:
+  renderer: networkd
+  version: 2
+  ethernets:
+    enp5s0:
+      dhcp4: true
+      optional: true
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+`[1:]
+
+	src := `
+network:
+  ethernets:
+    newnic0:            # Add a new key to the map
+      dhcp4: true
+    enp5s0:
+      dhcp4: false      # Overwrite value of existing key
+      optional: true
+      nameservers:
+        search: [foo.local, baz.local] # Add new key to nested, existing map
+`[1:]
+
+	exp := `
+network:
+  renderer: networkd
+  version: 2
+  ethernets:
+    enp5s0:
+      dhcp4: false
+      optional: true
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+        search:
+        - foo.local
+        - baz.local
+    newnic0:
+      dhcp4: true
+`[1:]
+
+	s.assertMergeResult(c, base, src, exp)
+}
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsSliceConcatenation(c *gc.C) {
+	base := `
+network:
+  ethernets:
+    enp5s0:
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+`[1:]
+
+	src := `
+network:
+  ethernets:
+    enp5s0:
+      nameservers:
+        addresses:
+        - 8.8.8.8     # Value already exists in base sequence and should be skipped
+        - 42.42.42.42 # Value does not exist in base sequence and should be added
+        - 1.1.1.1     # Value already exists in base sequence and should be skipped
+`[1:]
+
+	exp := `
+network:
+  ethernets:
+    enp5s0:
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+        - 42.42.42.42
+`[1:]
+
+	s.assertMergeResult(c, base, src, exp)
+}
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsErrorsWhenMergingMaps(c *gc.C) {
+	base := `
+network:
+  ethernets:
+    enp5s0:
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+`[1:]
+
+	src := `
+network:
+  ethernets: "this is not the map you are looking for"
+`[1:]
+
+	s.assertMergeError(c, base, src, `merging configuration key "network": merging configuration key "ethernets": configuration values have different types \(destination: map.*, src: string\)`)
+}
+
+func (s *NetplanConfigurationMergeSuite) TestMergeNetplanConfigsErrorsWhenMergingSlices(c *gc.C) {
+	base := `
+network:
+  ethernets:
+    enp5s0:
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+`[1:]
+
+	src := `
+network:
+  ethernets:
+    enp5s0:
+      nameservers:
+        addresses: "this is not the slice you are looking for"
+`[1:]
+
+	s.assertMergeError(c, base, src, `merging configuration key "network": merging configuration key "ethernets": merging configuration key "enp5s0": merging configuration key "nameservers": merging configuration key "addresses": configuration values have different types \(destination: \[\].*, src: string\)`)
+}
+
+func (s *NetplanConfigurationMergeSuite) assertMergeResult(c *gc.C, base, src, exp string) {
+	var (
+		baseMap, srcMap, expMap map[interface{}]interface{}
+	)
+
+	c.Assert(goyaml.Unmarshal([]byte(base), &baseMap), jc.ErrorIsNil)
+	c.Assert(goyaml.Unmarshal([]byte(src), &srcMap), jc.ErrorIsNil)
+	c.Assert(goyaml.Unmarshal([]byte(exp), &expMap), jc.ErrorIsNil)
+
+	mergeRes, err := mergeNetplanConfigs(baseMap, srcMap)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mergeResMap, ok := mergeRes.(map[interface{}]interface{})
+	c.Assert(ok, jc.IsTrue, gc.Commentf("expected merge result to be a map[interface{}]interface{}; got %T", mergeRes))
+	c.Assert(mergeResMap, gc.DeepEquals, expMap)
+}
+
+func (s *NetplanConfigurationMergeSuite) assertMergeError(c *gc.C, base, src, expErr string) {
+	var (
+		baseMap, srcMap map[interface{}]interface{}
+	)
+
+	c.Assert(goyaml.Unmarshal([]byte(base), &baseMap), jc.ErrorIsNil)
+	c.Assert(goyaml.Unmarshal([]byte(src), &srcMap), jc.ErrorIsNil)
+
+	_, err := mergeNetplanConfigs(baseMap, srcMap)
+	c.Assert(err, gc.ErrorMatches, expErr)
+}

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -105,19 +105,36 @@ network:
 `)
 }
 
-func (s *NetplanSuite) TestParseEthernetDeviceWithLinkLocalField(c *gc.C) {
-	MustNetplanFromYaml(c, `
+func (s *NetplanSuite) TestSerializationOfEthernetDevicesWithLinkLocalFields(c *gc.C) {
+	np := MustNetplanFromYaml(c, `
 network:
   version: 2
-  renderer: NetworkManager
   ethernets:
     eth0:
-      match:
-        macaddress: "00:11:22:33:44:55"
       link-local: [ipv4, ipv6]
-      wakeonlan: true
-      set-name: main-if
+    eth1:
+      link-local: []
+    eth2:
+      critical: true
 `)
+
+	exp := `
+network:
+  version: 2
+  ethernets:
+    eth0:
+      link-local:
+      - ipv4
+      - ipv6
+    eth1:
+      link-local: []
+    eth2:
+      critical: true
+`[1:]
+
+	npYAML, err := netplan.Marshal(np)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(npYAML), gc.Equals, exp)
 }
 
 func (s *NetplanSuite) TestBasicBond(c *gc.C) {

--- a/network/netplan/testdata/TestReadDirectory/01.yaml
+++ b/network/netplan/testdata/TestReadDirectory/01.yaml
@@ -4,6 +4,8 @@ network:
   ethernets:
     id0:
       gateway4: 1.2.3.8
+      nameservers:
+        addresses: [8.8.8.8, 1.1.1.1]
     id2:
       match:
         driver: iwldvm


### PR DESCRIPTION
This PR fixes LP1701429 by introducing support for merging
configuration values when parsing netplan files.

The netplan yaml files are first lexicographically sorted and the very
first file serves as the base configuration. Subsequent files get merged
into the base configuration following the set of rules described in the
man page of the "netplan-generate" command
(http://manpages.ubuntu.com/manpages/groovy/man8/netplan-generate.8.html).

Each netplan yaml file is unmarshaled into a `map[interface{}]interface{}`
(and **not** a `map[string]interface{}` as the former is used by the goyaml
package for nested maps) and a recursive merge function visits all map
entries and applies the appropriate merge rules based on their type
(scalar, map or slice).

The final merged configuration is marshalled back into YAML and then
unmarshaled (in strict mode) to the Netplan struct used by juju.

## QA steps

Try the steps from https://bugs.launchpad.net/juju/+bug/1919144/comments/2

Or this: 

You need a virtual maas with a dual-spaced machine (in this example, the machine gets an eth0 and eth1 NIC)

```console
$ juju bootstrap vmaas test --constraints "spaces=space1,space2"
$ juju switch controller

# ssh into the controller and set up a netplan file as follows:
$ juju ssh 0
$ cat /etc/netplan/99-juju-post.yaml
network:
    ethernets:
        eth0:
            link-local: []
        eth1:
            link-local: [ipv4]
    version: 2

# For reference, the seeded cloud-init yaml should look like this:
network:
    ethernets:
        eth0:
            addresses:
            - 10.0.0.79/24
            gateway4: 10.0.0.1
            match:
                macaddress: 52:54:00:a4:ee:93
            mtu: 1500
            nameservers:
                addresses:
                - 10.0.0.1
                search:
                - maas
            set-name: eth0
        eth1:
            dhcp4: true
            match:
                macaddress: 52:54:00:5b:59:87
            mtu: 1500
            set-name: eth1
    version: 2

# Back to the client, run the following:
$ juju deploy ubuntu --bind space2 --to lxd:0

# SSH back to the machine and ensure that the original configuration has been backed up 
# and a new "99-juju.yaml" file has been created with the bridge setup:
$ juju ssh 0
$ cat /etc/netplan/99-juju.yaml
network:
  version: 2
  ethernets:
    eth0:
      match:
        macaddress: 52:54:00:a4:ee:93
      set-name: eth0
      addresses:
      - 10.0.0.79/24
      gateway4: 10.0.0.1
      nameservers:
        search: [maas]
        addresses: [10.0.0.1]
      mtu: 1500
      link-local: []              <- the empty list for this link-local attr. is preserved; the empty list has special meaning for netplan
    eth1:
      match:
        macaddress: 52:54:00:5b:59:87
      set-name: eth1
      mtu: 1500
  bridges:
    br-eth1:
      interfaces: [eth1]
      dhcp4: true
      mtu: 1500
      link-local:
      - ipv4          <-----  link local block should be relocated from eth1 here

```

NOTE: As per the bridging [implementation](https://github.com/juju/juju/blob/2.8/network/netplan/netplan.go#L280-L291), the bridge **steals all** `netplan.Interface` values from the interface that gets bridged **except** the MTU. The `eth1` fields above are all that's remaining in `netplan.Ethernet` (which embeds `netplan.Interface`). As a result of this implementation detail, the `link-local` field gets moved to the bridge.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1701429