### PR TITLE
Initial work to allow juju trust for sidecar charms

### DIFF
--- a/api/caasunitprovisioner/client_test.go
+++ b/api/caasunitprovisioner/client_test.go
@@ -512,3 +512,55 @@ func (s *unitprovisionerSuite) TestClearApplicationResources(c *gc.C) {
 	err := client.ClearApplicationResources("gitlab")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
+
+func (s *unitprovisionerSuite) TestWatchApplicationTrustHash(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "WatchApplicationsTrustHash")
+		c.Assert(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: "application-gitlab",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
+		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
+			Results: []params.StringsWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	watcher, err := client.WatchApplicationTrustHash("gitlab")
+	c.Assert(watcher, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "FAIL")
+}
+
+func (s *unitprovisionerSuite) TestApplicationTrust(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "CAASUnitProvisioner")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "ApplicationsTrust")
+		c.Assert(arg, jc.DeepEquals, params.Entities{
+			Entities: []params.Entity{{
+				Tag: "application-gitlab",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.BoolResults{})
+		*(result.(*params.BoolResults)) = params.BoolResults{
+			Results: []params.BoolResult{{
+				Result: true,
+			}},
+		}
+		return nil
+	})
+
+	client := caasunitprovisioner.NewClient(apiCaller)
+	trust, err := client.ApplicationTrust("gitlab")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(trust, jc.IsTrue)
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -34,7 +34,7 @@ var facadeVersions = map[string]int{
 	"CAASOperator":                 1,
 	"CAASOperatorProvisioner":      1,
 	"CAASOperatorUpgrader":         1,
-	"CAASUnitProvisioner":          1,
+	"CAASUnitProvisioner":          2,
 	"CharmHub":                     1,
 	"CharmRevisionUpdater":         2,
 	"Charms":                       4,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -198,7 +198,7 @@ func AllFacades() *facade.Registry {
 	reg("CAASModelOperator", 1, caasmodeloperator.NewAPIFromContext)
 	reg("CAASOperatorProvisioner", 1, caasoperatorprovisioner.NewStateCAASOperatorProvisionerAPI)
 	reg("CAASOperatorUpgrader", 1, caasoperatorupgrader.NewStateCAASOperatorUpgraderAPI)
-	reg("CAASUnitProvisioner", 1, caasunitprovisioner.NewStateFacade)
+	reg("CAASUnitProvisioner", 2, caasunitprovisioner.NewStateFacade)
 	reg("CAASApplication", 1, caasapplication.NewStateFacade)
 	reg("CAASApplicationProvisioner", 1, caasapplicationprovisioner.NewStateCAASApplicationProvisionerAPI)
 

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -144,6 +144,7 @@ type mockApplication struct {
 	testing.Stub
 	life         state.Life
 	scaleWatcher *statetesting.MockNotifyWatcher
+	settingsWatcher *statetesting.MockStringsWatcher
 
 	tag        names.Tag
 	scale      int
@@ -182,6 +183,11 @@ func (a *mockApplication) SetScale(scale int, generation int64, force bool) erro
 	a.MethodCall(a, "SetScale", scale)
 	a.scale = scale
 	return nil
+}
+
+func (a *mockApplication) WatchConfigSettingsHash() state.StringsWatcher {
+	a.MethodCall(a, "WatchConfigSettingsHash")
+	return a.settingsWatcher
 }
 
 func (a *mockApplication) ClearResources() error {

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -74,6 +74,7 @@ type Model interface {
 type Application interface {
 	GetScale() int
 	SetScale(int, int64, bool) error
+	WatchConfigSettingsHash() state.StringsWatcher
 	WatchScale() state.NotifyWatcher
 	ApplicationConfig() (application.ConfigAttributes, error)
 	AllUnits() (units []Unit, err error)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -11227,7 +11227,7 @@
     {
         "Name": "CAASUnitProvisioner",
         "Description": "",
-        "Version": 1,
+        "Version": 2,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -11260,6 +11260,18 @@
                         }
                     },
                     "description": "ApplicationsScale returns the scaling info for specified applications in this model."
+                },
+                "ApplicationsTrust": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BoolResults"
+                        }
+                    },
+                    "description": "ApplicationsTrust returns the trust status for specified applications in this model."
                 },
                 "ClearApplicationsResources": {
                     "type": "object",
@@ -11365,6 +11377,18 @@
                         }
                     },
                     "description": "WatchApplicationsScale starts a NotifyWatcher to watch changes\nto the applications' scale."
+                },
+                "WatchApplicationsTrustHash": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    },
+                    "description": "WatchApplicationsTrustHash starts a StringsWatcher to watch changes\nto the applications' trust status."
                 },
                 "WatchPodSpec": {
                     "type": "object",
@@ -11494,6 +11518,36 @@
                         "ports",
                         "status",
                         "info"
+                    ]
+                },
+                "BoolResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "BoolResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BoolResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "ConfigResult": {
@@ -12136,6 +12190,21 @@
                     "additionalProperties": false,
                     "required": [
                         "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "UpdateApplicationServiceArg": {

--- a/caas/application.go
+++ b/caas/application.go
@@ -23,10 +23,14 @@ type Application interface {
 	Watch() (watcher.NotifyWatcher, error)
 	WatchReplicas() (watcher.NotifyWatcher, error)
 
-	// Scale scales the Application's unit to the value specificied. Scale must
+	// Scale scales the Application's unit to the value specified. Scale must
 	// be >= 0. Application units will be removed or added to meet the scale
 	// defined.
 	Scale(int) error
+
+	// Trust sets up the role on the application's service account to
+	// give full access to the cluster.
+	Trust(bool) error
 
 	State() (ApplicationState, error)
 	Units() ([]Unit, error)

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kr/pretty"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,6 +157,56 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		},
 	}
 	applier.Apply(&secret)
+
+	serviceAccount := resources.ServiceAccount{
+		ServiceAccount: corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        a.serviceAccountName(),
+				Namespace:   a.namespace,
+				Labels:      a.labels(),
+				Annotations: a.annotations(config),
+			},
+			// Will be automounted by the pod.
+			AutomountServiceAccountToken: boolPtr(false),
+		},
+	}
+	applier.Apply(&serviceAccount)
+
+	role := resources.Role{
+		Role: rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        a.serviceAccountName(),
+				Namespace:   a.namespace,
+				Labels:      a.labels(),
+				Annotations: a.annotations(config),
+			},
+			Rules: defaultApplicationRoles,
+		},
+	}
+	applier.Apply(&role)
+
+	roleBinding := resources.RoleBinding{
+		RoleBinding: rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        a.serviceAccountName(),
+				Namespace:   a.namespace,
+				Labels:      a.labels(),
+				Annotations: a.annotations(config),
+			},
+			RoleRef: rbacv1.RoleRef{
+				Name: a.serviceAccountName(),
+				Kind: "Role",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      a.serviceAccountName(),
+					Namespace: a.namespace,
+				},
+			},
+		},
+	}
+	applier.Apply(&roleBinding)
 
 	if err := a.configureDefaultService(a.annotations(config)); err != nil {
 		return errors.Annotatef(err, "ensuring the default service %q", a.name)
@@ -397,6 +448,9 @@ func (a *app) Exists() (caas.DeploymentState, error) {
 		{},
 		{"secret", a.secretExists, false},
 		{"service", a.serviceExists, false},
+		{"roleBinding", a.roleBindingExists, false},
+		{"role", a.roleExists, false},
+		{"serviceAccount", a.serviceAccountExists, false},
 	}
 	switch a.deploymentType {
 	case caas.DeploymentStateful:
@@ -670,6 +724,39 @@ func (a *app) serviceExists() (exists bool, terminating bool, err error) {
 	return true, ss.DeletionTimestamp != nil, nil
 }
 
+func (a *app) roleExists() (exists bool, terminating bool, err error) {
+	r := resources.NewRole(a.serviceAccountName(), a.namespace, nil)
+	err = r.Get(context.Background(), a.client)
+	if errors.IsNotFound(err) {
+		return false, false, nil
+	} else if err != nil {
+		return false, false, errors.Trace(err)
+	}
+	return true, r.DeletionTimestamp != nil, nil
+}
+
+func (a *app) roleBindingExists() (exists bool, terminating bool, err error) {
+	rb := resources.NewRoleBinding(a.serviceAccountName(), a.namespace, nil)
+	err = rb.Get(context.Background(), a.client)
+	if errors.IsNotFound(err) {
+		return false, false, nil
+	} else if err != nil {
+		return false, false, errors.Trace(err)
+	}
+	return true, rb.DeletionTimestamp != nil, nil
+}
+
+func (a *app) serviceAccountExists() (exists bool, terminating bool, err error) {
+	sa := resources.NewServiceAccount(a.serviceAccountName(), a.namespace, nil)
+	err = sa.Get(context.Background(), a.client)
+	if errors.IsNotFound(err) {
+		return false, false, nil
+	} else if err != nil {
+		return false, false, errors.Trace(err)
+	}
+	return true, sa.DeletionTimestamp != nil, nil
+}
+
 // Delete deletes the specified application.
 func (a *app) Delete() error {
 	logger.Debugf("deleting %s application", a.name)
@@ -687,6 +774,9 @@ func (a *app) Delete() error {
 	}
 	applier.Delete(resources.NewService(a.name, a.namespace, nil))
 	applier.Delete(resources.NewSecret(a.secretName(), a.namespace, nil))
+	applier.Delete(resources.NewRoleBinding(a.serviceAccountName(), a.namespace, nil))
+	applier.Delete(resources.NewRole(a.serviceAccountName(), a.namespace, nil))
+	applier.Delete(resources.NewServiceAccount(a.serviceAccountName(), a.namespace, nil))
 	return applier.Run(context.Background(), a.client, false)
 }
 
@@ -827,6 +917,10 @@ func (a *app) Units() ([]caas.Unit, error) {
 			vol, ok := volumesByName[volMount.Name]
 			if !ok {
 				logger.Warningf("volume for volume mount %q not found", volMount.Name)
+				continue
+			}
+			if vol.Secret != nil && strings.HasPrefix(vol.Secret.SecretName, a.name+"-token") {
+				logger.Tracef("ignoring volume source for service account secret: %v", vol.Name)
 				continue
 			}
 			fsInfo, err := storage.FilesystemInfo(ctx, a.client, a.namespace, vol, volMount, now)
@@ -1035,9 +1129,10 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		nodeSelector = map[string]string{"kubernetes.io/arch": cpuArch}
 	}
 
-	automountToken := false
+	automountToken := true
 	return &corev1.PodSpec{
 		AutomountServiceAccountToken: &automountToken,
+		ServiceAccountName:           a.serviceAccountName(),
 		NodeSelector:                 nodeSelector,
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",
@@ -1136,6 +1231,10 @@ func (a *app) fieldSelector() string {
 
 func (a *app) secretName() string {
 	return a.name + "-application-config"
+}
+
+func (a *app) serviceAccountName() string {
+	return a.name
 }
 
 type annotationGetter interface {

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -208,7 +208,8 @@ func (s *applicationSuite) assertEnsure(c *gc.C, deploymentType caas.DeploymentT
 func getPodSpec(c *gc.C) corev1.PodSpec {
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
-		AutomountServiceAccountToken: application.BoolPtr(false),
+		ServiceAccountName: "gitlab",
+		AutomountServiceAccountToken: application.BoolPtr(true),
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",
 			ImagePullPolicy: corev1.PullIfNotPresent,
@@ -753,6 +754,9 @@ func (s *applicationSuite) TestDeleteStateful(c *gc.C) {
 		s.applier.EXPECT().Delete(resources.NewService("gitlab-endpoints", "test", nil)),
 		s.applier.EXPECT().Delete(resources.NewService("gitlab", "test", nil)),
 		s.applier.EXPECT().Delete(resources.NewSecret("gitlab-application-config", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewRoleBinding("gitlab", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewRole("gitlab", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewServiceAccount("gitlab", "test", nil)),
 		s.applier.EXPECT().Run(context.Background(), s.client, false).Return(nil),
 	)
 	c.Assert(app.Delete(), jc.ErrorIsNil)
@@ -766,6 +770,9 @@ func (s *applicationSuite) TestDeleteStateless(c *gc.C) {
 		s.applier.EXPECT().Delete(resources.NewDeployment("gitlab", "test", nil)),
 		s.applier.EXPECT().Delete(resources.NewService("gitlab", "test", nil)),
 		s.applier.EXPECT().Delete(resources.NewSecret("gitlab-application-config", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewRoleBinding("gitlab", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewRole("gitlab", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewServiceAccount("gitlab", "test", nil)),
 		s.applier.EXPECT().Run(context.Background(), s.client, false).Return(nil),
 	)
 	c.Assert(app.Delete(), jc.ErrorIsNil)
@@ -779,6 +786,9 @@ func (s *applicationSuite) TestDeleteDaemon(c *gc.C) {
 		s.applier.EXPECT().Delete(resources.NewDaemonSet("gitlab", "test", nil)),
 		s.applier.EXPECT().Delete(resources.NewService("gitlab", "test", nil)),
 		s.applier.EXPECT().Delete(resources.NewSecret("gitlab-application-config", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewRoleBinding("gitlab", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewRole("gitlab", "test", nil)),
+		s.applier.EXPECT().Delete(resources.NewServiceAccount("gitlab", "test", nil)),
 		s.applier.EXPECT().Run(context.Background(), s.client, false).Return(nil),
 	)
 	c.Assert(app.Delete(), jc.ErrorIsNil)

--- a/caas/kubernetes/provider/application/trust.go
+++ b/caas/kubernetes/provider/application/trust.go
@@ -1,0 +1,62 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var defaultApplicationRoles = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods", "services"},
+		Verbs: []string{
+			"get",
+			"list",
+			"patch",
+		},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"pods/exec"},
+		Verbs: []string{
+			"create",
+		},
+	},
+}
+
+var fullAccessApplicationRoles = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{rbacv1.APIGroupAll},
+		Resources: []string{rbacv1.ResourceAll},
+		Verbs:     []string{rbacv1.VerbAll},
+	},
+}
+
+// Trust updates application roles to give full access to the cluster
+// by patching the role used for the application pod service account.
+func (a *app) Trust(trust bool) error {
+	logger.Debugf("application %q, trust %v", a.name, trust)
+
+	rules := defaultApplicationRoles
+	if trust {
+		rules = fullAccessApplicationRoles
+	}
+
+	api := a.client.RbacV1().Roles(a.namespace)
+	role, err := api.Get(context.Background(), a.serviceAccountName(), metav1.GetOptions{})
+	if err != nil {
+		return errors.Annotatef(err, "getting service account role %q", a.serviceAccountName())
+	}
+	role.Rules = rules
+
+	roleResource := resources.NewRole(role.Name, role.Namespace, role)
+	err = roleResource.Apply(context.Background(), a.client)
+	return errors.Annotatef(err, "setting rules to %v for role %q", rules, a.serviceAccountName())
+}

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas"
+)
+
+type trustSuite struct {
+	applicationSuite
+}
+
+var _ = gc.Suite(&trustSuite{})
+
+func (s *trustSuite) TestTrust(c *gc.C) {
+	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	defer ctrl.Finish()
+
+	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.appName,
+			Namespace: s.namespace,
+		},
+	}, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = app.Trust(true)
+	c.Assert(err, jc.ErrorIsNil)
+	role, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		},
+	})
+}
+
+func (s *trustSuite) TestRemoveTrust(c *gc.C) {
+	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	defer ctrl.Finish()
+
+	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.appName,
+			Namespace: s.namespace,
+		},
+	}, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = app.Trust(false)
+	c.Assert(err, jc.ErrorIsNil)
+	role, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "services"},
+			Verbs:     []string{"get", "list", "patch"},
+		}, {
+			APIGroups:[]string{""},
+			Resources:[]string{"pods/exec"},
+			Verbs:[]string{"create"},
+		},
+	})
+}

--- a/caas/kubernetes/provider/resources/role.go
+++ b/caas/kubernetes/provider/resources/role.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
+)
+
+// Role extends the k8s role.
+type Role struct {
+	rbacv1.Role
+}
+
+// NewRole creates a new role resource.
+func NewRole(name string, namespace string, in *rbacv1.Role) *Role {
+	if in == nil {
+		in = &rbacv1.Role{}
+	}
+	in.SetName(name)
+	in.SetNamespace(namespace)
+	return &Role{*in}
+}
+
+// Clone returns a copy of the resource.
+func (r *Role) Clone() Resource {
+	clone := *r
+	return &clone
+}
+
+// Apply patches the resource change.
+func (r *Role) Apply(ctx context.Context, client kubernetes.Interface) error {
+	api := client.RbacV1().Roles(r.Namespace)
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &r.Role)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	res, err := api.Patch(ctx, r.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+		FieldManager: JujuFieldManager,
+	})
+	if k8serrors.IsNotFound(err) {
+		res, err = api.Create(ctx, &r.Role, metav1.CreateOptions{
+			FieldManager: JujuFieldManager,
+		})
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	r.Role = *res
+	return nil
+}
+
+// Get refreshes the resource.
+func (r *Role) Get(ctx context.Context, client kubernetes.Interface) error {
+	api := client.RbacV1().Roles(r.Namespace)
+	res, err := api.Get(ctx, r.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NewNotFound(err, "k8s")
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	r.Role = *res
+	return nil
+}
+
+// Delete removes the resource.
+func (r *Role) Delete(ctx context.Context, client kubernetes.Interface) error {
+	api := client.RbacV1().Roles(r.Namespace)
+	err := api.Delete(ctx, r.Name, metav1.DeleteOptions{
+		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// Events emitted by the resource.
+func (r *Role) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, client, r.Namespace, r.Name, "ServiceAccount")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (r *Role) ComputeStatus(_ context.Context, _ kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if r.DeletionTimestamp != nil {
+		return "", status.Terminated, r.DeletionTimestamp.Time, nil
+	}
+	return "", status.Active, now, nil
+}

--- a/caas/kubernetes/provider/resources/role_test.go
+++ b/caas/kubernetes/provider/resources/role_test.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources_test
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
+)
+
+type roleSuite struct {
+	resourceSuite
+}
+
+var _ = gc.Suite(&roleSuite{})
+
+func (s *roleSuite) TestApply(c *gc.C) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "role1",
+			Namespace: "test",
+		},
+	}
+	// Create.
+	roleResource := resources.NewRole("role1", "test", role)
+	c.Assert(roleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	result, err := s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
+
+	// Update.
+	role.SetAnnotations(map[string]string{"a": "b"})
+	roleResource = resources.NewRole("role1", "test", role)
+	c.Assert(roleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+
+	result, err = s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `role1`)
+	c.Assert(result.GetNamespace(), gc.Equals, `test`)
+	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *roleSuite) TestGet(c *gc.C) {
+	template := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "role1",
+			Namespace: "test",
+		},
+	}
+	role1 := template
+	role1.SetAnnotations(map[string]string{"a": "b"})
+	_, err := s.client.RbacV1().Roles("test").Create(context.TODO(), &role1, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	roleResource := resources.NewRole("role1", "test", &template)
+	c.Assert(len(roleResource.GetAnnotations()), gc.Equals, 0)
+	err = roleResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(roleResource.GetName(), gc.Equals, `role1`)
+	c.Assert(roleResource.GetNamespace(), gc.Equals, `test`)
+	c.Assert(roleResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *roleSuite) TestDelete(c *gc.C) {
+	role := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "role1",
+			Namespace: "test",
+		},
+	}
+	_, err := s.client.RbacV1().Roles("test").Create(context.TODO(), &role, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `role1`)
+
+	roleResource := resources.NewRole("role1", "test", &role)
+	err = roleResource.Delete(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = roleResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = s.client.RbacV1().Roles("test").Get(context.TODO(), "role1", metav1.GetOptions{})
+	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
+}

--- a/caas/kubernetes/provider/resources/rolebinding.go
+++ b/caas/kubernetes/provider/resources/rolebinding.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
+)
+
+// RoleBinding extends the k8s role binding.
+type RoleBinding struct {
+	rbacv1.RoleBinding
+}
+
+// NewRoleBinding creates a new role resource.
+func NewRoleBinding(name string, namespace string, in *rbacv1.RoleBinding) *RoleBinding {
+	if in == nil {
+		in = &rbacv1.RoleBinding{}
+	}
+	in.SetName(name)
+	in.SetNamespace(namespace)
+	return &RoleBinding{*in}
+}
+
+// Clone returns a copy of the resource.
+func (rb *RoleBinding) Clone() Resource {
+	clone := *rb
+	return &clone
+}
+
+// Apply patches the resource change.
+func (rb *RoleBinding) Apply(ctx context.Context, client kubernetes.Interface) error {
+	api := client.RbacV1().RoleBindings(rb.Namespace)
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &rb.RoleBinding)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	res, err := api.Patch(ctx, rb.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+		FieldManager: JujuFieldManager,
+	})
+	if k8serrors.IsNotFound(err) {
+		res, err = api.Create(ctx, &rb.RoleBinding, metav1.CreateOptions{
+			FieldManager: JujuFieldManager,
+		})
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rb.RoleBinding = *res
+	return nil
+}
+
+// Get refreshes the resource.
+func (rb *RoleBinding) Get(ctx context.Context, client kubernetes.Interface) error {
+	api := client.RbacV1().RoleBindings(rb.Namespace)
+	res, err := api.Get(ctx, rb.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NewNotFound(err, "k8s")
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	rb.RoleBinding = *res
+	return nil
+}
+
+// Delete removes the resource.
+func (rb *RoleBinding) Delete(ctx context.Context, client kubernetes.Interface) error {
+	api := client.RbacV1().RoleBindings(rb.Namespace)
+	err := api.Delete(ctx, rb.Name, metav1.DeleteOptions{
+		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// Events emitted by the resource.
+func (rb *RoleBinding) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, client, rb.Namespace, rb.Name, "ServiceAccount")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (rb *RoleBinding) ComputeStatus(_ context.Context, _ kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if rb.DeletionTimestamp != nil {
+		return "", status.Terminated, rb.DeletionTimestamp.Time, nil
+	}
+	return "", status.Active, now, nil
+}

--- a/caas/kubernetes/provider/resources/rolebinding_test.go
+++ b/caas/kubernetes/provider/resources/rolebinding_test.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources_test
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
+)
+
+type roleBindingSuite struct {
+	resourceSuite
+}
+
+var _ = gc.Suite(&roleBindingSuite{})
+
+func (s *roleBindingSuite) TestApply(c *gc.C) {
+	RoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "roleBinding1",
+			Namespace: "test",
+		},
+	}
+	// Create.
+	rbResource := resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
+	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	result, err := s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
+
+	// Update.
+	RoleBinding.SetAnnotations(map[string]string{"a": "b"})
+	rbResource = resources.NewRoleBinding("roleBinding1", "test", RoleBinding)
+	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+
+	result, err = s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
+	c.Assert(result.GetNamespace(), gc.Equals, `test`)
+	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *roleBindingSuite) TestGet(c *gc.C) {
+	template := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "roleBinding1",
+			Namespace: "test",
+		},
+	}
+	roleBinding1 := template
+	roleBinding1.SetAnnotations(map[string]string{"a": "b"})
+	_, err := s.client.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	rbResource := resources.NewRoleBinding("roleBinding1", "test", &template)
+	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
+	err = rbResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rbResource.GetName(), gc.Equals, `roleBinding1`)
+	c.Assert(rbResource.GetNamespace(), gc.Equals, `test`)
+	c.Assert(rbResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *roleBindingSuite) TestDelete(c *gc.C) {
+	roleBinding := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "roleBinding1",
+			Namespace: "test",
+		},
+	}
+	_, err := s.client.RbacV1().RoleBindings("test").Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
+
+	rbResource := resources.NewRoleBinding("roleBinding1", "test", &roleBinding)
+	err = rbResource.Delete(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = rbResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = s.client.RbacV1().RoleBindings("test").Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
+	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
+}

--- a/caas/kubernetes/provider/resources/serviceaccount.go
+++ b/caas/kubernetes/provider/resources/serviceaccount.go
@@ -1,0 +1,104 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/status"
+)
+
+// ServiceAccount extends the k8s service account.
+type ServiceAccount struct {
+	corev1.ServiceAccount
+}
+
+// NewServiceAccount creates a new service account resource.
+func NewServiceAccount(name string, namespace string, in *corev1.ServiceAccount) *ServiceAccount {
+	if in == nil {
+		in = &corev1.ServiceAccount{}
+	}
+	in.SetName(name)
+	in.SetNamespace(namespace)
+	return &ServiceAccount{*in}
+}
+
+// Clone returns a copy of the resource.
+func (sa *ServiceAccount) Clone() Resource {
+	clone := *sa
+	return &clone
+}
+
+// Apply patches the resource change.
+func (sa *ServiceAccount) Apply(ctx context.Context, client kubernetes.Interface) error {
+	api := client.CoreV1().ServiceAccounts(sa.Namespace)
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, &sa.ServiceAccount)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	res, err := api.Patch(ctx, sa.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+		FieldManager: JujuFieldManager,
+	})
+	if k8serrors.IsNotFound(err) {
+		res, err = api.Create(ctx, &sa.ServiceAccount, metav1.CreateOptions{
+			FieldManager: JujuFieldManager,
+		})
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	sa.ServiceAccount = *res
+	return nil
+}
+
+// Get refreshes the resource.
+func (sa *ServiceAccount) Get(ctx context.Context, client kubernetes.Interface) error {
+	api := client.CoreV1().ServiceAccounts(sa.Namespace)
+	res, err := api.Get(ctx, sa.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return errors.NewNotFound(err, "k8s")
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	sa.ServiceAccount = *res
+	return nil
+}
+
+// Delete removes the resource.
+func (sa *ServiceAccount) Delete(ctx context.Context, client kubernetes.Interface) error {
+	api := client.CoreV1().ServiceAccounts(sa.Namespace)
+	err := api.Delete(ctx, sa.Name, metav1.DeleteOptions{
+		PropagationPolicy: k8sconstants.DefaultPropagationPolicy(),
+	})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// Events emitted by the resource.
+func (sa *ServiceAccount) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
+	return ListEventsForObject(ctx, client, sa.Namespace, sa.Name, "ServiceAccount")
+}
+
+// ComputeStatus returns a juju status for the resource.
+func (sa *ServiceAccount) ComputeStatus(_ context.Context, _ kubernetes.Interface, now time.Time) (string, status.Status, time.Time, error) {
+	if sa.DeletionTimestamp != nil {
+		return "", status.Terminated, sa.DeletionTimestamp.Time, nil
+	}
+	return "", status.Active, now, nil
+}

--- a/caas/kubernetes/provider/resources/serviceaccount_test.go
+++ b/caas/kubernetes/provider/resources/serviceaccount_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources_test
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
+)
+
+type serviceAccountSuite struct {
+	resourceSuite
+}
+
+var _ = gc.Suite(&serviceAccountSuite{})
+
+func (s *serviceAccountSuite) TestApply(c *gc.C) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa1",
+			Namespace: "test",
+		},
+	}
+	// Create.
+	saResource := resources.NewServiceAccount("sa1", "test", sa)
+	c.Assert(saResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(result.GetAnnotations()), gc.Equals, 0)
+
+	// Update.
+	sa.SetAnnotations(map[string]string{"a": "b"})
+	saResource = resources.NewServiceAccount("sa1", "test", sa)
+	c.Assert(saResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
+
+	result, err = s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `sa1`)
+	c.Assert(result.GetNamespace(), gc.Equals, `test`)
+	c.Assert(result.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *serviceAccountSuite) TestGet(c *gc.C) {
+	template := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa1",
+			Namespace: "test",
+		},
+	}
+	sa1 := template
+	sa1.SetAnnotations(map[string]string{"a": "b"})
+	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa1, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	saResource := resources.NewServiceAccount("sa1", "test", &template)
+	c.Assert(len(saResource.GetAnnotations()), gc.Equals, 0)
+	err = saResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(saResource.GetName(), gc.Equals, `sa1`)
+	c.Assert(saResource.GetNamespace(), gc.Equals, `test`)
+	c.Assert(saResource.GetAnnotations(), gc.DeepEquals, map[string]string{"a": "b"})
+}
+
+func (s *serviceAccountSuite) TestDelete(c *gc.C) {
+	sa := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa1",
+			Namespace: "test",
+		},
+	}
+	_, err := s.client.CoreV1().ServiceAccounts("test").Create(context.TODO(), &sa, metav1.CreateOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.GetName(), gc.Equals, `sa1`)
+
+	saResource := resources.NewServiceAccount("sa1", "test", &sa)
+	err = saResource.Delete(context.TODO(), s.client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = saResource.Get(context.TODO(), s.client)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = s.client.CoreV1().ServiceAccounts("test").Get(context.TODO(), "sa1", metav1.GetOptions{})
+	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
+}

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -106,6 +106,20 @@ func (mr *MockApplicationMockRecorder) State() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockApplication)(nil).State))
 }
 
+// Trust mocks base method
+func (m *MockApplication) Trust(arg0 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Trust", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Trust indicates an expected call of Trust
+func (mr *MockApplicationMockRecorder) Trust(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trust", reflect.TypeOf((*MockApplication)(nil).Trust), arg0)
+}
+
 // Units mocks base method
 func (m *MockApplication) Units() ([]caas.Unit, error) {
 	m.ctrl.T.Helper()

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5036,3 +5036,32 @@ deployment:
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(embedded, jc.IsFalse)
 }
+
+func (s *ApplicationSuite) TestWatchApplicationConfigSettingsHash(c *gc.C) {
+	w := s.mysql.WatchConfigSettingsHash()
+	defer testing.AssertStop(c, w)
+
+	wc := testing.NewStringsWatcherC(c, s.State, w)
+	wc.AssertChange("1e11259677ef769e0ec4076b873c76dcc3a54be7bc651b081d0f0e2b87077717")
+
+	schema := environschema.Fields{
+		"username":    environschema.Attr{Type: environschema.Tstring},
+		"alive":       environschema.Attr{Type: environschema.Tbool},
+		"skill-level": environschema.Attr{Type: environschema.Tint},
+		"options":     environschema.Attr{Type: environschema.Tattrs},
+	}
+
+	err := s.mysql.UpdateApplicationConfig(application.ConfigAttributes{
+		"username":    "abbas",
+		"alive":       true,
+		"skill-level": 23,
+		"options": map[string]string{
+			"fortuna": "crescis",
+			"luna":    "velut",
+			"status":  "malus",
+		},
+	}, nil, schema, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wc.AssertChange("e1471e8a7299da0ac2150445ffc6d08d9d801194037d88416c54b01899b8a9b2")
+}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -4260,6 +4260,13 @@ func (a *Application) WatchServiceAddressesHash() StringsWatcher {
 	return w
 }
 
+// WatchConfigSettingsHash returns a watcher that yields a hash of the
+// application's config settings whenever they are changed.
+func (a *Application) WatchConfigSettingsHash() StringsWatcher {
+	applicationConfigKey := applicationConfigKey(a.Name())
+	return newSettingsHashWatcher(a.st, applicationConfigKey)
+}
+
 func hashServiceAddresses(a *Application, firstCall bool) (string, error) {
 	service, err := a.ServiceInfo()
 	if errors.IsNotFound(err) && firstCall {

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -103,6 +103,9 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 	appScaleChan := make(chan struct{}, 1)
 	appScaleWatcher := watchertest.NewMockNotifyWatcher(appScaleChan)
 
+	appTrustHashChan := make(chan []string, 1)
+	appTrushHashWatcher := watchertest.NewMockStringsWatcher(appTrustHashChan)
+
 	brokerApp := caasmocks.NewMockApplication(ctrl)
 	broker := mocks.NewMockCAASBroker(ctrl)
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
@@ -125,6 +128,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 		),
 
 		unitFacade.EXPECT().WatchApplicationScale("test").Return(appScaleWatcher, nil),
+		unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(appTrushHashWatcher, nil),
 
 		// Initial run - Ensure() for the application.
 		facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {

--- a/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
@@ -48,6 +48,21 @@ func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationScale(arg0 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationScale", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationScale), arg0)
 }
 
+// ApplicationTrust mocks base method
+func (m *MockCAASUnitProvisionerFacade) ApplicationTrust(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplicationTrust", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplicationTrust indicates an expected call of ApplicationTrust
+func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationTrust(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTrust", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationTrust), arg0)
+}
+
 // WatchApplicationScale mocks base method
 func (m *MockCAASUnitProvisionerFacade) WatchApplicationScale(arg0 string) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
@@ -61,4 +76,19 @@ func (m *MockCAASUnitProvisionerFacade) WatchApplicationScale(arg0 string) (watc
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) WatchApplicationScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationScale", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).WatchApplicationScale), arg0)
+}
+
+// WatchApplicationTrustHash mocks base method
+func (m *MockCAASUnitProvisionerFacade) WatchApplicationTrustHash(arg0 string) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchApplicationTrustHash", arg0)
+	ret0, _ := ret[0].(watcher.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchApplicationTrustHash indicates an expected call of WatchApplicationTrustHash
+func (mr *MockCAASUnitProvisionerFacadeMockRecorder) WatchApplicationTrustHash(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationTrustHash", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).WatchApplicationTrustHash), arg0)
 }

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -32,6 +32,8 @@ var _ logger = struct{}{}
 type CAASUnitProvisionerFacade interface {
 	ApplicationScale(string) (int, error)
 	WatchApplicationScale(string) (watcher.NotifyWatcher, error)
+	ApplicationTrust(string) (bool, error)
+	WatchApplicationTrustHash(string) (watcher.StringsWatcher, error)
 }
 
 // CAASProvisionerFacade exposes CAAS provisioning functionality to a worker.

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -799,6 +799,9 @@ func (ctx *HookContext) GetRawK8sSpec() (string, error) {
 // CloudSpec return the cloud specification for the running unit's model.
 // Implements jujuc.HookContext.ContextUnit, part of runner.Context.
 func (ctx *HookContext) CloudSpec() (*params.CloudSpec, error) {
+	if ctx.modelType == model.CAAS {
+		return nil, errors.NotSupportedf("credential-get on a %q model", model.CAAS)
+	}
 	var err error
 	ctx.cloudSpec, err = ctx.state.CloudSpec()
 	if err != nil {


### PR DESCRIPTION
Add support for `juju trust` with sidecar charms.
This needed extra work to create, for each deployed application, a service account, roles, and rolebindings. The application pod is then given this service account rather than the cluster default. The initial role policy rules are the same as those used for pod spec charms. 

Still need to implement this for pod spec charms

Also, a bigger issue is that the unit agent and k8s application provisioner workers both watch for trust changes separately. So the uniter agent might fire the config-change hook to signal a trust change before the provisioner has updated the service account roles. This will need to be addressed.

## QA steps

```
juju bootstrap microk8s --config logging-config="juju.kubernetes.provider.application=DEBUG"
juju deploy facundo-snappass-test
```

Check application pod has service account set
```
kubectl -n controller-ian get -o json pod/facundo-snappass-test-0 | jq .spec.serviceAccount
facundo-snappass-test
```

Check app service account, role bindings, roles are created.
```
kubectl -n controller-ian get -o json serviceaccount/facundo-snappass-test
kubectl -n controller-ian get -o json roles/facundo-snappass-test
kubectl -n controller-ian get -o json rolebindings/facundo-snappass-test
```

Trust the app
```
juju trust facundo-snappass-test
```
Debug logs should have
```
DEBUG juju.kubernetes.provider.application Application "facundo-snappass-test", trust true
```

Role should have new rules:
```
kubectl -n controller-ian get -o json roles/facundo-snappass-test : jq .rules
[
    {
        "apiGroups": [
            "*"
        ],
        "resources": [
            "*"
        ],
        "verbs": [
            "*"
        ]
    }
]

```

Remove trust:

```
juju trust facundo-snappass-test --remove
kubectl -n controller-ian get -o json roles/facundo-snappass-test | jq .rules
[
  {
    "apiGroups": [
      ""
    ],
    "resources": [
      "pods",
      "services"
    ],
    "verbs": [
      "get",
      "list",
      "patch"
    ]
  },
  {
    "apiGroups": [
      ""
    ],
    "resources": [
      "pods/exec"
    ],
    "verbs": [
      "create"
    ]
  }
]
```



