### PR TITLE
WIP: Upgrade charm-url to include bases

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -301,7 +301,7 @@ func (s *toolsSuite) TestFindToolsOldAgent(c *gc.C) {
 			stateenvirons.EnvironConfigGetter{Model: s.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"), newEnviron,
 		)
 		result, err := toolsFinder.FindTools(params.FindToolsParams{
-			Number: version.MustParse("2.8.9"),
+			Number:       version.MustParse("2.8.9"),
 			MajorVersion: 2,
 			MinorVersion: 8,
 			OSType:       "ubuntu",

--- a/cmd/juju/application/store/charmadapter.go
+++ b/cmd/juju/application/store/charmadapter.go
@@ -114,16 +114,19 @@ func (c *CharmAdaptor) ResolveBundleURL(maybeBundle *charm.URL, preferredOrigin 
 	if err != nil {
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}
+	if storeCharmOrBundleURL == nil {
+		return nil, commoncharm.Origin{}, errors.NotValidf("charmstore bundle %q", maybeBundle.Name)
+	}
 	// We're a bundle so return out before handling the invalid flow.
 	if transport.BundleType.Matches(origin.Type) || storeCharmOrBundleURL.Series == "bundle" {
 		return storeCharmOrBundleURL, origin, nil
 	}
 
 	logger.Debugf(
-		`cannot interpret as charmstore bundle: %v (series) != "bundle"`,
+		`cannot interpret as bundle: %v (series) != "bundle"`,
 		storeCharmOrBundleURL.Series,
 	)
-	return nil, commoncharm.Origin{}, errors.NotValidf("charmstore bundle %q", maybeBundle)
+	return nil, commoncharm.Origin{}, errors.NotValidf("charmstore bundle %q", maybeBundle.Name)
 }
 
 // GetBundle returns a bundle from a given charmstore path.

--- a/core/charm/url.go
+++ b/core/charm/url.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/charm/v8"
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/series"
+)
+
+// CharmURLSeriesToBase converts a charm url that contains a series, to one
+// that contains a base.
+func CharmURLSeriesToBase(url *charm.URL) (*charm.URL, error) {
+	if url.Series == "" {
+		return url, nil
+	}
+
+	baseNameType, err := series.GetOSFromSeries(url.Series)
+	if err != nil {
+		return nil, errors.Annotatef(err, "os name invalid")
+	}
+
+	baseVersion, err := series.SeriesVersion(url.Series)
+	if err != nil {
+		return nil, errors.Annotatef(err, "version invalid")
+	}
+
+	baseName := strings.ToLower(baseNameType.String())
+	return url.WithSeries("").WithBase(fmt.Sprintf("%s:%s", baseName, baseVersion)), nil
+}

--- a/core/charm/url_test.go
+++ b/core/charm/url_test.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"github.com/juju/charm/v8"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type urlSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&urlSuite{})
+
+func (s urlSuite) TestCharmURLSeriesToBase(c *gc.C) {
+	tests := []struct {
+		input  *charm.URL
+		output *charm.URL
+		err    string
+	}{{
+		input:  charm.MustParseURL("ch:foo"),
+		output: charm.MustParseURL("ch:foo"),
+	}, {
+		input:  charm.MustParseURL("ch:amd64/foo"),
+		output: charm.MustParseURL("ch:amd64/foo"),
+	}, {
+		input:  &charm.URL{Schema: "ch", Architecture: "amd64", Series: "focal", Name: "foo", Revision: -1},
+		output: charm.MustParseURL("ch:amd64/ubuntu:20.04/foo"),
+	}, {
+		input:  &charm.URL{Schema: "ch", Architecture: "amd64", Series: "centos7", Name: "foo", Revision: 42},
+		output: charm.MustParseURL("ch:amd64/centos:centos7/foo-42"),
+	}, {
+		input: &charm.URL{Schema: "ch", Architecture: "amd64", Series: "meshuggah", Name: "foo", Revision: 42},
+		err:   `os name invalid: unknown OS for series: "meshuggah"`,
+	}}
+	for i, test := range tests {
+		c.Logf("%d charm url %s", i, test.input)
+
+		got, err := CharmURLSeriesToBase(test.input)
+		if test.err != "" {
+			c.Assert(test.err, gc.Equals, err.Error())
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+		}
+		c.Assert(got, gc.DeepEquals, test.output)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -147,3 +147,5 @@ replace (
 	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.19.6
 	k8s.io/client-go v0.0.0 => k8s.io/client-go v0.19.6
 )
+
+replace github.com/juju/charm/v8 => github.com/SimonRichardson/charm/v8 v8.0.0-20210401131532-2ef8a25276b0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/SimonRichardson/charm/v8 v8.0.0-20210401131532-2ef8a25276b0 h1:cc1fePQcOF7gVfRgU1LyklYkAQg/ndK1HfOgdCAHMU0=
+github.com/SimonRichardson/charm/v8 v8.0.0-20210401131532-2ef8a25276b0/go.mod h1:qLPehvw0bN6af2pzSEXGgVrd+aAHqd5yneC0u4kGBCI=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd h1:JdtityihAc6A+gVfYh6vGXfZQg+XOLyBvla/7NbXFCg=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -397,6 +399,8 @@ github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
 github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f h1:cAmcDXpeI44jQ5ccZs6FF/eTmjJKCGmxnA1erbMtjlI=
 github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f/go.mod h1:AttoXjf7BuW3tQJxUyvDGtPZ+QgZwYLXztWBgIAMW4U=
+github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee h1:Sa+juB94sYHtCPAaEQRrckf8xZfLzE+Mhn+dSv4wrxs=
+github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee/go.mod h1:iMgXKAsiVw2Qd5LvT7GHzJiPpC7V4PacaD3LdAjTmuE=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=

--- a/go.sum
+++ b/go.sum
@@ -393,12 +393,6 @@ github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c/go.mod h1:J4
 github.com/juju/charm/v7 v7.0.0-20200424215011-2c5875af8596/go.mod h1:/Hb24f6NaHMuxV/XeKR9v1QY8qCc0NanWAXQuv6+Ob0=
 github.com/juju/charm/v7 v7.0.0-20200424224456-5fe646695e85/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
 github.com/juju/charm/v7 v7.0.0-20200625165032-ef717232a815/go.mod h1:gcqIN/pHfzDCH6sBeZxmUfrNogknAPejOLS2KN0zY/0=
-github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI/PZPnS5feY4/7Ue2v1zm1YtT8rsXHeWCg=
-github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
-github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
-github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f h1:cAmcDXpeI44jQ5ccZs6FF/eTmjJKCGmxnA1erbMtjlI=
-github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f/go.mod h1:AttoXjf7BuW3tQJxUyvDGtPZ+QgZwYLXztWBgIAMW4U=
 github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee h1:Sa+juB94sYHtCPAaEQRrckf8xZfLzE+Mhn+dSv4wrxs=
 github.com/juju/charm/v9 v9.0.0-20210324234318-1204b46e47ee/go.mod h1:iMgXKAsiVw2Qd5LvT7GHzJiPpC7V4PacaD3LdAjTmuE=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
@@ -538,7 +532,6 @@ github.com/juju/schema v0.0.0-20180109041850-e4f08199aa80/go.mod h1:7dL+43wADDfx
 github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989 h1:qx1Zh1bnHHVIMmRxq0fehYk7npCG50GhUwEkYeUg/t4=
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
-github.com/juju/systems v0.0.0-20200925032749-8c613192c759/go.mod h1:FcXkVf5o+mosxneWzQsHQ7h9sU3lD2GDOttJClqgnuA=
 github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca h1:KmPR6hTiZ8kDALV8YgFagYlRvyJCfJVvihwDvXgma6I=
 github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca/go.mod h1:FcXkVf5o+mosxneWzQsHQ7h9sU3lD2GDOttJClqgnuA=
 github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae h1:wGk/zIPORICWlu4giN7CLGlP0PNvY/oZCRwfVLgjOZw=
@@ -1006,7 +999,6 @@ golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200817085935-3ff754bf58a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -93,6 +93,7 @@ type StateBackend interface {
 	RemoveUnusedLinkLayerDeviceProviderIDs() error
 	TranslateK8sServiceTypes() error
 	UpdateKubernetesCloudCredentials() error
+	UpdateSeriesToBaseCharmhubCharmURLs() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -392,4 +393,8 @@ func (s stateBackend) TranslateK8sServiceTypes() error {
 
 func (s stateBackend) UpdateKubernetesCloudCredentials() error {
 	return state.UpdateLegacyKubernetesCloudCredentials(s.pool.SystemState())
+}
+
+func (s stateBackend) UpdateSeriesToBaseCharmhubCharmURLs() error {
+	return state.UpdateSeriesToBaseCharmhubCharmURLs(s.pool)
 }

--- a/upgrades/steps_29.go
+++ b/upgrades/steps_29.go
@@ -61,6 +61,13 @@ func stateStepsFor29() []Step {
 				return context.State().UpdateKubernetesCloudCredentials()
 			},
 		},
+		&upgradeStep{
+			description: "update series to base for charmhub charms",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateSeriesToBaseCharmhubCharmURLs()
+			},
+		},
 	}
 }
 


### PR DESCRIPTION

Requires https://github.com/juju/charm/pull/346

**This breaks juju and requires more work**

The following adds an upgrade step to ensure that previous charm urls
are re-written from series to bases. This probably breaks a lot of
existing things, as deployment can no longer happen, as it's expected
that series is a thing.

The code is quite simple, it just walks over the charms and application
collections.

FYI: this works as well for all 2.9 RCs, as a build tag is stripped and
matched with the major,  minor, and patch. So 2.9rc9 is matched to 2.9.

## QA steps

Bootstrap latest rc

```sh
$ /snap/bin/juju bootstrap lxd test
$ juju deploy ubuntu
$ juju upgrade-controller --build-agent
$ juju upgrade-model
$ juju mongo
$ db.applications.find().pretty()
# notice the charm / application URL has been re-written with bases.
```
