### PR TITLE
Ensure refresh uses version

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -757,3 +757,37 @@ func (selectReleaseByChannelSuite) TestMultipleSelection(c *gc.C) {
 		Series: "bionic",
 	})
 }
+
+type channelTrackSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&channelTrackSuite{})
+
+func (*channelTrackSuite) ChannelTrack(c *gc.C) {
+	tests := []struct {
+		channel string
+		result  string
+	}{{
+		channel: "20.10",
+		result:  "20.10",
+	}, {
+		channel: "focal",
+		result:  "focal",
+	}, {
+		channel: "20.10/stable",
+		result:  "20.10",
+	}, {
+		channel: "focal/stable",
+		result:  "focal",
+	}, {
+		channel: "so/many/forward/slashes/here",
+		result:  "so",
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d - %s", i, test.channel)
+		got := channelTrack(test.channel)
+		c.Assert(got, gc.Equals, test.result)
+	}
+}

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -110,6 +110,8 @@ func ParsePlatform(s string) (Platform, error) {
 		series = &p[1]
 	case 3:
 		arch, os, series = &p[0], &p[1], &p[2]
+	case 4:
+		arch, os, series = &p[0], &p[1], strptr(fmt.Sprintf("%s/%s", p[2], p[3]))
 	default:
 		return Platform{}, errors.Errorf("platform is malformed and has too many components %q", s)
 	}
@@ -135,6 +137,10 @@ func ParsePlatform(s string) (Platform, error) {
 	}
 
 	return platform, nil
+}
+
+func strptr(s string) *string {
+	return &s
 }
 
 // ParsePlatformNormalize parses a string presenting a store platform.

--- a/core/charm/origin_test.go
+++ b/core/charm/origin_test.go
@@ -73,6 +73,14 @@ func (s platformSuite) TestParsePlatform(c *gc.C) {
 			Series:       "series",
 		},
 	}, {
+		Name:  "architecture, os, version and risk",
+		Value: "amd64/os/version/risk",
+		Expected: charm.Platform{
+			Architecture: "amd64",
+			OS:           "os",
+			Series:       "version/risk",
+		},
+	}, {
 		Name:  "architecture, unknown os and series",
 		Value: "amd64/unknown/series",
 		Expected: charm.Platform{
@@ -126,6 +134,10 @@ func (s platformSuite) TestString(c *gc.C) {
 		Name:     "architecture, os and series",
 		Value:    "amd64/os/series",
 		Expected: "amd64/os/series",
+	}, {
+		Name:     "architecture, os, version and risk",
+		Value:    "amd64/os/version/risk",
+		Expected: "amd64/os/version/risk",
 	}}
 	for k, test := range tests {
 		c.Logf("test %q at %d", test.Name, k)


### PR DESCRIPTION
The following ensures that we handle the version correctly when
installing a charm. Currently, we get a series from the charm URL and we
actually need the version. The following code gets the version from the
series and drops the channel risk on the floor.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model seven --config charmhub-url="https://api.staging.charmhub.io"
$ juju deploy facundo-snappass-test  
```
