### PR TITLE
Fix upgrade series agent version handling

### DIFF
--- a/cmd/jujud/agent/agentconf/agentconf.go
+++ b/cmd/jujud/agent/agentconf/agentconf.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/jujud/agent/config"
@@ -140,20 +139,6 @@ func SetupAgentLogging(context *loggo.Context, config agent.Config) {
 	if flags := featureflag.String(); flags != "" {
 		logger.Warningf("developer feature flags enabled: %s", flags)
 	}
-}
-
-// GetJujuVersion gets the version of the agent from agent's config file
-func GetJujuVersion(machineAgent string, dataDir string) (version.Number, error) {
-	agentConf := NewAgentConf(dataDir)
-	if err := agentConf.ReadConfig(machineAgent); err != nil {
-		err = errors.Annotate(err, "failed to read agent config file.")
-		return version.Number{}, err
-	}
-	config := agentConf.CurrentConfig()
-	if config == nil {
-		return version.Number{}, errors.Errorf("%s agent conf is not found", machineAgent)
-	}
-	return config.UpgradedToVersion(), nil
 }
 
 // AgentConfigWriter encapsulates disk I/O operations with the agent

--- a/service/agentconf_test.go
+++ b/service/agentconf_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
@@ -216,27 +215,6 @@ func (s *agentConfSuite) agentUnitNames() []string {
 		unitAgents[i] = "jujud-" + name
 	}
 	return unitAgents
-}
-
-func (s *agentConfSuite) TestCopyAgentBinaryIdempotent(c *gc.C) {
-	jujuVersion, err := agentconf.GetJujuVersion(s.machineName, s.dataDir)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.manager.CopyAgentBinary(s.machineName, s.dataDir, "xenial", "trusty", jujuVersion)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertToolsCopySymlink(c, "xenial")
-
-	err = s.manager.CopyAgentBinary(s.machineName, s.dataDir, "xenial", "trusty", jujuVersion)
-	c.Assert(err, jc.ErrorIsNil)
-	s.assertToolsCopySymlink(c, "xenial")
-}
-
-func (s *agentConfSuite) TestCopyAgentBinaryOriginalAgentBinariesNotFound(c *gc.C) {
-	jujuVersion, err := agentconf.GetJujuVersion(s.machineName, s.dataDir)
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = s.manager.CopyAgentBinary(s.machineName, s.dataDir, "xenial", "xenial", jujuVersion)
-	c.Assert(err, gc.ErrorMatches, "copying agent binaries: .* no such file or directory")
 }
 
 func (s *agentConfSuite) TestWriteSystemdAgent(c *gc.C) {

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/v2/series"
 	"github.com/juju/utils/v2/arch"
+	"github.com/juju/utils/v2/fs"
+	"github.com/juju/utils/v2/symlink"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v2/catacomb"
 
@@ -116,6 +119,68 @@ func AllowedTargetVersion(
 	return true
 }
 
+func (u *Upgrader) maybeCopyAgentBinary(dataDir, hostSeries string) (err error) {
+	// Only need to rewrite tools symlink for older agents.
+	if u.config.OrigAgentVersion.Major > 2 || u.config.OrigAgentVersion.Minor > 8 {
+		return nil
+	}
+
+	toVer := version.Binary{
+		Number:  jujuversion.Current,
+		Arch:    arch.HostArch(),
+		Release: coreos.HostOSTypeName(),
+	}
+	// See if we already have what we want.
+	if _, err = os.Stat(agenttools.SharedToolsDir(dataDir, toVer)); err == nil {
+		return nil
+	}
+
+	fromVer := version.Binary{
+		Number:  jujuversion.Current,
+		Arch:    arch.HostArch(),
+		Release: hostSeries,
+	}
+	// If the old tools have already been removed, there's nothing we really need to do.
+	if _, err = os.Stat(agenttools.SharedToolsDir(dataDir, fromVer)); err != nil {
+		return nil
+	}
+
+	// Copy tools to new directory with correct release string.
+	if err = fs.Copy(agenttools.SharedToolsDir(dataDir, fromVer), agenttools.SharedToolsDir(dataDir, toVer)); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Write tools metadata with new version, however don't change
+	// the URL, so we know where it came from.
+	jujuTools, err := agenttools.ReadTools(dataDir, toVer)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Only write once
+	if jujuTools.Version != toVer {
+		jujuTools.Version = toVer
+		if err = agenttools.WriteToolsMetadataData(agenttools.ToolsDir(dataDir, toVer.String()), jujuTools); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// Update machine agent tool link.
+	toolPath := agenttools.ToolsDir(dataDir, toVer.String())
+	toolsDir := agenttools.ToolsDir(dataDir, u.tag.String())
+
+	if err = symlink.Replace(toolsDir, toolPath); err != nil {
+		return errors.Trace(err)
+	}
+
+	return &agenterrors.UpgradeReadyError{
+		OldTools:  fromVer,
+		NewTools:  toVer,
+		AgentName: u.tag.String(),
+		DataDir:   u.dataDir,
+	}
+}
+
 func (u *Upgrader) loop() error {
 	logger := u.config.Logger
 	// Start by reporting current tools (which includes arch/os type, and is
@@ -123,6 +188,20 @@ func (u *Upgrader) loop() error {
 	hostOSType := coreos.HostOSTypeName()
 	if err := u.st.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostOSType)); err != nil {
 		return errors.Annotate(err, "cannot set agent version")
+	}
+
+	// Older 2.8 agents still use for tools based on series.
+	// Old upgrade the original agent will write the tool symlink
+	// also based on series so we need to copy it across to one
+	// based on OS type.
+	// TODO(juju4) - remove this logic
+	hostSeries, err := series.HostSeries()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := u.maybeCopyAgentBinary(u.dataDir, hostSeries); err != nil {
+		// Do not wrap to preserve naked UpgradeReadyError.
+		return err
 	}
 
 	if u.config.UpgradeStepsWaiter == nil {

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -132,7 +132,8 @@ func (s *UpgraderSuite) TestUpgraderSetsTools(c *gc.C) {
 	u := s.makeUpgrader(c)
 	workertest.CleanKill(c, u)
 	s.expectInitialUpgradeCheckDone(c)
-	s.machine.Refresh()
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	gotTools, err := s.machine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
 	agentTools.Version.Build = 666
@@ -154,7 +155,8 @@ func (s *UpgraderSuite) TestUpgraderSetVersion(c *gc.C) {
 	u := s.makeUpgrader(c)
 	workertest.CleanKill(c, u)
 	s.expectInitialUpgradeCheckDone(c)
-	s.machine.Refresh()
+	err = s.machine.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	gotTools, err := s.machine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
 	vers.Build = 666

--- a/worker/upgradeseries/mocks/servicemanager_mock.go
+++ b/worker/upgradeseries/mocks/servicemanager_mock.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/juju/juju/service/common"
-	version "github.com/juju/version/v2"
 	reflect "reflect"
 )
 
@@ -32,20 +31,6 @@ func NewMockSystemdServiceManager(ctrl *gomock.Controller) *MockSystemdServiceMa
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockSystemdServiceManager) EXPECT() *MockSystemdServiceManagerMockRecorder {
 	return m.recorder
-}
-
-// CopyAgentBinary mocks base method
-func (m *MockSystemdServiceManager) CopyAgentBinary(arg0, arg1, arg2, arg3 string, arg4 version.Number) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CopyAgentBinary", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CopyAgentBinary indicates an expected call of CopyAgentBinary
-func (mr *MockSystemdServiceManagerMockRecorder) CopyAgentBinary(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyAgentBinary", reflect.TypeOf((*MockSystemdServiceManager)(nil).CopyAgentBinary), arg0, arg1, arg2, arg3, arg4)
 }
 
 // CreateAgentConf mocks base method


### PR DESCRIPTION
When doing an upgrade-series, there's no need to copy across agent binaries to the new series as everything is now "ubuntu".
So this operation is removed.

When, when upgrading from 2.8, the controller agent itself still is recorded as running the original "series" agent. This is because it is the old 2.8 agent that write out the new agent symlink prior to exiting. However, this breaks upgrade series on the upgraded controller so add a check to the upgrade worker so that older agent binaries are copied. The code to do this is a cut down copy of what was deleted from upgrade series.

## QA steps

Using Juju 2.8, bootstrap controller, switch to controller model, eg:
juju bootstrap lxd --bootstrap-series bionic
juju switch controller

Using Juju 2.9, this branch (gh pr checkout 12842):
juju deploy cs:ubuntu --series bionic --to 0
juju upgrade-controller --build-agent
juju status
juju ssh 0 "ls -l /var/lib/juju/tools"
(both machine-0 and ubuntu-0 should point to the ubuntu tools)

juju switch default
juju upgrade-model
juju deploy cs:ubuntu --series bionic
juju upgrade-series 0 prepare focal
juju upgrade-series 0 complete
check logs for errors
juju status
juju ssh 0 "ls -l /var/lib/juju/tools"
(both machine-0 and ubuntu-0 should point to the ubuntu tools)
