### PR TITLE
Improve destroy model messages if aborted or timed out

### DIFF
--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -458,7 +458,14 @@ func (s *DestroySuite) TestDestroyCommandWait(c *gc.C) {
 	case <-done:
 		c.Assert(<-outStdErr, gc.Equals, `
 Destroying model
-Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)....`[1:])
+Waiting for model to be removed, 5 error(s), 1 machine(s), 2 application(s), 3 volume(s), 2 filesystems(s)....
+The following resources have not yet been removed:
+ - 1 machine(s)
+ - 2 application(s)
+ - 3 volume(s)
+ - 2 filesystems(s)
+Because the destroy model operation did not finish, there may be cloud resources left behind.
+`[1:])
 		c.Assert(<-outStdOut, gc.Equals, `
 
 The following errors were encountered during destroying the model.
@@ -510,7 +517,9 @@ func (s *DestroySuite) TestDestroyCommandLeanMessage(c *gc.C) {
 	case <-done:
 		c.Assert(<-outStdErr, gc.Equals, `
 Destroying model
-Waiting for model to be removed....`[1:])
+Waiting for model to be removed....
+Because the destroy model operation did not finish, there may be cloud resources left behind.
+`[1:])
 		// timeout after 3s.
 		c.Assert(<-outErr, jc.Satisfies, errors.IsTimeout)
 		checkModelExistsInStore(c, "test1:admin/test2", s.store)


### PR DESCRIPTION
When destroy model is run, cleaning up all cloud resources can take a while. The CLI will block and report progress, but the maximum wait time can be exceeded or the user can hit Ctrl^C. In such cases, the messages printed to the console are improved to tell the user there may be cloud resources that need to be cleaned up.

This is in response to bug 1910810 where deleting a k8s namespace can take a long time. We can't do much about that, but if the user hits Ctrl^C or uses a reasonable timeout like 5m, then the messaging is hopefully better.

Ultimately we may need to consider removing the model from the juju database even if there are cloud resources still in existence if the user supplies the --force option.

## QA steps

deploy a k8s model
destroy model with a short timeout
```
$ juju destroy-model test -y --timeout=1s
Destroying model
Waiting for model to be removed, 1 application(s)...
The following resources have not yet been removed:
 - 1 application(s)
Because the destroy model operation did not finish, there may be cloud resources left behind.
ERROR timeout after 1s
```

or destroy a model and Ctrl^C before it is done

```
$ juju destroy-model test -y
Destroying model
Waiting for model to be removed, 1 application(s)...^C

destroy model is still running in the background...
The following resources have not yet been removed:
 - 1 application(s)
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1910810
