### PR TITLE
Suppress charm name in status oci image path

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -165,6 +165,24 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			if len(parts) > 1 && len(version) > maxVersionWidth {
 				version = strings.Join(parts[1:], "/")
 			}
+			// Charms deployed from the rocks or jujucharm repos have the
+			// image path set to <repo-url>/<charm_name>/<resource_name>. Charm name
+			// is somewhat redundant and takes up value space. So we'll replace
+			// with "ch:" to indicate the named resource comes from the store repo.
+			parts = strings.Split(version, "/")
+			if len(parts) > 1 && (len(version) > maxVersionWidth || parts[0] == app.Charm) {
+				prefix := ""
+				switch app.CharmOrigin {
+				case "charmhub":
+					prefix = "ch"
+				case "charmstore":
+					prefix = "cs"
+				}
+				if prefix != "" {
+					parts[1] = prefix + ":" + parts[1]
+					version = strings.Join(parts[1:], "/")
+				}
+			}
 		}
 		// Don't let a long version push out the version column.
 		if len(version) > maxVersionWidth {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -162,26 +162,29 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 				}
 			}
 			parts := strings.Split(version, "/")
-			if len(parts) > 1 && len(version) > maxVersionWidth {
-				version = strings.Join(parts[1:], "/")
-			}
 			// Charms deployed from the rocks or jujucharm repos have the
-			// image path set to <repo-url>/<charm_name>/<resource_name>. Charm name
+			// image path set to <repo-url>/<user>/<charm_name>/<resource_name>. Charm name
 			// is somewhat redundant and takes up value space. So we'll replace
-			// with "ch:" to indicate the named resource comes from the store repo.
-			parts = strings.Split(version, "/")
-			if len(parts) > 1 && (len(version) > maxVersionWidth || parts[0] == app.Charm) {
+			// with "res:" to indicate the named resource comes from the store repo.
+			fromJujuRepo := strings.Contains(app.Version, "jujucharms.") || strings.Contains(app.Version, "rocks.")
+			if fromJujuRepo && len(parts) > 2 && (len(version) > maxVersionWidth || parts[1] == app.Charm) {
 				prefix := ""
 				switch app.CharmOrigin {
-				case "charmhub":
-					prefix = "ch"
-				case "charmstore":
-					prefix = "cs"
+				case "charmhub", "charmstore":
+					prefix = "res:"
 				}
 				if prefix != "" {
-					parts[1] = prefix + ":" + parts[1]
-					version = strings.Join(parts[1:], "/")
+					parts[2] = prefix + parts[2]
+					version = strings.Join(parts[2:], "/")
 				}
+			}
+			// For qualified images, if they are too long, we still
+			// want to see the core image name, but we can compromise
+			// on the namespace part and replace that with "...".
+			parts = strings.Split(version, "/")
+			if len(parts) > 1 && len(version) > maxVersionWidth {
+				parts[0] = ellipsis
+				version = strings.Join(parts, "/")
 			}
 		}
 		// Don't let a long version push out the version column.

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5338,9 +5338,11 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 				},
 			},
 			"bar": {
+				Charm: "bar",
+				CharmOrigin: "charmhub",
 				Scale:   1,
 				Address: "54.32.1.3",
-				Version: "registry.jujucharms.com/mine/image:0.5",
+				Version: "registry.jujucharms.com/bar/image:0.5",
 				Units: map[string]unitStatus{
 					"bar/0": {
 						JujuStatusInfo: statusInfoContents{
@@ -5376,10 +5378,10 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version            Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
-bar  mine/image:0.5               0/1                           0      54.32.1.3  
-baz  image:0.6                    0/1                           0      54.32.1.4  
-foo  image:tag@3046a3d            0/1                           0      54.32.1.2  
+App  Version            Status  Scale  Charm  Store     Channel  Rev  OS  Address    Message
+bar  ch:image:0.5                 0/1         charmhub             0      54.32.1.3  
+baz  image:0.6                    0/1                              0      54.32.1.4  
+foo  image:tag@3046a3d            0/1                              0      54.32.1.2  
 
 Unit   Workload  Agent       Address  Ports  Message
 bar/0  active    allocating                  

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5325,7 +5325,7 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 			"foo": {
 				Scale:   1,
 				Address: "54.32.1.2",
-				Version: "registry.jujucharms.com/image:tag@sha256:3046a3dc76ee23417f889675bce3a4c08f223b87d1e378eeea3e7490cd27fbc5",
+				Version: "registry.jujucharms.com/fred/mysql/mysql_image:tag@sha256:3046a3dc76ee23417f889675bce3a4c08f223b87d1e378eeea3e7490cd27fbc5",
 				Units: map[string]unitStatus{
 					"foo/0": {
 						JujuStatusInfo: statusInfoContents{
@@ -5342,7 +5342,7 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 				CharmOrigin: "charmhub",
 				Scale:   1,
 				Address: "54.32.1.3",
-				Version: "registry.jujucharms.com/bar/image:0.5",
+				Version: "registry.jujucharms.com/fredbloggsthethrid/bar/image:0.5",
 				Units: map[string]unitStatus{
 					"bar/0": {
 						JujuStatusInfo: statusInfoContents{
@@ -5357,7 +5357,7 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 			"baz": {
 				Scale:   1,
 				Address: "54.32.1.4",
-				Version: "registry.jujucharms.com/reallyreallyreallyreallyreallylong/image:0.6",
+				Version: "docker.io/reallyreallyreallyreallyreallylong/image:0.6",
 				Units: map[string]unitStatus{
 					"baz/0": {
 						JujuStatusInfo: statusInfoContents{
@@ -5378,10 +5378,10 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version            Status  Scale  Charm  Store     Channel  Rev  OS  Address    Message
-bar  ch:image:0.5                 0/1         charmhub             0      54.32.1.3  
-baz  image:0.6                    0/1                              0      54.32.1.4  
-foo  image:tag@3046a3d            0/1                              0      54.32.1.2  
+App  Version                         Status  Scale  Charm  Store     Channel  Rev  OS  Address    Message
+bar  res:image:0.5                             0/1         charmhub             0      54.32.1.3  
+baz  .../image:0.6                             0/1                              0      54.32.1.4  
+foo  .../mysql/mysql_image:tag@3...            0/1                              0      54.32.1.2  
 
 Unit   Workload  Agent       Address  Ports  Message
 bar/0  active    allocating                  


### PR DESCRIPTION
k8s charms deployed from the rocks or jujucharm repos have the image path set to
`<repo-urll>/<charm_name>/<resource_name>`.
 Charm name is somewhat redundant and takes up value space. So we'll replace with "ch:" to indicate the named resource comes from the store repo.

## QA steps

```
juju  deploy cs:~juju/mariadb-k8s
juju deploy ambassador
juju status
...
App            Version                  Status  Scale  Charm          Store       Channel  Rev  OS          Address         Message
ambassador     res:oci-image@ac02890    active      1  ambassador     charmhub    stable    13  kubernetes                  
mariadb-k8s    res:mysql_image@e6ea77e  active      2  mariadb-k8s    charmstore  stable     3  kubernetes  10.152.183.134  
...
```
