### PR TITLE
Use channel logic in charm library

### DIFF
--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -4,6 +4,8 @@
 package charm
 
 import (
+	"github.com/juju/charm/v8"
+
 	"github.com/juju/juju/apiserver/params"
 	corecharm "github.com/juju/juju/core/charm"
 )
@@ -56,14 +58,14 @@ func (o Origin) WithSeries(series string) Origin {
 }
 
 // CoreChannel returns the core charm channel.
-func (o Origin) CoreChannel() corecharm.Channel {
+func (o Origin) CoreChannel() charm.Channel {
 	var track string
 	if o.Track != nil {
 		track = *o.Track
 	}
-	return corecharm.Channel{
+	return charm.Channel{
 		Track: track,
-		Risk:  corecharm.Risk(o.Risk),
+		Risk:  charm.Risk(o.Risk),
 	}
 }
 
@@ -90,10 +92,10 @@ func (o Origin) CoreCharmOrigin() corecharm.Origin {
 	if o.Track != nil {
 		track = *o.Track
 	}
-	var channel *corecharm.Channel
+	var channel *charm.Channel
 	if o.Risk != "" {
-		channel = &corecharm.Channel{
-			Risk:  corecharm.Risk(o.Risk),
+		channel = &charm.Channel{
+			Risk:  charm.Risk(o.Risk),
 			Track: track,
 		}
 	}
@@ -132,7 +134,7 @@ func APICharmOrigin(origin params.CharmOrigin) Origin {
 // CoreCharmOrigin is a helper function to convert params.CharmOrigin
 // to an Origin.
 func CoreCharmOrigin(origin corecharm.Origin) Origin {
-	var ch corecharm.Channel
+	var ch charm.Channel
 	if origin.Channel != nil {
 		ch = *origin.Channel
 	}

--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -57,8 +57,8 @@ func (o Origin) WithSeries(series string) Origin {
 	return other
 }
 
-// CoreChannel returns the core charm channel.
-func (o Origin) CoreChannel() charm.Channel {
+// CharmChannel returns the the channel indicated by this origin.
+func (o Origin) CharmChannel() charm.Channel {
 	var track string
 	if o.Track != nil {
 		track = *o.Track

--- a/api/common/charm/charmorigin_test.go
+++ b/api/common/charm/charmorigin_test.go
@@ -20,7 +20,7 @@ func (originSuite) TestCoreChannel(c *gc.C) {
 		Risk:  "edge",
 		Track: &track,
 	}
-	c.Assert(origin.CoreChannel(), gc.DeepEquals, charm.Channel{
+	c.Assert(origin.CharmChannel(), gc.DeepEquals, charm.Channel{
 		Risk:  charm.Edge,
 		Track: "latest",
 	})
@@ -30,12 +30,12 @@ func (originSuite) TestCoreChannelWithEmptyTrack(c *gc.C) {
 	origin := commoncharm.Origin{
 		Risk: "edge",
 	}
-	c.Assert(origin.CoreChannel(), gc.DeepEquals, charm.Channel{
+	c.Assert(origin.CharmChannel(), gc.DeepEquals, charm.Channel{
 		Risk: charm.Edge,
 	})
 }
 
 func (originSuite) TestCoreChannelThatIsEmpty(c *gc.C) {
 	origin := commoncharm.Origin{}
-	c.Assert(origin.CoreChannel(), gc.DeepEquals, charm.Channel{})
+	c.Assert(origin.CharmChannel(), gc.DeepEquals, charm.Channel{})
 }

--- a/api/common/charm/charmorigin_test.go
+++ b/api/common/charm/charmorigin_test.go
@@ -4,9 +4,10 @@
 package charm_test
 
 import (
-	"github.com/juju/juju/api/common/charm"
-	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/charm/v8"
 	gc "gopkg.in/check.v1"
+
+	commoncharm "github.com/juju/juju/api/common/charm"
 )
 
 type originSuite struct{}
@@ -15,26 +16,26 @@ var _ = gc.Suite(&originSuite{})
 
 func (originSuite) TestCoreChannel(c *gc.C) {
 	track := "latest"
-	origin := charm.Origin{
+	origin := commoncharm.Origin{
 		Risk:  "edge",
 		Track: &track,
 	}
-	c.Assert(origin.CoreChannel(), gc.DeepEquals, corecharm.Channel{
-		Risk:  corecharm.Edge,
+	c.Assert(origin.CoreChannel(), gc.DeepEquals, charm.Channel{
+		Risk:  charm.Edge,
 		Track: "latest",
 	})
 }
 
 func (originSuite) TestCoreChannelWithEmptyTrack(c *gc.C) {
-	origin := charm.Origin{
+	origin := commoncharm.Origin{
 		Risk: "edge",
 	}
-	c.Assert(origin.CoreChannel(), gc.DeepEquals, corecharm.Channel{
-		Risk: corecharm.Edge,
+	c.Assert(origin.CoreChannel(), gc.DeepEquals, charm.Channel{
+		Risk: charm.Edge,
 	})
 }
 
 func (originSuite) TestCoreChannelThatIsEmpty(c *gc.C) {
-	origin := charm.Origin{}
-	c.Assert(origin.CoreChannel(), gc.DeepEquals, corecharm.Channel{})
+	origin := commoncharm.Origin{}
+	c.Assert(origin.CoreChannel(), gc.DeepEquals, charm.Channel{})
 }

--- a/api/resources/client/client.go
+++ b/api/resources/client/client.go
@@ -214,7 +214,7 @@ func newAddPendingResourcesArgs(tag names.ApplicationTag, chID CharmID, csMac *m
 	if chID.URL != nil {
 		args.URL = chID.URL.String()
 	}
-	args.Channel = chID.Origin.CoreChannel().String()
+	args.Channel = chID.Origin.CharmChannel().String()
 	args.CharmStoreMacaroon = csMac
 
 	return args, nil

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -808,10 +808,10 @@ func convertCharmOrigin(origin *params.CharmOrigin, curl *charm.URL, charmStoreC
 		if curl.Revision != -1 {
 			rev = &curl.Revision
 		}
-		var ch *corecharm.Channel
+		var ch *charm.Channel
 		if charmStoreChannel != "" {
-			ch = &corecharm.Channel{
-				Risk: corecharm.Risk(charmStoreChannel),
+			ch = &charm.Channel{
+				Risk: charm.Risk(charmStoreChannel),
 			}
 		}
 		return corecharm.Origin{
@@ -837,8 +837,8 @@ func convertCharmOrigin(origin *params.CharmOrigin, curl *charm.URL, charmStoreC
 	// We do guarantee that there will be a risk value.
 	// Ignore the error, as only caused by risk as an
 	// empty string.
-	var channel *corecharm.Channel
-	if ch, err := corecharm.MakeChannel(track, origin.Risk, ""); err == nil {
+	var channel *charm.Channel
+	if ch, err := charm.MakeChannel(track, origin.Risk, ""); err == nil {
 		channel = &ch
 	}
 
@@ -2757,7 +2757,7 @@ func (api *APIBase) ApplicationsInfo(in params.Entities) (params.ApplicationInfo
 		origin := app.CharmOrigin()
 		if origin != nil && origin.Channel != nil {
 			ch := origin.Channel
-			channel = corecharm.MakePermissiveChannel(ch.Track, ch.Risk, ch.Branch).String()
+			channel = charm.MakePermissiveChannel(ch.Track, ch.Risk, ch.Branch).String()
 		} else {
 			channel = details.Channel
 		}

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -11,12 +11,12 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/charm/v8"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
-	"github.com/juju/juju/core/charm"
 	"github.com/juju/juju/environs/config"
 )
 

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -122,7 +122,7 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin corecharm.O
 
 	// Use the channel that was actually picked by the API. This should
 	// account for the closed tracks in a given channel.
-	channel, err := corecharm.ParseChannelNormalize(res.EffectiveChannel)
+	channel, err := charm.ParseChannelNormalize(res.EffectiveChannel)
 	if err != nil {
 		return nil, corecharm.Origin{}, nil, errors.Annotatef(err, "invalid channel")
 	}
@@ -408,7 +408,7 @@ func composeSuggestions(releases []transport.Release, origin corecharm.Origin) [
 	var suggestions []string
 	// Sort for latest channels to be suggested first.
 	// Assumes that releases have normalized channels.
-	for _, r := range corecharm.Risks {
+	for _, r := range charm.Risks {
 		risk := string(r)
 		if values, ok := channelSeries[risk]; ok {
 			suggestions = append(suggestions, fmt.Sprintf("%s with %s", risk, strings.Join(values, ", ")))
@@ -430,7 +430,7 @@ type Release struct {
 func selectReleaseByArchAndChannel(releases []transport.Release, origin corecharm.Origin) (Release, error) {
 	var (
 		empty   = origin.Channel == nil
-		channel corecharm.Channel
+		channel charm.Channel
 	)
 	if !empty {
 		channel = origin.Channel.Normalize()

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -69,7 +69,7 @@ func (s *charmHubRepositoriesSuite) testResolve(c *gc.C, id string) {
 
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
-	origin.Channel = &corecharm.Channel{
+	origin.Channel = &charm.Channel{
 		Risk: "stable",
 	}
 	origin.Platform.Architecture = arch.DefaultArchitecture
@@ -95,7 +95,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 			OS:           "ubuntu",
 			Series:       "focal",
 		},
-		Channel: &corecharm.Channel{
+		Channel: &charm.Channel{
 			Track: "latest",
 			Risk:  "stable",
 		},
@@ -109,7 +109,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithChannel(c *gc.C) {
 
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
-	origin.Channel = &corecharm.Channel{
+	origin.Channel = &charm.Channel{
 		Risk: "stable",
 	}
 	origin.Platform.Architecture = arch.DefaultArchitecture
@@ -143,7 +143,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithoutSeries(c *gc.C) {
 
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
-	origin.Channel = &corecharm.Channel{
+	origin.Channel = &charm.Channel{
 		Risk: "stable",
 	}
 	origin.Platform.Architecture = arch.DefaultArchitecture
@@ -175,7 +175,7 @@ func (s *charmHubRepositoriesSuite) TestResolveWithBundles(c *gc.C) {
 
 	origin.Type = "bundle"
 	origin.Revision = &curl.Revision
-	origin.Channel = &corecharm.Channel{
+	origin.Channel = &charm.Channel{
 		Risk: "stable",
 	}
 	origin.Platform.Architecture = arch.DefaultArchitecture
@@ -208,7 +208,7 @@ func (s *charmHubRepositoriesSuite) TestResolveInvalidPlatformError(c *gc.C) {
 
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
-	origin.Channel = &corecharm.Channel{
+	origin.Channel = &charm.Channel{
 		Risk: "stable",
 	}
 	origin.Platform.Architecture = arch.DefaultArchitecture
@@ -261,7 +261,7 @@ func (s *charmHubRepositoriesSuite) TestResolveRevisionNotFoundError(c *gc.C) {
 
 	origin.Type = "charm"
 	origin.Revision = &curl.Revision
-	origin.Channel = &corecharm.Channel{
+	origin.Channel = &charm.Channel{
 		Risk: "stable",
 	}
 	origin.Platform.Architecture = arch.DefaultArchitecture
@@ -635,7 +635,7 @@ func (selectReleaseByChannelSuite) TestSelection(c *gc.C) {
 		Platform: corecharm.Platform{
 			Architecture: "arch",
 		},
-		Channel: &corecharm.Channel{
+		Channel: &charm.Channel{
 			Risk: "stable",
 		},
 	})
@@ -658,7 +658,7 @@ func (selectReleaseByChannelSuite) TestAllSelection(c *gc.C) {
 		Platform: corecharm.Platform{
 			Architecture: "arch",
 		},
-		Channel: &corecharm.Channel{
+		Channel: &charm.Channel{
 			Risk: "stable",
 		},
 	})
@@ -695,7 +695,7 @@ func (selectReleaseByChannelSuite) TestMultipleSelection(c *gc.C) {
 		Platform: corecharm.Platform{
 			Architecture: "h",
 		},
-		Channel: &corecharm.Channel{
+		Channel: &charm.Channel{
 			Track: "3.0",
 			Risk:  "stable",
 		},

--- a/apiserver/facades/client/charms/charmstorerepo.go
+++ b/apiserver/facades/client/charms/charmstorerepo.go
@@ -45,7 +45,7 @@ func (c *csRepo) ResolveWithPreferredChannel(curl *charm.URL, origin corecharm.O
 
 	newOrigin := origin
 	newOrigin.Type = t
-	newOrigin.Channel.Risk = corecharm.Risk(newRisk)
+	newOrigin.Channel.Risk = charm.Risk(newRisk)
 	return newCurl, newOrigin, supportedSeries, err
 }
 
@@ -63,7 +63,7 @@ func (c *csRepo) FindDownloadURL(curl *charm.URL, origin corecharm.Origin) (*url
 	return nil, origin, nil
 }
 
-func (c *csRepo) ListResources(curl *charm.URL, origin corecharm.Origin) ([]charmresource.Resource, error) {
+func (c *csRepo) ListResources(curl *charm.URL, _ corecharm.Origin) ([]charmresource.Resource, error) {
 	logger.Tracef("CharmStore ListResources %q", curl)
 	return nil, nil
 }

--- a/apiserver/facades/client/charms/conversions.go
+++ b/apiserver/facades/client/charms/conversions.go
@@ -259,9 +259,9 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 		ID:       origin.ID,
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
-		Channel: &corecharm.Channel{
+		Channel: &charm.Channel{
 			Track: track,
-			Risk:  corecharm.Risk(origin.Risk),
+			Risk:  charm.Risk(origin.Risk),
 		},
 		Platform: corecharm.Platform{
 			Architecture: origin.Architecture,

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/cache"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
@@ -1198,9 +1197,9 @@ func (context *statusContext) processApplication(application *state.Application)
 	var channel string
 	if origin := application.CharmOrigin(); origin != nil && origin.Channel != nil {
 		stChannel := origin.Channel
-		channel = (corecharm.Channel{
+		channel = (charm.Channel{
 			Track:  stChannel.Track,
-			Risk:   corecharm.Risk(stChannel.Risk),
+			Risk:   charm.Risk(stChannel.Risk),
 			Branch: stChannel.Branch,
 		}).Normalize().String()
 	} else {

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -294,9 +294,9 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 		ID:       origin.ID,
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
-		Channel: &corecharm.Channel{
+		Channel: &charm.Channel{
 			Track: track,
-			Risk:  corecharm.Risk(origin.Risk),
+			Risk:  charm.Risk(origin.Risk),
 		},
 		Platform: corecharm.Platform{
 			Architecture: origin.Architecture,

--- a/apiserver/facades/client/resources/repository_test.go
+++ b/apiserver/facades/client/resources/repository_test.go
@@ -132,7 +132,7 @@ func (s *CharmHubClientSuite) TestResolveResourcesUpload(c *gc.C) {
 
 func (s *CharmHubClientSuite) newClient() NewCharmRepository {
 	curl := charm.MustParseURL("ubuntu")
-	channel, _ := corecharm.ParseChannel("stable")
+	channel, _ := charm.ParseChannel("stable")
 	c := &charmHubClient{
 		client: s.client,
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmstore"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
 )
@@ -165,7 +164,7 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 					curl, origin.Revision, origin.Channel, origin.Platform)
 				continue
 			}
-			channel, err := corecharm.MakeChannel(origin.Channel.Track, origin.Channel.Risk, origin.Channel.Branch)
+			channel, err := charm.MakeChannel(origin.Channel.Track, origin.Channel.Risk, origin.Channel.Branch)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -33,7 +33,6 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/model"
@@ -257,7 +256,7 @@ type DeployCommand struct {
 
 	// Channel holds the channel to use when obtaining
 	// the charm to be deployed.
-	Channel corecharm.Channel
+	Channel charm.Channel
 
 	channelStr string
 
@@ -684,7 +683,7 @@ func (c *DeployCommand) Init(args []string) error {
 		c.unknownModel = true
 	}
 	if c.channelStr != "" {
-		c.Channel, err = corecharm.ParseChannelNormalize(c.channelStr)
+		c.Channel, err = charm.ParseChannelNormalize(c.channelStr)
 		if err != nil {
 			return errors.Annotate(err, "error in --channel")
 		}

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1587,7 +1587,7 @@ func (s *DeploySuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) {
 
 	fallbackCons := constraints.MustParse("arch=amd64")
 	platform, _ := apputils.DeducePlatform(constraints.Value{}, "", fallbackCons)
-	origin, _ := apputils.DeduceOrigin(meteredCharmURL, corecharm.Channel{}, platform)
+	origin, _ := apputils.DeduceOrigin(meteredCharmURL, charm.Channel{}, platform)
 	s.fakeAPI.Call("AddCharm", meteredCharmURL, origin, false).Returns(origin, error(nil))
 	s.fakeAPI.Call("CharmInfo", meteredCharmURL.String()).Returns(
 		&apicommoncharms.CharmInfo{
@@ -2015,7 +2015,7 @@ func (s *FakeStoreStateSuite) setupCharmMaybeAddForce(c *gc.C, url, name, series
 					Architecture: a,
 					Series:       serie,
 				}
-				origin, err := apputils.DeduceOrigin(url, corecharm.Channel{}, platform)
+				origin, err := apputils.DeduceOrigin(url, charm.Channel{}, platform)
 				c.Assert(err, jc.ErrorIsNil)
 
 				s.fakeAPI.Call("ResolveCharm", url, origin).Returns(
@@ -2055,7 +2055,7 @@ func (s *FakeStoreStateSuite) setupBundle(c *gc.C, url, name string, series ...s
 	// Resolve a bundle with no revision and return a url with a version.  Ensure
 	// GetBundle expects the url with revision.
 	for _, serie := range append([]string{"", baseURL.Series}, series...) {
-		origin, err := apputils.DeduceOrigin(bundleResolveURL, corecharm.Channel{}, corecharm.Platform{Series: serie})
+		origin, err := apputils.DeduceOrigin(bundleResolveURL, charm.Channel{}, corecharm.Platform{Series: serie})
 		c.Assert(err, jc.ErrorIsNil)
 		s.fakeAPI.Call("ResolveBundleURL", &baseURL, origin).Returns(
 			bundleResolveURL,
@@ -3033,7 +3033,7 @@ func withCharmDeployableWithDevicesAndStorage(
 	}
 	fallbackCons := constraints.MustParse("arch=amd64")
 	platform, _ := apputils.DeducePlatform(constraints.Value{}, series, fallbackCons)
-	origin, _ := apputils.DeduceOrigin(url, corecharm.Channel{}, platform)
+	origin, _ := apputils.DeduceOrigin(url, charm.Channel{}, platform)
 	fakeAPI.Call("AddCharm", &deployURL, origin, force).Returns(origin, error(nil))
 	fakeAPI.Call("CharmInfo", deployURL.String()).Returns(
 		&apicommoncharms.CharmInfo{

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -127,7 +127,7 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 					return errors.Trace(err)
 				}
 
-				origin, err := utils.DeduceOrigin(charmURL, d.origin.CoreChannel(), platform)
+				origin, err := utils.DeduceOrigin(charmURL, d.origin.CharmChannel(), platform)
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -221,7 +221,7 @@ func (d *localBundle) String() string {
 		return str
 	}
 	var channel string
-	if ch := d.origin.CoreChannel().String(); ch != "" {
+	if ch := d.origin.CharmChannel().String(); ch != "" {
 		channel = fmt.Sprintf(" from channel %s", ch)
 	}
 	return fmt.Sprintf("%s%s", str, channel)
@@ -243,7 +243,7 @@ func (d *repositoryBundle) String() string {
 		return str
 	}
 	var channel string
-	if ch := d.origin.CoreChannel().String(); ch != "" {
+	if ch := d.origin.CharmChannel().String(); ch != "" {
 		channel = fmt.Sprintf(" from channel %s", ch)
 	}
 	return fmt.Sprintf("%s%s", str, channel)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -417,23 +417,23 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, ch
 // constructChannelAndOrigin attempts to construct a fully qualified channel
 // along with an origin that matches the hardware constraints and the charm url
 // source.
-func (h *bundleHandler) constructChannelAndOrigin(curl *charm.URL, charmSeries, charmChannel string, cons constraints.Value) (corecharm.Channel, commoncharm.Origin, error) {
-	var channel corecharm.Channel
+func (h *bundleHandler) constructChannelAndOrigin(curl *charm.URL, charmSeries, charmChannel string, cons constraints.Value) (charm.Channel, commoncharm.Origin, error) {
+	var channel charm.Channel
 	if charmChannel != "" {
 		var err error
-		if channel, err = corecharm.ParseChannelNormalize(charmChannel); err != nil {
-			return corecharm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
+		if channel, err = charm.ParseChannelNormalize(charmChannel); err != nil {
+			return charm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
 		}
 	}
 
 	platform, err := utils.DeducePlatform(cons, charmSeries, h.modelConstraints)
 	if err != nil {
-		return corecharm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
+		return charm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
 	}
 
 	origin, err := utils.DeduceOrigin(curl, channel, platform)
 	if err != nil {
-		return corecharm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
+		return charm.Channel{}, commoncharm.Origin{}, errors.Trace(err)
 	}
 	return channel, origin, nil
 }
@@ -631,11 +631,11 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 	}
 
 	// A channel is needed whether the risk is valid or not.
-	var channel corecharm.Channel
+	var channel charm.Channel
 	if charm.CharmHub.Matches(ch.Schema) {
 		channel = corecharm.DefaultChannel
 		if chParams.Channel != "" {
-			channel, err = corecharm.ParseChannelNormalize(chParams.Channel)
+			channel, err = charm.ParseChannelNormalize(chParams.Channel)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -876,7 +876,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 			return errors.Trace(err)
 		}
 		// A channel is needed whether the risk is valid or not.
-		channel, _ := corecharm.MakeChannel(track, origin.Risk, "")
+		channel, _ := charm.MakeChannel(track, origin.Risk, "")
 		origin, err = utils.DeduceOrigin(chID.URL, channel, platform)
 		if err != nil {
 			return errors.Trace(err)
@@ -1497,14 +1497,14 @@ func (h *bundleHandler) topLevelMachine(id string) string {
 	return tag.Parent().Id()
 }
 
-func (h *bundleHandler) addOrigin(curl charm.URL, channel corecharm.Channel, origin commoncharm.Origin) {
+func (h *bundleHandler) addOrigin(curl charm.URL, channel charm.Channel, origin commoncharm.Origin) {
 	if _, ok := h.origins[curl]; !ok {
 		h.origins[curl] = make(map[string]commoncharm.Origin)
 	}
 	h.origins[curl][channel.Normalize().String()] = origin
 }
 
-func (h *bundleHandler) getOrigin(curl charm.URL, channel corecharm.Channel) (commoncharm.Origin, bool) {
+func (h *bundleHandler) getOrigin(curl charm.URL, channel charm.Channel) (commoncharm.Origin, bool) {
 	c, ok := h.origins[curl]
 	if !ok {
 		return commoncharm.Origin{}, false
@@ -1513,13 +1513,13 @@ func (h *bundleHandler) getOrigin(curl charm.URL, channel corecharm.Channel) (co
 	return o, ok
 }
 
-func constructNormalizedChannel(channel string) (corecharm.Channel, error) {
+func constructNormalizedChannel(channel string) (charm.Channel, error) {
 	if channel == "" {
-		return corecharm.Channel{}, nil
+		return charm.Channel{}, nil
 	}
-	ch, err := corecharm.ParseChannelNormalize(channel)
+	ch, err := charm.ParseChannelNormalize(channel)
 	if err != nil {
-		return corecharm.Channel{}, errors.Trace(err)
+		return charm.Channel{}, errors.Trace(err)
 	}
 	return ch, nil
 }

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -406,7 +406,7 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, ch
 	if err != nil {
 		return "", -1, errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
 	}
-	resolvedChan := origin.CoreChannel().Normalize().String()
+	resolvedChan := origin.CharmChannel().Normalize().String()
 	rev := origin.Revision
 	if rev == nil {
 		return resolvedChan, -1, nil

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -1232,7 +1232,7 @@ func (s *BundleHandlerOriginSuite) TestConstructChannelAndOriginEmptyChannel(c *
 
 	resultChannel, resultOrigin, err := handler.constructChannelAndOrigin(curl, series, channel, cons)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resultChannel, gc.DeepEquals, corecharm.Channel{})
+	c.Assert(resultChannel, gc.DeepEquals, charm.Channel{})
 	c.Assert(resultOrigin, gc.DeepEquals, commoncharm.Origin{
 		Source:       "charm-hub",
 		OS:           "ubuntu",

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -348,7 +347,7 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 	if err != nil {
 		return errors.Trace(err)
 	}
-	origin, err := utils.DeduceOrigin(userCharmURL, corecharm.Channel{}, platform)
+	origin, err := utils.DeduceOrigin(userCharmURL, charm.Channel{}, platform)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -390,7 +389,7 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 	if err != nil {
 		return errors.Trace(err)
 	}
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{}, platform)
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{}, platform)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -286,7 +286,7 @@ func (d *deployCharm) formatDeployingText() string {
 		name = curl.Name
 	}
 	origin := d.id.Origin
-	channel := origin.CoreChannel().String()
+	channel := origin.CharmChannel().String()
 	if channel != "" {
 		channel = fmt.Sprintf(" in channel %s", channel)
 	}
@@ -307,7 +307,7 @@ func (d *predeployedLocalCharm) String() string {
 		return str
 	}
 	var channel string
-	if ch := d.origin.CoreChannel().String(); ch != "" {
+	if ch := d.origin.CharmChannel().String(); ch != "" {
 		channel = fmt.Sprintf(" from channel %s", ch)
 	}
 	return fmt.Sprintf("%s%s", str, channel)
@@ -418,7 +418,7 @@ func (c *repositoryCharm) String() string {
 		return str
 	}
 	var channel string
-	if ch := c.origin.CoreChannel().String(); ch != "" {
+	if ch := c.origin.CharmChannel().String(); ch != "" {
 		channel = fmt.Sprintf(" from channel %s", ch)
 	}
 	return fmt.Sprintf("%s%s", str, channel)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -124,7 +123,7 @@ type DeployerConfig struct {
 	BundleMachines       map[string]string
 	BundleOverlayFile    []string
 	BundleStorage        map[string]map[string]storage.Constraints
-	Channel              corecharm.Channel
+	Channel              charm.Channel
 	CharmOrBundle        string
 	ConfigOptions        common.ConfigFlag
 	ConstraintsStr       string
@@ -160,7 +159,7 @@ type factory struct {
 	attachStorage     []string
 	charmOrBundle     string
 	bundleOverlayFile []string
-	channel           corecharm.Channel
+	channel           charm.Channel
 	series            string
 	force             bool
 	dryRun            bool

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/api/resources/client"
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testcharms"
@@ -320,7 +319,7 @@ func (s *deployerSuite) basicDeployerConfig() DeployerConfig {
 func (s *deployerSuite) channelDeployerConfig() DeployerConfig {
 	return DeployerConfig{
 		Series: "focal",
-		Channel: corecharm.Channel{
+		Channel: charm.Channel{
 			Risk: "edge",
 		},
 	}

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -32,14 +32,11 @@ import (
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/arch"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 )
 
 const (
-	// SeriesAll defines a platform that targets all series.
-	SeriesAll = "all"
 	// ArchAll defines a platform that targets all architectures.
 	ArchAll = "all"
 )
@@ -119,7 +116,7 @@ type diffBundleCommand struct {
 	bundle         string
 	bundleOverlays []string
 	channelStr     string
-	channel        corecharm.Channel
+	channel        charm.Channel
 	arch           string
 	arches         arch.Arches
 	series         string
@@ -177,7 +174,7 @@ func (c *diffBundleCommand) Init(args []string) error {
 	}
 	c.bundleMachines = mapping
 	if c.channelStr != "" {
-		c.channel, err = corecharm.ParseChannelNormalize(c.channelStr)
+		c.channel, err = charm.ParseChannelNormalize(c.channelStr)
 		if err != nil {
 			return errors.Annotate(err, "error in --channel")
 		}

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -390,7 +390,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		// If not upgrading from a local path, display the channel we
 		// are pulling the charm from.
 		var channel string
-		if ch := oldOrigin.CoreChannel().String(); ch != "" {
+		if ch := oldOrigin.CharmChannel().String(); ch != "" {
 			channel = fmt.Sprintf(" from channel %s", ch)
 		}
 		ctx.Infof("Looking up metadata for %s charm %q%s", oldOrigin.Source, oldURL.Name, channel)

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -167,7 +167,7 @@ type refreshCommand struct {
 
 	// Channel holds the charmstore or charmhub channel to use when obtaining
 	// the charm to be refreshed to.
-	Channel    corecharm.Channel
+	Channel    charm.Channel
 	channelStr string
 
 	// Config is a config file variable, pointing at a YAML file containing
@@ -378,9 +378,9 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	// cannot determine the difference between the "latest" track and the current
 	// track if only risk is specified.
 	if c.channelStr == "" {
-		c.Channel, _ = corecharm.ParseChannel(applicationInfo.Channel)
+		c.Channel, _ = charm.ParseChannel(applicationInfo.Channel)
 	} else {
-		c.Channel, err = corecharm.ParseChannel(c.channelStr)
+		c.Channel, err = charm.ParseChannel(c.channelStr)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -574,7 +574,7 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Beta}, corecharm.Platform{
 		Architecture: arch.DefaultArchitecture,
 	})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
@@ -598,7 +598,7 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{})
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Beta}, corecharm.Platform{})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -621,7 +621,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 	s.charmClient.CheckCallNames(c, "CharmInfo")
 	s.charmClient.CheckCall(c, 0, "CharmInfo", s.resolvedCharmURL.String())
 	s.charmAdder.CheckCallNames(c, "AddCharm")
-	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, corecharm.Channel{Risk: corecharm.Stable}, corecharm.Platform{})
+	origin, _ := utils.DeduceOrigin(s.resolvedCharmURL, charm.Channel{Risk: charm.Stable}, corecharm.Platform{})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
@@ -924,7 +924,7 @@ func (m *mockAPIConnection) APIHostPorts() []network.MachineHostPorts {
 	return []network.MachineHostPorts{{*hp}}
 }
 
-func (m *mockAPIConnection) BestFacadeVersion(name string) int {
+func (m *mockAPIConnection) BestFacadeVersion(_ string) int {
 	return m.bestFacadeVersion
 }
 
@@ -1000,7 +1000,7 @@ func (m *mockCharmRefreshClient) SetCharm(branchName string, cfg application.Set
 	return m.NextErr()
 }
 
-func (m *mockCharmRefreshClient) Get(branchName, applicationName string) (*params.ApplicationGetResults, error) {
+func (m *mockCharmRefreshClient) Get(_, applicationName string) (*params.ApplicationGetResults, error) {
 	m.MethodCall(m, "Get", applicationName)
 	return &params.ApplicationGetResults{
 		EndpointBindings: m.bindings,
@@ -1053,7 +1053,7 @@ type mockDownloadBundleClient struct {
 	bundle charm.Bundle
 }
 
-func (m *mockDownloadBundleClient) DownloadAndReadBundle(ctx context.Context, resourceURL *url.URL, archivePath string, options ...charmhub.DownloadOption) (charm.Bundle, error) {
+func (m *mockDownloadBundleClient) DownloadAndReadBundle(_ context.Context, resourceURL *url.URL, archivePath string, _ ...charmhub.DownloadOption) (charm.Bundle, error) {
 	m.MethodCall(m, "DownloadAndReadBundle", resourceURL, archivePath)
 	return m.bundle, m.NextErr()
 }

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -277,7 +277,7 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 		// available.
 		return nil, commoncharm.Origin{}, errors.Errorf("already running latest charm %q", newURL.Name)
 	}
-	r.logger.Verbosef("Using channel %q", origin.CoreChannel().String())
+	r.logger.Verbosef("Using channel %q", origin.CharmChannel().String())
 	return newURL, origin, nil
 }
 

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -35,7 +35,7 @@ type RefresherConfig struct {
 	CharmURL        *charm.URL
 	CharmOrigin     corecharm.Origin
 	CharmRef        string
-	Channel         corecharm.Channel
+	Channel         charm.Channel
 	DeployedSeries  string
 	Force           bool
 	ForceSeries     bool
@@ -169,8 +169,8 @@ type localCharmRefresher struct {
 }
 
 // Allowed will attempt to check if a local charm is allowed to be refreshed.
-// Currently this is alway true.
-func (d *localCharmRefresher) Allowed(cfg RefresherConfig) (bool, error) {
+// Currently this is always true.
+func (d *localCharmRefresher) Allowed(_ RefresherConfig) (bool, error) {
 	// We should always return true here, because of the current design.
 	return true, nil
 }
@@ -212,7 +212,7 @@ func (d *localCharmRefresher) String() string {
 
 // ResolveOriginFunc attempts to resolve a new charm Origin from the given
 // arguments, ensuring that we work for multiple stores (charmhub vs charmstore)
-type ResolveOriginFunc = func(*charm.URL, corecharm.Origin, corecharm.Channel) (commoncharm.Origin, error)
+type ResolveOriginFunc = func(*charm.URL, corecharm.Origin, charm.Channel) (commoncharm.Origin, error)
 
 type baseRefresher struct {
 	charmAdder      store.CharmAdder
@@ -221,7 +221,7 @@ type baseRefresher struct {
 	charmURL        *charm.URL
 	charmOrigin     corecharm.Origin
 	charmRef        string
-	channel         corecharm.Channel
+	channel         charm.Channel
 	deployedSeries  string
 	force           bool
 	forceSeries     bool
@@ -284,7 +284,7 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 // charmStoreResolveOrigin attempts to resolve the origin required to resolve
 // a charm. It does this by deducing the origin from the charm URL and the
 // incoming channel.
-func charmStoreResolveOrigin(curl *charm.URL, origin corecharm.Origin, channel corecharm.Channel) (commoncharm.Origin, error) {
+func charmStoreResolveOrigin(curl *charm.URL, origin corecharm.Origin, channel charm.Channel) (commoncharm.Origin, error) {
 	result, err := utils.DeduceOrigin(curl, channel, origin.Platform)
 	if err != nil {
 		return commoncharm.Origin{}, errors.Trace(err)
@@ -353,7 +353,7 @@ func (defaultCharmRepo) NewCharmAtPathForceSeries(path, series string, force boo
 // charmHubResolveOrigin attempts to resolve the origin required to resolve
 // a charm. It does this by updating the incoming origin with the user requested
 // channel, so we can correctly resolve the charm.
-func charmHubResolveOrigin(_ *charm.URL, origin corecharm.Origin, channel corecharm.Channel) (commoncharm.Origin, error) {
+func charmHubResolveOrigin(_ *charm.URL, origin corecharm.Origin, channel charm.Channel) (commoncharm.Origin, error) {
 	if channel.Track == "" {
 		origin.Channel.Risk = channel.Risk
 		return commoncharm.CoreCharmOrigin(origin), nil

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -425,12 +425,12 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithOriginChannel(c *gc.C) {
 	cfg := basicRefresherConfig(curl, ref)
 	cfg.CharmOrigin = corecharm.Origin{
 		Source: corecharm.CharmHub,
-		Channel: &corecharm.Channel{
-			Risk: corecharm.Edge,
+		Channel: &charm.Channel{
+			Risk: charm.Edge,
 		},
 	}
-	cfg.Channel = corecharm.Channel{
-		Risk: corecharm.Beta,
+	cfg.Channel = charm.Channel{
+		Risk: charm.Beta,
 	}
 
 	refresher := (&factory{}).maybeCharmHub(charmAdder, charmResolver)
@@ -526,7 +526,7 @@ func refresherConfigWithOrigin(curl *charm.URL, ref, series string) RefresherCon
 	rc := basicRefresherConfig(curl, ref)
 	rc.CharmOrigin = corecharm.Origin{
 		Source:  corecharm.CharmHub,
-		Channel: &corecharm.Channel{},
+		Channel: &charm.Channel{},
 		Platform: corecharm.Platform{
 			Series: series,
 		},

--- a/cmd/juju/application/store/store_test.go
+++ b/cmd/juju/application/store/store_test.go
@@ -35,7 +35,7 @@ func (s *storeSuite) TestAddCharmFromURLAddCharmSuccess(c *gc.C) {
 
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, _, err := store.AddCharmFromURL(
@@ -53,7 +53,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFail(c *gc.C) {
 	s.expectAddCharm(errors.NotFoundf("testing"))
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, _, err := store.AddCharmFromURL(
@@ -74,7 +74,7 @@ func (s *storeSuite) TestAddCharmFromURLFailAddCharmFailUnauthorized(c *gc.C) {
 	})
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, _, err := store.AddCharmFromURL(
@@ -93,7 +93,7 @@ func (s *storeSuite) TestAddCharmWithAuthorizationFromURLAddCharmSuccess(c *gc.C
 
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, obtainedMac, _, err := store.AddCharmWithAuthorizationFromURL(
@@ -113,7 +113,7 @@ func (s *storeSuite) TestAddCharmWithAuthorizationFromURLFailAddCharmFail(c *gc.
 	s.expectAddCharm(errors.NotFoundf("testing"))
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedCurl, obtainedMac, _, err := store.AddCharmWithAuthorizationFromURL(
@@ -136,7 +136,7 @@ func (s *storeSuite) TestAddCharmWithAuthorizationFromURLFailAddCharmFailUnautho
 	})
 	curl, err := charm.ParseURL("cs:testme")
 	c.Assert(err, jc.ErrorIsNil)
-	origin, err := utils.DeduceOrigin(curl, corecharm.Channel{Risk: corecharm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
+	origin, err := utils.DeduceOrigin(curl, charm.Channel{Risk: charm.Beta}, corecharm.Platform{Architecture: arch.DefaultArchitecture})
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectGet("/delegatable-macaroon?id=" + url.QueryEscape(curl.String()))
 	s.expectAddCharmWithAuthorization()

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -19,7 +19,7 @@ import (
 // DeduceOrigin attempts to deduce the origin from a channel and a platform.
 // Depending on what the charm URL schema is, will then construct the correct
 // origin for that application.
-func DeduceOrigin(url *charm.URL, channel corecharm.Channel, platform corecharm.Platform) (commoncharm.Origin, error) {
+func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Platform) (commoncharm.Origin, error) {
 	if url == nil {
 		return commoncharm.Origin{}, errors.NotValidf("charm url")
 	}

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -212,7 +212,7 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	if channel == "" {
 		channel = corecharm.DefaultChannelString
 	}
-	normChannel, err := corecharm.ParseChannelNormalize(channel)
+	normChannel, err := charm.ParseChannelNormalize(channel)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	corecharm "github.com/juju/juju/core/charm"
 )
 
 const (
@@ -150,7 +149,7 @@ func (c *infoCommand) Run(ctx *cmd.Context) error {
 
 	channel := c.channel
 	if channel != "" {
-		charmChannel, err := corecharm.ParseChannelNormalize(c.channel)
+		charmChannel, err := charm.ParseChannelNormalize(c.channel)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/core/charm"
 )
 
 // Note:

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/charmstore"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
-	corecharm "github.com/juju/juju/core/charm"
 )
 
 // ResourceLister lists resources for the given charm ids.
@@ -38,7 +37,7 @@ type CharmID struct {
 	URL *charm.URL
 
 	// Channel is the channel in which the charm was published.
-	Channel corecharm.Channel
+	Channel charm.Channel
 }
 
 // BakeryClient defines a way to create a bakery client.
@@ -168,14 +167,14 @@ func (c *baseCharmResourcesCommand) baseRun(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	var channel corecharm.Channel
+	var channel charm.Channel
 	if charm.CharmHub.Matches(charmURL.Schema) {
-		channel, err = corecharm.ParseChannelNormalize(c.channel)
+		channel, err = charm.ParseChannelNormalize(c.channel)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	} else {
-		channel = corecharm.MakePermissiveChannel("", c.channel, "")
+		channel = charm.MakePermissiveChannel("", c.channel, "")
 	}
 
 	resourceLister, err := c.CreateResourceListerFn(charmURL.Schema, c)

--- a/core/charm/channel.go
+++ b/core/charm/channel.go
@@ -4,10 +4,7 @@
 package charm
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/juju/errors"
+	"github.com/juju/charm/v8"
 )
 
 const (
@@ -18,201 +15,30 @@ const (
 
 var (
 	// DefaultChannel represents the default track and risk.
-	DefaultChannel = Channel{
+	DefaultChannel = charm.Channel{
 		Track: "latest",
-		Risk:  Stable,
+		Risk:  charm.Stable,
 	}
 	// DefaultRiskChannel represents the default only risk channel.
-	DefaultRiskChannel = Channel{
-		Risk: Stable,
+	DefaultRiskChannel = charm.Channel{
+		Risk: charm.Stable,
 	}
 )
-
-// Risk describes the type of risk in a current channel.
-type Risk string
-
-const (
-	Stable    Risk = "stable"
-	Candidate Risk = "candidate"
-	Beta      Risk = "beta"
-	Edge      Risk = "edge"
-)
-
-// Risks is a list of the available channel risks.
-var Risks = []Risk{
-	Stable,
-	Candidate,
-	Beta,
-	Edge,
-}
-
-func isRisk(potential string) bool {
-	for _, risk := range Risks {
-		if potential == string(risk) {
-			return true
-		}
-	}
-	return false
-}
-
-// Channel identifies and describes completely a store channel.
-//
-// A channel consists of, and is subdivided by, tracks, risk-levels and
-// branches:
-//  - Tracks enable snap developers to publish multiple supported releases of
-//    their application under the same snap name.
-//  - Risk-levels represent a progressive potential trade-off between stability
-//    and new features.
-//  - Branches are _optional_ and hold temporary releases intended to help with
-//    bug-fixing.
-//
-// The complete channel name can be structured as three distinct parts separated
-// by slashes:
-//
-//    <track>/<risk>/<branch>
-//
-type Channel struct {
-	Track  string
-	Risk   Risk
-	Branch string
-}
 
 // MakeRiskOnlyChannel creates a charm channel that is backwards compatible with
 // old style charm store channels. This creates a risk aware channel only.
 // No validation is performed on the risk and is just accepted as is.
-func MakeRiskOnlyChannel(risk string) Channel {
-	return Channel{
-		Risk: Risk(risk),
+func MakeRiskOnlyChannel(risk string) charm.Channel {
+	return charm.Channel{
+		Risk: charm.Risk(risk),
 	}
-}
-
-// MakeChannel creates a core charm Channel from a set of component parts.
-func MakeChannel(track, risk, branch string) (Channel, error) {
-	if !isRisk(risk) {
-		return Channel{}, errors.NotValidf("risk %q", risk)
-	}
-	return Channel{
-		Track:  track,
-		Risk:   Risk(risk),
-		Branch: branch,
-	}, nil
-}
-
-// MakePermissiveChannel creates a normalized core charm channel which
-// never fails.  It assumes that the risk has been prechecked.
-func MakePermissiveChannel(track, risk, branch string) Channel {
-	ch := Channel{
-		Track:  track,
-		Risk:   Risk(risk),
-		Branch: branch,
-	}
-	return ch.Normalize()
 }
 
 // MustParseChannel parses a given string or returns a panic.
-func MustParseChannel(s string) Channel {
-	c, err := ParseChannelNormalize(s)
+func MustParseChannel(s string) charm.Channel {
+	c, err := charm.ParseChannelNormalize(s)
 	if err != nil {
 		panic(err)
 	}
 	return c
-}
-
-// ParseChannel parses a string representing a store channel.
-func ParseChannel(s string) (Channel, error) {
-	if s == "" {
-		return Channel{}, errors.Errorf("channel cannot be empty")
-	}
-
-	p := strings.Split(s, "/")
-
-	var risk, track, branch *string
-	switch len(p) {
-	case 1:
-		if isRisk(p[0]) {
-			risk = &p[0]
-		} else {
-			track = &p[0]
-		}
-	case 2:
-		if isRisk(p[0]) {
-			risk, branch = &p[0], &p[1]
-		} else {
-			track, risk = &p[0], &p[1]
-		}
-	case 3:
-		track, risk, branch = &p[0], &p[1], &p[2]
-	default:
-		return Channel{}, errors.Errorf("channel is malformed and has too many components %q", s)
-	}
-
-	ch := Channel{}
-
-	if risk != nil {
-		if !isRisk(*risk) {
-			return Channel{}, errors.NotValidf("risk in channel %q", s)
-		}
-		// We can lift this into a risk, as we've validated prior to this to
-		// ensure it's a valid risk.
-		ch.Risk = Risk(*risk)
-	}
-	if track != nil {
-		if *track == "" {
-			return Channel{}, errors.NotValidf("track in channel %q", s)
-		}
-		ch.Track = *track
-	}
-	if branch != nil {
-		if *branch == "" {
-			return Channel{}, errors.NotValidf("branch in channel %q", s)
-		}
-		ch.Branch = *branch
-	}
-	return ch, nil
-}
-
-// ParseChannelNormalize parses a string representing a store channel.
-// The returned channel's track, risk and name are normalized.
-func ParseChannelNormalize(s string) (Channel, error) {
-	ch, err := ParseChannel(s)
-	if err != nil {
-		return Channel{}, errors.Trace(err)
-	}
-	return ch.Normalize(), nil
-}
-
-// Normalize the channel with normalized track, risk and names.
-func (ch Channel) Normalize() Channel {
-	track := ch.Track
-	if track == "latest" {
-		track = ""
-	}
-
-	risk := ch.Risk
-	if risk == "" {
-		risk = "stable"
-	}
-
-	return Channel{
-		Track:  track,
-		Risk:   risk,
-		Branch: ch.Branch,
-	}
-}
-
-// Empty returns true if all it's components are empty.
-func (ch Channel) Empty() bool {
-	return ch.Track == "" && ch.Risk == "" && ch.Branch == ""
-}
-
-func (ch Channel) String() string {
-	path := string(ch.Risk)
-	if track := ch.Track; track != "" {
-		path = fmt.Sprintf("%s/%s", track, path)
-	}
-	if branch := ch.Branch; branch != "" {
-		path = fmt.Sprintf("%s/%s", path, branch)
-	}
-
-	return path
 }

--- a/core/charm/channel_test.go
+++ b/core/charm/channel_test.go
@@ -4,12 +4,11 @@
 package charm_test
 
 import (
-	"github.com/juju/errors"
+	"github.com/juju/charm/v8"
 	"github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/charm"
+	corecharm "github.com/juju/juju/core/charm"
 )
 
 type channelSuite struct {
@@ -18,177 +17,10 @@ type channelSuite struct {
 
 var _ = gc.Suite(&channelSuite{})
 
-func (s channelSuite) TestParseChannelNormalize(c *gc.C) {
-	// ParseChannelNoramlize tests ParseChannel as well.
-	tests := []struct {
-		Name        string
-		Value       string
-		Expected    charm.Channel
-		ExpectedErr string
-	}{{
-		Name:        "empty",
-		Value:       "",
-		ExpectedErr: "channel cannot be empty",
-	}, {
-		Name:        "empty components",
-		Value:       "//",
-		ExpectedErr: `risk in channel "//" not valid`,
-	}, {
-		Name:        "too many components",
-		Value:       "////",
-		ExpectedErr: `channel is malformed and has too many components "////"`,
-	}, {
-		Name:        "invalid risk",
-		Value:       "track/meshuggah",
-		ExpectedErr: `risk in channel "track/meshuggah" not valid`,
-	}, {
-		Name:  "risk",
-		Value: "stable",
-		Expected: charm.Channel{
-			Risk: "stable",
-		},
-	}, {
-		Name:  "track",
-		Value: "meshuggah",
-		Expected: charm.Channel{
-			Track: "meshuggah",
-			Risk:  "stable",
-		},
-	}, {
-		Name:  "risk and branch",
-		Value: "stable/foo",
-		Expected: charm.Channel{
-			Risk:   "stable",
-			Branch: "foo",
-		},
-	}, {
-		Name:  "track and risk",
-		Value: "foo/stable",
-		Expected: charm.Channel{
-			Track: "foo",
-			Risk:  "stable",
-		},
-	}, {
-		Name:  "track, risk and branch",
-		Value: "foo/stable/bar",
-		Expected: charm.Channel{
-			Track:  "foo",
-			Risk:   "stable",
-			Branch: "bar",
-		},
-	}}
-	for k, test := range tests {
-		c.Logf("test %q at %d", test.Name, k)
-		ch, err := charm.ParseChannelNormalize(test.Value)
-		if test.ExpectedErr != "" {
-			c.Assert(err, gc.ErrorMatches, test.ExpectedErr)
-		} else {
-			c.Assert(ch, gc.DeepEquals, test.Expected)
-			c.Assert(err, gc.IsNil)
-		}
-	}
-}
-
-func (s channelSuite) TestString(c *gc.C) {
-	tests := []struct {
-		Name     string
-		Value    string
-		Expected string
-	}{{
-		Name:     "risk",
-		Value:    "stable",
-		Expected: "stable",
-	}, {
-		Name:     "latest track",
-		Value:    "latest/stable",
-		Expected: "stable",
-	}, {
-		Name:     "track",
-		Value:    "1.0",
-		Expected: "1.0/stable",
-	}, {
-		Name:     "track and risk",
-		Value:    "1.0/edge",
-		Expected: "1.0/edge",
-	}, {
-		Name:     "track, risk and branch",
-		Value:    "1.0/edge/foo",
-		Expected: "1.0/edge/foo",
-	}, {
-		Name:     "latest, risk and branch",
-		Value:    "latest/edge/foo",
-		Expected: "edge/foo",
-	}}
-	for k, test := range tests {
-		c.Logf("test %q at %d", test.Name, k)
-		ch, err := charm.ParseChannelNormalize(test.Value)
-		c.Assert(err, gc.IsNil)
-		c.Assert(ch.String(), gc.DeepEquals, test.Expected)
-	}
-}
-
-func (s channelSuite) TestMakeChannel(c *gc.C) {
-	tests := []struct {
-		Name      string
-		Track     string
-		Risk      string
-		Branch    string
-		Expected  string
-		ErrorType func(err error) bool
-	}{{
-		Name:      "track, risk, branch not normalized",
-		Track:     "latest",
-		Risk:      "beta",
-		Branch:    "bar",
-		Expected:  "latest/beta/bar",
-		ErrorType: nil,
-	}, {
-		Name:      "",
-		Track:     "",
-		Risk:      "testme",
-		Branch:    "",
-		ErrorType: errors.IsNotValid,
-	}}
-	for k, test := range tests {
-		c.Logf("test %q at %d", test.Name, k)
-		ch, err := charm.MakeChannel(test.Track, test.Risk, test.Branch)
-		if test.ErrorType == nil {
-			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(ch, gc.DeepEquals, charm.Channel{
-				Track:  test.Track,
-				Risk:   charm.Risk(test.Risk),
-				Branch: test.Branch,
-			})
-		} else {
-			c.Assert(err, jc.Satisfies, errors.IsNotValid)
-		}
-	}
-}
-
-func (s channelSuite) TestMakePermissiveChannelAndEmpty(c *gc.C) {
-	tests := []struct {
-		Name     string
-		Track    string
-		Risk     string
-		Expected string
-	}{{
-		Name:     "latest track, risk",
-		Track:    "latest",
-		Risk:     "beta",
-		Expected: "beta",
-	}, {
-		Name:     "risk not valid",
-		Track:    "",
-		Risk:     "testme",
-		Expected: "testme",
-	}}
-	for k, test := range tests {
-		c.Logf("test %q at %d", test.Name, k)
-		ch := charm.MakePermissiveChannel(test.Track, test.Risk, "")
-		c.Assert(ch.String(), gc.Equals, test.Expected)
-	}
-}
-
-func (s channelSuite) TestEmpty(c *gc.C) {
-	c.Assert(charm.Channel{}.Empty(), jc.IsTrue)
+func (s channelSuite) TestMakeRiskOnlyChannel(c *gc.C) {
+	c.Assert(corecharm.MakeRiskOnlyChannel("edge"), gc.DeepEquals, charm.Channel{
+		Track:  "",
+		Risk:   "edge",
+		Branch: "",
+	})
 }

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 )
 
@@ -44,7 +45,7 @@ type Origin struct {
 	// Users can request a revision to be installed instead of a channel, so
 	// we should model that correctly here.
 	Revision *int
-	Channel  *Channel
+	Channel  *charm.Channel
 	Platform Platform
 }
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f
+	github.com/juju/charm/v8 v8.0.0-20210413155121-83cb5fed06b4
 	github.com/juju/charmrepo/v6 v6.0.0-20210309083204-29c3dbf03675
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f h1:cAmcDXpeI44jQ5ccZs6FF/eTmjJKCGmxnA1erbMtjlI=
-github.com/juju/charm/v8 v8.0.0-20210317062702-a072bae3ba6f/go.mod h1:AttoXjf7BuW3tQJxUyvDGtPZ+QgZwYLXztWBgIAMW4U=
+github.com/juju/charm/v8 v8.0.0-20210413155121-83cb5fed06b4 h1:a/TTne0mQijysVyF8Lk0Qusiv4kOEnO++Og1q+Gdv7s=
+github.com/juju/charm/v8 v8.0.0-20210413155121-83cb5fed06b4/go.mod h1:AttoXjf7BuW3tQJxUyvDGtPZ+QgZwYLXztWBgIAMW4U=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=

--- a/resource/resourceadapters/charmhub.go
+++ b/resource/resourceadapters/charmhub.go
@@ -10,11 +10,11 @@ import (
 	"github.com/juju/errors"
 	"github.com/kr/pretty"
 
+	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/charmstore"
-	"github.com/juju/juju/core/charm"
 	"github.com/juju/juju/resource/repositories"
 )
 

--- a/resource/resourceadapters/charmstore.go
+++ b/resource/resourceadapters/charmstore.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/controller"
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/resource/repositories"
 	"github.com/juju/juju/state"
 )
@@ -57,7 +56,7 @@ func (cs *csClient) GetResource(req repositories.ResourceRequest) (charmstore.Re
 		return cs.client.GetResource(csReq)
 	}
 
-	channel, err := corecharm.MakeChannel(stChannel.Track, stChannel.Risk, stChannel.Branch)
+	channel, err := charm.MakeChannel(stChannel.Track, stChannel.Risk, stChannel.Branch)
 	if err != nil {
 		return charmstore.ResourceData{}, errors.Trace(err)
 	}

--- a/resource/resourceadapters/retryclient.go
+++ b/resource/resourceadapters/retryclient.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/retry"
 
 	"github.com/juju/juju/charmstore"
-	"github.com/juju/juju/core/charm"
 	"github.com/juju/juju/resource/repositories"
 )
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	jujucharm "github.com/juju/charm/v8"
+	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v3"
 	"github.com/juju/errors"
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/os/v2/series"
 
 	"github.com/juju/juju/core/arch"
-	"github.com/juju/juju/core/charm"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
@@ -1941,7 +1941,7 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 			return description.CharmOriginArgs{}, errors.Trace(err)
 		}
 	}
-	var platform charm.Platform
+	var platform corecharm.Platform
 	if origin.Platform != nil {
 		// Platform is now mandatory moving forward, so we need to ensure that
 		// the architecture is set in the platform if it's not set. This
@@ -1960,7 +1960,7 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 			}
 			os = strings.ToLower(sys.String())
 		}
-		platform = charm.Platform{
+		platform = corecharm.Platform{
 			Architecture: arch,
 			OS:           os,
 			Series:       origin.Platform.Series,
@@ -1977,7 +1977,7 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 	}, nil
 }
 
-func deduceOrigin(url *jujucharm.URL) (description.CharmOriginArgs, error) {
+func deduceOrigin(url *charm.URL) (description.CharmOriginArgs, error) {
 	if url == nil {
 		return description.CharmOriginArgs{}, errors.NotValidf("charm url")
 	}
@@ -1985,15 +1985,15 @@ func deduceOrigin(url *jujucharm.URL) (description.CharmOriginArgs, error) {
 	switch url.Schema {
 	case "cs":
 		return description.CharmOriginArgs{
-			Source: charm.CharmStore.String(),
+			Source: corecharm.CharmStore.String(),
 		}, nil
 	case "local":
 		return description.CharmOriginArgs{
-			Source: charm.Local.String(),
+			Source: corecharm.Local.String(),
 		}, nil
 	default:
 		return description.CharmOriginArgs{
-			Source: charm.CharmHub.String(),
+			Source: corecharm.CharmHub.String(),
 		}, nil
 	}
 }

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1357,7 +1357,7 @@ func (i *importer) makeCharmOrigin(a description.Application, curl *charm.URL, u
 
 	var channel *Channel
 	if serialized := co.Channel(); serialized != "" {
-		c, err := corecharm.ParseChannelNormalize(serialized)
+		c, err := charm.ParseChannelNormalize(serialized)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1444,7 +1444,7 @@ func getApplicationSourceChannel(a description.Application, url *charm.URL) (cor
 		return source, &Channel{Risk: a.Channel()}
 	}
 
-	norm, err := corecharm.ParseChannelNormalize(a.Channel())
+	norm, err := charm.ParseChannelNormalize(a.Channel())
 	if err != nil {
 		return source, nil
 	}


### PR DESCRIPTION
Updates Juju to:
- Remove the logic that was relocated to charm/v8.
- Update the charm dependency to the latest version.
- Point usages of the removed logic to the charm dependency instead of core/charm.

## QA steps

Mechanical change, verified by tests.
Regression can be tested for by deploying something from CharmHub.

## Documentation changes

None.

## Bug reference

N/A
