### PR TITLE
Fix passing empty string container name to unit params;

### DIFF
--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"path"
-	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
@@ -36,8 +35,6 @@ type initCommand struct {
 
 	dataDir string
 	binDir  string
-
-	containerNames []string
 }
 
 // ApplicationAPI provides methods for unit introduction.
@@ -88,7 +85,6 @@ func (c *initCommand) Init(args []string) error {
 	if c.binDir == "" {
 		return errors.NotValidf("--bin-dir")
 	}
-	c.containerNames = strings.Split(c.environment.Getenv("JUJU_CONTAINER_NAMES"), ",")
 	return c.CommandBase.Init(args)
 }
 

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -102,7 +102,6 @@ apiport: 17070`[1:])
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/jujuc", os.FileMode(0755)).Return(NopWriteCloser(jujucWritten), nil)
 
 	gomock.InOrder(
-		s.environment.EXPECT().Getenv("JUJU_CONTAINER_NAMES").Return("gitlab,proxy"),
 		s.applicationAPI.EXPECT().UnitIntroduction(`gitlab-0`, `gitlab-uuid`).Times(1).Return(&caasapplication.UnitConfig{
 			UnitTag:   names.NewUnitTag("gitlab/0"),
 			AgentConf: data,

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -52,7 +52,6 @@ type containerUnitAgent struct {
 	clk              clock.Clock
 	runner           *worker.Runner
 	bufferedLogger   *logsender.BufferedLogWriter
-	setupLogging     func(agent.Config) error
 	ctx              *cmd.Context
 	dead             chan struct{}
 	errReason        error
@@ -187,8 +186,10 @@ func (c *containerUnitAgent) Init(args []string) error {
 	if err := c.ensureToolSymlinks(srcDir, dataDir, unitTag); err != nil {
 		return errors.Annotate(err, "ensuring agent tool symlinks")
 	}
-
-	c.containerNames = strings.Split(c.environment.Getenv("JUJU_CONTAINER_NAMES"), ",")
+	containerNames := c.environment.Getenv("JUJU_CONTAINER_NAMES")
+	if len(containerNames) > 0 {
+		c.containerNames = strings.Split(containerNames, ",")
+	}
 	return nil
 }
 

--- a/cmd/containeragent/unit/agent_test.go
+++ b/cmd/containeragent/unit/agent_test.go
@@ -122,6 +122,43 @@ func (s *containerUnitAgentSuite) TestParseSuccess(c *gc.C) {
 	c.Assert(s.cmd.CurrentConfig().Controller().String(), jc.DeepEquals, `controller-deadbeef-1bad-500d-9000-4b1d0d06f00d`)
 	c.Assert(s.cmd.CurrentConfig().Model().String(), jc.DeepEquals, `model-deadbeef-0bad-400d-8000-4b1d0d06f00d`)
 	c.Assert(s.cmd.CharmModifiedVersion(), gc.Equals, 10)
+	c.Assert(s.cmd.GetContainerNames(), jc.DeepEquals, []string{"a", "b", "c"})
+}
+
+func (s *containerUnitAgentSuite) TestParseSuccessNoContainer(c *gc.C) {
+	ctrl := s.setupCommand(c, nil)
+	defer ctrl.Finish()
+
+	_ = s.prepareAgentConf(c, "wordpress")
+
+	toolsDir := filepath.Join(s.dataDir, "tools", "unit-wordpress-0")
+	gomock.InOrder(
+		s.environment.EXPECT().ExpandEnv("$PATH:test-bin").Return("old-path:test-bin"),
+		s.environment.EXPECT().Setenv("PATH", "old-path:test-bin").Return(nil),
+		s.environment.EXPECT().Unsetenv("DELETE").Return(nil),
+		s.fileReaderWriter.EXPECT().RemoveAll(toolsDir).Return(nil),
+		s.fileReaderWriter.EXPECT().MkdirAll(toolsDir, os.FileMode(0755)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.ContainerAgent)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuRun)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuIntrospect)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.Jujuc)).Return(nil),
+		s.environment.EXPECT().Getenv("JUJU_CONTAINER_NAMES").Return(""),
+	)
+
+	err := cmdtesting.InitCommand(s.cmd, []string{
+		"--data-dir", s.dataDir,
+		"--charm-modified-version", "10",
+		"--append-env", "PATH=$PATH:test-bin",
+		"--append-env", "DELETE=",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.cmd.DataDir(), gc.Equals, s.dataDir)
+	c.Assert(s.cmd.Tag().String(), jc.DeepEquals, `unit-wordpress-0`)
+	c.Assert(s.cmd.CurrentConfig().Controller().String(), jc.DeepEquals, `controller-deadbeef-1bad-500d-9000-4b1d0d06f00d`)
+	c.Assert(s.cmd.CurrentConfig().Model().String(), jc.DeepEquals, `model-deadbeef-0bad-400d-8000-4b1d0d06f00d`)
+	c.Assert(s.cmd.CharmModifiedVersion(), gc.Equals, 10)
+	c.Assert(len(s.cmd.GetContainerNames()), gc.Equals, 0)
 }
 
 func (s *containerUnitAgentSuite) TestParseUnknown(c *gc.C) {

--- a/cmd/containeragent/unit/export_test.go
+++ b/cmd/containeragent/unit/export_test.go
@@ -29,6 +29,7 @@ type ContainerUnitAgentTest interface {
 	CurrentConfig() agent.Config
 	Tag() names.UnitTag
 	CharmModifiedVersion() int
+	GetContainerNames() []string
 }
 
 func NewForTest(
@@ -50,6 +51,10 @@ func NewForTest(
 
 func (c *containerUnitAgent) SetAgentConf(cfg agentconf.AgentConf) {
 	c.AgentConf = cfg
+}
+
+func (c *containerUnitAgent) GetContainerNames() []string {
+	return c.containerNames
 }
 
 func (c *containerUnitAgent) DataDir() string {

--- a/worker/uniter/pebblepoller.go
+++ b/worker/uniter/pebblepoller.go
@@ -96,7 +96,7 @@ func (p *pebblePoller) run(containerName string) error {
 			timer.Reset(pebblePollInterval)
 			err := p.poll(containerName)
 			if err != nil && err != tomb.ErrDying {
-				p.logger.Errorf("pebble poll failed: %v", err)
+				p.logger.Errorf("pebble poll failed for container %q: %v", containerName, err)
 			}
 		}
 	}


### PR DESCRIPTION
*Fix passing empty string container name to unit params;*

Driveby: removed containerNames from init command;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
$ juju add-model t1 --config charmhub-url=https://api.staging.charmhub.io

# deploy metadata v2 sidecar charm with no containers provided in metadata.yaml
$ juju deploy facundo-snappass-test

$ mkubectl -nt1 get pod/facundo-snappass-test-0 -o json | jq '.spec.containers[].name'
"charm"

$ juju run --unit facundo-snappass-test/0  printenv | grep JUJU_CONTAINER_NAMES
JUJU_CONTAINER_NAMES=

# no errors in model log
$ juju debug-log -m k1:t1 --color --replay

# previously error shown in model log: 
# unit-facundo-snappass-test-0: 15:19:06 ERROR juju.worker.uniter pebble poll failed for container "": failed to get pebble info: cannot obtain system details: cannot communicate with server: Get "http://localhost/v1/system-info": dial unix /charm/containers/pebble.socket: connect: no such file or directory
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1924280
