### PR TITLE
Fix tags and add compatibility fields to NetworkInfo Type

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -327,6 +327,10 @@ func addAddressToResult(networkInfos []params.NetworkInfo, address *state.Addres
 		InterfaceName: address.DeviceName(),
 		MACAddress:    MAC,
 		Addresses:     []params.InterfaceAddress{deviceAddr},
+
+		// Compatibility preservation. Remove for Juju 3/4.
+		InterfaceNameX: address.DeviceName(),
+		MACAddressX:    MAC,
 	}
 	return append(networkInfos, networkInfo), nil
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4693,6 +4693,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				Addresses: []params.InterfaceAddress{
 					{Address: "10.0.0.10", CIDR: "10.0.0.0/24"},
 				},
+
+				MACAddressX:    "00:11:22:33:10:50",
+				InterfaceNameX: "eth0.100",
 			},
 			{
 				MACAddress:    "00:11:22:33:10:51",
@@ -4700,6 +4703,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				Addresses: []params.InterfaceAddress{
 					{Address: "10.0.0.11", CIDR: "10.0.0.0/24"},
 				},
+
+				MACAddressX:    "00:11:22:33:10:51",
+				InterfaceNameX: "eth1.100",
 			},
 		},
 		EgressSubnets:    []string{"10.0.0.10/32"},
@@ -4715,6 +4721,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				Addresses: []params.InterfaceAddress{
 					{Address: "8.8.8.10", CIDR: "8.8.0.0/16"},
 				},
+
+				MACAddressX:    "00:11:22:33:10:50",
+				InterfaceNameX: "eth0",
 			},
 			{
 				MACAddress:    "00:11:22:33:10:51",
@@ -4723,6 +4732,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 					{Address: "8.8.4.10", CIDR: "8.8.0.0/16"},
 					{Address: "8.8.4.11", CIDR: "8.8.0.0/16"},
 				},
+
+				MACAddressX:    "00:11:22:33:10:51",
+				InterfaceNameX: "eth1",
 			},
 			{
 				MACAddress:    "00:11:22:33:10:55",
@@ -4730,6 +4742,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				Addresses: []params.InterfaceAddress{
 					{Address: "1.1.1.10", CIDR: "1.0.0.0/12"},
 				},
+
+				MACAddressX:    "00:11:22:33:10:55",
+				InterfaceNameX: "fan-1",
 			},
 		},
 		// Egress is based on the first ingress address.
@@ -4748,6 +4763,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				Addresses: []params.InterfaceAddress{
 					{Address: "100.64.0.10", CIDR: "100.64.0.0/16"},
 				},
+
+				MACAddressX:    "00:11:22:33:10:52",
+				InterfaceNameX: "eth2",
 			},
 		},
 		EgressSubnets:    []string{"100.64.0.10/32"},
@@ -4779,6 +4797,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoL2Binding(c *gc.C) {
 			{
 				MACAddress:    "00:11:22:33:10:50",
 				InterfaceName: "eth2",
+
+				MACAddressX:    "00:11:22:33:10:50",
+				InterfaceNameX: "eth2",
 			},
 		},
 	}
@@ -4817,6 +4838,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForImplicitlyBoundEndpoint(c *gc
 				Addresses: []params.InterfaceAddress{
 					{Address: "192.168.1.20", CIDR: "192.168.1.0/24"},
 				},
+
+				MACAddressX:    "00:11:22:33:20:54",
+				InterfaceNameX: "eth4",
 			},
 		},
 		EgressSubnets:    []string{"192.168.1.20/32"},
@@ -4853,6 +4877,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForJujuInfoDefaultSpace(c *gc.C)
 				Addresses: []params.InterfaceAddress{
 					{Address: "192.168.1.20", CIDR: "192.168.1.0/24"},
 				},
+
+				MACAddressX:    "00:11:22:33:20:54",
+				InterfaceNameX: "eth4",
 			},
 		},
 		EgressSubnets:    []string{"192.168.1.20/32"},
@@ -4908,6 +4935,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 				Addresses: []params.InterfaceAddress{
 					{Address: "192.168.1.20", CIDR: "192.168.1.0/24"},
 				},
+
+				MACAddressX:    "00:11:22:33:20:54",
+				InterfaceNameX: "eth4",
 			},
 		},
 		EgressSubnets:    []string{"192.168.1.0/24"},
@@ -4979,6 +5009,9 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 				Addresses: []params.InterfaceAddress{
 					{Address: "10.0.0.20", CIDR: "10.0.0.0/24"},
 				},
+
+				MACAddressX:    "00:11:22:33:20:50",
+				InterfaceNameX: "eth0.100",
 			},
 		},
 		EgressSubnets:    []string{"192.168.1.0/24"},
@@ -5010,10 +5043,16 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoV6Results(c *gc.C) {
 						MACAddress:    "00:11:22:33:10:50",
 						InterfaceName: "eth0.100",
 						Addresses:     []params.InterfaceAddress{{Address: "10.0.0.10", CIDR: "10.0.0.0/24"}},
+
+						MACAddressX:    "00:11:22:33:10:50",
+						InterfaceNameX: "eth0.100",
 					}, {
 						MACAddress:    "00:11:22:33:10:51",
 						InterfaceName: "eth1.100",
 						Addresses:     []params.InterfaceAddress{{Address: "10.0.0.11", CIDR: "10.0.0.0/24"}},
+
+						MACAddressX:    "00:11:22:33:10:51",
+						InterfaceNameX: "eth1.100",
 					},
 				},
 			},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -44448,7 +44448,13 @@
                         "interface-name": {
                             "type": "string"
                         },
+                        "interfacename": {
+                            "type": "string"
+                        },
                         "mac-address": {
+                            "type": "string"
+                        },
+                        "macaddress": {
                             "type": "string"
                         }
                     },
@@ -44456,7 +44462,9 @@
                     "required": [
                         "mac-address",
                         "interface-name",
-                        "addresses"
+                        "addresses",
+                        "macaddress",
+                        "interfacename"
                     ]
                 },
                 "NetworkInfoParams": {

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -1200,14 +1200,19 @@ type InterfaceAddress struct {
 type NetworkInfo struct {
 	// MACAddress is the network interface's hardware MAC address
 	// (e.g. "aa:bb:cc:dd:ee:ff").
-	MACAddress string `json:"mac-address"`
+	MACAddress string `json:"mac-address" yaml:"mac-address"`
 
 	// InterfaceName is the raw OS-specific network device name (e.g.
 	// "eth1", even for a VLAN eth1.42 virtual interface).
-	InterfaceName string `json:"interface-name"`
+	InterfaceName string `json:"interface-name" yaml:"interface-name"`
 
 	// Addresses contains a list of addresses configured on the interface.
-	Addresses []InterfaceAddress `json:"addresses"`
+	Addresses []InterfaceAddress `json:"addresses" yaml:"addresses"`
+
+	// These fields are for preserving backward compatibility with agents that
+	// anticipate the old YAML format. Remove for Juju 3/4.
+	MACAddressX    string `json:"-" yaml:"macaddress"`
+	InterfaceNameX string `json:"-" yaml:"interfacename"`
 }
 
 // NetworkInfoResult Adds egress and ingress subnets and changes the serialized

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -1211,8 +1211,8 @@ type NetworkInfo struct {
 
 	// These fields are for preserving backward compatibility with agents that
 	// anticipate the old YAML format. Remove for Juju 3/4.
-	MACAddressX    string `json:"-" yaml:"macaddress"`
-	InterfaceNameX string `json:"-" yaml:"interfacename"`
+	MACAddressX    string `json:"macaddress" yaml:"macaddress"`
+	InterfaceNameX string `json:"interfacename" yaml:"interfacename"`
 }
 
 // NetworkInfoResult Adds egress and ingress subnets and changes the serialized

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -32,7 +32,8 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 	presetBindings := make(map[string]params.NetworkInfoResult)
 	presetBindings["known-relation"] = params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
-			{MACAddress: "00:11:22:33:44:00",
+			{
+				MACAddress:    "00:11:22:33:44:00",
 				InterfaceName: "eth0",
 				Addresses: []params.InterfaceAddress{
 					{
@@ -45,7 +46,8 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 					},
 				},
 			},
-			{MACAddress: "00:11:22:33:44:11",
+			{
+				MACAddress:    "00:11:22:33:44:11",
 				InterfaceName: "eth1",
 				Addresses: []params.InterfaceAddress{
 					{
@@ -62,7 +64,8 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 	}
 	presetBindings["known-extra"] = params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
-			{MACAddress: "00:11:22:33:44:22",
+			{
+				MACAddress:    "00:11:22:33:44:22",
 				InterfaceName: "eth2",
 				Addresses: []params.InterfaceAddress{
 					{
@@ -81,7 +84,8 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 	// Simulate known but unspecified bindings.
 	presetBindings["known-unbound"] = params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
-			{MACAddress: "00:11:22:33:44:33",
+			{
+				MACAddress:    "00:11:22:33:44:33",
 				InterfaceName: "eth3",
 				Addresses: []params.InterfaceAddress{
 					{
@@ -89,13 +93,17 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 						CIDR:    "10.33.1.8/24",
 					},
 				},
+
+				MACAddressX:    "00:11:22:33:44:33",
+				InterfaceNameX: "eth3",
 			},
 		},
 	}
 	// Simulate info with egress and ingress data.
 	presetBindings["ingress-egress"] = params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
-			{MACAddress: "00:11:22:33:44:33",
+			{
+				MACAddress:    "00:11:22:33:44:33",
 				InterfaceName: "eth3",
 				Addresses: []params.InterfaceAddress{
 					{
@@ -166,15 +174,17 @@ ingress-address: 10.20.1.42`[1:],
 		args:    []string{"known-extra"},
 		out: `
 bind-addresses:
-- macaddress: "00:11:22:33:44:22"
-  interfacename: eth2
+- mac-address: "00:11:22:33:44:22"
+  interface-name: eth2
   addresses:
   - hostname: ""
     address: 10.20.1.42
     cidr: 10.20.1.42/24
   - hostname: ""
     address: fc00::1
-    cidr: fc00::/64`[1:],
+    cidr: fc00::/64
+  macaddress: ""
+  interfacename: ""`[1:],
 	}, {
 		summary: "explicitly bound relation name given with single flag arg",
 		args:    []string{"known-relation", "--ingress-address"},
@@ -184,8 +194,8 @@ bind-addresses:
 		args:    []string{"known-relation"},
 		out: `
 bind-addresses:
-- macaddress: "00:11:22:33:44:00"
-  interfacename: eth0
+- mac-address: "00:11:22:33:44:00"
+  interface-name: eth0
   addresses:
   - hostname: ""
     address: 10.10.0.23
@@ -193,15 +203,19 @@ bind-addresses:
   - hostname: ""
     address: 192.168.1.111
     cidr: 192.168.1.0/24
-- macaddress: "00:11:22:33:44:11"
-  interfacename: eth1
+  macaddress: ""
+  interfacename: ""
+- mac-address: "00:11:22:33:44:11"
+  interface-name: eth1
   addresses:
   - hostname: ""
     address: 10.10.1.23
     cidr: 10.10.1.0/24
   - hostname: ""
     address: 192.168.2.111
-    cidr: 192.168.2.0/24`[1:],
+    cidr: 192.168.2.0/24
+  macaddress: ""
+  interfacename: ""`[1:],
 	}, {
 		summary: "no user requested binding falls back to binding address, with ingress-address arg",
 		args:    []string{"known-unbound", "--ingress-address"},
@@ -211,12 +225,14 @@ bind-addresses:
 		args:    []string{"known-unbound"},
 		out: `
 bind-addresses:
-- macaddress: "00:11:22:33:44:33"
-  interfacename: eth3
+- mac-address: "00:11:22:33:44:33"
+  interface-name: eth3
   addresses:
   - hostname: ""
     address: 10.33.1.8
-    cidr: 10.33.1.8/24`[1:],
+    cidr: 10.33.1.8/24
+  macaddress: "00:11:22:33:44:33"
+  interfacename: eth3`[1:],
 	}, {
 		summary: "explicit ingress and egress information",
 		args:    []string{"ingress-egress", "--ingress-address", "--bind-address", "--egress-subnets"},
@@ -231,12 +247,14 @@ ingress-address: 100.1.2.3`[1:],
 		args:    []string{"ingress-egress"},
 		out: `
 bind-addresses:
-- macaddress: "00:11:22:33:44:33"
-  interfacename: eth3
+- mac-address: "00:11:22:33:44:33"
+  interface-name: eth3
   addresses:
   - hostname: ""
     address: 10.33.1.8
     cidr: 10.33.1.8/24
+  macaddress: ""
+  interfacename: ""
 egress-subnets:
 - 192.168.1.0/8
 - 10.0.0.0/8


### PR DESCRIPTION
To-date, the JSON and YAML representations of `params.NetworkInfo` have been inconsistent due to the omission of YAML serialisation tags.

Here, we add YAML tags to make them consistent, but also include field copies that when serialised to YAML will render with the old field names for compatibility.

For the next major Juju version, the compatibility fields can be removed.

## QA steps

- Bootstrap to LXD.
- `juju deploy ubuntu`
- `juju run --unit ubuntu/0 "network-get juju-info --format json"|jq .`:
```
{
  "bind-addresses": [
    {
      "mac-address": "00:16:3e:fe:cd:8c",
      "interface-name": "eth0",
      "addresses": [
        {
          "hostname": "",
          "value": "10.62.163.32",
          "cidr": "10.62.163.0/24"
        }
      ],
      "macaddress": "00:16:3e:fe:cd:8c",
      "interfacename": "eth0"
    }
  ],
  "egress-subnets": [
    "10.62.163.32/32"
  ],
  "ingress-addresses": [
    "10.62.163.32"
  ]
}
```
- `juju run --unit ubuntu/0 "network-get juju-info --format yaml`:
```
bind-addresses:
- mac-address: 00:16:3e:fe:cd:8c
  interface-name: eth0
  addresses:
  - hostname: ""
    address: 10.62.163.32
    cidr: 10.62.163.0/24
  macaddress: 00:16:3e:fe:cd:8c
  interfacename: eth0
egress-subnets:
- 10.62.163.32/32
ingress-addresses:
- 10.62.163.32
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1915418
