### PR TITLE
Fixes bug where empty error can happen in storage

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -122,7 +122,6 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 			}}
 		}
 	}
-
 	// If the user has not specified storage and cloudType is usable, check Juju's opinionated defaults.
 	err = storageParams.MetadataChecker.CheckDefaultWorkloadStorage(
 		cloudType, clusterMetadata.NominatedStorageClass,
@@ -141,7 +140,10 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 				// And no preferred storage classes with expected annotations found.
 				//  - workloadStorageClassAnnotationKey
 				//  - operatorStorageClassAnnotationKey
-				return "", UnknownClusterError{CloudName: cloudType}
+				return "", UnknownClusterError{
+					Message:   "Suitable Kubernetes storage class for workload storage not found in cluster. Consider adding a default storage class to the cluster",
+					CloudName: cloudType,
+				}
 			}
 			// Do further EnsureStorageProvisioner if preferred storage found via juju preferred/default annotations.
 		} else if err != nil {


### PR DESCRIPTION
When bootstrapping to a cluster and no storage classes can be found this
will result in an empty error message for the end user.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Easiest way to test this is start up a minikube cluster and delete all it's storage classes then try and bootstrap Juju.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1923535
