### PR TITLE
Remove redundant AddressConfigMethod

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -836,7 +836,7 @@ func (s *provisionerSuite) TestHostChangesForContainer(c *gc.C) {
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "ens3",
 			CIDRAddress:  "10.0.0.10/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -239,15 +239,9 @@ func networkAddressToStateArgs(
 		return state.LinkLayerDeviceAddress{}, errors.Trace(err)
 	}
 
-	var derivedConfigMethod network.AddressConfigMethod
-	switch method := network.AddressConfigMethod(dev.ConfigType); method {
-	case network.StaticAddress, network.DynamicAddress,
-		network.LoopbackAddress, network.ManualAddress:
-		derivedConfigMethod = method
-	case "dhcp": // awkward special case
-		derivedConfigMethod = network.DynamicAddress
-	default:
-		derivedConfigMethod = network.StaticAddress
+	configType := dev.ConfigType
+	if configType == network.ConfigUnknown {
+		configType = network.ConfigStatic
 	}
 
 	return state.LinkLayerDeviceAddress{
@@ -255,7 +249,7 @@ func networkAddressToStateArgs(
 		ProviderID:        dev.ProviderAddressId,
 		ProviderNetworkID: dev.ProviderNetworkId,
 		ProviderSubnetID:  dev.ProviderSubnetId,
-		ConfigMethod:      derivedConfigMethod,
+		ConfigMethod:      configType,
 		CIDRAddress:       cidrAddress,
 		DNSServers:        dev.DNSServers.ToIPAddresses(),
 		DNSSearchDomains:  dev.DNSSearchDomains,

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -332,52 +332,52 @@ var expectedLinkLayerDeviceArgsWithFinalNetworkConfig = []state.LinkLayerDeviceA
 
 var expectedLinkLayerDeviceAddressesWithFinalNetworkConfig = []state.LinkLayerDeviceAddress{{
 	DeviceName:   "lo",
-	ConfigMethod: network.LoopbackAddress,
+	ConfigMethod: network.ConfigLoopback,
 	CIDRAddress:  "127.0.0.1/8",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth0",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.20.19.100/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth0",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.20.19.123/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth0.100",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.100.19.100/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth0.250",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.250.19.100/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth0.50",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.50.19.100/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth1",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.20.19.105/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth1.11",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.11.19.101/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth1.12",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.12.19.101/24",
 	Origin:       network.OriginMachine,
 }, {
 	DeviceName:   "br-eth1.13",
-	ConfigMethod: network.StaticAddress,
+	ConfigMethod: network.ConfigStatic,
 	CIDRAddress:  "10.13.19.101/24",
 	Origin:       network.OriginMachine,
 }}

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -87,7 +87,7 @@ func (s *networkInfoSuite) addDevicesWithAddresses(c *gc.C, machine *state.Machi
 
 		addressesArg := state.LinkLayerDeviceAddress{
 			DeviceName:   name,
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  address,
 		}
 		err = machine.SetDevicesAddresses(addressesArg)
@@ -752,7 +752,7 @@ func (s *networkInfoSuite) createNICWithIP(
 		state.LinkLayerDeviceAddress{
 			DeviceName:   deviceName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4292,19 +4292,19 @@ func (s *uniterNetworkConfigSuite) makeMachineDevicesAndAddressesArgs(addrSuffix
 		}},
 		[]state.LinkLayerDeviceAddress{{
 			DeviceName:   "eth0",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("8.8.8.%d/16", addrSuffix),
 		}, {
 			DeviceName:   "eth0.100",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("10.0.0.%d/24", addrSuffix),
 		}, {
 			DeviceName:   "eth1",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("8.8.4.%d/16", addrSuffix),
 		}, {
 			DeviceName:   "eth1.100",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("10.0.0.%d/24", addrSuffix+1),
 		}}
 }
@@ -4568,35 +4568,35 @@ func (s *uniterNetworkInfoSuite) makeMachineDevicesAndAddressesArgs(addrSuffix i
 		}},
 		[]state.LinkLayerDeviceAddress{{
 			DeviceName:   "eth0",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("8.8.8.%d/16", addrSuffix),
 		}, {
 			DeviceName:   "eth0.100",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("10.0.0.%d/24", addrSuffix),
 		}, {
 			DeviceName:   "eth1",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("8.8.4.%d/16", addrSuffix),
 		}, {
 			DeviceName:   "eth1",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("8.8.4.%d/16", addrSuffix+1),
 		}, {
 			DeviceName:   "eth1.100",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("10.0.0.%d/24", addrSuffix+1),
 		}, {
 			DeviceName:   "eth2",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("100.64.0.%d/16", addrSuffix),
 		}, {
 			DeviceName:   "eth4",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("192.168.1.%d/24", addrSuffix),
 		}, {
 			DeviceName:   "fan-1",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  fmt.Sprintf("1.1.1.%d/12", addrSuffix),
 		}}
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -194,14 +194,14 @@ func (s *statusSuite) TestFullStatusInterfaceScaling(c *gc.C) {
 	err = machine.SetDevicesAddresses(
 		state.LinkLayerDeviceAddress{
 			DeviceName:        "eth1",
-			ConfigMethod:      network.StaticAddress,
+			ConfigMethod:      network.ConfigStatic,
 			ProviderNetworkID: "vpc-abcd",
 			ProviderSubnetID:  "prov-ffff",
 			CIDRAddress:       "10.20.0.42/24",
 		},
 		state.LinkLayerDeviceAddress{
 			DeviceName:        "eth2",
-			ConfigMethod:      network.StaticAddress,
+			ConfigMethod:      network.ConfigStatic,
 			ProviderNetworkID: "vpc-abcd",
 			ProviderSubnetID:  "prov-abcd",
 			CIDRAddress:       "10.30.0.99/24",
@@ -246,7 +246,7 @@ func (s *statusSuite) createNICWithIP(c *gc.C, machine *state.Machine, deviceNam
 		state.LinkLayerDeviceAddress{
 			DeviceName:   deviceName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/spaces/integrity.go
+++ b/apiserver/facades/client/spaces/integrity.go
@@ -117,7 +117,7 @@ func (n *affectedNetworks) processMachines(machines []Machine) error {
 		var machineSubnets network.SubnetInfos
 		for _, address := range addresses {
 			// These are not going to have subnets, so just ignore them.
-			if address.ConfigMethod() == network.LoopbackAddress {
+			if address.ConfigMethod() == network.ConfigLoopback {
 				continue
 			}
 

--- a/apiserver/facades/client/spaces/interface.go
+++ b/apiserver/facades/client/spaces/interface.go
@@ -32,7 +32,7 @@ type BlockChecker interface {
 // Address is an indirection for state.Address.
 type Address interface {
 	SubnetCIDR() string
-	ConfigMethod() network.AddressConfigMethod
+	ConfigMethod() network.AddressConfigType
 	Value() string
 }
 

--- a/apiserver/facades/client/spaces/move_test.go
+++ b/apiserver/facades/client/spaces/move_test.go
@@ -340,7 +340,7 @@ func (s *moveSubnetsAPISuite) TestMoveSubnetsNegativeConstraintsViolatedForOverl
 	// So we expect the subnet to be looked up by the address value.
 	address := spaces.NewMockAddress(ctrl)
 	address.EXPECT().SubnetCIDR().Return("10.0.0.0/8")
-	address.EXPECT().ConfigMethod().Return(network.DynamicAddress)
+	address.EXPECT().ConfigMethod().Return(network.ConfigDHCP)
 	address.EXPECT().Value().Return("10.10.0.5")
 
 	m := spaces.NewMockMachine(ctrl)
@@ -590,13 +590,13 @@ func expectMachine(ctrl *gomock.Controller, cidrs ...string) *spaces.MockMachine
 	for i, cidr := range cidrs {
 		address := spaces.NewMockAddress(ctrl)
 		address.EXPECT().SubnetCIDR().Return(cidr)
-		address.EXPECT().ConfigMethod().Return(network.DynamicAddress)
+		address.EXPECT().ConfigMethod().Return(network.ConfigDHCP)
 		addrs[i] = address
 	}
 
 	// Add a loopback into the mix to test that we don't ask for its subnets.
 	loopback := spaces.NewMockAddress(ctrl)
-	loopback.EXPECT().ConfigMethod().Return(network.LoopbackAddress)
+	loopback.EXPECT().ConfigMethod().Return(network.ConfigLoopback)
 
 	machine := spaces.NewMockMachine(ctrl)
 	machine.EXPECT().AllAddresses().Return(append(addrs, loopback), nil)

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -19,7 +19,7 @@ import (
 	space "github.com/juju/juju/environs/space"
 	state "github.com/juju/juju/state"
 	txn "github.com/juju/mgo/v2/txn"
-	names "github.com/juju/names/v4"
+	v4 "github.com/juju/names/v4"
 	reflect "reflect"
 )
 
@@ -225,10 +225,10 @@ func (mr *MockBackingMockRecorder) ModelConfig() *gomock.Call {
 }
 
 // ModelTag mocks base method
-func (m *MockBacking) ModelTag() names.ModelTag {
+func (m *MockBacking) ModelTag() v4.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(v4.ModelTag)
 	return ret0
 }
 
@@ -1004,10 +1004,10 @@ func (m *MockAddress) EXPECT() *MockAddressMockRecorder {
 }
 
 // ConfigMethod mocks base method
-func (m *MockAddress) ConfigMethod() network.AddressConfigMethod {
+func (m *MockAddress) ConfigMethod() network.AddressConfigType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigMethod")
-	ret0, _ := ret[0].(network.AddressConfigMethod)
+	ret0, _ := ret[0].(network.AddressConfigType)
 	return ret0
 }
 
@@ -1374,10 +1374,10 @@ func (m *MockAuthorizerState) EXPECT() *MockAuthorizerStateMockRecorder {
 }
 
 // ModelTag mocks base method
-func (m *MockAuthorizerState) ModelTag() names.ModelTag {
+func (m *MockAuthorizerState) ModelTag() v4.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(names.ModelTag)
+	ret0, _ := ret[0].(v4.ModelTag)
 	return ret0
 }
 

--- a/cmd/juju/commands/ssh_machine_test.go
+++ b/cmd/juju/commands/ssh_machine_test.go
@@ -257,11 +257,11 @@ func (s *SSHMachineSuite) setLinkLayerDevicesAddresses(c *gc.C, m *state.Machine
 	addressesArgs := []state.LinkLayerDeviceAddress{{
 		DeviceName:   "lo",
 		CIDRAddress:  "127.0.0.1/8", // will be filtered
-		ConfigMethod: network.LoopbackAddress,
+		ConfigMethod: network.ConfigLoopback,
 	}, {
 		DeviceName:   "eth0",
 		CIDRAddress:  "0.1.2.3/24", // needs to be a valid CIDR
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 	}}
 	err = m.SetDevicesAddresses(addressesArgs...)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4052,13 +4052,13 @@ func (sa setAddresses) step(c *gc.C, ctx *context) {
 	for i, address := range sa.addresses {
 		devName := fmt.Sprintf("eth%d", i)
 		macAddr := "aa:bb:cc:dd:ee:ff"
-		configMethod := network.StaticAddress
+		configMethod := network.ConfigStatic
 		devType := network.EthernetDevice
 		if address.Scope == network.ScopeMachineLocal ||
 			address.Value == "localhost" {
 			devName = "lo"
 			macAddr = "00:00:00:00:00:00"
-			configMethod = network.LoopbackAddress
+			configMethod = network.ConfigLoopback
 			devType = network.LoopbackDevice
 		}
 		lldevs[i] = state.LinkLayerDeviceArgs{

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -45,6 +45,20 @@ const (
 	ConfigLoopback AddressConfigType = "loopback"
 )
 
+// IsValidAddressConfigType returns whether the given value is a valid
+// method to configure a link-layer network device's IP address.
+// TODO (manadart 2021-05-04): There is an issue with the usage of this
+// method in state where we have denormalised the config method so it is
+// against device addresses. This is because "manual" indicates a device that
+// has no configuration by default. This could never apply to an address.
+func IsValidAddressConfigType(value string) bool {
+	switch AddressConfigType(value) {
+	case ConfigLoopback, ConfigStatic, ConfigDHCP, ConfigManual:
+		return true
+	}
+	return false
+}
+
 // AddressType represents the possible ways of specifying a machine location by
 // either a hostname resolvable by dns lookup, or IPv4 or IPv6 address.
 type AddressType string

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -958,3 +958,28 @@ func (s *AddressSuite) TestNetworkCIDRFromIPAndMask(c *gc.C) {
 		c.Assert(gotCIDR, gc.Equals, spec.expCIDR)
 	}
 }
+
+func (s *AddressSuite) TestIsValidAddressConfigTypeWithValidValues(c *gc.C) {
+	validTypes := []network.AddressConfigType{
+		network.ConfigLoopback,
+		network.ConfigStatic,
+		network.ConfigDHCP,
+		network.ConfigManual,
+	}
+
+	for _, value := range validTypes {
+		result := network.IsValidAddressConfigType(string(value))
+		c.Check(result, jc.IsTrue)
+	}
+}
+
+func (s *AddressSuite) TestIsValidAddressConfigTypeWithInvalidValues(c *gc.C) {
+	result := network.IsValidAddressConfigType("")
+	c.Check(result, jc.IsFalse)
+
+	result = network.IsValidAddressConfigType("anything")
+	c.Check(result, jc.IsFalse)
+
+	result = network.IsValidAddressConfigType(" ")
+	c.Check(result, jc.IsFalse)
+}

--- a/core/network/linklayer.go
+++ b/core/network/linklayer.go
@@ -8,34 +8,6 @@ import (
 	"strings"
 )
 
-// AddressConfigMethod is the method used to configure a link-layer device's IP
-// address.
-type AddressConfigMethod string
-
-const (
-	// LoopbackAddress is used for IP addresses of LoopbackDevice types.
-	LoopbackAddress AddressConfigMethod = "loopback"
-
-	// StaticAddress is used for statically configured addresses.
-	StaticAddress AddressConfigMethod = "static"
-
-	// DynamicAddress is used for addresses dynamically configured via DHCP.
-	DynamicAddress AddressConfigMethod = "dynamic"
-
-	// ManualAddress is used for manually configured addresses.
-	ManualAddress AddressConfigMethod = "manual"
-)
-
-// IsValidAddressConfigMethod returns whether the given value is a valid method
-// to configure a link-layer network device's IP address.
-func IsValidAddressConfigMethod(value string) bool {
-	switch AddressConfigMethod(value) {
-	case LoopbackAddress, StaticAddress, DynamicAddress, ManualAddress:
-		return true
-	}
-	return false
-}
-
 // LinkLayerDeviceType defines the type of a link-layer network device.
 type LinkLayerDeviceType string
 

--- a/core/network/linklayer_test.go
+++ b/core/network/linklayer_test.go
@@ -141,28 +141,3 @@ func (s *linkLayerSuite) TestStringLengthBetweenWhenWithinLimit(c *gc.C) {
 		c.Check(result, jc.IsTrue)
 	}
 }
-
-func (s *linkLayerSuite) TestIsValidAddressConfigMethodWithValidValues(c *gc.C) {
-	validTypes := []AddressConfigMethod{
-		LoopbackAddress,
-		StaticAddress,
-		DynamicAddress,
-		ManualAddress,
-	}
-
-	for _, value := range validTypes {
-		result := IsValidAddressConfigMethod(string(value))
-		c.Check(result, jc.IsTrue)
-	}
-}
-
-func (s *linkLayerSuite) TestIsValidAddressConfigMethodWithInvalidValues(c *gc.C) {
-	result := IsValidAddressConfigMethod("")
-	c.Check(result, jc.IsFalse)
-
-	result = IsValidAddressConfigMethod("anything")
-	c.Check(result, jc.IsFalse)
-
-	result = IsValidAddressConfigMethod(" ")
-	c.Check(result, jc.IsFalse)
-}

--- a/network/containerizer/bridgepolicy_integration_test.go
+++ b/network/containerizer/bridgepolicy_integration_test.go
@@ -99,7 +99,7 @@ func (s *bridgePolicyStateSuite) createNICWithIPAndPortType(c *gc.C, machine con
 		state.LinkLayerDeviceAddress{
 			DeviceName:   deviceName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -119,7 +119,7 @@ func (s *bridgePolicyStateSuite) createBridgeWithIP(c *gc.C, machine containeriz
 		state.LinkLayerDeviceAddress{
 			DeviceName:   bridgeName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -160,7 +160,7 @@ func (s *bridgePolicyStateSuite) createLoopbackNIC(c *gc.C, machine containerize
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "lo",
 			CIDRAddress:  "127.0.0.1/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -275,7 +275,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesCorrectlyP
 		devAddresses[i] = state.LinkLayerDeviceAddress{
 			DeviceName:   devArg.Name,
 			CIDRAddress:  fmt.Sprintf("10.%d.0.10/24", subnet),
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		}
 	}
 
@@ -357,7 +357,7 @@ func (s *bridgePolicyStateSuite) TestPopulateContainerLinkLayerDevicesHostOneSpa
 			DeviceName: "br-eth0",
 			// In the DMZ subnet
 			CIDRAddress:  "10.10.0.20/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -995,7 +995,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerBondedNICs(c 
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "zbond0",
 			CIDRAddress:  "10.0.0.10/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 		// TODO(jam): 2016-12-20 These devices *shouldn't* have IP addresses
 		// when they are in a bond, however eventually we should detect what
@@ -1005,12 +1005,12 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerBondedNICs(c 
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "eth0",
 			CIDRAddress:  "10.0.0.11/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "eth1",
 			CIDRAddress:  "10.0.0.12/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1054,7 +1054,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerVLAN(c *gc.C)
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "eth0.100",
 			CIDRAddress:  "10.10.0.11/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1119,12 +1119,12 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerVLANOnBond(c 
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "bond0",
 			CIDRAddress:  "10.0.0.20/24", // somespace
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "bond0.100",
 			CIDRAddress:  "10.10.0.20/24", // dmz
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -537,7 +537,7 @@ func (s *ApplicationSuite) assignUnitOnMachineWithSpaceToApplication(c *gc.C, a 
 	err = m1.SetDevicesAddresses(state.LinkLayerDeviceAddress{
 		DeviceName:   "enp5s0",
 		CIDRAddress:  "10.0.254.42/24",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 	})
 	c.Assert(err, gc.IsNil)
 

--- a/state/ipaddresses_internal_test.go
+++ b/state/ipaddresses_internal_test.go
@@ -88,7 +88,7 @@ func (s *ipAddressesInternalSuite) TestGlobalKeyMethod(c *gc.C) {
 
 func (s *ipAddressesInternalSuite) TestStringIncludesConfigMethodAndValue(c *gc.C) {
 	doc := ipAddressDoc{
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		Value:        "0.1.2.3",
 		MachineID:    "42",
 		DeviceName:   "eno1",
@@ -107,7 +107,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 		DeviceName:       "eth0",
 		MachineID:        "42",
 		SubnetCIDR:       "10.20.30.0/24",
-		ConfigMethod:     network.StaticAddress,
+		ConfigMethod:     network.ConfigStatic,
 		Value:            "10.20.30.40",
 		DNSServers:       []string{"ns1.example.com", "ns2.example.org"},
 		DNSSearchDomains: []string{"example.com", "example.org"},
@@ -120,7 +120,7 @@ func (s *ipAddressesInternalSuite) TestRemainingSimpleGetterMethods(c *gc.C) {
 	c.Check(result.DeviceName(), gc.Equals, "eth0")
 	c.Check(result.MachineID(), gc.Equals, "42")
 	c.Check(result.SubnetCIDR(), gc.Equals, "10.20.30.0/24")
-	c.Check(result.ConfigMethod(), gc.Equals, network.StaticAddress)
+	c.Check(result.ConfigMethod(), gc.Equals, network.ConfigStatic)
 	c.Check(result.Value(), gc.Equals, "10.20.30.40")
 	c.Check(result.DNSServers(), jc.DeepEquals, []string{"ns1.example.com", "ns2.example.org"})
 	c.Check(result.DNSSearchDomains(), jc.DeepEquals, []string{"example.com", "example.org"})

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -81,7 +81,7 @@ func (s *ipAddressesStateSuite) addNamedDeviceWithAddresses(
 	for i, address := range addresses {
 		addressesArgs[i] = state.LinkLayerDeviceAddress{
 			DeviceName:   name,
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  address,
 		}
 	}
@@ -266,7 +266,7 @@ func (s *ipAddressesStateSuite) TestMachineRemoveAllAddressesRemovesProviderIDRe
 	s.addNamedDevice(c, "foo")
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "foo",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 		CIDRAddress:  "0.1.2.3/24",
 		ProviderID:   "bar",
 	}
@@ -468,7 +468,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithEmptyDeviceName(
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithUnknownDeviceName(c *gc.C) {
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:  "0.1.2.3/24",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 		DeviceName:   "missing",
 	}
 	expectedError := `invalid address "0.1.2.3/24": DeviceName "missing" on machine "0" not found`
@@ -491,7 +491,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithInvalidGatewayAd
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:    "0.1.2.3/24",
 		DeviceName:     "eth0",
-		ConfigMethod:   network.StaticAddress,
+		ConfigMethod:   network.ConfigStatic,
 		GatewayAddress: "boo hoo",
 	}
 	s.assertSetDevicesAddressesFailsValidationForArgs(c, args, `GatewayAddress "boo hoo" not valid`)
@@ -502,7 +502,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesOKWhenCIDRAddressDoesNotM
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:  "192.168.123.42/16",
 		DeviceName:   "eth0",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 	}
 	err := s.machine.SetDevicesAddresses(args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -536,7 +536,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenCIDRAddressMatch
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:  "10.20.30.40/16",
 		DeviceName:   "eth0",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 	}
 	expectedError := fmt.Sprintf(
 		"invalid address %q: subnet %q is not alive",
@@ -553,7 +553,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWhenMachineNotAliveO
 	args := state.LinkLayerDeviceAddress{
 		CIDRAddress:  "10.20.30.40/16",
 		DeviceName:   "eth0",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 	}
 	err = s.otherStateMachine.SetDevicesAddresses(args)
 	c.Assert(err, gc.ErrorMatches, `.*: machine "0" not alive`)
@@ -573,7 +573,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesUpdatesExistingDocs(c *gc
 	setArgs := []state.LinkLayerDeviceAddress{{
 		// All fields that can be set are included below.
 		DeviceName:       "eth0",
-		ConfigMethod:     network.ManualAddress,
+		ConfigMethod:     network.ConfigManual,
 		CIDRAddress:      "0.1.2.3/24",
 		ProviderID:       "id-0123",
 		DNSServers:       []string{"ns1.example.com", "ns2.example.org"},
@@ -583,7 +583,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesUpdatesExistingDocs(c *gc
 		// No changed fields, just the required values are set: CIDRAddress +
 		// DeviceName (and s.machine.Id) are used to construct the DocID.
 		DeviceName:   "eth0",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 		CIDRAddress:  "10.20.30.42/16",
 	}}
 	err := s.machine.SetDevicesAddresses(setArgs...)
@@ -605,7 +605,7 @@ func (s *ipAddressesStateSuite) TestRemoveAddressRemovesProviderID(c *gc.C) {
 	device := s.addNamedDevice(c, "eth0")
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		ProviderID:   "id-0123",
 	}
@@ -626,7 +626,7 @@ func (s *ipAddressesStateSuite) TestChangeOriginOpsNoProviderID(c *gc.C) {
 
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		Origin:       network.OriginMachine,
 	}
@@ -654,7 +654,7 @@ func (s *ipAddressesStateSuite) TestChangeOriginOpsWithProviderID(c *gc.C) {
 
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		Origin:       network.OriginProvider,
 		ProviderID:   "p1",
@@ -682,7 +682,7 @@ func (s *ipAddressesStateSuite) TestChangeOriginOpsWithProviderID(c *gc.C) {
 	// Success means the provider ID was removed from the global collection.
 	addrArgs = state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		Origin:       network.OriginProvider,
 		ProviderID:   "p1",
@@ -696,7 +696,7 @@ func (s *ipAddressesStateSuite) TestSetProviderIDOps(c *gc.C) {
 
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		Origin:       network.OriginMachine,
 	}
@@ -733,7 +733,7 @@ func (s *ipAddressesStateSuite) TestSetProviderNetIDsOps(c *gc.C) {
 
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:        "eth0",
-		ConfigMethod:      network.ManualAddress,
+		ConfigMethod:      network.ConfigManual,
 		CIDRAddress:       "0.1.2.3/24",
 		Origin:            network.OriginMachine,
 		ProviderNetworkID: "p-net-1",
@@ -765,7 +765,7 @@ func (s *ipAddressesStateSuite) TestUpdateOps(c *gc.C) {
 
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		Origin:       network.OriginMachine,
 	}
@@ -777,7 +777,7 @@ func (s *ipAddressesStateSuite) TestUpdateOps(c *gc.C) {
 
 	ops, err := addrs[0].UpdateOps(state.LinkLayerDeviceAddress{
 		DeviceName:     "eth0",
-		ConfigMethod:   network.ManualAddress,
+		ConfigMethod:   network.ConfigManual,
 		CIDRAddress:    "0.1.2.3/24",
 		Origin:         network.OriginMachine,
 		GatewayAddress: "0.1.2.0",
@@ -795,7 +795,7 @@ func (s *ipAddressesStateSuite) TestUpdateAddressFailsToChangeProviderID(c *gc.C
 	s.addNamedDevice(c, "eth0")
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 		ProviderID:   "id-0123",
 	}
@@ -810,7 +810,7 @@ func (s *ipAddressesStateSuite) TestUpdateAddressPreventsDuplicateProviderID(c *
 	s.addNamedDevice(c, "eth0")
 	addrArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.ManualAddress,
+		ConfigMethod: network.ConfigManual,
 		CIDRAddress:  "0.1.2.3/24",
 	}
 	err := s.machine.SetDevicesAddresses(addrArgs)
@@ -847,12 +847,12 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesWithMultipleUpdatesOfSame
 		// No changes - same args as used by addNamedDeviceWithAddresses, so
 		// this is testing a no-op case.
 		DeviceName:   "eth0",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 		CIDRAddress:  "0.1.2.3/24",
 	}, {
 		// Change all fields that can change.
 		DeviceName:       "eth0",
-		ConfigMethod:     network.ManualAddress,
+		ConfigMethod:     network.ConfigManual,
 		CIDRAddress:      "0.1.2.3/24",
 		ProviderID:       "id-0123",
 		DNSServers:       []string{"ns1.example.com", "ns2.example.org"},
@@ -861,7 +861,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesWithMultipleUpdatesOfSame
 	}, {
 		// Test deletes work for DNS settings, also change method, and gateway.
 		DeviceName:       "eth0",
-		ConfigMethod:     network.DynamicAddress,
+		ConfigMethod:     network.ConfigDHCP,
 		CIDRAddress:      "0.1.2.3/24",
 		ProviderID:       "id-0123", // not allowed to change ProviderID once set
 		DNSServers:       nil,
@@ -901,13 +901,13 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesMultipleDevicesWithSameAd
 	addressArgs := []state.LinkLayerDeviceAddress{
 		{
 			DeviceName:   "eth2",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  "0.1.2.3/24",
 			ProviderID:   network.Id(providerID),
 		},
 		{
 			DeviceName:   "br0",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  "0.1.2.3/24",
 			ProviderID:   network.Id(providerID),
 		},
@@ -917,7 +917,7 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesMultipleDevicesWithSameAd
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that we can still change one of the addresses.
-	addressArgs[0].ConfigMethod = network.DynamicAddress
+	addressArgs[0].ConfigMethod = network.ConfigDHCP
 	err = s.machine.SetDevicesAddresses(addressArgs[0])
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -930,13 +930,13 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesMultipleDevicesWithSameAd
 	addressArgs := []state.LinkLayerDeviceAddress{
 		{
 			DeviceName:   "eth2",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  "0.1.2.3/24",
 			ProviderID:   network.Id(providerID),
 		},
 		{
 			DeviceName:   "br0",
-			ConfigMethod: network.StaticAddress,
+			ConfigMethod: network.ConfigStatic,
 			CIDRAddress:  "0.1.2.4/24",
 			ProviderID:   network.Id(providerID),
 		},
@@ -971,7 +971,7 @@ func (s *ipAddressesStateSuite) addDeviceWithAddressAndProviderIDForMachine(
 	device := s.addNamedDeviceForMachine(c, "eth0", machine)
 	addressArgs := state.LinkLayerDeviceAddress{
 		DeviceName:   "eth0",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 		CIDRAddress:  "0.1.2.3/24",
 		ProviderID:   network.Id(providerID),
 	}

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -476,16 +476,6 @@ func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithUnknownDeviceNam
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithInvalidConfigMethod(c *gc.C) {
-	s.addNamedDevice(c, "eth0")
-	args := state.LinkLayerDeviceAddress{
-		CIDRAddress:  "0.1.2.3/24",
-		DeviceName:   "eth0",
-		ConfigMethod: "something else",
-	}
-	s.assertSetDevicesAddressesFailsValidationForArgs(c, args, `ConfigMethod "something else" not valid`)
-}
-
 func (s *ipAddressesStateSuite) TestSetDevicesAddressesFailsWithInvalidGatewayAddress(c *gc.C) {
 	s.addNamedDevice(c, "eth0")
 	args := state.LinkLayerDeviceAddress{

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -47,7 +47,7 @@ type ipAddressDoc struct {
 	SubnetCIDR string `bson:"subnet-cidr"`
 
 	// ConfigMethod is the method used to configure this IP address.
-	ConfigMethod network.AddressConfigMethod `bson:"config-method"`
+	ConfigMethod network.AddressConfigType `bson:"config-method"`
 
 	// Value is the value of the configured IP address, e.g. 192.168.1.2 or
 	// 2001:db8::/64.
@@ -168,14 +168,14 @@ func (addr *Address) Subnet() (*Subnet, error) {
 }
 
 // ConfigMethod returns the AddressConfigMethod used for this IP address.
-func (addr *Address) ConfigMethod() network.AddressConfigMethod {
+func (addr *Address) ConfigMethod() network.AddressConfigType {
 	return addr.doc.ConfigMethod
 }
 
 // LoopbackConfigMethod returns whether AddressConfigMethod used for this IP
 // address was loopback.
 func (addr *Address) LoopbackConfigMethod() bool {
-	return addr.doc.ConfigMethod == network.LoopbackAddress
+	return addr.doc.ConfigMethod == network.ConfigLoopback
 }
 
 // Value returns the value of this IP address.

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -734,7 +734,7 @@ func (s *linkLayerDevicesStateSuite) createNICWithIP(c *gc.C, machine *state.Mac
 		state.LinkLayerDeviceAddress{
 			DeviceName:   deviceName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -754,7 +754,7 @@ func (s *linkLayerDevicesStateSuite) createLoopbackNIC(c *gc.C, machine *state.M
 		state.LinkLayerDeviceAddress{
 			DeviceName:   "lo",
 			CIDRAddress:  "127.0.0.1/24",
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -774,7 +774,7 @@ func (s *linkLayerDevicesStateSuite) createBridgeWithIP(c *gc.C, machine *state.
 		state.LinkLayerDeviceAddress{
 			DeviceName:   bridgeName,
 			CIDRAddress:  cidrAddress,
-			ConfigMethod: corenetwork.StaticAddress,
+			ConfigMethod: corenetwork.ConfigStatic,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1097,14 +1097,14 @@ func (s *linkLayerDevicesStateSuite) TestSetDeviceAddressesWithSubnetID(c *gc.C)
 	err = s.machine.SetDevicesAddresses(
 		state.LinkLayerDeviceAddress{
 			DeviceName:        "eth1",
-			ConfigMethod:      corenetwork.StaticAddress,
+			ConfigMethod:      corenetwork.ConfigStatic,
 			ProviderNetworkID: "vpc-abcd",
 			ProviderSubnetID:  "prov-ffff",
 			CIDRAddress:       "10.20.0.42/24",
 		},
 		state.LinkLayerDeviceAddress{
 			DeviceName:        "eth2",
-			ConfigMethod:      corenetwork.StaticAddress,
+			ConfigMethod:      corenetwork.ConfigStatic,
 			ProviderNetworkID: "vpc-abcd",
 			ProviderSubnetID:  "prov-abcd",
 			CIDRAddress:       "10.30.0.99/24",

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -567,6 +567,9 @@ func (a *LinkLayerDeviceAddress) addressAndSubnet() (string, string, error) {
 // - errors.NotValidError, when any of the fields in args contain invalid values;
 // - errors.NotFoundError, when any DeviceName in args refers to unknown device;
 // - ErrProviderIDNotUnique, when one or more specified ProviderIDs are not unique.
+//
+// Deprecated: (manadart 2021-05-04) This method is only used by tests and is in
+// the process of removal. Do not add new usages of it.
 func (m *Machine) SetDevicesAddresses(devicesAddresses ...LinkLayerDeviceAddress) (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot set link-layer device addresses of machine %q", m.doc.Id)
 	if len(devicesAddresses) == 0 {
@@ -640,10 +643,6 @@ func (m *Machine) validateSetDevicesAddressesArgs(args *LinkLayerDeviceAddress) 
 	}
 	if err := m.verifyDeviceAlreadyExists(args.DeviceName); err != nil {
 		return errors.Trace(err)
-	}
-
-	if !corenetwork.IsValidAddressConfigType(string(args.ConfigMethod)) {
-		return errors.NotValidf("ConfigMethod %q", args.ConfigMethod)
 	}
 
 	if args.GatewayAddress != "" {

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -501,7 +501,7 @@ type LinkLayerDeviceAddress struct {
 	DeviceName string
 
 	// ConfigMethod is the method used to configure this address.
-	ConfigMethod corenetwork.AddressConfigMethod
+	ConfigMethod corenetwork.AddressConfigType
 
 	// ProviderID is the provider-specific ID of the address. Empty when not
 	// supported. Cannot be changed once set to non-empty.
@@ -642,7 +642,7 @@ func (m *Machine) validateSetDevicesAddressesArgs(args *LinkLayerDeviceAddress) 
 		return errors.Trace(err)
 	}
 
-	if !corenetwork.IsValidAddressConfigMethod(string(args.ConfigMethod)) {
+	if !corenetwork.IsValidAddressConfigType(string(args.ConfigMethod)) {
 		return errors.NotValidf("ConfigMethod %q", args.ConfigMethod)
 	}
 

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1448,7 +1448,7 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.LinkLayerDeviceAddress{
 		DeviceName:        "foo",
-		ConfigMethod:      network.StaticAddress,
+		ConfigMethod:      network.ConfigStatic,
 		CIDRAddress:       "0.1.2.3/24",
 		ProviderID:        "bar",
 		DNSServers:        []string{"bam", "mam"},
@@ -1470,7 +1470,7 @@ func (s *MigrationExportSuite) TestIPAddresses(c *gc.C) {
 	c.Assert(addr.Value(), gc.Equals, "0.1.2.3")
 	c.Assert(addr.MachineID(), gc.Equals, machine.Id())
 	c.Assert(addr.DeviceName(), gc.Equals, "foo")
-	c.Assert(addr.ConfigMethod(), gc.Equals, string(network.StaticAddress))
+	c.Assert(addr.ConfigMethod(), gc.Equals, string(network.ConfigStatic))
 	c.Assert(addr.SubnetCIDR(), gc.Equals, "0.1.2.0/24")
 	c.Assert(addr.ProviderID(), gc.Equals, "bar")
 	c.Assert(addr.DNSServers(), jc.DeepEquals, []string{"bam", "mam"})
@@ -1496,7 +1496,7 @@ func (s *MigrationExportSuite) TestIPAddressesSkipped(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.LinkLayerDeviceAddress{
 		DeviceName:       "foo",
-		ConfigMethod:     network.StaticAddress,
+		ConfigMethod:     network.ConfigStatic,
 		CIDRAddress:      "0.1.2.3/24",
 		ProviderID:       "bar",
 		DNSServers:       []string{"bam", "mam"},

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2043,6 +2043,12 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 
 	modelUUID := i.st.ModelUUID()
 
+	// Compatibility shim for deployments prior to 2.9.1.
+	configType := addr.ConfigMethod()
+	if configType == "dynamic" {
+		configType = string(network.ConfigDHCP)
+	}
+
 	newDoc := &ipAddressDoc{
 		DocID:             ipAddressDocID,
 		ModelUUID:         modelUUID,
@@ -2050,7 +2056,7 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 		DeviceName:        addr.DeviceName(),
 		MachineID:         addr.MachineID(),
 		SubnetCIDR:        subnetCIDR,
-		ConfigMethod:      network.AddressConfigType(addr.ConfigMethod()),
+		ConfigMethod:      network.AddressConfigType(configType),
 		Value:             addressValue,
 		DNSServers:        addr.DNSServers(),
 		DNSSearchDomains:  addr.DNSSearchDomains(),

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2050,7 +2050,7 @@ func (i *importer) addIPAddress(addr description.IPAddress) error {
 		DeviceName:        addr.DeviceName(),
 		MachineID:         addr.MachineID(),
 		SubnetCIDR:        subnetCIDR,
-		ConfigMethod:      network.AddressConfigMethod(addr.ConfigMethod()),
+		ConfigMethod:      network.AddressConfigType(addr.ConfigMethod()),
 		Value:             addressValue,
 		DNSServers:        addr.DNSServers(),
 		DNSSearchDomains:  addr.DNSSearchDomains(),

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1788,7 +1788,7 @@ func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	args := state.LinkLayerDeviceAddress{
 		DeviceName:        "foo",
-		ConfigMethod:      network.StaticAddress,
+		ConfigMethod:      network.ConfigStatic,
 		CIDRAddress:       "0.1.2.3/24",
 		ProviderID:        "bar",
 		DNSServers:        []string{"bam", "mam"},
@@ -1810,7 +1810,7 @@ func (s *MigrationImportSuite) TestIPAddress(c *gc.C) {
 	c.Assert(addr.Value(), gc.Equals, "0.1.2.3")
 	c.Assert(addr.MachineID(), gc.Equals, machine.Id())
 	c.Assert(addr.DeviceName(), gc.Equals, "foo")
-	c.Assert(addr.ConfigMethod(), gc.Equals, network.StaticAddress)
+	c.Assert(addr.ConfigMethod(), gc.Equals, network.ConfigStatic)
 	c.Assert(addr.SubnetCIDR(), gc.Equals, "0.1.2.0/24")
 	c.Assert(addr.ProviderID(), gc.Equals, network.Id("bar"))
 	c.Assert(addr.DNSServers(), jc.DeepEquals, []string{"bam", "mam"})

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2684,8 +2684,8 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	)
 	c.Assert(err, gc.IsNil)
 	err = m1.SetDevicesAddresses(
-		state.LinkLayerDeviceAddress{DeviceName: "enp5s0", CIDRAddress: "10.0.0.1/24", ConfigMethod: network.StaticAddress},
-		state.LinkLayerDeviceAddress{DeviceName: "enp5s1", CIDRAddress: "10.0.254.42/24", ConfigMethod: network.StaticAddress},
+		state.LinkLayerDeviceAddress{DeviceName: "enp5s0", CIDRAddress: "10.0.0.1/24", ConfigMethod: network.ConfigStatic},
+		state.LinkLayerDeviceAddress{DeviceName: "enp5s1", CIDRAddress: "10.0.254.42/24", ConfigMethod: network.ConfigStatic},
 	)
 	c.Assert(err, gc.IsNil)
 
@@ -2714,7 +2714,7 @@ func (s *UnitSuite) TestWatchMachineAndEndpointAddressesHash(c *gc.C) {
 	err = m1.SetDevicesAddresses(state.LinkLayerDeviceAddress{
 		DeviceName:   "enp5s0",
 		CIDRAddress:  "10.0.0.100/24",
-		ConfigMethod: network.StaticAddress,
+		ConfigMethod: network.ConfigStatic,
 	})
 	c.Assert(err, gc.IsNil)
 	err = m1.SetProviderAddresses(network.NewSpaceAddress("10.0.0.100"))


### PR DESCRIPTION
For some time we've had the types `AddressConfigType` and `AddressConfigMethod` kicking around. These are essentially duplicates with the exception of one using "dynamic" (from [man page](https://manpages.debian.org/jessie/ifupdown/interfaces.5.en.html)) where the other uses "dhcp".

Removing `AddressConfigMethod` is the smallest change in terms API compatibility, but requires a DB upgrade to change "dynamic" to "dhcp" (which happens to be a correction too, as these mean different things). A patch for this will follow.

Members are not renamed in this patch, but will be later as a mechanical step. This eases review.

## QA steps

For these scenarios:
- Bootstrapped with this patch.
- Bootstrapped with 2.8 and a controller (only) upgraded to this patch;

Check that machine and container-in-machine provisioning work on:
- MAAS (container-networking-method=provider)
- AWS (container-networking-method=fan)

## Documentation changes

None.

## Bug reference

N/A
