### PR TITLE
Ensure assess-upgrade-series does not report started prematuremly

### DIFF
--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -20,6 +20,7 @@ from utility import (
     add_basic_testing_arguments,
     configure_logging,
     JujuAssertionError,
+    wait_for_port,
 )
 
 __metaclass__ = type
@@ -81,12 +82,9 @@ def reboot_machine(client, machine):
             raise e
         log.info("Ignoring `juju ssh` exit status after triggering reboot")
 
-    # Wait a bit so that we do not detect the started condition
-    # *before* Juju actually reports it as "down".
-    time.sleep(5)
-
-    log.info("wait_for_started()")
-    client.wait_for_started()
+    log.info("waiting for reboot")
+    hostname = client.get_status().get_machine_dns_name(machine)
+    wait_for_port(hostname, 22, timeout=600)
 
 
 def assert_correct_series(client, machine, expected):

--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -81,6 +81,10 @@ def reboot_machine(client, machine):
             raise e
         log.info("Ignoring `juju ssh` exit status after triggering reboot")
 
+    # Wait a bit so that we do not detect the started condition
+    # *before* Juju actually reports it as "down".
+    time.sleep(5)
+
     log.info("wait_for_started()")
     client.wait_for_started()
 

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1743,7 +1743,7 @@ class ModelClient:
         return info_dict.get('controller-member-status')
 
     def wait_for_ha(self, timeout=1200, start=None, quorum=3):
-        """Wait for voiting to be enabled.
+        """Wait for voting to be enabled.
 
         May only be called on a controller client."""
         if self.env.environment != self.get_controller_model_name():
@@ -1767,7 +1767,7 @@ class ModelClient:
         self._wait_for_status(reporter, status_to_ha, VotingNotEnabled,
                               timeout=timeout, start=start)
         # XXX sinzui 2014-12-04: bug 1399277 happens because
-        # juju claims HA is ready when the monogo replica sets
+        # juju claims HA is ready when the mongo replica sets
         # are not. Juju is not fully usable. The replica set
         # lag might be 5 minutes.
         self._backend.pause(300)


### PR DESCRIPTION
The _assess_upgrade_series_ acceptance test has an intermittent failure mode where we progress the test too soon after issuing a reboot command, subsequently failing when the machine is in the "down" state. This is because it is possible to detect the machine's "started" status _before_ it has been reported as "down".

Instead of relying on Juju status, we can use the same technique as in the network health test - wait for port 22 to become available on the rebooted machine.

## QA steps

`cd acceptancetests && ./assess upgrade_series --juju ~/go/bin/juju --logging-config '<root>=DEBUG'`

## Documentation changes

None.

## Bug reference

N/A