### PR TITLE
Constraint tags can be used for pod affinity

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -834,58 +834,26 @@ func processConstraints(pod *core.PodSpec, appName string, cons constraints.Valu
 		}
 	}
 
-	// Translate tags to node affinity.
+	// Translate tags to pod or node affinity.
+	// Tag names are prefixed with "pod.", "anti-pod.", or "node."
+	// with the default being "node".
 	if cons.Tags != nil {
-		affinityLabels := *cons.Tags
-		var (
-			affinityTags     = make(map[string]string)
-			antiAffinityTags = make(map[string]string)
-		)
-		for _, labelPair := range affinityLabels {
+		affinityLabels := make(map[string]string)
+		for _, labelPair := range *cons.Tags {
 			parts := strings.Split(labelPair, "=")
 			if len(parts) != 2 {
-				return errors.Errorf("invalid node affinity constraints: %v", affinityLabels)
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
 			}
 			key := strings.Trim(parts[0], " ")
 			value := strings.Trim(parts[1], " ")
-			if strings.HasPrefix(key, "^") {
-				if len(key) == 1 {
-					return errors.Errorf("invalid node affinity constraints: %v", affinityLabels)
-				}
-				antiAffinityTags[key[1:]] = value
-			} else {
-				affinityTags[key] = value
-			}
+			affinityLabels[key] = value
 		}
 
-		updateSelectorTerms := func(nodeSelectorTerm *core.NodeSelectorTerm, tags map[string]string, op core.NodeSelectorOperator) {
-			// Sort for stable ordering.
-			var keys []string
-			for k := range tags {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			for _, tag := range keys {
-				allValues := strings.Split(tags[tag], "|")
-				for i, v := range allValues {
-					allValues[i] = strings.Trim(v, " ")
-				}
-				nodeSelectorTerm.MatchExpressions = append(nodeSelectorTerm.MatchExpressions, core.NodeSelectorRequirement{
-					Key:      tag,
-					Operator: op,
-					Values:   allValues,
-				})
-			}
+		if err := processNodeAffinity(pod, affinityLabels); err != nil {
+			return errors.Annotatef(err, "configuring node affinity for %s", appName)
 		}
-		var nodeSelectorTerm core.NodeSelectorTerm
-		updateSelectorTerms(&nodeSelectorTerm, affinityTags, core.NodeSelectorOpIn)
-		updateSelectorTerms(&nodeSelectorTerm, antiAffinityTags, core.NodeSelectorOpNotIn)
-		pod.Affinity = &core.Affinity{
-			NodeAffinity: &core.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
-					NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
-				},
-			},
+		if err := processPodAffinity(pod, affinityLabels); err != nil {
+			return errors.Annotatef(err, "configuring pod affinity for %s", appName)
 		}
 	}
 	if cons.Zones != nil {
@@ -908,6 +876,147 @@ func processConstraints(pod *core.PodSpec, appName string, cons constraints.Valu
 				Operator: core.NodeSelectorOpIn,
 				Values:   zones,
 			})
+	}
+	return nil
+}
+
+const (
+	podPrefix     = "pod."
+	antiPodPrefix = "anti-pod."
+	nodePrefix    = "node."
+)
+
+func processNodeAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
+	affinityTags := make(map[string]string)
+	for key, value := range affinityLabels {
+		keyVal := key
+		if strings.HasPrefix(key, "^") {
+			if len(key) == 1 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			key = key[1:]
+		}
+		if strings.HasPrefix(key, podPrefix) || strings.HasPrefix(key, antiPodPrefix) {
+			continue
+		}
+		key = strings.TrimPrefix(keyVal, nodePrefix)
+		affinityTags[key] = value
+	}
+
+	updateSelectorTerms := func(nodeSelectorTerm *core.NodeSelectorTerm, tags map[string]string) {
+		// Sort for stable ordering.
+		var keys []string
+		for k := range tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, tag := range keys {
+			allValues := strings.Split(tags[tag], "|")
+			for i, v := range allValues {
+				allValues[i] = strings.Trim(v, " ")
+			}
+			op := core.NodeSelectorOpIn
+			if strings.HasPrefix(tag, "^") {
+				tag = tag[1:]
+				op = core.NodeSelectorOpNotIn
+			}
+			nodeSelectorTerm.MatchExpressions = append(nodeSelectorTerm.MatchExpressions, core.NodeSelectorRequirement{
+				Key:      tag,
+				Operator: op,
+				Values:   allValues,
+			})
+		}
+	}
+	var nodeSelectorTerm core.NodeSelectorTerm
+	updateSelectorTerms(&nodeSelectorTerm, affinityTags)
+	if pod.Affinity == nil {
+		pod.Affinity = &core.Affinity{}
+	}
+	pod.Affinity.NodeAffinity = &core.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+			NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
+		},
+	}
+	return nil
+}
+
+func processPodAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
+	affinityTags := make(map[string]string)
+	antiAffinityTags := make(map[string]string)
+	for key, value := range affinityLabels {
+		notVal := false
+		if strings.HasPrefix(key, "^") {
+			if len(key) == 1 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			notVal = true
+			key = key[1:]
+		}
+		if !strings.HasPrefix(key, podPrefix) && !strings.HasPrefix(key, antiPodPrefix) {
+			continue
+		}
+		if strings.HasPrefix(key, podPrefix) {
+			key = strings.TrimPrefix(key, podPrefix)
+			if notVal {
+				key = "^" + key
+			}
+			affinityTags[key] = value
+		}
+		if strings.HasPrefix(key, antiPodPrefix) {
+			key = strings.TrimPrefix(key, antiPodPrefix)
+			if notVal {
+				key = "^" + key
+			}
+			antiAffinityTags[key] = value
+		}
+	}
+	if len(affinityTags) == 0 && len(antiAffinityTags) == 0 {
+		return nil
+	}
+
+	updateAffinityTerm := func(affinityTerm *core.PodAffinityTerm, tags map[string]string) {
+		// Sort for stable ordering.
+		var keys []string
+		for k := range tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var labelSelector v1.LabelSelector
+		for _, tag := range keys {
+			allValues := strings.Split(tags[tag], "|")
+			for i, v := range allValues {
+				allValues[i] = strings.Trim(v, " ")
+			}
+			op := v1.LabelSelectorOpIn
+			if strings.HasPrefix(tag, "^") {
+				tag = tag[1:]
+				op = v1.LabelSelectorOpNotIn
+			}
+			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, v1.LabelSelectorRequirement{
+				Key:      tag,
+				Operator: op,
+				Values:   allValues,
+			})
+		}
+		affinityTerm.LabelSelector = &labelSelector
+	}
+	if pod.Affinity == nil {
+		pod.Affinity = &core.Affinity{}
+	}
+	var affinityTerm core.PodAffinityTerm
+	updateAffinityTerm(&affinityTerm, affinityTags)
+	if len(affinityTerm.LabelSelector.MatchExpressions) > 0 {
+		pod.Affinity.PodAffinity = &core.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{affinityTerm},
+		}
+	}
+
+	var antiAffinityTerm core.PodAffinityTerm
+	updateAffinityTerm(&antiAffinityTerm, antiAffinityTags)
+	if len(antiAffinityTerm.LabelSelector.MatchExpressions) > 0 {
+		pod.Affinity.PodAntiAffinity = &core.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{antiAffinityTerm},
+		}
 	}
 	return nil
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -5645,10 +5645,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 				NodeSelectorTerms: []core.NodeSelectorTerm{{
 					MatchExpressions: []core.NodeSelectorRequirement{{
-						Key:      "foo",
-						Operator: core.NodeSelectorOpIn,
-						Values:   []string{"a", "b", "c"},
-					}, {
 						Key:      "bar",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"d", "e", "f"},
@@ -5656,9 +5652,43 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 						Key:      "foo",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"g", "h"},
+					}, {
+						Key:      "foo",
+						Operator: core.NodeSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
 					}},
 				}},
 			},
+		},
+		PodAffinity: &core.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{{
+				LabelSelector: &v1.LabelSelector{
+					MatchExpressions: []v1.LabelSelectorRequirement{{
+						Key:      "bar",
+						Operator: v1.LabelSelectorOpNotIn,
+						Values:   []string{"4", "5", "6"},
+					}, {
+						Key:      "foo",
+						Operator: v1.LabelSelectorOpIn,
+						Values:   []string{"1", "2", "3"},
+					}},
+				},
+			}},
+		},
+		PodAntiAffinity: &core.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{{
+				LabelSelector: &v1.LabelSelector{
+					MatchExpressions: []v1.LabelSelectorRequirement{{
+						Key:      "abar",
+						Operator: v1.LabelSelectorOpNotIn,
+						Values:   []string{"7", "8", "9"},
+					}, {
+						Key:      "afoo",
+						Operator: v1.LabelSelectorOpIn,
+						Values:   []string{"x", "y", "z"},
+					}},
+				},
+			}},
 		},
 	}
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -5789,7 +5819,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 				Path: "path/to/there",
 			},
 		}},
-		Constraints: constraints.MustParse(`tags=foo=a|b|c,^bar=d|e|f,^foo=g|h`),
+		Constraints: constraints.MustParse(`tags=node.foo=a|b|c,^bar=d|e|f,^foo=g|h,pod.foo=1|2|3,^pod.bar=4|5|6,anti-pod.afoo=x|y|z,^anti-pod.abar=7|8|9`),
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, application.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -5822,10 +5852,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 				NodeSelectorTerms: []core.NodeSelectorTerm{{
 					MatchExpressions: []core.NodeSelectorRequirement{{
-						Key:      "foo",
-						Operator: core.NodeSelectorOpIn,
-						Values:   []string{"a", "b", "c"},
-					}, {
 						Key:      "bar",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"d", "e", "f"},
@@ -5833,6 +5859,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 						Key:      "foo",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"g", "h"},
+					}, {
+						Key:      "foo",
+						Operator: core.NodeSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
 					}},
 				}},
 			},
@@ -5994,10 +6024,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 				NodeSelectorTerms: []core.NodeSelectorTerm{{
 					MatchExpressions: []core.NodeSelectorRequirement{{
-						Key:      "foo",
-						Operator: core.NodeSelectorOpIn,
-						Values:   []string{"a", "b", "c"},
-					}, {
 						Key:      "bar",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"d", "e", "f"},
@@ -6005,6 +6031,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 						Key:      "foo",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"g", "h"},
+					}, {
+						Key:      "foo",
+						Operator: core.NodeSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
 					}},
 				}},
 			},
@@ -6180,10 +6210,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 				NodeSelectorTerms: []core.NodeSelectorTerm{{
 					MatchExpressions: []core.NodeSelectorRequirement{{
-						Key:      "foo",
-						Operator: core.NodeSelectorOpIn,
-						Values:   []string{"a", "b", "c"},
-					}, {
 						Key:      "bar",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"d", "e", "f"},
@@ -6191,6 +6217,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 						Key:      "foo",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"g", "h"},
+					}, {
+						Key:      "foo",
+						Operator: core.NodeSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
 					}},
 				}},
 			},
@@ -6297,10 +6327,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 				NodeSelectorTerms: []core.NodeSelectorTerm{{
 					MatchExpressions: []core.NodeSelectorRequirement{{
-						Key:      "foo",
-						Operator: core.NodeSelectorOpIn,
-						Values:   []string{"a", "b", "c"},
-					}, {
 						Key:      "bar",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"d", "e", "f"},
@@ -6308,6 +6334,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 						Key:      "foo",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"g", "h"},
+					}, {
+						Key:      "foo",
+						Operator: core.NodeSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
 					}},
 				}},
 			},
@@ -6571,10 +6601,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 			RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 				NodeSelectorTerms: []core.NodeSelectorTerm{{
 					MatchExpressions: []core.NodeSelectorRequirement{{
-						Key:      "foo",
-						Operator: core.NodeSelectorOpIn,
-						Values:   []string{"a", "b", "c"},
-					}, {
 						Key:      "bar",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"d", "e", "f"},
@@ -6582,6 +6608,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 						Key:      "foo",
 						Operator: core.NodeSelectorOpNotIn,
 						Values:   []string{"g", "h"},
+					}, {
+						Key:      "foo",
+						Operator: core.NodeSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
 					}},
 				}},
 			},


### PR DESCRIPTION
k8s constraint tags have been extended to support pod affinity as well as node affinity
Use the "pod." or "anti-pod." prefix for pod affinity and pod anti affinity.
No prefix or "node." is for node affinity

## QA steps


```
juju deploy somecharm --constraints="tags=node.foo=a|b|c,^bar=d|e|f,^foo=g|h,pod.foo=1|2|3,^pod.bar=4|5|6,anti-pod.afoo=x|y|z,^anti-pod.abar=7|8|9"

kubectl get -o json statefulset.apps/somecharm | jq .spec.template.spec.affinity
{
  "nodeAffinity": {
    "requiredDuringSchedulingIgnoredDuringExecution": {
      "nodeSelectorTerms": [
        {
          "matchExpressions": [
            {
              "key": "bar",
              "operator": "NotIn",
              "values": [
                "d",
                "e",
                "f"
              ]
            },
            {
              "key": "foo",
              "operator": "NotIn",
              "values": [
                "g",
                "h"
              ]
            },
            {
              "key": "foo",
              "operator": "In",
              "values": [
                "a",
                "b",
                "c"
              ]
            }
          ]
        }
      ]
    }
  },
  "podAffinity": {
    "requiredDuringSchedulingIgnoredDuringExecution": [
      {
        "labelSelector": {
          "matchExpressions": [
            {
              "key": "bar",
              "operator": "NotIn",
              "values": [
                "4",
                "5",
                "6"
              ]
            },
            {
              "key": "foo",
              "operator": "In",
              "values": [
                "1",
                "2",
                "3"
              ]
            }
          ]
        },
        "topologyKey": ""
      }
    ]
  },
  "podAntiAffinity": {
    "requiredDuringSchedulingIgnoredDuringExecution": [
      {
        "labelSelector": {
          "matchExpressions": [
            {
              "key": "abar",
              "operator": "NotIn",
              "values": [
                "7",
                "8",
                "9"
              ]
            },
            {
              "key": "afoo",
              "operator": "In",
              "values": [
                "x",
                "y",
                "z"
              ]
            }
          ]
        },
        "topologyKey": ""
      }
    ]
  }
}
```