### PR TITLE
Correct error message for add-unit on CAAS

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1623,7 +1623,7 @@ func (api *APIv5) AddUnits(args params.AddApplicationUnitsV5) (params.AddApplica
 // AddUnits adds a given number of units to an application.
 func (api *APIBase) AddUnits(args params.AddApplicationUnits) (params.AddApplicationUnitsResults, error) {
 	if api.modelType == state.ModelTypeCAAS {
-		return params.AddApplicationUnitsResults{}, errors.NotSupportedf("adding units on a non-container model")
+		return params.AddApplicationUnitsResults{}, errors.NotSupportedf("adding units to a container-based model")
 	}
 	if err := api.checkCanWrite(); err != nil {
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1240,7 +1240,7 @@ func (s *ApplicationSuite) TestAddUnitsCAASModel(c *gc.C) {
 		ApplicationName: "postgresql",
 		NumUnits:        1,
 	})
-	c.Assert(err, gc.ErrorMatches, "adding units on a non-container model not supported")
+	c.Assert(err, gc.ErrorMatches, "adding units to a container-based model not supported")
 	app := s.backend.applications["postgresql"]
 	app.CheckNoCalls(c)
 }


### PR DESCRIPTION
We were correctly returning an error for attempts to `add-unit` on a k8s model, but the error content was misleading, suggesting a "non-container model". The message is addressed here.

## QA steps

Deploy this bundle to a k8s model and observe the correct error message.
```
# Note no series.
applications:
  mariadb:
    charm: cs:~charmed-osm/mariadb-k8s-35
    scale: 1
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925720
