### PR TITLE
Record attempt and duration when observing state transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/juju/jsonschema v0.0.0-20161102181919-a0ef8b74ebcf
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
-	github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208
+	github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,9 @@ github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7L
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible/go.mod h1:YQBneJkXlAAye6yHFYH8CabVID+0Oq2by8DDKGj5OIU=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f h1:a3Vd00a20dTKLpyS2hdUafNG5zxQdTw5KhDMK5C0a8U=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f/go.mod h1:+7K7MqWi5xWI+s1LyB2g0Di71jZo27y+XOlmhNtV1Y0=
-github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208 h1:/WiCm+Vpj87e4QWuWwPD/bNE9kDrWCLvPBHOQNcG2+A=
 github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
+github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f h1:/Wj+9vztEkhkudRz596GbOu3x6FmftHk2vurf4yaaxw=
+github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31 h1:v6GpXmpXOD6KwPbApRlwDGQxf1FpS6gfLdfVbE4ZLzk=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31/go.mod h1:m6E+J+I+cE+6rcaVxSI4HwGLIEOCSOBMYedt3Sewh+U=
 github.com/juju/mgotest v1.0.1/go.mod h1:vTaDufYul+Ps8D7bgseHjq87X8eu0ivlKLp9mVc/Bfc=

--- a/mongo/mongometrics/txnmetrics.go
+++ b/mongo/mongometrics/txnmetrics.go
@@ -4,6 +4,8 @@
 package mongometrics
 
 import (
+	"time"
+
 	"github.com/juju/mgo/v2/txn"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -28,12 +30,14 @@ var (
 // mgo/txn operations.
 type TxnCollector struct {
 	txnOpsTotalCounter *prometheus.CounterVec
+	txnRetries prometheus.Histogram
+	txnDurations prometheus.Histogram
 }
 
 // NewTxnCollector returns a new TxnCollector.
 func NewTxnCollector() *TxnCollector {
 	return &TxnCollector{
-		prometheus.NewCounterVec(
+		txnOpsTotalCounter: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: "juju",
 				Name:      "mgo_txn_ops_total",
@@ -41,17 +45,33 @@ func NewTxnCollector() *TxnCollector {
 			},
 			jujuMgoTxnLabelNames,
 		),
+		txnRetries: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace:   "juju",
+				Name:        "mgo_txn_retries",
+				Help:        "Number of attempts to complete a transaction",
+				Buckets:     prometheus.LinearBuckets(0, 1, 50),
+			},
+		),
+		txnDurations: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace:   "juju",
+				Name:        "mgo_txn_durations",
+				Help:        "Time (ms) taken to complete a transaction",
+				Buckets:     prometheus.LinearBuckets(0, 2, 50),
+			},
+		),
 	}
 }
 
 // AfterRunTransaction is called when a mgo/txn transaction has run.
-func (c *TxnCollector) AfterRunTransaction(dbName, modelUUID string, ops []txn.Op, err error) {
+func (c *TxnCollector) AfterRunTransaction(dbName, modelUUID string, attempt int, duration time.Duration, ops []txn.Op, err error) {
 	for _, op := range ops {
-		c.updateMetrics(dbName, op, err)
+		c.updateMetrics(dbName, attempt, duration, op, err)
 	}
 }
 
-func (c *TxnCollector) updateMetrics(dbName string, op txn.Op, err error) {
+func (c *TxnCollector) updateMetrics(dbName string, attempt int, duration time.Duration, op txn.Op, err error) {
 	var failed string
 	if err != nil {
 		failed = "failed"
@@ -73,14 +93,20 @@ func (c *TxnCollector) updateMetrics(dbName string, op txn.Op, err error) {
 		optypeLabel:     optype,
 		failedLabel:     failed,
 	}).Inc()
+	c.txnRetries.Observe(float64(attempt))
+	c.txnDurations.Observe(float64(duration/time.Millisecond))
 }
 
 // Describe is part of the prometheus.Collector interface.
 func (c *TxnCollector) Describe(ch chan<- *prometheus.Desc) {
 	c.txnOpsTotalCounter.Describe(ch)
+	c.txnRetries.Describe(ch)
+	c.txnDurations.Describe(ch)
 }
 
 // Collect is part of the prometheus.Collector interface.
 func (c *TxnCollector) Collect(ch chan<- prometheus.Metric) {
 	c.txnOpsTotalCounter.Collect(ch)
+	c.txnRetries.Collect(ch)
+	c.txnDurations.Collect(ch)
 }

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -393,7 +393,7 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperationMany(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	numActions := 50
+	numActions := 500
 
 	wg := sync.WaitGroup{}
 	var actions []state.Action

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4308,6 +4308,8 @@ func (s *StateSuite) TestRunTransactionObserver(c *gc.C) {
 	type args struct {
 		dbName    string
 		modelUUID string
+		attempt   int
+		duration  time.Duration
 		ops       []mgotxn.Op
 		err       error
 	}
@@ -4320,12 +4322,14 @@ func (s *StateSuite) TestRunTransactionObserver(c *gc.C) {
 	}
 
 	params := s.testOpenParams()
-	params.RunTransactionObserver = func(dbName, modelUUID string, ops []mgotxn.Op, err error) {
+	params.RunTransactionObserver = func(dbName, modelUUID string, attempt int, duration time.Duration, ops []mgotxn.Op, err error) {
 		mu.Lock()
 		defer mu.Unlock()
 		recordedCalls = append(recordedCalls, args{
 			dbName:    dbName,
 			modelUUID: modelUUID,
+			attempt:   attempt,
+			duration:  duration,
 			ops:       ops,
 			err:       err,
 		})
@@ -4350,6 +4354,7 @@ func (s *StateSuite) TestRunTransactionObserver(c *gc.C) {
 		}
 		c.Check(call.dbName, gc.Equals, "juju")
 		c.Check(call.modelUUID, gc.Equals, s.modelTag.Id())
+		c.Check(call.duration, gc.Not(gc.Equals), 0)
 		c.Check(call.err, gc.IsNil)
 		c.Check(call.ops, gc.HasLen, 1)
 		c.Check(call.ops[0].Update, gc.NotNil)


### PR DESCRIPTION
Add extra info to the mongo transaction metrics:
- number of retries
- txn duration
(these are histograms),

Bring in a new juju/mgo/v2 update to deal with underlying mongo write conflicts.
Also reduce the number of txn retries Juju will use for sstxn. To test this, the concurrent action test has been changed to create 500 not 50 actions to save simultaneously.

## QA

unit tests
bootstrap
deploy some charms