### PR TITLE
CAAS bundle deployments

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5009,9 +5009,6 @@ func (s *ApplicationSuite) TestCAASEmbeddedCharm(c *gc.C) {
 name: cockroachdb
 description: foo
 summary: foo
-bases:
-  - name: ubuntu
-    channel: "18.04"
 containers:
   redis:
     resource: redis-container-resource

--- a/state/state.go
+++ b/state/state.go
@@ -1340,7 +1340,9 @@ func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) err
 			supportedSeries = []string{cSeries}
 			// If a charm has a url, but is a kubernetes charm then we need to
 			// add this to the list of supported series.
-			if set.NewStrings(args.Charm.Meta().Series...).Contains(series.Kubernetes.String()) || len(args.Charm.Meta().Containers) > 0 {
+			if cSeries != series.Kubernetes.String() &&
+				(set.NewStrings(args.Charm.Meta().Series...).Contains(series.Kubernetes.String()) ||
+					len(args.Charm.Meta().Containers) > 0) {
 				supportedSeries = append(supportedSeries, series.Kubernetes.String())
 			}
 		} else {

--- a/state/state.go
+++ b/state/state.go
@@ -1336,8 +1336,13 @@ func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) err
 		// in the URL, that series is the one and only supported
 		// series.
 		var supportedSeries []string
-		if series := args.Charm.URL().Series; series != "" {
-			supportedSeries = []string{series}
+		if cSeries := args.Charm.URL().Series; cSeries != "" {
+			supportedSeries = []string{cSeries}
+			// If a charm has a url, but is a kubernetes charm then we need to
+			// add this to the list of supported series.
+			if set.NewStrings(args.Charm.Meta().Series...).Contains(series.Kubernetes.String()) || len(args.Charm.Meta().Containers) > 0 {
+				supportedSeries = append(supportedSeries, series.Kubernetes.String())
+			}
 		} else {
 			var err error
 			supportedSeries, err = corecharm.ComputedSeries(args.Charm)


### PR DESCRIPTION
As we don't have the kubernetes in the charm URL we have to then
fallback to the charm metadata. In this instances we can do that and we
can inspect it.

The great thing about this change is that is suppliments the existing
workflow of checking the computed series, so this should work with old
style charms. The worst case is that you might end up with checking the
same series twice, but that's always been the case.

## QA steps

bundle.yaml:
```
bundle: kubernetes
applications:
  snappass:
    charm: facundo-snappass-test
    scale: 1
```

```console
$ make microk8s-operator-update
$ juju bootstrap microk8s micro

$ juju deploy ./bundle.yaml
Located charm "facundo-snappass-test" in charm-hub
Executing changes:
- upload charm facundo-snappass-test from charm-hub for series kubernetes
- deploy application snappass from charm-hub with 1 unit on kubernetes using facundo-snappass-test
  added resource redis-image
  added resource snappass-image
Deploy of bundle completed.
```
