### PR TITLE
Update charn/v8 and remove use of juju/version

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -423,7 +423,7 @@ func (c *Client) UploadCharm(curl *charm.URL, content io.ReadSeeker) (*charm.URL
 }
 
 func (c *Client) validateCharmVersion(ch charm.Charm) error {
-	minver := jujuversion.ToVersion2(ch.Meta().MinJujuVersion)
+	minver := ch.Meta().MinJujuVersion
 	if minver != version.Zero {
 		agentver, err := c.AgentVersion()
 		if err != nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -391,7 +391,7 @@ func testMinVer(client *api.Client, t minverTest, c *gc.C) {
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
-	charmArchive.Meta().MinJujuVersion = jujuversion.ToVersion1(charmMinVer)
+	charmArchive.Meta().MinJujuVersion = charmMinVer
 
 	_, err := client.AddLocalCharm(curl, charmArchive, t.force)
 

--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/apiserver/params"

--- a/api/common/charms/common_test.go
+++ b/api/common/charms/common_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	basemocks "github.com/juju/juju/api/base/mocks"

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -648,7 +648,7 @@ func caasPrecheck(
 
 	// For older charms, operator-storage model config is mandatory.
 	minver := ch.Meta().MinJujuVersion
-	if k8s.RequireOperatorStorage(jujuversion.ToVersion2(minver)) {
+	if k8s.RequireOperatorStorage(minver) {
 		storageClassName, _ := cfg.AllAttrs()[k8sconstants.OperatorStorageKey].(string)
 		if storageClassName == "" {
 			return errors.New(
@@ -727,7 +727,7 @@ func deployApplication(
 	}
 
 	minver := ch.Meta().MinJujuVersion
-	if err := jujuversion.CheckJujuMinVersion(jujuversion.ToVersion2(minver), jujuversion.Current); err != nil {
+	if err := jujuversion.CheckJujuMinVersion(minver, jujuversion.Current); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1128,7 +1128,7 @@ func (s *ApplicationSuite) TestDeployCAASModelCharmNeedsNoOperatorStorage(c *gc.
 	s.PatchValue(&jujuversion.Current, version.MustParse("2.8-beta1"))
 	s.backend.charm = &mockCharm{
 		meta: &charm.Meta{
-			MinJujuVersion: jujuversion.ToVersion1(version.MustParse("2.8.0")),
+			MinJujuVersion: version.MustParse("2.8.0"),
 		},
 	}
 

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -155,7 +155,7 @@ type versionValidator struct{}
 
 func (versionValidator) Validate(meta *charm.Meta) error {
 	minver := meta.MinJujuVersion
-	return jujuversion.CheckJujuMinVersion(jujuversion.ToVersion2(minver), jujuversion.Current)
+	return jujuversion.CheckJujuMinVersion(minver, jujuversion.Current)
 }
 
 type charmStateShim struct {

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -391,7 +391,7 @@ type versionValidator struct{}
 
 func (versionValidator) Validate(meta *charm.Meta) error {
 	minver := meta.MinJujuVersion
-	return jujuversion.CheckJujuMinVersion(jujuversion.ToVersion2(minver), jujuversion.Current)
+	return jujuversion.CheckJujuMinVersion(minver, jujuversion.Current)
 }
 
 // CharmArchive is the data that needs to be stored for a charm archive in

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -191,7 +191,7 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 			continue
 		}
 		minVer := ch.Meta().MinJujuVersion
-		needStorage := provider.RequireOperatorStorage(version.ToVersion2(minVer))
+		needStorage := provider.RequireOperatorStorage(minVer)
 		logger.Debugf("application %s has min-juju-version=%v, so charm storage is %v",
 			appName.String(), ch.Meta().MinJujuVersion, needStorage)
 		result.Results[i] = oneProvisioningInfo(needStorage)

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -178,7 +178,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStorage(c *gc.C) {
 	s.st.operatorRepo = "somerepo"
 	minVers := version.MustParse("2.8.0")
 	s.st.app = &mockApplication{
-		charm: &mockCharm{meta: &charm.Meta{MinJujuVersion: jujuversion.ToVersion1(minVers)}},
+		charm: &mockCharm{meta: &charm.Meta{MinJujuVersion: minVers}},
 	}
 	result, err := s.api.OperatorProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -199,7 +199,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C
 	s.st.operatorRepo = "somerepo"
 	minVers := version.MustParse("2.7.0")
 	s.st.app = &mockApplication{
-		charm: &mockCharm{meta: &charm.Meta{MinJujuVersion: jujuversion.ToVersion1(minVers)}},
+		charm: &mockCharm{meta: &charm.Meta{MinJujuVersion: minVers}},
 	}
 	result, err := s.api.OperatorProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/charm/strategies_test.go
+++ b/core/charm/strategies_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210416185554-91e97e2c7708
+	github.com/juju/charm/v8 v8.0.0-20210419074656-80e7fc2f335e
 	github.com/juju/charmrepo/v6 v6.0.0-20210309083204-29c3dbf03675
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
@@ -75,7 +75,6 @@ require (
 	github.com/juju/txn v0.0.0-20210302043154-251cea9e140a
 	github.com/juju/utils v0.0.0-20200604140309-9d78121a29e0
 	github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1
-	github.com/juju/version v0.0.0-20210303051006-2015802527a8
 	github.com/juju/version/v2 v2.0.0-20210319015800-dcfac8f4f057
 	github.com/juju/webbrowser v1.0.0
 	github.com/juju/worker/v2 v2.0.0-20200916234526-d6e694f1c54a

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/juju/charm/v8 v8.0.0-20200925053015-07d39c0154ac/go.mod h1:QZwgFXYuJI
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210416185554-91e97e2c7708 h1:b83/UuEB+1exgVlCfJJjHOsnA47ki6v7qA5IKIfsZfQ=
-github.com/juju/charm/v8 v8.0.0-20210416185554-91e97e2c7708/go.mod h1:23+X8evI7M++Bv2qr5JXrG+zMYRTmbA2D5ocqok/ur0=
+github.com/juju/charm/v8 v8.0.0-20210419074656-80e7fc2f335e h1:kSYBtK7H4n1NauUOWE0Fevhrd2YdE3ftSTHLBr1pgpc=
+github.com/juju/charm/v8 v8.0.0-20210419074656-80e7fc2f335e/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
 github.com/juju/charmrepo/v5 v5.0.0-20200424225329-cddcb4fdcd09/go.mod h1:KJGLR+Nx+PY2hw4EBNAjBWQacWlnxv1oVan1kJ9MlLM=
 github.com/juju/charmrepo/v5 v5.0.0-20200626080438-30e3069e6e8e/go.mod h1:cnwzYYTH1gV7V4ywqBix21av9LhFmdwbFEyE9CwpJ0s=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=

--- a/state/charm.go
+++ b/state/charm.go
@@ -689,7 +689,7 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 	defer closer()
 
 	minVer := info.Charm.Meta().MinJujuVersion
-	if err := jujuversion.CheckJujuMinVersion(jujuversion.ToVersion2(minVer), jujuversion.Current); err != nil {
+	if err := jujuversion.CheckJujuMinVersion(minVer, jujuversion.Current); err != nil {
 		return nil, errors.Trace(err)
 	}
 	model, err := st.Model()

--- a/state/state.go
+++ b/state/state.go
@@ -1068,7 +1068,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	}
 
 	minver := args.Charm.Meta().MinJujuVersion
-	if err := jujuversion.CheckJujuMinVersion(jujuversion.ToVersion2(minver), jujuversion.Current); err != nil {
+	if err := jujuversion.CheckJujuMinVersion(minver, jujuversion.Current); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	semversion1 "github.com/juju/version"
 	semversion "github.com/juju/version/v2"
 )
 
@@ -132,32 +131,4 @@ type minJujuVersionErr struct {
 func IsMinVersionError(err error) bool {
 	_, ok := errors.Cause(err).(minJujuVersionErr)
 	return ok
-}
-
-// TODO(juju3) - remove these once juju/charm and juju/description
-// have been updated to use juju/version/v2
-
-// The following are for compatibility with upstream repos that have
-// not yet been updated to use juju/version/v2.
-
-// ToVersion2 converts version number v1 to v2.
-func ToVersion2(v semversion1.Number) semversion.Number {
-	return semversion.Number{
-		Major: v.Major,
-		Minor: v.Minor,
-		Tag:   v.Tag,
-		Patch: v.Patch,
-		Build: v.Build,
-	}
-}
-
-// ToVersion1 converts version number v2 to v1.
-func ToVersion1(v semversion.Number) semversion1.Number {
-	return semversion1.Number{
-		Major: v.Major,
-		Minor: v.Minor,
-		Tag:   v.Tag,
-		Patch: v.Patch,
-		Build: v.Build,
-	}
 }


### PR DESCRIPTION
Bring in a new charm/v8 upstream which uses juju/version/v2 so we can also remove juju/version from juju also.

## QA steps

unit tests