### PR TITLE
Ensure upgraded 2.8 models can start containers on machines

### DIFF
--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -33,7 +33,7 @@ func (t *ToolsImportSuite) TestPackageDependencies(c *gc.C) {
 	// resulting slice has that prefix removed to keep the output short.
 	c.Assert(testing.FindJujuCoreImports(c, "github.com/juju/juju/agent/tools"),
 		gc.DeepEquals,
-		[]string{"juju/names", "tools"})
+		[]string{"core/os", "core/series", "juju/names", "tools"})
 }
 
 type ToolsSuite struct {

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -290,7 +290,7 @@ func (s *toolsSuite) TestFindToolsOldAgent(c *gc.C) {
 			c.Assert(major, gc.Equals, 2)
 			c.Assert(minor, gc.Equals, 8)
 			c.Assert(streams, gc.DeepEquals, test.agentStreamsUsed)
-			c.Assert(filter.OSType, gc.Equals, "")
+			c.Assert(filter.OSType, gc.Equals, "ubuntu")
 			c.Assert(filter.Arch, gc.Equals, "amd64")
 			return envtoolsList, nil
 		})

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -155,32 +155,43 @@ func (h *toolsDownloadHandler) getToolsForRequest(r *http.Request, st *state.Sta
 	// TODO(juju4) = remove this compatibility logic
 	// Looked for stored tools which are recorded for a series
 	// but which have the same os type as the wanted version.
+	// Alternatively, the request may have been for a specifc
+	// series and we need to use stored tools for the corresponding
+	// os type.
 	storageVers := vers
 	var osTypeName string
 	if vers.Number.Major == 2 && vers.Number.Minor <= 8 {
+		wantedOSType := vers.Release
+		if !coreos.IsValidOSTypeName(vers.Release) {
+			wantedOSType = coreseries.DefaultOSTypeNameFromSeries(vers.Release)
+		}
+		vers.Release = wantedOSType
+
 		all, err := storage.AllMetadata()
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}
 		var osMatchVersion *version.Binary
 		for _, m := range all {
+			metaVers, err := version.ParseBinary(m.Version)
+			if err != nil {
+				return nil, 0, errors.Annotate(err, "error parsing metadata version")
+			}
+
 			// Exact match so just use that with os type name substitution.
 			if m.Version == vers.String() {
+				osMatchVersion = &metaVers
 				break
 			}
 			if osMatchVersion != nil {
 				continue
 			}
-			metaVers, err := version.ParseBinary(m.Version)
-			if err != nil {
-				return nil, 0, errors.Annotate(err, "error parsing metadata version")
-			}
-			osType, _ := coreseries.GetOSFromSeries(metaVers.Release)
-			if osType == coreos.Unknown {
-				continue
+			metaOSType := metaVers.Release
+			if !coreos.IsValidOSTypeName(metaVers.Release) {
+				metaOSType = coreseries.DefaultOSTypeNameFromSeries(metaVers.Release)
 			}
 			toCompare := metaVers
-			toCompare.Release = strings.ToLower(osType.String())
+			toCompare.Release = strings.ToLower(metaOSType)
 			if toCompare.String() == vers.String() {
 				logger.Debugf("using os based version %s for requested %s", toCompare, vers)
 				osMatchVersion = &metaVers

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -386,13 +386,49 @@ func (s *toolsSuite) TestDownloadModelUUIDPath(c *gc.C) {
 }
 
 // TODO(juju4) - remove
-func (s *toolsSuite) TestDownloadOldAgent(c *gc.C) {
+func (s *toolsSuite) TestDownloadOldAgentNewRequest(c *gc.C) {
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
 		Version: "2.8.9-focal-amd64",
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
 	resp := s.downloadRequest(c, version.MustParseBinary("2.8.9-ubuntu-amd64"), s.State.ModelUUID())
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.HasLen, int(tools.Size))
+
+	hash := sha256.New()
+	hash.Write(data)
+	c.Assert(fmt.Sprintf("%x", hash.Sum(nil)), gc.Equals, tools.SHA256)
+}
+
+// TODO(juju4) - remove
+func (s *toolsSuite) TestDownloadAgentOldRequest(c *gc.C) {
+	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
+		Version: "2.8.9-ubuntu-amd64",
+		Size:    3,
+		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	})
+	resp := s.downloadRequest(c, version.MustParseBinary("2.8.9-focal-amd64"), s.State.ModelUUID())
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, gc.HasLen, int(tools.Size))
+
+	hash := sha256.New()
+	hash.Write(data)
+	c.Assert(fmt.Sprintf("%x", hash.Sum(nil)), gc.Equals, tools.SHA256)
+}
+
+// TODO(juju4) - remove
+func (s *toolsSuite) TestDownloadSeriesAgentOldRequest(c *gc.C) {
+	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
+		Version: "2.8.9-bionic-amd64",
+		Size:    3,
+		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+	})
+	resp := s.downloadRequest(c, version.MustParseBinary("2.8.9-focal-amd64"), s.State.ModelUUID())
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)

--- a/tools/list_test.go
+++ b/tools/list_test.go
@@ -349,3 +349,11 @@ func (s *ListSuite) TestMatchVersions(c *gc.C) {
 		c.Check(actual, gc.DeepEquals, expectVersions)
 	}
 }
+
+// TODO(juju4) - remove
+func (s *ListSuite) TestMatchLegacy(c *gc.C) {
+	bionic := tools.List{mustParseTools("2.1.0-bionic-amd64")}
+	actual, err := bionic.Match(tools.Filter{OSType: "ubuntu"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actual, jc.DeepEquals, bionic)
+}


### PR DESCRIPTION
Upgraded 2.8 models on 2.9 controllers can not deploy containers (lxd/kvm) to machines due to a bug in the 2.8 machine agents. 

The root cause is a 2.8 bug in the lxd borker which provisions containers. The series to provision is passed in via the instance config args. But we ignore that and instead get the series from the tools metadata. A 2.9 controller populates tools metadata with os type, not series. It wouldn't be an issue if the 2.8 code did not have the bug, and this has already been fixed in 2.9

The fix here is to tweak the 2.9 controller agent binary and metadata lookup logic to handle this additional use case of 2.8 compatibility. The call to FindTools() by a 2.8 agent passes in the series to look for and so we map this to the relevant os type when looking for agents. We then ensure the returned agent metadata is set to the requested series rather tan leaving it as queries. This ensure the buggy 2.8 agent which uses tools.OneSeries() gets the correct series to use to start the container.

## QA steps

On 2.8.9
juju bootstrap
juju switch default
juju deploy ubuntu --series=bionic
juju add-machine lxd --series=focal

WIth 2.9 client
juju upgrade-controller --build-agent
juju add-machine --series=xenial
juju add-machine lxd:1 --series=xenial
juju add-machine lxd --series=xenial
check the machines get provisioned and are shown as started

juju upgrade-model
add more machines and containers and check



## Bug reference

https://bugs.launchpad.net/juju/+bug/1926826
