### PR TITLE
Handle k8s v1 charm inside a bundle

### DIFF
--- a/core/charm/computedseries.go
+++ b/core/charm/computedseries.go
@@ -22,7 +22,7 @@ func ComputedSeries(c charm.CharmMeta) ([]string, error) {
 
 	// We use a set to ensure uniqueness and a slice to ensure that we
 	// preserve the order of elements as they appear in the manifest.
-	seriesSlice := []string(nil)
+	var seriesSlice []string
 	seriesSet := set.NewStrings()
 
 	for _, base := range manifest.Bases {
@@ -36,5 +36,10 @@ func ComputedSeries(c charm.CharmMeta) ([]string, error) {
 			seriesSlice = append(seriesSlice, series)
 		}
 	}
+
+	if IsKubernetes(c) && !seriesSet.Contains(coreseries.Kubernetes.String()) {
+		seriesSlice = append(seriesSlice, coreseries.Kubernetes.String())
+	}
+
 	return seriesSlice, nil
 }

--- a/core/charm/computedseries_test.go
+++ b/core/charm/computedseries_test.go
@@ -103,7 +103,7 @@ func (s *computedSeriesSuite) TestComputedSeriesKubernetes(c *gc.C) {
 	}).AnyTimes()
 	series, err := ComputedSeries(cm)
 	c.Assert(err, gc.IsNil)
-	c.Assert(series, jc.DeepEquals, []string{"bionic"})
+	c.Assert(series, jc.DeepEquals, []string{"bionic", "kubernetes"})
 }
 
 func (s *computedSeriesSuite) TestComputedSeriesError(c *gc.C) {


### PR DESCRIPTION
Deploying a v1 charm metadata inside a k8s bundle looses the ability to
know that the computed series for a charm is actually a kubernetes
charm.

The code just checks to ensure that the computed series also contains
kubernetes so that we can deploy correctly. This is a workaround for v1
charm metadata and if we ever remove support for it, we can safely drop
kubernetes series.

## QA steps

Save the following bundle yaml locally:

```yaml
bundle: kubernetes
applications:
  snappass:
    charm: snappass-test
    scale: 1
```

```sh
$ juju bootstrap microk8s
$ juju deploy ./bundle.yaml
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1925717
