### PR TITLE
Fix for LP1921557 sni in Juju login.

### DIFF
--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -257,7 +257,7 @@ func (s *CAASProvisionerSuite) TestIssueOperatorCertificate(c *gc.C) {
 		[]byte(certInfo.PrivateKey)...))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(signers), gc.Equals, 1)
-	c.Assert(len(certs), gc.Equals, 1)
+	c.Assert(len(certs), gc.Equals, 2)
 
 	roots := x509.NewCertPool()
 	ok := roots.AppendCertsFromPEM([]byte(certInfo.CACert))

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -362,10 +363,16 @@ func (c *loginCommand) publicControllerLogin(
 			dialOpts.BakeryClient.AddInteractor(i)
 		}
 
+		sniHost, _, err := net.SplitHostPort(host)
+		if err != nil {
+			return nil, errors.Annotatef(err, "getting sni host from host %q", host)
+		}
+
 		return apiOpen(&c.CommandBase, &api.Info{
-			Tag:      tag,
-			Password: d.Password,
-			Addrs:    []string{host},
+			Tag:         tag,
+			Password:    d.Password,
+			Addrs:       []string{host},
+			SNIHostName: sniHost,
 		}, dialOpts)
 	}
 	conn, accountDetails, err := c.login(ctx, currentAccountDetails, dial)

--- a/pki/authority.go
+++ b/pki/authority.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	DefaultLeafGroup = "controller"
+	DefaultLeafGroup      = "controller"
+	ControllerIPLeafGroup = "controllerip"
 )
 
 // Authority represents a secure means of issuing groups of common interest
@@ -80,6 +81,14 @@ func (a *DefaultAuthority) Chain() []*x509.Certificate {
 	return a.authority.Chain()
 }
 
+func (a *DefaultAuthority) ChainWithAuthority() []*x509.Certificate {
+	chain := a.authority.Chain()
+	if chain == nil {
+		chain = []*x509.Certificate{}
+	}
+	return append(chain, a.authority.Certificate())
+}
+
 // leafMaker is responsible for providing a method to make new leafs after
 // request signing.
 func (a *DefaultAuthority) leafMaker(groupKey string) LeafMaker {
@@ -104,11 +113,11 @@ func (a *DefaultAuthority) LeafRequestForGroup(group string) LeafRequest {
 	defer a.leafSignerMutex.Unlock()
 	if a.leafSigner != nil {
 		return NewDefaultLeafRequestWithSigner(subject, a.leafSigner,
-			NewDefaultRequestSigner(a.Certificate(), a.Chain(), a.Signer()),
+			NewDefaultRequestSigner(a.Certificate(), a.ChainWithAuthority(), a.Signer()),
 			a.leafMaker(groupKey))
 	}
 	return NewDefaultLeafRequest(subject,
-		NewDefaultRequestSigner(a.Certificate(), a.Chain(), a.Signer()),
+		NewDefaultRequestSigner(a.Certificate(), a.ChainWithAuthority(), a.Signer()),
 		a.leafMaker(groupKey))
 }
 

--- a/pki/authority_test.go
+++ b/pki/authority_test.go
@@ -76,6 +76,21 @@ func (a *AuthoritySuite) TestLeafRequest(c *gc.C) {
 	c.Assert(leaf.Certificate().IPAddresses, jc.DeepEquals, ipAddresses)
 }
 
+func (a *AuthoritySuite) TestLeafRequestChain(c *gc.C) {
+	authority, err := pki.NewDefaultAuthority(a.ca, a.signer)
+	c.Assert(err, jc.ErrorIsNil)
+	dnsNames := []string{"test.juju.is"}
+	ipAddresses := []net.IP{net.ParseIP("fe80:abcd::1")}
+	leaf, err := authority.LeafRequestForGroup("testgroup").
+		AddDNSNames(dnsNames...).
+		AddIPAddresses(ipAddresses...).
+		Commit()
+
+	chain := leaf.Chain()
+	c.Assert(len(chain), gc.Equals, 1)
+	c.Assert(chain[0], jc.DeepEquals, authority.Certificate())
+}
+
 func (a *AuthoritySuite) TestLeafFromPem(c *gc.C) {
 	authority, err := pki.NewDefaultAuthority(a.ca, a.signer)
 	c.Assert(err, jc.ErrorIsNil)

--- a/pki/tls/sni_test.go
+++ b/pki/tls/sni_test.go
@@ -89,6 +89,12 @@ func (s *SNISuite) TestAuthorityTLSGetter(c *gc.C) {
 			Group:         pki.DefaultLeafGroup,
 			ServerName:    "doesnotexist.juju.example",
 		},
+		{
+			// Regression test for LP1921557
+			ExpectedGroup: pki.ControllerIPLeafGroup,
+			Group:         pki.ControllerIPLeafGroup,
+			ServerName:    "",
+		},
 	}
 
 	for _, test := range tests {

--- a/worker/certupdater/certupdater.go
+++ b/worker/certupdater/certupdater.go
@@ -17,10 +17,6 @@ import (
 	"github.com/juju/juju/watcher/legacy"
 )
 
-const (
-	ControllerIPLeafGroup = "controllerip"
-)
-
 var (
 	logger = loggo.GetLogger("juju.worker.certupdater")
 )
@@ -112,7 +108,7 @@ func (c *CertificateUpdater) updateCertificate(addresses network.SpaceAddresses)
 	logger.Debugf("new machine addresses: %#v", addresses)
 	c.addresses = addresses
 
-	request := c.authority.LeafRequestForGroup(ControllerIPLeafGroup)
+	request := c.authority.LeafRequestForGroup(pki.ControllerIPLeafGroup)
 
 	for _, addr := range addresses {
 		if addr.Value == "localhost" {

--- a/worker/certupdater/certupdater_test.go
+++ b/worker/certupdater/certupdater_test.go
@@ -13,6 +13,7 @@ import (
 
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/pki"
 	pkitest "github.com/juju/juju/pki/test"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -105,7 +106,7 @@ func (s *CertUpdaterSuite) TestStartStop(c *gc.C) {
 	})
 	workertest.CleanKill(c, worker)
 
-	leaf, err := authority.LeafForGroup(certupdater.ControllerIPLeafGroup)
+	leaf, err := authority.LeafForGroup(pki.ControllerIPLeafGroup)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(leaf.Certificate().IPAddresses, coretesting.IPsEqual,
 		[]net.IP{net.ParseIP("192.168.1.1")})
@@ -126,7 +127,7 @@ func (s *CertUpdaterSuite) TestAddressChange(c *gc.C) {
 	// Certificate should be updated with the address value.
 
 	workertest.CleanKill(c, worker)
-	leaf, err := authority.LeafForGroup(certupdater.ControllerIPLeafGroup)
+	leaf, err := authority.LeafForGroup(pki.ControllerIPLeafGroup)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(leaf.Certificate().IPAddresses, coretesting.IPsEqual,
 		[]net.IP{net.ParseIP("0.1.2.3")})


### PR DESCRIPTION
Juju login has been failing with recent changes to Juju's certificate
management. Specifically there are two problems that have come up.

The first is the Juju controller selecting the right certificate when ip
connections are being initiated that don't have an SNI name set. This
has been fixed by returning Juju's ip certificate with empty SNI names.

The second is Juju returning the CA cert in it's certificate chain.
Normally it's not considered valid to return a root CA in a chain but
for the way Juju works when logging in it needs to in order to trust the
CA and add it to the config file.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Follow the steps outline in the bug report below. Also perform the below check with openssl.

```sh
openssl s_client --connect <controller-ip>:17070 -servername <controller-ip>
You need to confirm here that a certificate is returned covering the ip sans of the controller and that CA cert is returned in the chain.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1921557
