### PR TITLE
ToolsFinder refactor

### DIFF
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -33,8 +33,8 @@ type ToolsURLGetter interface {
 	ToolsURLs(v version.Binary) ([]string, error)
 }
 
-// APIHostPortsGetter is an interface providing the APIHostPortsForAgents
-// method.
+// APIHostPortsForAgentsGetter is an interface providing
+// the APIHostPortsForAgents method.
 type APIHostPortsForAgentsGetter interface {
 	// APIHostPortsForAgents returns the HostPorts for each API server that
 	// are suitable for agent-to-controller API communication based on the
@@ -239,14 +239,12 @@ func NewToolsFinder(
 
 // FindTools returns a List containing all tools matching the given parameters.
 func (f *ToolsFinder) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
-	result := params.FindToolsResult{}
 	list, err := f.findTools(args)
 	if err != nil {
-		result.Error = apiservererrors.ServerError(err)
-	} else {
-		result.List = list
+		return params.FindToolsResult{Error: apiservererrors.ServerError(err)}, nil
 	}
-	return result, nil
+
+	return params.FindToolsResult{List: list}, nil
 }
 
 // findTools calls findMatchingTools and then rewrites the URLs
@@ -256,6 +254,23 @@ func (f *ToolsFinder) findTools(args params.FindToolsParams) (coretools.List, er
 	if err != nil {
 		return nil, err
 	}
+
+	// This handles clients and agents that may be attempting to find tools in
+	// the context of series instead of OS type.
+	// If we get a request by series we ensure that any matched OS tools are
+	// converted to the requested series.
+	// Conversely, if we get a request by OS type, matching series tools are
+	// converted to match the OS.
+	// TODO: Remove this block and the called methods for Juju 3/4.
+	if args.Number.Major == 2 && args.Number.Minor <= 8 && (args.OSType != "" || args.Series != "") {
+		if args.OSType != "" {
+			list = f.resultForOSTools(list, args.OSType)
+		}
+		if args.Series != "" {
+			list = f.resultForSeriesTools(list, args.Series)
+		}
+	}
+
 	// Rewrite the URLs so they point at the API servers. If the
 	// tools are not in tools storage, then the API server will
 	// download and cache them if the client requests that version.
@@ -274,84 +289,68 @@ func (f *ToolsFinder) findTools(args params.FindToolsParams) (coretools.List, er
 	return fullList, nil
 }
 
+func (f *ToolsFinder) resultForOSTools(list coretools.List, osType string) coretools.List {
+	added := make(map[version.Binary]bool)
+	var matched coretools.List
+	for _, t := range list {
+		converted := *t
+
+		// t might be for a series so convert to an OS type.
+		if !coreos.IsValidOSTypeName(t.Version.Release) {
+			osTypeName, err := coreseries.GetOSFromSeries(t.Version.Release)
+			if err != nil {
+				continue
+			}
+			converted.Version.Release = strings.ToLower(osTypeName.String())
+		}
+
+		if converted.Version.Release != osType {
+			continue
+		}
+		if added[converted.Version] {
+			continue
+		}
+
+		matched = append(matched, &converted)
+		added[converted.Version] = true
+	}
+
+	return matched
+}
+
+func (f *ToolsFinder) resultForSeriesTools(list coretools.List, series string) coretools.List {
+	osType := coreseries.DefaultOSTypeNameFromSeries(series)
+
+	added := make(map[version.Binary]bool)
+	var matched coretools.List
+	for _, t := range list {
+		converted := *t
+
+		if coreos.IsValidOSTypeName(t.Version.Release) {
+			if osType != t.Version.Release {
+				continue
+			}
+			converted.Version.Release = series
+		} else if series != t.Version.Release {
+			continue
+		}
+		if added[converted.Version] {
+			continue
+		}
+
+		matched = append(matched, &converted)
+		added[converted.Version] = true
+	}
+
+	return matched
+}
+
 // findMatchingTools searches tools storage and simplestreams for tools matching the
 // given parameters. If an exact match is specified (number, series and arch)
 // and is found in tools storage, then simplestreams will not be searched.
 func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (result coretools.List, _ error) {
 	exactMatch := args.Number != version.Zero && (args.OSType != "" || args.Series != "") && args.Arch != ""
 
-	// TODO(juju4) - remove this logic
-	// Older versions of Juju publish agent binary metadata based on series.
-	// The following functions convert the result tools list to the required format.
-
-	// For a given list of tools, return those which match the required
-	// os type. If the tools is for a series, first convert the series into
-	// the corresponding os type before doing the match.
-	// eg if ubuntu tools are requested, and we have bionic tools, say they're ubuntu.
-	wantedOSType := args.OSType
-	compatibleOSTypeTools := func() {
-		added := make(map[version.Binary]bool)
-		var matched coretools.List
-		for _, t := range result {
-			converted := *t
-			// t might be for a series so convert to an os type.
-			if !coreos.IsValidOSTypeName(t.Version.Release) {
-				osTypeName, err := coreseries.GetOSFromSeries(t.Version.Release)
-				if err != nil {
-					continue
-				}
-				converted.Version.Release = strings.ToLower(osTypeName.String())
-			}
-			if converted.Version.Release != wantedOSType {
-				continue
-			}
-			if added[converted.Version] {
-				continue
-			}
-			matched = append(matched, &converted)
-			added[converted.Version] = true
-		}
-		result = matched
-	}
-
-	// For a given list of tools, return those which match the required series.
-	// If the tools is for an os type, match on the os type of the series.
-	// The returned tools are converted to the requested series.
-	// eg if bionic tools are requested, we return bionic if we have then
-	// or convert ubuntu tools to say they're bionic.
-	compatibleSeriesTools := func() {
-		osType := coreseries.DefaultOSTypeNameFromSeries(args.Series)
-		added := make(map[version.Binary]bool)
-		var matched coretools.List
-		for _, t := range result {
-			converted := *t
-			if coreos.IsValidOSTypeName(t.Version.Release) {
-				if osType != t.Version.Release {
-					continue
-				}
-				converted.Version.Release = args.Series
-			} else if args.Series != t.Version.Release {
-				continue
-			}
-			if added[converted.Version] {
-				continue
-			}
-			matched = append(matched, &converted)
-			added[converted.Version] = true
-		}
-		result = matched
-	}
-
-	// TODO(juju4) - remove this logic
-	// Set up the final metadata conversion if old tools are requested.
-	if args.Number.Major == 2 && args.Number.Minor <= 8 && (args.OSType != "" || args.Series != "") {
-		if args.OSType != "" {
-			defer compatibleOSTypeTools()
-		}
-		if args.Series != "" {
-			defer compatibleSeriesTools()
-		}
-	}
 	storageList, err := f.matchingStorageTools(args)
 	if err != nil && err != coretools.ErrNoMatches {
 		return nil, err

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -102,9 +102,6 @@ func (t *ToolsGetter) Tools(args params.Entities) (params.ToolsResults, error) {
 		agentToolsList, err := t.oneAgentTools(canRead, tag, agentVersion)
 		if err == nil {
 			result.Results[i].ToolsList = agentToolsList
-			// TODO(axw) Get rid of this in 1.22, when all upgraders
-			// are known to ignore the flag.
-			result.Results[i].DisableSSLHostnameVerification = true
 		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
@@ -345,9 +342,10 @@ func (f *ToolsFinder) resultForSeriesTools(list coretools.List, series string) c
 	return matched
 }
 
-// findMatchingTools searches tools storage and simplestreams for tools matching the
-// given parameters. If an exact match is specified (number, series and arch)
-// and is found in tools storage, then simplestreams will not be searched.
+// findMatchingTools searches tools storage and simplestreams for tools
+// matching the given parameters.
+// If an exact match is specified (number, series and arch) and is found in
+// tools storage, then simplestreams will not be searched.
 func (f *ToolsFinder) findMatchingTools(args params.FindToolsParams) (result coretools.List, _ error) {
 	exactMatch := args.Number != version.Zero && (args.OSType != "" || args.Series != "") && args.Arch != ""
 
@@ -400,7 +398,8 @@ func (f *ToolsFinder) matchingStorageTools(args params.FindToolsParams) (coretoo
 	if err != nil {
 		return nil, err
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
+
 	allMetadata, err := storage.AllMetadata()
 	if err != nil {
 		return nil, err

--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -286,6 +286,7 @@ func (f *ToolsFinder) findTools(args params.FindToolsParams) (coretools.List, er
 	return fullList, nil
 }
 
+// TODO: Remove for Juju 3/4.
 func (f *ToolsFinder) resultForOSTools(list coretools.List, osType string) coretools.List {
 	added := make(map[version.Binary]bool)
 	var matched coretools.List
@@ -315,6 +316,7 @@ func (f *ToolsFinder) resultForOSTools(list coretools.List, osType string) coret
 	return matched
 }
 
+// TODO: Remove for Juju 3/4.
 func (f *ToolsFinder) resultForSeriesTools(list coretools.List, series string) coretools.List {
 	osType := coreseries.DefaultOSTypeNameFromSeries(series)
 

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -76,7 +76,6 @@ func (s *toolsSuite) TestTools(c *gc.C) {
 	tools := result.Results[0].ToolsList[0]
 	c.Assert(tools.Version, gc.DeepEquals, current)
 	c.Assert(tools.URL, gc.Equals, "tools:"+current.String())
-	c.Assert(result.Results[0].DisableSSLHostnameVerification, jc.IsTrue)
 	c.Assert(result.Results[1].Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
 	c.Assert(result.Results[2].Error, gc.DeepEquals, apiservertesting.NotFoundError("machine 42"))
 }
@@ -114,7 +113,6 @@ func (s *toolsSuite) TestSeriesTools(c *gc.C) {
 	tools := result.Results[0].ToolsList[0]
 	c.Assert(tools.Version, gc.DeepEquals, current)
 	c.Assert(tools.URL, gc.Equals, "tools:"+current.String())
-	c.Assert(result.Results[0].DisableSSLHostnameVerification, jc.IsTrue)
 }
 
 func (s *toolsSuite) TestToolsError(c *gc.C) {

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -51,7 +51,6 @@ type ProvisionerAPI struct {
 	*common.ModelWatcher
 	*common.ModelMachinesWatcher
 	*common.InstanceIdGetter
-	*common.ToolsFinder
 	*common.ToolsGetter
 	*networkingcommon.NetworkConfigAPI
 
@@ -65,6 +64,7 @@ type ProvisionerAPI struct {
 	getAuthFunc             common.GetAuthFunc
 	getCanModify            common.GetAuthFunc
 	providerCallContext     context.ProviderCallContext
+	toolsFinder             *common.ToolsFinder
 
 	// Used for MaybeWriteLXDProfile()
 	mu sync.Mutex
@@ -168,7 +168,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		return environs.GetEnviron(configGetter, environs.New)
 	}
 	api.InstanceIdGetter = common.NewInstanceIdGetter(st, getAuthFunc)
-	api.ToolsFinder = common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
+	api.toolsFinder = common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	api.ToolsGetter = common.NewToolsGetter(st, configGetter, st, urlGetter, getAuthOwner, newEnviron)
 	return api, nil
 }
@@ -817,6 +817,11 @@ func (api *ProvisionerAPI) Constraints(args params.Entities) (params.Constraints
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
+}
+
+// FindTools returns a List containing all tools matching the given parameters.
+func (api *ProvisionerAPI) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+	return api.toolsFinder.FindTools(args)
 }
 
 // SetInstanceInfo sets the provider specific machine id, nonce,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -34815,9 +34815,6 @@
                 "ToolsResult": {
                     "type": "object",
                     "properties": {
-                        "disable-ssl-hostname-verification": {
-                            "type": "boolean"
-                        },
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
@@ -34830,8 +34827,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "tools",
-                        "disable-ssl-hostname-verification"
+                        "tools"
                     ]
                 },
                 "ToolsResults": {
@@ -46737,9 +46733,6 @@
                 "ToolsResult": {
                     "type": "object",
                     "properties": {
-                        "disable-ssl-hostname-verification": {
-                            "type": "boolean"
-                        },
                         "error": {
                             "$ref": "#/definitions/Error"
                         },
@@ -46752,8 +46745,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "tools",
-                        "disable-ssl-hostname-verification"
+                        "tools"
                     ]
                 },
                 "ToolsResults": {

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -236,7 +236,7 @@ type SettingsResults struct {
 	Results []SettingsResult `json:"results"`
 }
 
-// ConfigSettings holds unit, application or cham configuration settings
+// ConfigSettings holds unit, application or charm configuration settings
 // with string keys and arbitrary values.
 type ConfigSettings map[string]interface{}
 
@@ -560,11 +560,11 @@ type SetModelEnvironVersions struct {
 	Models []SetModelEnvironVersion `json:"models,omitempty"`
 }
 
-// SetModelEnvironVersions holds the tag and associated environ version
+// SetModelEnvironVersion holds the tag and associated environ version
 // of a model.
 type SetModelEnvironVersion struct {
 	// ModelTag is the string representation of a model tag, which
-	// should be parseable using names.ParseModelTag.
+	// should be parsable using names.ParseModelTag.
 	ModelTag string `json:"model-tag"`
 
 	// Version is the environ version to set for the model.
@@ -574,9 +574,8 @@ type SetModelEnvironVersion struct {
 // ToolsResult holds the tools and possibly error for a given
 // Tools() API call.
 type ToolsResult struct {
-	ToolsList                      tools.List `json:"tools"`
-	DisableSSLHostnameVerification bool       `json:"disable-ssl-hostname-verification"`
-	Error                          *Error     `json:"error,omitempty"`
+	ToolsList tools.List `json:"tools"`
+	Error     *Error     `json:"error,omitempty"`
 }
 
 // ToolsResults is a list of tools for various requested agents.
@@ -680,7 +679,7 @@ type RelationUnitsWatchResults struct {
 	Results []RelationUnitsWatchResult `json:"results"`
 }
 
-// RelationUnitStatusResult holds details about scope
+// RelationUnitStatus holds details about scope
 // and suspended status for a relation unit.
 type RelationUnitStatus struct {
 	RelationTag string `json:"relation-tag"`
@@ -838,7 +837,7 @@ type ProvisioningNetworkTopology struct {
 	SpaceSubnets map[string][]string `json:"space-subnets"`
 }
 
-// ProvisioningInfo holds machine provisioning info returned by
+// ProvisioningInfoV10 holds machine provisioning info returned by
 // versions 10 and above of the provisioner API facade.
 type ProvisioningInfoV10 struct {
 	ProvisioningInfoBase
@@ -852,7 +851,7 @@ type ProvisioningInfoResultV10 struct {
 	Error  *Error               `json:"error,omitempty"`
 }
 
-// ProvisioningInfoResults holds multiple machine provisioning info results
+// ProvisioningInfoResultsV10 holds multiple machine provisioning info results
 // for versions 10 and above of the provisioner API facade.
 type ProvisioningInfoResultsV10 struct {
 	Results []ProvisioningInfoResultV10 `json:"results"`
@@ -909,7 +908,7 @@ type MeterStatusResults struct {
 }
 
 // SingularClaim represents a request for exclusive administrative access
-// to an entity (model or controller) on the part of the claimaint.
+// to an entity (model or controller) on the part of the claimant.
 type SingularClaim struct {
 	EntityTag   string        `json:"entity-tag"`
 	ClaimantTag string        `json:"claimant-tag"`

--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -127,7 +127,7 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "error checking if provisioned: subprocess encountered error code 255")
 }
 
-func (s *provisionerSuite) TestFinishInstancConfig(c *gc.C) {
+func (s *provisionerSuite) TestFinishInstanceConfig(c *gc.C) {
 	var series = jujuversion.DefaultSupportedLTS()
 	const arch = "amd64"
 	defer fakeSSH{


### PR DESCRIPTION
This refactoring follows #12943. It "unembeds" `ToolsFinder` from the provisioner API, making version wrangling easier in the future.

`findTools` itself is reworked for clarity, removing inline function definitions and the defer-modify-named-returns trick.

`DisableSSLHostnameVerification` is removed from `ToolsResult`. This was an overhang from way back in version 1, with no consumers of the member. Removing it does not break compatibility.

## QA steps

Changes are mechanical, but the steps from #12943 will check for regression.

## Documentation changes

None.

## Bug reference

N/A
