### PR TITLE
Fix for LP:1925721.

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -979,7 +979,7 @@ func (a *app) Units() ([]caas.Unit, error) {
 				logger.Warningf("volume for volume mount %q not found", volMount.Name)
 				continue
 			}
-			if vol.Secret != nil && strings.HasPrefix(vol.Secret.SecretName, a.name+"-token") {
+			if vol.Secret != nil && strings.Contains(vol.Secret.SecretName, "-token") {
 				logger.Tracef("ignoring volume source for service account secret: %v", vol.Name)
 				continue
 			}

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -1461,6 +1461,25 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 				},
 			},
 		)
+		// Add a volume with a secret for lp:1925721, the secret name must contain
+		// `-token` to be ignored.
+		podSpec.Volumes = append(podSpec.Volumes,
+			corev1.Volume{
+				Name: "testme",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "charm-data-token",
+					},
+				},
+			},
+		)
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "testme",
+				MountPath: "path/to/here",
+			},
+		)
 		pod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   s.namespace,


### PR DESCRIPTION
Loosen restrictions on Volume secret names, they only need to include `-token`.

## QA steps

```console
# bootstrap microk8s
$ make make microk8s-operator-update
$ juju bootstrap microk8s testme

# download and build jnsgruk-kubernetes-dashboard
$ cd /tmp
$ git clone https://github.com/jnsgruk/charm-kubernetes-dashboard
# Build the charm
$ cd charm-kubernetes-dashboard
$ charmcraft build

# deploy
juju deploy ./jnsgruk-kubernetes-dashboard.charm --resource dashboard-image=kubernetesui/dashboard:v2.0.0

# verify no errors in model logs along the lines of "finding filesystem info for "
$ juju debug-log --level error

# deploy another k8s charm
juju deploy postgresql-charmers-postgresql-k8s
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925751
