### PR TITLE
Merge 2.8 

### DIFF
--- a/api/action/client_test.go
+++ b/api/action/client_test.go
@@ -231,7 +231,8 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 					Results: []params.OperationResult{{
 						OperationTag: "operation-1",
 						Summary:      "hello",
-						Status:       "running",
+						Fail:         "fail",
+						Status:       "error",
 						Actions: []params.ActionResult{{
 							Action: &params.Action{Tag: "action-666", Name: "test", Receiver: "unit-mysql-0"},
 						}},
@@ -258,7 +259,8 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 		Operations: []action.Operation{{
 			ID:      "1",
 			Summary: "hello",
-			Status:  "running",
+			Status:  "error",
+			Fail:    "fail",
 			Actions: []action.ActionResult{{
 				Action: &action.Action{ID: "666", Name: "test", Receiver: "unit-mysql-0"},
 			}},
@@ -300,6 +302,7 @@ func (s *actionSuite) TestOperation(c *gc.C) {
 					Results: []params.OperationResult{{
 						OperationTag: "operation-1",
 						Summary:      "hello",
+						Fail:         "fail",
 						Actions: []params.ActionResult{{
 							Action: &params.Action{Tag: "action-666", Name: "test", Receiver: "unit-mysql-0"},
 						}},
@@ -316,6 +319,7 @@ func (s *actionSuite) TestOperation(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, action.Operation{
 		ID:      "1",
 		Summary: "hello",
+		Fail:    "fail",
 		Actions: []action.ActionResult{{
 			Action: &action.Action{ID: "666", Name: "test", Receiver: "unit-mysql-0"},
 		}},

--- a/api/action/types.go
+++ b/api/action/types.go
@@ -23,6 +23,7 @@ type Operations struct {
 type Operation struct {
 	ID        string
 	Summary   string
+	Fail      string
 	Enqueued  time.Time
 	Started   time.Time
 	Completed time.Time
@@ -224,6 +225,7 @@ func unmarshallOperations(in params.OperationResults) Operations {
 func unmarshallOperation(in params.OperationResult) Operation {
 	result := Operation{
 		Summary:   in.Summary,
+		Fail:      in.Fail,
 		Enqueued:  in.Enqueued,
 		Started:   in.Started,
 		Completed: in.Completed,

--- a/apiserver/common/action.go
+++ b/apiserver/common/action.go
@@ -35,6 +35,8 @@ func ParamsActionExecutionResultsToStateActionResults(arg params.ActionExecution
 		status = state.ActionAborting
 	case params.ActionAborted:
 		status = state.ActionAborted
+	case params.ActionError:
+		status = state.ActionError
 	default:
 		return state.ActionResults{}, errors.Errorf("unrecognized action status '%s'", arg.Status)
 	}
@@ -45,17 +47,17 @@ func ParamsActionExecutionResultsToStateActionResults(arg params.ActionExecution
 	}, nil
 }
 
-// TagToActionReceiver takes a tag string and tries to convert it to an
+// TagToActionReceiverFn takes a tag string and tries to convert it to an
 // ActionReceiver. It needs a findEntity function passed in that can search for the tags in state.
 func TagToActionReceiverFn(findEntity func(names.Tag) (state.Entity, error)) func(tag string) (state.ActionReceiver, error) {
 	return func(tag string) (state.ActionReceiver, error) {
 		receiverTag, err := names.ParseTag(tag)
 		if err != nil {
-			return nil, errors.NotValidf("%s", tag)
+			return nil, errors.NotValidf("%q", tag)
 		}
 		entity, err := findEntity(receiverTag)
 		if err != nil {
-			return nil, errors.NotFoundf("%s", receiverTag)
+			return nil, errors.NotFoundf("%q", receiverTag)
 		}
 		receiver, ok := entity.(state.ActionReceiver)
 		if !ok {

--- a/apiserver/common/action_test.go
+++ b/apiserver/common/action_test.go
@@ -46,10 +46,10 @@ func (s *actionsSuite) TestTagToActionReceiverFn(c *gc.C) {
 		err: errors.NotImplementedf("action receiver interface on entity unit-invalid-0"),
 	}, {
 		tag: "unit-flustered-0",
-		err: errors.NotFoundf("unit-flustered-0"),
+		err: errors.NotFoundf(`"unit-flustered-0"`),
 	}, {
 		tag: "notatag",
-		err: errors.NotValidf("notatag"),
+		err: errors.NotValidf(`"notatag"`),
 	}} {
 		c.Logf("test %d", i)
 		receiver, err := tagFn(test.tag)
@@ -227,7 +227,7 @@ func (s *actionsSuite) TestWatchOneActionReceiverNotifications(c *gc.C) {
 		watcherId string
 	}{{
 		tag: names.NewMachineTag("0"),
-		err: "machine-0 not found",
+		err: `"machine-0" not found`,
 	}, {
 		tag:       names.NewMachineTag("1"),
 		watcherId: "bambalam",
@@ -264,7 +264,7 @@ func (s *actionsSuite) TestWatchPendingActionsForReceiver(c *gc.C) {
 		watcherId string
 	}{{
 		tag: names.NewMachineTag("0"),
-		err: "machine-0 not found",
+		err: `"machine-0" not found`,
 	}, {
 		tag:       names.NewMachineTag("1"),
 		watcherId: "bambalam",

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1160,13 +1160,13 @@ func (s *uniterSuite) TestWatchTrustConfigSettingsHash(c *gc.C) {
 func (s *uniterSuite) TestLogActionMessage(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	anAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(anAction.Messages(), gc.HasLen, 0)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
 
-	wrongAction, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	wrongAction, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.ActionMessageParams{Messages: []params.EntityString{
@@ -1194,7 +1194,7 @@ func (s *uniterSuite) TestLogActionMessage(c *gc.C) {
 func (s *uniterSuite) TestLogActionMessageAborting(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	anAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(anAction.Messages(), gc.HasLen, 0)
 	_, err = anAction.Begin()
@@ -1254,7 +1254,7 @@ func (s *uniterSuite) TestWatchActionNotifications(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	addedAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	addedAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(addedAction.Id())
@@ -1277,9 +1277,9 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action1, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	action1, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	action2, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	action2, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -1302,7 +1302,7 @@ func (s *uniterSuite) TestWatchPreexistingActions(c *gc.C) {
 	wc := statetesting.NewStringsWatcherC(c, s.State, resource.(state.StringsWatcher))
 	wc.AssertNoChange()
 
-	addedAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	addedAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(addedAction.Id())
 	wc.AssertNoChange()
@@ -1337,7 +1337,7 @@ func (s *uniterSuite) TestWatchActionNotificationsMalformedUnitName(c *gc.C) {
 func (s *uniterSuite) TestWatchActionNotificationsNotUnit(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: action.Tag().String()},
@@ -1710,7 +1710,7 @@ func (s *uniterSuite) TestActions(c *gc.C) {
 
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		a, err := s.wordpressUnit.AddAction(
+		a, err := s.Model.AddAction(s.wordpressUnit,
 			operationID,
 			actionTest.action.Action.Name,
 			actionTest.action.Action.Parameters)
@@ -1760,7 +1760,7 @@ func (s *uniterSuite) TestActionsWrongUnit(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{
@@ -1776,7 +1776,7 @@ func (s *uniterSuite) TestActionsWrongUnit(c *gc.C) {
 func (s *uniterSuite) TestActionsPermissionDenied(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{
 		Entities: []params.Entity{{
@@ -1799,7 +1799,7 @@ func (s *uniterSuite) TestFinishActionsSuccess(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.wordpressUnit.AddAction(operationID, testName, nil)
+	action, err := s.Model.AddAction(s.wordpressUnit, operationID, testName, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	actionResults := params.ActionExecutionResults{
@@ -1833,7 +1833,7 @@ func (s *uniterSuite) TestFinishActionsFailure(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.wordpressUnit.AddAction(operationID, testName, nil)
+	action, err := s.Model.AddAction(s.wordpressUnit, operationID, testName, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	actionResults := params.ActionExecutionResults{
@@ -1861,10 +1861,10 @@ func (s *uniterSuite) TestFinishActionsFailure(c *gc.C) {
 func (s *uniterSuite) TestFinishActionsAuthAccess(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	good, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	good, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	bad, err := s.mysqlUnit.AddAction(operationID, "fakeaction", nil)
+	bad, err := s.Model.AddAction(s.mysqlUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var tests = []struct {
@@ -1905,7 +1905,7 @@ func (s *uniterSuite) TestBeginActions(c *gc.C) {
 	ten_seconds_ago := time.Now().Add(-10 * time.Second)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	good, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	good, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	running, err := s.wordpressUnit.RunningActions()
@@ -5725,7 +5725,7 @@ func (s *uniterV14Suite) TestWatchActionNotificationsLegacy(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	addedAction, err := s.wordpressUnit.AddAction(operationID, "fakeaction", nil)
+	addedAction, err := s.Model.AddAction(s.wordpressUnit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(addedAction.Id())
 

--- a/apiserver/facades/client/action/legacy_test.go
+++ b/apiserver/facades/client/action/legacy_test.go
@@ -43,7 +43,7 @@ func (s *actionSuite) TestListAll(c *gc.C) {
 			// add each action from the test case.
 			for j, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				// make expectation
@@ -129,7 +129,7 @@ func (s *actionSuite) TestListPending(c *gc.C) {
 			// add each action from the test case.
 			for _, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				if act.Execute {
@@ -194,7 +194,7 @@ func (s *actionSuite) TestListRunning(c *gc.C) {
 			// add each action from the test case.
 			for _, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				if act.Execute {
@@ -255,7 +255,7 @@ func (s *actionSuite) TestListCompleted(c *gc.C) {
 			// add each action from the test case.
 			for _, act := range group.Actions {
 				// add action.
-				added, err := unit.AddAction(operationID, act.Name, act.Parameters)
+				added, err := s.Model.AddAction(unit, operationID, act.Name, act.Parameters)
 				c.Assert(err, jc.ErrorIsNil)
 
 				if act.Execute {

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -83,30 +83,45 @@ func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, e
 
 	tagToActionReceiver := common.TagToActionReceiverFn(a.state.FindEntity)
 	response := params.ActionResults{Results: make([]params.ActionResult, len(arg.Actions))}
+	errorRecorded := false
 	for i, action := range arg.Actions {
 		currentResult := &response.Results[i]
 		actionReceiver := action.Receiver
+		var (
+			actionErr    error
+			enqueued     state.Action
+			receiver     state.ActionReceiver
+			receiverName string
+		)
 		if strings.HasSuffix(actionReceiver, "leader") {
 			app := strings.Split(actionReceiver, "/")[0]
-			receiverName, err := getLeader(app)
-			if err != nil {
-				currentResult.Error = apiservererrors.ServerError(err)
-				continue
+			receiverName, actionErr = getLeader(app)
+			if actionErr != nil {
+				currentResult.Error = apiservererrors.ServerError(actionErr)
+				goto failOperation
 			}
 			actionReceiver = names.NewUnitTag(receiverName).String()
 		}
-		receiver, err := tagToActionReceiver(actionReceiver)
-		if err != nil {
-			currentResult.Error = apiservererrors.ServerError(err)
-			continue
+		receiver, actionErr = tagToActionReceiver(actionReceiver)
+		if actionErr != nil {
+			currentResult.Error = apiservererrors.ServerError(actionErr)
+			goto failOperation
 		}
-		enqueued, err := receiver.AddAction(operationID, action.Name, action.Parameters)
-		if err != nil {
-			currentResult.Error = apiservererrors.ServerError(err)
-			continue
+		enqueued, actionErr = a.model.AddAction(receiver, operationID, action.Name, action.Parameters)
+		if actionErr != nil {
+			currentResult.Error = apiservererrors.ServerError(actionErr)
+			goto failOperation
 		}
-
 		response.Results[i] = common.MakeActionResult(receiver.Tag(), enqueued, false)
+		continue
+
+	failOperation:
+		// If we failed to enqueue the action, record the error on the operation.
+		if !errorRecorded {
+			errorRecorded = true
+			err = a.model.FailOperation(operationID, actionErr)
+		}
+		currentResult.Error = apiservererrors.ServerError(actionErr)
 	}
 	return operationID, response, nil
 }
@@ -175,6 +190,7 @@ func (a *ActionAPI) ListOperations(arg params.OperationQueryArgs) (params.Operat
 		result.Results[i] = params.OperationResult{
 			OperationTag: r.Operation.Tag().String(),
 			Summary:      r.Operation.Summary(),
+			Fail:         r.Operation.Fail(),
 			Enqueued:     r.Operation.Enqueued(),
 			Started:      r.Operation.Started(),
 			Completed:    r.Operation.Completed(),
@@ -217,6 +233,7 @@ func (a *ActionAPI) Operations(arg params.Entities) (params.OperationResults, er
 		results.Results[i] = params.OperationResult{
 			OperationTag: op.Operation.Tag().String(),
 			Summary:      op.Operation.Summary(),
+			Fail:         op.Operation.Fail(),
 			Enqueued:     op.Operation.Enqueued(),
 			Started:      op.Operation.Started(),
 			Completed:    op.Operation.Completed(),

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -6,6 +6,7 @@ package action_test
 import (
 	"strconv"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
@@ -50,6 +51,30 @@ func (s *operationSuite) setupOperations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = a.Finish(state.ActionResults{Status: state.ActionCompleted})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *operationSuite) TestFailedOperations(c *gc.C) {
+	s.toSupportNewActionID(c)
+
+	arg := params.Actions{
+		Actions: []params.Action{
+			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
+		}}
+
+	r, err := s.action.Enqueue(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Results, gc.HasLen, len(arg.Actions))
+
+	// There's only one operation created.
+	ops, err := s.Model.AllOperations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ops, gc.HasLen, 1)
+	err = s.Model.FailOperation(ops[0].Id(), errors.New("fail"))
+	c.Assert(err, jc.ErrorIsNil)
+	op, err := s.Model.Operation(ops[0].Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Status(), gc.Equals, state.ActionError)
+	c.Assert(op.Fail(), gc.Equals, "fail")
 }
 
 func (s *operationSuite) TestListOperationsStatusFilter(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -610,6 +610,9 @@
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
+                        "fail": {
+                            "type": "string"
+                        },
                         "operation": {
                             "type": "string"
                         },

--- a/apiserver/params/actions.go
+++ b/apiserver/params/actions.go
@@ -33,6 +33,10 @@ const (
 	// ActionAborted is the status of an Action that was aborted.
 	// Identical to ActionFailed and can have an error.
 	ActionAborted string = "aborted"
+
+	// ActionError is the status of an Action that did not get run
+	// due to an error.
+	ActionError string = "error"
 )
 
 // Actions is a slice of Action for bulk requests.
@@ -146,6 +150,7 @@ type OperationResults struct {
 type OperationResult struct {
 	OperationTag string         `json:"operation"`
 	Summary      string         `json:"summary"`
+	Fail         string         `json:"fail,omitempty"`
 	Enqueued     time.Time      `json:"enqueued,omitempty"`
 	Started      time.Time      `json:"started,omitempty"`
 	Completed    time.Time      `json:"completed,omitempty"`

--- a/caas/kubernetes/provider/resources/clusterrole_test.go
+++ b/caas/kubernetes/provider/resources/clusterrole_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&clusterRoleSuite{})
 func (s *clusterRoleSuite) TestApply(c *gc.C) {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "role1",
+			Name: "role1",
 		},
 	}
 	// Create.
@@ -37,7 +37,7 @@ func (s *clusterRoleSuite) TestApply(c *gc.C) {
 
 	// Update.
 	role.SetAnnotations(map[string]string{"a": "b"})
-	clusterRoleResource = resources.NewClusterRole("role1",role)
+	clusterRoleResource = resources.NewClusterRole("role1", role)
 	c.Assert(clusterRoleResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
 
 	result, err = s.client.RbacV1().ClusterRoles().Get(context.TODO(), "role1", metav1.GetOptions{})
@@ -49,7 +49,7 @@ func (s *clusterRoleSuite) TestApply(c *gc.C) {
 func (s *clusterRoleSuite) TestGet(c *gc.C) {
 	template := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "role1",
+			Name: "role1",
 		},
 	}
 	role1 := template
@@ -68,7 +68,7 @@ func (s *clusterRoleSuite) TestGet(c *gc.C) {
 func (s *clusterRoleSuite) TestDelete(c *gc.C) {
 	role := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "role1",
+			Name: "role1",
 		},
 	}
 	_, err := s.client.RbacV1().ClusterRoles().Create(context.TODO(), &role, metav1.CreateOptions{})
@@ -78,7 +78,7 @@ func (s *clusterRoleSuite) TestDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `role1`)
 
-	roleResource := resources.NewClusterRole("role1",&role)
+	roleResource := resources.NewClusterRole("role1", &role)
 	err = roleResource.Delete(context.TODO(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/caas/kubernetes/provider/resources/clusterrolebinding_test.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding_test.go
@@ -25,11 +25,11 @@ var _ = gc.Suite(&clusterRoleBindingSuite{})
 func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 	roleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "roleBinding1",
+			Name: "roleBinding1",
 		},
 	}
 	// Create.
-	rbResource := resources.NewClusterRoleBinding("roleBinding1",  roleBinding)
+	rbResource := resources.NewClusterRoleBinding("roleBinding1", roleBinding)
 	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
 	result, err := s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -37,7 +37,7 @@ func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 
 	// Update.
 	roleBinding.SetAnnotations(map[string]string{"a": "b"})
-	rbResource = resources.NewClusterRoleBinding("roleBinding1",  roleBinding)
+	rbResource = resources.NewClusterRoleBinding("roleBinding1", roleBinding)
 	c.Assert(rbResource.Apply(context.TODO(), s.client), jc.ErrorIsNil)
 
 	result, err = s.client.RbacV1().ClusterRoleBindings().Get(context.TODO(), "roleBinding1", metav1.GetOptions{})
@@ -49,7 +49,7 @@ func (s *clusterRoleBindingSuite) TestApply(c *gc.C) {
 func (s *clusterRoleBindingSuite) TestGet(c *gc.C) {
 	template := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "roleBinding1",
+			Name: "roleBinding1",
 		},
 	}
 	roleBinding1 := template
@@ -57,7 +57,7 @@ func (s *clusterRoleBindingSuite) TestGet(c *gc.C) {
 	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding1, metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	rbResource := resources.NewClusterRoleBinding("roleBinding1",  &template)
+	rbResource := resources.NewClusterRoleBinding("roleBinding1", &template)
 	c.Assert(len(rbResource.GetAnnotations()), gc.Equals, 0)
 	err = rbResource.Get(context.TODO(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
@@ -68,7 +68,7 @@ func (s *clusterRoleBindingSuite) TestGet(c *gc.C) {
 func (s *clusterRoleBindingSuite) TestDelete(c *gc.C) {
 	roleBinding := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "roleBinding1",
+			Name: "roleBinding1",
 		},
 	}
 	_, err := s.client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
@@ -78,7 +78,7 @@ func (s *clusterRoleBindingSuite) TestDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.GetName(), gc.Equals, `roleBinding1`)
 
-	rbResource := resources.NewClusterRoleBinding("roleBinding1",  &roleBinding)
+	rbResource := resources.NewClusterRoleBinding("roleBinding1", &roleBinding)
 	err = rbResource.Delete(context.TODO(), s.client)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -128,7 +128,8 @@ func (c *listOperationsCommand) Init(args []string) error {
 			params.ActionFailed,
 			params.ActionCancelled,
 			params.ActionAborting,
-			params.ActionAborted:
+			params.ActionAborted,
+			params.ActionError:
 		default:
 			nameErrors = append(nameErrors,
 				fmt.Sprintf("%q is not a valid task status, want one of %v",
@@ -139,7 +140,8 @@ func (c *listOperationsCommand) Init(args []string) error {
 						params.ActionFailed,
 						params.ActionCancelled,
 						params.ActionAborting,
-						params.ActionAborted}))
+						params.ActionAborted,
+						params.ActionError}))
 		}
 	}
 	if len(nameErrors) > 0 {
@@ -297,6 +299,7 @@ func (s byId) Less(i, j int) bool {
 type operationInfo struct {
 	Summary string              `yaml:"summary" json:"summary"`
 	Status  string              `yaml:"status" json:"status"`
+	Fail    string              `yaml:"fail,omitempty" json:"fail,omitempty"`
 	Error   string              `yaml:"error,omitempty" json:"error,omitempty"`
 	Action  *actionSummary      `yaml:"action,omitempty" json:"action,omitempty"`
 	Timing  timingInfo          `yaml:"timing,omitempty" json:"timing,omitempty"`
@@ -329,6 +332,7 @@ type taskInfo struct {
 func formatOperationResult(operation actionapi.Operation, utc bool) operationInfo {
 	result := operationInfo{
 		Summary: operation.Summary,
+		Fail:    operation.Fail,
 		Status:  operation.Status,
 		Timing: timingInfo{
 			Enqueued:  formatTimestamp(operation.Enqueued, false, utc, false),

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -34,7 +34,7 @@ type sshContainerSuite struct {
 	testing.BaseSuite
 
 	modelUUID          string
-	modelName string
+	modelName          string
 	cloudCredentialAPI *mocks.MockCloudCredentialAPI
 	modelAPI           *mocks.MockModelAPI
 	applicationAPI     *mocks.MockApplicationAPI
@@ -306,7 +306,7 @@ func (s *sshContainerSuite) TestGetExecClient(c *gc.C) {
 		s.modelAPI.EXPECT().ModelInfo([]names.ModelTag{names.NewModelTag(s.modelUUID)}).
 			Return([]params.ModelInfoResult{
 				{Result: &params.ModelInfo{
-					Name: s.modelName,
+					Name:               s.modelName,
 					CloudCredentialTag: "cloudcred-microk8s_admin_microk8s"}},
 			}, nil),
 		s.cloudCredentialAPI.EXPECT().CredentialContents(cloudCredentailTag.Cloud().Id(), cloudCredentailTag.Name(), true).

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5338,11 +5338,11 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 				},
 			},
 			"bar": {
-				Charm: "bar",
+				Charm:       "bar",
 				CharmOrigin: "charmhub",
-				Scale:   1,
-				Address: "54.32.1.3",
-				Version: "registry.jujucharms.com/fredbloggsthethrid/bar/image:0.5",
+				Scale:       1,
+				Address:     "54.32.1.3",
+				Version:     "registry.jujucharms.com/fredbloggsthethrid/bar/image:0.5",
 				Units: map[string]unitStatus{
 					"bar/0": {
 						JujuStatusInfo: statusInfoContents{

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v3 v3.0.0-20210322020148-5f792d83b709
+	github.com/juju/description/v3 v3.0.0-20210429063345-9e7a833a1aae
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d

--- a/go.sum
+++ b/go.sum
@@ -380,8 +380,8 @@ github.com/juju/collections v0.0.0-20180516022642-90152009b5f3/go.mod h1:Ep+c0vn
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v3 v3.0.0-20210322020148-5f792d83b709 h1:5Zu7YFKk/qtFiLD7/dfthr2KENwUWA8eK/82jNothTU=
-github.com/juju/description/v3 v3.0.0-20210322020148-5f792d83b709/go.mod h1:l94w+OBJ7b3BAfIInxoX6FHxzERxBtLh9FNABsGNO2U=
+github.com/juju/description/v3 v3.0.0-20210429063345-9e7a833a1aae h1:u8nHVB+v90aRgs+Sxi63lFOQ0NNMsS2jKnQVFSY9ffA=
+github.com/juju/description/v3 v3.0.0-20210429063345-9e7a833a1aae/go.mod h1:l94w+OBJ7b3BAfIInxoX6FHxzERxBtLh9FNABsGNO2U=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -930,7 +930,7 @@ func (s *allWatcherStateSuite) TestChangeActions(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			operationID, err := m.EnqueueOperation("a test")
 			c.Assert(err, jc.ErrorIsNil)
-			action, err := m.EnqueueAction(operationID, u.Tag(), "vacuumdb", map[string]interface{}{})
+			action, err := m.EnqueueAction(operationID, u.Tag(), "vacuumdb", map[string]interface{}{}, nil)
 			c.Assert(err, jc.ErrorIsNil)
 			enqueued := makeActionInfo(action, st)
 			action, err = action.Begin()

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -1135,7 +1135,7 @@ func (st *State) cleanupRemovedUnit(unitId string, cleanupArgs []bson.Raw) error
 	}
 	for _, action := range actions {
 		switch action.Status() {
-		case ActionCompleted, ActionCancelled, ActionFailed, ActionAborted:
+		case ActionCompleted, ActionCancelled, ActionFailed, ActionAborted, ActionError:
 			// nothing to do here
 		default:
 			if _, err = action.Finish(cancelled); err != nil {

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -749,9 +749,9 @@ func (s *CleanupSuite) TestCleanupActions(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a couple actions to the unit
-	_, err = unit.AddAction(operationID, "snapshot", nil)
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit.AddAction(operationID, "snapshot", nil)
+	_, err = s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// make sure unit still has actions
@@ -801,7 +801,7 @@ func (s *CleanupSuite) TestCleanupWithCompletedActions(c *gc.C) {
 		// Add a completed action to the unit.
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := unit.AddAction(operationID, "snapshot", nil)
+		action, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 		c.Assert(err, jc.ErrorIsNil)
 		action, err = action.Finish(state.ActionResults{
 			Status:  status,

--- a/state/interface.go
+++ b/state/interface.go
@@ -143,9 +143,8 @@ type ActionsWatcher interface {
 type ActionReceiver interface {
 	Entity
 
-	// AddAction queues an action belonging to the specified operation,
-	// with the given name and payload for this ActionReceiver.
-	AddAction(operationID, name string, payload map[string]interface{}) (Action, error)
+	// PrepareActionPayload returns the payload to use in creating an action for this receiver.
+	PrepareActionPayload(name string, payload map[string]interface{}) (map[string]interface{}, error)
 
 	// CancelAction removes a pending Action from the queue for this
 	// ActionReceiver and marks it as cancelled.

--- a/state/machine.go
+++ b/state/machine.go
@@ -2081,8 +2081,13 @@ func (m *Machine) VolumeAttachments() ([]VolumeAttachment, error) {
 	return sb.MachineVolumeAttachments(m.MachineTag())
 }
 
-// AddAction is part of the ActionReceiver interface.
-func (m *Machine) AddAction(operationID, name string, payload map[string]interface{}) (Action, error) {
+// PrepareActionPayload returns the payload to use in creating an action for this machine.
+// Note that the use of spec.InsertDefaults mutates payload.
+func (m *Machine) PrepareActionPayload(name string, payload map[string]interface{}) (map[string]interface{}, error) {
+	if len(name) == 0 {
+		return nil, errors.New("no action name given")
+	}
+
 	spec, ok := actions.PredefinedActionsSpec[name]
 	if !ok {
 		return nil, errors.Errorf("cannot add action %q to a machine; only predefined actions allowed", name)
@@ -2097,13 +2102,7 @@ func (m *Machine) AddAction(operationID, name string, payload map[string]interfa
 	if err != nil {
 		return nil, err
 	}
-
-	model, err := m.st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return model.EnqueueAction(operationID, m.Tag(), name, payloadWithDefaults)
+	return payloadWithDefaults, nil
 }
 
 // CancelAction is part of the ActionReceiver interface.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -2567,7 +2567,7 @@ func (s *MachineSuite) TestMachineValidActions(c *gc.C) {
 		c.Logf("running test %d", i)
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := m.AddAction(operationID, t.actionName, t.givenPayload)
+		action, err := s.Model.AddAction(m, operationID, t.actionName, t.givenPayload)
 		if t.errString != "" {
 			c.Assert(err.Error(), gc.Equals, t.errString)
 			continue
@@ -2578,12 +2578,17 @@ func (s *MachineSuite) TestMachineValidActions(c *gc.C) {
 	}
 }
 
-func (s *MachineSuite) TestMachineAddDifferentAction(c *gc.C) {
+func (s *MachineSuite) TestAddActionWithError(c *gc.C) {
 	m, err := s.State.AddMachine("trusty", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = m.AddAction("666", "benchmark", nil)
+	operationID, err := s.Model.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.Model.AddAction(m, operationID, "benchmark", nil)
 	c.Assert(err, gc.ErrorMatches, `cannot add action "benchmark" to a machine; only predefined actions allowed`)
+	op, err := s.Model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Status(), gc.Equals, state.ActionError)
 }
 
 func (s *MachineSuite) setupTestUpdateMachineSeries(c *gc.C) *state.Machine {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1693,6 +1693,7 @@ func (e *exporter) operations() error {
 	for _, op := range operations {
 		arg := description.OperationArgs{
 			Summary:           op.Summary(),
+			Fail:              op.Fail(),
 			Enqueued:          op.Enqueued(),
 			Started:           op.Started(),
 			Completed:         op.Completed(),

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1624,7 +1624,7 @@ func (s *MigrationExportSuite) TestActions(c *gc.C) {
 
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	a, err := m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil)
+	a, err := m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	a, err = a.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1657,7 +1657,7 @@ func (s *MigrationExportSuite) TestActionsSkipped(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil)
+	_, err = m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	model, err := s.State.ExportPartial(state.ExportConfig{
 		SkipActions: true,
@@ -1671,18 +1671,12 @@ func (s *MigrationExportSuite) TestActionsSkipped(c *gc.C) {
 }
 
 func (s *MigrationExportSuite) TestOperations(c *gc.C) {
-	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
-		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
-	})
-
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	a, err := m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	a, err = a.Begin()
+	err = m.FailOperation(operationID, errors.New("fail"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
@@ -1691,7 +1685,8 @@ func (s *MigrationExportSuite) TestOperations(c *gc.C) {
 	c.Assert(operations, gc.HasLen, 1)
 	op := operations[0]
 	c.Check(op.Summary(), gc.Equals, "a test")
-	c.Check(op.Status(), gc.Equals, "running")
+	c.Check(op.Fail(), gc.Equals, "fail")
+	c.Check(op.Status(), gc.Equals, "error")
 }
 
 type goodToken struct{}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2205,6 +2205,7 @@ func (i *importer) addOperation(op description.Operation) error {
 		DocId:             i.st.docID(op.Id()),
 		ModelUUID:         modelUUID,
 		Summary:           op.Summary(),
+		Fail:              op.Fail(),
 		Enqueued:          op.Enqueued(),
 		Started:           op.Started(),
 		Completed:         op.Completed(),

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1910,7 +1910,7 @@ func (s *MigrationImportSuite) TestAction(c *gc.C) {
 
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil)
+	_, err = m.EnqueueAction(operationID, machine.MachineTag(), "foo", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	newModel, newState := s.importModel(c, s.State)
@@ -1933,6 +1933,8 @@ func (s *MigrationImportSuite) TestOperation(c *gc.C) {
 
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
+	err = m.FailOperation(operationID, errors.New("fail"))
+	c.Assert(err, jc.ErrorIsNil)
 
 	newModel, newState := s.importModel(c, s.State)
 	defer func() {
@@ -1943,8 +1945,9 @@ func (s *MigrationImportSuite) TestOperation(c *gc.C) {
 	c.Assert(operations, gc.HasLen, 1)
 	op := operations[0]
 	c.Check(op.Summary(), gc.Equals, "a test")
+	c.Check(op.Fail(), gc.Equals, "fail")
 	c.Check(op.Id(), gc.Equals, operationID)
-	c.Check(op.Status(), gc.Equals, state.ActionPending)
+	c.Check(op.Status(), gc.Equals, state.ActionError)
 }
 
 func (s *MigrationImportSuite) TestVolumes(c *gc.C) {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -746,6 +746,23 @@ func (s *MigrationSuite) TestActionDocFields(c *gc.C) {
 	s.AssertExportedFields(c, actionDoc{}, migrated.Union(ignored))
 }
 
+func (s *MigrationSuite) TestOperationDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"ModelUUID",
+		"CompleteTaskCount",
+	)
+	migrated := set.NewStrings(
+		"DocId",
+		"Summary",
+		"Enqueued",
+		"Started",
+		"Completed",
+		"Status",
+		"Fail",
+	)
+	s.AssertExportedFields(c, operationDoc{}, migrated.Union(ignored))
+}
+
 func (s *MigrationSuite) TestVolumeDocFields(c *gc.C) {
 	ignored := set.NewStrings(
 		"ModelUUID",

--- a/state/operation_test.go
+++ b/state/operation_test.go
@@ -42,6 +42,27 @@ func (s *OperationSuite) TestEnqueueOperation(c *gc.C) {
 	c.Assert(operation.Summary(), gc.Equals, "an operation")
 }
 
+func (s *OperationSuite) TestFailOperation(c *gc.C) {
+	clock := testclock.NewClock(coretesting.NonZeroTime().Round(time.Second))
+	err := s.State.SetClockForTesting(clock)
+	c.Assert(err, jc.ErrorIsNil)
+
+	operationID, err := s.Model.EnqueueOperation("an operation")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.Model.FailOperation(operationID, errors.New("fail"))
+	c.Assert(err, jc.ErrorIsNil)
+	operation, err := s.Model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(operation.Id(), gc.Equals, operationID)
+	c.Assert(operation.Tag(), gc.Equals, names.NewOperationTag(operationID))
+	c.Assert(operation.Status(), gc.Equals, state.ActionError)
+	c.Assert(operation.Enqueued(), gc.Equals, clock.Now())
+	c.Assert(operation.Started(), gc.Equals, time.Time{})
+	c.Assert(operation.Completed(), gc.Equals, time.Time{})
+	c.Assert(operation.Fail(), gc.Equals, "fail")
+}
+
 func (s *OperationSuite) TestAllOperations(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("an operation")
 	c.Assert(err, jc.ErrorIsNil)
@@ -72,7 +93,7 @@ func (s *OperationSuite) TestOperationStatus(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("an operation")
 	c.Assert(err, jc.ErrorIsNil)
 	clock.Advance(5 * time.Second)
-	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil)
+	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -95,7 +116,7 @@ func (s *OperationSuite) TestRefresh(c *gc.C) {
 	operation, err := s.Model.Operation(operationID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil)
+	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -129,11 +150,11 @@ func (s *OperationSuite) setupOperations(c *gc.C) names.Tag {
 	c.Assert(err, jc.ErrorIsNil)
 
 	clock.Advance(5 * time.Second)
-	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil)
+	anAction, err := s.Model.EnqueueAction(operationID, unit.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction.Begin()
 	c.Assert(err, jc.ErrorIsNil)
-	anAction2, err := s.Model.EnqueueAction(operationID2, unit.Tag(), "restore", nil)
+	anAction2, err := s.Model.EnqueueAction(operationID2, unit.Tag(), "restore", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	a, err := anAction2.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -150,7 +171,7 @@ func (s *OperationSuite) setupOperations(c *gc.C) names.Tag {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID3, err := s.Model.EnqueueOperation("yet another operation")
 	c.Assert(err, jc.ErrorIsNil)
-	anAction3, err := s.Model.EnqueueAction(operationID3, unit2.Tag(), "backup", nil)
+	anAction3, err := s.Model.EnqueueAction(operationID3, unit2.Tag(), "backup", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = anAction3.Begin()
 	c.Assert(err, jc.ErrorIsNil)
@@ -241,7 +262,7 @@ func (s *OperationSuite) TestListOperationsSubset(c *gc.C) {
 	for i := 0; i < 20; i++ {
 		operationID, err := s.Model.EnqueueOperation(fmt.Sprintf("operation %d", i))
 		c.Assert(err, jc.ErrorIsNil)
-		anAction, err := s.Model.EnqueueAction(operationID, names.NewUnitTag("dummy/0"), "backup", nil)
+		anAction, err := s.Model.EnqueueAction(operationID, names.NewUnitTag("dummy/0"), "backup", nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		_, err = anAction.Begin()
 		c.Assert(err, jc.ErrorIsNil)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -618,7 +618,7 @@ func (s *MultiModelStateSuite) TestWatchTwoModels(c *gc.C) {
 				c.Assert(err, jc.ErrorIsNil)
 				operationID, err := m.EnqueueOperation("a test")
 				c.Assert(err, jc.ErrorIsNil)
-				_, err = unit.AddAction(operationID, "snapshot", nil)
+				_, err = m.AddAction(unit, operationID, "snapshot", nil)
 				c.Assert(err, jc.ErrorIsNil)
 			},
 		}, {
@@ -3304,7 +3304,7 @@ func (s *StateSuite) TestFindEntity(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.Model.EnqueueOperation("something")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit.AddAction(operationID, "fakeaction", nil)
+	_, err = s.Model.AddAction(unit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "arble"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -3385,7 +3385,7 @@ func (s *StateSuite) TestParseActionTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	f, err := u.AddAction(operationID, "snapshot", nil)
+	f, err := s.Model.AddAction(u, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	action, err := s.Model.Action(f.Id())

--- a/state/unit.go
+++ b/state/unit.go
@@ -2674,10 +2674,9 @@ func (u *Unit) UnassignFromMachine() (err error) {
 // ActionSpecsByName is a map of action names to their respective ActionSpec.
 type ActionSpecsByName map[string]charm.ActionSpec
 
-// AddAction adds a new Action of type name and using arguments payload to
-// this Unit, and returns its ID.  Note that the use of spec.InsertDefaults
-// mutates payload.
-func (u *Unit) AddAction(operationID, name string, payload map[string]interface{}) (Action, error) {
+// PrepareActionPayload returns the payload to use in creating an action for this unit.
+// Note that the use of spec.InsertDefaults mutates payload.
+func (u *Unit) PrepareActionPayload(name string, payload map[string]interface{}) (map[string]interface{}, error) {
 	if len(name) == 0 {
 		return nil, errors.New("no action name given")
 	}
@@ -2718,12 +2717,7 @@ func (u *Unit) AddAction(operationID, name string, payload map[string]interface{
 			payloadWithDefaults["workload-context"] = false
 		}
 	}
-
-	m, err := u.st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return m.EnqueueAction(operationID, u.Tag(), name, payloadWithDefaults)
+	return payloadWithDefaults, nil
 }
 
 // ActionSpecs gets the ActionSpec map for the Unit's charm.

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2520,7 +2520,7 @@ snapshot:
 		c.Logf("running test %d", i)
 		operationID, err := s.Model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := unit1.AddAction(operationID, t.actionName, t.givenPayload)
+		action, err := s.Model.AddAction(unit1, operationID, t.actionName, t.givenPayload)
 		if t.errString != "" {
 			c.Assert(err, gc.ErrorMatches, t.errString)
 		} else {
@@ -2529,6 +2529,16 @@ snapshot:
 			c.Assert(state.ActionOperationId(action), gc.Equals, operationID)
 		}
 	}
+}
+
+func (s *UnitSuite) TestAddActionWithError(c *gc.C) {
+	operationID, err := s.Model.EnqueueOperation("a test")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.Model.AddAction(s.unit, operationID, "benchmark", nil)
+	c.Assert(err, gc.ErrorMatches, `action "benchmark" not defined on unit "wordpress/0"`)
+	op, err := s.Model.Operation(operationID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Status(), gc.Equals, state.ActionError)
 }
 
 func (s *UnitSuite) TestUnitActionsFindsRightActions(c *gc.C) {
@@ -2553,16 +2563,16 @@ action-b-b:
 	// Add 3 actions to first unit, and 2 to the second unit
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit1.AddAction(operationID, "action-a-a", nil)
+	_, err = s.Model.AddAction(unit1, operationID, "action-a-a", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit1.AddAction(operationID, "action-a-b", nil)
+	_, err = s.Model.AddAction(unit1, operationID, "action-a-b", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit1.AddAction(operationID, "action-a-c", nil)
+	_, err = s.Model.AddAction(unit1, operationID, "action-a-c", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = unit2.AddAction(operationID, "action-b-a", nil)
+	_, err = s.Model.AddAction(unit2, operationID, "action-b-a", nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = unit2.AddAction(operationID, "action-b-b", nil)
+	_, err = s.Model.AddAction(unit2, operationID, "action-b-b", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify that calling Actions on unit1 returns only
@@ -3105,7 +3115,7 @@ func (s *CAASUnitSuite) TestOperatorAddAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := unit.AddAction(operationID, "snapshot", nil)
+	action, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(action.Parameters(), jc.DeepEquals, map[string]interface{}{
 		"outfile": "abcd", "workload-context": false,

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -3445,19 +3445,6 @@ func (f *controllerIdFilter) match(key interface{}) bool {
 	return false
 }
 
-// WatchActionResults starts and returns a StringsWatcher that
-// notifies on new ActionResults being added.
-func (m *Model) WatchActionResults() StringsWatcher {
-	return m.WatchActionResultsFilteredBy()
-}
-
-// WatchActionResultsFilteredBy starts and returns a StringsWatcher
-// that notifies on new ActionResults being added for the ActionRecevers
-// being watched.
-func (m *Model) WatchActionResultsFilteredBy(receivers ...ActionReceiver) StringsWatcher {
-	return newActionStatusWatcher(m.st, receivers, []ActionStatus{ActionCompleted, ActionCancelled, ActionFailed}...)
-}
-
 // openedPortsWatcher notifies of changes in the openedPorts
 // collection
 type openedPortsWatcher struct {

--- a/state/watcher_test.go
+++ b/state/watcher_test.go
@@ -76,7 +76,7 @@ func (s *watcherSuite) TestLegacyActionNotificationWatcher(c *gc.C) {
 
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := unit.AddAction(operationID, "snapshot", nil)
+	action, err := s.Model.AddAction(unit, operationID, "snapshot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(action.Id())
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -404,7 +404,7 @@ func (s *InterfaceSuite) TestLogActionMessage(c *gc.C) {
 	s.toSupportNewActionID(c)
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.unit.AddAction(operationID, "fakeaction", nil)
+	action, err := s.Model.AddAction(s.unit, operationID, "fakeaction", nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = action.Begin()
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -176,7 +176,7 @@ func (s *ContextFactorySuite) TestNewActionContextLeadershipContext(c *gc.C) {
 		s.SetCharm(c, "dummy")
 		operationID, err := s.Model(c).EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil)
+		action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil, nil)
 		c.Assert(err, jc.ErrorIsNil)
 
 		actionData := &context.ActionData{
@@ -577,7 +577,7 @@ func (s *ContextFactorySuite) TestActionContext(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	operationID, err := s.Model(c).EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil)
+	action, err := s.Model(c).EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	actionData := &context.ActionData{

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -241,7 +241,7 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 		c.Logf("test %d", i)
 		operationID, err := s.model.EnqueueOperation("a test")
 		c.Assert(err, jc.ErrorIsNil)
-		action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), test.actionName, test.payload)
+		action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), test.actionName, test.payload, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 		c.Assert(err, jc.ErrorIsNil)
@@ -282,7 +282,7 @@ func (s *FactorySuite) TestNewActionRunnerBadName(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "no-such-action", nil)
+	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "no-such-action", nil, nil)
 	c.Assert(err, jc.ErrorIsNil) // this will fail when using AddAction on unit
 	rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 	c.Check(rnr, gc.IsNil)
@@ -296,7 +296,7 @@ func (s *FactorySuite) TestNewActionRunnerBadParams(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "snapshot", map[string]interface{}{
 		"outfile": 123,
-	})
+	}, nil)
 	c.Assert(err, jc.ErrorIsNil) // this will fail when state is done right
 	rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 	c.Check(rnr, gc.IsNil)
@@ -308,7 +308,7 @@ func (s *FactorySuite) TestNewActionRunnerMissingAction(c *gc.C) {
 	s.SetCharm(c, "dummy")
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil)
+	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), "snapshot", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.unit.CancelAction(action)
 	c.Assert(err, jc.ErrorIsNil)
@@ -324,7 +324,7 @@ func (s *FactorySuite) TestNewActionRunnerUnauthAction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, otherUnit.Tag(), "snapshot", nil)
+	action, err := s.model.EnqueueAction(operationID, otherUnit.Tag(), "snapshot", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	rnr, err := s.factory.NewActionRunner(action.Id(), nil)
 	c.Check(rnr, gc.IsNil)
@@ -341,7 +341,7 @@ func (s *FactorySuite) TestNewActionRunnerWithCancel(c *gc.C) {
 	cancel := make(chan struct{})
 	operationID, err := s.model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), actionName, payload)
+	action, err := s.model.EnqueueAction(operationID, s.unit.Tag(), actionName, payload, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	rnr, err := s.factory.NewActionRunner(action.Id(), cancel)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -961,7 +961,7 @@ func (s addAction) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	operationID, err := m.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.EnqueueAction(operationID, ctx.unit.Tag(), s.name, s.params)
+	_, err = m.EnqueueAction(operationID, ctx.unit.Tag(), s.name, s.params, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Merge 2.8

#12892 Add CLA checker GH action
#12937 Actions with errors queuing them can be listed

Also, go fmt made some other changes.

```
# Conflicts:
#       api/action/client_test.go
#       apiserver/facades/client/action/operation.go
#       cmd/juju/action/listoperations_test.go
#       go.mod
#       go.sum
#       state/action_test.go
```

## QA steps

See PR
