### PR TITLE
bug: fix for bootstrap fail on vsphere 7 + multi network

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -617,7 +617,7 @@ func (c *Client) buildConfigSpec(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		device, err := c.addNetworkDevice(ctx, &spec, networkReference, networkDevice.MAC, dvportgroupConfig)
+		device, err := c.addNetworkDevice(ctx, &spec, networkReference, networkDevice.MAC, dvportgroupConfig, int32(i+1))
 		if err != nil {
 			return nil, errors.Annotatef(err, "adding network device %d - network %s", i, network)
 		}

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -521,6 +521,7 @@ func (c *Client) addNetworkDevice(
 	network *mo.Network,
 	mac string,
 	dvportgroupConfig map[types.ManagedObjectReference]types.DVPortgroupConfigInfo,
+	idx int32,
 ) (*types.VirtualVmxnet3, error) {
 	var networkBacking types.BaseVirtualDeviceBackingInfo
 	if dvportgroupConfigInfo, ok := dvportgroupConfig[network.Reference()]; !ok {
@@ -556,6 +557,7 @@ func (c *Client) addNetworkDevice(
 	wakeOnLan := true
 	networkDevice.WakeOnLanEnabled = &wakeOnLan
 	networkDevice.Backing = networkBacking
+	networkDevice.Key = -idx // negative to avoid conflicts
 	if mac != "" {
 		if !VerifyMAC(mac) {
 			return nil, fmt.Errorf("Invalid MAC address: %q", mac)

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -313,6 +313,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 
 	var networkDevice1, networkDevice2 types.VirtualVmxnet3
 	wakeOnLan := true
+	networkDevice1.Key = -1
 	networkDevice1.WakeOnLanEnabled = &wakeOnLan
 	networkDevice1.Connectable = &types.VirtualDeviceConnectInfo{
 		StartConnected:    true,
@@ -326,6 +327,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 		},
 	}
 
+	networkDevice2.Key = -2
 	networkDevice2.WakeOnLanEnabled = &wakeOnLan
 	networkDevice2.Connectable = &types.VirtualDeviceConnectInfo{
 		StartConnected:    true,
@@ -384,6 +386,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 
 	var networkDevice types.VirtualVmxnet3
 	wakeOnLan := true
+	networkDevice.Key = -1
 	networkDevice.WakeOnLanEnabled = &wakeOnLan
 	networkDevice.Connectable = &types.VirtualDeviceConnectInfo{
 		StartConnected:    true,


### PR DESCRIPTION
Bootstrap on vSphere 7.0 fails when both `--primary-network` and `--external-network` are specified. The error provided by juju when the bootstrap fails is:

```plain
 - cloning template VM: waiting for task "CloneVM_Task": A specified parameter wERROR failed to bootstrap model: cannot start bootstrap instance in availability zone "Cluster": cloning template VM: waiting for task "CloneVM_Task": A specified parameter was not correct: deviceChange[1].device.key
```

This PR adds unique temporary keys for the new network interfaces to appease vSphere's requirements in the `deviceChange[*].device` stanzas.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

1. Install vSphere 7.0
2. Create a datacentre called `dc1`
3. Set up multiple networks, named `network1` and `network2` in vCenter
4. Configure juju to connect to vCenter with a new cloud called `vsphere`
5. Run bootstrap as follows:

```sh
juju bootstrap vsphere/dc1 overlord --config primary-network=network1 --config external-network=network2
```

## Documentation changes

This is a bugfix only. It does not affect any workflows other than fixing a currently broken one.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1923606
