### PR TITLE
[vsphere] Add ability to specify local templates for vsphere

### DIFF
--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -22,18 +22,23 @@ type DialFunc func(_ context.Context, _ *url.URL, datacenter string) (Client, er
 type Client interface {
 	Close(context.Context) error
 	ComputeResources(context.Context) ([]vsphereclient.ComputeResource, error)
-	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
 	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
+	CreateTemplateVM(ctx context.Context, ovaArgs vsphereclient.ImportOVAParameters) (vm *object.VirtualMachine, err error)
+	FindVMTemplatesByName(ctx context.Context, path string, name string) ([]*object.VirtualMachine, error)
 	Folders(ctx context.Context) (*object.DatacenterFolders, error)
 	Datastores(context.Context) ([]mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error
 	DestroyVMFolder(context.Context, string) error
 	EnsureVMFolder(context.Context, string, string) (*object.Folder, error)
+	GetTargetDatastore(ctx context.Context, computeResource *mo.ComputeResource, rootDiskSource string) (*object.Datastore, error)
+	ListVMTemplates(ctx context.Context, path string) ([]*object.VirtualMachine, error)
 	MoveVMFolderInto(context.Context, string, string) error
 	MoveVMsInto(context.Context, string, ...types.ManagedObjectReference) error
 	RemoveVirtualMachines(context.Context, string) error
+	ResourcePools(context.Context, string) ([]*object.ResourcePool, error)
 	UpdateVirtualMachineExtraConfig(context.Context, *mo.VirtualMachine, map[string]string) error
 	VirtualMachines(context.Context, string) ([]*mo.VirtualMachine, error)
+	VirtualMachineObjectToManagedObject(ctx context.Context, vmObject *object.VirtualMachine) (mo.VirtualMachine, error)
 	UserHasRootLevelPrivilege(context.Context, string) (bool, error)
 	FindFolder(ctx context.Context, folderPath string) (vmFolder *object.Folder, err error)
 }

--- a/provider/vsphere/client.go
+++ b/provider/vsphere/client.go
@@ -24,7 +24,6 @@ type Client interface {
 	ComputeResources(context.Context) ([]vsphereclient.ComputeResource, error)
 	CreateVirtualMachine(context.Context, vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error)
 	CreateTemplateVM(ctx context.Context, ovaArgs vsphereclient.ImportOVAParameters) (vm *object.VirtualMachine, err error)
-	FindVMTemplatesByName(ctx context.Context, path string, name string) ([]*object.VirtualMachine, error)
 	Folders(ctx context.Context) (*object.DatacenterFolders, error)
 	Datastores(context.Context) ([]mo.Datastore, error)
 	DeleteDatastoreFile(context.Context, string) error

--- a/provider/vsphere/credentials.go
+++ b/provider/vsphere/credentials.go
@@ -23,14 +23,19 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.UserPassAuthType: {
 			{
-				credAttrUser, cloud.CredentialAttr{Description: "The username to authenticate with."},
+				Name: credAttrUser,
+				CredentialAttr: cloud.CredentialAttr{
+					Description: "The username to authenticate with.",
+				},
 			}, {
-				credAttrPassword, cloud.CredentialAttr{
+				Name: credAttrPassword,
+				CredentialAttr: cloud.CredentialAttr{
 					Description: "The password to authenticate with.",
 					Hidden:      true,
 				},
 			}, {
-				credAttrVMFolder, cloud.CredentialAttr{
+				Name: credAttrVMFolder,
+				CredentialAttr: cloud.CredentialAttr{
 					Description: "The folder to add VMs from the model.",
 					Optional:    true,
 				},

--- a/provider/vsphere/environ_availzones.go
+++ b/provider/vsphere/environ_availzones.go
@@ -148,7 +148,7 @@ func (env *sessionEnviron) InstanceAvailabilityZoneNames(ctx context.ProviderCal
 		return nil, errors.Trace(err)
 	}
 
-	results := make(map[instance.Id]string, 0)
+	results := make(map[instance.Id]string)
 	for _, inst := range instances {
 		if inst == nil {
 			continue

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -5,8 +5,6 @@ package vsphere
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"path"
 	"sync"
 	"time"
@@ -24,6 +22,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
 	"github.com/juju/juju/tools"
@@ -70,17 +69,18 @@ func (env *environ) StartInstance(ctx context.ProviderCallContext, args environs
 	return result, err
 }
 
+// Region is specified in the HasRegion interface.
+func (env *environ) Region() (simplestreams.CloudSpec, error) {
+	spec := simplestreams.CloudSpec{
+		Region:   env.cloud.Region,
+		Endpoint: env.cloud.Endpoint,
+	}
+	return spec, nil
+}
+
 // StartInstance implements environs.InstanceBroker.
 func (env *sessionEnviron) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
-	img, err := findImageMetadata(env, args)
-	if err != nil {
-		return nil, common.ZoneIndependentError(err)
-	}
-	if err := env.finishMachineConfig(args, img); err != nil {
-		return nil, common.ZoneIndependentError(err)
-	}
-
-	vm, hw, err := env.newRawInstance(ctx, args, img)
+	vm, hw, err := env.newRawInstance(ctx, args)
 	if err != nil {
 		_ = args.StatusCallback(status.ProvisioningError, fmt.Sprint(err), nil)
 		return nil, errors.Trace(err)
@@ -101,8 +101,8 @@ var FinishInstanceConfig = instancecfg.FinishInstanceConfig
 
 // finishMachineConfig updates args.MachineConfig in place. Setting up
 // the API, StateServing, and SSHkeys information.
-func (env *sessionEnviron) finishMachineConfig(args environs.StartInstanceParams, img *OvaFileMetadata) error {
-	envTools, err := args.Tools.Match(tools.Filter{Arch: img.Arch})
+func (env *sessionEnviron) finishMachineConfig(args environs.StartInstanceParams, arch string) error {
+	envTools, err := args.Tools.Match(tools.Filter{Arch: arch})
 	if err != nil {
 		return err
 	}
@@ -118,8 +118,65 @@ func (env *sessionEnviron) finishMachineConfig(args environs.StartInstanceParams
 func (env *sessionEnviron) newRawInstance(
 	ctx context.ProviderCallContext,
 	args environs.StartInstanceParams,
-	img *OvaFileMetadata,
 ) (_ *mo.VirtualMachine, _ *instance.HardwareCharacteristics, err error) {
+	// Obtain the final constraints by merging with defaults.
+	cons := args.Constraints
+	minRootDisk := common.MinRootDiskSizeGiB(args.InstanceConfig.Series) * 1024
+	if cons.RootDisk == nil || *cons.RootDisk < minRootDisk {
+		cons.RootDisk = &minRootDisk
+	}
+
+	defaultDatastore := env.ecfg.datastore()
+	if cons.RootDiskSource != nil && *cons.RootDiskSource != "" {
+		defaultDatastore = *cons.RootDiskSource
+	}
+
+	// Attempt to create a VM in each of the AZs in turn.
+	logger.Debugf("attempting to create VM in availability zone %q", args.AvailabilityZone)
+	availZone, err := env.availZone(ctx, args.AvailabilityZone)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	datastore, err := env.client.GetTargetDatastore(env.ctx, &availZone.r, defaultDatastore)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	updateProgressInterval := startInstanceUpdateProgressInterval
+	if args.InstanceConfig.Bootstrap != nil {
+		updateProgressInterval = bootstrapUpdateProgressInterval
+	}
+	updateProgress := func(message string) {
+		_ = args.StatusCallback(status.Provisioning, message, nil)
+	}
+
+	statusUpdateArgs := vsphereclient.StatusUpdateParams{
+		UpdateProgress:         updateProgress,
+		UpdateProgressInterval: updateProgressInterval,
+		Clock:                  clock.WallClock,
+	}
+
+	tplManager := vmTemplateManager{
+		imageMetadata:    args.ImageMetadata,
+		env:              env,
+		az:               availZone,
+		datastore:        datastore,
+		controllerUUID:   args.ControllerUUID,
+		statusUpdateArgs: statusUpdateArgs,
+	}
+
+	vmTemplate, arch, err := tplManager.EnsureTemplate(env.ctx, args.InstanceConfig.Series, args.Tools.Arches())
+	if err != nil {
+		return nil, nil, common.ZoneIndependentError(err)
+	}
+
+	logger.Warningf(">>> ImageMetadata: %v", args.ImageMetadata)
+
+	if err := env.finishMachineConfig(args, arch); err != nil {
+		return nil, nil, common.ZoneIndependentError(err)
+	}
+
 	if args.AvailabilityZone == "" {
 		return nil, nil, errors.NotValidf("empty available zone")
 	}
@@ -184,61 +241,22 @@ func (env *sessionEnviron) newRawInstance(
 	}
 	logger.Debugf("Vmware user data; %d bytes", len(userData))
 
-	// Obtain the final constraints by merging with defaults.
-	cons := args.Constraints
-	minRootDisk := common.MinRootDiskSizeGiB(args.InstanceConfig.Series) * 1024
-	if cons.RootDisk == nil || *cons.RootDisk < minRootDisk {
-		cons.RootDisk = &minRootDisk
-	}
-	defaultDatastore := env.ecfg.datastore()
-	if (cons.RootDiskSource == nil || *cons.RootDiskSource == "") && defaultDatastore != "" {
-		cons.RootDiskSource = &defaultDatastore
-	}
-
-	// Download and extract the OVA file. If we're bootstrapping we use
-	// a temporary directory, otherwise we cache the image for future use.
-	updateProgressInterval := startInstanceUpdateProgressInterval
-	if args.InstanceConfig.Bootstrap != nil {
-		updateProgressInterval = bootstrapUpdateProgressInterval
-	}
-	updateProgress := func(message string) {
-		_ = args.StatusCallback(status.Provisioning, message, nil)
-	}
-
-	readOVA := func() (string, io.ReadCloser, error) {
-		resp, err := http.Get(img.URL)
-		if err != nil {
-			return "", nil, errors.Trace(err)
-		}
-		return img.URL, resp.Body, nil
-	}
-
 	createVMArgs := vsphereclient.CreateVirtualMachineParams{
 		Name:                   vmName,
 		Folder:                 path.Join(env.getVMFolder(), controllerFolderName(args.ControllerUUID), env.modelFolderName()),
 		RootVMFolder:           env.getVMFolder(),
 		Series:                 args.InstanceConfig.Series,
-		ReadOVA:                readOVA,
-		OVASHA256:              img.Sha256,
 		VMDKDirectory:          templateDirectoryName(controllerFolderName(args.ControllerUUID)),
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,
 		NetworkDevices:         networkDevices,
-		UpdateProgress:         updateProgress,
-		UpdateProgressInterval: updateProgressInterval,
-		Clock:                  clock.WallClock,
 		EnableDiskUUID:         env.ecfg.enableDiskUUID(),
 		ForceVMHardwareVersion: env.ecfg.forceVMHardwareVersion(),
-		IsBootstrap:            args.InstanceConfig.Bootstrap != nil,
 		DiskProvisioningType:   env.ecfg.diskProvisioningType(),
-	}
-
-	// Attempt to create a VM in each of the AZs in turn.
-	logger.Debugf("attempting to create VM in availability zone %q", args.AvailabilityZone)
-	availZone, err := env.availZone(ctx, args.AvailabilityZone)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
+		StatusUpdateParams:     statusUpdateArgs,
+		Datastore:              datastore,
+		VMTemplate:             vmTemplate,
 	}
 
 	createVMArgs.ComputeResource = &availZone.r
@@ -257,7 +275,7 @@ func (env *sessionEnviron) newRawInstance(
 	}
 
 	hw := &instance.HardwareCharacteristics{
-		Arch:           &img.Arch,
+		Arch:           &arch,
 		Mem:            cons.Mem,
 		CpuCores:       cons.CpuCores,
 		CpuPower:       cons.CpuPower,
@@ -265,6 +283,12 @@ func (env *sessionEnviron) newRawInstance(
 		RootDiskSource: cons.RootDiskSource,
 	}
 	return vm, hw, err
+}
+
+func (env *sessionEnviron) controllerTemplatesFolder(controllerUUID string) string {
+	vmFolder := env.getVMFolder()
+	templateFolder := templateDirectoryName(controllerFolderName(controllerUUID))
+	return path.Join(vmFolder, templateFolder)
 }
 
 // AllInstances implements environs.InstanceBroker.

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -171,8 +171,6 @@ func (env *sessionEnviron) newRawInstance(
 		return nil, nil, common.ZoneIndependentError(err)
 	}
 
-	logger.Warningf(">>> ImageMetadata: %v", args.ImageMetadata)
-
 	if err := env.finishMachineConfig(args, arch); err != nil {
 		return nil, nil, common.ZoneIndependentError(err)
 	}

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -159,8 +159,10 @@ func (env *sessionEnviron) newRawInstance(
 
 	tplManager := vmTemplateManager{
 		imageMetadata:    args.ImageMetadata,
-		env:              env,
-		az:               availZone,
+		env:              env.environ,
+		client:           env.client,
+		vmFolder:         env.getVMFolder(),
+		azPoolRef:        availZone.pool.Reference(),
 		datastore:        datastore,
 		controllerUUID:   args.ControllerUUID,
 		statusUpdateArgs: statusUpdateArgs,
@@ -278,12 +280,6 @@ func (env *sessionEnviron) newRawInstance(
 		RootDiskSource: cons.RootDiskSource,
 	}
 	return vm, hw, err
-}
-
-func (env *sessionEnviron) controllerTemplatesFolder(controllerUUID string) string {
-	vmFolder := env.getVMFolder()
-	templateFolder := templateDirectoryName(controllerFolderName(controllerUUID))
-	return path.Join(vmFolder, templateFolder)
 }
 
 // AllInstances implements environs.InstanceBroker.

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -127,8 +127,8 @@ func (env *sessionEnviron) newRawInstance(
 	}
 
 	defaultDatastore := env.ecfg.datastore()
-	if cons.RootDiskSource != nil && *cons.RootDiskSource != "" {
-		defaultDatastore = *cons.RootDiskSource
+	if cons.RootDiskSource == nil || *cons.RootDiskSource == "" {
+		cons.RootDiskSource = &defaultDatastore
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.
@@ -138,7 +138,7 @@ func (env *sessionEnviron) newRawInstance(
 		return nil, nil, errors.Trace(err)
 	}
 
-	datastore, err := env.client.GetTargetDatastore(env.ctx, &availZone.r, defaultDatastore)
+	datastore, err := env.client.GetTargetDatastore(env.ctx, &availZone.r, *cons.RootDiskSource)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -244,9 +244,7 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs := vsphereclient.CreateVirtualMachineParams{
 		Name:                   vmName,
 		Folder:                 path.Join(env.getVMFolder(), controllerFolderName(args.ControllerUUID), env.modelFolderName()),
-		RootVMFolder:           env.getVMFolder(),
 		Series:                 args.InstanceConfig.Series,
-		VMDKDirectory:          templateDirectoryName(controllerFolderName(args.ControllerUUID)),
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,
@@ -257,10 +255,9 @@ func (env *sessionEnviron) newRawInstance(
 		StatusUpdateParams:     statusUpdateArgs,
 		Datastore:              datastore,
 		VMTemplate:             vmTemplate,
+		ComputeResource:        &availZone.r,
+		ResourcePool:           availZone.pool.Reference(),
 	}
-
-	createVMArgs.ComputeResource = &availZone.r
-	createVMArgs.ResourcePool = availZone.pool.Reference()
 
 	vm, err := env.client.CreateVirtualMachine(env.ctx, createVMArgs)
 	if vsphereclient.IsExtendDiskError(err) {

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -165,7 +165,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstance(c *gc.C) {
 		EnableDiskUUID: true,
 		Datastore: object.NewDatastore(nil, types.ManagedObjectReference{
 			Type:  "Datastore",
-			Value: "baz",
+			Value: "bar",
 		}),
 		VMTemplate: object.NewVirtualMachine(nil, types.ManagedObjectReference{
 			Type:  "VirtualMachine",

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -150,7 +150,6 @@ func (s *legacyEnvironBrokerSuite) TestStartInstance(c *gc.C) {
 		},
 		UpdateProgressInterval: 5 * time.Second,
 		EnableDiskUUID:         true,
-		IsBootstrap:            true,
 		DiskProvisioningType:   vsphereclient.DefaultDiskProvisioningType,
 	})
 
@@ -679,7 +678,4 @@ func (s *legacyEnvironBrokerSuite) TestNotBootstrapping(c *gc.C) {
 	c.Assert(call.Args, gc.HasLen, 2)
 	c.Assert(call.Args[0], gc.Implements, new(context.Context))
 	c.Assert(call.Args[1], gc.FitsTypeOf, vsphereclient.CreateVirtualMachineParams{})
-
-	createVMArgs := call.Args[1].(vsphereclient.CreateVirtualMachineParams)
-	c.Assert(createVMArgs.IsBootstrap, gc.Equals, false)
 }

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package vsphere
 
 import (

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -4,11 +4,12 @@
 package vsphere
 
 import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 // NewVMTemplateManager returns a new vmTemplateManager. This function

--- a/provider/vsphere/export_test.go
+++ b/provider/vsphere/export_test.go
@@ -1,0 +1,32 @@
+package vsphere
+
+import (
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// NewVMTemplateManager returns a new vmTemplateManager. This function
+// is useful for testing.
+func NewVMTemplateManager(
+	imgMeta []*imagemetadata.ImageMetadata,
+	env environs.Environ, client Client,
+	azRef types.ManagedObjectReference,
+	datastore *object.Datastore,
+	statusUpdateArgs vsphereclient.StatusUpdateParams,
+	vmFolder, controllerUUID string) vmTemplateManager {
+
+	return vmTemplateManager{
+		imageMetadata:    imgMeta,
+		env:              env,
+		client:           client,
+		azPoolRef:        azRef,
+		datastore:        datastore,
+		statusUpdateArgs: statusUpdateArgs,
+
+		vmFolder:       vmFolder,
+		controllerUUID: controllerUUID,
+	}
+}

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -31,11 +31,10 @@ func init() {
 	simplestreams.RegisterStructTags(OvaFileMetadata{})
 }
 
-func findImageMetadata(env environs.Environ, args environs.StartInstanceParams) (*OvaFileMetadata, error) {
-	arches := args.Tools.Arches()
+func findImageMetadata(env environs.Environ, arches []string, series string) (*OvaFileMetadata, error) {
 	ic := &imagemetadata.ImageConstraint{
 		LookupParams: simplestreams.LookupParams{
-			Releases: []string{args.InstanceConfig.Series},
+			Releases: []string{series},
 			Arches:   arches,
 			Stream:   env.Config().ImageStream(),
 		},

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -298,23 +298,8 @@ func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.Virtua
 	return vms, nil
 }
 
-func (c *Client) FindVMTemplatesByName(ctx context.Context, path string, name string) ([]*object.VirtualMachine, error) {
-	templates, err := c.ListVMTemplates(ctx, path)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var filtered []*object.VirtualMachine
-	for _, tpl := range templates {
-		if tpl.Name() == name {
-			filtered = append(filtered, tpl)
-		}
-	}
-	return filtered, nil
-}
-
 func (c *Client) ListVMTemplates(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
-	c.logger.Debugf("ListVMTemplates() path=%q", path)
+	c.logger.Tracef("ListVMTemplates() path=%q", path)
 	finder, _, err := c.finder(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -262,6 +262,7 @@ func (c *Client) RemoveVirtualMachines(ctx context.Context, path string) error {
 	return errors.Annotate(lastError, "failed to remove instances")
 }
 
+// VirtualMachineObjectToManagedObject returns a virtual machine managed object, given an *object.VirtualMachine
 func (c *Client) VirtualMachineObjectToManagedObject(ctx context.Context, vmObject *object.VirtualMachine) (mo.VirtualMachine, error) {
 	var vm mo.VirtualMachine
 	err := c.client.RetrieveOne(ctx, vmObject.Reference(), nil, &vm)
@@ -298,6 +299,8 @@ func (c *Client) VirtualMachines(ctx context.Context, path string) ([]*mo.Virtua
 	return vms, nil
 }
 
+// ListVMTemplates returns a list of virtual machine objects in the given path,
+// that have been marked as templates.
 func (c *Client) ListVMTemplates(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
 	c.logger.Tracef("ListVMTemplates() path=%q", path)
 	finder, _, err := c.finder(ctx)

--- a/provider/vsphere/internal/vsphereclient/client.go
+++ b/provider/vsphere/internal/vsphereclient/client.go
@@ -307,7 +307,7 @@ func (c *Client) ListVMTemplates(ctx context.Context, path string) ([]*object.Vi
 	items, err := finder.VirtualMachineList(ctx, path)
 	if err != nil {
 		if _, ok := err.(*find.NotFoundError); ok {
-			return nil, errors.NotFoundf("path not found: %s", path)
+			return nil, errors.NotFoundf("path %s", path)
 		}
 		return nil, errors.Annotate(err, "listing VMs")
 	}

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -266,6 +266,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 			},
 			PropSet: []types.DynamicProperty{
 				{Name: "name", Val: "juju-vm-template"},
+				{Name: "summary.config.template", Val: true},
 			},
 		},
 			{
@@ -420,6 +421,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 				{Name: "name", Val: "juju-vm-template"},
 				{Name: "runtime.powerState", Val: "poweredOff"},
 				{Name: "config.version", Val: "vmx-10"},
+				{Name: "summary.config.template", Val: true},
 				{
 					Name: "config.hardware.device",
 					Val: []types.BaseVirtualDevice{
@@ -1004,6 +1006,28 @@ func (s *clientSuite) TestVirtualMachines(c *gc.C) {
 	c.Assert(result[0].Name, gc.Equals, "juju-vm-template")
 	c.Assert(result[1].Name, gc.Equals, "juju-vm-0")
 	c.Assert(result[2].Name, gc.Equals, "juju-vm-1")
+}
+
+func (s *clientSuite) TestListVMTemplates(c *gc.C) {
+	client := s.newFakeClient(&s.roundTripper, "dc0")
+	result, err := client.ListVMTemplates(context.Background(), "foo/bar/*")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.roundTripper.CheckCalls(c, []testing.StubCall{
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeRootFolder"),
+		retrievePropertiesStubCall("FakeDatacenter"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeVmFolder"),
+		retrievePropertiesStubCall("FakeControllerVmFolder"),
+		retrievePropertiesStubCall("FakeModelVmFolder"),
+		retrievePropertiesStubCall("FakeVmTemplate"),
+		retrievePropertiesStubCall("FakeVm0"),
+		retrievePropertiesStubCall("FakeVm1"),
+	})
+
+	c.Assert(result, gc.HasLen, 1)
+	c.Assert(result[0].Name(), gc.Equals, "juju-vm-template")
 }
 
 func (s *clientSuite) TestDatastores(c *gc.C) {

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -903,9 +903,11 @@ func (s *clientSuite) TestMaybeUpgradeVMVersion(c *gc.C) {
 				Value: "FakeEnvironmentBrowser",
 			},
 		},
-		Clock:                  testclock.NewClock(time.Time{}),
-		UpdateProgress:         func(status string) {},
-		UpdateProgressInterval: time.Second,
+		StatusUpdateParams: StatusUpdateParams{
+			Clock:                  testclock.NewClock(time.Time{}),
+			UpdateProgress:         func(status string) {},
+			UpdateProgressInterval: time.Second,
+		},
 	}
 	client := s.newFakeClient(&s.roundTripper, "dc0")
 	var vm mo.VirtualMachine
@@ -916,9 +918,9 @@ func (s *clientSuite) TestMaybeUpgradeVMVersion(c *gc.C) {
 
 	vmObj := object.NewVirtualMachine(client.client.Client, vm.Reference())
 	err := client.maybeUpgradeVMHardware(context.Background(), args, vmObj, &taskWaiter{
-		clock:                  args.Clock,
-		updateProgress:         args.UpdateProgress,
-		updateProgressInterval: args.UpdateProgressInterval,
+		clock:                  args.StatusUpdateParams.Clock,
+		updateProgress:         args.StatusUpdateParams.UpdateProgress,
+		updateProgressInterval: args.StatusUpdateParams.UpdateProgressInterval,
 	})
 
 	// We ignore the request and log the event.

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -578,7 +578,9 @@ func (s *clientSuite) TestDial(c *gc.C) {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		e := xml.NewEncoder(w)
 		e.Encode(soap.Envelope{Body: methods.RetrieveServiceContentBody{
-			Res: &types.RetrieveServiceContentResponse{s.serviceContent},
+			Res: &types.RetrieveServiceContentResponse{
+				Returnval: s.serviceContent,
+			},
 		}})
 		e.Flush()
 	})
@@ -650,10 +652,10 @@ func (s *clientSuite) TestDestroyVMFolder(c *gc.C) {
 		retrievePropertiesStubCall("FakeDatacenter"),
 		retrievePropertiesStubCall("FakeVmFolder"),
 		retrievePropertiesStubCall("FakeHostFolder"),
-		{"Destroy_Task", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
+		{FuncName: "Destroy_Task", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
 	})
 }
 
@@ -678,8 +680,8 @@ func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeDatacenter"),
-		{"CreateFolder", []interface{}{"foo"}},
-		{"CreateFolder", []interface{}{"bar"}},
+		{FuncName: "CreateFolder", Args: []interface{}{"foo"}},
+		{FuncName: "CreateFolder", Args: []interface{}{"bar"}},
 	})
 }
 
@@ -735,10 +737,10 @@ func (s *clientSuite) TestMoveVMFolderInto(c *gc.C) {
 		retrievePropertiesStubCall("FakeVmFolder"),
 		retrievePropertiesStubCall("FakeControllerVmFolder"),
 		retrievePropertiesStubCall("FakeHostFolder"),
-		{"MoveIntoFolder_Task", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
+		{FuncName: "MoveIntoFolder_Task", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
 	})
 }
 
@@ -765,10 +767,10 @@ func (s *clientSuite) TestMoveVMsInto(c *gc.C) {
 		retrievePropertiesStubCall("FakeDatacenter"),
 		retrievePropertiesStubCall("FakeVmFolder"),
 		retrievePropertiesStubCall("FakeHostFolder"),
-		{"MoveIntoFolder_Task", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
+		{FuncName: "MoveIntoFolder_Task", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
 	})
 }
 
@@ -786,22 +788,22 @@ func (s *clientSuite) TestRemoveVirtualMachines(c *gc.C) {
 		retrievePropertiesStubCall("FakeControllerVmFolder"),
 		retrievePropertiesStubCall("FakeModelVmFolder"),
 		retrievePropertiesStubCall("FakeVmTemplate", "FakeVm0", "FakeVm1"),
-		{"Destroy_Task", nil},
-		{"Destroy_Task", nil},
-		{"PowerOffVM_Task", nil},
-		{"Destroy_Task", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
+		{FuncName: "Destroy_Task", Args: nil},
+		{FuncName: "Destroy_Task", Args: nil},
+		{FuncName: "PowerOffVM_Task", Args: nil},
+		{FuncName: "Destroy_Task", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
 	})
 }
 
@@ -1031,10 +1033,10 @@ func (s *clientSuite) TestDeleteDatastoreFile(c *gc.C) {
 	s.roundTripper.CheckCalls(c, []testing.StubCall{
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeRootFolder"),
-		{"DeleteDatastoreFile", []interface{}{"[datastore1] file/path"}},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
+		{FuncName: "DeleteDatastoreFile", Args: []interface{}{"[datastore1] file/path"}},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
 	})
 }
 
@@ -1092,7 +1094,7 @@ func (s *clientSuite) TestUserHasRootLevelPrivilege(c *gc.C) {
 
 	s.roundTripper.CheckCalls(c, []testing.StubCall{
 		retrievePropertiesStubCall("FakeSessionManager"),
-		{"HasPrivilegeOnEntities", []interface{}{
+		{FuncName: "HasPrivilegeOnEntities", Args: []interface{}{
 			"FakeAuthorizationManager",
 			[]types.ManagedObjectReference{s.serviceContent.RootFolder},
 			"session-key",

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -87,7 +87,6 @@ type ImportOVAParameters struct {
 // CreateVirtualMachineParams contains the parameters required for creating
 // a new virtual machine.
 type CreateVirtualMachineParams struct {
-	// TODO(gsamfira)
 	StatusUpdateParams StatusUpdateParams
 
 	// Name is the name to give the virtual machine. The VM name is used

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/mutex"
-	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -46,9 +45,51 @@ type NetworkDevice struct {
 // That's a default network that's defined in OVF.
 const defaultNetwork = "VM Network"
 
+type StatusUpdateParams struct {
+	// UpdateProgress is a function that should be called before/during
+	// long-running operations to provide a progress reporting.
+	UpdateProgress func(string)
+
+	// UpdateProgressInterval is the amount of time to wait between calls
+	// to UpdateProgress. This should be lower when the operation is
+	// interactive (bootstrap), and higher when non-interactive.
+	UpdateProgressInterval time.Duration
+
+	// Clock is used for controlling the timing of progress updates.
+	Clock clock.Clock
+}
+
+type ImportOVAParameters struct {
+	StatusUpdateParams StatusUpdateParams
+	// ReadOVA returns the location of, and an io.ReadCloser for,
+	// the OVA from which to extract the VMDK. The location may be
+	// used for reporting progress. The ReadCloser must be closed
+	// by the caller when it is finished with it.
+	ReadOVA func() (location string, _ io.ReadCloser, _ error)
+
+	// OVASHA256 is the expected SHA-256 hash of the OVA.
+	OVASHA256 string
+
+	// ResourcePool is a reference to the pool the VM should be
+	// created in.
+	ResourcePool types.ManagedObjectReference
+
+	// TemplateName is the name of the template that gets created
+	// from the OVA
+	TemplateName string
+
+	Datastore         *object.Datastore
+	DestinationFolder *object.Folder
+	Arch              string
+	Series            string
+}
+
 // CreateVirtualMachineParams contains the parameters required for creating
 // a new virtual machine.
 type CreateVirtualMachineParams struct {
+	// TODO(gsamfira)
+	StatusUpdateParams StatusUpdateParams
+
 	// Name is the name to give the virtual machine. The VM name is used
 	// for its hostname also.
 	Name string
@@ -67,12 +108,6 @@ type CreateVirtualMachineParams struct {
 
 	// Series is the name of the OS series that the image will run.
 	Series string
-
-	// ReadOVA returns the location of, and an io.ReadCloser for,
-	// the OVA from which to extract the VMDK. The location may be
-	// used for reporting progress. The ReadCloser must be closed
-	// by the caller when it is finished with it.
-	ReadOVA func() (location string, _ io.ReadCloser, _ error)
 
 	// OVASHA256 is the expected SHA-256 hash of the OVA.
 	OVASHA256 string
@@ -103,35 +138,17 @@ type CreateVirtualMachineParams struct {
 	// Networks contain a list of network devices the VM should have.
 	NetworkDevices []NetworkDevice
 
-	// UpdateProgress is a function that should be called before/during
-	// long-running operations to provide a progress reporting.
-	UpdateProgress func(string)
-
-	// UpdateProgressInterval is the amount of time to wait between calls
-	// to UpdateProgress. This should be lower when the operation is
-	// interactive (bootstrap), and higher when non-interactive.
-	UpdateProgressInterval time.Duration
-
-	// Clock is used for controlling the timing of progress updates.
-	Clock clock.Clock
-
 	// EnableDiskUUID controls whether the VMware disk should expose a
 	// consistent UUID to the guest OS.
 	EnableDiskUUID bool
 
-	// IsBootstrap indicates whether the requested instance will be a
-	// newly bootstrapped controller.
-	IsBootstrap bool
-
 	// DiskProvisioningType specifies how disks should be provisioned when
 	// cloning a template.
 	DiskProvisioningType DiskProvisioningType
-}
 
-// vmTemplateName returns the well-known name to
-// the template VM for this controller and its models
-func vmTemplateName(args CreateVirtualMachineParams) string {
-	return "juju-template-" + args.OVASHA256
+	Datastore *object.Datastore
+
+	VMTemplate *object.VirtualMachine
 }
 
 // vmTemplatePath returns the a path inside the vSphere datastore
@@ -151,16 +168,22 @@ func acquireMutex(spec mutex.Spec) (func(), error) {
 	return func() { releaser.Release() }, nil
 }
 
-func (c *Client) getTargetDatastore(
+func (c *Client) GetTargetDatastore(
 	ctx context.Context,
-	datacenter *object.Datacenter,
-	args CreateVirtualMachineParams,
+	computeResource *mo.ComputeResource,
+	rootDiskSource string,
 ) (*object.Datastore, error) {
+	_, datacenter, err := c.finder(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	folders, err := datacenter.Folders(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	datastoreMo, err := c.selectDatastore(ctx, args)
+
+	datastoreMo, err := c.selectDatastore(ctx, computeResource, rootDiskSource)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -170,66 +193,38 @@ func (c *Client) getTargetDatastore(
 	return datastore, nil
 }
 
-// ensureTemplateVM returns a vSphere template VM
+// CreateTemplateVM returns a vSphere template VM
 // that instances can be created from.
-func (c *Client) ensureTemplateVM(
+func (c *Client) CreateTemplateVM(
 	ctx context.Context,
-	datastore *object.Datastore,
-	args CreateVirtualMachineParams,
+	ovaArgs ImportOVAParameters,
 ) (vm *object.VirtualMachine, err error) {
-	templateFolder, err := c.FindFolder(ctx, path.Join(args.RootVMFolder, vmTemplatePath(args)))
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, errors.Trace(err)
-	}
-	// Consider only the case without error: it means folder already exists
-	// and we can look if there is a template inside.
-	if err == nil {
-		finder, _, err := c.finder(ctx)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		templateVM, err := finder.VirtualMachine(ctx, path.Join(templateFolder.InventoryPath, vmTemplateName(args)))
-		if err == nil && templateVM != nil {
-			return templateVM, nil
-		}
-		if _, ok := err.(*find.NotFoundError); !ok {
-			return nil, errors.Trace(nil)
-		}
-	}
-
-	spec, err := c.createImportSpec(ctx, args, datastore)
+	spec, err := c.createImportSpec(
+		ctx, ovaArgs.TemplateName, ovaArgs.ResourcePool, ovaArgs.Datastore)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating import spec")
 	}
 
-	vmFolder, err := c.EnsureVMFolder(ctx, args.RootVMFolder, vmTemplatePath(args))
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	importSpec := spec.ImportSpec
-	args.UpdateProgress(fmt.Sprintf("creating template VM %q", vmTemplateName(args)))
-	c.logger.Debugf("creating template VM in folder %s", vmFolder)
+	ovaArgs.StatusUpdateParams.UpdateProgress(
+		fmt.Sprintf("creating template VM %q", ovaArgs.TemplateName))
+	c.logger.Debugf("creating template VM in folder %s", ovaArgs.DestinationFolder)
 
-	if !args.IsBootstrap {
-		// Each controller maintains its own image cache. All compute
-		// provisioners (i.e. each model's) run on the same controller
-		// machine, so taking a machine lock ensures that only one
-		// process is updating VMDKs at the same time. We lock around
-		// access to the series directory.
-		release, err := c.acquireMutex(mutex.Spec{
-			Name:  "vsphere-" + args.Series,
-			Clock: args.Clock,
-			Delay: time.Second,
-		})
-		if err != nil {
-			return nil, errors.Annotate(err, "acquiring lock")
-		}
-		defer release()
+	// We can acquire the mutex here, even if we are bootstrapping.
+	// This action only runs once, no need to add a special case for something
+	// that occurs only once in the entire lifetime of a controller.
+	release, err := c.acquireMutex(mutex.Spec{
+		Name:  "vsphere-" + ovaArgs.Series,
+		Clock: ovaArgs.StatusUpdateParams.Clock,
+		Delay: time.Second,
+	})
+	if err != nil {
+		return nil, errors.Annotate(err, "acquiring lock")
 	}
+	defer release()
 
-	resourcePool := object.NewResourcePool(c.client.Client, args.ResourcePool)
-	lease, err := resourcePool.ImportVApp(ctx, importSpec, vmFolder, nil)
+	resourcePool := object.NewResourcePool(c.client.Client, ovaArgs.ResourcePool)
+	lease, err := resourcePool.ImportVApp(ctx, importSpec, ovaArgs.DestinationFolder, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to import vapp")
 	}
@@ -249,7 +244,7 @@ func (c *Client) ensureTemplateVM(
 		}
 	}()
 
-	ovaLocation, ovaReadCloser, err := args.ReadOVA()
+	ovaLocation, ovaReadCloser, err := ovaArgs.ReadOVA()
 	if err != nil {
 		return nil, errors.Annotate(err, "fetching OVA")
 	}
@@ -264,7 +259,8 @@ func (c *Client) ensureTemplateVM(
 		if strings.HasSuffix(header.Name, ".vmdk") {
 			item := info.Items[0]
 			c.logger.Infof("Streaming VMDK from %s to %s", ovaLocation, item.URL)
-			withStatusUpdater(ctx, "streaming vmdk", args.Clock, args.UpdateProgress, args.UpdateProgressInterval,
+			statusArgs := ovaArgs.StatusUpdateParams
+			withStatusUpdater(ctx, "streaming vmdk", statusArgs.Clock, statusArgs.UpdateProgress, statusArgs.UpdateProgressInterval,
 				func(ctx context.Context, sink progress.Sinker) {
 					opts := soap.Upload{
 						ContentLength: header.Size,
@@ -292,14 +288,30 @@ func (c *Client) ensureTemplateVM(
 	if err := lease.Complete(ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if fmt.Sprintf("%x", sha256sum.Sum(nil)) != args.OVASHA256 {
+	if fmt.Sprintf("%x", sha256sum.Sum(nil)) != ovaArgs.OVASHA256 {
 		return nil, errors.New("SHA-256 hash mismatch for OVA")
 	}
 	vm = object.NewVirtualMachine(c.client.Client, info.Entity)
+	if ovaArgs.Arch != "" {
+		var spec types.VirtualMachineConfigSpec
+		spec.ExtraConfig = []types.BaseOptionValue{
+			&types.OptionValue{Key: ArchTag, Value: ovaArgs.Arch},
+		}
+
+		task, err := vm.Reconfigure(ctx, spec)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if _, err := task.WaitForResult(ctx, nil); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
 	err = vm.MarkAsTemplate(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "marking as template")
 	}
+
 	return vm, nil
 }
 
@@ -328,27 +340,17 @@ func (c *Client) CreateVirtualMachine(
 		return nil, errors.Trace(err)
 	}
 
-	datastore, err := c.getTargetDatastore(ctx, datacenter, args)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	templateVM, err := c.ensureTemplateVM(ctx, datastore, args)
-	if err != nil {
-		return nil, errors.Annotate(err, "creating template VM")
-	}
-
-	args.UpdateProgress("cloning template")
-	vm, err := c.cloneVM(ctx, args, templateVM, vmFolder, datastore)
+	args.StatusUpdateParams.UpdateProgress("cloning template")
+	vm, err := c.cloneVM(ctx, args, args.VMTemplate, vmFolder)
 	if err != nil {
 		return nil, errors.Annotate(err, "cloning template VM")
 	}
-	args.UpdateProgress("VM cloned")
+	args.StatusUpdateParams.UpdateProgress("VM cloned")
 
 	taskWaiter := &taskWaiter{
-		args.Clock,
-		args.UpdateProgress,
-		args.UpdateProgressInterval,
+		args.StatusUpdateParams.Clock,
+		args.StatusUpdateParams.UpdateProgress,
+		args.StatusUpdateParams.UpdateProgressInterval,
 	}
 
 	// Make sure to delete the VM if anything goes wrong before we've finished with it.
@@ -362,14 +364,14 @@ func (c *Client) CreateVirtualMachine(
 	}()
 
 	if err := c.maybeUpgradeVMHardware(ctx, args, vm, taskWaiter); err != nil {
-		args.UpdateProgress(fmt.Sprintf("VM upgrade failed: %s", err))
+		args.StatusUpdateParams.UpdateProgress(fmt.Sprintf("VM upgrade failed: %s", err))
 		return nil, errors.Annotate(err, "upgrading VM hardware")
 	}
 
 	if args.Constraints.RootDisk != nil {
 		// The user specified a root disk, so extend the VM's
 		// disk before powering the VM on.
-		args.UpdateProgress(fmt.Sprintf(
+		args.StatusUpdateParams.UpdateProgress(fmt.Sprintf(
 			"extending disk to %s",
 			humanize.IBytes(megabytesToB(*args.Constraints.RootDisk)),
 		))
@@ -382,7 +384,7 @@ func (c *Client) CreateVirtualMachine(
 		}
 	}
 
-	args.UpdateProgress("powering on")
+	args.StatusUpdateParams.UpdateProgress("powering on")
 	task, err := vm.PowerOn(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -438,18 +440,19 @@ func (c *Client) extendVMRootDisk(
 
 func (c *Client) createImportSpec(
 	ctx context.Context,
-	args CreateVirtualMachineParams,
+	templateName string,
+	resourcePool types.ManagedObjectReference,
 	datastore *object.Datastore,
 ) (*types.OvfCreateImportSpecResult, error) {
 	cisp := types.OvfCreateImportSpecParams{
-		EntityName: vmTemplateName(args),
+		EntityName: templateName,
 	}
 	c.logger.Debugf("Creating import spec: pool=%q, datastore=%q, entity=%q",
-		args.ResourcePool, datastore, cisp.EntityName)
+		resourcePool, datastore, cisp.EntityName)
 
 	c.logger.Debugf("Fetching OVF manager")
 	ovfManager := ovf.NewManager(c.client.Client)
-	spec, err := ovfManager.CreateImportSpec(ctx, UbuntuOVF, args.ResourcePool, datastore, cisp)
+	spec, err := ovfManager.CreateImportSpec(ctx, UbuntuOVF, resourcePool, datastore, cisp)
 	if err != nil {
 		c.logger.Debugf("CreateImportSpec error: err=%v", err)
 		return nil, errors.Trace(err)
@@ -468,7 +471,9 @@ func (c *Client) createImportSpec(
 
 func (c *Client) selectDatastore(
 	ctx context.Context,
-	args CreateVirtualMachineParams,
+	computeResource *mo.ComputeResource,
+	rootDiskSource string,
+	// args CreateVirtualMachineParams,
 ) (_ *mo.Datastore, err error) {
 	defer func() {
 		if err != nil {
@@ -479,8 +484,8 @@ func (c *Client) selectDatastore(
 	// Select a datastore. If the user specified one, use that. When no datastore
 	// is provided and there is only datastore accessible, use that. Otherwise return
 	// an error and ask for guidance.
-	refs := make([]types.ManagedObjectReference, len(args.ComputeResource.Datastore))
-	for i, ds := range args.ComputeResource.Datastore {
+	refs := make([]types.ManagedObjectReference, len(computeResource.Datastore))
+	for i, ds := range computeResource.Datastore {
 		refs[i] = ds.Reference()
 	}
 	var datastores []mo.Datastore
@@ -503,8 +508,8 @@ func (c *Client) selectDatastore(
 		return nil, errors.New("no accessible datastores available")
 	}
 
-	if args.Constraints.RootDiskSource != nil {
-		dsName := *args.Constraints.RootDiskSource
+	if rootDiskSource != "" {
+		dsName := rootDiskSource
 		c.logger.Debugf("desired datastore %q", dsName)
 		c.logger.Debugf("accessible datastores %q", datastoreNames)
 		for _, ds := range datastores {

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -98,19 +98,8 @@ type CreateVirtualMachineParams struct {
 	// in which to create the VM.
 	Folder string
 
-	// RootVMFolder is the customized root vm folder.
-	RootVMFolder string
-
-	// VMDKDirectory is the datastore path in which VMDKs are stored for
-	// this controller. Within this directory there will be subdirectories
-	// for each series, and within those the VMDKs will be stored.
-	VMDKDirectory string
-
 	// Series is the name of the OS series that the image will run.
 	Series string
-
-	// OVASHA256 is the expected SHA-256 hash of the OVA.
-	OVASHA256 string
 
 	// UserData is the cloud-init user-data.
 	UserData string
@@ -149,12 +138,6 @@ type CreateVirtualMachineParams struct {
 	Datastore *object.Datastore
 
 	VMTemplate *object.VirtualMachine
-}
-
-// vmTemplatePath returns the a path inside the vSphere datastore
-// where the template VM is housed.
-func vmTemplatePath(args CreateVirtualMachineParams) string {
-	return path.Join(args.VMDKDirectory, args.Series)
 }
 
 // acquireMutex claims a mutex to prevent multiple workers from

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -317,11 +317,12 @@ func (c *Client) CreateVirtualMachine(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
+	c.logger.Debugf(">>>> Folder: %q", args.Folder)
 	vmFolder, err := c.FindFolder(ctx, args.Folder)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	c.logger.Debugf(">>>> Folder2: %q", vmFolder)
 
 	args.StatusUpdateParams.UpdateProgress("cloning template")
 	vm, err := c.cloneVM(ctx, args, args.VMTemplate, vmFolder)
@@ -456,7 +457,6 @@ func (c *Client) selectDatastore(
 	ctx context.Context,
 	computeResource *mo.ComputeResource,
 	rootDiskSource string,
-	// args CreateVirtualMachineParams,
 ) (_ *mo.Datastore, err error) {
 	defer func() {
 		if err != nil {

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -567,7 +567,7 @@ func (c *Client) addNetworkDevice(
 	networkDevice.Key = -idx // negative to avoid conflicts
 	if mac != "" {
 		if !VerifyMAC(mac) {
-			return nil, fmt.Errorf("Invalid MAC address: %q", mac)
+			return nil, fmt.Errorf("invalid MAC address: %q", mac)
 		}
 		networkDevice.AddressType = "Manual"
 		networkDevice.MacAddress = mac

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -317,12 +317,10 @@ func (c *Client) CreateVirtualMachine(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	c.logger.Debugf(">>>> Folder: %q", args.Folder)
 	vmFolder, err := c.FindFolder(ctx, args.Folder)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	c.logger.Debugf(">>>> Folder2: %q", vmFolder)
 
 	args.StatusUpdateParams.UpdateProgress("cloning template")
 	vm, err := c.cloneVM(ctx, args, args.VMTemplate, vmFolder)

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	"github.com/juju/errors"
 	"github.com/juju/mutex"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -731,21 +730,6 @@ func (s *clientSuite) TestAcquiresMutexWhenNotBootstrapping(c *gc.C) {
 	})
 }
 
-func (s *clientSuite) TestNoAcquireOnBootstrap(c *gc.C) {
-	var stub testing.Stub
-	acquire := func(spec mutex.Spec) (func(), error) {
-		stub.AddCall("acquire")
-		return nil, errors.Errorf("boom")
-	}
-	args := baseCreateVirtualMachineParams(c)
-	args.IsBootstrap = true
-	client := s.newFakeClient(&s.roundTripper, "dc0")
-	client.acquireMutex = acquire
-	_, err := client.CreateVirtualMachine(context.Background(), args)
-	c.Assert(err, jc.ErrorIsNil)
-	stub.CheckCallNames(c)
-}
-
 func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 	readOVA := func() (string, io.ReadCloser, error) {
 		r := bytes.NewReader(ovatest.FakeOVAContents())
@@ -796,7 +780,6 @@ func baseCreateVirtualMachineParams(c *gc.C) CreateVirtualMachineParams {
 		UpdateProgressInterval: time.Second,
 		Clock:                  testclock.NewClock(time.Time{}),
 		EnableDiskUUID:         true,
-		IsBootstrap:            false,
 		DiskProvisioningType:   DiskTypeThin,
 	}
 }

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -72,33 +72,33 @@ func (s *clientSuite) TestCreateTemplateVM(c *gc.C) {
 	templateCisp := baseCisp()
 	templateCisp.EntityName = args.TemplateName
 	s.roundTripper.CheckCalls(c, []testing.StubCall{
-		{"CreateImportSpec", []interface{}{
+		{FuncName: "CreateImportSpec", Args: []interface{}{
 			UbuntuOVF,
 			types.ManagedObjectReference{Type: "Datastore", Value: "FakeDatastore1"},
 			templateCisp,
 		}},
-		{"ImportVApp", []interface{}{
+		{FuncName: "ImportVApp", Args: []interface{}{
 			&types.VirtualMachineImportSpec{
 				ConfigSpec: types.VirtualMachineConfigSpec{
 					Name: "vm-name",
 				},
 			},
 		}},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
-		{"HttpNfcLeaseComplete", []interface{}{"FakeLease"}},
-		{"ReconfigVM_Task", []interface{}{
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
+		{FuncName: "HttpNfcLeaseComplete", Args: []interface{}{"FakeLease"}},
+		{FuncName: "ReconfigVM_Task", Args: []interface{}{
 			types.VirtualMachineConfigSpec{
 				ExtraConfig: []types.BaseOptionValue{
 					&types.OptionValue{Key: ArchTag, Value: "amd64"},
 				},
 			},
 		}},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
-		{"MarkAsTemplate", []interface{}{"FakeVm0"}},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
+		{FuncName: "MarkAsTemplate", Args: []interface{}{"FakeVm0"}},
 	})
 }
 
@@ -160,7 +160,7 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 		retrievePropertiesStubCall("dvportgroup-0"),
 		retrievePropertiesStubCall("FakeVm0"),
 		retrievePropertiesStubCall("FakeVm0"),
-		{"CloneVM_Task", []interface{}{
+		{FuncName: "CloneVM_Task", Args: []interface{}{
 			types.ManagedObjectReference{
 				Type: "Folder", Value: "FakeControllerVmFolder",
 			},
@@ -197,13 +197,13 @@ func (s *clientSuite) TestCreateVirtualMachine(c *gc.C) {
 				},
 			},
 		}},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
-		{"PowerOnVM_Task", nil},
-		{"CreatePropertyCollector", nil},
-		{"CreateFilter", nil},
-		{"WaitForUpdatesEx", nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
+		{FuncName: "PowerOnVM_Task", Args: nil},
+		{FuncName: "CreatePropertyCollector", Args: nil},
+		{FuncName: "CreateFilter", Args: nil},
+		{FuncName: "WaitForUpdatesEx", Args: nil},
 		retrievePropertiesStubCall(""),
 	})
 }
@@ -694,7 +694,7 @@ func (s *clientSuite) TestCreateVirtualMachineInvalidMAC(c *gc.C) {
 	}
 
 	_, err := client.CreateVirtualMachine(context.Background(), args)
-	c.Assert(err, gc.ErrorMatches, `cloning template VM: building clone VM config: adding network device 0 - network VM Network: Invalid MAC address: "00:11:22:33:44:55"`)
+	c.Assert(err, gc.ErrorMatches, `cloning template VM: building clone VM config: adding network device 0 - network VM Network: invalid MAC address: "00:11:22:33:44:55"`)
 }
 
 func (s *clientSuite) TestCreateVirtualMachineRootDiskSize(c *gc.C) {

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -115,7 +115,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		res.Res = &types.PowerOnVM_TaskResponse{powerOnVMTask}
 	case *methods.CloneVM_TaskBody:
 		req := req.(*methods.CloneVM_TaskBody).Req
-		r.MethodCall(r, "CloneVM_Task", req.Name, req.Spec.Config, req.Spec.Location)
+		r.MethodCall(r, "CloneVM_Task", req.Folder, req.Name, req.Spec.Config, req.Spec.Location)
 		res.Res = &types.CloneVM_TaskResponse{cloneVMTask}
 	case *methods.CreateFolderBody:
 		req := req.(*methods.CreateFolderBody).Req

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -100,23 +100,23 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.ReconfigVM_TaskBody:
 		req := req.(*methods.ReconfigVM_TaskBody).Req
 		r.MethodCall(r, "ReconfigVM_Task", req.Spec)
-		res.Res = &types.ReconfigVM_TaskResponse{reconfigVMTask}
+		res.Res = &types.ReconfigVM_TaskResponse{Returnval: reconfigVMTask}
 	case *methods.Destroy_TaskBody:
 		r.MethodCall(r, "Destroy_Task")
-		res.Res = &types.Destroy_TaskResponse{destroyTask}
+		res.Res = &types.Destroy_TaskResponse{Returnval: destroyTask}
 	case *methods.MoveIntoFolder_TaskBody:
 		r.MethodCall(r, "MoveIntoFolder_Task")
-		res.Res = &types.MoveIntoFolder_TaskResponse{moveIntoFolderTask}
+		res.Res = &types.MoveIntoFolder_TaskResponse{Returnval: moveIntoFolderTask}
 	case *methods.PowerOffVM_TaskBody:
 		r.MethodCall(r, "PowerOffVM_Task")
-		res.Res = &types.PowerOffVM_TaskResponse{powerOffVMTask}
+		res.Res = &types.PowerOffVM_TaskResponse{Returnval: powerOffVMTask}
 	case *methods.PowerOnVM_TaskBody:
 		r.MethodCall(r, "PowerOnVM_Task")
-		res.Res = &types.PowerOnVM_TaskResponse{powerOnVMTask}
+		res.Res = &types.PowerOnVM_TaskResponse{Returnval: powerOnVMTask}
 	case *methods.CloneVM_TaskBody:
 		req := req.(*methods.CloneVM_TaskBody).Req
 		r.MethodCall(r, "CloneVM_Task", req.Folder, req.Name, req.Spec.Config, req.Spec.Location)
-		res.Res = &types.CloneVM_TaskResponse{cloneVMTask}
+		res.Res = &types.CloneVM_TaskResponse{Returnval: cloneVMTask}
 	case *methods.CreateFolderBody:
 		req := req.(*methods.CreateFolderBody).Req
 		logger.Debugf("CreateFolder: %q", req.Name)
@@ -126,7 +126,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		req := req.(*methods.CreateImportSpecBody).Req
 		r.MethodCall(r, "CreateImportSpec", req.OvfDescriptor, req.Datastore, req.Cisp)
 		res.Res = &types.CreateImportSpecResponse{
-			types.OvfCreateImportSpecResult{
+			Returnval: types.OvfCreateImportSpecResult{
 				FileItem: []types.OvfFileItem{
 					{
 						DeviceId: "key1",
@@ -144,19 +144,19 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.ImportVAppBody:
 		req := req.(*methods.ImportVAppBody).Req
 		r.MethodCall(r, "ImportVApp", req.Spec)
-		res.Res = &types.ImportVAppResponse{lease}
+		res.Res = &types.ImportVAppResponse{Returnval: lease}
 	case *methods.SearchDatastore_TaskBody:
 		req := req.(*methods.SearchDatastore_TaskBody).Req
 		r.MethodCall(r, "SearchDatastore", req.DatastorePath, req.SearchSpec)
-		res.Res = &types.SearchDatastore_TaskResponse{searchDatastoreTask}
+		res.Res = &types.SearchDatastore_TaskResponse{Returnval: searchDatastoreTask}
 	case *methods.DeleteDatastoreFile_TaskBody:
 		req := req.(*methods.DeleteDatastoreFile_TaskBody).Req
 		r.MethodCall(r, "DeleteDatastoreFile", req.Name)
-		res.Res = &types.DeleteDatastoreFile_TaskResponse{deleteDatastoreFileTask}
+		res.Res = &types.DeleteDatastoreFile_TaskResponse{Returnval: deleteDatastoreFileTask}
 	case *methods.MoveDatastoreFile_TaskBody:
 		req := req.(*methods.MoveDatastoreFile_TaskBody).Req
 		r.MethodCall(r, "MoveDatastoreFile", req.SourceName, req.DestinationName, req.Force)
-		res.Res = &types.MoveDatastoreFile_TaskResponse{moveDatastoreFileTask}
+		res.Res = &types.MoveDatastoreFile_TaskResponse{Returnval: moveDatastoreFileTask}
 	case *methods.MakeDirectoryBody:
 		req := req.(*methods.MakeDirectoryBody).Req
 		r.MethodCall(r, "MakeDirectory", req.Name)
@@ -164,7 +164,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.ExtendVirtualDisk_TaskBody:
 		req := req.(*methods.ExtendVirtualDisk_TaskBody).Req
 		r.MethodCall(r, "ExtendVirtualDisk", req.Name, req.NewCapacityKb)
-		res.Res = &types.ExtendVirtualDisk_TaskResponse{extendVirtualDiskTask}
+		res.Res = &types.ExtendVirtualDisk_TaskResponse{Returnval: extendVirtualDiskTask}
 	case *methods.CreatePropertyCollectorBody:
 		r.MethodCall(r, "CreatePropertyCollector")
 		uuid := utils.MustNewUUID().String()
@@ -342,7 +342,7 @@ func (r *mockRoundTripper) retrieveProperties(req *types.RetrieveProperties) *ty
 		}
 	}
 	logger.Debugf("received %s", contents)
-	return &types.RetrievePropertiesResponse{contents}
+	return &types.RetrievePropertiesResponse{Returnval: contents}
 }
 
 func (r *mockRoundTripper) setContents(contents map[string][]types.ObjectContent) {
@@ -366,7 +366,7 @@ func makeStubCall(method string, vals ...string) testing.StubCall {
 	for i, vals := range vals {
 		args[i] = vals
 	}
-	return testing.StubCall{method, args}
+	return testing.StubCall{FuncName: method, Args: args}
 }
 
 type collector struct {

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -50,6 +50,26 @@ func (c *mockClient) Close(ctx context.Context) error {
 	return c.NextErr()
 }
 
+func (c *mockClient) CreateTemplateVM(ctx context.Context, ovaArgs vsphereclient.ImportOVAParameters) (vm *object.VirtualMachine, err error) {
+	return nil, nil
+}
+
+func (c *mockClient) FindVMTemplatesByName(ctx context.Context, path string, name string) ([]*object.VirtualMachine, error) {
+	return nil, nil
+}
+
+func (c *mockClient) GetTargetDatastore(ctx context.Context, computeResource *mo.ComputeResource, rootDiskSource string) (*object.Datastore, error) {
+	return nil, nil
+}
+
+func (c *mockClient) ListVMTemplates(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
+	return nil, nil
+}
+
+func (c *mockClient) VirtualMachineObjectToManagedObject(ctx context.Context, vmObject *object.VirtualMachine) (mo.VirtualMachine, error) {
+	return mo.VirtualMachine{}, nil
+}
+
 func (c *mockClient) ComputeResources(ctx context.Context) ([]vsphereclient.ComputeResource, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -126,7 +126,7 @@ func (c *mockClient) VirtualMachineObjectToManagedObject(ctx context.Context, vm
 
 	vmTplObj := buildVM(vmTpl.args.TemplateName).extraConfig(vsphereclient.ArchTag, vmTpl.args.Arch).vm()
 	c.MethodCall(c, "VirtualMachineObjectToManagedObject", ctx, vmObject)
-	return *vmTplObj, nil
+	return *vmTplObj, c.NextErr()
 }
 
 func (c *mockClient) ComputeResources(ctx context.Context) ([]vsphereclient.ComputeResource, error) {

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -6,6 +6,7 @@ package vsphere_test
 import (
 	"context"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/juju/testing"
@@ -33,14 +34,20 @@ type mockClient struct {
 	mu sync.Mutex
 	testing.Stub
 
-	computeResources      []vsphereclient.ComputeResource
-	resourcePools         map[string][]*object.ResourcePool
-	createdVirtualMachine *mo.VirtualMachine
-	virtualMachines       []*mo.VirtualMachine
-	folders               *object.DatacenterFolders
-	datastores            []mo.Datastore
-	vmFolder              *object.Folder
-	hasPrivilege          bool
+	computeResources        []vsphereclient.ComputeResource
+	resourcePools           map[string][]*object.ResourcePool
+	createdVirtualMachine   *mo.VirtualMachine
+	virtualMachines         []*mo.VirtualMachine
+	virtualMachineTemplates []mockTemplateVM
+	folders                 *object.DatacenterFolders
+	datastores              []mo.Datastore
+	vmFolder                *object.Folder
+	hasPrivilege            bool
+}
+
+type mockTemplateVM struct {
+	vm   *object.VirtualMachine
+	args vsphereclient.ImportOVAParameters
 }
 
 func (c *mockClient) Close(ctx context.Context) error {
@@ -51,23 +58,73 @@ func (c *mockClient) Close(ctx context.Context) error {
 }
 
 func (c *mockClient) CreateTemplateVM(ctx context.Context, ovaArgs vsphereclient.ImportOVAParameters) (vm *object.VirtualMachine, err error) {
-	return nil, nil
-}
-
-func (c *mockClient) FindVMTemplatesByName(ctx context.Context, path string, name string) ([]*object.VirtualMachine, error) {
-	return nil, nil
+	tpl := mockTemplateVM{
+		vm: object.NewVirtualMachine(nil, types.ManagedObjectReference{
+			Type:  "VirtualMachine",
+			Value: "juju-template-" + ovaArgs.OVASHA256,
+		}),
+		args: ovaArgs,
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.virtualMachineTemplates = append(c.virtualMachineTemplates, tpl)
+	c.MethodCall(c, "CreateTemplateVM", ctx, ovaArgs)
+	return tpl.vm, c.NextErr()
 }
 
 func (c *mockClient) GetTargetDatastore(ctx context.Context, computeResource *mo.ComputeResource, rootDiskSource string) (*object.Datastore, error) {
-	return nil, nil
+	if rootDiskSource == "" {
+		for _, ds := range c.datastores {
+			if ds.Summary.Accessible {
+				rootDiskSource = ds.GetManagedEntity().Name
+			}
+		}
+	}
+	ds := object.NewDatastore(nil, types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: rootDiskSource,
+	})
+	c.MethodCall(c, "GetTargetDatastore", ctx, computeResource, rootDiskSource)
+	return ds, c.NextErr()
 }
 
 func (c *mockClient) ListVMTemplates(ctx context.Context, path string) ([]*object.VirtualMachine, error) {
-	return nil, nil
+	var ret []*object.VirtualMachine
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, vm := range c.virtualMachineTemplates {
+		ref := vm.args.DestinationFolder.Reference()
+		if strings.HasPrefix(ref.Value, path) {
+			ret = append(ret, vm.vm)
+		}
+	}
+	c.MethodCall(c, "ListVMTemplates", ctx, path)
+	return ret, c.NextErr()
 }
 
 func (c *mockClient) VirtualMachineObjectToManagedObject(ctx context.Context, vmObject *object.VirtualMachine) (mo.VirtualMachine, error) {
-	return mo.VirtualMachine{}, nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if vmObject == nil {
+		panic("test data not properly set")
+	}
+	var vmTpl mockTemplateVM
+	ref := vmObject.Reference()
+	for _, vm := range c.virtualMachineTemplates {
+		if vm.args.TemplateName == ref.Value {
+			vmTpl = vm
+			break
+		}
+	}
+	if vmTpl.vm == nil {
+		panic("test data not properly set")
+	}
+
+	vmTplObj := buildVM(vmTpl.args.TemplateName).extraConfig(vsphereclient.ArchTag, vmTpl.args.Series).vm()
+	c.MethodCall(c, "VirtualMachineObjectToManagedObject", ctx, vmObject)
+	return *vmTplObj, nil
 }
 
 func (c *mockClient) ComputeResources(ctx context.Context) ([]vsphereclient.ComputeResource, error) {
@@ -130,7 +187,10 @@ func (c *mockClient) EnsureVMFolder(ctx context.Context, credAttrFolder string, 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.MethodCall(c, "EnsureVMFolder", ctx, credAttrFolder, path)
-	return c.vmFolder, c.NextErr()
+	return object.NewFolder(nil, types.ManagedObjectReference{
+		Type:  "Folder",
+		Value: path,
+	}), c.NextErr()
 }
 
 func (c *mockClient) MoveVMFolderInto(ctx context.Context, parent string, child string) error {

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -77,6 +77,7 @@ func (c *mockClient) GetTargetDatastore(ctx context.Context, computeResource *mo
 		for _, ds := range c.datastores {
 			if ds.Summary.Accessible {
 				rootDiskSource = ds.GetManagedEntity().Name
+				break
 			}
 		}
 	}

--- a/provider/vsphere/mock_test.go
+++ b/provider/vsphere/mock_test.go
@@ -96,6 +96,7 @@ func (c *mockClient) ListVMTemplates(ctx context.Context, path string) ([]*objec
 
 	for _, vm := range c.virtualMachineTemplates {
 		ref := vm.args.DestinationFolder.Reference()
+
 		if strings.HasPrefix(ref.Value, path) {
 			ret = append(ret, vm.vm)
 		}
@@ -123,7 +124,7 @@ func (c *mockClient) VirtualMachineObjectToManagedObject(ctx context.Context, vm
 		panic("test data not properly set")
 	}
 
-	vmTplObj := buildVM(vmTpl.args.TemplateName).extraConfig(vsphereclient.ArchTag, vmTpl.args.Series).vm()
+	vmTplObj := buildVM(vmTpl.args.TemplateName).extraConfig(vsphereclient.ArchTag, vmTpl.args.Arch).vm()
 	c.MethodCall(c, "VirtualMachineObjectToManagedObject", ctx, vmObject)
 	return *vmTplObj, nil
 }

--- a/provider/vsphere/mocks/client_mock.go
+++ b/provider/vsphere/mocks/client_mock.go
@@ -170,21 +170,6 @@ func (mr *MockClientMockRecorder) FindFolder(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindFolder", reflect.TypeOf((*MockClient)(nil).FindFolder), arg0, arg1)
 }
 
-// FindVMTemplatesByName mocks base method.
-func (m *MockClient) FindVMTemplatesByName(arg0 context.Context, arg1, arg2 string) ([]*object.VirtualMachine, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindVMTemplatesByName", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*object.VirtualMachine)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindVMTemplatesByName indicates an expected call of FindVMTemplatesByName.
-func (mr *MockClientMockRecorder) FindVMTemplatesByName(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVMTemplatesByName", reflect.TypeOf((*MockClient)(nil).FindVMTemplatesByName), arg0, arg1, arg2)
-}
-
 // Folders mocks base method.
 func (m *MockClient) Folders(arg0 context.Context) (*object.DatacenterFolders, error) {
 	m.ctrl.T.Helper()

--- a/provider/vsphere/mocks/client_mock.go
+++ b/provider/vsphere/mocks/client_mock.go
@@ -6,38 +6,39 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	vsphereclient "github.com/juju/juju/provider/vsphere/internal/vsphereclient"
 	object "github.com/vmware/govmomi/object"
 	mo "github.com/vmware/govmomi/vim25/mo"
 	types "github.com/vmware/govmomi/vim25/types"
-	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockClient) Close(arg0 context.Context) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close", arg0)
@@ -45,13 +46,13 @@ func (m *MockClient) Close(arg0 context.Context) error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockClientMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close), arg0)
 }
 
-// ComputeResources mocks base method
+// ComputeResources mocks base method.
 func (m *MockClient) ComputeResources(arg0 context.Context) ([]vsphereclient.ComputeResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ComputeResources", arg0)
@@ -60,13 +61,28 @@ func (m *MockClient) ComputeResources(arg0 context.Context) ([]vsphereclient.Com
 	return ret0, ret1
 }
 
-// ComputeResources indicates an expected call of ComputeResources
+// ComputeResources indicates an expected call of ComputeResources.
 func (mr *MockClientMockRecorder) ComputeResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeResources", reflect.TypeOf((*MockClient)(nil).ComputeResources), arg0)
 }
 
-// CreateVirtualMachine mocks base method
+// CreateTemplateVM mocks base method.
+func (m *MockClient) CreateTemplateVM(arg0 context.Context, arg1 vsphereclient.ImportOVAParameters) (*object.VirtualMachine, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTemplateVM", arg0, arg1)
+	ret0, _ := ret[0].(*object.VirtualMachine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTemplateVM indicates an expected call of CreateTemplateVM.
+func (mr *MockClientMockRecorder) CreateTemplateVM(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemplateVM", reflect.TypeOf((*MockClient)(nil).CreateTemplateVM), arg0, arg1)
+}
+
+// CreateVirtualMachine mocks base method.
 func (m *MockClient) CreateVirtualMachine(arg0 context.Context, arg1 vsphereclient.CreateVirtualMachineParams) (*mo.VirtualMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualMachine", arg0, arg1)
@@ -75,13 +91,13 @@ func (m *MockClient) CreateVirtualMachine(arg0 context.Context, arg1 vsphereclie
 	return ret0, ret1
 }
 
-// CreateVirtualMachine indicates an expected call of CreateVirtualMachine
+// CreateVirtualMachine indicates an expected call of CreateVirtualMachine.
 func (mr *MockClientMockRecorder) CreateVirtualMachine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualMachine", reflect.TypeOf((*MockClient)(nil).CreateVirtualMachine), arg0, arg1)
 }
 
-// Datastores mocks base method
+// Datastores mocks base method.
 func (m *MockClient) Datastores(arg0 context.Context) ([]mo.Datastore, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Datastores", arg0)
@@ -90,13 +106,13 @@ func (m *MockClient) Datastores(arg0 context.Context) ([]mo.Datastore, error) {
 	return ret0, ret1
 }
 
-// Datastores indicates an expected call of Datastores
+// Datastores indicates an expected call of Datastores.
 func (mr *MockClientMockRecorder) Datastores(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Datastores", reflect.TypeOf((*MockClient)(nil).Datastores), arg0)
 }
 
-// DeleteDatastoreFile mocks base method
+// DeleteDatastoreFile mocks base method.
 func (m *MockClient) DeleteDatastoreFile(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDatastoreFile", arg0, arg1)
@@ -104,13 +120,13 @@ func (m *MockClient) DeleteDatastoreFile(arg0 context.Context, arg1 string) erro
 	return ret0
 }
 
-// DeleteDatastoreFile indicates an expected call of DeleteDatastoreFile
+// DeleteDatastoreFile indicates an expected call of DeleteDatastoreFile.
 func (mr *MockClientMockRecorder) DeleteDatastoreFile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDatastoreFile", reflect.TypeOf((*MockClient)(nil).DeleteDatastoreFile), arg0, arg1)
 }
 
-// DestroyVMFolder mocks base method
+// DestroyVMFolder mocks base method.
 func (m *MockClient) DestroyVMFolder(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyVMFolder", arg0, arg1)
@@ -118,13 +134,13 @@ func (m *MockClient) DestroyVMFolder(arg0 context.Context, arg1 string) error {
 	return ret0
 }
 
-// DestroyVMFolder indicates an expected call of DestroyVMFolder
+// DestroyVMFolder indicates an expected call of DestroyVMFolder.
 func (mr *MockClientMockRecorder) DestroyVMFolder(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyVMFolder", reflect.TypeOf((*MockClient)(nil).DestroyVMFolder), arg0, arg1)
 }
 
-// EnsureVMFolder mocks base method
+// EnsureVMFolder mocks base method.
 func (m *MockClient) EnsureVMFolder(arg0 context.Context, arg1, arg2 string) (*object.Folder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureVMFolder", arg0, arg1, arg2)
@@ -133,13 +149,13 @@ func (m *MockClient) EnsureVMFolder(arg0 context.Context, arg1, arg2 string) (*o
 	return ret0, ret1
 }
 
-// EnsureVMFolder indicates an expected call of EnsureVMFolder
+// EnsureVMFolder indicates an expected call of EnsureVMFolder.
 func (mr *MockClientMockRecorder) EnsureVMFolder(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVMFolder", reflect.TypeOf((*MockClient)(nil).EnsureVMFolder), arg0, arg1, arg2)
 }
 
-// FindFolder mocks base method
+// FindFolder mocks base method.
 func (m *MockClient) FindFolder(arg0 context.Context, arg1 string) (*object.Folder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindFolder", arg0, arg1)
@@ -148,13 +164,28 @@ func (m *MockClient) FindFolder(arg0 context.Context, arg1 string) (*object.Fold
 	return ret0, ret1
 }
 
-// FindFolder indicates an expected call of FindFolder
+// FindFolder indicates an expected call of FindFolder.
 func (mr *MockClientMockRecorder) FindFolder(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindFolder", reflect.TypeOf((*MockClient)(nil).FindFolder), arg0, arg1)
 }
 
-// Folders mocks base method
+// FindVMTemplatesByName mocks base method.
+func (m *MockClient) FindVMTemplatesByName(arg0 context.Context, arg1, arg2 string) ([]*object.VirtualMachine, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVMTemplatesByName", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*object.VirtualMachine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindVMTemplatesByName indicates an expected call of FindVMTemplatesByName.
+func (mr *MockClientMockRecorder) FindVMTemplatesByName(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVMTemplatesByName", reflect.TypeOf((*MockClient)(nil).FindVMTemplatesByName), arg0, arg1, arg2)
+}
+
+// Folders mocks base method.
 func (m *MockClient) Folders(arg0 context.Context) (*object.DatacenterFolders, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Folders", arg0)
@@ -163,13 +194,43 @@ func (m *MockClient) Folders(arg0 context.Context) (*object.DatacenterFolders, e
 	return ret0, ret1
 }
 
-// Folders indicates an expected call of Folders
+// Folders indicates an expected call of Folders.
 func (mr *MockClientMockRecorder) Folders(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Folders", reflect.TypeOf((*MockClient)(nil).Folders), arg0)
 }
 
-// MoveVMFolderInto mocks base method
+// GetTargetDatastore mocks base method.
+func (m *MockClient) GetTargetDatastore(arg0 context.Context, arg1 *mo.ComputeResource, arg2 string) (*object.Datastore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTargetDatastore", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*object.Datastore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTargetDatastore indicates an expected call of GetTargetDatastore.
+func (mr *MockClientMockRecorder) GetTargetDatastore(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTargetDatastore", reflect.TypeOf((*MockClient)(nil).GetTargetDatastore), arg0, arg1, arg2)
+}
+
+// ListVMTemplates mocks base method.
+func (m *MockClient) ListVMTemplates(arg0 context.Context, arg1 string) ([]*object.VirtualMachine, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListVMTemplates", arg0, arg1)
+	ret0, _ := ret[0].([]*object.VirtualMachine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListVMTemplates indicates an expected call of ListVMTemplates.
+func (mr *MockClientMockRecorder) ListVMTemplates(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVMTemplates", reflect.TypeOf((*MockClient)(nil).ListVMTemplates), arg0, arg1)
+}
+
+// MoveVMFolderInto mocks base method.
 func (m *MockClient) MoveVMFolderInto(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MoveVMFolderInto", arg0, arg1, arg2)
@@ -177,13 +238,13 @@ func (m *MockClient) MoveVMFolderInto(arg0 context.Context, arg1, arg2 string) e
 	return ret0
 }
 
-// MoveVMFolderInto indicates an expected call of MoveVMFolderInto
+// MoveVMFolderInto indicates an expected call of MoveVMFolderInto.
 func (mr *MockClientMockRecorder) MoveVMFolderInto(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveVMFolderInto", reflect.TypeOf((*MockClient)(nil).MoveVMFolderInto), arg0, arg1, arg2)
 }
 
-// MoveVMsInto mocks base method
+// MoveVMsInto mocks base method.
 func (m *MockClient) MoveVMsInto(arg0 context.Context, arg1 string, arg2 ...types.ManagedObjectReference) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -195,14 +256,14 @@ func (m *MockClient) MoveVMsInto(arg0 context.Context, arg1 string, arg2 ...type
 	return ret0
 }
 
-// MoveVMsInto indicates an expected call of MoveVMsInto
+// MoveVMsInto indicates an expected call of MoveVMsInto.
 func (mr *MockClientMockRecorder) MoveVMsInto(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveVMsInto", reflect.TypeOf((*MockClient)(nil).MoveVMsInto), varargs...)
 }
 
-// RemoveVirtualMachines mocks base method
+// RemoveVirtualMachines mocks base method.
 func (m *MockClient) RemoveVirtualMachines(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveVirtualMachines", arg0, arg1)
@@ -210,13 +271,13 @@ func (m *MockClient) RemoveVirtualMachines(arg0 context.Context, arg1 string) er
 	return ret0
 }
 
-// RemoveVirtualMachines indicates an expected call of RemoveVirtualMachines
+// RemoveVirtualMachines indicates an expected call of RemoveVirtualMachines.
 func (mr *MockClientMockRecorder) RemoveVirtualMachines(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVirtualMachines", reflect.TypeOf((*MockClient)(nil).RemoveVirtualMachines), arg0, arg1)
 }
 
-// ResourcePools mocks base method
+// ResourcePools mocks base method.
 func (m *MockClient) ResourcePools(arg0 context.Context, arg1 string) ([]*object.ResourcePool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResourcePools", arg0, arg1)
@@ -225,13 +286,13 @@ func (m *MockClient) ResourcePools(arg0 context.Context, arg1 string) ([]*object
 	return ret0, ret1
 }
 
-// ResourcePools indicates an expected call of ResourcePools
+// ResourcePools indicates an expected call of ResourcePools.
 func (mr *MockClientMockRecorder) ResourcePools(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourcePools", reflect.TypeOf((*MockClient)(nil).ResourcePools), arg0, arg1)
 }
 
-// UpdateVirtualMachineExtraConfig mocks base method
+// UpdateVirtualMachineExtraConfig mocks base method.
 func (m *MockClient) UpdateVirtualMachineExtraConfig(arg0 context.Context, arg1 *mo.VirtualMachine, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateVirtualMachineExtraConfig", arg0, arg1, arg2)
@@ -239,13 +300,13 @@ func (m *MockClient) UpdateVirtualMachineExtraConfig(arg0 context.Context, arg1 
 	return ret0
 }
 
-// UpdateVirtualMachineExtraConfig indicates an expected call of UpdateVirtualMachineExtraConfig
+// UpdateVirtualMachineExtraConfig indicates an expected call of UpdateVirtualMachineExtraConfig.
 func (mr *MockClientMockRecorder) UpdateVirtualMachineExtraConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVirtualMachineExtraConfig", reflect.TypeOf((*MockClient)(nil).UpdateVirtualMachineExtraConfig), arg0, arg1, arg2)
 }
 
-// UserHasRootLevelPrivilege mocks base method
+// UserHasRootLevelPrivilege mocks base method.
 func (m *MockClient) UserHasRootLevelPrivilege(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserHasRootLevelPrivilege", arg0, arg1)
@@ -254,13 +315,28 @@ func (m *MockClient) UserHasRootLevelPrivilege(arg0 context.Context, arg1 string
 	return ret0, ret1
 }
 
-// UserHasRootLevelPrivilege indicates an expected call of UserHasRootLevelPrivilege
+// UserHasRootLevelPrivilege indicates an expected call of UserHasRootLevelPrivilege.
 func (mr *MockClientMockRecorder) UserHasRootLevelPrivilege(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserHasRootLevelPrivilege", reflect.TypeOf((*MockClient)(nil).UserHasRootLevelPrivilege), arg0, arg1)
 }
 
-// VirtualMachines mocks base method
+// VirtualMachineObjectToManagedObject mocks base method.
+func (m *MockClient) VirtualMachineObjectToManagedObject(arg0 context.Context, arg1 *object.VirtualMachine) (mo.VirtualMachine, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VirtualMachineObjectToManagedObject", arg0, arg1)
+	ret0, _ := ret[0].(mo.VirtualMachine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VirtualMachineObjectToManagedObject indicates an expected call of VirtualMachineObjectToManagedObject.
+func (mr *MockClientMockRecorder) VirtualMachineObjectToManagedObject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualMachineObjectToManagedObject", reflect.TypeOf((*MockClient)(nil).VirtualMachineObjectToManagedObject), arg0, arg1)
+}
+
+// VirtualMachines mocks base method.
 func (m *MockClient) VirtualMachines(arg0 context.Context, arg1 string) ([]*mo.VirtualMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VirtualMachines", arg0, arg1)
@@ -269,7 +345,7 @@ func (m *MockClient) VirtualMachines(arg0 context.Context, arg1 string) ([]*mo.V
 	return ret0, ret1
 }
 
-// VirtualMachines indicates an expected call of VirtualMachines
+// VirtualMachines indicates an expected call of VirtualMachines.
 func (mr *MockClientMockRecorder) VirtualMachines(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualMachines", reflect.TypeOf((*MockClient)(nil).VirtualMachines), arg0, arg1)

--- a/provider/vsphere/upgrades.go
+++ b/provider/vsphere/upgrades.go
@@ -17,8 +17,8 @@ import (
 // UpgradeOperations is part of the upgrades.OperationSource interface.
 func (env *environ) UpgradeOperations(ctx context.ProviderCallContext, args environs.UpgradeOperationsParams) []environs.UpgradeOperation {
 	return []environs.UpgradeOperation{{
-		providerVersion1,
-		[]environs.UpgradeStep{
+		TargetVersion: providerVersion1,
+		Steps: []environs.UpgradeStep{
 			extraConfigUpgradeStep{env, args.ControllerUUID},
 			modelFoldersUpgradeStep{env, args.ControllerUUID},
 		},

--- a/provider/vsphere/userdata.go
+++ b/provider/vsphere/userdata.go
@@ -16,7 +16,7 @@ type VsphereRenderer struct{}
 
 func (VsphereRenderer) Render(cfg cloudinit.CloudConfig, os jujuos.OSType) ([]byte, error) {
 	switch os {
-	case jujuos.Ubuntu, jujuos.CentOS:
+	case jujuos.Ubuntu, jujuos.CentOS, jujuos.Windows:
 		return renderers.RenderYAML(cfg, renderers.ToBase64)
 	default:
 		return nil, errors.Errorf("Cannot encode userdata for OS: %s", os.String())

--- a/provider/vsphere/userdata_test.go
+++ b/provider/vsphere/userdata_test.go
@@ -35,12 +35,17 @@ func (s *UserdataSuite) TestVsphereUnix(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected = base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
+
+	result, err = renderer.Render(cloudcfg, os.Windows)
+	c.Assert(err, jc.ErrorIsNil)
+	expected = base64.StdEncoding.EncodeToString(cloudcfg.YAML)
+	c.Assert(string(result), jc.DeepEquals, expected)
 }
 
 func (s *UserdataSuite) TestVsphereUnknownOS(c *gc.C) {
 	renderer := vsphere.VsphereRenderer{}
 	cloudcfg := &cloudinittest.CloudConfig{}
-	result, err := renderer.Render(cloudcfg, os.Windows)
+	result, err := renderer.Render(cloudcfg, os.GenericLinux)
 	c.Assert(result, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: Windows")
+	c.Assert(err, gc.ErrorMatches, "Cannot encode userdata for OS: GenericLinux")
 }

--- a/provider/vsphere/userdata_test.go
+++ b/provider/vsphere/userdata_test.go
@@ -35,10 +35,15 @@ func (s *UserdataSuite) TestVsphereUnix(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expected = base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
+}
 
-	result, err = renderer.Render(cloudcfg, os.Windows)
+func (s *UserdataSuite) TestVsphereWindows(c *gc.C) {
+	renderer := vsphere.VsphereRenderer{}
+	cloudcfg := &cloudinittest.CloudConfig{YAML: []byte("yaml")}
+
+	result, err := renderer.Render(cloudcfg, os.Windows)
 	c.Assert(err, jc.ErrorIsNil)
-	expected = base64.StdEncoding.EncodeToString(cloudcfg.YAML)
+	expected := base64.StdEncoding.EncodeToString(cloudcfg.YAML)
 	c.Assert(string(result), jc.DeepEquals, expected)
 }
 

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -1,3 +1,6 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package vsphere
 
 import (

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -67,17 +67,19 @@ func (v *vmTemplateManager) findTemplate(ctx context.Context) (*object.VirtualMa
 	}
 
 	for _, img := range v.imageMetadata {
-		vms, err := v.env.client.FindVMTemplatesByName(ctx, "*", img.Id)
+		vms, err := v.env.client.ListVMTemplates(ctx, img.Id)
 		if err != nil {
 			return nil, "", errors.Trace(err)
 		}
-		if len(vms) == 0 {
+		switch len(vms) {
+		case 1:
+			// trust that due diligence was made when generating simplestreams
+			// and the img.Arch, reflects the architecture of the OS running insude
+			// the VM generated from the found template.
+			return vms[0], img.Arch, nil
+		default:
 			continue
 		}
-		// trust that due diligence was exercised when generating simplestreams
-		// and the img.Arch, reflects the architecture of the OS running insude
-		// the VM generated from the found template.
-		return vms[0], img.Arch, nil
 	}
 	return nil, "", errors.NotFoundf("could not find a suitable template")
 }

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -171,7 +171,6 @@ func (v *vmTemplateManager) downloadAndImportTemplate(
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
-
 	img, err := findImageMetadata(v.env, arches, series)
 	if err != nil {
 		return nil, "", common.ZoneIndependentError(err)

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -160,7 +161,10 @@ func (v *vmTemplateManager) downloadAndImportTemplate(
 
 	baseFolder := v.env.getVMFolder()
 	seriesTemplateFolder := v.seriesTemplateFolder(series)
-	relativePath := seriesTemplateFolder[len(baseFolder)+1:]
+	relativePath := seriesTemplateFolder
+	if len(baseFolder) > 0 && strings.HasPrefix(relativePath, baseFolder) {
+		relativePath = relativePath[len(baseFolder)+1:]
+	}
 
 	vmFolder, err := v.env.client.EnsureVMFolder(
 		ctx, baseFolder, relativePath)

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -1,0 +1,198 @@
+package vsphere
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"path"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/provider/common"
+	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
+	"github.com/vmware/govmomi/object"
+)
+
+// vmTemplateManager implements a template registry that
+// can return a proper VMware template given a series and
+// image metadata.
+type vmTemplateManager struct {
+	imageMetadata    []*imagemetadata.ImageMetadata
+	env              *sessionEnviron
+	az               *vmwareAvailZone
+	datastore        *object.Datastore
+	controllerUUID   string
+	statusUpdateArgs vsphereclient.StatusUpdateParams
+}
+
+// EnsureTemplate will return a virtual machine template, given the template
+// constraints. If the template does not exist, this function will attempt
+// to create a new template with the characteristics described by the givem
+// constraints.
+func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, arches []string) (*object.VirtualMachine, string, error) {
+	// Attempt to find image in image-metadata
+	logger.Debugf("looking for local templates")
+	tpl, arch, err := v.findTemplate(ctx)
+	if err == nil {
+		logger.Debugf("Found requested template for series %s", series)
+		return tpl, arch, nil
+	}
+	if !errors.IsNotFound(err) {
+		return nil, "", errors.Annotate(err, "searching for template")
+	}
+
+	logger.Debugf("Looking for already imported templates for arches %q", arches)
+	// Attempt to find a previously imported instance template
+	importedTemplate, arch, err := v.getImportedTemplate(ctx, series, arches)
+	if err == nil {
+		logger.Debugf("Found already imported template for series %s", series)
+		return importedTemplate, arch, nil
+	}
+
+	// Ignore not found errors. It means we have not imported a template yet.
+	if !errors.IsNotFound(err) {
+		return nil, "", errors.Trace(err)
+	}
+	logger.Debugf("Downloading and importing template from simplestreams")
+	// Last resort, download and import a template.
+	return v.downloadAndImportTemplate(ctx, series, arches)
+}
+
+// findTemplate uses the imageMetadata provided to find a local template.
+// The imageMetadata parameter holds a list of already filtered templates,
+// that should match the series that was requested.
+func (v *vmTemplateManager) findTemplate(ctx context.Context) (*object.VirtualMachine, string, error) {
+	if len(v.imageMetadata) == 0 {
+		return nil, "", errors.NotFoundf("no image metadata was supplied")
+	}
+
+	for _, img := range v.imageMetadata {
+		vms, err := v.env.client.FindVMTemplatesByName(ctx, "*", img.Id)
+		if err != nil {
+			return nil, "", errors.Trace(err)
+		}
+		if len(vms) == 0 {
+			continue
+		}
+		// trust that due diligence was exercised when generating simplestreams
+		// and the img.Arch, reflects the architecture of the OS running insude
+		// the VM generated from the found template.
+		return vms[0], img.Arch, nil
+	}
+	return nil, "", errors.NotFoundf("could not find a suitable template")
+}
+
+func (v *vmTemplateManager) seriesTemplateFolder(series string) string {
+	templatesPath := v.env.controllerTemplatesFolder(v.controllerUUID)
+	return path.Join(templatesPath, series)
+}
+
+func (v *vmTemplateManager) getVMArch(ctx context.Context, vmObj *object.VirtualMachine) (string, error) {
+	vmMo, err := v.env.client.VirtualMachineObjectToManagedObject(ctx, vmObj)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	for _, item := range vmMo.Config.ExtraConfig {
+		value := item.GetOptionValue()
+		if value.Key == vsphereclient.ArchTag {
+			arch, ok := value.Value.(string)
+			if !ok {
+				return "", errors.Errorf("invalid arch tag for VM")
+			}
+			return arch, nil
+		}
+	}
+	return "", errors.NotFoundf("arch tag not found for VM")
+}
+
+func (v *vmTemplateManager) isValidArch(arch string, desiredArches []string) bool {
+	for _, item := range desiredArches {
+		if item == arch {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series string, arches []string) (*object.VirtualMachine, string, error) {
+	seriesTemplatesFolder := v.seriesTemplateFolder(series)
+	seriesTemplates, err := v.env.client.ListVMTemplates(ctx, path.Join(seriesTemplatesFolder, "*"))
+	if err != nil {
+		logger.Errorf("failed to fetch templates: %v", err)
+		return nil, "", errors.Trace(err)
+	}
+	logger.Debugf("Series templates: %v", seriesTemplates)
+	if len(seriesTemplates) == 0 {
+		return nil, "", errors.NotFoundf("no valid templates found")
+	}
+	var vmTpl *object.VirtualMachine
+	if len(arches) > 0 {
+		for _, item := range seriesTemplates {
+			arch, err := v.getVMArch(ctx, item)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					continue
+				}
+			}
+			if !v.isValidArch(arch, arches) {
+				continue
+			}
+
+			vmTpl = item
+			break
+		}
+		if vmTpl == nil {
+			return nil, "", errors.NotFoundf("no valid templates found")
+		}
+	} else {
+		vmTpl = seriesTemplates[0]
+	}
+
+	return vmTpl, "", nil
+}
+
+func (v *vmTemplateManager) downloadAndImportTemplate(
+	ctx context.Context,
+	series string, arches []string,
+) (*object.VirtualMachine, string, error) {
+
+	baseFolder := v.env.getVMFolder()
+	seriesTemplateFolder := v.seriesTemplateFolder(series)
+	relativePath := seriesTemplateFolder[len(baseFolder)+1:]
+
+	vmFolder, err := v.env.client.EnsureVMFolder(
+		ctx, baseFolder, relativePath)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	img, err := findImageMetadata(v.env, arches, series)
+	if err != nil {
+		return nil, "", common.ZoneIndependentError(err)
+	}
+
+	readOVA := func() (string, io.ReadCloser, error) {
+		resp, err := http.Get(img.URL)
+		if err != nil {
+			return "", nil, errors.Trace(err)
+		}
+		return img.URL, resp.Body, nil
+	}
+
+	ovaArgs := vsphereclient.ImportOVAParameters{
+		ReadOVA:            readOVA,
+		OVASHA256:          img.Sha256,
+		TemplateName:       "juju-template-" + img.Sha256,
+		ResourcePool:       v.az.pool.Reference(),
+		DestinationFolder:  vmFolder,
+		StatusUpdateParams: v.statusUpdateArgs,
+		Datastore:          v.datastore,
+		Arch:               img.Arch,
+		Series:             series,
+	}
+	vmTpl, err := v.env.client.CreateTemplateVM(ctx, ovaArgs)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	return vmTpl, img.Arch, nil
+}

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -10,15 +10,15 @@ import (
 	"path"
 	"strings"
 
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
-
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 // vmTemplateManager implements a template registry that

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 // vmTemplateManager implements a template registry that
@@ -22,17 +24,26 @@ import (
 // image metadata.
 type vmTemplateManager struct {
 	imageMetadata    []*imagemetadata.ImageMetadata
-	env              *sessionEnviron
-	az               *vmwareAvailZone
+	env              environs.Environ
+	client           Client
+	azPoolRef        types.ManagedObjectReference
 	datastore        *object.Datastore
-	controllerUUID   string
 	statusUpdateArgs vsphereclient.StatusUpdateParams
+
+	vmFolder       string
+	controllerUUID string
 }
 
-// EnsureTemplate will return a virtual machine template, given the template
-// constraints. If the template does not exist, this function will attempt
-// to create a new template with the characteristics described by the givem
-// constraints.
+// EnsureTemplate will return a virtual machine template for the requested series.
+// If image metadata is supplied, this function will first look for image-ids entries
+// describing a template already available in the vsphere deployment. If none is found
+// or if no image-ids entries exist, it will then try to find a previously imported
+// template via image-download simplestreams entries. As a last resort, it will try
+// to import a new template from simplestreams.
+//
+// The series parameter is not used when looking for local templates. The image metadata
+// field in the vmTemplateManager should contain already filtered entries, which means
+// the templates should match the requested series.
 func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, arches []string) (*object.VirtualMachine, string, error) {
 	// Attempt to find image in image-metadata
 	logger.Debugf("looking for local templates")
@@ -45,14 +56,14 @@ func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, a
 		return nil, "", errors.Annotate(err, "searching for template")
 	}
 
-	logger.Debugf("Looking for already imported templates for arches %q", arches)
+	logger.Debugf("Looking for already imported templates for series %q", series)
 	// Attempt to find a previously imported instance template
 	importedTemplate, arch, err := v.getImportedTemplate(ctx, series, arches)
 	if err == nil {
-		logger.Debugf("Found already imported template for series %s", series)
+		logger.Debugf("Using already imported template for series %s", series)
 		return importedTemplate, arch, nil
 	}
-
+	logger.Debugf("could not find cached image: %s", err)
 	// Ignore not found errors. It means we have not imported a template yet.
 	if !errors.IsNotFound(err) {
 		return nil, "", errors.Trace(err)
@@ -71,14 +82,17 @@ func (v *vmTemplateManager) findTemplate(ctx context.Context) (*object.VirtualMa
 	}
 
 	for _, img := range v.imageMetadata {
-		vms, err := v.env.client.ListVMTemplates(ctx, img.Id)
+		vms, err := v.client.ListVMTemplates(ctx, img.Id)
 		if err != nil {
 			return nil, "", errors.Trace(err)
 		}
 		switch len(vms) {
 		case 1:
-			// trust that due diligence was made when generating simplestreams
-			// and the img.Arch, reflects the architecture of the OS running insude
+			// Simplestreams image-id entries should point to only one template,
+			// and not to a folder with multiple templates.
+			//
+			// Trust that due diligence was made when generating simplestreams
+			// and the img.Arch, reflects the architecture of the OS running inside
 			// the VM generated from the found template.
 			return vms[0], img.Arch, nil
 		default:
@@ -88,13 +102,18 @@ func (v *vmTemplateManager) findTemplate(ctx context.Context) (*object.VirtualMa
 	return nil, "", errors.NotFoundf("could not find a suitable template")
 }
 
+func (v *vmTemplateManager) controllerTemplatesFolder() string {
+	templateFolder := templateDirectoryName(controllerFolderName(v.controllerUUID))
+	return path.Join(v.vmFolder, templateFolder)
+}
+
 func (v *vmTemplateManager) seriesTemplateFolder(series string) string {
-	templatesPath := v.env.controllerTemplatesFolder(v.controllerUUID)
+	templatesPath := v.controllerTemplatesFolder()
 	return path.Join(templatesPath, series)
 }
 
 func (v *vmTemplateManager) getVMArch(ctx context.Context, vmObj *object.VirtualMachine) (string, error) {
-	vmMo, err := v.env.client.VirtualMachineObjectToManagedObject(ctx, vmObj)
+	vmMo, err := v.client.VirtualMachineObjectToManagedObject(ctx, vmObj)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -122,19 +141,20 @@ func (v *vmTemplateManager) isValidArch(arch string, desiredArches []string) boo
 
 func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series string, arches []string) (*object.VirtualMachine, string, error) {
 	seriesTemplatesFolder := v.seriesTemplateFolder(series)
-	seriesTemplates, err := v.env.client.ListVMTemplates(ctx, path.Join(seriesTemplatesFolder, "*"))
+	seriesTemplates, err := v.client.ListVMTemplates(ctx, path.Join(seriesTemplatesFolder, "*"))
 	if err != nil {
-		logger.Errorf("failed to fetch templates: %v", err)
+		logger.Tracef("failed to fetch templates: %v", err)
 		return nil, "", errors.Trace(err)
 	}
-	logger.Debugf("Series templates: %v", seriesTemplates)
+	logger.Tracef("Series templates: %v", seriesTemplates)
 	if len(seriesTemplates) == 0 {
-		return nil, "", errors.NotFoundf("no valid templates found")
+		return nil, "", errors.NotFoundf("valid template")
 	}
 	var vmTpl *object.VirtualMachine
+	var arch string
 	if len(arches) > 0 {
 		for _, item := range seriesTemplates {
-			arch, err := v.getVMArch(ctx, item)
+			arch, err = v.getVMArch(ctx, item)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					continue
@@ -148,13 +168,13 @@ func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series stri
 			break
 		}
 		if vmTpl == nil {
-			return nil, "", errors.NotFoundf("no valid templates found")
+			return nil, "", errors.NotFoundf("valid template")
 		}
 	} else {
 		vmTpl = seriesTemplates[0]
 	}
 
-	return vmTpl, "", nil
+	return vmTpl, arch, nil
 }
 
 func (v *vmTemplateManager) downloadAndImportTemplate(
@@ -162,15 +182,13 @@ func (v *vmTemplateManager) downloadAndImportTemplate(
 	series string, arches []string,
 ) (*object.VirtualMachine, string, error) {
 
-	baseFolder := v.env.getVMFolder()
 	seriesTemplateFolder := v.seriesTemplateFolder(series)
-	relativePath := seriesTemplateFolder
-	if len(baseFolder) > 0 && strings.HasPrefix(relativePath, baseFolder) {
-		relativePath = relativePath[len(baseFolder)+1:]
+	if len(v.vmFolder) > 0 && strings.HasPrefix(seriesTemplateFolder, v.vmFolder) {
+		seriesTemplateFolder = seriesTemplateFolder[len(v.vmFolder)+1:]
 	}
 
-	vmFolder, err := v.env.client.EnsureVMFolder(
-		ctx, baseFolder, relativePath)
+	vmFolder, err := v.client.EnsureVMFolder(
+		ctx, v.vmFolder, seriesTemplateFolder)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
@@ -191,14 +209,14 @@ func (v *vmTemplateManager) downloadAndImportTemplate(
 		ReadOVA:            readOVA,
 		OVASHA256:          img.Sha256,
 		TemplateName:       "juju-template-" + img.Sha256,
-		ResourcePool:       v.az.pool.Reference(),
+		ResourcePool:       v.azPoolRef,
 		DestinationFolder:  vmFolder,
 		StatusUpdateParams: v.statusUpdateArgs,
 		Datastore:          v.datastore,
 		Arch:               img.Arch,
 		Series:             series,
 	}
-	vmTpl, err := v.env.client.CreateTemplateVM(ctx, ovaArgs)
+	vmTpl, err := v.client.CreateTemplateVM(ctx, ovaArgs)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -47,18 +47,18 @@ func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, a
 	logger.Debugf("looking for local templates")
 	tpl, arch, err := v.findTemplate(ctx)
 	if err == nil {
-		logger.Debugf("Found requested template for series %s", series)
+		logger.Debugf("found requested template for series %s", series)
 		return tpl, arch, nil
 	}
 	if !errors.IsNotFound(err) {
 		return nil, "", errors.Annotate(err, "searching for template")
 	}
 
-	logger.Debugf("Looking for already imported templates for series %q", series)
+	logger.Debugf("looking for already imported templates for series %q", series)
 	// Attempt to find a previously imported instance template
 	importedTemplate, arch, err := v.getImportedTemplate(ctx, series, arches)
 	if err == nil {
-		logger.Debugf("Using already imported template for series %s", series)
+		logger.Debugf("using already imported template for series %s", series)
 		return importedTemplate, arch, nil
 	}
 	logger.Debugf("could not find cached image: %s", err)
@@ -67,7 +67,7 @@ func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, a
 	if !errors.IsNotFound(err) {
 		return nil, "", errors.Trace(err)
 	}
-	logger.Debugf("Downloading and importing template from simplestreams")
+	logger.Debugf("downloading and importing template from simplestreams")
 	// Last resort, download and import a template.
 	return v.downloadAndImportTemplate(ctx, series, arches)
 }

--- a/provider/vsphere/vm_template_test.go
+++ b/provider/vsphere/vm_template_test.go
@@ -1,0 +1,234 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vsphere_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/imagemetadata"
+	"github.com/juju/juju/provider/vsphere"
+	"github.com/juju/juju/provider/vsphere/internal/ovatest"
+	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	gc "gopkg.in/check.v1"
+)
+
+type vmTemplateSuite struct {
+	EnvironFixture
+	statusCallbackStub testing.Stub
+
+	statusUpdateParams vsphereclient.StatusUpdateParams
+	datastore          *object.Datastore
+	mockTemplate       *object.VirtualMachine
+}
+
+var _ = gc.Suite(&vmTemplateSuite{})
+
+func (v *vmTemplateSuite) SetUpTest(c *gc.C) {
+	v.EnvironFixture.SetUpTest(c)
+	v.statusCallbackStub.ResetCalls()
+	v.statusUpdateParams = vsphereclient.StatusUpdateParams{
+		UpdateProgressInterval: time.Second,
+		UpdateProgress:         func(status string) {},
+		Clock:                  testclock.NewClock(time.Time{}),
+	}
+	v.client.folders = makeFolders("/DC/host")
+	v.client.computeResources = []vsphereclient.ComputeResource{
+		{Resource: newComputeResource("z1"), Path: "/DC/host/z1"},
+		{Resource: newComputeResource("z2"), Path: "/DC/host/z2"},
+	}
+	v.client.resourcePools = map[string][]*object.ResourcePool{
+		"/DC/host/z1/...": {makeResourcePool("pool-1", "/DC/host/z1/Resources")},
+		"/DC/host/z2/...": {makeResourcePool("pool-2", "/DC/host/z2/Resources")},
+	}
+
+	v.client.createdVirtualMachine = buildVM("new-vm").vm()
+	v.client.datastores = []mo.Datastore{{
+		ManagedEntity: mo.ManagedEntity{Name: "foo"},
+	}, {
+		ManagedEntity: mo.ManagedEntity{Name: "bar"},
+		Summary: types.DatastoreSummary{
+			Accessible: true,
+		},
+	}, {
+		ManagedEntity: mo.ManagedEntity{Name: "baz"},
+		Summary: types.DatastoreSummary{
+			Accessible: true,
+		},
+	}}
+	v.datastore = object.NewDatastore(nil, types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: "bar",
+	})
+
+	v.mockTemplate = object.NewVirtualMachine(nil, types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: "juju-template-" + ovatest.FakeOVASHA256(),
+	})
+}
+
+func (v *vmTemplateSuite) addMockLocalTemplateToClient() {
+	args := vsphereclient.ImportOVAParameters{
+		OVASHA256:    ovatest.FakeOVASHA256(),
+		Series:       "trusty",
+		Arch:         "amd64",
+		TemplateName: "juju-template-" + ovatest.FakeOVASHA256(),
+		DestinationFolder: object.NewFolder(nil, types.ManagedObjectReference{
+			Type:  "Folder",
+			Value: "custom-templates/trusty",
+		}),
+	}
+	v.client.virtualMachineTemplates = []mockTemplateVM{
+		{
+			vm: object.NewVirtualMachine(nil, types.ManagedObjectReference{
+				Type:  "VirtualMachine",
+				Value: args.TemplateName,
+			}),
+			args: args,
+		},
+	}
+}
+
+func (v *vmTemplateSuite) addMockDownloadedTemplateToClient() {
+	args := vsphereclient.ImportOVAParameters{
+		OVASHA256:    ovatest.FakeOVASHA256(),
+		Series:       "trusty",
+		Arch:         "amd64",
+		TemplateName: "juju-template-" + ovatest.FakeOVASHA256(),
+		DestinationFolder: object.NewFolder(nil, types.ManagedObjectReference{
+			Type: "Folder",
+			// The mocked client does a strings.HasPrefix() on this path when listing templates.
+			// We do a greedy search when looking for already imported templates.
+			Value: "Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/templates/trusty/*",
+		}),
+	}
+	v.client.virtualMachineTemplates = []mockTemplateVM{
+		{
+			vm: object.NewVirtualMachine(nil, types.ManagedObjectReference{
+				Type:  "VirtualMachine",
+				Value: args.TemplateName,
+			}),
+			args: args,
+		},
+	}
+}
+
+func (v *vmTemplateSuite) TestEnsureTemplateNoImageMetadataSuppliedButImageExistsUpstream(c *gc.C) {
+	arches := []string{
+		"amd64",
+	}
+	resPool := v.client.resourcePools["/DC/host/z1/..."][0]
+	tplMgr := vsphere.NewVMTemplateManager(
+		nil, v.env, v.client, resPool.Reference(),
+		v.datastore, v.statusUpdateParams, "",
+		coretesting.FakeControllerConfig().ControllerUUID(),
+	)
+
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "trusty", arches)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tpl, gc.NotNil)
+	c.Assert(arch, gc.Equals, "amd64")
+	v.client.CheckCallNames(c, "ListVMTemplates", "EnsureVMFolder", "CreateTemplateVM")
+}
+
+func (v *vmTemplateSuite) TestEnsureTemplateNoImageMetadataSuppliedAndImageDoesNotExistUpstream(c *gc.C) {
+	arches := []string{
+		"amd64",
+	}
+	resPool := v.client.resourcePools["/DC/host/z1/..."][0]
+	tplMgr := vsphere.NewVMTemplateManager(
+		nil, v.env, v.client, resPool.Reference(),
+		v.datastore, v.statusUpdateParams, "",
+		coretesting.FakeControllerConfig().ControllerUUID(),
+	)
+
+	_, _, err := tplMgr.EnsureTemplate(context.Background(), "xenial", arches)
+	c.Assert(err, jc.Satisfies, environs.IsAvailabilityZoneIndependent)
+	c.Assert(err.Error(), gc.Matches, "no matching images found for given constraints.*")
+	v.client.CheckCallNames(c, "ListVMTemplates", "EnsureVMFolder")
+}
+
+func (v *vmTemplateSuite) TestEnsureTemplateWithImageMetadataSupplied(c *gc.C) {
+	arches := []string{
+		"amd64",
+	}
+	imgMeta := []*imagemetadata.ImageMetadata{
+		{
+			Id:         "custom-templates/trusty",
+			RegionName: "/datacenter1",
+			Endpoint:   "host1",
+			Arch:       "amd64",
+		},
+	}
+	v.addMockLocalTemplateToClient()
+	resPool := v.client.resourcePools["/DC/host/z1/..."][0]
+	tplMgr := vsphere.NewVMTemplateManager(
+		imgMeta, v.env, v.client, resPool.Reference(),
+		v.datastore, v.statusUpdateParams, "",
+		coretesting.FakeControllerConfig().ControllerUUID(),
+	)
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "trusty", arches)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tpl, jc.DeepEquals, v.client.virtualMachineTemplates[0].vm)
+	c.Assert(arch, gc.Equals, "amd64")
+	v.client.CheckCallNames(c, "ListVMTemplates")
+}
+
+func (v *vmTemplateSuite) TestEnsureTemplateImageNotFoundLocally(c *gc.C) {
+	arches := []string{
+		"amd64",
+	}
+	imgMeta := []*imagemetadata.ImageMetadata{
+		{
+			// this image ID does not exist in our mocked templates.
+			Id:         "custom-templates/xenial",
+			RegionName: "/datacenter1",
+			Endpoint:   "host1",
+			Arch:       "amd64",
+		},
+	}
+
+	v.addMockLocalTemplateToClient()
+	resPool := v.client.resourcePools["/DC/host/z1/..."][0]
+	tplMgr := vsphere.NewVMTemplateManager(
+		imgMeta, v.env, v.client, resPool.Reference(),
+		v.datastore, v.statusUpdateParams, "",
+		coretesting.FakeControllerConfig().ControllerUUID(),
+	)
+	// trusty exists in the image-download simplestreams
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "trusty", arches)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tpl, gc.NotNil)
+	c.Assert(arch, gc.Equals, "amd64")
+	// List of calls should be identical to when no custom simplestreams are supplied.
+	v.client.CheckCallNames(c, "ListVMTemplates", "ListVMTemplates", "EnsureVMFolder", "CreateTemplateVM")
+}
+
+func (v *vmTemplateSuite) TestEnsureTemplateImageCachedImage(c *gc.C) {
+	arches := []string{
+		"amd64",
+	}
+
+	v.addMockDownloadedTemplateToClient()
+	resPool := v.client.resourcePools["/DC/host/z1/..."][0]
+	tplMgr := vsphere.NewVMTemplateManager(
+		nil, v.env, v.client, resPool.Reference(),
+		v.datastore, v.statusUpdateParams, "",
+		coretesting.FakeControllerConfig().ControllerUUID(),
+	)
+
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "trusty", arches)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(tpl, gc.NotNil)
+	c.Assert(arch, gc.Equals, "amd64")
+	v.client.CheckCallNames(c, "ListVMTemplates", "VirtualMachineObjectToManagedObject")
+}

--- a/provider/vsphere/vm_template_test.go
+++ b/provider/vsphere/vm_template_test.go
@@ -7,6 +7,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/clock/testclock"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -16,10 +21,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/mo"
-	"github.com/vmware/govmomi/vim25/types"
-	gc "gopkg.in/check.v1"
 )
 
 type vmTemplateSuite struct {


### PR DESCRIPTION
This PR adds ability to specify local templates via simplestreams using the ```image-id``` format. I

## QA steps

Steps are as follows:

  * Identify the region you want to generate simplestreams for: juju regions yourcloud
  * Create a template for a series inside that particular datacenter. The template should have the same characteristics as the ones Juju creates if no simplestreams is supplied by the user. As a quick hack, simply deploy a controller, and clone the resulting template in a different location.
  * Generate simplestreams
  * Deploy a new controller using the generated simplestreams
  * Check that Juju skips downloading the template and moves straight to cloning the template.

### Generate tools metadata

```bash
mkdir -p $HOME/simplestreams/tools/proposed
cp $GOPATH/bin/jujud $HOME/simplestreams/tools/proposed
cd $HOME/simplestreams/tools/proposed
tar czf juju-`./jujud version`.tgz ./jujud
rm ./jujud
cd ~

juju-metadata generate-agents -d $HOME/simplestreams --stream proposed
```
### Generate image metadata

When generating simplestreams, use the relative path to the template in relation to the datacenter path (/datacenter-name/vm):

```bash
juju-metadata generate-image -d $HOME/simplestreams/ -i "gsamfira/juju-focal-template" -s focal -r datacenter6.5 -u 10.107.8.11
```

This will generate the following: https://paste.ubuntu.com/p/9zk5hX7wR6/

Given the above simplesrteams, the provider will look for the template in:

```bash
/datacenter6.5/vm/gsamfira/juju-focal-template
```

then deploy a new controller:

```bash
juju bootstrap --metadata-source $HOME/simplestreams --debug --verbose --show-log  vsphere vsphere-controller
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1867154