### PR TITLE
Merge 2.9 bases branch

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -301,7 +301,7 @@ func (s *toolsSuite) TestFindToolsOldAgent(c *gc.C) {
 			stateenvirons.EnvironConfigGetter{Model: s.Model}, &mockToolsStorage{metadata: storageMetadata}, sprintfURLGetter("tools:%s"), newEnviron,
 		)
 		result, err := toolsFinder.FindTools(params.FindToolsParams{
-			Number: version.MustParse("2.8.9"),
+			Number:       version.MustParse("2.8.9"),
 			MajorVersion: 2,
 			MinorVersion: 8,
 			OSType:       "ubuntu",

--- a/apiserver/facades/client/charmhub/charmhub_test.go
+++ b/apiserver/facades/client/charmhub/charmhub_test.go
@@ -172,10 +172,10 @@ func getCharmHubFindResponses() []transport.FindResponse {
 		DefaultRelease: transport.FindChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: transport.Platform{
+				Base: transport.Base{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				},
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Risk:       "stable",
@@ -188,14 +188,14 @@ func getCharmHubFindResponses() []transport.FindResponse {
 					Size:       12042240,
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
-				Platforms: []transport.Platform{{
+				Bases: []transport.Base{{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				}, {
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "xenial",
+					Name:         "ubuntu",
+					Channel:      "16.04",
 				}},
 				Revision: 16,
 				Version:  "1.0.3",
@@ -212,10 +212,10 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 		ChannelMap: []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: transport.Platform{
+				Base: transport.Base{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				},
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Risk:       "stable",
@@ -230,10 +230,10 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []transport.Platform{{
+				Bases: []transport.Base{{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				}},
 				Revision: 16,
 				Version:  "1.0.3",
@@ -260,10 +260,10 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 		DefaultRelease: transport.InfoChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: transport.Platform{
+				Base: transport.Base{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				},
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Risk:       "stable",
@@ -278,10 +278,10 @@ func getCharmHubInfoResponse() transport.InfoResponse {
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: entityMeta,
-				Platforms: []transport.Platform{{
+				Bases: []transport.Base{{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				}},
 				Revision: 16,
 				Version:  "1.0.3",

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -5,6 +5,7 @@ package charmhub
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub/transport"
+	coreseries "github.com/juju/juju/core/series"
 )
 
 func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
@@ -25,16 +27,17 @@ func convertCharmInfoResult(info transport.InfoResponse) params.InfoResponse {
 		Tags:        categories(info.Entity.Categories),
 		StoreURL:    info.Entity.StoreURL,
 	}
+	var isKub bool
 	switch transport.Type(ir.Type) {
 	case transport.BundleType:
 		ir.Bundle = convertBundle(info.Entity.Charms)
 		// TODO (stickupkid): Get the Bundle.Release and set it to the
 		// InfoResponse at a high level.
 	case transport.CharmType:
-		ir.Charm, ir.Series = convertCharm(info)
+		ir.Charm, ir.Series, isKub = convertCharm(info)
 	}
 
-	ir.Tracks, ir.Channels = transformInfoChannelMap(info.ChannelMap)
+	ir.Tracks, ir.Channels = transformInfoChannelMap(info.ChannelMap, isKub)
 	return ir
 }
 
@@ -87,7 +90,7 @@ type supported struct {
 // transformFindArchitectureSeries returns a supported type which contains
 // architectures and series for a given channel map.
 func transformFindArchitectureSeries(channel transport.FindChannelMap) supported {
-	if len(channel.Revision.Platforms) < 1 {
+	if len(channel.Revision.Bases) < 1 {
 		return supported{}
 	}
 
@@ -96,10 +99,12 @@ func transformFindArchitectureSeries(channel transport.FindChannelMap) supported
 		os     = set.NewStrings()
 		series = set.NewStrings()
 	)
-	for _, p := range channel.Revision.Platforms {
+	for _, p := range channel.Revision.Bases {
 		arches.Add(p.Architecture)
-		os.Add(p.OS)
-		series.Add(p.Series)
+		os.Add(p.Name)
+		// TODO hml - for this to be correct, must determine IsKubernetes from metadata.
+		s, _ := coreseries.VersionSeries(p.Channel)
+		series.Add(s)
 	}
 	return supported{
 		Architectures: arches.SortedValues(),
@@ -111,7 +116,7 @@ func transformFindArchitectureSeries(channel transport.FindChannelMap) supported
 // transformInfoChannelMap returns channel map data in a format that facilitates
 // determining track order and open vs closed channels for displaying channel
 // data.
-func transformInfoChannelMap(channelMap []transport.InfoChannelMap) ([]string, map[string]params.Channel) {
+func transformInfoChannelMap(channelMap []transport.InfoChannelMap, isKub bool) ([]string, map[string]params.Channel) {
 	var trackList []string
 
 	seen := set.NewStrings("")
@@ -131,7 +136,7 @@ func transformInfoChannelMap(channelMap []transport.InfoChannelMap) ([]string, m
 			Track:      ch.Track,
 			Size:       cm.Revision.Download.Size,
 			Version:    cm.Revision.Version,
-			Platforms:  convertPlatforms(cm.Revision.Platforms),
+			Platforms:  convertBasesToPlatforms(cm.Revision.Bases, isKub),
 		}
 		if !seen.Contains(ch.Track) {
 			seen.Add(ch.Track)
@@ -142,32 +147,44 @@ func transformInfoChannelMap(channelMap []transport.InfoChannelMap) ([]string, m
 	return trackList, channels
 }
 
-func convertPlatforms(in []transport.Platform) []params.Platform {
+// convertBasesToPlatforms converts a base to a platform.  Is mean to be a short
+// term solution due to schedule.  It should be removed once platforms are
+// replaced with bases through out the code.
+func convertBasesToPlatforms(in []transport.Base, isKub bool) []params.Platform {
 	out := make([]params.Platform, len(in))
 	for i, v := range in {
+		var series string
+		if isKub {
+			series = "kubernetes"
+		} else {
+			series, _ = coreseries.VersionSeries(v.Channel)
+		}
+		os, _ := coreseries.GetOSFromSeries(series)
 		out[i] = params.Platform{
 			Architecture: v.Architecture,
-			OS:           v.OS,
-			Series:       v.Series,
+			OS:           strings.ToLower(os.String()),
+			Series:       series,
 		}
 	}
 	return out
 }
 
-func convertCharm(info transport.InfoResponse) (*params.CharmHubCharm, []string) {
+func convertCharm(info transport.InfoResponse) (*params.CharmHubCharm, []string, bool) {
 	charmHubCharm := params.CharmHubCharm{
 		UsedBy: info.Entity.UsedBy,
 	}
 	var series []string
+	var isKub bool
 	if meta := unmarshalCharmMetadata(info.DefaultRelease.Revision.MetadataYAML); meta != nil {
 		charmHubCharm.Subordinate = meta.Subordinate
 		charmHubCharm.Relations = transformRelations(meta.Requires, meta.Provides)
 		series = meta.ComputedSeries()
+		isKub = isKubernetes(meta)
 	}
 	if cfg := unmarshalCharmConfig(info.DefaultRelease.Revision.ConfigYAML); cfg != nil {
 		charmHubCharm.Config = params.ToCharmOptionMap(cfg)
 	}
-	return &charmHubCharm, series
+	return &charmHubCharm, series, isKub
 }
 
 func unmarshalCharmMetadata(metadataYAML string) *charm.Meta {
@@ -243,4 +260,18 @@ func convertBundle(charms []transport.Charm) *params.CharmHubBundle {
 		}
 	}
 	return bundle
+}
+
+// TODO (hml) 2021-04-08
+// Update location of series for kubernetes series once manifest.yaml
+// is available.
+func isKubernetes(meta *charm.Meta) bool {
+	if len(meta.Containers) > 0 {
+		return true
+	}
+	seriesSet := set.NewStrings(meta.Series...)
+	if seriesSet.Contains("kubernetes") {
+		return true
+	}
+	return false
 }

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 	corecharm "github.com/juju/juju/core/charm"
+	coreseries "github.com/juju/juju/core/series"
 )
 
 // CharmHubClient represents the methods required of a
@@ -69,8 +70,10 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin corecharm.O
 	if resErr := res.Error; resErr != nil {
 		switch resErr.Code {
 		case transport.ErrorCodeInvalidCharmPlatform:
-			logger.Tracef("Invalid charm platform %q %v - Default Platforms: %v", curl, origin, resErr.Extra.DefaultPlatforms)
-			platform, err := c.selectNextPlatform(resErr.Extra.DefaultPlatforms, origin)
+			fallthrough
+		case transport.ErrorCodeInvalidCharmBase:
+			logger.Tracef("Invalid charm platform %q %v - Default Platforms: %v", curl, origin, resErr.Extra.DefaultBases)
+			platform, err := c.selectNextPlatform(resErr.Extra.DefaultBases, origin)
 			if err != nil {
 				return nil, corecharm.Origin{}, nil, errors.Annotatef(err, "refresh")
 			}
@@ -250,28 +253,38 @@ func (c *chRepo) refreshOne(curl *charm.URL, origin corecharm.Origin) (transport
 	return result[0], nil
 }
 
-func (c *chRepo) selectNextPlatform(platforms []transport.Platform, origin corecharm.Origin) (transport.Platform, error) {
-	if len(platforms) == 0 {
-		return transport.Platform{}, errors.Errorf("no platforms available")
+func (c *chRepo) selectNextPlatform(bases []transport.Base, origin corecharm.Origin) (corecharm.Platform, error) {
+	if len(bases) == 0 {
+		return corecharm.Platform{}, errors.Errorf("no bases available")
 	}
 	// We've got a invalid charm platform error, the error should contain
 	// a valid platform to query again to get the right information. If
 	// the platform is empty, consider it a failure.
 	var (
-		found    bool
-		platform transport.Platform
+		found bool
+		base  transport.Base
 	)
-	for _, platform = range platforms {
-		if platform.Architecture != origin.Platform.Architecture {
+	for _, base = range bases {
+		if base.Architecture != origin.Platform.Architecture {
 			continue
 		}
 		found = true
 		break
 	}
 	if !found {
-		return transport.Platform{}, errors.NotFoundf("platform")
+		return corecharm.Platform{}, errors.NotFoundf("base")
 	}
-	return platform, nil
+
+	series, err := coreseries.VersionSeries(base.Channel)
+	if err != nil {
+		return corecharm.Platform{}, errors.Trace(err)
+	}
+
+	return corecharm.Platform{
+		Architecture: base.Architecture,
+		OS:           base.Name,
+		Series:       series,
+	}, nil
 }
 
 func (c *chRepo) selectNextRelease(releases []transport.Release, origin corecharm.Origin) (Release, error) {
@@ -391,8 +404,13 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 func composeSuggestions(releases []transport.Release, origin corecharm.Origin) []string {
 	channelSeries := make(map[string][]string, 0)
 	for _, release := range releases {
-		platform := release.Platform
-		arch, series := platform.Architecture, platform.Series
+		base := release.Base
+		arch := base.Architecture
+		series, err := coreseries.VersionSeries(base.Channel)
+		if err != nil {
+			logger.Errorf("converting version to series: %s", err)
+			continue
+		}
 		if arch == "all" {
 			arch = origin.Platform.Architecture
 		}
@@ -423,6 +441,7 @@ func composeSuggestions(releases []transport.Release, origin corecharm.Origin) [
 }
 
 // Release represents a release that a charm can be selected from.
+// TODO HML, what if anything to do here?
 type Release struct {
 	OS, Series string
 }
@@ -436,9 +455,13 @@ func selectReleaseByArchAndChannel(releases []transport.Release, origin corechar
 		channel = origin.Channel.Normalize()
 	}
 	for _, release := range releases {
-		platform := release.Platform
+		base := release.Base
 
-		arch, os, series := platform.Architecture, platform.OS, platform.Series
+		arch, os := base.Architecture, base.Name
+		series, err := coreseries.VersionSeries(base.Channel)
+		if err != nil {
+			return Release{}, errors.Trace(err)
+		}
 		if (empty || channel.String() == release.Channel) && (arch == "all" || arch == origin.Platform.Architecture) {
 			return Release{
 				OS:     os,

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -331,13 +331,13 @@ func (s *charmHubRepositoriesSuite) expectedRefreshInvalidPlatformError(c *gc.C)
 			ID:          "charmCHARMcharmCHARMcharmCHARM01",
 			InstanceKey: id,
 			Error: &transport.APIError{
-				Code:    transport.ErrorCodeInvalidCharmPlatform,
+				Code:    transport.ErrorCodeInvalidCharmBase,
 				Message: "invalid charm platform",
 				Extra: transport.APIErrorExtra{
-					DefaultPlatforms: []transport.Platform{{
+					DefaultBases: []transport.Base{{
 						Architecture: "amd64",
-						OS:           "ubuntu",
-						Series:       "focal",
+						Name:         "ubuntu",
+						Channel:      "20.04",
 					}},
 				},
 			},
@@ -357,10 +357,10 @@ func (s *charmHubRepositoriesSuite) expectedRefreshRevisionNotFoundError(c *gc.C
 				Message: "revision not found",
 				Extra: transport.APIErrorExtra{
 					Releases: []transport.Release{{
-						Platform: transport.Platform{
+						Base: transport.Base{
 							Architecture: "amd64",
-							OS:           "ubuntu",
-							Series:       "focal",
+							Name:         "ubuntu",
+							Channel:      "20.04",
 						},
 						Channel: "stable",
 					}},
@@ -440,9 +440,9 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 			InstanceKey: instanceKey,
 			Name:        &curl.Name,
 			Channel:     &ch,
-			Platform: &transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: "amd64",
 			},
 		}},
@@ -472,9 +472,9 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 			InstanceKey: instanceKey,
 			Name:        &curl.Name,
 			Revision:    &revision,
-			Platform: &transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: "amd64",
 			},
 		}},
@@ -510,9 +510,9 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 			InstanceKey: instanceKey,
 			ID:          id,
 			Revision:    revision,
-			Platform: transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: "amd64",
 			},
 		}},
@@ -532,9 +532,9 @@ func (composeSuggestionsSuite) TestNoReleases(c *gc.C) {
 
 func (composeSuggestionsSuite) TestNoMatchingArch(c *gc.C) {
 	suggestions := composeSuggestions([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "os",
-			Series:       "series",
+		Base: transport.Base{
+			Name:         "os",
+			Channel:      "series",
 			Architecture: "arch",
 		},
 		Channel: "stable",
@@ -544,9 +544,9 @@ func (composeSuggestionsSuite) TestNoMatchingArch(c *gc.C) {
 
 func (composeSuggestionsSuite) TestSuggestion(c *gc.C) {
 	suggestions := composeSuggestions([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "os",
-			Series:       "series",
+		Base: transport.Base{
+			Name:         "os",
+			Channel:      "20.04",
 			Architecture: "arch",
 		},
 		Channel: "stable",
@@ -556,36 +556,36 @@ func (composeSuggestionsSuite) TestSuggestion(c *gc.C) {
 		},
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		"stable with series",
+		"stable with focal",
 	})
 }
 
 func (composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 	suggestions := composeSuggestions([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "a",
-			Series:       "b",
+		Base: transport.Base{
+			Name:         "a",
+			Channel:      "20.04",
 			Architecture: "c",
 		},
 		Channel: "stable",
 	}, {
-		Platform: transport.Platform{
-			OS:           "a",
-			Series:       "d",
+		Base: transport.Base{
+			Name:         "a",
+			Channel:      "18.04",
 			Architecture: "c",
 		},
 		Channel: "stable",
 	}, {
-		Platform: transport.Platform{
-			OS:           "e",
-			Series:       "f",
+		Base: transport.Base{
+			Name:         "e",
+			Channel:      "18.04",
 			Architecture: "all",
 		},
 		Channel: "2.0/stable",
 	}, {
-		Platform: transport.Platform{
-			OS:           "g",
-			Series:       "h",
+		Base: transport.Base{
+			Name:         "g",
+			Channel:      "h",
 			Architecture: "i",
 		},
 		Channel: "stable",
@@ -595,8 +595,8 @@ func (composeSuggestionsSuite) TestMultipleSuggestion(c *gc.C) {
 		},
 	})
 	c.Assert(suggestions, gc.DeepEquals, []string{
-		"stable with b, d",
-		"2.0/stable with f",
+		"stable with focal, bionic",
+		"2.0/stable with bionic",
 	})
 }
 
@@ -613,21 +613,21 @@ func (selectReleaseByChannelSuite) TestNoReleases(c *gc.C) {
 
 func (selectReleaseByChannelSuite) TestInvalidChannel(c *gc.C) {
 	_, err := selectReleaseByArchAndChannel([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "os",
-			Series:       "series",
+		Base: transport.Base{
+			Name:         "os",
+			Channel:      "series",
 			Architecture: "arch",
 		},
 		Channel: "",
 	}}, corecharm.Origin{})
-	c.Assert(err, gc.ErrorMatches, `release not found`)
+	c.Assert(err, gc.ErrorMatches, `unknown series for version: "series"`)
 }
 
 func (selectReleaseByChannelSuite) TestSelection(c *gc.C) {
 	release, err := selectReleaseByArchAndChannel([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "os",
-			Series:       "series",
+		Base: transport.Base{
+			Name:         "os",
+			Channel:      "20.04",
 			Architecture: "arch",
 		},
 		Channel: "stable",
@@ -642,15 +642,15 @@ func (selectReleaseByChannelSuite) TestSelection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(release, gc.DeepEquals, Release{
 		OS:     "os",
-		Series: "series",
+		Series: "focal",
 	})
 }
 
 func (selectReleaseByChannelSuite) TestAllSelection(c *gc.C) {
 	release, err := selectReleaseByArchAndChannel([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "os",
-			Series:       "series",
+		Base: transport.Base{
+			Name:         "os",
+			Channel:      "16.04",
 			Architecture: "all",
 		},
 		Channel: "stable",
@@ -665,29 +665,29 @@ func (selectReleaseByChannelSuite) TestAllSelection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(release, gc.DeepEquals, Release{
 		OS:     "os",
-		Series: "series",
+		Series: "xenial",
 	})
 }
 
 func (selectReleaseByChannelSuite) TestMultipleSelection(c *gc.C) {
 	release, err := selectReleaseByArchAndChannel([]transport.Release{{
-		Platform: transport.Platform{
-			OS:           "a",
-			Series:       "b",
+		Base: transport.Base{
+			Name:         "a",
+			Channel:      "14.04",
 			Architecture: "c",
 		},
 		Channel: "1.0/edge",
 	}, {
-		Platform: transport.Platform{
-			OS:           "d",
-			Series:       "e",
+		Base: transport.Base{
+			Name:         "d",
+			Channel:      "16.04",
 			Architecture: "all",
 		},
 		Channel: "2.0/stable",
 	}, {
-		Platform: transport.Platform{
-			OS:           "f",
-			Series:       "g",
+		Base: transport.Base{
+			Name:         "f",
+			Channel:      "18.04",
 			Architecture: "h",
 		},
 		Channel: "3.0/stable",
@@ -703,6 +703,6 @@ func (selectReleaseByChannelSuite) TestMultipleSelection(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(release, gc.DeepEquals, Release{
 		OS:     "f",
-		Series: "g",
+		Series: "bionic",
 	})
 }

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -38,7 +38,8 @@ import (
 // An alternate location can be configured by changing the URL
 // field in the Params struct.
 const (
-	CharmHubServerURL     = "https://api.charmhub.io"
+	// TODO(2.9) - use staging API until bases are supported in production
+	CharmHubServerURL     = "https://api.staging.charmhub.io"
 	CharmHubServerVersion = "v2"
 	CharmHubServerEntity  = "charms"
 

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -127,10 +127,10 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 			DefaultRelease: transport.FindChannelMap{
 				Channel: transport.Channel{
 					Name: "latest/stable",
-					Platform: transport.Platform{
+					Base: transport.Base{
 						Architecture: "all",
-						OS:           "ubuntu",
-						Series:       "bionic",
+						Name:         "ubuntu",
+						Channel:      "18.04",
 					},
 					ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 					Risk:       "stable",
@@ -143,10 +143,10 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 						Size:       12042240,
 						URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 					},
-					Platforms: []transport.Platform{{
+					Bases: []transport.Base{{
 						Architecture: "all",
-						OS:           "ubuntu",
-						Series:       "bionic",
+						Name:         "ubuntu",
+						Channel:      "18.04",
 					}},
 					Revision: 16,
 					Version:  "1.0.3",

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -116,18 +116,18 @@ var infoDefaultRevisionFilter = []string{
 	"revision.config-yaml",
 	"revision.metadata-yaml",
 	"revision.bundle-yaml",
-	"revision.platforms.architecture",
-	"revision.platforms.os",
-	"revision.platforms.series",
+	"revision.bases.architecture",
+	"revision.bases.name",
+	"revision.bases.channel",
 	"revision.revision",
 	"revision.version",
 }
 
 var infoChannelMapRevisionFilter = []string{
 	"revision.created-at",
-	"revision.platforms.architecture",
-	"revision.platforms.os",
-	"revision.platforms.series",
+	"revision.bases.architecture",
+	"revision.bases.name",
+	"revision.bases.channel",
 	"revision.revision",
 	"revision.version",
 }

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -156,10 +156,10 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 		ChannelMap: []transport.InfoChannelMap{{
 			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: transport.Platform{
+				Base: transport.Base{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				},
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Risk:       "stable",
@@ -174,10 +174,10 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []transport.Platform{{
+				Bases: []transport.Base{{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				}},
 				Revision: 16,
 				Version:  "1.0.3",
@@ -203,10 +203,10 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 		DefaultRelease: transport.InfoChannelMap{
 			Channel: transport.Channel{
 				Name: "latest/stable",
-				Platform: transport.Platform{
+				Base: transport.Base{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				},
 				ReleasedAt: "2019-12-16T19:44:44.076943+00:00",
 				Risk:       "stable",
@@ -221,10 +221,10 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 					URL:        "https://api.snapcraft.io/api/v1/snaps/download/QLLfVfIKfcnTZiPFnmGcigB2vB605ZY7_16.snap",
 				},
 				MetadataYAML: "name: myname\nversion: 1.0.3\nsummary: A charm or bundle.\ndescription: |\n  This will install and setup services optimized to run in the cloud.\n  By default it will place Ngnix configured to scale horizontally\n  with Nginx's reverse proxy.\n",
-				Platforms: []transport.Platform{{
+				Bases: []transport.Base{{
 					Architecture: "all",
-					OS:           "ubuntu",
-					Series:       "bionic",
+					Name:         "ubuntu",
+					Channel:      "18.04",
 				}},
 				Revision: 16,
 				Version:  "1.0.3",

--- a/charmhub/refresh_integration_test.go
+++ b/charmhub/refresh_integration_test.go
@@ -39,8 +39,8 @@ func (s *RefreshClientSuite) TestLiveRefreshRequest(c *gc.C) {
 
 	client := charmhub.NewRefreshClient(refreshPath, restClient, logger)
 
-	charmConfig, err := charmhub.RefreshOne("wordpress", 0, "latest/stable", charmhub.RefreshPlatform{
-		Series:       "kubernetes",
+	charmConfig, err := charmhub.RefreshOne("wordpress", 0, "latest/stable", charmhub.RefreshBase{
+		Channel:      "kubernetes",
 		Architecture: "all",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,16 +69,16 @@ func (s *RefreshClientSuite) TestLiveRefreshManyRequest(c *gc.C) {
 
 	client := charmhub.NewRefreshClient(refreshPath, restClient, logger)
 
-	wordpressConfig, err := charmhub.RefreshOne("wordpress", 16, "latest/stable", charmhub.RefreshPlatform{
-		OS:           "ubuntu",
-		Series:       "focal",
+	wordpressConfig, err := charmhub.RefreshOne("wordpress", 16, "latest/stable", charmhub.RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "focal",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	mysqlConfig, err := charmhub.RefreshOne("mysql", 1, "latest/stable", charmhub.RefreshPlatform{
-		OS:           "ubuntu",
-		Series:       "focal",
+	mysqlConfig, err := charmhub.RefreshOne("mysql", 1, "latest/stable", charmhub.RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "focal",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -110,9 +110,9 @@ func (s *RefreshClientSuite) TestLiveInstallRequest(c *gc.C) {
 
 	client := charmhub.NewRefreshClient(refreshPath, restClient, logger)
 
-	charmConfig, err := charmhub.InstallOneFromRevision("wordpress", 16, charmhub.RefreshPlatform{
-		OS:           "ubuntu",
-		Series:       "focal",
+	charmConfig, err := charmhub.InstallOneFromRevision("wordpress", 16, charmhub.RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "focal",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -39,9 +39,9 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          id,
 			Revision:    1,
-			Platform: transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 			TrackingChannel: "latest/stable",
@@ -274,9 +274,9 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          "foo",
 			Revision:    1,
-			Platform: transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 			TrackingChannel: "latest/stable",
@@ -327,9 +327,9 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Revision:    &revision,
-			Platform: &transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
@@ -358,9 +358,9 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Channel:     &channel,
-			Platform: &transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
@@ -387,9 +387,9 @@ func (s *RefreshConfigSuite) TestInstallOneWithPartialPlatform(c *gc.C) {
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Channel:     &channel,
-			Platform: &transport.Platform{
-				OS:           NotAvailable,
-				Series:       NotAvailable,
+			Base: &transport.Base{
+				Name:         NotAvailable,
+				Channel:      NotAvailable,
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
@@ -478,9 +478,9 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          &id,
 			Channel:     &channel,
-			Platform: &transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
@@ -568,9 +568,9 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			InstanceKey: "foo-bar",
 			ID:          "foo",
 			Revision:    1,
-			Platform: transport.Platform{
-				OS:           "ubuntu",
-				Series:       "focal",
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 			TrackingChannel: "latest/stable",
@@ -578,9 +578,9 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			InstanceKey: "foo-baz",
 			ID:          "bar",
 			Revision:    2,
-			Platform: transport.Platform{
-				OS:           "ubuntu",
-				Series:       "trusty",
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "14.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 			TrackingChannel: "latest/edge",
@@ -597,9 +597,9 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			Action:      "install",
 			InstanceKey: "foo-taz",
 			Name:        &name3,
-			Platform: &transport.Platform{
-				OS:           "ubuntu",
-				Series:       "disco",
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "19.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 			Channel: &channel,

--- a/charmhub/transport/common.go
+++ b/charmhub/transport/common.go
@@ -26,22 +26,22 @@ const (
 )
 
 // Channel defines a unique permutation that corresponds to the track, risk
-// and platform. There can be multiple channels of the same track and risk, but
-// with different platforms.
+// and base. There can be multiple channels of the same track and risk, but
+// with different bases.
 type Channel struct {
-	Name       string   `json:"name"`
-	Platform   Platform `json:"platform"`
-	ReleasedAt string   `json:"released-at"`
-	Risk       string   `json:"risk"`
-	Track      string   `json:"track"`
+	Name       string `json:"name"`
+	Base       Base   `json:"base"`
+	ReleasedAt string `json:"released-at"`
+	Risk       string `json:"risk"`
+	Track      string `json:"track"`
 }
 
-// Platform is a typed tuple for identifying charms or bundles with a matching
-// architecture, os and series.
-type Platform struct {
+// Base is a typed tuple for identifying charms or bundles with a matching
+// architecture, os and channel.
+type Base struct {
 	Architecture string `json:"architecture"`
-	OS           string `json:"os"`
-	Series       string `json:"series"`
+	Name         string `json:"name"`
+	Channel      string `json:"channel"`
 }
 
 // Download represents the download structure from CharmHub.

--- a/charmhub/transport/error.go
+++ b/charmhub/transport/error.go
@@ -38,15 +38,15 @@ func (a APIErrors) Error() string {
 // of this object as a series of suggestions to perform against the errorred
 // API request, in the chance of the new request being successful.
 type APIErrorExtra struct {
-	Releases         []Release  `json:"releases"`
-	DefaultPlatforms []Platform `json:"default-platforms"`
+	Releases     []Release `json:"releases"`
+	DefaultBases []Base    `json:"default-bases"`
 }
 
 // Release defines a set of suggested releases that might also work for the
 // given request.
 type Release struct {
-	Platform Platform `json:"platform"`
-	Channel  string   `json:"channel"`
+	Base    Base   `json:"base"`
+	Channel string `json:"channel"`
 }
 
 // APIErrorCode classifies the error code we get back from the API. This isn't
@@ -68,32 +68,35 @@ const (
 	ErrorCodeInconsistentData                  APIErrorCode = "inconsistent-data"
 	ErrorCodeInstanceKeyNotUnique              APIErrorCode = "instance-key-not-unique"
 	ErrorCodeInvalidChannel                    APIErrorCode = "invalid-channel"
-	ErrorCodeInvalidCharmPlatform              APIErrorCode = "invalid-charm-platform"
-	ErrorCodeInvalidCohortKey                  APIErrorCode = "invalid-cohort-key"
-	ErrorCodeInvalidGrade                      APIErrorCode = "invalid-grade"
-	ErrorCodeInvalidMetric                     APIErrorCode = "invalid-metric"
-	ErrorCodeInvalidUnboundEmptySearch         APIErrorCode = "invalid-unbound-empty-search"
-	ErrorCodeMacaroonPermissionRequired        APIErrorCode = "macaroon-permission-required"
-	ErrorCodeMissingCharmPlatform              APIErrorCode = "missing-charm-platform"
-	ErrorCodeMissingContext                    APIErrorCode = "missing-context"
-	ErrorCodeMissingFetchAssertionsKey         APIErrorCode = "missing-fetch-assertions-key"
-	ErrorCodeMissingHeader                     APIErrorCode = "missing-header"
-	ErrorCodeMissingInstanceKey                APIErrorCode = "missing-instance-key"
-	ErrorCodeMissingKey                        APIErrorCode = "missing-key"
-	ErrorCodeNameNotFound                      APIErrorCode = "name-not-found"
-	ErrorCodeNotFound                          APIErrorCode = "not-found"
-	ErrorCodePaymentRequired                   APIErrorCode = "payment-required"
-	ErrorCodeRateLimitExceeded                 APIErrorCode = "rate-limit-exceeded"
-	ErrorCodeRefreshBundleNotSupported         APIErrorCode = "refresh-bundle-not-supported"
-	ErrorCodeRemoteServiceUnavailable          APIErrorCode = "remote-service-unavailable"
-	ErrorCodeResourceNotFound                  APIErrorCode = "resource-not-found"
-	ErrorCodeRevisionConflict                  APIErrorCode = "revision-conflict"
-	ErrorCodeRevisionNotFound                  APIErrorCode = "revision-not-found"
-	ErrorCodeServiceMisconfigured              APIErrorCode = "service-misconfigured"
-	ErrorCodeStoreAuthorizationNeedsRefresh    APIErrorCode = "store-authorization-needs-refresh"
-	ErrorCodeStoreDisallowed                   APIErrorCode = "store-disallowed"
-	ErrorCodeUnexpectedData                    APIErrorCode = "unexpected-data"
-	ErrorCodeUnknownGrade                      APIErrorCode = "unknown-grade"
-	ErrorCodeUserAuthenticationError           APIErrorCode = "user-authentication-error"
-	ErrorCodeUserAuthorizationNeedsRefresh     APIErrorCode = "user-authorization-needs-refresh"
+	ErrorCodeInvalidCharmBase                  APIErrorCode = "invalid-charm-base"
+	// TODO 2021-04-08 hml
+	// Remove once Charmhub API returns ErrorCodeInvalidCharmBase
+	ErrorCodeInvalidCharmPlatform           APIErrorCode = "invalid-charm-platform"
+	ErrorCodeInvalidCohortKey               APIErrorCode = "invalid-cohort-key"
+	ErrorCodeInvalidGrade                   APIErrorCode = "invalid-grade"
+	ErrorCodeInvalidMetric                  APIErrorCode = "invalid-metric"
+	ErrorCodeInvalidUnboundEmptySearch      APIErrorCode = "invalid-unbound-empty-search"
+	ErrorCodeMacaroonPermissionRequired     APIErrorCode = "macaroon-permission-required"
+	ErrorCodeMissingCharmPlatform           APIErrorCode = "missing-charm-platform"
+	ErrorCodeMissingContext                 APIErrorCode = "missing-context"
+	ErrorCodeMissingFetchAssertionsKey      APIErrorCode = "missing-fetch-assertions-key"
+	ErrorCodeMissingHeader                  APIErrorCode = "missing-header"
+	ErrorCodeMissingInstanceKey             APIErrorCode = "missing-instance-key"
+	ErrorCodeMissingKey                     APIErrorCode = "missing-key"
+	ErrorCodeNameNotFound                   APIErrorCode = "name-not-found"
+	ErrorCodeNotFound                       APIErrorCode = "not-found"
+	ErrorCodePaymentRequired                APIErrorCode = "payment-required"
+	ErrorCodeRateLimitExceeded              APIErrorCode = "rate-limit-exceeded"
+	ErrorCodeRefreshBundleNotSupported      APIErrorCode = "refresh-bundle-not-supported"
+	ErrorCodeRemoteServiceUnavailable       APIErrorCode = "remote-service-unavailable"
+	ErrorCodeResourceNotFound               APIErrorCode = "resource-not-found"
+	ErrorCodeRevisionConflict               APIErrorCode = "revision-conflict"
+	ErrorCodeRevisionNotFound               APIErrorCode = "revision-not-found"
+	ErrorCodeServiceMisconfigured           APIErrorCode = "service-misconfigured"
+	ErrorCodeStoreAuthorizationNeedsRefresh APIErrorCode = "store-authorization-needs-refresh"
+	ErrorCodeStoreDisallowed                APIErrorCode = "store-disallowed"
+	ErrorCodeUnexpectedData                 APIErrorCode = "unexpected-data"
+	ErrorCodeUnknownGrade                   APIErrorCode = "unknown-grade"
+	ErrorCodeUserAuthenticationError        APIErrorCode = "user-authentication-error"
+	ErrorCodeUserAuthorizationNeedsRefresh  APIErrorCode = "user-authorization-needs-refresh"
 )

--- a/charmhub/transport/error_test.go
+++ b/charmhub/transport/error_test.go
@@ -50,8 +50,8 @@ two`)
 func (ErrorSuite) TestExtras(c *gc.C) {
 	expected := APIError{
 		Extra: APIErrorExtra{
-			DefaultPlatforms: []Platform{
-				{Architecture: "amd64", OS: "ubuntu", Series: "focal "},
+			DefaultBases: []Base{
+				{Architecture: "amd64", Name: "ubuntu", Channel: "20.04"},
 			},
 		},
 	}

--- a/charmhub/transport/find.go
+++ b/charmhub/transport/find.go
@@ -24,9 +24,9 @@ type FindChannelMap struct {
 // FindRevision is different from InfoRevision.  It is missing
 // ConfigYAML and MetadataYAML
 type FindRevision struct {
-	CreatedAt string     `json:"created-at"`
-	Download  Download   `json:"download"`
-	Platforms []Platform `json:"platforms"`
-	Revision  int        `json:"revision"`
-	Version   string     `json:"version"`
+	CreatedAt string   `json:"created-at"`
+	Download  Download `json:"download"`
+	Bases     []Base   `json:"bases"`
+	Revision  int      `json:"revision"`
+	Version   string   `json:"version"`
 }

--- a/charmhub/transport/info.go
+++ b/charmhub/transport/info.go
@@ -33,10 +33,10 @@ type InfoRevision struct {
 	ConfigYAML string `json:"config-yaml"`
 	CreatedAt  string `json:"created-at"`
 	// Via filters, only Download.Size will be available.
-	Download     Download   `json:"download"`
-	MetadataYAML string     `json:"metadata-yaml"`
-	BundleYAML   string     `json:"bundle-yaml"`
-	Platforms    []Platform `json:"platforms"`
-	Revision     int        `json:"revision"`
-	Version      string     `json:"version"`
+	Download     Download `json:"download"`
+	MetadataYAML string   `json:"metadata-yaml"`
+	BundleYAML   string   `json:"bundle-yaml"`
+	Bases        []Base   `json:"bases"`
+	Revision     int      `json:"revision"`
+	Version      string   `json:"version"`
 }

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -22,7 +22,7 @@ type RefreshRequestContext struct {
 	ID          string `json:"id"`
 
 	Revision        int        `json:"revision"`
-	Platform        Platform   `json:"platform,omitempty"`
+	Base            Base       `json:"base,omitempty"`
 	TrackingChannel string     `json:"tracking-channel,omitempty"`
 	RefreshedDate   *time.Time `json:"refresh-date,omitempty"`
 }
@@ -34,12 +34,12 @@ type RefreshRequestAction struct {
 	// InstanceKey should be unique for every action, as results may not be
 	// ordered in the same way, so it is expected to use this to ensure
 	// completeness and ordering.
-	InstanceKey string    `json:"instance-key"`
-	ID          *string   `json:"id,omitempty"`
-	Name        *string   `json:"name,omitempty"`
-	Channel     *string   `json:"channel,omitempty"`
-	Revision    *int      `json:"revision,omitempty"`
-	Platform    *Platform `json:"platform,omitempty"`
+	InstanceKey string  `json:"instance-key"`
+	ID          *string `json:"id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Channel     *string `json:"channel,omitempty"`
+	Revision    *int    `json:"revision,omitempty"`
+	Base        *Base   `json:"base,omitempty"`
 }
 
 // RefreshResponses holds a series of typed RefreshResponse or a series of

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -263,31 +263,31 @@ func (s *downloadSuite) expectRefreshUnsupportedSeries() {
 				Extra: transport.APIErrorExtra{
 					Releases: []transport.Release{
 						{
-							Platform: transport.Platform{Architecture: "amd64", OS: "ubuntu", Series: "bionic"},
-							Channel:  "stable",
+							Base:    transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "18.04"},
+							Channel: "stable",
 						},
 						{
-							Platform: transport.Platform{Architecture: "amd64", OS: "ubuntu", Series: "trusty"},
-							Channel:  "stable",
+							Base:    transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "14.04"},
+							Channel: "stable",
 						},
 						{
-							Platform: transport.Platform{Architecture: "amd64", OS: "ubuntu", Series: "trusty"},
-							Channel:  "candidate",
+							Base:    transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "14.04"},
+							Channel: "candidate",
 						},
 						{
-							Platform: transport.Platform{Architecture: "amd64", OS: "ubuntu", Series: "xenial"},
-							Channel:  "stable",
+							Base:    transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "16.04"},
+							Channel: "stable",
 						},
 						{
-							Platform: transport.Platform{Architecture: "amd64", OS: "ubuntu", Series: "focal"},
-							Channel:  "beta",
+							Base:    transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "20.04"},
+							Channel: "beta",
 						},
 						{
-							Platform: transport.Platform{Architecture: "amd64", OS: "ubuntu", Series: "xenial"},
-							Channel:  "edge",
+							Base:    transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "14.04"},
+							Channel: "edge",
 						},
 					},
-					DefaultPlatforms: nil,
+					DefaultBases: nil,
 				}},
 		}}, nil
 	})


### PR DESCRIPTION
Merge the 2.9-bases branch (no conflicts).

Update the default charmhub URL to staging for now so we can test charms with newer metadata.

## QA steps

bootstrap
juju deploy postgresql