### PR TITLE
Help when no controller is selected

### DIFF
--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -54,13 +54,15 @@ func (e ErrNoCurrentController) Error() string {
 	if len(e.controllerNames) == 0 {
 		return `No selected controller.
 
-Please use "juju switch" to select a controller.
+Use "juju switch" to select a controller.
 `
 	}
 
 	return fmt.Sprintf(`No selected controller.
 
-Please use "juju switch" to select from the following controllers: %s`, strings.Join(e.controllerNames, ","))
+Use "juju switch" to select from the following controllers:
+
+  - %s`, strings.Join(e.controllerNames, "\n  - "))
 }
 
 // IsErrNoCurrentController returns if the underlying error is the sentinel

--- a/cmd/modelcmd/controller.go
+++ b/cmd/modelcmd/controller.go
@@ -33,15 +33,44 @@ var (
 Please either create a new controller using "juju bootstrap" or connect to
 another controller that you have been given access to using "juju register".
 `)
-	// ErrNoCurrentController is returned by commands that operate on
-	// a controller if there is no current controller, no controller has been
-	// explicitly specified, and there is no default controller but there are
-	// controllers that client knows about.
-	ErrNoCurrentController = errors.New(`No selected controller.
+)
+
+// ErrNoCurrentController is returned by commands that operate on
+// a controller if there is no current controller, no controller has been
+// explicitly specified, and there is no default controller but there are
+// controllers that client knows about.
+type ErrNoCurrentController struct {
+	controllerNames []string
+}
+
+// NewNoCurrentController creates a new ErrNoCurrentController error.
+func NewNoCurrentController(names []string) ErrNoCurrentController {
+	return ErrNoCurrentController{
+		controllerNames: names,
+	}
+}
+
+func (e ErrNoCurrentController) Error() string {
+	if len(e.controllerNames) == 0 {
+		return `No selected controller.
 
 Please use "juju switch" to select a controller.
-`)
-)
+`
+	}
+
+	return fmt.Sprintf(`No selected controller.
+
+Please use "juju switch" to select from the following controllers: %s`, strings.Join(e.controllerNames, ","))
+}
+
+// IsErrNoCurrentController returns if the underlying error is the sentinel
+// ErrNoCurrentController error.
+func IsNoCurrentController(err error) bool {
+	if _, ok := errors.Cause(err).(ErrNoCurrentController); ok {
+		return true
+	}
+	return false
+}
 
 // ControllerCommand is intended to be a base for all commands
 // that need to operate on controllers as opposed to models.
@@ -382,7 +411,11 @@ func translateControllerError(store jujuclient.ClientStore, err error) error {
 	if len(controllers) == 0 {
 		return errors.Wrap(err, ErrNoControllersDefined)
 	}
-	return errors.Wrap(err, ErrNoCurrentController)
+	names := make([]string, 0, len(controllers))
+	for name := range controllers {
+		names = append(names, name)
+	}
+	return errors.Wrap(err, NewNoCurrentController(names))
 }
 
 // OptionalControllerCommand is used as a base for commands which can

--- a/cmd/modelcmd/modelcommand.go
+++ b/cmd/modelcmd/modelcommand.go
@@ -137,7 +137,7 @@ func (c *ModelCommandBase) maybeInitModel() error {
 	// If any other error result was returned, we bail early here.
 	noRetry := func(original error) bool {
 		c := errors.Cause(c.initModelError)
-		return c != ErrNoModelSpecified && c != ErrNoControllersDefined && c != ErrNoCurrentController
+		return c != ErrNoModelSpecified && c != ErrNoControllersDefined && !IsNoCurrentController(c)
 	}
 	if c.doneInitModel && noRetry(c.initModelError) {
 		return errors.Trace(c.initModelError)

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -116,7 +116,7 @@ func (c *imageMetadataCommand) setParams(context *cmd.Context) error {
 
 	controllerName, err := c.ControllerName()
 	err = errors.Cause(err)
-	if err != nil && err != modelcmd.ErrNoControllersDefined && err != modelcmd.ErrNoCurrentController {
+	if err != nil && err != modelcmd.ErrNoControllersDefined && !modelcmd.IsNoCurrentController(err) {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
One thing that annoys me is that we have all the information at hand to
help with the UX for simple error messages and a path forward to users.

A case in point is that when you end up having removed or destroyed a
controller and the `controllers.yaml` isn't correctly updated, then you
get a brain-dead error message.

The code fixes this and gives a pointer to the user about what they
could select, without having to go to another command `juju controllers`
to get that information.

---

<strike>Happy for wordage changes as well.</strike> changed

## QA steps

```sh
$ juju bootstrap lxd test
```

Edit the `~/.local/share/juju/controllers.yaml` and set to `current-controller: test2`

```
$ juju status
ERROR No selected controller.

Use "juju switch" to select from the following controllers:

  - test
```
