### PR TITLE
Remove "caas" from error messages

### DIFF
--- a/api/caasoperatorprovisioner/client.go
+++ b/api/caasoperatorprovisioner/client.go
@@ -112,7 +112,7 @@ type OperatorProvisioningInfo struct {
 
 // OperatorProvisioningInfo returns the info needed to provision an operator for an application.
 func (c *Client) OperatorProvisioningInfo(applicationName string) (OperatorProvisioningInfo, error) {
-	args := params.Entities{[]params.Entity{
+	args := params.Entities{Entities: []params.Entity{
 		{Tag: names.NewApplicationTag(applicationName).String()},
 	}}
 	var result params.OperatorProvisioningInfoResults
@@ -161,7 +161,7 @@ func (c *Client) IssueOperatorCertificate(applicationName string) (OperatorCerti
 	if !names.IsValidApplication(applicationName) {
 		return OperatorCertificate{}, errors.NotValidf("application name %q", applicationName)
 	}
-	args := params.Entities{[]params.Entity{
+	args := params.Entities{Entities: []params.Entity{
 		{Tag: names.NewApplicationTag(applicationName).String()},
 	}}
 	var result params.IssueOperatorCertificateResults

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -407,7 +407,7 @@ func (op *caasOperator) loop() (err error) {
 
 	localState, err := op.init()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	logger.Infof("operator %q started", op.config.Application)
 
@@ -552,17 +552,17 @@ func (op *caasOperator) loop() (err error) {
 					delete(unitRunningChannels, unitID)
 					logger.Debugf("stopping uniter for dead unit %q", unitID)
 					if err := op.runner.StopWorker(unitID); err != nil {
-						return err
+						return errors.Trace(err)
 					}
 					logger.Debugf("removing unit dir for dead unit %q", unitID)
 					// Remove the unit's directory
 					if err := op.removeUnitDir(unitTag); err != nil {
-						return err
+						return errors.Trace(err)
 					}
 					logger.Debugf("removing dead unit %q", unitID)
 					// Remove the unit from state.
 					if err := op.config.UnitRemover.RemoveUnit(unitID); err != nil {
-						return err
+						return errors.Trace(err)
 					}
 					// Nothing to do for a dead unit further.
 					continue

--- a/worker/caasoperatorprovisioner/worker.go
+++ b/worker/caasoperatorprovisioner/worker.go
@@ -264,7 +264,7 @@ func (p *provisioner) updateOperatorConfig(appName, password string, prevCfg caa
 			return nil, errors.NotSupportedf("operator storage provider %q", spType)
 		}
 	}
-	p.logger.Debugf("using caas operator info %+v", info)
+	p.logger.Debugf("using operator info %+v", info)
 
 	cfg := &caas.OperatorConfig{
 		OperatorImagePath:   info.ImagePath,

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -295,8 +295,8 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			errorString = err.Error()
 		}
 		if errors.Cause(err) == ErrCAASUnitDead {
+			errorString = err.Error()
 			err = nil
-			errorString = "caas unit dead"
 		} else if u.embedded {
 			err = jworker.ErrRestartAgent
 		}
@@ -326,7 +326,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 
 	canApplyCharmProfile, charmURL, charmModifiedVersion, err := u.charmState()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	// Check we are running the correct charm version.


### PR DESCRIPTION
We don't want to surface the use of "CAAS" (container-as-a-service) to Juju users. It is a code nomenclature concept that if leaked, just reduces cogency.

Here, we delete superfluous "caas" strings from some logging/errors.

Some extra error tracing is also included.

## QA steps

- Deploy a unit into a CAAS model with debug level logging.
- Model logs should stream a line starting with "using operator info ...".

## Documentation changes

None.

## Bug reference

N/A
