### PR TITLE
Fix k8s bundle deploys with v2 charms

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -11,6 +11,8 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	corecharm "github.com/juju/juju/core/charm"
+	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -1206,12 +1208,18 @@ func (context *statusContext) processApplication(application *state.Application)
 		channel = string(application.Channel())
 	}
 
+	series := application.Series()
+	// Sidecar k8s charms have the series set to that of the underlying base.
+	// We want to ensure they are still shown as "kubernetes" in status.
+	if corecharm.IsKubernetes(applicationCharm) {
+		series = coreseries.Kubernetes.String()
+	}
 	var processedStatus = params.ApplicationStatus{
 		Charm:            applicationCharm.URL().String(),
 		CharmVersion:     applicationCharm.Version(),
 		CharmProfile:     charmProfileName,
 		CharmChannel:     channel,
-		Series:           application.Series(),
+		Series:           series,
 		Exposed:          application.IsExposed(),
 		ExposedEndpoints: mappedExposedEndpoints,
 		Life:             processLife(application),

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -95,7 +95,7 @@ func CloudSpecToK8sRestConfig(cloudSpec environscloudspec.CloudSpec) (*rest.Conf
 			return nil, errors.Trace(err)
 		}
 		if rc != nil {
-			logger.Infof("using in-cluster config")
+			logger.Tracef("using in-cluster config")
 			return rc, nil
 		}
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -9,14 +9,14 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
-	charm "github.com/juju/charm/v8"
+	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	macaroon "gopkg.in/macaroon.v2"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/base"
@@ -363,8 +363,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccessWithCharm
 	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
-	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "kubernetes")
-	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "kubernetes")
+	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "focal")
+	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "focal")
 
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"gitlab-k8s\" in charm-hub\n"+
@@ -1000,6 +1000,10 @@ func (s *BundleDeployRepositorySuite) setupMetadataV2CharmUnits(charmUnits []cha
 					},
 				},
 			},
+			Manifest: &charm.Manifest{Bases: []charm.Base{{
+				Name: "ubuntu",
+				Channel: charm.Channel{Track: "20.04"},
+			}}},
 		}
 		s.expectCharmInfo(chUnit.curl.String(), charmInfo)
 		s.expectDeploy()

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -486,13 +486,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	if charm.IsUnsupportedSeriesError(err) {
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	}
-	// although we try and get the charmSeries from the charm series
-	// selector it will return an error and an empty string for the series.
-	// So we need to approximate what the seriesName should be when
-	// displaying an error to the user. We do this by getting the potential
-	// series name.
-	seriesName := getPotentialSeriesName(series, storeCharmOrBundleURL.Series, userRequestedSeries)
-	if validationErr := charmValidationError(seriesName, storeCharmOrBundleURL.Name, errors.Trace(err)); validationErr != nil {
+	if validationErr := charmValidationError(storeCharmOrBundleURL.Name, errors.Trace(err)); validationErr != nil {
 		return errors.Trace(validationErr)
 	}
 

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -351,7 +351,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 		}
 
 		seriesName, err = seriesSelector.charmSeries()
-		if err = charmValidationError(seriesName, ch.Meta().Name, errors.Trace(err)); err != nil {
+		if err = charmValidationError(ch.Meta().Name, errors.Trace(err)); err != nil {
 			return nil, errors.Trace(err)
 		}
 
@@ -587,13 +587,13 @@ func (d *factory) validateCharmSeries(seriesName string, imageStream string) err
 // message if that's found.
 func (d *factory) validateCharmSeriesWithName(series, name string, imageStream string) error {
 	err := d.validateCharmSeries(series, imageStream)
-	return charmValidationError(series, name, errors.Trace(err))
+	return charmValidationError(name, errors.Trace(err))
 }
 
 // charmValidationError consumes an error along with a charmSeries and name
 // to help provide better feedback to the user when somethings gone wrong around
 // validating a charm validation
-func charmValidationError(charmSeries, name string, err error) error {
+func charmValidationError(name string, err error) error {
 	if err != nil {
 		if errors.IsNotSupported(err) {
 			return errors.Errorf("%v is not available on the following %v", name, err)

--- a/core/charm/computedseries.go
+++ b/core/charm/computedseries.go
@@ -20,13 +20,6 @@ func ComputedSeries(c charm.CharmMeta) ([]string, error) {
 		return c.Meta().Series, nil
 	}
 
-	// If we have V2 metadata *and* a non-empty containers collection,
-	// then this is a side-car based charm and we return "kubernetes"
-	// instead of translating the collection of supplied bases.
-	if IsKubernetes(c) {
-		return []string{coreseries.Kubernetes.String()}, nil
-	}
-
 	// We use a set to ensure uniqueness and a slice to ensure that we
 	// preserve the order of elements as they appear in the manifest.
 	seriesSlice := []string(nil)

--- a/core/charm/computedseries_test.go
+++ b/core/charm/computedseries_test.go
@@ -103,7 +103,7 @@ func (s *computedSeriesSuite) TestComputedSeriesKubernetes(c *gc.C) {
 	}).AnyTimes()
 	series, err := ComputedSeries(cm)
 	c.Assert(err, gc.IsNil)
-	c.Assert(series, jc.DeepEquals, []string{"kubernetes"})
+	c.Assert(series, jc.DeepEquals, []string{"bionic"})
 }
 
 func (s *computedSeriesSuite) TestComputedSeriesError(c *gc.C) {

--- a/core/charm/format.go
+++ b/core/charm/format.go
@@ -15,11 +15,12 @@ const (
 	FormatV2      MetadataFormat = iota
 )
 
+// CharmManifest provides access to a charm's manifest info.
 type CharmManifest interface {
 	Manifest() *charm.Manifest
 }
 
-// Given a charm, what format is it in?
+// Format returns the metadata format for a given charm.
 func Format(ch CharmManifest) MetadataFormat {
 	if ch.Manifest() == nil || len(ch.Manifest().Bases) == 0 {
 		return FormatV1


### PR DESCRIPTION
k8s v2 charms need to be deployed with a series that matches that of the `base` in the manifest.
Bundles which contained v2 charms were incorrectly being processed and having the deploy series set to "kubernetes".
There was a unit test for this, but it was incorrectly set up such that the test charm used was not a v2 charm, hence the test passed.

Also some drive by fixes for excess logging and an unused function parameter.

A side effect of this change is that sidecar k8s apps now show up in status as OS/series "ubuntu/focal" or whatever, not "kubernetes/kubernetes". This strictly represents the underlying container where the workload is running, but there's now no visible indication in status that it is a k8s app. The second commit addresses this by ensuring all k8s changes have "kubernetes" as the series.

## QA steps

bootstrap k8s
add a model pointing to staging charmhub
deploy this bundle with both a v1 k8s charm and a v2 k8s charm

```
bundle: kubernetes
applications:
  mariadb:
    charm: cs:~juju/mariadb-k8s
    scale: 1
  snappass:
    charm: facundo-snappass-test
    scale: 1
```

also deploy the charms directly
```
juju deploy facundo-snappass-test
juju deploy cs:~juju/mariadb-k8s
```
