### PR TITLE
Display ... for really long k8s app versions in status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -142,6 +142,12 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		version := app.Version
 		// CAAS versions may have repo prefix we don't care about.
 		if fs.Model.Type == caasModelType {
+			// Really long version strings are pretty useless so just use "..."
+			// and the user can use the YAML/JSON status to see the value.
+			if strings.HasPrefix(version, "registry.jujucharms.com") ||
+				strings.Contains(version, "@sha256") {
+				version = ellipsis
+			}
 			parts := strings.Split(version, "/")
 			if len(parts) == 2 {
 				version = parts[1]


### PR DESCRIPTION
k8s charms use oci images from the juju registry, which results in a useless app version string in status.
For such cass, just print "..."; the full value is displayed in status --format yaml.

## QA steps

deploy a k8s charm from the store
juju status
juju status --format yaml