### PR TITLE
Improve error message for invalid API result

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -271,12 +271,12 @@ func (c *chRepo) selectNextBase(bases []transport.Base, origin corecharm.Origin)
 		break
 	}
 	if !found {
-		return corecharm.Platform{}, errors.NotFoundf("base")
+		return corecharm.Platform{}, errors.NotFoundf("no bases located for architecture %q", origin.Platform.Architecture)
 	}
 
 	track, err := channelTrack(base.Channel)
 	if err != nil {
-		return corecharm.Platform{}, errors.Trace(err)
+		return corecharm.Platform{}, errors.Annotate(err, "base")
 	}
 	series, err := coreseries.VersionSeries(track)
 	if err != nil {

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -271,7 +271,7 @@ func (c *chRepo) selectNextBase(bases []transport.Base, origin corecharm.Origin)
 		break
 	}
 	if !found {
-		return corecharm.Platform{}, errors.NotFoundf("no bases located for architecture %q", origin.Platform.Architecture)
+		return corecharm.Platform{}, errors.NotFoundf("bases matching architecture %q", origin.Platform.Architecture)
 	}
 
 	track, err := channelTrack(base.Channel)

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -573,7 +573,7 @@ func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBases(c *gc.C) {
 			Architecture: "amd64",
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `no bases located for architecture "amd64" not found`)
+	c.Assert(err, gc.ErrorMatches, `bases matching architecture "amd64" not found`)
 }
 
 func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBaseChannel(c *gc.C) {

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -552,6 +552,63 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	})
 }
 
+type selectNextBaseSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&selectNextBaseSuite{})
+
+func (selectNextBaseSuite) TestSelectNextBaseWithNoBases(c *gc.C) {
+	repo := &chRepo{}
+	_, err := repo.selectNextBase(nil, corecharm.Origin{})
+	c.Assert(err, gc.ErrorMatches, `no bases available`)
+}
+
+func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBases(c *gc.C) {
+	repo := &chRepo{}
+	_, err := repo.selectNextBase([]transport.Base{{
+		Architecture: "all",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `no bases located for architecture "amd64" not found`)
+}
+
+func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBaseChannel(c *gc.C) {
+	repo := &chRepo{}
+	_, err := repo.selectNextBase([]transport.Base{{
+		Architecture: "amd64",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `base: channel cannot be empty`)
+}
+
+func (selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *gc.C) {
+	repo := &chRepo{}
+	platform, err := repo.selectNextBase([]transport.Base{{
+		Architecture: "amd64",
+		Name:         "ubuntu",
+		Channel:      "20.04",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Series:       "focal",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(platform, gc.DeepEquals, corecharm.Platform{
+		Architecture: "amd64",
+		OS:           "ubuntu",
+		Series:       "focal",
+	})
+}
+
 type composeSuggestionsSuite struct {
 	testing.IsolationSuite
 }


### PR DESCRIPTION
It is expected that we can always get valid API results, except when we
don't we should return an error message that is more informative. In
this instance, we end up returning an error message about missing bases.

The following code just improves that by giving a bit more context. I
can't change the error type as we use that to diagnose other issues, but
I do wish that `not found` wouldn't be appended to the end of the error
message as it's rather restricting on the message returned.

## QA steps

Bootstrap to microk8s

```sh
$ juju deploy ambassador
ERROR refresh: no bases located for architecture "amd64" not found
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925728
