### PR TITLE
Fix/lp 1923561

### DIFF
--- a/cmd/juju/caas/eks.go
+++ b/cmd/juju/caas/eks.go
@@ -111,12 +111,8 @@ type eksDetailLegacy struct {
 	Region string `json:"region"`
 }
 
-func (ed eksDetailLegacy) name() string {
-	return ed.Name
-}
-
 type eksStatus struct {
-	EKSctlCreated string `json:"eksctlCreated"`
+	EKSCTLCreated string `json:"eksctlCreated"`
 }
 
 type eksDetail struct {
@@ -124,28 +120,26 @@ type eksDetail struct {
 	Status   eksStatus       `json:"status"`
 }
 
-func (ed eksDetail) name() string {
-	return ed.MetaData.Name
-}
-
 func getClusterNames(data []byte) (out []string, err error) {
 	var clusterDetails []eksDetail
-	if err := json.Unmarshal(data, &clusterDetails); err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, detail := range clusterDetails {
-		out = append(out, detail.name())
+	if err := json.Unmarshal(data, &clusterDetails); err == nil {
+		for _, detail := range clusterDetails {
+			if len(detail.MetaData.Name) > 0 {
+				out = append(out, detail.MetaData.Name)
+			}
+		}
 	}
 	if len(out) > 0 {
 		return out, nil
 	}
-
 	var clusterDetailsLegacy []eksDetailLegacy
 	if err := json.Unmarshal(data, &clusterDetailsLegacy); err != nil {
 		return nil, errors.Trace(err)
 	}
 	for _, detail := range clusterDetailsLegacy {
-		out = append(out, detail.name())
+		if len(detail.Name) > 0 {
+			out = append(out, detail.Name)
+		}
 	}
 
 	return out, nil

--- a/cmd/juju/caas/eks_test.go
+++ b/cmd/juju/caas/eks_test.go
@@ -158,7 +158,7 @@ Enter region:
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 }
 
-func (s *eksSuite) TestInteractiveParamMultiClusters(c *gc.C) {
+func (s *eksSuite) TestInteractiveParamMultiClustersLegacyCLI(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -211,6 +211,73 @@ Select cluster [mycluster]:
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
 	c.Assert(outParams, jc.DeepEquals, &clusterParams{
 		name:   "mycluster",
+		region: "ap-southeast-2",
+	})
+}
+
+func (s *eksSuite) TestInteractiveParamMultiClusters(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockRunner := mocks.NewMockCommandRunner(ctrl)
+	eksCMD := &eks{
+		tool:          "eksctl",
+		CommandRunner: mockRunner,
+	}
+	clusterJSONResp := `
+[
+    {
+        "metadata": {
+            "name": "nw-deploy-kubeflow-1272",
+            "region": "ap-southeast-2"
+        },
+        "status": {
+            "eksctlCreated": "True"
+        }
+    },
+    {
+        "metadata": {
+            "name": "k1",
+            "region": "ap-southeast-2"
+        },
+        "status": {
+            "eksctlCreated": "True"
+        }
+    }
+]`
+
+	gomock.InOrder(
+		mockRunner.EXPECT().RunCommands(exec.RunParams{
+			Commands:    "eksctl get cluster --region ap-southeast-2 -o json",
+			Environment: os.Environ(),
+		}).
+			Return(&exec.ExecResponse{
+				Code:   0,
+				Stdout: []byte(clusterJSONResp),
+			}, nil),
+	)
+	stdin := strings.NewReader("ap-southeast-2\nk1\n")
+	out := &bytes.Buffer{}
+	ctx := &cmd.Context{
+		Dir:    c.MkDir(),
+		Stdout: out,
+		Stderr: ioutil.Discard,
+		Stdin:  stdin,
+	}
+	expected := `
+Enter region: 
+Available Clusters In Ap-Southeast-2
+  nw-deploy-kubeflow-1272
+  k1
+
+Select cluster [nw-deploy-kubeflow-1272]: 
+`[1:]
+
+	outParams, err := eksCMD.interactiveParams(ctx, &clusterParams{})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(outParams, jc.DeepEquals, &clusterParams{
+		name:   "k1",
 		region: "ap-southeast-2",
 	})
 }


### PR DESCRIPTION
*Add support for newer eksctl for juju add-k8s --eks eks;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ eksctl version
0.40.0

# create an EKS cluster;
$ eksctl create cluster \
 --name k1 \
 --node-ami-family=Ubuntu2004 \
 --node-type='m5.large'

$ eksctl get cluster -o json --region ap-southeast-2
[
    {
        "metadata": {
            "name": "k1",
            "region": "ap-southeast-2"
        },
        "status": {
            "eksctlCreated": "True"
        }
    }
]

$ juju add-k8s --eks eks
Enter region: ap-southeast-2

This operation can be applied to both a copy on this client and to the one on a controller.
No current controller was detected and there are no registered controllers on this client: either bootstrap one or register one.

k8s substrate "k1.ap-southeast-2.eksctl.io" added as cloud "eks".
You can now bootstrap to this cloud by running 'juju bootstrap eks'.

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1923561