### PR TITLE
Filter out more full registry paths for app version in status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -144,7 +144,10 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		if fs.Model.Type == caasModelType {
 			// Really long version strings are pretty useless so just use "..."
 			// and the user can use the YAML/JSON status to see the value.
-			if strings.HasPrefix(version, "registry.jujucharms.com") ||
+			if strings.HasPrefix(version, "registry.") ||
+				strings.HasPrefix(version, "rocks.canonical.com") ||
+				strings.HasPrefix(version, "docker.io") ||
+				strings.HasPrefix(version, "gcr.io") ||
 				strings.Contains(version, "@sha256") {
 				version = ellipsis
 			}


### PR DESCRIPTION
#12903 landed to filter out long registry paths from app version in status.
This PR adds a couple more filter terms.

## QA steps

Deploy kubeflow and run juju status
pipelines-db app should have version "..."
