### PR TITLE
[2.9] Select default charm url depending on controller version

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -792,9 +792,21 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		return c.NewDownloadClient()
 	}
 
-	charmAdapter := c.NewResolver(apicharms.NewClient(apiRoot), csRepoFn, downloadClientFn)
+	charmAPIClient := apicharms.NewClient(apiRoot)
+	charmAdapter := c.NewResolver(charmAPIClient, csRepoFn, downloadClientFn)
 
-	factory, cfg := c.getDeployerFactory()
+	// Check whether the controller includes charmhub support. If not,
+	// assume that the default schema for charms URL without one is
+	// charm.Charmstore. Otherwise use charm.Charmhub.
+	//
+	// This ensures that we don't break backwards compatibility when using
+	// a 2.9 client and run "juju deploy X" against a 2.8 controller.
+	defaultCharmSchema := charm.CharmHub
+	if charmAPIClient.BestAPIVersion() < 3 {
+		defaultCharmSchema = charm.CharmStore
+	}
+
+	factory, cfg := c.getDeployerFactory(defaultCharmSchema)
 	deploy, err := factory.GetDeployer(cfg, apiRoot, charmAdapter)
 	if err != nil {
 		return errors.Trace(err)
@@ -838,7 +850,7 @@ func (c *DeployCommand) getMeteringAPIURL(controllerAPIRoot api.Connection) (str
 	return controllerCfg.MeteringURL(), nil
 }
 
-func (c *DeployCommand) getDeployerFactory() (deployer.DeployerFactory, deployer.DeployerConfig) {
+func (c *DeployCommand) getDeployerFactory(defaultCharmSchema charm.Schema) (deployer.DeployerFactory, deployer.DeployerConfig) {
 	dep := deployer.DeployerDependencies{
 		Model:                c,
 		FileSystem:           c.ModelCommandBase.Filesystem(),
@@ -847,30 +859,31 @@ func (c *DeployCommand) getDeployerFactory() (deployer.DeployerFactory, deployer
 		Steps:                c.Steps,
 	}
 	cfg := deployer.DeployerConfig{
-		ApplicationName:   c.ApplicationName,
-		AttachStorage:     c.AttachStorage,
-		Bindings:          c.Bindings,
-		BundleDevices:     c.BundleDevices,
-		BundleMachines:    c.BundleMachines,
-		BundleOverlayFile: c.BundleOverlayFile,
-		BundleStorage:     c.BundleStorage,
-		Channel:           c.Channel,
-		CharmOrBundle:     c.CharmOrBundle,
-		ConfigOptions:     c.ConfigOptions,
-		Constraints:       c.Constraints,
-		ModelConstraints:  c.ModelConstraints,
-		Devices:           c.Devices,
-		DryRun:            c.DryRun,
-		FlagSet:           c.flagSet,
-		Force:             c.Force,
-		NumUnits:          c.NumUnits,
-		PlacementSpec:     c.PlacementSpec,
-		Placement:         c.Placement,
-		Resources:         c.Resources,
-		Series:            c.Series,
-		Storage:           c.Storage,
-		Trust:             c.Trust,
-		UseExisting:       c.UseExisting,
+		ApplicationName:    c.ApplicationName,
+		AttachStorage:      c.AttachStorage,
+		Bindings:           c.Bindings,
+		BundleDevices:      c.BundleDevices,
+		BundleMachines:     c.BundleMachines,
+		BundleOverlayFile:  c.BundleOverlayFile,
+		BundleStorage:      c.BundleStorage,
+		Channel:            c.Channel,
+		CharmOrBundle:      c.CharmOrBundle,
+		DefaultCharmSchema: defaultCharmSchema,
+		ConfigOptions:      c.ConfigOptions,
+		Constraints:        c.Constraints,
+		ModelConstraints:   c.ModelConstraints,
+		Devices:            c.Devices,
+		DryRun:             c.DryRun,
+		FlagSet:            c.flagSet,
+		Force:              c.Force,
+		NumUnits:           c.NumUnits,
+		PlacementSpec:      c.PlacementSpec,
+		Placement:          c.Placement,
+		Resources:          c.Resources,
+		Series:             c.Series,
+		Storage:            c.Storage,
+		Trust:              c.Trust,
+		UseExisting:        c.UseExisting,
 	}
 	return c.NewDeployerFactory(dep), cfg
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2471,11 +2471,12 @@ func basicDeployerConfig(charmOrBundle string) deployer.DeployerConfig {
 	cfgOps := common.ConfigFlag{}
 	cfgOps.SetPreserveStringValue(true)
 	return deployer.DeployerConfig{
-		BundleMachines: map[string]string{},
-		CharmOrBundle:  charmOrBundle,
-		ConfigOptions:  cfgOps,
-		Constraints:    constraints.Value{},
-		NumUnits:       1,
+		BundleMachines:     map[string]string{},
+		CharmOrBundle:      charmOrBundle,
+		ConfigOptions:      cfgOps,
+		Constraints:        constraints.Value{},
+		NumUnits:           1,
+		DefaultCharmSchema: charm.CharmHub,
 	}
 }
 
@@ -2875,7 +2876,7 @@ func vanillaFakeModelAPI(cfgAttrs map[string]interface{}) *fakeDeployAPI {
 	fakeAPI.Call("ModelGet").Returns(cfgAttrs, error(nil))
 	fakeAPI.Call("ModelUUID").Returns("deadbeef-0bad-400d-8000-4b1d0d06f00d", true)
 	fakeAPI.Call("BestFacadeVersion", "Application").Returns(6)
-	fakeAPI.Call("BestFacadeVersion", "Charms").Returns(2)
+	fakeAPI.Call("BestFacadeVersion", "Charms").Returns(3)
 
 	return fakeAPI
 }

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -37,6 +37,11 @@ type deployBundle struct {
 	origin            commoncharm.Origin
 	modelConstraints  constraints.Value
 
+	// The default schema to use for charms that do not specify one. The
+	// value depends on whether we are deploying to a 2.9+ or an older
+	// controller.
+	defaultCharmSchema charm.Schema
+
 	resolver             Resolver
 	authorizer           store.MacaroonGetter
 	newConsumeDetailsAPI func(url *charm.OfferURL) (ConsumeDetails, error)
@@ -114,7 +119,7 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 			for _, step := range d.steps {
 				s := step
 
-				charmURL, err := resolveCharmURL(applicationSpec.Charm)
+				charmURL, err := resolveCharmURL(applicationSpec.Charm, d.defaultCharmSchema)
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -163,7 +168,7 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 	// TODO(ericsnow) Do something with the CS macaroons that were returned?
 	// Deploying bundles does not allow the use force, it's expected that the
 	// bundle is correct and therefore the charms are also.
-	if _, err := bundleDeploy(bundleData, spec); err != nil {
+	if _, err := bundleDeploy(d.defaultCharmSchema, bundleData, spec); err != nil {
 		return errors.Annotate(err, "cannot deploy bundle")
 	}
 	return nil

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -83,7 +83,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleNotFoundCharmStore(c *gc.C
 		},
 	}
 
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, gc.ErrorMatches, `cannot resolve charm or bundle "no-such": bundle not found`)
 }
 
@@ -116,7 +116,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSuccess(c *gc.C) {
 	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "xenial")
@@ -186,7 +186,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeries(c *gc.C)
 
 	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundleInvalidSeries))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, gc.ErrorMatches, "mysql is not available on the following series: precise not supported")
 }
 
@@ -225,7 +225,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeriesWithForce
 	c.Assert(err, jc.ErrorIsNil)
 	spec := s.bundleDeploySpec()
 	spec.force = true
-	_, err = bundleDeploy(bundleData, spec)
+	_, err = bundleDeploy(charm.CharmHub, bundleData, spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
@@ -296,7 +296,7 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	bundleData, err := charm.ReadBundleData(strings.NewReader(kubernetesGitlabBundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "kubernetes")
@@ -360,7 +360,7 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccessWithCharm
 	bundleData, err := charm.ReadBundleData(strings.NewReader(kubernetesCharmhubGitlabBundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "focal")
@@ -423,7 +423,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleStorage(c *gc.C) {
 	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundleWithStorage))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
@@ -504,7 +504,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleDevices(c *gc.C) {
 			},
 		},
 	}
-	_, err = bundleDeploy(bundleData, spec)
+	_, err = bundleDeploy(charm.CharmHub, bundleData, spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, dashboardCurl.String(), dashboardCurl.Name, "kubernetes")
@@ -571,7 +571,7 @@ func (s *BundleDeployRepositorySuite) TestDryRunExistingModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	spec := s.bundleDeploySpec()
-	_, err = bundleDeploy(bundleData, spec)
+	_, err = bundleDeploy(charm.CharmHub, bundleData, spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.deployArgs, gc.HasLen, 2)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
@@ -603,7 +603,7 @@ func (s *BundleDeployRepositorySuite) TestDryRunExistingModel(c *gc.C) {
 	spec.dryRun = true
 	spec.useExistingMachines = true
 	spec.bundleMachines = map[string]string{}
-	_, err = bundleDeploy(bundleData, spec)
+	_, err = bundleDeploy(charm.CharmHub, bundleData, spec)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, expectedOutput)
 }
@@ -641,7 +641,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleInvalidMachineContainerTyp
 
 	bundleData, err := charm.ReadBundleData(strings.NewReader(quickBundle))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, gc.ErrorMatches, `cannot create machine for holding wp unit: invalid container type "bad"`)
 }
 
@@ -698,7 +698,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedToMachines(c *gc
 
 	bundleData, err := charm.ReadBundleData(strings.NewReader(quickBundle))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"wordpress\" in charm-store, revision 47\n"+
@@ -749,7 +749,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
    `
 	bundleData, err := charm.ReadBundleData(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.output.String(), gc.Equals, ""+
@@ -821,7 +821,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMultipleRelations(c *gc.C)
    `
 	bundleData, err := charm.ReadBundleData(strings.NewReader(content))
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "bionic")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "bionic")
@@ -894,7 +894,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleLocalDeployment(c *gc.C) {
 	bundleData, err := charm.ReadBundleData(strings.NewReader(bundle))
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = bundleDeploy(bundleData, s.bundleDeploySpec())
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "xenial")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "xenial")

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -224,28 +224,42 @@ func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
 
 func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
 	tests := []struct {
-		path string
-		url  *charm.URL
-		err  error
+		defaultSchema charm.Schema
+		path          string
+		url           *charm.URL
+		err           error
 	}{{
-		path: "wordpress",
-		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "wordpress",
+		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
 	}, {
-		path: "ch:wordpress",
-		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "ch:wordpress",
+		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
 	}, {
-		path: "cs:wordpress",
-		url:  &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "cs:wordpress",
+		url:           &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
 	}, {
-		path: "local:wordpress",
-		url:  &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "local:wordpress",
+		url:           &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
 	}, {
-		path: "cs:~user/series/name",
-		url:  &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "cs:~user/series/name",
+		url:           &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
+	}, {
+		defaultSchema: charm.CharmHub,
+		path:          "wordpress",
+		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
+	}, {
+		defaultSchema: charm.CharmStore,
+		path:          "wordpress",
+		url:           &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
 	}}
 	for i, test := range tests {
 		c.Logf("%d %s", i, test.path)
-		url, err := resolveCharmURL(test.path)
+		url, err := resolveCharmURL(test.path, test.defaultSchema)
 		if test.err != nil {
 			c.Assert(err, gc.ErrorMatches, test.err.Error())
 		} else {
@@ -257,26 +271,39 @@ func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
 
 func (s *deployerSuite) TestResolveAndValidateCharmURL(c *gc.C) {
 	tests := []struct {
-		path string
-		url  *charm.URL
-		err  error
+		defaultSchema charm.Schema
+		path          string
+		url           *charm.URL
+		err           error
 	}{{
-		path: "ch:wordpress-42",
-		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: 42},
-		err:  errors.Errorf("specifying a revision for wordpress is not supported, please use a channel."),
+		defaultSchema: charm.CharmHub,
+		path:          "ch:wordpress-42",
+		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: 42},
+		err:           errors.Errorf("specifying a revision for wordpress is not supported, please use a channel."),
 	}, {
-		path: "ch:wordpress",
-		url:  &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "ch:wordpress",
+		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
 	}, {
-		path: "cs:wordpress-42",
-		url:  &charm.URL{Schema: "cs", Name: "wordpress", Revision: 42},
+		defaultSchema: charm.CharmHub,
+		path:          "cs:wordpress-42",
+		url:           &charm.URL{Schema: "cs", Name: "wordpress", Revision: 42},
 	}, {
-		path: "local:wordpress",
-		url:  &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
+		defaultSchema: charm.CharmHub,
+		path:          "local:wordpress",
+		url:           &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
+	}, {
+		defaultSchema: charm.CharmHub,
+		path:          "wordpress",
+		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
+	}, {
+		defaultSchema: charm.CharmStore,
+		path:          "wordpress-42",
+		url:           &charm.URL{Schema: "cs", Name: "wordpress", Revision: 42},
 	}}
 	for i, test := range tests {
 		c.Logf("%d %s", i, test.path)
-		url, err := resolveAndValidateCharmURL(test.path)
+		url, err := resolveAndValidateCharmURL(test.path, test.defaultSchema)
 		if test.err != nil {
 			c.Assert(err, gc.ErrorMatches, test.err.Error())
 		} else {

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -502,7 +502,7 @@ func (c *refreshCommand) isCharmHubWithRevision(source commoncharm.OriginSource)
 		return true
 	}
 	// EnsureSchema will error if input is an empty string.
-	path, err := charm.EnsureSchema(c.SwitchURL)
+	path, err := charm.EnsureSchema(c.SwitchURL, charm.CharmHub)
 	if err != nil {
 		return false
 	}

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -341,6 +341,22 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	// Select a suitable default URL schema for charm URLs that don't
+	// provide one depending on whether the current controller supports
+	// charmhub (i.e. it is a 2.9+ controller).
+	var defaultCharmSchema = charm.CharmHub
+	if apiRoot.BestFacadeVersion("CharmHub") < 1 {
+		defaultCharmSchema = charm.CharmStore
+	}
+
+	// Ensure that the switchURL (if provided) always contains a schema. If
+	// one is missing inject the default value we selected above.
+	if c.SwitchURL != "" {
+		if c.SwitchURL, err = charm.EnsureSchema(c.SwitchURL, defaultCharmSchema); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	if c.isCharmHubWithRevision(oldOrigin.Source) {
 		return errors.Errorf("specifying a revision is not supported, please use a channel.")
 	}
@@ -501,12 +517,7 @@ func (c *refreshCommand) isCharmHubWithRevision(source commoncharm.OriginSource)
 	if source == commoncharm.OriginCharmHub && c.Revision > -1 {
 		return true
 	}
-	// EnsureSchema will error if input is an empty string.
-	path, err := charm.EnsureSchema(c.SwitchURL, charm.CharmHub)
-	if err != nil {
-		return false
-	}
-	curl, err := charm.ParseURL(path)
+	curl, err := charm.ParseURL(c.SwitchURL)
 	if err != nil {
 		return false
 	}

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -303,7 +303,7 @@ type charmStoreRefresher struct {
 // Allowed will attempt to check if the charm store is allowed to refresh.
 // Depending on the charm url, will then determine if that's true or not.
 func (r *charmStoreRefresher) Allowed(cfg RefresherConfig) (bool, error) {
-	path, err := charm.EnsureSchema(cfg.CharmRef)
+	path, err := charm.EnsureSchema(cfg.CharmRef, charm.CharmHub)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
@@ -375,7 +375,7 @@ type charmHubRefresher struct {
 // Allowed will attempt to check if the charm store is allowed to refresh.
 // Depending on the charm url, will then determine if that's true or not.
 func (r *charmHubRefresher) Allowed(cfg RefresherConfig) (bool, error) {
-	path, err := charm.EnsureSchema(cfg.CharmRef)
+	path, err := charm.EnsureSchema(cfg.CharmRef, charm.CharmHub)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -303,7 +303,7 @@ type charmStoreRefresher struct {
 // Allowed will attempt to check if the charm store is allowed to refresh.
 // Depending on the charm url, will then determine if that's true or not.
 func (r *charmStoreRefresher) Allowed(cfg RefresherConfig) (bool, error) {
-	path, err := charm.EnsureSchema(cfg.CharmRef, charm.CharmHub)
+	path, err := charm.EnsureSchema(cfg.CharmRef, charm.CharmStore)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/cmd/juju/application/store/charmadapter.go
+++ b/cmd/juju/application/store/charmadapter.go
@@ -75,7 +75,7 @@ func (c *CharmAdaptor) ResolveCharm(url *charm.URL, preferredOrigin commoncharm.
 	resolved, err := c.charmsAPI.ResolveCharms([]apicharm.CharmToResolve{{URL: url, Origin: preferredOrigin}})
 	if errors.IsNotSupported(err) {
 		if charm.CharmHub.Matches(url.Schema) {
-			return nil, commoncharm.Origin{}, nil, errors.Trace(err)
+			return nil, commoncharm.Origin{}, nil, errors.NewNotSupported(nil, "charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+.")
 		}
 		return c.resolveCharmFallback(url, preferredOrigin)
 	}

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c
-	github.com/juju/charm/v8 v8.0.0-20210422143038-0e0160321724
+	github.com/juju/charm/v8 v8.0.0-20210504171051-24818e83067e
 	github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/juju/bundlechanges/v4 v4.0.0-20210223105356-e3037fe2412c/go.mod h1:J4
 github.com/juju/charm/v8 v8.0.0-20201117030444-62c13a9fe0f0/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210115142305-1eb0c22cff4e/go.mod h1:3gMi15p+v4CxEquVduhcOoPLWM7IaRB+OZB6bT3Glww=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210422143038-0e0160321724 h1:MtmcLT3nz4fQ6jzueGDilvRGJ5KNYoH6aannrmmKwGA=
-github.com/juju/charm/v8 v8.0.0-20210422143038-0e0160321724/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
+github.com/juju/charm/v8 v8.0.0-20210504171051-24818e83067e h1:ubWctc0P8Qn4fAcubeBXz4PVdodfxg9b4sP2sCD2bpk=
+github.com/juju/charm/v8 v8.0.0-20210504171051-24818e83067e/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
 github.com/juju/charm/v9 v9.0.0-20210421060150-6a300db18162/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charmrepo/v6 v6.0.0-20201118043529-e9fbdc1a746f/go.mod h1:4V0vrJRD/0oxG+D9j/53elHpXiZ1FoBIXdJGm3Jq4Js=
 github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c h1:+p8LWnIJCzmptGw1Tz7mb0EtOjMEZUHARbnW5vI1oSI=


### PR DESCRIPTION
Prior to this PR, 2.9 clients always assumed charmhub (ch) to be the
default charm URL schema for charms URLs without one. This breaks
backward compatibility with older controllers when a 2.9 client attempts
to deploy a charm (`juju deploy wordpress`) without an explicit schema
prefix to a 2.8 controller.

In this case, the client assumes that we try to deploy a charmhub charm to the
controller but since the controller lacks the appropriate APIs, the
charm API client returns back a NotSupported error which the charm
adapter spits out to the user with a totally incomprehensible error:
"ERROR resolve charms not supported".

To address this problem, the client will first check the supported charm
API version and use this information to select the default schema for
schema-less charm URLs. This is accomplished via the updated
charm/v8.EnsureSchema signature which requires the default schema to be
specified.

The default schema is threaded through the various deploy-related
structs (charms/bundles etc.) and is also used by the `juju refresh` command.

Finally, if the user tries to explicitly deploy a charmhub charm against
a pre 2.9 controller, they will get a straightforward error with a
recommendation to update to 2.9+ if they want to use charmhub.

## QA steps

```sh
$ sudo snap install --channel 2.8 juju
$ /snap/bin/juju bootstrap lxd test

# Using the 2.9 client from this PR
$ juju deploy ceph-mon
Located charm "ceph-mon" in charm-store, revision 55
Deploying "ceph-mon" from charm-store charm "ceph-mon", revision 55 in channel stable

$ juju refresh ceph-mon
Looking up metadata for charm-store charm "ceph-mon"
ERROR already running latest charm "ceph-mon"

$ juju refresh ceph-mon --switch influxdb
Looking up metadata for charm-store charm "ceph-mon"
Added charm-store charm "influxdb", revision 23 in channel stable, to the model
Adding endpoint "grafana-source" to default space "alpha"
Adding endpoint "query" to default space "alpha"
Leaving endpoints in "alpha": admin, nrpe-external-master

$ juju refresh ceph-mon --switch ch:wordpress                                                                                               
Looking up metadata for charm-store charm "influxdb"
ERROR charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+.

$ juju deploy ch:wordpress
ERROR charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+.

# Use the following bundle
$ cat b.yaml
series: bionic
applications:
  ceph-mon:
    charm: ceph-mon
    num_units: 1

$ juju remove-application ceph-mon
$ juju deploy ./b.yaml
Located charm "ceph-mon" in charm-store, channel stable
Executing changes:
- upload charm ceph-mon from charm-store for series bionic
- deploy application ceph-mon from charm-store on bionic
- add unit ceph-mon/7 to new machine 7
Deploy of bundle completed.

# Now try this bundle
$ cat ch.yaml
series: bionic
applications:
  wordpress:
    charm: ch:wordpress
    num_units: 1

$ juju deploy ./ch.yaml
ERROR cannot deploy bundle: cannot resolve charm or bundle "wordpress": charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+
```

Please also try the same steps against a 2.9 controller.

## Bug reference
https://bugs.launchpad.net/juju/+bug/1927091