### PR TITLE
Do not panic on nil origin Channel.

### DIFF
--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -355,7 +355,9 @@ func (defaultCharmRepo) NewCharmAtPathForceSeries(path, series string, force boo
 // channel, so we can correctly resolve the charm.
 func charmHubResolveOrigin(_ *charm.URL, origin corecharm.Origin, channel charm.Channel) (commoncharm.Origin, error) {
 	if channel.Track == "" {
-		origin.Channel.Risk = channel.Risk
+		if origin.Channel != nil {
+			origin.Channel.Risk = channel.Risk
+		}
 		return commoncharm.CoreCharmOrigin(origin), nil
 	}
 	normalizedC := channel.Normalize()

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -268,6 +268,9 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 
 	// If no explicit revision was set with either SwitchURL
 	// or Revision flags, discover the latest.
+	if r.charmURL == nil {
+		return nil, origin, errors.Errorf("unexpected charm URL")
+	}
 	if *newURL == *r.charmURL {
 		if refURL.Revision != -1 {
 			return nil, commoncharm.Origin{}, errors.Errorf("already running specified charm %q, revision %d", newURL.Name, newURL.Revision)

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -513,6 +513,58 @@ func (s *charmHubCharmRefresherSuite) TestAllowedError(c *gc.C) {
 	c.Assert(allowed, jc.IsFalse)
 }
 
+func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOriginEmpty(c *gc.C) {
+	origin := corecharm.Origin{}
+	channel := charm.Channel{}
+	result, err := charmHubResolveOrigin(nil, origin, channel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(origin))
+}
+
+func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOrigin(c *gc.C) {
+	track := "meshuggah"
+	origin := corecharm.Origin{}
+	channel := charm.Channel{
+		Track: track,
+	}
+	result, err := charmHubResolveOrigin(nil, origin, channel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(corecharm.Origin{
+		Channel: &charm.Channel{
+			Track: track,
+			Risk:  "stable",
+		},
+	}))
+}
+
+func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOriginEmptyTrackNonEmptyChannel(c *gc.C) {
+	origin := corecharm.Origin{
+		Channel: &charm.Channel{},
+	}
+	channel := charm.Channel{
+		Risk: "edge",
+	}
+	result, err := charmHubResolveOrigin(nil, origin, channel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(corecharm.Origin{
+		Channel: &charm.Channel{
+			Risk: "edge",
+		},
+	}))
+}
+
+func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOriginEmptyTrackEmptyChannel(c *gc.C) {
+	origin := corecharm.Origin{}
+	channel := charm.Channel{
+		Risk: "edge",
+	}
+	result, err := charmHubResolveOrigin(nil, origin, channel)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(corecharm.Origin{
+		Channel: &charm.Channel{},
+	}))
+}
+
 func basicRefresherConfig(curl *charm.URL, ref string) RefresherConfig {
 	return RefresherConfig{
 		ApplicationName: "winnie",


### PR DESCRIPTION
Do not panic on nil origin Channel.  Occurred when trying to switch during refresh from a local charm to a non
local charm.

## QA steps

```console
$ cd testcharms/charm-hub/charms/juju-qa-test-v2
$ charmcraft build
$ juju deploy ./juju-qa-test-v2.charm juju-qa-test

# Will fail to refresh, but do not panic.
$ juju refresh juju-qa-test --switch ch:juju-qa-test
Requested channel ""
ERROR origin source "local" with schema not valid
```

