### PR TITLE
Actions with errors queuing them can be listed

### DIFF
--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -228,6 +228,7 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 				*(result.(*params.OperationResults)) = params.OperationResults{
 					Results: []params.OperationResult{{
 						Summary: "hello",
+						Fail:    "fail",
 					}},
 				}
 				return nil
@@ -241,6 +242,7 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, params.OperationResults{
 		Results: []params.OperationResult{{
 			Summary: "hello",
+			Fail:    "fail",
 		}},
 	})
 }
@@ -277,6 +279,7 @@ func (s *actionSuite) TestOperation(c *gc.C) {
 				*(result.(*params.OperationResults)) = params.OperationResults{
 					Results: []params.OperationResult{{
 						Summary: "hello",
+						Fail:    "fail",
 					}},
 				}
 				return nil
@@ -289,6 +292,7 @@ func (s *actionSuite) TestOperation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.OperationResult{
 		Summary: "hello",
+		Fail:    "fail",
 	})
 }
 

--- a/apiserver/common/action.go
+++ b/apiserver/common/action.go
@@ -34,6 +34,8 @@ func ParamsActionExecutionResultsToStateActionResults(arg params.ActionExecution
 		status = state.ActionAborting
 	case params.ActionAborted:
 		status = state.ActionAborted
+	case params.ActionError:
+		status = state.ActionError
 	default:
 		return state.ActionResults{}, errors.Errorf("unrecognized action status '%s'", arg.Status)
 	}
@@ -44,17 +46,17 @@ func ParamsActionExecutionResultsToStateActionResults(arg params.ActionExecution
 	}, nil
 }
 
-// TagToActionReceiver takes a tag string and tries to convert it to an
+// TagToActionReceiverFn takes a tag string and tries to convert it to an
 // ActionReceiver. It needs a findEntity function passed in that can search for the tags in state.
 func TagToActionReceiverFn(findEntity func(names.Tag) (state.Entity, error)) func(tag string) (state.ActionReceiver, error) {
 	return func(tag string) (state.ActionReceiver, error) {
 		receiverTag, err := names.ParseTag(tag)
 		if err != nil {
-			return nil, errors.NotValidf("%s", tag)
+			return nil, errors.NotValidf("%q", tag)
 		}
 		entity, err := findEntity(receiverTag)
 		if err != nil {
-			return nil, errors.NotFoundf("%s", receiverTag)
+			return nil, errors.NotFoundf("%q", receiverTag)
 		}
 		receiver, ok := entity.(state.ActionReceiver)
 		if !ok {

--- a/apiserver/common/action_test.go
+++ b/apiserver/common/action_test.go
@@ -45,10 +45,10 @@ func (s *actionsSuite) TestTagToActionReceiverFn(c *gc.C) {
 		err: errors.NotImplementedf("action receiver interface on entity unit-invalid-0"),
 	}, {
 		tag: "unit-flustered-0",
-		err: errors.NotFoundf("unit-flustered-0"),
+		err: errors.NotFoundf(`"unit-flustered-0"`),
 	}, {
 		tag: "notatag",
-		err: errors.NotValidf("notatag"),
+		err: errors.NotValidf(`"notatag"`),
 	}} {
 		c.Logf("test %d", i)
 		receiver, err := tagFn(test.tag)
@@ -226,7 +226,7 @@ func (s *actionsSuite) TestWatchOneActionReceiverNotifications(c *gc.C) {
 		watcherId string
 	}{{
 		tag: names.NewMachineTag("0"),
-		err: "machine-0 not found",
+		err: `"machine-0" not found`,
 	}, {
 		tag:       names.NewMachineTag("1"),
 		watcherId: "bambalam",
@@ -263,7 +263,7 @@ func (s *actionsSuite) TestWatchPendingActionsForReceiver(c *gc.C) {
 		watcherId string
 	}{{
 		tag: names.NewMachineTag("0"),
-		err: "machine-0 not found",
+		err: `"machine-0" not found`,
 	}, {
 		tag:       names.NewMachineTag("1"),
 		watcherId: "bambalam",

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1153,13 +1153,13 @@ func (s *uniterSuite) TestWatchTrustConfigSettingsHash(c *gc.C) {
 func (s *uniterSuite) TestLogActionMessage(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	anAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(anAction.Messages(), gc.HasLen, 0)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
 
-	wrongAction, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	wrongAction, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.ActionMessageParams{Messages: []params.EntityString{
@@ -1187,7 +1187,7 @@ func (s *uniterSuite) TestLogActionMessage(c *gc.C) {
 func (s *uniterSuite) TestLogActionMessageAborting(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	anAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(anAction.Messages(), gc.HasLen, 0)
 	_, err = anAction.Begin()
@@ -1247,7 +1247,7 @@ func (s *uniterSuite) TestWatchActionNotifications(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	addedAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	addedAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(addedAction.Id())
@@ -1270,9 +1270,9 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action1, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	action1, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	action2, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	action2, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -1295,7 +1295,7 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 	wc := statetesting.NewStringsWatcherC(c, s.State, resource.(state.StringsWatcher))
 	wc.AssertNoChange()
 
-	addedAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	addedAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(addedAction.Id())
 	wc.AssertNoChange()
@@ -1330,7 +1330,7 @@ func (s *uniterSuite) TestWatchActionNotificationsMalformedUnitName(c *gc.C) {
 func (s *uniterSuite) TestWatchActionNotificationsNotUnit(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: action.Tag().String()},
@@ -1703,7 +1703,7 @@ func (s *uniterSuite) TestActions(c *gc.C) {
 
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		a, err := s.wordpressUnit.AddAction(
+		a, err := s.Model.AddAction(s.wordpressUnit,
 			operationID,
 			actionTest.action.Action.Name,
 			actionTest.action.Action.Parameters)
@@ -1753,7 +1753,7 @@ func (s *uniterSuite) TestActionsWrongUnit(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{
@@ -1769,7 +1769,7 @@ func (s *uniterSuite) TestActionsWrongUnit(c *gc.C) {
 func (s *uniterSuite) TestActionsPermissionDenied(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{
@@ -1792,7 +1792,7 @@ func (s *uniterSuite) TestFinishActionsSuccess(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.wordpressUnit.AddAction(operationID, testName, nil)
+	action, err := s.Model.AddAction(s.wordpressUnit, operationID, testName, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	actionResults := params.ActionExecutionResults{
@@ -1826,7 +1826,7 @@ func (s *uniterSuite) TestFinishActionsFailure(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.wordpressUnit.AddAction(operationID, testName, nil)
+	action, err := s.Model.AddAction(s.wordpressUnit, operationID, testName, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	actionResults := params.ActionExecutionResults{
@@ -1854,10 +1854,10 @@ func (s *uniterSuite) TestFinishActionsFailure(c *gc.C) {
 func (s *uniterSuite) TestFinishActionsAuthAccess(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	good, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	good, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	bad, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	bad, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var tests = []struct {
@@ -1898,7 +1898,7 @@ func (s *uniterSuite) TestBeginActions(c *gc.C) {
 	ten_seconds_ago := time.Now().Add(-10 * time.Second)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	good, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	good, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	running, err := s.wordpressUnit.RunningActions()
@@ -5601,7 +5601,7 @@ func (s *uniterV14Suite) TestWatchActionNotificationsLegacy(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	addedAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	addedAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(addedAction.Id())
 

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -270,7 +270,7 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	c.Assert(res.Results[2].Error, gc.DeepEquals, &params.Error{Message: errorString, Code: "not implemented"})
 	c.Assert(res.Results[2].Action, gc.IsNil)
 
-	c.Assert(res.Results[3].Error, gc.ErrorMatches, "no action name given")
+	c.Assert(res.Results[3].Error, gc.ErrorMatches, "action name required")
 	c.Assert(res.Results[3].Action, gc.IsNil)
 
 	c.Assert(res.Results[4].Error, gc.IsNil)
@@ -671,7 +671,7 @@ func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	added, err := unit.AddAction(operationID, "fakeaction", nil)
+	added, err := s.Model.AddAction(unit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := s.action.WatchActionsProgress(

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -258,7 +258,7 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 
 	emptyActionTag := names.ActionTag{}
 	c.Assert(res.Results[0].Error, gc.DeepEquals,
-		&params.Error{Message: fmt.Sprintf("%s not valid", arg.Actions[0].Receiver), Code: ""})
+		&params.Error{Message: fmt.Sprintf("%q not valid", arg.Actions[0].Receiver), Code: ""})
 	c.Assert(res.Results[0].Action, gc.IsNil)
 
 	c.Assert(res.Results[1].Error, gc.IsNil)
@@ -297,6 +297,51 @@ func (s *actionSuite) TestEnqueue(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(operations, gc.HasLen, 1)
 	c.Assert(operations[0].Summary(), gc.Equals, "multiple actions run on unit-wordpress-0,application-wordpress,unit-mysql-0,wordpress/leader")
+}
+
+func (s *actionSuite) TestEnqueueOperation(c *gc.C) {
+	s.toSupportNewActionID(c)
+
+	unit, err := s.State.Unit("mysql/0")
+	c.Assert(err, jc.ErrorIsNil)
+	assertReadyToTest(c, unit)
+
+	expectedParameters := map[string]interface{}{"kan jy nie": "verstaand"}
+	arg := params.Actions{
+		Actions: []params.Action{
+			// No receiver.
+			{Name: "fakeaction"},
+			// Good.
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: expectedParameters},
+			// Application tag instead of Unit tag.
+			{Receiver: s.wordpress.Tag().String(), Name: "fakeaction"},
+		},
+	}
+	result, err := s.action.EnqueueOperation(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.EnqueuedActions{
+		OperationTag: result.OperationTag,
+		Actions: []params.StringResult{{
+			Error: &params.Error{Message: `"" not valid`},
+		}, {
+			Result: "action-2",
+		}, {
+			Error: &params.Error{
+				Message: "action receiver interface on entity application-wordpress not implemented",
+				Code:    "not implemented"},
+		}},
+	})
+
+	opInfo, _, err := s.Model.ListOperations(nil, nil, nil, 0, 0)
+	c.Assert(err, jc.ErrorIsNil)
+	// Operation is in error because at least one action was.
+	c.Assert(opInfo, gc.HasLen, 1)
+	c.Assert(opInfo[0].Operation.Status(), gc.Equals, state.ActionError)
+	c.Assert(opInfo[0].Operation.Summary(), gc.Equals, "fakeaction run on unit-wordpress-0,application-wordpress")
+	// Only the valid action gets queued.
+	c.Assert(opInfo[0].Actions, gc.HasLen, 1)
+	c.Assert(opInfo[0].Actions[0].Receiver(), gc.Equals, s.wordpressUnit.Name())
+	c.Assert(opInfo[0].Actions[0].Status(), gc.Equals, state.ActionPending)
 }
 
 type testCaseAction struct {

--- a/apiserver/facades/client/action/legacy_test.go
+++ b/apiserver/facades/client/action/legacy_test.go
@@ -43,7 +43,7 @@ func (s *actionSuite) TestListAll(c *gc.C) {
 			// add each action from the test case.
 			for j, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				// make expectation
@@ -129,7 +129,7 @@ func (s *actionSuite) TestListPending(c *gc.C) {
 			// add each action from the test case.
 			for _, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				if act.Execute {
@@ -194,7 +194,7 @@ func (s *actionSuite) TestListRunning(c *gc.C) {
 			// add each action from the test case.
 			for _, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				if act.Execute {
@@ -255,7 +255,7 @@ func (s *actionSuite) TestListCompleted(c *gc.C) {
 			// add each action from the test case.
 			for _, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				if act.Execute {

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -82,30 +82,45 @@ func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, e
 
 	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
+	errorRecorded := false
 	for i, action := range arg.Actions {
 		currentResult := &response.Results[i]
 		actionReceiver := action.Receiver
+		var (
+			actionErr    error
+			enqueued     state.Action
+			receiver     state.ActionReceiver
+			receiverName string
+		)
 		if strings.HasSuffix(actionReceiver, "leader") {
 			app := strings.Split(actionReceiver, "/")[0]
-			receiverName, err := getLeader(app)
-			if err != nil {
-				currentResult.Error = common.ServerError(err)
-				continue
+			receiverName, actionErr = getLeader(app)
+			if actionErr != nil {
+				currentResult.Error = common.ServerError(actionErr)
+				goto failOperation
 			}
 			actionReceiver = names.NewUnitTag(receiverName).String()
 		}
-		receiver, err := tagToActionReceiver(actionReceiver)
-		if err != nil {
-			currentResult.Error = common.ServerError(err)
-			continue
+		receiver, actionErr = tagToActionReceiver(actionReceiver)
+		if actionErr != nil {
+			currentResult.Error = common.ServerError(actionErr)
+			goto failOperation
 		}
-		enqueued, err := receiver.AddAction(operationID, action.Name, action.Parameters)
-		if err != nil {
-			currentResult.Error = common.ServerError(err)
-			continue
+		enqueued, actionErr = receiver.AddAction(operationID, action.Name, action.Parameters)
+		if actionErr != nil {
+			currentResult.Error = common.ServerError(actionErr)
+			goto failOperation
 		}
-
 		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued, false)
+		continue
+
+	failOperation:
+		// If we failed to enqueue the action, record the error on the operation.
+		if !errorRecorded {
+			errorRecorded = true
+			err = a.model.FailOperation(operationID, actionErr)
+		}
+		currentResult.Error = common.ServerError(actionErr)
 	}
 	return operationID, response, nil
 }
@@ -174,6 +189,7 @@ func (a *ActionAPI) ListOperations(arg params.OperationQueryArgs) (params.Operat
 		result.Results[i] = params.OperationResult{
 			OperationTag: r.Operation.Tag().String(),
 			Summary:      r.Operation.Summary(),
+			Fail:         r.Operation.Fail(),
 			Enqueued:     r.Operation.Enqueued(),
 			Started:      r.Operation.Started(),
 			Completed:    r.Operation.Completed(),
@@ -216,6 +232,7 @@ func (a *ActionAPI) Operations(arg params.Entities) (params.OperationResults, er
 		results.Results[i] = params.OperationResult{
 			OperationTag: op.Operation.Tag().String(),
 			Summary:      op.Operation.Summary(),
+			Fail:         op.Operation.Fail(),
 			Enqueued:     op.Operation.Enqueued(),
 			Started:      op.Operation.Started(),
 			Completed:    op.Operation.Completed(),

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -106,7 +106,7 @@ func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, e
 			currentResult.Error = common.ServerError(actionErr)
 			goto failOperation
 		}
-		enqueued, actionErr = receiver.AddAction(operationID, action.Name, action.Parameters)
+		enqueued, actionErr = a.model.AddAction(receiver, operationID, action.Name, action.Parameters)
 		if actionErr != nil {
 			currentResult.Error = common.ServerError(actionErr)
 			goto failOperation

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -6,6 +6,7 @@ package action_test
 import (
 	"strconv"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
@@ -50,6 +51,30 @@ func (s *operationSuite) setupOperations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = a.Finish(state.ActionResults{Status: state.ActionCompleted})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *operationSuite) TestFailedOperations(c *gc.C) {
+	s.toSupportNewActionID(c)
+
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+
+	r, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Results, gc.HasLen, len(arg.Actions))
+
+	// There's only one operation created.
+	ops, err := s.Model.AllOperations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.HasLen, 1)
+	err = s.Model.FailOperation(ops[0].Id(), errors.New("fail"))
+	c.Assert(err, jc.ErrorIsNil)
+	op, err := s.Model.Operation(ops[0].Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Status(), gc.Equals, state.ActionError)
+	c.Assert(op.Fail(), gc.Equals, "fail")
 }
 
 func (s *operationSuite) TestListOperationsStatusFilter(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -610,6 +610,9 @@
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
+                        "fail": {
+                            "type": "string"
+                        },
                         "operation": {
                             "type": "string"
                         },

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -33,6 +33,10 @@ const (
 	// ActionAborted is the status of an Action that was aborted.
 	// Identical to ActionFailed and can have an error.
 	ActionAborted string = "aborted"
+
+	// ActionError is the status of an Action that did not get run
+	// due to an error.
+	ActionError string = "error"
 )
 
 // Actions is a slice of Action for bulk requests.
@@ -146,6 +150,7 @@ type OperationResults struct {
 type OperationResult struct {
 	OperationTag string         `json:"operation"`
 	Summary      string         `json:"summary"`
+	Fail         string         `json:"fail,omitempty"`
 	Enqueued     time.Time      `json:"enqueued,omitempty"`
 	Started      time.Time      `json:"started,omitempty"`
 	Completed    time.Time      `json:"completed,omitempty"`

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -113,7 +113,8 @@ func (c *listOperationsCommand) Init(args []string) error {
 			params.ActionFailed,
 			params.ActionCancelled,
 			params.ActionAborting,
-			params.ActionAborted:
+			params.ActionAborted,
+			params.ActionError:
 		default:
 			nameErrors = append(nameErrors,
 				fmt.Sprintf("%q is not a valid task status, want one of %v",
@@ -124,7 +125,8 @@ func (c *listOperationsCommand) Init(args []string) error {
 						params.ActionFailed,
 						params.ActionCancelled,
 						params.ActionAborting,
-						params.ActionAborted}))
+						params.ActionAborted,
+						params.ActionError}))
 		}
 	}
 	if len(nameErrors) > 0 {
@@ -271,6 +273,7 @@ func (s byId) Less(i, j int) bool {
 type operationInfo struct {
 	Summary string              `yaml:"summary" json:"summary"`
 	Status  string              `yaml:"status" json:"status"`
+	Fail    string              `yaml:"fail,omitempty" json:"fail,omitempty"`
 	Error   string              `yaml:"error,omitempty" json:"error,omitempty"`
 	Action  *actionSummary      `yaml:"action,omitempty" json:"action,omitempty"`
 	Timing  timingInfo          `yaml:"timing,omitempty" json:"timing,omitempty"`
@@ -303,6 +306,7 @@ type taskInfo struct {
 func formatOperationResult(operation params.OperationResult, utc bool) operationInfo {
 	result := operationInfo{
 		Summary: operation.Summary,
+		Fail:    operation.Fail,
 		Status:  operation.Status,
 		Timing: timingInfo{
 			Enqueued:  formatTimestamp(operation.Enqueued, false, utc, false),

--- a/cmd/juju/action/listoperations_test.go
+++ b/cmd/juju/action/listoperations_test.go
@@ -49,8 +49,8 @@ func (s *ListOperationsSuite) TestInit(c *gc.C) {
 		expectedErr: "invalid machine id \"" + invalidMachineId + "\"",
 	}, {
 		should:      "fail with invalid status value",
-		args:        []string{"--status", "pending," + "error"},
-		expectedErr: `"error" is not a valid task status, want one of \[pending running completed failed cancelled aborting aborted\]`,
+		args:        []string{"--status", "pending," + "foo"},
+		expectedErr: `"foo" is not a valid task status, want one of \[pending running completed failed cancelled aborting aborted error\]`,
 	}, {
 		should:      "fail with multiple errors",
 		args:        []string{"--units", "valid/0," + invalidUnitId, "--apps", "valid," + invalidApplicationId},
@@ -116,11 +116,12 @@ var listOperationResults = []params.OperationResult{
 			},
 		}},
 		Summary:      "operation 1",
+		Fail:         "fail",
 		OperationTag: "operation-1",
-		Enqueued:     time.Time{},
-		Started:      time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
+		Enqueued:     time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
+		Started:      time.Time{},
 		Completed:    time.Time{},
-		Status:       "completed",
+		Status:       "error",
 	}, {
 		Actions: []params.ActionResult{{
 			Action: &params.Action{
@@ -186,11 +187,11 @@ func (s *ListOperationsSuite) TestRunPlain(c *gc.C) {
 		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--utc")
 		c.Assert(err, jc.ErrorIsNil)
 		expected := `
-Id  Status     Started              Finished             Task IDs  Summary
- 1  completed  2015-02-14T06:06:06                       2         operation 1
- 3  running                         2014-02-14T06:06:06  4         operation 3
- 5  pending                                              6         operation 5
- 7  error                                                          operation 7
+Id  Status   Started  Finished             Task IDs  Summary
+ 1  error                                  2         operation 1
+ 3  running           2014-02-14T06:06:06  4         operation 3
+ 5  pending                                6         operation 5
+ 7  error                                            operation 7
 
 `[1:]
 		c.Check(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, expected)
@@ -233,6 +234,7 @@ var listOperationManyTasksResults = []params.OperationResult{
 		}},
 		Summary:      "operation 1",
 		OperationTag: "operation-1",
+		Fail:         "fail",
 		Enqueued:     time.Time{},
 		Started:      time.Date(2015, time.February, 14, 6, 6, 6, 0, time.UTC),
 		Completed:    time.Time{},
@@ -276,12 +278,13 @@ func (s *ListOperationsSuite) TestRunYaml(c *gc.C) {
 		expected := `
 "1":
   summary: operation 1
-  status: completed
+  status: error
+  fail: fail
   action:
     name: backup
     parameters: {}
   timing:
-    started: 2015-02-14 06:06:06 +0000 UTC
+    enqueued: 2015-02-14 06:06:06 +0000 UTC
   tasks:
     "2":
       host: mysql/0

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a
+	github.com/juju/description/v2 v2.0.0-20210429075918-d7956ed9de2b
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,9 @@ github.com/juju/collections v0.0.0-20180516022642-90152009b5f3/go.mod h1:Ep+c0vn
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a h1:/ygBd+M6aG7v3SSUJYhwCc6dqKZCI467+eNaEYUAWXg=
 github.com/juju/description/v2 v2.0.0-20200623093622-bd6ec044a72a/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
+github.com/juju/description/v2 v2.0.0-20210429075918-d7956ed9de2b h1:Y/sMOFx4+NpZb/1lQclQ9ylceqR0tKaMqzeVMXjL7pI=
+github.com/juju/description/v2 v2.0.0-20210429075918-d7956ed9de2b/go.mod h1:R0uVxoEejueoMqD3tiidghBvVe9q3pshSFNqCToOTBo=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
@@ -398,7 +399,6 @@ github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/
 github.com/juju/os v0.0.0-20200701063157-8e6dd7a2b438/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
 github.com/juju/os v1.1.1 h1:EkRDibV86T2jPJI3kpEN6sN5TfhTR0A1yNB9oeVC6XY=
 github.com/juju/os v1.1.1/go.mod h1:aswA7dG+jFZC4cTmuTphPpWS9jm7NXP5dG6jEPvfQBY=
-github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
 github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
 github.com/juju/packaging v0.0.0-20210322161715-32d1b6c12454 h1:Wcxl0szmXbgdAvMia0y9U9hnR3UXM2bAEDC8iYnhluc=
 github.com/juju/packaging v0.0.0-20210322161715-32d1b6c12454/go.mod h1:tC/T9cCGw0tgm2xgx+7ZVmFbfV1ZPZSmO/E+HlRdPjc=
@@ -458,7 +458,6 @@ github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0t
 github.com/juju/testing v0.0.0-20200608005635-e4eedbc6f7aa/go.mod h1:hpGvhGHPVbNBraRLZEhoQwFLMrjK8PSlO4D3nDjKYXo=
 github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd/go.mod h1:hpGvhGHPVbNBraRLZEhoQwFLMrjK8PSlO4D3nDjKYXo=
 github.com/juju/testing v0.0.0-20200923013621-75df6121fbb0/go.mod h1:Ky6DwobyXXeXSqRJCCuHpAtVEGRPOT8gUsFpJhDoXZ8=
-github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07 h1:6QA3rIUc3TBPbv8zWa2KQ2TWn6gsn1EU0UhwRi6kOhA=
 github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07/go.mod h1:7lxZW0B50+xdGFkvhAb8bwAGt6IU87JB1H9w4t8MNVM=
 github.com/juju/testing v0.0.0-20210324180055-18c50b0c2098 h1:yrhek184cGp0IRyHg0uV1khLaorNg6GtDLkry4oNNjE=
 github.com/juju/testing v0.0.0-20210324180055-18c50b0c2098/go.mod h1:7lxZW0B50+xdGFkvhAb8bwAGt6IU87JB1H9w4t8MNVM=

--- a/state/action.go
+++ b/state/action.go
@@ -773,6 +773,20 @@ func (m *Model) EnqueueAction(operationID string, receiver names.Tag, actionName
 	return nil, err
 }
 
+// AddAction adds a new Action of type name and using arguments payload to
+// the receiver, and returns its ID.
+func (m *Model) AddAction(receiver ActionReceiver, operationID, name string, payload map[string]interface{}) (Action, error) {
+	payload, err := receiver.PrepareActionPayload(name, payload)
+	if err != nil {
+		_, err2 := m.EnqueueAction(operationID, receiver.Tag(), name, payload, err)
+		if err2 != nil {
+			err = err2
+		}
+		return nil, errors.Trace(err)
+	}
+	return m.EnqueueAction(operationID, receiver.Tag(), name, payload, nil)
+}
+
 // matchingActions finds actions that match ActionReceiver.
 func (st *State) matchingActions(ar ActionReceiver) ([]Action, error) {
 	return st.matchingActionsByReceiverId(ar.Tag().Id())

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -95,7 +95,7 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 func (s *ActionSuite) TestActionTag(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.unit.AddAction(operationID, "snapshot", nil)
+	action, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	tag := action.Tag()
@@ -159,7 +159,7 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 		// Verify we can add an Action
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		a, err := t.whichUnit.AddAction(operationID, t.name, params)
+		a, err := s.Model.AddAction(t.whichUnit, operationID, t.name, params)
 
 		if t.expectedErr == "" {
 			c.Assert(err, jc.ErrorIsNil)
@@ -280,7 +280,7 @@ act:
 		// is tested in the gojsonschema package.
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := u.AddAction(operationID, "act", t.params)
+		action, err := s.Model.AddAction(u, operationID, "act", t.params)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(action.Parameters(), jc.DeepEquals, t.expectedParams)
 	}
@@ -295,9 +295,9 @@ func (s *ActionSuite) TestActionBeginStartsOperation(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	anAction2, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction2, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	anAction, err = anAction.Begin()
@@ -327,9 +327,9 @@ func (s *ActionSuite) TestActionBeginStartsOperationRace(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	anAction2, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction2, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer state.SetBeforeHooks(c, s.State, func() {
@@ -357,9 +357,9 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperation(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	anAction2, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction2, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	anAction, err = anAction.Begin()
@@ -399,7 +399,7 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperationMany(c *gc.C) {
 	wg := sync.WaitGroup{}
 	var actions []state.Action
 	for i := 0; i < numActions; i++ {
-		anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+		anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		anAction, err = anAction.Begin()
@@ -444,9 +444,9 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperationRace(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	anAction2, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction2, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	anAction, err = anAction.Begin()
@@ -489,7 +489,7 @@ func (s *ActionSuite) TestActionMessages(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(anAction.Messages(), gc.HasLen, 0)
 
@@ -550,7 +550,7 @@ func (s *ActionSuite) TestActionLogMessageRace(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.unit.AddAction(operationID, "snapshot", nil)
+	anAction, err := s.Model.AddAction(s.unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(anAction.Messages(), gc.HasLen, 0)
 
@@ -638,10 +638,10 @@ func (s *ActionSuite) TestAddActionAcceptsDuplicateNames(c *gc.C) {
 	// verify can add two actions with same name
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	a1, err := s.unit.AddAction(operationID, name, params1)
+	a1, err := s.Model.AddAction(s.unit, operationID, name, params1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	a2, err := s.unit.AddAction(operationID, name, params2)
+	a2, err := s.Model.AddAction(s.unit, operationID, name, params2)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(a1.Id(), gc.Not(gc.Equals), a2.Id())
@@ -683,7 +683,7 @@ func (s *ActionSuite) TestAddActionLifecycle(c *gc.C) {
 	// can add action to a dying unit
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit.AddAction(operationID, "snapshot", map[string]interface{}{})
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", map[string]interface{}{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// make sure unit is dead
@@ -691,7 +691,7 @@ func (s *ActionSuite) TestAddActionLifecycle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// cannot add action to a dead unit
-	_, err = unit.AddAction(operationID, "snapshot", map[string]interface{}{})
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", map[string]interface{}{})
 	c.Assert(err, gc.Equals, state.ErrDead)
 }
 
@@ -710,7 +710,7 @@ func (s *ActionSuite) TestAddActionFailsOnDeadUnitInTransaction(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit.AddAction(operationID, "snapshot", map[string]interface{}{})
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", map[string]interface{}{})
 	c.Assert(err, gc.Equals, state.ErrDead)
 }
 
@@ -722,7 +722,7 @@ func (s *ActionSuite) TestFail(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	a, err := unit.AddAction(operationID, "snapshot", nil)
+	a, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Model()
@@ -774,7 +774,7 @@ func (s *ActionSuite) TestComplete(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	a, err := unit.AddAction(operationID, "snapshot", nil)
+	a, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Model()
@@ -949,9 +949,9 @@ func (s *ActionSuite) TestActionsWatcherEmitsInitialChanges(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 	// queue up actions
-	a1, err := u.AddAction(operationID, "snapshot", nil)
+	a1, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	a2, err := u.AddAction(operationID, "snapshot", nil)
+	a2, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// start watcher but don't consume Changes() yet
@@ -984,9 +984,9 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	// queue some actions before starting the watcher
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	fa1, err := unit1.AddAction(operationID, "snapshot", nil)
+	fa1, err := s.Model.AddAction(unit1, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	fa2, err := unit1.AddAction(operationID, "snapshot", nil)
+	fa2, err := s.Model.AddAction(unit1, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
 
@@ -1008,7 +1008,7 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 
 	// add action on unit2 and makes sure unit1 watcher doesn't trigger
 	// and unit2 watcher does
-	fa3, err := unit2.AddAction(operationID, "snapshot", nil)
+	fa3, err := s.Model.AddAction(unit2, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 	expect2 := expectActionIds(fa3)
@@ -1016,9 +1016,9 @@ func (s *ActionSuite) TestUnitWatchActionNotifications(c *gc.C) {
 	wc2.AssertNoChange()
 
 	// add a couple actions on unit1 and make sure watcher sees events
-	fa4, err := unit1.AddAction(operationID, "snapshot", nil)
+	fa4, err := s.Model.AddAction(unit1, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	fa5, err := unit1.AddAction(operationID, "snapshot", nil)
+	fa5, err := s.Model.AddAction(unit1, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expect = expectActionIds(fa4, fa5)
@@ -1157,11 +1157,11 @@ func (s *ActionSuite) TestWatchActionNotifications(c *gc.C) {
 	// add 3 actions
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	fa1, err := u.AddAction(operationID, "snapshot", nil)
+	fa1, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	fa2, err := u.AddAction(operationID, "snapshot", nil)
+	fa2, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	fa3, err := u.AddAction(operationID, "snapshot", nil)
+	fa3, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Model()
@@ -1222,7 +1222,7 @@ func (s *ActionSuite) TestActionStatusWatcher(c *gc.C) {
 	for _, tcase := range testCase {
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		a, err := tcase.receiver.AddAction(operationID, tcase.name, nil)
+		a, err := s.Model.AddAction(tcase.receiver, operationID, tcase.name, nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		model, err := s.State.Model()
@@ -1270,7 +1270,7 @@ func (s *ActionSuite) TestWatchActionLogs(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 	// queue some actions before starting the watcher
-	fa1, err := unit1.AddAction(operationID, "snapshot", nil)
+	fa1, err := s.Model.AddAction(unit1, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	fa1, err = fa1.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1278,7 +1278,7 @@ func (s *ActionSuite) TestWatchActionLogs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure no cross contamination - add another action.
-	fa2, err := unit1.AddAction(operationID, "snapshot", nil)
+	fa2, err := s.Model.AddAction(unit1, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	fa2, err = fa2.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1412,7 +1412,7 @@ type mockAR struct {
 
 var _ state.ActionReceiver = (*mockAR)(nil)
 
-func (r mockAR) AddAction(operationID, name string, payload map[string]interface{}) (state.Action, error) {
+func (r mockAR) PrepareActionPayload(name string, payload map[string]interface{}) (map[string]interface{}, error) {
 	return nil, nil
 }
 func (r mockAR) CancelAction(state.Action) (state.Action, error)       { return nil, nil }

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -935,7 +935,7 @@ func (s *allWatcherStateSuite) TestChangeActions(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			operationID, err := m.EnqueueOperation("a test")
 			c.Assert(err, jc.ErrorIsNil)
-			action, err := m.EnqueueAction(operationID, u.Tag(), "vacuumdb", map[string]interface{}{})
+			action, err := m.EnqueueAction(operationID, u.Tag(), "vacuumdb", map[string]interface{}{}, nil)
 			c.Assert(err, jc.ErrorIsNil)
 			enqueued := makeActionInfo(action, st)
 			action, err = action.Begin()

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -1134,7 +1134,7 @@ func (st *State) cleanupRemovedUnit(unitId string, cleanupArgs []bson.Raw) error
 	}
 	for _, action := range actions {
 		switch action.Status() {
-		case ActionCompleted, ActionCancelled, ActionFailed, ActionAborted:
+		case ActionCompleted, ActionCancelled, ActionFailed, ActionAborted, ActionError:
 			// nothing to do here
 		default:
 			if _, err = action.Finish(cancelled); err != nil {

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -747,9 +747,9 @@ func (s *CleanupSuite) TestCleanupActions(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a couple actions to the unit
-	_, err = unit.AddAction(operationID, "snapshot", nil)
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit.AddAction(operationID, "snapshot", nil)
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// make sure unit still has actions
@@ -799,7 +799,7 @@ func (s *CleanupSuite) TestCleanupWithCompletedActions(c *gc.C) {
 		// Add a completed action to the unit.
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := unit.AddAction(operationID, "snapshot", nil)
+		action, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		action, err = action.Finish(state.ActionResults{
 			Status:  status,

--- a/state/interface.go
+++ b/state/interface.go
@@ -143,9 +143,8 @@ type ActionsWatcher interface {
 type ActionReceiver interface {
 	Entity
 
-	// AddAction queues an action belonging to the specified operation,
-	// with the given name and payload for this ActionReceiver.
-	AddAction(operationID, name string, payload map[string]interface{}) (Action, error)
+	// PrepareActionPayload returns the payload to use in creating an action for this receiver.
+	PrepareActionPayload(name string, payload map[string]interface{}) (map[string]interface{}, error)
 
 	// CancelAction removes a pending Action from the queue for this
 	// ActionReceiver and marks it as cancelled.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2567,12 +2567,17 @@ func (s *MachineSuite) TestMachineValidActions(c *gc.C) {
 	}
 }
 
-func (s *MachineSuite) TestMachineAddDifferentAction(c *gc.C) {
+func (s *MachineSuite) TestAddActionWithError(c *gc.C) {
 	m, err := s.State.AddMachine("trusty", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = m.AddAction("666", "benchmark", nil)
+	operationID, err := s.Model.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = m.AddAction(operationID, "benchmark", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add action "benchmark" to a machine; only predefined actions allowed`)
+	op, err := s.Model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Status(), gc.Equals, state.ActionError)
 }
 
 func (s *MachineSuite) setupTestUpdateMachineSeries(c *gc.C) *state.Machine {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2556,7 +2556,7 @@ func (s *MachineSuite) TestMachineValidActions(c *gc.C) {
 		c.Logf("running test %d", i)
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := m.AddAction(operationID, t.actionName, t.givenPayload)
+		action, err := s.Model.AddAction(m, operationID, t.actionName, t.givenPayload)
 		if t.errString != "" {
 			c.Assert(err.Error(), gc.Equals, t.errString)
 			continue
@@ -2573,7 +2573,7 @@ func (s *MachineSuite) TestAddActionWithError(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.AddAction(operationID, "benchmark", nil)
+	_, err = s.Model.AddAction(m, operationID, "benchmark", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add action "benchmark" to a machine; only predefined actions allowed`)
 	op, err := s.Model.Operation(operationID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1652,6 +1652,7 @@ func (e *exporter) operations() error {
 	for _, op := range operations {
 		arg := description.OperationArgs{
 			Summary:           op.Summary(),
+			Fail:              op.Fail(),
 			Enqueued:          op.Enqueued(),
 			Started:           op.Started(),
 			Completed:         op.Completed(),

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1954,6 +1954,7 @@ func (i *importer) addOperation(op description.Operation) error {
 		DocId:             i.st.docID(op.Id()),
 		ModelUUID:         modelUUID,
 		Summary:           op.Summary(),
+		Fail:              op.Fail(),
 		Enqueued:          op.Enqueued(),
 		Started:           op.Started(),
 		Completed:         op.Completed(),

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1786,7 +1786,7 @@ func (s *MigrationImportSuite) TestAction(c *gc.C) {
 
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil)
+	_, err = m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newModel, newState := s.importModel(c, s.State)
@@ -1809,6 +1809,8 @@ func (s *MigrationImportSuite) TestOperation(c *gc.C) {
 
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
+	err = m.FailOperation(operationID, errors.New("fail"))
+	c.Assert(err, jc.ErrorIsNil)
 
 	newModel, newState := s.importModel(c, s.State)
 	defer func() {
@@ -1819,8 +1821,9 @@ func (s *MigrationImportSuite) TestOperation(c *gc.C) {
 	c.Assert(operations, gc.HasLen, 1)
 	op := operations[0]
 	c.Check(op.Summary(), gc.Equals, "a test")
+	c.Check(op.Fail(), gc.Equals, "fail")
 	c.Check(op.Id(), gc.Equals, operationID)
-	c.Check(op.Status(), gc.Equals, state.ActionPending)
+	c.Check(op.Status(), gc.Equals, state.ActionError)
 }
 
 func (s *MigrationImportSuite) TestVolumes(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -743,6 +743,23 @@ func (s *MigrationSuite) TestActionDocFields(c *gc.C) {
 	s.AssertExportedFields(c, actionDoc{}, migrated.Union(ignored))
 }
 
+func (s *MigrationSuite) TestOperationDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"CompleteTaskCount",
+	)
+	migrated := set.NewStrings(
+		"DocId",
+		"Summary",
+		"Enqueued",
+		"Started",
+		"Completed",
+		"Status",
+		"Fail",
+	)
+	s.AssertExportedFields(c, operationDoc{}, migrated.Union(ignored))
+}
+
 func (s *MigrationSuite) TestVolumeDocFields(c *gc.C) {
 	ignored := set.NewStrings(
 		"ModelUUID",

--- a/state/operation_test.go
+++ b/state/operation_test.go
@@ -41,6 +41,27 @@ func (s *OperationSuite) TestEnqueueOperation(c *gc.C) {
 	c.Assert(operation.Summary(), gc.Equals, "an operation")
 }
 
+func (s *OperationSuite) TestFailOperation(c *gc.C) {
+	clock := testclock.NewClock(coretesting.NonZeroTime().Round(time.Second))
+	err := s.State.SetClockForTesting(clock)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operationID, err := s.Model.EnqueueOperation("an operation")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.Model.FailOperation(operationID, errors.New("fail"))
+	c.Assert(err, jc.ErrorIsNil)
+	operation, err := s.Model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(operation.Id(), gc.Equals, operationID)
+	c.Assert(operation.Tag(), gc.Equals, names.NewOperationTag(operationID))
+	c.Assert(operation.Status(), gc.Equals, state.ActionError)
+	c.Assert(operation.Enqueued(), gc.Equals, clock.Now())
+	c.Assert(operation.Started(), gc.Equals, time.Time{})
+	c.Assert(operation.Completed(), gc.Equals, time.Time{})
+	c.Assert(operation.Fail(), gc.Equals, "fail")
+}
+
 func (s *OperationSuite) TestAllOperations(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("an operation")
 	c.Assert(err, jc.ErrorIsNil)
@@ -71,7 +92,7 @@ func (s *OperationSuite) TestOperationStatus(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("an operation")
 	c.Assert(err, jc.ErrorIsNil)
 	clock.Advance(5 * time.Second)
-	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil)
+	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,7 +115,7 @@ func (s *OperationSuite) TestRefresh(c *gc.C) {
 	operation, err := s.Model.Operation(operationID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil)
+	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -128,11 +149,11 @@ func (s *OperationSuite) setupOperations(c *gc.C) names.Tag {
 	c.Assert(err, jc.ErrorIsNil)
 
 	clock.Advance(5 * time.Second)
-	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil)
+	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
-	anAction2, err := s.Model.EnqueueAction(operationID2, unit.Tag(), "restore", nil)
+	anAction2, err := s.Model.EnqueueAction(operationID2, unit.Tag(), "restore", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	a, err := anAction2.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -149,7 +170,7 @@ func (s *OperationSuite) setupOperations(c *gc.C) names.Tag {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID3, err := s.Model.EnqueueOperation("yet another operation")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction3, err := s.Model.EnqueueAction(operationID3, unit2.Tag(), "backup", nil)
+	anAction3, err := s.Model.EnqueueAction(operationID3, unit2.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction3.Begin()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -614,7 +614,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 				c.Assert(err, jc.ErrorIsNil)
 				operationID, err := m.EnqueueOperation("a test")
 				c.Assert(err, jc.ErrorIsNil)
-				_, err = unit.AddAction(operationID, "snapshot", nil)
+				_, err = m.AddAction(unit, operationID, "snapshot", nil)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		}, {
@@ -3281,7 +3281,7 @@ func (s *StateSuite) TestFindEntity(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.Model.EnqueueOperation("something")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit.AddAction(operationID, "fakeaction", nil)
+	_, err = s.Model.AddAction(unit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "arble"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -3362,7 +3362,7 @@ func (s *StateSuite) TestParseActionTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	f, err := u.AddAction(operationID, "snapshot", nil)
+	f, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	action, err := s.Model.Action(f.Id())

--- a/state/unit.go
+++ b/state/unit.go
@@ -2801,28 +2801,12 @@ func (u *Unit) UnassignFromMachine() (err error) {
 // ActionSpecsByName is a map of action names to their respective ActionSpec.
 type ActionSpecsByName map[string]charm.ActionSpec
 
-// AddAction adds a new Action of type name and using arguments payload to
-// this Unit, and returns its ID.  Note that the use of spec.InsertDefaults
-// mutates payload.
-func (u *Unit) AddAction(operationID, name string, payload map[string]interface{}) (_ Action, err error) {
+// PrepareActionPayload returns the payload to use in creating an action for this unit.
+// Note that the use of spec.InsertDefaults mutates payload.
+func (u *Unit) PrepareActionPayload(name string, payload map[string]interface{}) (map[string]interface{}, error) {
 	if len(name) == 0 {
 		return nil, errors.New("no action name given")
 	}
-	m, err := u.st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	saveActionError := true
-	defer func() {
-		if !saveActionError || err == nil {
-			return
-		}
-		_, err2 := m.EnqueueAction(operationID, u.Tag(), name, payload, err)
-		if err2 != nil {
-			err = err2
-		}
-	}()
 
 	// If the action is predefined inside juju, get spec from map
 	spec, ok := actions.PredefinedActionsSpec[name]
@@ -2837,7 +2821,7 @@ func (u *Unit) AddAction(operationID, name string, payload map[string]interface{
 		}
 	}
 	// Reject bad payloads before attempting to insert defaults.
-	err = spec.ValidateParams(payload)
+	err := spec.ValidateParams(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -2860,8 +2844,7 @@ func (u *Unit) AddAction(operationID, name string, payload map[string]interface{
 			payloadWithDefaults["workload-context"] = false
 		}
 	}
-	saveActionError = false
-	return m.EnqueueAction(operationID, u.Tag(), name, payloadWithDefaults, nil)
+	return payloadWithDefaults, nil
 }
 
 // ActionSpecs gets the ActionSpec map for the Unit's charm.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2580,6 +2580,16 @@ snapshot:
 	}
 }
 
+func (s *UnitSuite) TestAddActionWithError(c *gc.C) {
+	operationID, err := s.Model.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.unit.AddAction(operationID, "benchmark", nil)
+	c.Assert(err, gc.ErrorMatches, `action "benchmark" not defined on unit "wordpress/0"`)
+	op, err := s.Model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Status(), gc.Equals, state.ActionError)
+}
+
 func (s *UnitSuite) TestUnitActionsFindsRightActions(c *gc.C) {
 	// An actions.yaml which permits actions by the following names
 	basicActions := `

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2569,7 +2569,7 @@ snapshot:
 		c.Logf("running test %d", i)
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := unit1.AddAction(operationID, t.actionName, t.givenPayload)
+		action, err := s.Model.AddAction(unit1, operationID, t.actionName, t.givenPayload)
 		if t.errString != "" {
 			c.Assert(err, gc.ErrorMatches, t.errString)
 		} else {
@@ -2583,7 +2583,7 @@ snapshot:
 func (s *UnitSuite) TestAddActionWithError(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.unit.AddAction(operationID, "benchmark", nil)
+	_, err = s.Model.AddAction(s.unit, operationID, "benchmark", nil)
 	c.Assert(err, gc.ErrorMatches, `action "benchmark" not defined on unit "wordpress/0"`)
 	op, err := s.Model.Operation(operationID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2612,16 +2612,16 @@ action-b-b:
 	// Add 3 actions to first unit, and 2 to the second unit
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit1.AddAction(operationID, "action-a-a", nil)
+	_, err = s.Model.AddAction(unit1, operationID, "action-a-a", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit1.AddAction(operationID, "action-a-b", nil)
+	_, err = s.Model.AddAction(unit1, operationID, "action-a-b", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit1.AddAction(operationID, "action-a-c", nil)
+	_, err = s.Model.AddAction(unit1, operationID, "action-a-c", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = unit2.AddAction(operationID, "action-b-a", nil)
+	_, err = s.Model.AddAction(unit2, operationID, "action-b-a", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit2.AddAction(operationID, "action-b-b", nil)
+	_, err = s.Model.AddAction(unit2, operationID, "action-b-b", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify that calling Actions on unit1 returns only
@@ -3163,7 +3163,7 @@ func (s *CAASUnitSuite) TestOperatorAddAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := unit.AddAction(operationID, "snapshot", nil)
+	action, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(action.Parameters(), jc.DeepEquals, map[string]interface{}{
 		"outfile": "abcd", "workload-context": false,

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -3445,19 +3445,6 @@ func (f *controllerIdFilter) match(key interface{}) bool {
 	return false
 }
 
-// WatchActionResults starts and returns a StringsWatcher that
-// notifies on new ActionResults being added.
-func (m *Model) WatchActionResults() StringsWatcher {
-	return m.WatchActionResultsFilteredBy()
-}
-
-// WatchActionResultsFilteredBy starts and returns a StringsWatcher
-// that notifies on new ActionResults being added for the ActionRecevers
-// being watched.
-func (m *Model) WatchActionResultsFilteredBy(receivers ...ActionReceiver) StringsWatcher {
-	return newActionStatusWatcher(m.st, receivers, []ActionStatus{ActionCompleted, ActionCancelled, ActionFailed}...)
-}
-
 // openedPortsWatcher notifies of changes in the openedPorts
 // collection
 type openedPortsWatcher struct {

--- a/state/watcher_test.go
+++ b/state/watcher_test.go
@@ -76,7 +76,7 @@ func (s *watcherSuite) TestLegacyActionNotificationWatcher(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := unit.AddAction(operationID, "snapshot", nil)
+	action, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(action.Id())
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -397,7 +397,7 @@ func (s *InterfaceSuite) TestLogActionMessage(c *gc.C) {
 	s.toSupportNewActionID(c)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.unit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.unit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = action.Begin()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -173,7 +173,7 @@ func (s *ContextFactorySuite) TestNewActionContextLeadershipContext(c *gc.C) {
 		s.SetCharm(c, "dummy")
 		operationID, err := s.Model(c).EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil)
+		action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		actionData := &context.ActionData{
@@ -558,7 +558,7 @@ func (s *ContextFactorySuite) TestActionContext(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	operationID, err := s.Model(c).EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil)
+	action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	actionData := &context.ActionData{

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -241,7 +241,7 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 		c.Logf("test %d", i)
 		operationID, err := s.model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), test.actionName, test.payload)
+		action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), test.actionName, test.payload, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 		c.Assert(err, jc.ErrorIsNil)
@@ -284,7 +284,7 @@ func (s *FactorySuite) TestNewActionRunnerBadName(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "no-such-action", nil)
+	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "no-such-action", nil, nil)
 	c.Assert(err, jc.ErrorIsNil) // this will fail when using AddAction on unit
 	rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 	c.Check(rnr, gc.IsNil)
@@ -298,7 +298,7 @@ func (s *FactorySuite) TestNewActionRunnerBadParams(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "snapshot", map[string]interface{}{
 		"outfile": 123,
-	})
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil) // this will fail when state is done right
 	rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 	c.Check(rnr, gc.IsNil)
@@ -310,7 +310,7 @@ func (s *FactorySuite) TestNewActionRunnerMissingAction(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil)
+	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.unit.CancelAction(action)
 	c.Assert(err, jc.ErrorIsNil)
@@ -326,7 +326,7 @@ func (s *FactorySuite) TestNewActionRunnerUnauthAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, otherUnit.Tag(), "snapshot", nil)
+	action, err := s.model.EnqueueAction(operationID, otherUnit.Tag(), "snapshot", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 	c.Check(rnr, gc.IsNil)
@@ -343,7 +343,7 @@ func (s *FactorySuite) TestNewActionRunnerWithCancel(c *gc.C) {
 	cancel := make(chan struct{})
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), actionName, payload)
+	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), actionName, payload, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	rnr, err := s.factory.NewActionRunner(action.Id(), cancel)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -946,7 +946,7 @@ func (s addAction) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.EnqueueAction(operationID, ctx.unit.Tag(), s.name, s.params)
+	_, err = m.EnqueueAction(operationID, ctx.unit.Tag(), s.name, s.params, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
If an action is run with bad parameters, the CLI prints the error but only the parent operation record was being stored.
The list-operations API queries actions matching the search criteria and collates the parent operation ids. So in the case ot an error validating action params, the failed operation would be in the DB but never show up.

The change here is two fold:
1. always record an action record even if there's an error
 (if there's an error, do not create the corresponding action notification entry)
2. mark the parent operation as being in error state

The allows the list-operations and show-task commands to work as expected for actions with errors. The time the action was enqueued is recorded but the action and operation are in error state with the action having the error message.

## QA steps

juju bootstrap
deploy a charm with an action taking an int parameter, eg
```
test:
  description: test
  params:
    count:
      type: integer
      description: test
```

Run the action with invalid parameters
```
juju run ubuntu-lite/0 test count=aa
Running operation 1 with 1 task
ERROR validation failed: (root).count : must be of type integer, given "aa"
```

List the operations
```
$ juju operations
Id  Status  Started  Finished  Task IDs  Summary
 1  error                      2         test run on unit-ubuntu-lite-0

$ juju show-task 2 --format yaml
id: "2"
message: 'validation failed: (root).count : must be of type integer, given "aa"'
status: error
timing:
  enqueued: 2021-04-29 11:32:03 +1000 AEST
unit: ubuntu-lite/0

$ juju show-operation 1
summary: test run on unit-ubuntu-lite-0
status: error
fail: 'validation failed: (root).count : must be of type integer, given "aa"'
action:
  name: test
  parameters:
    count: aa
timing:
  enqueued: 2021-04-29 11:32:03 +1000 AEST
tasks:
  "2":
    host: ubuntu-lite/0
    status: error
    timing:
      enqueued: 2021-04-29 11:32:03 +1000 AEST
    message: 'validation failed: (root).count : must be of type integer, given "aa"'
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1926496
