### PR TITLE
Prevent starvation when asking for random values

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -17,7 +17,7 @@ wait_for() {
 
 	attempt=0
 	# shellcheck disable=SC2046,SC2143
-	until [ "$(juju status --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]; do
+	until [[ "$(juju status --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling status for" "${name}"
 		juju status --relations 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"

--- a/tests/suites/resources/upgrade.sh
+++ b/tests/suites/resources/upgrade.sh
@@ -57,7 +57,7 @@ run_resource_attach_large() {
 	# .txt suffix required for attach.
 	FILE=$(mktemp /tmp/resource-XXXXX.txt)
 	# Use urandom to add alpha numeric characters with new lines added to the file
-	cat /dev/urandom | base64 | head -c 100M >"${FILE}"
+	dd if=/dev/urandom bs=1048576 count=100 2>/dev/null | base64 > "${FILE}"
 	line=$(head -n 1 "${FILE}")
 	juju attach juju-qa-test foo-file="${FILE}"
 


### PR DESCRIPTION
The previous request of a 100M file would fail because the head
couldn't get enough characters to fulfill the request and die. Weirdly
you can get the test to pass sometimes and not others. 

The fix for this is to request a large enough size file without the usage 
of head. Using dd works nicely here and we just pipe it through base64 
so we get a clean output in juju status.


## QA steps

```sh
(cd tests && ./main.sh resources)
```
