### PR TITLE
Transport NIC config method with addresses instead of device

### DIFF
--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -954,9 +954,9 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoSingleNIC(c
 		Disabled:            false,
 		NoAutoStart:         false,
 		ConfigType:          "static",
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("192.168.0.6", corenetwork.WithCIDR("192.168.0.5/24")),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"192.168.0.6", corenetwork.WithCIDR("192.168.0.5/24"), corenetwork.WithConfigType(corenetwork.ConfigStatic),
+		)},
 		DNSServers:       corenetwork.NewProviderAddresses("8.8.8.8"),
 		DNSSearchDomains: []string{"mydomain"},
 		GatewayAddress:   corenetwork.NewProviderAddress("192.168.0.1"),

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -82,7 +82,7 @@ type BackingSubnetInfo struct {
 // BackingSpace defines the methods supported by a Space entity stored
 // persistently.
 type BackingSpace interface {
-	// ID returns the ID of the space.
+	// Id returns the ID of the space.
 	Id() string
 
 	// Name returns the space name.
@@ -198,7 +198,7 @@ func networkDeviceToStateArgs(dev network.InterfaceInfo) state.LinkLayerDeviceAr
 		Name:            dev.InterfaceName,
 		MTU:             mtu,
 		ProviderID:      dev.ProviderId,
-		Type:            network.LinkLayerDeviceType(dev.InterfaceType),
+		Type:            dev.InterfaceType,
 		MACAddress:      dev.MACAddress,
 		IsAutoStart:     !dev.NoAutoStart,
 		IsUp:            !dev.Disabled,
@@ -239,7 +239,12 @@ func networkAddressToStateArgs(
 		return state.LinkLayerDeviceAddress{}, errors.Trace(err)
 	}
 
-	configType := dev.ConfigType
+	// Prefer the config method supplied with the address.
+	// Fallback first to the device, then to "static".
+	configType := addr.AddressConfigType()
+	if configType == network.ConfigUnknown {
+		configType = dev.ConfigType
+	}
 	if configType == network.ConfigUnknown {
 		configType = network.ConfigStatic
 	}

--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -143,10 +143,13 @@ var observedNetworkConfigs = []params.NetworkConfig{{
 	InterfaceName: "br-eth1.12",
 	InterfaceType: string(network.BridgeDevice),
 	MACAddress:    "aa:bb:cc:dd:ee:f1",
-	CIDR:          "10.12.19.0/24",
-	Address:       "10.12.19.101",
+	Addresses: []params.Address{{
+		Value:       "10.12.19.101",
+		CIDR:        "10.12.19.0/24",
+		ConfigType:  string(network.ConfigStatic),
+		IsSecondary: false,
+	}},
 	MTU:           1500,
-	ConfigType:    string(network.ConfigStatic),
 	NetworkOrigin: params.NetworkOrigin(network.OriginMachine),
 }, {
 	DeviceIndex:   22,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -900,6 +900,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -983,6 +986,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -9568,6 +9574,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -9681,6 +9690,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -10005,6 +10017,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -10284,6 +10299,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -10701,6 +10719,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -10841,6 +10862,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -11441,6 +11465,9 @@
                     "type": "object",
                     "properties": {
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -14642,6 +14669,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -15437,6 +15467,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -20191,6 +20224,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -20376,6 +20412,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -23906,6 +23945,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -26136,6 +26178,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -27102,6 +27147,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -27241,6 +27289,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -33087,6 +33138,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -33830,6 +33884,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {
@@ -43483,6 +43540,9 @@
                         "cidr": {
                             "type": "string"
                         },
+                        "config-type": {
+                            "type": "string"
+                        },
                         "is-secondary": {
                             "type": "boolean"
                         },
@@ -44182,6 +44242,9 @@
                             "$ref": "#/definitions/Address"
                         },
                         "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
                             "type": "string"
                         },
                         "is-secondary": {

--- a/apiserver/params/network_test.go
+++ b/apiserver/params/network_test.go
@@ -262,7 +262,7 @@ func (s *NetworkSuite) TestProviderAddressConversion(c *gc.C) {
 	pAddrs := network.ProviderAddresses{
 		network.NewProviderAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal), network.WithCIDR("1.2.3.0/24")),
 		network.NewProviderAddress("1.2.3.5", network.WithScope(network.ScopeCloudLocal), network.WithSecondary()),
-		network.NewProviderAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
+		network.NewProviderAddress("2.3.4.5", network.WithScope(network.ScopePublic), network.WithConfigType("dhcp")),
 	}
 	pAddrs[0].SpaceName = "test-space"
 	pAddrs[0].ProviderSpaceID = "666"
@@ -275,13 +275,13 @@ func (s *NetworkSuite) TestMachineAddressConversion(c *gc.C) {
 	mAddrs := []network.MachineAddress{
 		network.NewMachineAddress("1.2.3.4", network.WithScope(network.ScopeCloudLocal), network.WithCIDR("1.2.3.0/24")),
 		network.NewMachineAddress("1.2.3.5", network.WithScope(network.ScopeCloudLocal), network.WithSecondary()),
-		network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic)),
+		network.NewMachineAddress("2.3.4.5", network.WithScope(network.ScopePublic), network.WithConfigType("dhcp")),
 	}
 
 	exp := []params.Address{
 		{Value: "1.2.3.4", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address), CIDR: "1.2.3.0/24"},
 		{Value: "1.2.3.5", Scope: string(network.ScopeCloudLocal), Type: string(network.IPv4Address), IsSecondary: true},
-		{Value: "2.3.4.5", Scope: string(network.ScopePublic), Type: string(network.IPv4Address)},
+		{Value: "2.3.4.5", Scope: string(network.ScopePublic), Type: string(network.IPv4Address), ConfigType: "dhcp"},
 	}
 	c.Assert(params.FromMachineAddresses(mAddrs...), jc.DeepEquals, exp)
 }

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1469,11 +1469,11 @@ func (env *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []ins
 				MACAddress:       fmt.Sprintf("aa:bb:cc:dd:ee:f%d", i),
 				Disabled:         i == 2,
 				NoAutoStart:      i%2 != 0,
-				ConfigType:       network.ConfigDHCP,
 				Addresses: network.ProviderAddresses{
 					network.NewProviderAddress(
 						fmt.Sprintf("0.%d.0.%d", (i+1)*10+idIndex, estate.maxAddr+2),
 						network.WithCIDR(fmt.Sprintf("0.%d.0.0/24", (i+1)*10)),
+						network.WithConfigType(network.ConfigDHCP),
 					),
 				},
 				DNSServers: network.NewProviderAddresses("ns1.dummy", "ns2.dummy"),

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -248,10 +248,9 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		MACAddress:       "aa:bb:cc:dd:ee:f0",
 		Disabled:         false,
 		NoAutoStart:      false,
-		ConfigType:       corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("0.10.0.2", corenetwork.WithCIDR("0.10.0.0/24")),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"0.10.0.2", corenetwork.WithCIDR("0.10.0.0/24"), corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		)},
 		DNSServers:     corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress: corenetwork.NewProviderAddress("0.10.0.1"),
 		Origin:         corenetwork.OriginProvider,
@@ -265,10 +264,9 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		MACAddress:       "aa:bb:cc:dd:ee:f1",
 		Disabled:         false,
 		NoAutoStart:      true,
-		ConfigType:       corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("0.20.0.2", corenetwork.WithCIDR("0.20.0.0/24")),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"0.20.0.2", corenetwork.WithCIDR("0.20.0.0/24"), corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		)},
 		DNSServers:     corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress: corenetwork.NewProviderAddress("0.20.0.1"),
 		Origin:         corenetwork.OriginProvider,
@@ -282,15 +280,14 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 		MACAddress:       "aa:bb:cc:dd:ee:f2",
 		Disabled:         true,
 		NoAutoStart:      false,
-		ConfigType:       corenetwork.ConfigDHCP,
-		Addresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress("0.30.0.2", corenetwork.WithCIDR("0.30.0.0/24")),
-		},
+		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			"0.30.0.2", corenetwork.WithCIDR("0.30.0.0/24"), corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		)},
 		DNSServers:     corenetwork.NewProviderAddresses("ns1.dummy", "ns2.dummy"),
 		GatewayAddress: corenetwork.NewProviderAddress("0.30.0.1"),
 		Origin:         corenetwork.OriginProvider,
 	}}
-	infoList, err := e.NetworkInterfaces(s.callCtx, []instance.Id{instance.Id("i-42")})
+	infoList, err := e.NetworkInterfaces(s.callCtx, []instance.Id{"i-42"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(infoList, gc.HasLen, 1)
 	info := infoList[0]
@@ -300,7 +297,7 @@ func (s *suite) TestNetworkInterfaces(c *gc.C) {
 
 	// Test we can induce errors.
 	s.breakMethods(c, e, "NetworkInterfaces")
-	infoList, err = e.NetworkInterfaces(s.callCtx, []instance.Id{instance.Id("i-any")})
+	infoList, err = e.NetworkInterfaces(s.callCtx, []instance.Id{"i-any"})
 	c.Assert(err, gc.ErrorMatches, `dummy\.NetworkInterfaces is broken`)
 	c.Assert(infoList, gc.HasLen, 0)
 }
@@ -369,7 +366,7 @@ func assertInterfaces(c *gc.C, e environs.Environ, opc chan dummy.Operation, exp
 
 func assertSubnets(
 	c *gc.C,
-	e environs.Environ,
+	_ environs.Environ,
 	opc chan dummy.Operation,
 	instId instance.Id,
 	subnetIds []corenetwork.Id,

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1367,7 +1367,6 @@ func mapNetworkInterface(iface amzec2.NetworkInterface, subnet amzec2.Subnet) ne
 		AvailabilityZones: []string{subnet.AvailZone},
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        network.ConfigDHCP,
 		InterfaceType:     network.EthernetDevice,
 		// The describe interface responses that we get back from EC2
 		// define a *list* of private IP addresses with one entry that
@@ -1379,17 +1378,18 @@ func mapNetworkInterface(iface amzec2.NetworkInterface, subnet amzec2.Subnet) ne
 			iface.PrivateIPAddress,
 			network.WithScope(network.ScopeCloudLocal),
 			network.WithCIDR(subnet.CIDRBlock),
+			network.WithConfigType(network.ConfigDHCP),
 		)},
 		Origin: network.OriginProvider,
 	}
 
 	for _, privAddr := range iface.PrivateIPs {
 		if privAddr.Association.PublicIP != "" {
-			ni.ShadowAddresses = append(
-				ni.ShadowAddresses,
-				network.NewProviderAddress(
-					privAddr.Association.PublicIP, network.WithScope(network.ScopePublic)),
-			)
+			ni.ShadowAddresses = append(ni.ShadowAddresses, network.NewProviderAddress(
+				privAddr.Association.PublicIP,
+				network.WithScope(network.ScopePublic),
+				network.WithConfigType(network.ConfigDHCP),
+			))
 		}
 
 		if privAddr.Address == iface.PrivateIPAddress {
@@ -1402,6 +1402,7 @@ func mapNetworkInterface(iface amzec2.NetworkInterface, subnet amzec2.Subnet) ne
 			iface.PrivateIPAddress,
 			network.WithScope(network.ScopeCloudLocal),
 			network.WithCIDR(subnet.CIDRBlock),
+			network.WithConfigType(network.ConfigDHCP),
 		))
 	}
 

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -1713,19 +1713,20 @@ func (t *localServerSuite) assertInterfaceLooksValid(c *gc.C, expIfaceID, expDev
 		VLANTag:          0,
 		Disabled:         false,
 		NoAutoStart:      false,
-		ConfigType:       corenetwork.ConfigDHCP,
 		InterfaceType:    corenetwork.EthernetDevice,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
-			addr, corenetwork.WithScope(corenetwork.ScopeCloudLocal), corenetwork.WithCIDR(cidr)),
-		},
+			addr,
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithCIDR(cidr),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		)},
 		// Each machine is also assigned a shadow IP with the pattern:
 		// 73.37.0.X where X=(provider iface ID + 1)
-		ShadowAddresses: corenetwork.ProviderAddresses{
-			corenetwork.NewProviderAddress(
-				fmt.Sprintf("73.37.0.%d", expIfaceID+1),
-				corenetwork.WithScope(corenetwork.ScopePublic),
-			),
-		},
+		ShadowAddresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
+			fmt.Sprintf("73.37.0.%d", expIfaceID+1),
+			corenetwork.WithScope(corenetwork.ScopePublic),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		)},
 		AvailabilityZones: zones,
 		Origin:            corenetwork.OriginProvider,
 	}

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -217,12 +217,12 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 					iface.NetworkIP,
 					corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 					corenetwork.WithCIDR(details.cidr),
+					corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 				)},
 				ShadowAddresses: shadowAddrs,
 				InterfaceType:   corenetwork.EthernetDevice,
 				Disabled:        false,
 				NoAutoStart:     false,
-				ConfigType:      corenetwork.ConfigDHCP,
 				Origin:          corenetwork.OriginProvider,
 			})
 		}

--- a/provider/gce/environ_network_test.go
+++ b/provider/gce/environ_network_test.go
@@ -155,7 +155,7 @@ func (s *environNetSuite) TestSpecificInstance(c *gc.C) {
 	s.cannedData()
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
 
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, instance.Id("moana"), nil)
+	subnets, err := s.NetEnv.Subnets(s.CallCtx, "moana", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnets, gc.DeepEquals, []corenetwork.SubnetInfo{{
@@ -171,7 +171,7 @@ func (s *environNetSuite) TestSpecificInstanceAndRestrictedSubnets(c *gc.C) {
 	s.cannedData()
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
 
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, instance.Id("moana"), []corenetwork.Id{"go-team"})
+	subnets, err := s.NetEnv.Subnets(s.CallCtx, "moana", []corenetwork.Id{"go-team"})
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnets, gc.DeepEquals, []corenetwork.SubnetInfo{{
@@ -187,7 +187,7 @@ func (s *environNetSuite) TestSpecificInstanceAndRestrictedSubnetsWithMissing(c 
 	s.cannedData()
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
 
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, instance.Id("moana"), []corenetwork.Id{"go-team", "shellac"})
+	subnets, err := s.NetEnv.Subnets(s.CallCtx, "moana", []corenetwork.Id{"go-team", "shellac"})
 	c.Assert(err, gc.ErrorMatches, `subnets \["shellac"\] not found`)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(subnets, gc.IsNil)
@@ -197,7 +197,7 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 	s.cannedData()
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
 
-	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{"moana"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
@@ -212,11 +212,11 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -243,7 +243,7 @@ func (s *environNetSuite) TestNetworkInterfaceInvalidCredentialError(c *gc.C) {
 	})
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	_, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
+	_, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{"moana"})
 	c.Check(err, gc.NotNil)
 	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
@@ -281,8 +281,8 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 	}
 
 	infoLists, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{
-		instance.Id("i-1"),
-		instance.Id("i-2"),
+		"i-1",
+		"i-2",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(infoLists, gc.HasLen, 2)
@@ -299,11 +299,11 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -320,11 +320,11 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.42",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
@@ -340,11 +340,11 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.20.42",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.20.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -355,7 +355,7 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 	baseInst1 := s.NewBaseInstance(c, "i-1")
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst1)}
 
-	infoLists, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("i-1"), instance.Id("bogus")})
+	infoLists, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{"i-1", "bogus"})
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
 	c.Assert(infoLists, gc.HasLen, 2)
 
@@ -371,11 +371,11 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		Origin: corenetwork.OriginProvider,
 	}})
@@ -403,7 +403,7 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 	})
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{"moana"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
@@ -418,11 +418,11 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		Origin: corenetwork.OriginProvider,
 	}, {
@@ -435,11 +435,11 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.20.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.20.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
@@ -466,7 +466,7 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 	}}
 	s.FakeEnviron.Insts = []instances.Instance{s.NewInstanceFromBase(baseInst)}
 
-	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{instance.Id("moana")})
+	infoList, err := s.NetEnv.NetworkInterfaces(s.CallCtx, []instance.Id{"moana"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(infoList, gc.HasLen, 1)
 	infos := infoList[0]
@@ -481,11 +481,11 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.240.0.2",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.240.0.0/16"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),
@@ -528,11 +528,11 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		Origin: corenetwork.OriginProvider,
 	}, {
@@ -545,11 +545,11 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		InterfaceType:     corenetwork.EthernetDevice,
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        corenetwork.ConfigDHCP,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewProviderAddress(
 			"10.0.10.4",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			corenetwork.WithCIDR("10.0.10.0/24"),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
 		)},
 		ShadowAddresses: corenetwork.ProviderAddresses{
 			corenetwork.NewProviderAddress("25.185.142.227", corenetwork.WithScope(corenetwork.ScopePublic)),

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -384,13 +384,12 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 				ParentInterfaceName: "lxdbr0",
 				InterfaceType:       network.EthernetDevice,
 				Origin:              network.OriginProvider,
-				ConfigType:          network.ConfigStatic,
 				ProviderId:          "nic-00:16:3e:19:29:cb",
 				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
 				ProviderNetworkId:   "net-lxdbr0",
-				Addresses: network.ProviderAddresses{
-					network.NewProviderAddress("10.55.158.99", network.WithCIDR("10.55.158.0/24")),
-				},
+				Addresses: network.ProviderAddresses{network.NewProviderAddress(
+					"10.55.158.99", network.WithCIDR("10.55.158.0/24"), network.WithConfigType(network.ConfigStatic),
+				)},
 			},
 			{
 				DeviceIndex:         1,
@@ -400,13 +399,12 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 				ParentInterfaceName: "ovsbr0",
 				InterfaceType:       network.EthernetDevice,
 				Origin:              network.OriginProvider,
-				ConfigType:          network.ConfigStatic,
 				ProviderId:          "nic-00:16:3e:fe:fe:fe",
 				ProviderSubnetId:    "subnet-ovsbr0-10.42.42.0/24",
 				ProviderNetworkId:   "net-ovsbr0",
-				Addresses: network.ProviderAddresses{
-					network.NewProviderAddress("10.42.42.99", network.WithCIDR("10.42.42.0/24")),
-				},
+				Addresses: network.ProviderAddresses{network.NewProviderAddress(
+					"10.42.42.99", network.WithCIDR("10.42.42.0/24"), network.WithConfigType(network.ConfigStatic),
+				)},
 			},
 		},
 	}
@@ -462,13 +460,12 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 				ParentInterfaceName: "lxdbr0",
 				InterfaceType:       network.EthernetDevice,
 				Origin:              network.OriginProvider,
-				ConfigType:          network.ConfigStatic,
 				ProviderId:          "nic-00:16:3e:19:29:cb",
 				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
 				ProviderNetworkId:   "net-lxdbr0",
-				Addresses: network.ProviderAddresses{
-					network.NewProviderAddress("10.55.158.99", network.WithCIDR("10.55.158.0/24")),
-				},
+				Addresses: network.ProviderAddresses{network.NewProviderAddress(
+					"10.55.158.99", network.WithCIDR("10.55.158.0/24"), network.WithConfigType(network.ConfigStatic),
+				)},
 			},
 		},
 		nil, // slot for second instance is nil as the container was not found

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -215,7 +215,7 @@ func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentNa
 		}
 
 		for _, link := range nic.Links {
-			nicInfo.ConfigType = maasLinkToInterfaceConfigType(string(link.Mode))
+			configType := maasLinkToInterfaceConfigType(string(link.Mode))
 
 			if link.IPAddress == "" {
 				logger.Debugf("device %q interface %q has no address", deviceID, nic.Name)
@@ -234,7 +234,10 @@ func (env *maasEnviron) deviceInterfaceInfo(deviceID instance.Id, nameToParentNa
 			// present in the original code. Do we need to revisit
 			// this in the future and append link addresses to the list?
 			nicInfo.Addresses = corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace(
-				link.Subnet.Space, link.IPAddress, corenetwork.WithCIDR(link.Subnet.CIDR),
+				link.Subnet.Space,
+				link.IPAddress,
+				corenetwork.WithCIDR(link.Subnet.CIDR),
+				corenetwork.WithConfigType(configType),
 			)}
 			nicInfo.ProviderSubnetId = corenetwork.Id(strconv.Itoa(link.Subnet.ID))
 			nicInfo.ProviderAddressId = corenetwork.Id(strconv.Itoa(link.ID))
@@ -306,7 +309,7 @@ func (env *maasEnviron) deviceInterfaceInfo2(
 		}
 
 		for _, link := range nic.Links() {
-			nicInfo.ConfigType = maasLinkToInterfaceConfigType(link.Mode())
+			configType := maasLinkToInterfaceConfigType(link.Mode())
 
 			subnet := link.Subnet()
 			if link.IPAddress() == "" || subnet == nil {
@@ -318,7 +321,10 @@ func (env *maasEnviron) deviceInterfaceInfo2(
 			// NOTE(achilleasa): the original code used a last-write-wins
 			// policy. Do we need to append link addresses to the list?
 			nicInfo.Addresses = corenetwork.ProviderAddresses{corenetwork.NewProviderAddressInSpace(
-				subnet.Space(), link.IPAddress(), corenetwork.WithCIDR(subnet.CIDR()),
+				subnet.Space(),
+				link.IPAddress(),
+				corenetwork.WithCIDR(subnet.CIDR()),
+				corenetwork.WithConfigType(configType),
 			)}
 			nicInfo.ProviderSubnetId = corenetwork.Id(strconv.Itoa(subnet.ID()))
 			nicInfo.ProviderAddressId = corenetwork.Id(strconv.Itoa(link.ID()))

--- a/provider/maas/interfaces.go
+++ b/provider/maas/interfaces.go
@@ -245,7 +245,7 @@ func maasObjectNetworkInterfaces(
 		}
 
 		for _, link := range iface.Links {
-			nicInfo.ConfigType = maasLinkToInterfaceConfigType(string(link.Mode))
+			configType := maasLinkToInterfaceConfigType(string(link.Mode))
 
 			if link.IPAddress == "" && link.Subnet == nil {
 				logger.Debugf("interface %q link %d has neither subnet nor address", iface.Name, link.ID)
@@ -259,7 +259,7 @@ func maasObjectNetworkInterfaces(
 				// present in the original code. Do we need to revisit
 				// this in the future and append link addresses to the list?
 				nicInfo.Addresses = corenetwork.ProviderAddresses{
-					corenetwork.NewProviderAddress(link.IPAddress),
+					corenetwork.NewProviderAddress(link.IPAddress, corenetwork.WithConfigType(configType)),
 				}
 				nicInfo.ProviderAddressId = corenetwork.Id(fmt.Sprintf("%v", link.ID))
 			}
@@ -281,7 +281,7 @@ func maasObjectNetworkInterfaces(
 			// Now we know the subnet and space, we can update the address to
 			// store the space with it.
 			nicInfo.Addresses[0] = corenetwork.NewProviderAddressInSpace(
-				space, link.IPAddress, corenetwork.WithCIDR(sub.CIDR))
+				space, link.IPAddress, corenetwork.WithCIDR(sub.CIDR), corenetwork.WithConfigType(configType))
 
 			spaceId, ok := subnetsMap[sub.CIDR]
 			if !ok {
@@ -368,7 +368,7 @@ func maas2NetworkInterfaces(
 		}
 
 		for _, link := range iface.Links() {
-			nicInfo.ConfigType = maasLinkToInterfaceConfigType(link.Mode())
+			configType := maasLinkToInterfaceConfigType(link.Mode())
 
 			if link.IPAddress() == "" && link.Subnet() == nil {
 				logger.Debugf("interface %q link %d has neither subnet nor address", iface.Name(), link.ID())
@@ -380,7 +380,7 @@ func maas2NetworkInterfaces(
 				// NOTE(achilleasa): the original code used a last-write-wins
 				// policy. Do we need to append link addresses to the list?
 				nicInfo.Addresses = corenetwork.ProviderAddresses{
-					corenetwork.NewProviderAddress(link.IPAddress()),
+					corenetwork.NewProviderAddress(link.IPAddress(), corenetwork.WithConfigType(configType)),
 				}
 				nicInfo.ProviderAddressId = corenetwork.Id(fmt.Sprintf("%v", link.ID()))
 			}
@@ -402,7 +402,7 @@ func maas2NetworkInterfaces(
 			// Now we know the subnet and space, we can update the address to
 			// store the space with it.
 			nicInfo.Addresses[0] = corenetwork.NewProviderAddressInSpace(
-				space, link.IPAddress(), corenetwork.WithCIDR(sub.CIDR()))
+				space, link.IPAddress(), corenetwork.WithCIDR(sub.CIDR()), corenetwork.WithConfigType(configType))
 
 			spaceId, ok := subnetsMap[sub.CIDR()]
 			if !ok {

--- a/provider/maas/interfaces_test.go
+++ b/provider/maas/interfaces_test.go
@@ -10,11 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	network "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network"
 )
-
-////////////////////////////////////////////////////////////////////////////////
-// New (1.9 and later) environs.NetworkInterfaces() implementation tests follow.
 
 type interfacesSuite struct {
 	providerSuite
@@ -431,9 +428,8 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:     "ethernet",
 	Disabled:          false,
 	NoAutoStart:       false,
-	ConfigType:        "static",
 	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-		"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+		"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 	)},
 	DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 	DNSSearchDomains: nil,
@@ -453,9 +449,8 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:     "ethernet",
 	Disabled:          false,
 	NoAutoStart:       false,
-	ConfigType:        "static",
 	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-		"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+		"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 	)},
 	DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 	DNSSearchDomains: nil,
@@ -476,9 +471,8 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:       "802.1q",
 	Disabled:            false,
 	NoAutoStart:         false,
-	ConfigType:          "static",
 	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-		"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"),
+		"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"), network.WithConfigType(network.ConfigStatic),
 	)},
 	DNSServers:       nil,
 	DNSSearchDomains: nil,
@@ -499,9 +493,8 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:       "802.1q",
 	Disabled:            false,
 	NoAutoStart:         false,
-	ConfigType:          "static",
 	Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-		"public", "10.100.19.103", network.WithCIDR("10.100.19.0/24"),
+		"public", "10.100.19.103", network.WithCIDR("10.100.19.0/24"), network.WithConfigType(network.ConfigStatic),
 	)},
 	DNSServers:       nil,
 	DNSSearchDomains: nil,
@@ -523,9 +516,8 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:       "802.1q",
 	Disabled:            false,
 	NoAutoStart:         false,
-	ConfigType:          "static",
 	Addresses: network.ProviderAddresses{newAddressOnSpaceWithId(
-		"storage", "3", "10.250.19.103", network.WithCIDR("10.250.19.0/24"),
+		"storage", "3", "10.250.19.103", network.WithCIDR("10.250.19.0/24"), network.WithConfigType(network.ConfigStatic),
 	)},
 	DNSServers:       nil,
 	DNSSearchDomains: nil,
@@ -546,7 +538,6 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:       "ethernet",
 	Disabled:            false,
 	NoAutoStart:         false,
-	ConfigType:          "",
 	DNSServers:          nil,
 	DNSSearchDomains:    nil,
 	MTU:                 0,
@@ -566,9 +557,8 @@ var exampleParsedInterfaceSetJSON = network.InterfaceInfos{{
 	InterfaceType:       "bridge",
 	Disabled:            false,
 	NoAutoStart:         false,
-	ConfigType:          "dhcp",
 	Addresses: network.ProviderAddresses{newAddressOnSpaceWithId(
-		"space-0", "4", "192.168.20.192", network.WithCIDR("192.168.20.0/24"),
+		"space-0", "4", "192.168.20.192", network.WithCIDR("192.168.20.0/24"), network.WithConfigType(network.ConfigDHCP),
 	)},
 	DNSServers:       nil,
 	DNSSearchDomains: nil,
@@ -961,9 +951,8 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		InterfaceType:     "ethernet",
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains: nil,
@@ -983,9 +972,8 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		InterfaceType:     "ethernet",
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+			"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains: nil,
@@ -1006,9 +994,8 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		InterfaceType:       "802.1q",
 		Disabled:            false,
 		NoAutoStart:         false,
-		ConfigType:          "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"),
+			"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       nil,
 		DNSSearchDomains: nil,
@@ -1029,9 +1016,8 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		InterfaceType:       "802.1q",
 		Disabled:            false,
 		NoAutoStart:         false,
-		ConfigType:          "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"public", "10.100.19.103", network.WithCIDR("10.100.19.0/24"),
+			"public", "10.100.19.103", network.WithCIDR("10.100.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       nil,
 		DNSSearchDomains: nil,
@@ -1053,9 +1039,8 @@ func (s *interfacesSuite) TestMAAS2NetworkInterfaces(c *gc.C) {
 		InterfaceType:       "802.1q",
 		Disabled:            false,
 		NoAutoStart:         false,
-		ConfigType:          "static",
 		Addresses: network.ProviderAddresses{newAddressOnSpaceWithId(
-			"storage", "3", "10.250.19.103", network.WithCIDR("10.250.19.0/24"),
+			"storage", "3", "10.250.19.103", network.WithCIDR("10.250.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       nil,
 		DNSSearchDomains: nil,
@@ -1121,9 +1106,8 @@ func (s *interfacesSuite) TestMAAS2InterfacesNilVLAN(c *gc.C) {
 		InterfaceType:     "ethernet",
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains: nil,

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -920,9 +920,8 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		InterfaceType:     "ethernet",
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"),
+			"default", "10.20.19.103", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains: nil,
@@ -942,9 +941,8 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		InterfaceType:     "ethernet",
 		Disabled:          false,
 		NoAutoStart:       false,
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+			"default", "10.20.19.104", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       network.NewProviderAddressesInSpace("default", "10.20.19.2", "10.20.19.3"),
 		DNSSearchDomains: nil,
@@ -965,9 +963,8 @@ func (suite *maas2EnvironSuite) TestStartInstanceNetworkInterfaces(c *gc.C) {
 		InterfaceType:       "802.1q",
 		Disabled:            false,
 		NoAutoStart:         false,
-		ConfigType:          "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"),
+			"admin", "10.50.19.103", network.WithCIDR("10.50.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:       nil,
 		DNSSearchDomains: nil,
@@ -1097,9 +1094,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 		ProviderAddressId: "480",
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"freckles", "192.168.1.127", network.WithCIDR("192.168.1.0/24"),
+			"freckles", "192.168.1.127", network.WithCIDR("192.168.1.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:            1500,
@@ -1228,9 +1224,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(
 		ProviderAddressId: "480",
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"freckles", "10.20.19.104", network.WithCIDR("10.20.19.0/24"),
+			"freckles", "10.20.19.104", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:            1500,
@@ -1470,9 +1465,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		ProviderAddressId: "480",
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"freckles", "10.20.19.127", network.WithCIDR("10.20.19.0/24"),
+			"freckles", "10.20.19.127", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:            1500,
@@ -1487,9 +1481,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesDualNic(c *gc.C) {
 		ProviderAddressId: "481",
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"freckles", "192.168.1.127", network.WithCIDR("192.168.1.0/24"),
+			"freckles", "192.168.1.127", network.WithCIDR("192.168.1.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:            1500,
@@ -1694,7 +1687,7 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		{InterfaceName: "eth1", MACAddress: "DEADBEEE"},
 	}
 	ignored := names.NewMachineTag("1/lxd/0")
-	allocated, err := env.AllocateContainerAddresses(suite.callCtx, instance.Id("1"), ignored, prepared)
+	allocated, err := env.AllocateContainerAddresses(suite.callCtx, "1", ignored, prepared)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allocated, jc.DeepEquals, network.InterfaceInfos{{
 		DeviceIndex:    0,
@@ -1706,7 +1699,6 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		InterfaceType:  "ethernet",
 		Disabled:       false,
 		NoAutoStart:    false,
-		ConfigType:     "manual",
 		MTU:            1500,
 		Origin:         network.OriginProvider,
 	}, {
@@ -1719,7 +1711,6 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSubnetMissing(c *g
 		InterfaceType:  "ethernet",
 		Disabled:       false,
 		NoAutoStart:    false,
-		ConfigType:     "manual",
 		MTU:            1500,
 		Origin:         network.OriginProvider,
 	}})
@@ -1951,9 +1942,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerReuseExistingDevice(c *gc.C
 		ProviderAddressId: "480",
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"space-1", "10.20.19.105", network.WithCIDR("10.20.19.0/24"),
+			"space-1", "10.20.19.105", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("space-1", "10.20.19.2", "10.20.19.3"),
 		MTU:            1500,
@@ -2152,9 +2142,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		ProviderAddressId: "480",
 		InterfaceName:     "eth0",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"freckles", "10.20.19.105", network.WithCIDR("10.20.19.0/24"),
+			"freckles", "10.20.19.105", network.WithCIDR("10.20.19.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("freckles", "10.20.19.2", "10.20.19.3"),
 		MTU:            1500,
@@ -2171,9 +2160,8 @@ func (suite *maas2EnvironSuite) TestAllocateContainerRefusesReuseInvalidNIC(c *g
 		ProviderAddressId: "481",
 		InterfaceName:     "eth1",
 		InterfaceType:     "ethernet",
-		ConfigType:        "static",
 		Addresses: network.ProviderAddresses{network.NewProviderAddressInSpace(
-			"freckles", "192.168.1.101", network.WithCIDR("192.168.1.0/24"),
+			"freckles", "192.168.1.101", network.WithCIDR("192.168.1.0/24"), network.WithConfigType(network.ConfigStatic),
 		)},
 		DNSServers:     network.NewProviderAddressesInSpace("freckles", "192.168.1.2"),
 		MTU:            1500,

--- a/provider/maas/maas2instance_test.go
+++ b/provider/maas/maas2instance_test.go
@@ -75,9 +75,9 @@ func (s *maas2InstanceSuite) TestAddresses(c *gc.C) {
 	instance := &maas2Instance{machine: machine, environ: s.makeEnviron(c, controller)}
 	addresses, err := instance.Addresses(s.callCtx)
 
-	expectedAddresses := network.ProviderAddresses{
-		newAddressOnSpaceWithId("freckles", "4567", "192.168.10.1", network.WithCIDR(subnet.cidr)),
-	}
+	expectedAddresses := network.ProviderAddresses{newAddressOnSpaceWithId(
+		"freckles", "4567", "192.168.10.1", network.WithCIDR(subnet.cidr), network.WithConfigType(network.ConfigStatic),
+	)}
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addresses, jc.SameContents, expectedAddresses)


### PR DESCRIPTION
When detecting link-layer devices and addresses (on-machine and via the instance-poller), Juju has until now transported the address configuration method with the **device**, but saved it against the **address**.

In this patch, we:
- Add `ConfigType` to the `Address` wire type.
- Ensure all providers report detected addresses with a populated `ConfigType`.
- Prefer the address member when transforming detected link-layer info to state args.

Note that the provider changes are non functional because at the time of writing we only ever decorate existing devices and address with provider IDs - we do not add them. This is expected to change in the future.

This is the last member from the **device** (prior members included CIDR) that required us to duplicate it per detected **address**. That means we can now follow this patch with a change to machine device detection that no longer does this duplication. We can simplify it and populate the slice of addresses, leaving the old cardinality mismatch behind us.

## QA steps

- Bootstrap to MAAS.
- Add a machine
- Add a LXD container to this machine, with positive space constraints.

## Documentation changes

None.

## Bug reference

N/A
