### PR TITLE
Merge 2.8 20210416

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -818,7 +818,7 @@ func (c *Client) buildConfigSpec(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		device, err := c.addNetworkDevice(ctx, &spec, networkReference, networkDevice.MAC, dvportgroupConfig)
+		device, err := c.addNetworkDevice(ctx, &spec, networkReference, networkDevice.MAC, dvportgroupConfig, int32(i+1))
 		if err != nil {
 			return nil, errors.Annotatef(err, "adding network device %d - network %s", i, network)
 		}

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -540,6 +540,7 @@ func (c *Client) addNetworkDevice(
 	network *mo.Network,
 	mac string,
 	dvportgroupConfig map[types.ManagedObjectReference]types.DVPortgroupConfigInfo,
+	idx int32,
 ) (*types.VirtualVmxnet3, error) {
 	var networkBacking types.BaseVirtualDeviceBackingInfo
 	if dvportgroupConfigInfo, ok := dvportgroupConfig[network.Reference()]; !ok {
@@ -575,6 +576,7 @@ func (c *Client) addNetworkDevice(
 	wakeOnLan := true
 	networkDevice.WakeOnLanEnabled = &wakeOnLan
 	networkDevice.Backing = networkBacking
+	networkDevice.Key = -idx // negative to avoid conflicts
 	if mac != "" {
 		if !VerifyMAC(mac) {
 			return nil, fmt.Errorf("Invalid MAC address: %q", mac)

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -487,6 +487,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 
 	var networkDevice1, networkDevice2 types.VirtualVmxnet3
 	wakeOnLan := true
+	networkDevice1.Key = -1
 	networkDevice1.WakeOnLanEnabled = &wakeOnLan
 	networkDevice1.Connectable = &types.VirtualDeviceConnectInfo{
 		StartConnected:    true,
@@ -500,6 +501,7 @@ func (s *clientSuite) TestCreateVirtualMachineMultipleNetworksSpecifiedFirstDefa
 		},
 	}
 
+	networkDevice2.Key = -2
 	networkDevice2.WakeOnLanEnabled = &wakeOnLan
 	networkDevice2.Connectable = &types.VirtualDeviceConnectInfo{
 		StartConnected:    true,
@@ -568,6 +570,7 @@ func (s *clientSuite) TestCreateVirtualMachineNetworkSpecifiedDVPortgroup(c *gc.
 
 	var networkDevice types.VirtualVmxnet3
 	wakeOnLan := true
+	networkDevice.Key = -1
 	networkDevice.WakeOnLanEnabled = &wakeOnLan
 	networkDevice.Connectable = &types.VirtualDeviceConnectInfo{
 		StartConnected:    true,


### PR DESCRIPTION
Merge 2.8 with:

#12864  fix for bootstrap fail on vsphere 7 + multi network

Conflicts (accept 2.9 version)
```
#       caas/kubernetes/provider/ingress.go
#       caas/kubernetes/provider/ingress_test.go

```

## QA steps

See PR