### PR TITLE
Adds support for missing Kubernetes vars to hook.

### DIFF
--- a/worker/meterstatus/context.go
+++ b/worker/meterstatus/context.go
@@ -41,7 +41,12 @@ func newLimitedContext(config hookConfig) *limitedContext {
 }
 
 // HookVars implements runner.Context.
-func (ctx *limitedContext) HookVars(paths context.Paths, remote bool, getEnv context.GetEnvFunc) ([]string, error) {
+func (ctx *limitedContext) HookVars(
+	paths context.Paths,
+	remote bool,
+	getEnv context.GetEnvFunc,
+	_ context.OSEnvFunc,
+) ([]string, error) {
 	vars := []string{
 		"CHARM_DIR=" + paths.GetCharmDir(), // legacy
 		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),

--- a/worker/meterstatus/context_test.go
+++ b/worker/meterstatus/context_test.go
@@ -43,7 +43,7 @@ func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 			c.Errorf("unexpected get env call for %q", k)
 		}
 		return ""
-	})
+	}, func() []string { return []string{} })
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -74,7 +74,7 @@ func (s *ContextSuite) TestHookContextSetEnv(c *gc.C) {
 			c.Errorf("unexpected get env call for %q", k)
 		}
 		return ""
-	})
+	}, func() []string { return []string{} })
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/metrics/collect/context.go
+++ b/worker/metrics/collect/context.go
@@ -40,7 +40,12 @@ func newHookContext(config hookConfig) *hookContext {
 }
 
 // HookVars implements runner.Context.
-func (ctx *hookContext) HookVars(paths context.Paths, remote bool, getEnv context.GetEnvFunc) ([]string, error) {
+func (ctx *hookContext) HookVars(
+	paths context.Paths,
+	remote bool,
+	getEnv context.GetEnvFunc,
+	_ context.OSEnvFunc,
+) ([]string, error) {
 	vars := []string{
 		"CHARM_DIR=" + paths.GetCharmDir(), // legacy
 		"JUJU_CHARM_DIR=" + paths.GetCharmDir(),

--- a/worker/metrics/collect/context_test.go
+++ b/worker/metrics/collect/context_test.go
@@ -73,7 +73,7 @@ func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 			c.Errorf("unexpected get env call for %q", k)
 		}
 		return ""
-	})
+	}, func() []string { return []string{} })
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -951,8 +951,19 @@ func (ctx *HookContext) ActionData() (*ActionData, error) {
 // such that it can know what environment it's operating in, and can call back
 // into context.
 // Implements runner.Context.
-func (ctx *HookContext) HookVars(paths Paths, remote bool, getEnv GetEnvFunc) ([]string, error) {
+func (ctx *HookContext) HookVars(
+	paths Paths,
+	remote bool,
+	getEnv GetEnvFunc,
+	osEnv OSEnvFunc,
+) ([]string, error) {
 	vars := ctx.legacyProxySettings.AsEnvironmentValues()
+
+	// We add all the host env's here because hooks are starting to expect that
+	// they can see this. This in response to lp1892255. We are doing this early
+	// so our overrides come out on top.
+	vars = append(vars, osEnv()...)
+
 	// TODO(thumper): as work on proxies progress, there will be additional
 	// proxy settings to be added.
 	vars = append(vars,
@@ -1017,6 +1028,7 @@ func (ctx *HookContext) HookVars(paths Paths, remote bool, getEnv GetEnvFunc) ([
 	if ctx.workloadName != "" {
 		vars = append(vars, "JUJU_WORKLOAD_NAME="+ctx.workloadName)
 	}
+
 	return append(vars, OSDependentEnvVars(paths, getEnv)...), nil
 }
 

--- a/worker/uniter/runner/context/env.go
+++ b/worker/uniter/runner/context/env.go
@@ -16,6 +16,9 @@ import (
 // based off existing variables.
 type GetEnvFunc func(key string) string
 
+// OSEnvFunc returns all env vars for the host os
+type OSEnvFunc func() []string
+
 // OSDependentEnvVars returns the OS-dependent environment variables that
 // should be set for a hook context.
 func OSDependentEnvVars(paths Paths, getEnv GetEnvFunc) []string {

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -259,11 +259,9 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 			switch k {
 			case "PATH", "Path":
 				return "pathy"
-			default:
-				c.Errorf("unexpected get env call for %q", k)
 			}
 			return ""
-		})
+		}, func() []string { return []string{} })
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(len(vars) > 0, jc.IsTrue, gc.Commentf("expected HookVars but found none"))
 		combined := strings.Join(vars, "|")
@@ -362,11 +360,9 @@ func (s *FactorySuite) TestNewActionRunnerWithCancel(c *gc.C) {
 		switch k {
 		case "PATH", "Path":
 			return "pathy"
-		default:
-			c.Errorf("unexpected get env call for %q", k)
 		}
 		return ""
-	})
+	}, func() []string { return []string{} })
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(vars) > 0, jc.IsTrue, gc.Commentf("expected HookVars but found none"))
 	combined := strings.Join(vars, "|")

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -110,7 +110,11 @@ type Runner interface {
 type Context interface {
 	jujuc.Context
 	Id() string
-	HookVars(paths context.Paths, remote bool, getEnvFunc context.GetEnvFunc) ([]string, error)
+	HookVars(
+		paths context.Paths,
+		remote bool,
+		getEnvFunc context.GetEnvFunc,
+		osEnvFunc context.OSEnvFunc) ([]string, error)
 	ActionData() (*context.ActionData, error)
 	SetProcess(process context.HookProcess)
 	HasExecutionSetUnitStatus() bool
@@ -149,12 +153,10 @@ type ExecParams struct {
 
 // execOnMachine executes commands on current machine.
 func execOnMachine(params ExecParams) (*utilexec.ExecResponse, error) {
-	hostEnv := os.Environ()
-	hostEnv = append(hostEnv, params.Env...)
 	command := utilexec.RunParams{
 		Commands:    strings.Join(params.Commands, " "),
 		WorkingDir:  params.WorkingDir,
-		Environment: hostEnv,
+		Environment: params.Env,
 		Clock:       params.Clock,
 	}
 	err := command.Run()
@@ -240,6 +242,7 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 	defer srv.Close()
 
 	getEnv := os.Getenv
+	osEnv := os.Environ
 	if rMode == runOnRemote {
 		env, err := runner.getRemoteEnviron(abort)
 		if err != nil {
@@ -249,8 +252,15 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 			v, _ := env[k]
 			return v
 		}
+		osEnv = func() []string {
+			rval := make([]string, 0, len(env))
+			for k, v := range env {
+				rval = append(rval, fmt.Sprintf("%s=%s", k, v))
+			}
+			return rval
+		}
 	}
-	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, getEnv)
+	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, getEnv, osEnv)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -407,6 +417,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 	defer srv.Close()
 
 	getEnv := os.Getenv
+	osEnv := os.Environ
 	if rMode == runOnRemote {
 		var cancel <-chan struct{}
 		actionData, err := runner.context.ActionData()
@@ -421,9 +432,16 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 			v, _ := env[k]
 			return v
 		}
+		osEnv = func() []string {
+			rval := make([]string, 0, len(env))
+			for k, v := range env {
+				rval = append(rval, fmt.Sprintf("%s=%s", k, v))
+			}
+			return rval
+		}
 	}
 
-	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, getEnv)
+	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, getEnv, osEnv)
 	if err != nil {
 		return InvalidHookHandler, errors.Trace(err)
 	}

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -47,7 +47,7 @@ func (s *RunCommandSuite) TestRunCommandsEnvStdOutAndErrAndRC(c *gc.C) {
 	r := runner.NewRunner(ctx, paths, nil)
 
 	// Ensure the current process env is passed through to the command.
-	s.PatchEnvironment("FOO", "BAR")
+	s.PatchEnvironment("KUBERNETES_PORT", "443")
 
 	commands := `
 echo $JUJU_CHARM_DIR
@@ -59,7 +59,7 @@ exit 42
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result.Code, gc.Equals, 42)
-	c.Assert(strings.ReplaceAll(string(result.Stdout), "\n", ""), gc.Equals, paths.GetCharmDir()+"BAR")
+	c.Assert(strings.ReplaceAll(string(result.Stdout), "\n", ""), gc.Equals, paths.GetCharmDir())
 	c.Assert(strings.TrimRight(string(result.Stderr), "\n"), gc.Equals, "this is standard err")
 	c.Assert(ctx.GetProcess(), gc.NotNil)
 }
@@ -236,7 +236,12 @@ func (ctx *MockContext) UnitName() string {
 	return "some-unit/999"
 }
 
-func (ctx *MockContext) HookVars(paths context.Paths, _ bool, getEnv context.GetEnvFunc) ([]string, error) {
+func (ctx *MockContext) HookVars(
+	paths context.Paths,
+	_ bool,
+	getEnv context.GetEnvFunc,
+	_ context.OSEnvFunc,
+) ([]string, error) {
 	pathKey := ""
 	if runtime.GOOS == "windows" {
 		pathKey = "Path"


### PR DESCRIPTION
Hook contexts have been missing Kubernetes var's. As per lp-1892255.
This change introduces platform scoped env vars that can be harvested
from the enviornment.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

See bug lp bug below.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1892255
