### PR TITLE
Ignore projected volume mounts when looking up juju storage

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -923,6 +923,10 @@ func (a *app) Units() ([]caas.Unit, error) {
 				logger.Tracef("ignoring volume source for service account secret: %v", vol.Name)
 				continue
 			}
+			if vol.Projected != nil {
+				logger.Tracef("ignoring volume source for projected volume: %v", vol.Name)
+				continue
+			}
 			fsInfo, err := storage.FilesystemInfo(ctx, a.client, a.namespace, vol, volMount, now)
 			if err != nil {
 				return nil, errors.Annotatef(err, "finding filesystem info for %v", volMount.Name)


### PR DESCRIPTION
A recent PR #12883 added juju trust support which also activated mounting of service account secrets.
Newer k8s do this as a projected volume so that needs to be added to the ignore list when looping over volume mounts.

## QA steps

Deploy the latest charmed k8s, add it as a cloud to juju, and deploy a sidecar charm.