### PR TITLE
Fix ssh to sidecar charm container

### DIFF
--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -184,6 +184,8 @@ func (c *sshContainer) cleanupRun() {
 	}
 }
 
+const charmContainerName = "charm"
+
 func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 	// If the user specified a leader unit, try to resolve it to the
 	// appropriate unit name and override the requested target name.
@@ -248,9 +250,10 @@ func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 	if isMetaV2 {
 		meta := charmInfo.Charm().Meta()
 		if c.container == "" {
-			c.container = "charm"
-		} else if _, ok := meta.Containers[c.container]; !ok {
-			containers := []string{"charm"}
+			c.container = charmContainerName
+		}
+		if _, ok := meta.Containers[c.container]; !ok && c.container != charmContainerName {
+			containers := []string{charmContainerName}
 			for k := range meta.Containers {
 				containers = append(containers, k)
 			}


### PR DESCRIPTION
This failed:

```
$ juju ssh --container charm snappass-test/0
ERROR container "charm" must be one of charm, redis, snappass
```

The PR fixes it.

## QA steps

Deploy snappass-test
`juju ssh --container charm snappass-test/0`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1926684
