### PR TITLE
Tweak display of app version in k8s models

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/docker/distribution/reference"
 	"github.com/juju/ansiterm"
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
@@ -141,19 +142,28 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		app := fs.Applications[appName]
 		version := app.Version
 		// CAAS versions may have repo prefix we don't care about.
-		if fs.Model.Type == caasModelType {
-			// Really long version strings are pretty useless so just use "..."
-			// and the user can use the YAML/JSON status to see the value.
-			if strings.HasPrefix(version, "registry.") ||
-				strings.HasPrefix(version, "rocks.canonical.com") ||
-				strings.HasPrefix(version, "docker.io") ||
-				strings.HasPrefix(version, "gcr.io") ||
-				strings.Contains(version, "@sha256") {
-				version = ellipsis
+		if fs.Model.Type == caasModelType && version != "" {
+			ref, err := reference.ParseNamed(version)
+			if err != nil {
+				if err != reference.ErrNameNotCanonical {
+					version = ellipsis
+				}
+			} else {
+				version = reference.Path(ref)
+				if withTag, ok := ref.(reference.NamedTagged); ok {
+					version += ":" + withTag.Tag()
+				}
+				if withDigest, ok := ref.(reference.Digested); ok {
+					digest := withDigest.Digest().Encoded()
+					if len(digest) > 7 {
+						digest = digest[:7]
+					}
+					version += "@" + digest
+				}
 			}
 			parts := strings.Split(version, "/")
-			if len(parts) == 2 {
-				version = parts[1]
+			if len(parts) > 1 && len(version) > maxVersionWidth {
+				version = strings.Join(parts[1:], "/")
 			}
 		}
 		// Don't let a long version push out the version column.

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5276,7 +5276,7 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 			"foo": {
 				Scale:   2,
 				Address: "54.32.1.2",
-				Version: "prefix/image:tag",
+				Version: "user/image:tag",
 				Units: map[string]unitStatus{
 					"foo/0": {
 						JujuStatusInfo: statusInfoContents{
@@ -5307,8 +5307,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version    Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
-foo  image:tag            1/2                           0      54.32.1.2  
+App  Version         Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
+foo  user/image:tag            1/2                           0      54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
@@ -5325,9 +5325,39 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 			"foo": {
 				Scale:   1,
 				Address: "54.32.1.2",
-				Version: "registry.jujucharms.com/image",
+				Version: "registry.jujucharms.com/image:tag@sha256:3046a3dc76ee23417f889675bce3a4c08f223b87d1e378eeea3e7490cd27fbc5",
 				Units: map[string]unitStatus{
 					"foo/0": {
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Allocating,
+						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Active,
+						},
+					},
+				},
+			},
+			"bar": {
+				Scale:   1,
+				Address: "54.32.1.3",
+				Version: "registry.jujucharms.com/mine/image:0.5",
+				Units: map[string]unitStatus{
+					"bar/0": {
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Allocating,
+						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Active,
+						},
+					},
+				},
+			},
+			"baz": {
+				Scale:   1,
+				Address: "54.32.1.4",
+				Version: "registry.jujucharms.com/reallyreallyreallyreallyreallylong/image:0.6",
+				Units: map[string]unitStatus{
+					"baz/0": {
 						JujuStatusInfo: statusInfoContents{
 							Current: status.Allocating,
 						},
@@ -5346,10 +5376,14 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
-foo  ...                0/1                           0      54.32.1.2  
+App  Version            Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
+bar  mine/image:0.5               0/1                           0      54.32.1.3  
+baz  image:0.6                    0/1                           0      54.32.1.4  
+foo  image:tag@3046a3d            0/1                           0      54.32.1.2  
 
 Unit   Workload  Agent       Address  Ports  Message
+bar/0  active    allocating                  
+baz/0  active    allocating                  
 foo/0  active    allocating                  
 `[1:])
 }


### PR DESCRIPTION
The truncation of long app versions in k8s model status tabular display was a little over aggressive.
We still show "..." for image paths with sha256 and anything more than simple user/image, but "..." for everything else.

## QA steps

juju deploy ch:ambassador
juju status
```
...
App          Version                     Status  Scale  Charm        Store       Channel  Rev  OS          Address         Message
ambassador   datawire/ambassador:0.50.0  active      1  ambassador   local                  0  kubernetes
```

Previously would have been "..." for Version
Other charms like `cs:~juju/mariadb-k8s` still show "...".

