### PR TITLE
Fix ssh to a k8s unit in the controller model

### DIFF
--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -45,11 +45,11 @@ func GetOperatorPodName(
 	podAPI typedcorev1.PodInterface,
 	nsAPI typedcorev1.NamespaceInterface,
 	appName string,
-	namespace string,
+	model string,
 ) (string, error) {
-	legacyLabels, err := utils.IsLegacyModelLabels(namespace, nsAPI)
+	legacyLabels, err := utils.IsLegacyModelLabels(model, nsAPI)
 	if err != nil {
-		return "", errors.Annotatef(err, "determining legacy label status for namespace %s", namespace)
+		return "", errors.Annotatef(err, "determining legacy label status for model %s", model)
 	}
 
 	podsList, err := podAPI.List(context.TODO(), v1.ListOptions{

--- a/cmd/juju/commands/export_test.go
+++ b/cmd/juju/commands/export_test.go
@@ -45,6 +45,10 @@ func (c *sshContainer) GetExecClient() (k8sexec.Executor, error) {
 	return c.getExecClient()
 }
 
+func (c *sshContainer) ModelName() string {
+	return c.modelName
+}
+
 func (c *sshContainer) SetArgs(args []string) {
 	c.setArgs(args)
 }
@@ -55,12 +59,13 @@ type SSHContainerInterfaceForTest interface {
 	SSH(Context, bool, *resolvedTarget) error
 	Copy(ctx Context) error
 	GetExecClient() (k8sexec.Executor, error)
+	ModelName() string
 
 	SetArgs([]string)
 }
 
 func NewSSHContainer(
-	modelUUID string,
+	modelUUID, modelName string,
 	cloudCredentialAPI CloudCredentialAPI,
 	modelAPI ModelAPI,
 	applicationAPI ApplicationAPI,
@@ -71,6 +76,7 @@ func NewSSHContainer(
 ) SSHContainerInterfaceForTest {
 	return &sshContainer{
 		modelUUID:          modelUUID,
+		modelName:          modelName,
 		cloudCredentialAPI: cloudCredentialAPI,
 		modelAPI:           modelAPI,
 		applicationAPI:     applicationAPI,

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -34,6 +34,7 @@ type sshContainerSuite struct {
 	testing.BaseSuite
 
 	modelUUID          string
+	modelName string
 	cloudCredentialAPI *mocks.MockCloudCredentialAPI
 	modelAPI           *mocks.MockModelAPI
 	applicationAPI     *mocks.MockApplicationAPI
@@ -50,6 +51,7 @@ var _ = gc.Suite(&sshContainerSuite{})
 func (s *sshContainerSuite) SetUpSuite(c *gc.C) {
 	s.BaseSuite.SetUpSuite(c)
 	s.modelUUID = "e0453597-8109-4f7d-a58f-af08bc72a414"
+	s.modelName = "controller"
 }
 
 func (s *sshContainerSuite) TearDownTest(c *gc.C) {
@@ -83,6 +85,7 @@ func (s *sshContainerSuite) setUpController(c *gc.C, remote bool, containerName 
 
 	s.sshC = commands.NewSSHContainer(
 		s.modelUUID,
+		s.modelName,
 		s.cloudCredentialAPI,
 		s.modelAPI,
 		s.applicationAPI,
@@ -232,7 +235,7 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPod(c *gc.C) {
 			}, nil),
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
 
-		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.modelName, metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
 		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
@@ -260,7 +263,7 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPodNoProviderID(c *gc.C)
 			}, nil),
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
 
-		s.mockNamespaces.EXPECT().Get(gomock.Any(), gomock.Any(), metav1.GetOptions{}).
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.modelName, metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
 		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
@@ -302,7 +305,9 @@ func (s *sshContainerSuite) TestGetExecClient(c *gc.C) {
 			Return(2),
 		s.modelAPI.EXPECT().ModelInfo([]names.ModelTag{names.NewModelTag(s.modelUUID)}).
 			Return([]params.ModelInfoResult{
-				{Result: &params.ModelInfo{CloudCredentialTag: "cloudcred-microk8s_admin_microk8s"}},
+				{Result: &params.ModelInfo{
+					Name: s.modelName,
+					CloudCredentialTag: "cloudcred-microk8s_admin_microk8s"}},
 			}, nil),
 		s.cloudCredentialAPI.EXPECT().CredentialContents(cloudCredentailTag.Cloud().Id(), cloudCredentailTag.Name(), true).
 			Return([]params.CredentialContentResult{
@@ -323,6 +328,7 @@ func (s *sshContainerSuite) TestGetExecClient(c *gc.C) {
 	)
 	execC, err := s.sshC.GetExecClient()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.sshC.ModelName(), gc.Equals, s.modelName)
 	c.Assert(execC, gc.DeepEquals, s.execClient)
 }
 


### PR DESCRIPTION
On k8s, ssh to a unit in the controller model failed because the legacy label detection was wrong.
We were using a label selector created from the namespace name, not the model name. For non-controller models, these are the same so it doesn't matter, but it matters a lot for the controller model.

## QA steps

bootstrap k8s
juju deploy mariadb-k8s
juju ssh mariadb-k8s/0

## Bug reference

https://bugs.launchpad.net/juju/+bug/1926394
