### PR TITLE
Update charm/v8 revision

### DIFF
--- a/apiserver/common/applicationwatcher.go
+++ b/apiserver/common/applicationwatcher.go
@@ -190,12 +190,7 @@ type AppWatcherState interface {
 
 // AppWatcherApplication is Application for AppWatcher.
 type AppWatcherApplication interface {
-	Charm() (AppWatcherCharm, bool, error)
-}
-
-// AppWatcherCharm is Charm for AppWatcher.
-type AppWatcherCharm interface {
-	Manifest() *charm.Manifest
+	Charm() (charm.CharmMeta, bool, error)
 }
 
 type appWatcherStateShim struct {
@@ -214,7 +209,7 @@ type appWatcherApplicationShim struct {
 	*state.Application
 }
 
-func (s *appWatcherApplicationShim) Charm() (AppWatcherCharm, bool, error) {
+func (s *appWatcherApplicationShim) Charm() (charm.CharmMeta, bool, error) {
 	ch, force, err := s.Application.Charm()
 	if err != nil {
 		return nil, false, err

--- a/apiserver/common/applicationwatcher_test.go
+++ b/apiserver/common/applicationwatcher_test.go
@@ -23,6 +23,7 @@ var _ = gc.Suite(&applicationWatcherSuite{})
 func (s *applicationWatcherSuite) TestEmbeddedFilter(c *gc.C) {
 	app1 := &mockAppWatcherApplication{
 		charm: mockAppWatcherCharm{
+			meta: &charm.Meta{},
 			manifest: &charm.Manifest{
 				// V2 metadata.
 				Bases: []charm.Base{
@@ -72,6 +73,7 @@ func (s *applicationWatcherSuite) TestEmbeddedFilter(c *gc.C) {
 func (s *applicationWatcherSuite) TestLegacyFilter(c *gc.C) {
 	app1 := &mockAppWatcherApplication{
 		charm: mockAppWatcherCharm{
+			meta: &charm.Meta{},
 			manifest: &charm.Manifest{
 				// V2 metadata.
 				Bases: []charm.Base{
@@ -192,7 +194,7 @@ type mockAppWatcherApplication struct {
 	charm mockAppWatcherCharm
 }
 
-func (s *mockAppWatcherApplication) Charm() (common.AppWatcherCharm, bool, error) {
+func (s *mockAppWatcherApplication) Charm() (charm.CharmMeta, bool, error) {
 	s.MethodCall(s, "Charm")
 	err := s.NextErr()
 	if err != nil {

--- a/apiserver/facades/controller/caasfirewaller/mock_test.go
+++ b/apiserver/facades/controller/caasfirewaller/mock_test.go
@@ -125,7 +125,7 @@ type mockAppWatcherApplication struct {
 	charm mockAppWatcherCharm
 }
 
-func (s *mockAppWatcherApplication) Charm() (common.AppWatcherCharm, bool, error) {
+func (s *mockAppWatcherApplication) Charm() (charm.CharmMeta, bool, error) {
 	s.MethodCall(s, "Charm")
 	err := s.NextErr()
 	if err != nil {

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -146,6 +146,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharm(c *gc.C) {
 						},
 					}},
 				},
+				Meta: &charm.Meta{},
 			}, nil),
 	)
 	target, err := s.sshC.ResolveTarget("mariadb-k8s/0")

--- a/core/charm/format.go
+++ b/core/charm/format.go
@@ -15,14 +15,10 @@ const (
 	FormatV2      MetadataFormat = iota
 )
 
-// CharmManifest provides access to a charm's manifest info.
-type CharmManifest interface {
-	Manifest() *charm.Manifest
-}
-
 // Format returns the metadata format for a given charm.
-func Format(ch CharmManifest) MetadataFormat {
-	if ch.Manifest() == nil || len(ch.Manifest().Bases) == 0 {
+func Format(ch charm.CharmMeta) MetadataFormat {
+	m := ch.Manifest()
+	if m == nil || len(m.Bases) == 0 || len(ch.Meta().Series) > 0 {
 		return FormatV1
 	}
 	return FormatV2

--- a/core/charm/format_test.go
+++ b/core/charm/format_test.go
@@ -19,7 +19,9 @@ var _ = gc.Suite(&formatSuite{})
 func (s formatSuite) TestFormatV2(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
+
 	cm := NewMockCharmMeta(ctrl)
+	cm.EXPECT().Meta().Return(&charm.Meta{})
 	cm.EXPECT().Manifest().Return(&charm.Manifest{
 		Bases: []charm.Base{
 			{Name: "ubuntu", Channel: charm.Channel{
@@ -27,16 +29,32 @@ func (s formatSuite) TestFormatV2(c *gc.C) {
 				Risk:  "stable",
 			}},
 		},
-	}).AnyTimes()
-	format := Format(cm)
-	c.Assert(format, gc.Equals, FormatV2)
+	})
+
+	c.Assert(Format(cm), gc.Equals, FormatV2)
 }
 
-func (s formatSuite) TestFormatV1(c *gc.C) {
+func (s formatSuite) TestFormatV1EmptyManifest(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
+
 	cm := NewMockCharmMeta(ctrl)
-	cm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
-	format := Format(cm)
-	c.Assert(format, gc.Equals, FormatV1)
+	cm.EXPECT().Manifest().Return(&charm.Manifest{})
+
+	c.Assert(Format(cm), gc.Equals, FormatV1)
+}
+
+func (s formatSuite) TestFormatV1Series(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	cm := NewMockCharmMeta(ctrl)
+	cm.EXPECT().Manifest().Return(&charm.Manifest{
+		Bases: []charm.Base{{}},
+	})
+	cm.EXPECT().Meta().Return(&charm.Meta{
+		Series: []string{"kubernetes"},
+	})
+
+	c.Assert(Format(cm), gc.Equals, FormatV1)
 }

--- a/core/charm/kubernetes_test.go
+++ b/core/charm/kubernetes_test.go
@@ -42,7 +42,7 @@ func (s *kubernetesSuite) TestMetadataV2NoKubernetes(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	cm := NewMockCharmMeta(ctrl)
-	cm.EXPECT().Meta().Return(&charm.Meta{})
+	cm.EXPECT().Meta().Return(&charm.Meta{}).AnyTimes()
 	cm.EXPECT().Manifest().Return(&charm.Manifest{Bases: []charm.Base{
 		{
 			Name: "ubuntu",
@@ -70,7 +70,7 @@ func (s *kubernetesSuite) TestMetadataV2Kubernetes(c *gc.C) {
 				Type: charmresource.TypeContainerImage,
 			},
 		},
-	})
+	}).AnyTimes()
 	cm.EXPECT().Manifest().Return(&charm.Manifest{Bases: []charm.Base{
 		{
 			Name: "ubuntu",

--- a/core/model/model_test.go
+++ b/core/model/model_test.go
@@ -36,7 +36,7 @@ func (*ModelSuite) TestValidateSeries(c *gc.C) {
 		ctrl := gomock.NewController(c)
 		defer ctrl.Finish()
 		cm := NewMockCharmMeta(ctrl)
-		cm.EXPECT().Meta().Return(&t.meta)
+		cm.EXPECT().Meta().Return(&t.meta).AnyTimes()
 		if len(t.meta.Containers) > 0 {
 			cm.EXPECT().Manifest().Return(&charm.Manifest{
 				Bases: []charm.Base{

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210419074656-80e7fc2f335e
+	github.com/juju/charm/v8 v8.0.0-20210422143038-0e0160321724
 	github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c/go.mod h1:J4
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210419074656-80e7fc2f335e h1:kSYBtK7H4n1NauUOWE0Fevhrd2YdE3ftSTHLBr1pgpc=
-github.com/juju/charm/v8 v8.0.0-20210419074656-80e7fc2f335e/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
+github.com/juju/charm/v8 v8.0.0-20210422143038-0e0160321724 h1:MtmcLT3nz4fQ6jzueGDilvRGJ5KNYoH6aannrmmKwGA=
+github.com/juju/charm/v8 v8.0.0-20210422143038-0e0160321724/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
 github.com/juju/charm/v9 v9.0.0-20210421060150-6a300db18162/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
 github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c h1:+p8LWnIJCzmptGw1Tz7mb0EtOjMEZUHARbnW5vI1oSI=
@@ -1105,7 +1105,6 @@ gopkg.in/juju/names.v2 v2.0.0-20190813004204-e057c73bd1be/go.mod h1:XXa/v5qG1IsS
 gopkg.in/juju/names.v3 v3.0.0-20191210002836-39289f373765/go.mod h1:BUnvpShrNFWsLV3tpb4UwtkDLlAzE2egyY49YS5HHW8=
 gopkg.in/juju/worker.v1 v1.0.0-20170308002458-6965b9d82671/go.mod h1:qrHtdkZtlLoAWF0wb7YwrREeiitm5EzizN0MmIbAFxA=
 gopkg.in/macaroon-bakery.v2 v2.0.0-20180423133735-a0743b6619d6/go.mod h1:B4/T17l+ZWGwxFSZQmlBwp25x+og7OkhETfr3S9MbIA=
-gopkg.in/macaroon-bakery.v2 v2.1.1-0.20190613120608-6734dc66fe81 h1:/MPcJFRjdUcx9QYT7gXszLmRVqHEJSSc39bYyfgwxOk=
 gopkg.in/macaroon-bakery.v2 v2.1.1-0.20190613120608-6734dc66fe81/go.mod h1:spseVueSWYSqcNJJ3cR/44ZwOk0Hb9rm5Gyo9B8isqg=
 gopkg.in/macaroon-bakery.v2 v2.3.0 h1:b40knPgPTke1QLTE8BSYeH7+R/hiIozB1A8CTLYN0Ic=
 gopkg.in/macaroon-bakery.v2 v2.3.0/go.mod h1:/8YhtPARXeRzbpEPLmRB66+gQE8/pzBBkWwg7Vz/guc=


### PR DESCRIPTION
Updates charm/v8 revision to detect charm metadata containing series as version 1.

## QA steps

On k8s, `juju deploy postgresql-k8s` and `juju deploy snappass-test` should succeed.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925427
