### PR TITLE
Remove usage of systems package from CAAS application provisioner

### DIFF
--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -54,6 +54,9 @@ func (c *CharmsClient) CharmInfo(charmURL string) (*CharmInfo, error) {
 		return nil, errors.Trace(err)
 	}
 	manifest, err := convertCharmManifest(info.Manifest)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	result := &CharmInfo{
 		Revision:   info.Revision,
 		URL:        info.URL,

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -154,10 +154,6 @@ type charmShim struct {
 	*state.Charm
 }
 
-type charmMeta struct {
-	*charm.Meta
-}
-
 type machineShim struct {
 	*state.Machine
 }

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -142,8 +142,8 @@ func (m *mockModel) Containers(providerIds ...string) ([]state.CloudContainer, e
 
 type mockApplication struct {
 	testing.Stub
-	life         state.Life
-	scaleWatcher *statetesting.MockNotifyWatcher
+	life            state.Life
+	scaleWatcher    *statetesting.MockNotifyWatcher
 	settingsWatcher *statetesting.MockStringsWatcher
 
 	tag        names.Tag

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -208,7 +208,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, deploymentType caas.DeploymentT
 func getPodSpec(c *gc.C) corev1.PodSpec {
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
-		ServiceAccountName: "gitlab",
+		ServiceAccountName:           "gitlab",
 		AutomountServiceAccountToken: application.BoolPtr(true),
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -67,9 +67,9 @@ func (s *trustSuite) TestRemoveTrust(c *gc.C) {
 			Resources: []string{"pods", "services"},
 			Verbs:     []string{"get", "list", "patch"},
 		}, {
-			APIGroups:[]string{""},
-			Resources:[]string{"pods/exec"},
-			Verbs:[]string{"create"},
+			APIGroups: []string{""},
+			Resources: []string{"pods/exec"},
+			Verbs:     []string{"create"},
 		},
 	})
 }

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -7,9 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
-	"github.com/juju/systems"
-	"github.com/juju/systems/channel"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/controller"
@@ -90,9 +89,9 @@ func imageRepoToPath(imageRepo string, ver version.Number) string {
 
 // ImageForBase returns the OCI image path for a generic base.
 // NOTE: resource referenced bases are not resolved via ImageForBase.
-func ImageForBase(imageRepo string, base systems.Base) (string, error) {
+func ImageForBase(imageRepo string, base charm.Base) (string, error) {
 	if base.Name == "" {
-		return "", errors.NotValidf("base name")
+		return "", errors.NotValidf("empty base name")
 	}
 	if imageRepo == "" {
 		imageRepo = JujudOCINamespace
@@ -101,7 +100,7 @@ func ImageForBase(imageRepo string, base systems.Base) (string, error) {
 		return "", errors.NotValidf("channel %q", base.Channel)
 	}
 	tag := fmt.Sprintf("%s-%s", base.Name, base.Channel.Track)
-	if base.Channel.Risk != channel.Stable {
+	if base.Channel.Risk != charm.Stable {
 		tag = fmt.Sprintf("%s-%s", tag, base.Channel.Risk)
 	}
 	image := fmt.Sprintf("%s/charm-base:%s", imageRepo, tag)

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -4,6 +4,7 @@
 package podcfg_test
 
 import (
+	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -11,8 +12,6 @@ import (
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/testing"
-	"github.com/juju/systems"
-	"github.com/juju/systems/channel"
 )
 
 type imageSuite struct {
@@ -35,25 +34,25 @@ func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
 }
 
 func (*imageSuite) TestImageForBase(c *gc.C) {
-	_, err := podcfg.ImageForBase("", systems.Base{})
-	c.Assert(err, gc.ErrorMatches, `base name not valid`)
+	_, err := podcfg.ImageForBase("", charm.Base{})
+	c.Assert(err, gc.ErrorMatches, `empty base name not valid`)
 
-	_, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu"})
+	_, err = podcfg.ImageForBase("", charm.Base{Name: "ubuntu"})
 	c.Assert(err, gc.ErrorMatches, `channel "" not valid`)
 
-	_, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
+	_, err = podcfg.ImageForBase("", charm.Base{Name: "ubuntu", Channel: charm.Channel{
 		Track: "20.04",
 	}})
-	c.Assert(err, gc.ErrorMatches, `channel "" not valid`)
+	c.Assert(err, gc.ErrorMatches, `channel "20.04/" not valid`)
 
-	path, err := podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
-		Track: "20.04", Risk: channel.Stable,
+	path, err := podcfg.ImageForBase("", charm.Base{Name: "ubuntu", Channel: charm.Channel{
+		Track: "20.04", Risk: charm.Stable,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, gc.DeepEquals, `jujusolutions/charm-base:ubuntu-20.04`)
 
-	path, err = podcfg.ImageForBase("", systems.Base{Name: "ubuntu", Channel: channel.Channel{
-		Track: "20.04", Risk: channel.Edge,
+	path, err = podcfg.ImageForBase("", charm.Base{Name: "ubuntu", Channel: charm.Channel{
+		Track: "20.04", Risk: charm.Edge,
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, gc.DeepEquals, `jujusolutions/charm-base:ubuntu-20.04-edge`)

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/juju/romulus v0.0.0-20210309074704-4fa3bbd32568
 	github.com/juju/rpcreflect v0.0.0-20200416001309-bb46e9ba1476
 	github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989
-	github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca
 	github.com/juju/terms-client/v2 v2.0.0-20210309081804-aed8368405f6
 	github.com/juju/testing v0.0.0-20210324180055-18c50b0c2098
 	github.com/juju/txn v0.0.0-20210302043154-251cea9e140a

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,6 @@ github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989 h1:qx1Zh1bnHHVIMmRxq0fehYk7npCG50GhUwEkYeUg/t4=
 github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/systems v0.0.0-20200925032749-8c613192c759/go.mod h1:FcXkVf5o+mosxneWzQsHQ7h9sU3lD2GDOttJClqgnuA=
-github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca h1:KmPR6hTiZ8kDALV8YgFagYlRvyJCfJVvihwDvXgma6I=
-github.com/juju/systems v0.0.0-20210311041303-bc6b2f9677ca/go.mod h1:FcXkVf5o+mosxneWzQsHQ7h9sU3lD2GDOttJClqgnuA=
 github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae h1:wGk/zIPORICWlu4giN7CLGlP0PNvY/oZCRwfVLgjOZw=
 github.com/juju/terms-client v1.0.2-0.20200331164339-fab45ea044ae/go.mod h1:oGYNRVtU+5D99X5rPRaSwzKCc0mqF8A/L2a2UZycbQg=
 github.com/juju/terms-client/v2 v2.0.0-20210309081804-aed8368405f6 h1:kyXBAn5zttmD328DUaqUGyF7aB26B3GvwbVfCE2w71o=

--- a/pki/authority_test.go
+++ b/pki/authority_test.go
@@ -85,7 +85,7 @@ func (a *AuthoritySuite) TestLeafRequestChain(c *gc.C) {
 		AddDNSNames(dnsNames...).
 		AddIPAddresses(ipAddresses...).
 		Commit()
-
+	c.Assert(err, jc.ErrorIsNil)
 	chain := leaf.Chain()
 	c.Assert(len(chain), gc.Equals, 1)
 	c.Assert(chain[0], jc.DeepEquals, authority.Certificate())


### PR DESCRIPTION
Here, we remove usage of the _systems_ package for determining:
- A base for the provisioning info series.
- A charm-base OCI image from the base.

Instead of `systems.ParseImageFromBase` we determine the OS and version using the _series_ package, and from the construct a `charm.Base` now expected by `ImageForBase`

When #12888 lands, there should by no further need of the _systems_ package.

## QA steps

- Update your MicroK8s operator image.
- Bootstrap and add a model.
- `juju deploy facundo-snappass-test` should complete without error.

## Documentation changes

None.

## Bug reference

N/A
