### PR TITLE
[2.9] Add CLA checker GH action and remove codecov push action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,10 @@
+name: "CLA check"
+on: [pull_request]
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1
+        with:
+          accept-existing-contributors: true

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -101,7 +101,3 @@ jobs:
         go test -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic
         go test -v ./cmd/plugins/... -check.v
       shell: bash
-
-    - name: Upload coverage to Codecov
-      if: (matrix.os == 'ubuntu-latest')
-      run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR adds a new GH action to check that contributors have accepted the CLA and removes an existing action for pushing code coverage metrics to codecov.io.