### PR TITLE
[2.9] Restore space support for manual machines

### DIFF
--- a/api/common/network.go
+++ b/api/common/network.go
@@ -186,8 +186,9 @@ func interfaceAddressToNetworkConfig(
 	}
 
 	if ipNet := addr.IPNet(); ipNet != nil && ipNet.Mask != nil {
-		config.CIDR = ipNet.String()
+		config.CIDR = network.NetworkCIDRFromIPAndMask(ip, ipNet.Mask)
 	}
+
 	config.Address = ip.String()
 	if configType != string(network.ConfigLoopback) {
 		config.ConfigType = string(network.ConfigStatic)

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -535,6 +535,7 @@ func FromMachineAddresses(mAddrs ...network.MachineAddress) []Address {
 func FromMachineAddress(addr network.MachineAddress) Address {
 	return Address{
 		Value:       addr.Value,
+		CIDR:        addr.CIDR,
 		Type:        string(addr.Type),
 		Scope:       string(addr.Scope),
 		IsSecondary: addr.IsSecondary,

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -279,7 +279,7 @@ func (s *NetworkSuite) TestMachineAddressConversion(c *gc.C) {
 	}
 
 	exp := []params.Address{
-		{Value: "1.2.3.4", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address)},
+		{Value: "1.2.3.4", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address), CIDR: "1.2.3.0/24"},
 		{Value: "1.2.3.5", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address), IsSecondary: true},
 		{Value: "2.3.4.5", Scope: string(network.ScopePublic), Type: string(network.IPv4Address)},
 	}

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -831,6 +831,20 @@ func CIDRAddressType(cidr string) (AddressType, error) {
 	return IPv6Address, nil
 }
 
+// NetworkCIDRFromIPAndMask constructs a CIDR for a network by applying the
+// provided netmask to the specified address (can be either a host or network
+// address) and formatting the result as a CIDR.
+//
+// For example, passing 10.0.0.4 and a /24 mask yields 10.0.0.0/24.
+func NetworkCIDRFromIPAndMask(ip net.IP, netmask net.IPMask) string {
+	if ip == nil || netmask == nil {
+		return ""
+	}
+
+	hostBits, _ := netmask.Size()
+	return fmt.Sprintf("%s/%d", ip.Mask(netmask), hostBits)
+}
+
 // noAddress represents an error when an address is requested but not available.
 type noAddress struct {
 	errors.Err


### PR DESCRIPTION
This PR fixes a networking-related bug which prevents bootstraps of manual machines on 2.9 and also enhances the fidelity of address-related information that gets captured by the machiner worker.

At some point along its execution, the machiner worker retrieves a list of observed network interfaces and sends it to the controller. When using netlink as our address source, it reports interface addresses (on manual machines) as `net.IPNet` values which represent the interface addresses in _CIDR notation-, e.g. `10.1.2.99/24`.

The controller, uses this information to populate the known subnet details as a workaround given that the manual provider does not support native subnet discovery.  However, storing a non-network CIDR is stored as the subnet CIDR causes issues when the machiner contacts the controller to report the machine addresses visible to the worker.

In particular, the machiner worker periodically makes an API call to `SetMachineAddresses`. The facade implementation first attempts to convert the input arguments into a`SpaceAddresses list`. However, that particular code path eventually calls
`core/network/SubnetInfos.GetByUnderlayCIDR` with the incorrect subnet CIDR which fails validation thus causing an error to be returned back to the machiner worker. The error then causes the machiner to get stuck in a restart loop.

To fix this issue, a new helper called `NetworkCIDRFromIPAndNetmask` has been added to the `core/network` package. This allows us to properly convert host addresses in CIDR notation into network CIDRS (e.g. 10.1.2.3/24 -> 10.1.2.0/24) and avoid the validation errors.

## QA steps

Deploy a bionic MAAS machine with NICs in two spaces. In the example below, the machine is accessible at 10.0.0.75

```console
$ juju bootstrap manual/ubuntu@10.0.0.75 manual-test --debug --no-gui

$ juju switch controller

# You should get a list of spaces/subnets
$ juju subnets
juju subnets
subnets:
  10.0.0.0/24:
    type: ipv4
    status: in-use
    space: alpha
    zones: []
  10.42.0.0/24:
    type: ipv4
    status: in-use
    space: alpha
    zones: []

$ juju add-space space1 10.42.0.0/24
added space "space1" with subnets 10.42.0.0/24

$ juju spaces
Name    Space ID  Subnets
alpha   0         10.0.0.0/24
space1  1         10.42.0.0/24

$ juju deploy cs:wordpress --to 0 --bind space1 --series bionic

# The charm should deploy as expected
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1922098