### PR TITLE
[2.9] Use production charmhub endpoint

### DIFF
--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -38,8 +38,7 @@ import (
 // An alternate location can be configured by changing the URL
 // field in the Params struct.
 const (
-	// TODO(2.9) - use staging API until bases are supported in production
-	CharmHubServerURL     = "https://api.staging.charmhub.io"
+	CharmHubServerURL     = "https://api.charmhub.io"
 	CharmHubServerVersion = "v2"
 	CharmHubServerEntity  = "charms"
 


### PR DESCRIPTION
This PR reverts https://github.com/juju/juju/commit/cbbabe8bea3a84f99260d498fed64360341d4fad and ensures we use the production charmhub API endpoint unless overridden by the user.