### PR TITLE
Fix/lp 1925735

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -591,6 +591,7 @@ func ParseConfigData(configData []byte) (ConfigSetterWriter, error) {
 		return nil, errors.Trace(err)
 	}
 	logger.Debugf("parsing agent config, format %q", format.version())
+	config.configFilePath = ConfigPath(config.paths.DataDir, config.tag)
 	return config, nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -584,6 +584,15 @@ func ReadConfig(configFilePath string) (ConfigSetterWriter, error) {
 	return config, nil
 }
 
+func ParseConfigData(configData []byte) (ConfigSetterWriter, error) {
+	format, config, err := parseConfigData(configData)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	logger.Debugf("parsing agent config, format %q", format.version())
+	return config, nil
+}
+
 func (c0 *configInternal) Clone() Config {
 	c1 := *c0
 	// Deep copy only fields which may be affected

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -584,6 +584,7 @@ func ReadConfig(configFilePath string) (ConfigSetterWriter, error) {
 	return config, nil
 }
 
+// ParseConfigData parses configuration data.
 func ParseConfigData(configData []byte) (ConfigSetterWriter, error) {
 	format, config, err := parseConfigData(configData)
 	if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -460,6 +460,19 @@ func (*suite) TestWriteAndRead(c *gc.C) {
 	c.Assert(reread, jc.DeepEquals, conf)
 }
 
+func (*suite) TestParseConfigData(c *gc.C) {
+	testParams := attributeParams
+	testParams.Paths.DataDir = c.MkDir()
+	testParams.Paths.LogDir = c.MkDir()
+	conf, err := agent.NewAgentConfig(testParams)
+	c.Assert(err, jc.ErrorIsNil)
+	data, err := conf.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	reread, err := agent.ParseConfigData(data)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(reread, jc.DeepEquals, conf)
+}
+
 func (*suite) TestAPIInfoMissingAddress(c *gc.C) {
 	conf := agent.EmptyConfig()
 	_, ok := conf.APIInfo()

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -386,9 +386,9 @@ func (k *kubernetesClient) OperatorExists(appName string) (caas.DeploymentState,
 	}
 	if exists || terminating {
 		if terminating {
-			logger.Tracef("operator %q exists and is terminating")
+			logger.Tracef("operator %q exists and is terminating", operatorName)
 		} else {
-			logger.Tracef("operator %q exists")
+			logger.Tracef("operator %q exists", operatorName)
 		}
 		return caas.DeploymentState{Exists: exists, Terminating: terminating}, nil
 	}

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -235,6 +235,41 @@ mongoversion: "0.0"
 	s.assertOperatorCreated(c, true, false)
 }
 
+func (s *CAASProvisionerSuite) TestNewApplicationUpdatesOperatorAgentConfAPIAddresses(c *gc.C) {
+	s.caasClient.operatorExists = true
+	s.caasClient.config = &caas.OperatorConfig{
+		OperatorImagePath: "juju-operator-image",
+		Version:           version.MustParse("2.99.0"),
+		AgentConf: []byte(fmt.Sprintf(`
+# format 2.0
+tag: application-myapp
+upgradedToVersion: 2.99.0
+controller: controller-deadbeef-1bad-500d-9000-4b1d0d06f00d
+model: model-deadbeef-0bad-400d-8000-4b1d0d06f00d
+oldpassword: wow
+cacert: %s
+apiaddresses:
+- 8.8.8.6:17070 # this address will be updated to 10.0.0.1:17070
+- 192.18.1.1:17070
+oldpassword: dxKwhgZPrNzXVTrZSxY1VLHA
+values: {}
+mongoversion: "0.0"
+`[1:], strconv.Quote(coretesting.CACert))),
+		OperatorInfo: []byte(
+			fmt.Sprintf(
+				"private-key: %s\ncert: %s\nca-cert: %s\n",
+				strconv.Quote(coretesting.ServerKey),
+				strconv.Quote(coretesting.ServerCert),
+				strconv.Quote(coretesting.CACert),
+			),
+		),
+	}
+
+	w := s.assertWorker(c)
+	defer workertest.CleanKill(c, w)
+	s.assertOperatorCreated(c, true, false)
+}
+
 func (s *CAASProvisionerSuite) TestNewApplicationUpdatesOperatorAndIssueCerts(c *gc.C) {
 	s.caasClient.operatorExists = true
 	s.caasClient.config = &caas.OperatorConfig{


### PR DESCRIPTION
*This PR ensures the CAAS operator's agent conf gets updated when controller connection information changed(For example, the model has been migrated to a new controller).*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
$ juju bootstrap microk8s k1

$ juju add-model t1 && juju deploy ch:ambassador

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.9.1    unsupported  15:30:28+10:00

App         Version                Status  Scale  Charm       Store     Channel  Rev  OS          Address  Message
ambassador  res:oci-image@ac02890  active      1  ambassador  charmhub  stable    13  kubernetes

Unit           Workload  Agent  Address       Ports   Message
ambassador/0*  active    idle   10.1.243.210  80/TCP

$ juju bootstrap microk8s k2

$ juju migrate k1:t1 k2
Migration started with ID "09bb97fa-fbac-4f27-821c-ebf460fba612:0"

$ mkubectl exec pod/ambassador-operator-0 -nt1 -it -- cat /var/lib/juju/agents/application-ambassador/agent.conf | yml2json | jq .apiaddresses
[
  "10.152.183.103:17070",
  "controller-service.controller-k2.svc.cluster.local:17070"
]

$ mkubectl get svc/controller-service -n controller-k2 -o json | jq .spec.clusterIP
"10.152.183.103"

# juju status should show the workloads in the migrated model are settled properly
$ juju status --relations --color --storage -m k2:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k2          microk8s/localhost  2.9.1    unsupported  15:37:41+10:00

App         Version                Status  Scale  Charm       Store     Channel  Rev  OS          Address  Message
ambassador  res:oci-image@ac02890  active      1  ambassador  charmhub  stable    13  kubernetes

Unit           Workload  Agent  Address       Ports   Message
ambassador/1*  active    idle   10.1.243.211  80/TCP

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925735
