### PR TITLE
improve bundle messaging output

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -367,13 +367,13 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccessWithCharm
 	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "focal")
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"gitlab-k8s\" in charm-hub\n"+
-		"Located charm \"mariadb-k8s\" in charm-hub\n"+
+		"Located charm \"gitlab-k8s\" in charm-hub, channel new/edge\n"+
+		"Located charm \"mariadb-k8s\" in charm-hub, channel old/stable\n"+
 		"Executing changes:\n"+
-		"- upload charm gitlab-k8s from charm-hub for series kubernetes\n"+
-		"- deploy application gitlab from charm-hub with 1 unit on kubernetes using gitlab-k8s\n"+
-		"- upload charm mariadb-k8s from charm-hub for series kubernetes\n"+
-		"- deploy application mariadb from charm-hub with 2 units on kubernetes using mariadb-k8s\n"+
+		"- upload charm gitlab-k8s from charm-hub for series kubernetes from channel new/edge\n"+
+		"- deploy application gitlab from charm-hub with 1 unit on kubernetes with new/edge using gitlab-k8s\n"+
+		"- upload charm mariadb-k8s from charm-hub for series kubernetes from channel old/stable\n"+
+		"- deploy application mariadb from charm-hub with 2 units on kubernetes with old/stable using mariadb-k8s\n"+
 		"- add relation gitlab:mysql - mariadb:server\n"+
 		"Deploy of bundle completed.\n")
 }
@@ -384,9 +384,11 @@ applications:
   mariadb:
     charm: mariadb-k8s
     scale: 2
+    channel: old/stable
   gitlab:
     charm: gitlab-k8s
     scale: 1
+    channel: new/edge
 relations:
   - - gitlab:mysql
     - mariadb:server
@@ -1001,7 +1003,7 @@ func (s *BundleDeployRepositorySuite) setupMetadataV2CharmUnits(charmUnits []cha
 				},
 			},
 			Manifest: &charm.Manifest{Bases: []charm.Base{{
-				Name: "ubuntu",
+				Name:    "ubuntu",
 				Channel: charm.Channel{Track: "20.04"},
 			}}},
 		}

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -552,9 +552,11 @@ func formatLocatedText(curl *charm.URL, origin commoncharm.Origin) string {
 	if repository == "" || repository == commoncharm.OriginLocal {
 		return fmt.Sprintf("Located local charm %q, revision %d", curl.Name, curl.Revision)
 	}
-	var revision string
+	var next string
 	if curl.Revision != -1 {
-		revision = fmt.Sprintf(", revision %d", curl.Revision)
+		next = fmt.Sprintf(", revision %d", curl.Revision)
+	} else if str := origin.CharmChannel().String(); str != "" {
+		next = fmt.Sprintf(", channel %s", str)
 	}
-	return fmt.Sprintf("Located charm %q in %s%s", curl.Name, repository, revision)
+	return fmt.Sprintf("Located charm %q in %s%s", curl.Name, repository, next)
 }


### PR DESCRIPTION
Add channel if available to "Locating charm" message while deploy a bundle.

When deploying a bundle using the same charm charm multiple times, output makes it appear that the same charm is located more than once.  We do print out a revision for charmstore charms, so add the channel to the output if available and there is no revision.  Unfortunately, at the point in time of message display, the name used for the application is not available.

## QA steps

```console
$ juju deploy juju-qa-bundle-test
Located bundle "juju-qa-bundle-test" in charm-hub, revision 2
Located charm "juju-qa-test" in charm-hub, channel 2.0/stable
Located charm "juju-qa-test" in charm-hub, channel candidate
Located charm "ntp" in charm-hub, channel stable
Located charm "ntp" in charm-hub, channel stable
Executing changes:
- upload charm juju-qa-test from charm-hub for series bionic from channel 2.0/stable with architecture=amd64
- deploy application juju-qa-test from charm-hub on bionic with 2.0/stable
  added resource foo-file
- set annotations for juju-qa-test
- upload charm juju-qa-test from charm-hub for series focal from channel latest/candidate with architecture=amd64
- deploy application juju-qa-test-focal from charm-hub on focal with latest/candidate using juju-qa-test
  added resource foo-file
- set annotations for juju-qa-test-focal
- upload charm ntp from charm-hub for series bionic from channel stable
- deploy application ntp from charm-hub on bionic with stable
- set annotations for ntp
- upload charm ntp from charm-hub for series focal from channel stable
- deploy application ntp-focal from charm-hub on focal with stable using ntp
- set annotations for ntp-focal
- add new machine 0
- add new machine 1
- add relation ntp:juju-info - juju-qa-test:juju-info
- add relation ntp-focal:juju-info - juju-qa-test-focal:juju-info
- add unit juju-qa-test/0 to new machine 0
- add unit juju-qa-test-focal/0 to new machine 1
Deploy of bundle completed.
```
