### PR TITLE
Better error for adding a k8s model with a used namespace

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -324,7 +324,7 @@ func (k *kubernetesClient) SetCloudSpec(spec environscloudspec.CloudSpec) error 
 	return nil
 }
 
-// PrepareForBootstrap prepares for bootstraping a controller.
+// PrepareForBootstrap prepares for bootstrapping a controller.
 func (k *kubernetesClient) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
 	alreadyExistErr := errors.NewAlreadyExists(nil,
 		fmt.Sprintf(`a controller called %q already exists on this k8s cluster.
@@ -360,10 +360,11 @@ Please bootstrap again and choose a different controller name.`, controllerName)
 	return errors.Trace(err)
 }
 
-// Create implements environs.BootstrapEnviron.
+// Create (environs.BootstrapEnviron) creates a new environ.
+// It must raise an error satisfying IsAlreadyExists if the
+// namespace is already used by another model.
 func (k *kubernetesClient) Create(envcontext.ProviderCallContext, environs.CreateParams) error {
-	// must raise errors.AlreadyExistsf if it's already exist.
-	return k.createNamespace(k.namespace)
+	return errors.Trace(k.createNamespace(k.namespace))
 }
 
 // Bootstrap deploys controller with mongoDB together into k8s cluster.

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -319,7 +319,7 @@ type BootstrapEnviron interface {
 	CloudDestroyer
 	ControllerDestroyer
 
-	// Environ implements storage.ProviderRegistry for acquiring
+	// ProviderRegistry is implemented in order to acquire
 	// environ-scoped storage providers supported by the Environ.
 	// StorageProviders returned from Environ.StorageProvider will
 	// be scoped specifically to that Environ.


### PR DESCRIPTION
Adding a model with a name already used by a non-Juju k8s namespace returns a cryptic error.

Here, we add an error annotation to indicate this fact.

Sundry nips and tucks accompany.

## QA steps

- On a k8s cloud, attempt to add a model named "kube-system".
- Error returned reads:
```
ERROR creating namespace "kube-system": namespace may be in use: annotation key "controller.juju.is/id" not found
```
## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925994
