### PR TITLE
Embed a context.Context in the environ ProviderCallContext

### DIFF
--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -57,7 +57,7 @@ func (s *CheckMachinesSuite) SetUpTest(c *gc.C) {
 			return []instances.Instance{s.instance}, nil
 		},
 	}
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 }
 
 func (s *CheckMachinesSuite) TestCheckMachinesSuccess(c *gc.C) {
@@ -231,7 +231,7 @@ type ModelCredentialSuite struct {
 func (s *ModelCredentialSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.backend = createModelBackend()
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 }
 
 func (s *ModelCredentialSuite) TestValidateNewModelCredentialUnknownModelType(c *gc.C) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -210,7 +210,7 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.State, *state.CAAS
 	c.Assert(err, jc.ErrorIsNil)
 
 	apiInfo, err := environs.APIInfo(
-		context.NewCloudCallContext(),
+		context.NewEmptyCloudCallContext(),
 		s.ControllerConfig.ControllerUUID(),
 		st.ModelUUID(),
 		coretesting.CACert,

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -4,7 +4,7 @@
 package applicationoffers_test
 
 import (
-	stdcontet "context"
+	stdcontext "context"
 	"fmt"
 	"strings"
 	"time"
@@ -386,7 +386,7 @@ func (m *mockState) OfferConnections(offerUUID string) ([]applicationoffers.Offe
 }
 
 func (m *mockState) GetModelCallContext() context.ProviderCallContext {
-	return context.NewCloudCallContext()
+	return context.NewEmptyCloudCallContext()
 }
 
 func (m *mockState) User(tag names.UserTag) (applicationoffers.User, error) {
@@ -525,7 +525,7 @@ type mockBakeryService struct {
 	caveats map[string][]checkers.Caveat
 }
 
-func (s *mockBakeryService) NewMacaroon(ctx stdcontet.Context, version bakery.Version, caveats []checkers.Caveat, ops ...bakery.Op) (*bakery.Macaroon, error) {
+func (s *mockBakeryService) NewMacaroon(ctx stdcontext.Context, version bakery.Version, caveats []checkers.Caveat, ops ...bakery.Op) (*bakery.Macaroon, error) {
 	s.MethodCall(s, "NewMacaroon", caveats)
 	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
 	if err != nil {

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -38,12 +38,12 @@ func (s *statusHistoryTestSuite) SetUpTest(c *gc.C) {
 		nil, // modelconfig API
 		nil, // resources
 		authorizer,
-		nil,                           // presence
-		nil,                           // statusSetter
-		nil,                           // toolsFinder
-		nil,                           // newEnviron
-		nil,                           // blockChecker
-		context.NewCloudCallContext(), // ProviderCallContext
+		nil,                                // presence
+		nil,                                // statusSetter
+		nil,                                // toolsFinder
+		nil,                                // newEnviron
+		nil,                                // blockChecker
+		context.NewEmptyCloudCallContext(), // ProviderCallContext
 		nil,
 		nil,
 		nil, // multiwatcher.Factory

--- a/apiserver/facades/client/cloud/cloudV2_test.go
+++ b/apiserver/facades/client/cloud/cloudV2_test.go
@@ -113,7 +113,7 @@ func (s *cloudSuiteV2) SetUpTest(c *gc.C) {
 	}
 	s.statePool = &mockStatePool{
 		getF: func(modelUUID string) (credentialcommon.PersistentBackend, context.ProviderCallContext, error) {
-			return modelBackend(modelUUID), context.NewCloudCallContext(), nil
+			return modelBackend(modelUUID), context.NewEmptyCloudCallContext(), nil
 		},
 	}
 }

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -89,7 +89,7 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 
 	s.statePool = &mockStatePool{
 		getF: func(modelUUID string) (credentialcommon.PersistentBackend, context.ProviderCallContext, error) {
-			return newModelBackend(c, aCloud, modelUUID), context.NewCloudCallContext(), nil
+			return newModelBackend(c, aCloud, modelUUID), context.NewEmptyCloudCallContext(), nil
 		},
 	}
 	s.setTestAPIForUser(c, names.NewUserTag("admin"))

--- a/apiserver/facades/client/cloud/instance_information_test.go
+++ b/apiserver/facades/client/cloud/instance_information_test.go
@@ -63,7 +63,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 	}
 	pool := &mockStatePool{
 		getF: func(modelUUID string) (credentialcommon.PersistentBackend, context.ProviderCallContext, error) {
-			return newModelBackend(c, aCloud, modelUUID), context.NewCloudCallContext(), nil
+			return newModelBackend(c, aCloud, modelUUID), context.NewEmptyCloudCallContext(), nil
 		},
 	}
 	api, err := cloud.NewCloudAPI(backend, ctlrBackend, pool, authorizer)

--- a/apiserver/facades/client/machinemanager/instance_information_test.go
+++ b/apiserver/facades/client/machinemanager/instance_information_test.go
@@ -66,7 +66,7 @@ func (p *instanceTypesSuite) TestInstanceTypes(c *gc.C) {
 			Authorizer: authorizer,
 			ModelTag:   backend.ModelTag(),
 		},
-		context.NewCloudCallContext(),
+		context.NewEmptyCloudCallContext(),
 		common.NewResources(),
 		leadership,
 		nil,

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -82,7 +82,7 @@ func (s *MachineManagerSuite) SetUpTest(c *gc.C) {
 	}
 	s.pool = &mockPool{}
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("admin")}
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 }
 
 func (s *MachineManagerSuite) setup(c *gc.C) *gomock.Controller {

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -58,7 +58,7 @@ func (s *ListModelsWithInfoSuite) SetUpTest(c *gc.C) {
 		Tag: s.adminUser,
 	}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	api, err := modelmanager.NewModelManagerAPI(s.st, &mockState{}, nil, nil, nil, s.authoriser, s.st.model, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -168,7 +168,7 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 
 	var err error
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, nil, nil, &s.authorizer, s.st.model, s.callContext)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -204,7 +204,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 		Tag: names.NewUserTag("admin"),
 	}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 
 	newBroker := func(args environs.OpenParams) (caas.Broker, error) {
 		s.caasBroker = &mockCaasBroker{namespace: args.Config.Name()}
@@ -922,7 +922,7 @@ func (s *modelManagerStateSuite) SetUpTest(c *gc.C) {
 	s.authoriser = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	loggo.GetLogger("juju.apiserver.modelmanager").SetLogLevel(loggo.TRACE)
 }
 

--- a/apiserver/facades/client/modelmanager/validatemodelupgrades_test.go
+++ b/apiserver/facades/client/modelmanager/validatemodelupgrades_test.go
@@ -45,7 +45,7 @@ func (s *ValidateModelUpgradesSuite) SetUpTest(c *gc.C) {
 		Tag: s.adminUser,
 	}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 }
 
 // TestValidateModelUpgradesWithNoModelTags tests that we don't fail if we don't

--- a/apiserver/facades/client/spaces/package_test.go
+++ b/apiserver/facades/client/spaces/package_test.go
@@ -56,7 +56,7 @@ func (s *APISuite) SetupMocks(c *gc.C, supportSpaces bool, providerSpaces bool) 
 	ctrl := gomock.NewController(c)
 
 	s.resource = facademocks.NewMockResources(ctrl)
-	s.cloudCallContext = context.NewCloudCallContext()
+	s.cloudCallContext = context.NewEmptyCloudCallContext()
 	s.OpFactory = NewMockOpFactory(ctrl)
 	s.Constraints = NewMockConstraints(ctrl)
 

--- a/apiserver/facades/client/spaces/reload_test.go
+++ b/apiserver/facades/client/spaces/reload_test.go
@@ -27,7 +27,7 @@ func (s *ReloadSpacesAPISuite) TestReloadSpaces(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	context := context.NewCloudCallContext()
+	context := context.NewEmptyCloudCallContext()
 	authorizer := func() error { return nil }
 
 	mockNetworkEnviron := environmocks.NewMockNetworkingEnviron(ctrl)
@@ -49,7 +49,7 @@ func (s *ReloadSpacesAPISuite) TestReloadSpacesWithNoEnviron(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	context := context.NewCloudCallContext()
+	context := context.NewEmptyCloudCallContext()
 	authorizer := func() error { return nil }
 
 	mockNetworkEnviron := environmocks.NewMockNetworkingEnviron(ctrl)
@@ -70,7 +70,7 @@ func (s *ReloadSpacesAPISuite) TestReloadSpacesWithReloadSpaceError(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	context := context.NewCloudCallContext()
+	context := context.NewEmptyCloudCallContext()
 	authorizer := func() error { return nil }
 
 	mockNetworkEnviron := environmocks.NewMockNetworkingEnviron(ctrl)

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -667,7 +667,7 @@ func (s *LegacySuite) SetUpTest(c *gc.C) {
 		Controller: false,
 	}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	s.blockChecker = mockBlockChecker{}
 	var err error
 	s.facade, err = spaces.NewAPIWithBacking(spaces.APIConfig{
@@ -708,7 +708,7 @@ func (s *LegacySuite) TestNewAPIWithBacking(c *gc.C) {
 	facade, err = spaces.NewAPIWithBacking(spaces.APIConfig{
 		Backing:    &stubBacking{apiservertesting.BackingInstance},
 		Check:      &s.blockChecker,
-		Context:    context.NewCloudCallContext(),
+		Context:    context.NewEmptyCloudCallContext(),
 		Resources:  s.resources,
 		Authorizer: agentAuthorizer,
 	})
@@ -1101,7 +1101,7 @@ func (s *LegacySuite) TestSupportsSpacesModelConfigError(c *gc.C) {
 		errors.New("boom"), // Backing.ModelConfig()
 	)
 
-	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewCloudCallContext())
+	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
 	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
@@ -1112,7 +1112,7 @@ func (s *LegacySuite) TestSupportsSpacesEnvironNewError(c *gc.C) {
 		errors.New("boom"), // environs.New()
 	)
 
-	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewCloudCallContext())
+	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
 	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
 }
 
@@ -1124,7 +1124,7 @@ func (s *LegacySuite) TestSupportsSpacesWithoutNetworking(c *gc.C) {
 		apiservertesting.WithoutSpaces,
 		apiservertesting.WithoutSubnets)
 
-	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewCloudCallContext())
+	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
@@ -1143,12 +1143,12 @@ func (s *LegacySuite) TestSupportsSpacesWithoutSpaces(c *gc.C) {
 		errors.New("boom"), // Backing.supportsSpaces()
 	)
 
-	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewCloudCallContext())
+	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *LegacySuite) TestSupportsSpaces(c *gc.C) {
-	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewCloudCallContext())
+	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -50,7 +50,7 @@ func (s *facadeSuite) SetUpTest(c *gc.C) {
 	s.authorizer.Tag = names.NewUserTag("igor")
 	s.authorizer.AdminTag = names.NewUserTag("igor")
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	facade, err := sshclient.InternalFacade(s.backend, s.authorizer, s.callContext)
 	c.Assert(err, jc.ErrorIsNil)
 	s.facade = facade

--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -68,7 +68,7 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.poolManager = s.constructPoolManager()
 	s.poolsInUse = []string{}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
 	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
 	newAPI := storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -84,7 +84,7 @@ func (s *SubnetSuite) TestSubnetsByCIDR(c *gc.C) {
 func (s *SubnetSuite) setupSubnetsAPI(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.mockResource = facademocks.NewMockResources(ctrl)
-	s.mockCloudCallContext = context.NewCloudCallContext()
+	s.mockCloudCallContext = context.NewEmptyCloudCallContext()
 	s.mockBacking = mocks.NewMockBacking(ctrl)
 
 	s.mockAuthorizer = facademocks.NewMockAuthorizer(ctrl)
@@ -143,7 +143,7 @@ func (s *SubnetsSuite) SetUpTest(c *gc.C) {
 		Controller: false,
 	}
 
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	var err error
 	s.facade, err = subnets.NewAPIWithBacking(
 		&stubBacking{apiservertesting.BackingInstance},

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -66,7 +66,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 		Tag:      s.Owner,
 		AdminTag: s.Owner,
 	}
-	s.callContext = context.NewCloudCallContext()
+	s.callContext = context.NewEmptyCloudCallContext()
 	s.facadeContext = facadetest.Context{
 		State_:     s.State,
 		StatePool_: s.StatePool,

--- a/caas/kubernetes/provider/constraints_test.go
+++ b/caas/kubernetes/provider/constraints_test.go
@@ -23,14 +23,14 @@ var _ = gc.Suite(&ConstraintsSuite{})
 
 func (s *ConstraintsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *ConstraintsSuite) TestConstraintsValidatorOkay(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	validator, err := s.broker.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := s.broker.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("mem=64G")
@@ -44,7 +44,7 @@ func (s *ConstraintsSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	validator, err := s.broker.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := s.broker.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	unsupported, err := validator.Validate(constraints.Value{})
@@ -57,7 +57,7 @@ func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	validator, err := s.broker.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := s.broker.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse(strings.Join([]string{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -1733,12 +1733,12 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 
 func (s *K8sBrokerSuite) TestDestroyController(c *gc.C) {
 	s.assertDestroy(c, true, func() error {
-		return s.broker.DestroyController(context.NewCloudCallContext(), testing.ControllerTag.Id())
+		return s.broker.DestroyController(context.NewEmptyCloudCallContext(), testing.ControllerTag.Id())
 	})
 }
 
 func (s *K8sBrokerSuite) TestDestroy(c *gc.C) {
-	s.assertDestroy(c, false, func() error { return s.broker.Destroy(context.NewCloudCallContext()) })
+	s.assertDestroy(c, false, func() error { return s.broker.Destroy(context.NewEmptyCloudCallContext()) })
 }
 
 func (s *K8sBrokerSuite) TestGetCurrentNamespace(c *gc.C) {

--- a/caas/kubernetes/provider/precheck_test.go
+++ b/caas/kubernetes/provider/precheck_test.go
@@ -22,14 +22,14 @@ var _ = gc.Suite(&PrecheckSuite{})
 
 func (s *PrecheckSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *PrecheckSuite) TestSuccess(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+	err := s.broker.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{
 		Series:      "kubernetes",
 		Constraints: constraints.MustParse("mem=4G"),
 	})
@@ -42,7 +42,7 @@ func (s *PrecheckSuite) TestWrongSeries(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+	err := s.broker.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{
 		Series: "quantal",
 	})
 	c.Assert(err, gc.ErrorMatches, `series "quantal" not valid`)
@@ -52,7 +52,7 @@ func (s *PrecheckSuite) TestUnsupportedConstraints(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+	err := s.broker.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{
 		Series:      "kubernetes",
 		Constraints: constraints.MustParse("instance-type=foo"),
 	})
@@ -63,7 +63,7 @@ func (s *PrecheckSuite) TestPlacementNotAllowed(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+	err := s.broker.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{
 		Series:    "kubernetes",
 		Placement: "a",
 	})
@@ -74,12 +74,12 @@ func (s *PrecheckSuite) TestInvalidConstraints(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+	err := s.broker.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{
 		Series:      "kubernetes",
 		Constraints: constraints.MustParse("tags=foo"),
 	})
 	c.Assert(err, gc.ErrorMatches, `invalid node affinity constraints: foo`)
-	err = s.broker.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{
+	err = s.broker.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{
 		Series:      "kubernetes",
 		Constraints: constraints.MustParse("tags=^=bar"),
 	})

--- a/caas/kubernetes/provider/resources_test.go
+++ b/caas/kubernetes/provider/resources_test.go
@@ -70,6 +70,6 @@ func (s *ResourcesSuite) TestAdoptResources(c *gc.C) {
 			Return(nil, nil),
 	)
 
-	err := s.broker.AdoptResources(context.NewCloudCallContext(), "uuid", version.MustParse("1.2.3"))
+	err := s.broker.AdoptResources(context.NewEmptyCloudCallContext(), "uuid", version.MustParse("1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -4,6 +4,7 @@
 package cloud
 
 import (
+	stdcontext "context"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -177,7 +178,7 @@ type AddCloudCommand struct {
 
 // NewAddCloudCommand returns a command to add cloud information.
 func NewAddCloudCommand(cloudMetadataStore CloudMetadataStore) cmd.Command {
-	cloudCallCtx := context.NewCloudCallContext()
+	cloudCallCtx := context.NewCloudCallContext(stdcontext.Background())
 	store := jujuclient.NewFileClientStore()
 	c := &AddCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{

--- a/cmd/juju/cloud/export_test.go
+++ b/cmd/juju/cloud/export_test.go
@@ -36,7 +36,7 @@ func NewAddCloudCommandForTest(
 	store jujuclient.ClientStore,
 	cloudAPI func() (AddCloudAPI, error),
 ) *AddCloudCommand {
-	cloudCallCtx := context.NewCloudCallContext()
+	cloudCallCtx := context.NewEmptyCloudCallContext()
 	return &AddCloudCommand{
 		OptionalControllerCommand: modelcmd.OptionalControllerCommand{Store: store},
 		cloudMetadataStore:        cloudMetadataStore,

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -664,15 +664,6 @@ to create a new model to deploy %sworkloads.
 		return errors.Trace(err)
 	}
 
-	cloudCallCtx := envcontext.NewCloudCallContext()
-	// At this stage, the credential we intend to use is not yet stored
-	// server-side. So, if the credential is not accepted by the provider,
-	// we cannot mark it as invalid, just log it as an informative message.
-	cloudCallCtx.InvalidateCredentialFunc = func(reason string) error {
-		ctx.Infof("Cloud credential %q is not accepted by cloud provider: %v", credentials.name, reason)
-		return nil
-	}
-
 	region, err := common.ChooseCloudRegion(cloud, regionName)
 	if err != nil {
 		return errors.Trace(err)
@@ -862,6 +853,15 @@ to create a new model to deploy %sworkloads.
 		"Creating Juju controller %q on %s",
 		c.controllerName, cloudRegion,
 	)
+
+	cloudCallCtx := envcontext.NewCloudCallContext(context.Background())
+	// At this stage, the credential we intend to use is not yet stored
+	// server-side. So, if the credential is not accepted by the provider,
+	// we cannot mark it as invalid, just log it as an informative message.
+	cloudCallCtx.InvalidateCredentialFunc = func(reason string) error {
+		ctx.Infof("Cloud credential %q is not accepted by cloud provider: %v", credentials.name, reason)
+		return nil
+	}
 
 	// If we error out for any reason, clean up the environment.
 	defer func() {

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"bufio"
 	"bytes"
+	stdcontext "context"
 	"fmt"
 	"io"
 	"strings"
@@ -655,7 +656,7 @@ func (c *destroyCommandBase) credentialAPIForControllerModel() (CredentialAPI, e
 type newCredentialAPIFunc func() (CredentialAPI, error)
 
 func cloudCallContext(newAPIFunc newCredentialAPIFunc) context.ProviderCallContext {
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewCloudCallContext(stdcontext.Background())
 	callCtx.InvalidateCredentialFunc = func(reason string) error {
 		api, err := newAPIFunc()
 		if err != nil {

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -3905,7 +3905,7 @@ func (sm startMachine) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
+	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewEmptyCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned(inst.Id(), "", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -3921,7 +3921,7 @@ func (sm startMissingMachine) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	_, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
+	_, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewEmptyCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned("i-missing", "", "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 	// lp:1558657
@@ -3947,7 +3947,7 @@ func (sam startAliveMachine) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
+	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewEmptyCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned(inst.Id(), sam.displayName, "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -3964,7 +3964,7 @@ func (sm startMachineWithHardware) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	inst, _ := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
+	inst, _ := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewEmptyCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned(inst.Id(), "", "fake_nonce", &sm.hc)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -3981,7 +3981,7 @@ func (sm startAliveMachineWithDisplayName) step(c *gc.C, ctx *context) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := ctx.st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
+	inst, hc := testing.AssertStartInstanceWithConstraints(c, ctx.env, environscontext.NewEmptyCloudCallContext(), cfg.ControllerUUID(), m.Id(), cons)
 	err = m.SetProvisioned(inst.Id(), sm.displayName, "fake_nonce", hc)
 	c.Assert(err, jc.ErrorIsNil)
 	_, displayName, err := m.InstanceNames()

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"bytes"
+	stdcontext "context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -238,7 +239,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 	}
 
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewCloudCallContext(stdcontext.Background())
 	// At this stage, cloud credential has not yet been stored server-side
 	// as there is no server-side. If these cloud calls will fail with
 	// invalid credential, just log it.

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -799,7 +799,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	err = env.PrepareForBootstrap(nullContext(), "controller-1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	callCtx := envcontext.NewCloudCallContext()
+	callCtx := envcontext.NewEmptyCloudCallContext()
 	s.AddCleanup(func(c *gc.C) {
 		err := env.DestroyController(callCtx, controllerCfg.ControllerUUID())
 		c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -288,7 +288,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	m, instId := s.waitProvisioned(c, unit)
-	insts, err := s.Environ.Instances(context.NewCloudCallContext(), []instance.Id{instId})
+	insts, err := s.Environ.Instances(context.NewEmptyCloudCallContext(), []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
 
 	netEnv, ok := s.Environ.(environs.Networking)
@@ -297,7 +297,7 @@ func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	// Since the dummy environ implements the environ.NetworkingEnviron,
 	// the instancepoller will pull the provider addresses directly from
 	// the environ and resolve their space ID.
-	ifLists, err := netEnv.NetworkInterfaces(context.NewCloudCallContext(), []instance.Id{instId})
+	ifLists, err := netEnv.NetworkInterfaces(context.NewEmptyCloudCallContext(), []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ifLists, gc.HasLen, 1)
 

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -138,7 +138,7 @@ func (s *commonMachineSuite) configureMachine(c *gc.C, machineId string, vers ve
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Add a machine and ensure it is provisioned.
-	inst, md := jujutesting.AssertStartInstance(c, s.Environ, context.NewCloudCallContext(), s.ControllerConfig.ControllerUUID(), machineId)
+	inst, md := jujutesting.AssertStartInstance(c, s.Environ, context.NewEmptyCloudCallContext(), s.ControllerConfig.ControllerUUID(), machineId)
 	c.Assert(m.SetProvisioned(inst.Id(), "", agent.BootstrapNonce, md), jc.ErrorIsNil)
 
 	// Add an address for the tests in case the initiateMongoServer
@@ -219,7 +219,7 @@ func (s *commonMachineSuite) setFakeMachineAddresses(c *gc.C, machine *state.Mac
 	// runs it won't overwrite them.
 	instId, err := machine.InstanceId()
 	c.Assert(err, jc.ErrorIsNil)
-	insts, err := s.Environ.Instances(context.NewCloudCallContext(), []instance.Id{instId})
+	insts, err := s.Environ.Instances(context.NewEmptyCloudCallContext(), []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
 	dummy.SetInstanceAddresses(insts[0], network.NewProviderAddresses("0.1.2.3"))
 }

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -298,7 +298,7 @@ func instancesFromResults(results ...*environs.StartInstanceResult) []instances.
 }
 
 func assertInstancesStarted(c *gc.C, broker environs.InstanceBroker, results ...*environs.StartInstanceResult) {
-	allInstances, err := broker.AllRunningInstances(context.NewCloudCallContext())
+	allInstances, err := broker.AllRunningInstances(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	instancetest.MatchInstances(c, allInstances, instancesFromResults(results...)...)
 }
@@ -331,7 +331,7 @@ func makeNoOpStatusCallback() func(settableStatus status.Status, info string, da
 }
 
 func callStartInstance(c *gc.C, s patcher, broker environs.InstanceBroker, machineId string) (*environs.StartInstanceResult, error) {
-	return broker.StartInstance(context.NewCloudCallContext(), environs.StartInstanceParams{
+	return broker.StartInstance(context.NewEmptyCloudCallContext(), environs.StartInstanceParams{
 		Constraints:    constraints.Value{},
 		Tools:          makePossibleTools(),
 		InstanceConfig: makeInstanceConfig(c, s, machineId),

--- a/container/broker/kvm-broker_test.go
+++ b/container/broker/kvm-broker_test.go
@@ -154,7 +154,7 @@ func (s *kvmBrokerSuite) TestStopInstance(c *gc.C) {
 	result2, err2 := s.startInstance(c, broker, "1/kvm/2")
 	c.Assert(err2, jc.ErrorIsNil)
 
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewEmptyCloudCallContext()
 	err := broker.StopInstances(callCtx, result0.Instance.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertResults(c, broker, result1, result2)
@@ -177,7 +177,7 @@ func (s *kvmBrokerSuite) TestAllRunningInstances(c *gc.C) {
 	c.Assert(err1, jc.ErrorIsNil)
 	s.assertResults(c, broker, result0, result1)
 
-	err := broker.StopInstances(context.NewCloudCallContext(), result1.Instance.Id())
+	err := broker.StopInstances(context.NewEmptyCloudCallContext(), result1.Instance.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	result2, err2 := s.startInstance(c, broker, "1/kvm/2")
 	c.Assert(err2, jc.ErrorIsNil)

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -125,7 +125,7 @@ func (s *lxdBrokerSuite) TestStartInstanceNoHostArchTools(c *gc.C) {
 	broker, brokerErr := s.newLXDBroker(c)
 	c.Assert(brokerErr, jc.ErrorIsNil)
 
-	_, err := broker.StartInstance(context.NewCloudCallContext(), environs.StartInstanceParams{
+	_, err := broker.StartInstance(context.NewEmptyCloudCallContext(), environs.StartInstanceParams{
 		Tools: coretools.List{{
 			// non-host-arch tools should be filtered out by StartInstance
 			Version: version.MustParseBinary("2.3.4-ubuntu-arm64"),

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -178,7 +178,7 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 	instanceId := instance.Id()
 	c.Check(string(instanceId), gc.Equals, hostName)
 
-	instanceStatus := instance.Status(context.NewCloudCallContext())
+	instanceStatus := instance.Status(context.NewEmptyCloudCallContext())
 	c.Check(instanceStatus.Status, gc.Equals, status.Running)
 	c.Check(*hc.AvailabilityZone, gc.Equals, "test-availability-zone")
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -93,7 +93,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(bootstrap.GUIFetchMetadata, func(string, int, int, ...simplestreams.DataSource) ([]*gui.Metadata, error) {
 		return nil, nil
 	})
-	s.callContext = envcontext.NewCloudCallContext()
+	s.callContext = envcontext.NewEmptyCloudCallContext()
 }
 
 func (s *bootstrapSuite) TearDownTest(c *gc.C) {
@@ -492,7 +492,7 @@ func (s *bootstrapSuite) setupProviderWithSomeSupportedArches(c *gc.C) bootstrap
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
 	// test provider constraints only has amd64 and arm64 as supported architectures
-	consBefore, err := env.ConstraintsValidator(envcontext.NewCloudCallContext())
+	consBefore, err := env.ConstraintsValidator(envcontext.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	desiredArch := constraints.MustParse("arch=i386")
 	unsupported, err := consBefore.Validate(desiredArch)
@@ -539,7 +539,7 @@ func (s *bootstrapSuite) setupProviderWithNoSupportedArches(c *gc.C) bootstrapEn
 	}
 	s.setDummyStorage(c, env.bootstrapEnviron)
 
-	consBefore, err := env.ConstraintsValidator(envcontext.NewCloudCallContext())
+	consBefore, err := env.ConstraintsValidator(envcontext.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	// test provider constraints only has amd64 and arm64 as supported architectures
 	desiredArch := constraints.MustParse("arch=i386")

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -37,7 +37,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleHostArch(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, devVersion)
 	env := newEnviron("foo", useDefaultKeys, nil)
 	arch := arch.PPC64EL
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, &arch, nil, validator)
 	c.Assert(err, gc.ErrorMatches, `cannot use agent built for "ppc64el" using a machine running on "amd64"`)
@@ -48,7 +48,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleHostOS(c *gc.C) {
 	s.PatchValue(&os.HostOS, func() os.OSType { return os.Ubuntu })
 	env := newEnviron("foo", useDefaultKeys, nil)
 	series := "win2012"
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, nil, &series, validator)
 	c.Assert(err, gc.ErrorMatches, `cannot use agent built for "win2012" using a machine running "Ubuntu"`)
@@ -64,7 +64,7 @@ func (s *toolsSuite) TestValidateUploadAllowedIncompatibleTargetArch(c *gc.C) {
 	devVersion.Build = 1234
 	s.PatchValue(&jujuversion.Current, devVersion)
 	env := newEnviron("foo", useDefaultKeys, nil)
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, nil, nil, validator)
 	c.Assert(err, gc.ErrorMatches, `model "foo" of type dummy does not support instances running on "ppc64el"`)
@@ -77,7 +77,7 @@ func (s *toolsSuite) TestValidateUploadAllowed(c *gc.C) {
 	centos7 := "centos7"
 	s.PatchValue(&arch.HostArch, func() string { return arm64 })
 	s.PatchValue(&os.HostOS, func() os.OSType { return os.CentOS })
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	err = bootstrap.ValidateUploadAllowed(env, &arm64, &centos7, validator)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/context/callcontext.go
+++ b/environs/context/callcontext.go
@@ -3,6 +3,8 @@
 
 package context
 
+import stdcontext "context"
+
 // ModelCredentialInvalidator defines a point of use interface for invalidating
 // a model credential.
 type ModelCredentialInvalidator interface {
@@ -14,7 +16,8 @@ type ModelCredentialInvalidator interface {
 // CallContext creates a CloudCallContext for use when calling environ methods
 // that may require invalidate a cloud credential.
 func CallContext(ctx ModelCredentialInvalidator) *CloudCallContext {
-	callCtx := NewCloudCallContext()
+	// TODO(wallyworld) - pass in the stdcontext
+	callCtx := NewCloudCallContext(stdcontext.Background())
 	callCtx.InvalidateCredentialFunc = ctx.InvalidateModelCredential
 	return callCtx
 }

--- a/environs/context/cloud.go
+++ b/environs/context/cloud.go
@@ -3,12 +3,29 @@
 
 package context
 
-import "github.com/juju/errors"
+import (
+	"context"
+
+	"github.com/juju/errors"
+)
 
 // NewCloudCallContext creates a new CloudCallContext to be used a
 // ProviderCallContext.
-func NewCloudCallContext() *CloudCallContext {
+func NewCloudCallContext(ctx context.Context) *CloudCallContext {
 	return &CloudCallContext{
+		Context: ctx,
+		InvalidateCredentialFunc: func(string) error {
+			return errors.NotImplementedf("InvalidateCredentialCallback")
+		},
+	}
+}
+
+// NewEmptyCloudCallContext creates a new CloudCallContext to be used a
+// ProviderCallContext in tests and other cases where an invalid
+// credential func is not required.
+func NewEmptyCloudCallContext() *CloudCallContext {
+	return &CloudCallContext{
+		Context: context.TODO(),
 		InvalidateCredentialFunc: func(string) error {
 			return errors.NotImplementedf("InvalidateCredentialCallback")
 		},
@@ -28,23 +45,16 @@ func NewCloudCallContext() *CloudCallContext {
 // as this knowledge is specific to where the call was made *from* not on what object
 // it was made.
 type CloudCallContext struct {
+	// This embedded context.Context instance allows this cloud call context to be
+	// passed to any provider SDK calls which need a standard context.
+	context.Context
+
 	// InvalidateCredentialFunc is the actual callback function
 	// that invalidates the credential used in the context of this call.
 	InvalidateCredentialFunc func(string) error
-
-	// DyingFunc returns the dying chan.
-	DyingFunc Dying
 }
 
 // InvalidateCredential implements context.InvalidateCredentialCallback.
 func (c *CloudCallContext) InvalidateCredential(reason string) error {
 	return c.InvalidateCredentialFunc(reason)
-}
-
-// Dying returns the dying chan.
-func (c *CloudCallContext) Dying() <-chan struct{} {
-	if c.DyingFunc == nil {
-		return nil
-	}
-	return c.DyingFunc()
 }

--- a/environs/context/cloud_test.go
+++ b/environs/context/cloud_test.go
@@ -4,6 +4,8 @@
 package context
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
@@ -16,8 +18,10 @@ type CloudCallContextSuite struct {
 var _ = gc.Suite(&CloudCallContextSuite{})
 
 func (s *CloudCallContextSuite) TestCloudCallContext(c *gc.C) {
-	ctx := NewCloudCallContext()
+	stdctx := stdcontext.TODO()
+	ctx := NewCloudCallContext(stdctx)
 	c.Assert(ctx, gc.NotNil)
+	c.Assert(ctx.Context, gc.Equals, stdctx)
 
 	err := ctx.InvalidateCredential("call")
 	c.Assert(err, gc.FitsTypeOf, errors.NewNotImplemented(nil, ""))

--- a/environs/context/provider.go
+++ b/environs/context/provider.go
@@ -3,17 +3,14 @@
 
 package context
 
+import "context"
+
 // ProviderCallContext exposes useful capabilities when making calls
 // to an underlying cloud substrate.
 type ProviderCallContext interface {
+	context.Context
 
 	// InvalidateCredential provides means to invalidate a credential
 	// that is used to make a call.
 	InvalidateCredential(string) error
-
-	// Dying returns the dying chan.
-	Dying() <-chan struct{}
 }
-
-// Dying returns the dying chan.
-type Dying func() <-chan struct{}

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -4,6 +4,7 @@
 package jujutest
 
 import (
+	stdcontext "context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -131,7 +132,7 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
 	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, nil))
-	t.ProviderCallContext = context.NewCloudCallContext()
+	t.ProviderCallContext = context.NewCloudCallContext(stdcontext.Background())
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -4,6 +4,7 @@
 package jujutest
 
 import (
+	stdcontext "context"
 	"path/filepath"
 
 	jc "github.com/juju/testing/checkers"
@@ -128,7 +129,7 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.toolsStorage = stor
 	t.ControllerStore = jujuclient.NewMemStore()
 	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
-	t.ProviderCallContext = context.NewCloudCallContext()
+	t.ProviderCallContext = context.NewCloudCallContext(stdcontext.Background())
 }
 
 func (t *Tests) TearDownTest(c *gc.C) {

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -69,7 +69,7 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	stor, err := filestorage.NewFileStorageWriter(storageDir)
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.UploadFakeTools(c, stor, cfg.AgentStream(), cfg.AgentStream())
-	err = bootstrap.Bootstrap(ctx, env, context.NewCloudCallContext(), bootstrap.BootstrapParams{
+	err = bootstrap.Bootstrap(ctx, env, context.NewEmptyCloudCallContext(), bootstrap.BootstrapParams{
 		ControllerConfig:         controllerCfg,
 		AdminSecret:              "admin-secret",
 		CAPrivateKey:             testing.CAKey,
@@ -138,7 +138,7 @@ func (*OpenSuite) TestNew(c *gc.C) {
 		Config: cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = e.ControllerInstances(context.NewCloudCallContext(), "uuid")
+	_, err = e.ControllerInstances(context.NewEmptyCloudCallContext(), "uuid")
 	c.Assert(err, gc.ErrorMatches, "model is not prepared")
 }
 
@@ -167,7 +167,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 	_, err = store.ControllerByName("controller-name")
 	c.Assert(err, jc.ErrorIsNil)
 
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewEmptyCloudCallContext()
 	err = environs.Destroy("controller-name", e, callCtx, store)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -182,7 +182,7 @@ func (*OpenSuite) TestDestroy(c *gc.C) {
 func (*OpenSuite) TestDestroyNotFound(c *gc.C) {
 	var env destroyControllerEnv
 	store := jujuclient.NewMemStore()
-	err := environs.Destroy("fnord", &env, context.NewCloudCallContext(), store)
+	err := environs.Destroy("fnord", &env, context.NewEmptyCloudCallContext(), store)
 	c.Assert(err, jc.ErrorIsNil)
 	env.CheckCallNames(c) // no controller details, no call
 }

--- a/environs/space/context_mock_test.go
+++ b/environs/space/context_mock_test.go
@@ -7,6 +7,7 @@ package space
 import (
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+	time "time"
 )
 
 // MockProviderCallContext is a mock of ProviderCallContext interface
@@ -32,18 +33,47 @@ func (m *MockProviderCallContext) EXPECT() *MockProviderCallContextMockRecorder 
 	return m.recorder
 }
 
-// Dying mocks base method
-func (m *MockProviderCallContext) Dying() <-chan struct{} {
+// Deadline mocks base method
+func (m *MockProviderCallContext) Deadline() (time.Time, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dying")
+	ret := m.ctrl.Call(m, "Deadline")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// Deadline indicates an expected call of Deadline
+func (mr *MockProviderCallContextMockRecorder) Deadline() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deadline", reflect.TypeOf((*MockProviderCallContext)(nil).Deadline))
+}
+
+// Done mocks base method
+func (m *MockProviderCallContext) Done() <-chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Done")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
-// Dying indicates an expected call of Dying
-func (mr *MockProviderCallContextMockRecorder) Dying() *gomock.Call {
+// Done indicates an expected call of Done
+func (mr *MockProviderCallContextMockRecorder) Done() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dying", reflect.TypeOf((*MockProviderCallContext)(nil).Dying))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockProviderCallContext)(nil).Done))
+}
+
+// Err mocks base method
+func (m *MockProviderCallContext) Err() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Err")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Err indicates an expected call of Err
+func (mr *MockProviderCallContextMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockProviderCallContext)(nil).Err))
 }
 
 // InvalidateCredential mocks base method
@@ -58,4 +88,18 @@ func (m *MockProviderCallContext) InvalidateCredential(arg0 string) error {
 func (mr *MockProviderCallContextMockRecorder) InvalidateCredential(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCredential", reflect.TypeOf((*MockProviderCallContext)(nil).InvalidateCredential), arg0)
+}
+
+// Value mocks base method
+func (m *MockProviderCallContext) Value(arg0 interface{}) interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Value", arg0)
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// Value indicates an expected call of Value
+func (mr *MockProviderCallContextMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockProviderCallContext)(nil).Value), arg0)
 }

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -268,7 +268,7 @@ func (s *upgradeSuite) configureMachine(c *gc.C, machineId string, vers version.
 
 	// Provision the machine if it isn't already
 	if _, err := m.InstanceId(); err != nil {
-		inst, md := jujutesting.AssertStartInstance(c, s.Environ, context.NewCloudCallContext(), s.ControllerConfig.ControllerUUID(), machineId)
+		inst, md := jujutesting.AssertStartInstance(c, s.Environ, context.NewEmptyCloudCallContext(), s.ControllerConfig.ControllerUUID(), machineId)
 		c.Assert(m.SetProvisioned(inst.Id(), "", agent.BootstrapNonce, md), jc.ErrorIsNil)
 	}
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -558,7 +558,7 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 	// Dummy provider uses a random port, which is added to cfg used to create environment.
 	apiPort := dummy.APIPort(environ.Provider())
 	s.ControllerConfig["api-port"] = apiPort
-	s.ProviderCallContext = envcontext.NewCloudCallContext()
+	s.ProviderCallContext = envcontext.NewCloudCallContext(context.Background())
 	err = bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), environ, s.ProviderCallContext, bootstrap.BootstrapParams{
 		ControllerConfig: s.ControllerConfig,
 		CloudRegion:      "dummy-region",

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	stdcontext "context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -290,6 +291,7 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.callCtx = &context.CloudCallContext{
+		Context: stdcontext.TODO(),
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidatedCredential = true
 			return nil
@@ -2151,7 +2153,7 @@ func (s *environSuite) TestConstraintsValidatorMerge(c *gc.C) {
 func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {
 	env := s.openEnviron(c)
 	s.sender = azuretesting.Senders{s.resourceSkusSender()}
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 	return validator
 }

--- a/provider/azure/instance.go
+++ b/provider/azure/instance.go
@@ -535,18 +535,17 @@ func (inst *azureInstance) ingressRulesForGroup(ctx context.ProviderCallContext,
 // i.e. both the ones opened by OpenPorts above, and the ones opened for API
 // access.
 func deleteInstanceNetworkSecurityRules(
-	sdkCtx stdcontext.Context,
 	ctx context.ProviderCallContext,
 	env *azureEnviron, id instance.Id,
 	networkInterfaces []network.Interface,
 ) error {
-	securityGroupInfos, err := getSecurityGroupInfoForInterfaces(sdkCtx, env, networkInterfaces)
+	securityGroupInfos, err := getSecurityGroupInfoForInterfaces(ctx, env, networkInterfaces)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	for _, info := range securityGroupInfos {
 		if err := deleteSecurityRules(
-			sdkCtx, ctx, id, info,
+			ctx, ctx, id, info,
 			network.SecurityRulesClient{env.network},
 		); err != nil {
 			return errors.Trace(err)

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	stdcontext "context"
 	"net/http"
 	"path"
 
@@ -63,6 +64,7 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 		makeDeployment("machine-1"),
 	}
 	s.callCtx = &context.CloudCallContext{
+		Context: stdcontext.TODO(),
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidteCredential = true
 			return nil

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -47,7 +47,7 @@ func (s *ErrorSuite) TestNilContext(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
@@ -56,7 +56,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		c.Assert(msg, gc.Matches, "azure cloud denied access: .*")
@@ -78,7 +78,7 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 }
 
 func (*ErrorSuite) TestNilAzureError(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		called = true

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -33,7 +33,7 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 	s.mockSender = mocks.NewSender()
 	s.client.BaseClient = compute.New("subscription-id")
 	s.client.Sender = s.mockSender
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *imageutilsSuite) TestSeriesImageLegacy(c *gc.C) {

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -143,7 +143,7 @@ func (e *azureStorageProvider) VolumeSource(cfg *storage.Config) (storage.Volume
 	// which means it uses unmanaged disks. All models created
 	// before Juju 2.3 will have a storage account already, so
 	// it's safe to do the check up front.
-	maybeStorageClient, maybeStorageAccount, err := e.env.maybeGetStorageClient()
+	maybeStorageClient, maybeStorageAccount, err := e.env.maybeGetStorageClient(stdcontext.Background())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -4,7 +4,6 @@
 package azure
 
 import (
-	stdcontext "context"
 	"math/rand"
 	"net/http"
 
@@ -69,15 +68,15 @@ func isForbiddenResult(resp autorest.Response) bool {
 // Management API, because the API version requested must match the
 // type of the resource being manipulated through the API, rather than
 // the API version specified statically in the resource client code.
-func collectAPIVersions(ctx context.ProviderCallContext, sdkCtx stdcontext.Context, client resources.ProvidersClient) (map[string]string, error) {
+func collectAPIVersions(ctx context.ProviderCallContext, client resources.ProvidersClient) (map[string]string, error) {
 	result := make(map[string]string)
 
 	var res resources.ProviderListResultIterator
-	res, err := client.ListComplete(sdkCtx, nil, "")
+	res, err := client.ListComplete(ctx, nil, "")
 	if err != nil {
 		return result, errorutils.HandleCredentialError(errors.Trace(err), ctx)
 	}
-	for ; res.NotDone(); err = res.NextWithContext(sdkCtx) {
+	for ; res.NotDone(); err = res.NextWithContext(ctx) {
 		if err != nil {
 			return map[string]string{}, errorutils.HandleCredentialError(errors.Trace(err), ctx)
 		}

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -57,7 +57,7 @@ func (s *environSuite) TestBase(c *gc.C) {
 	c.Assert(cfg, gc.NotNil)
 	c.Check(cfg.Name(), gc.Equals, "testname")
 
-	c.Check(env.PrecheckInstance(context.NewCloudCallContext(), environs.PrecheckInstanceParams{}), gc.IsNil)
+	c.Check(env.PrecheckInstance(context.NewEmptyCloudCallContext(), environs.PrecheckInstanceParams{}), gc.IsNil)
 
 	hasRegion, ok := env.(simplestreams.HasRegion)
 	c.Check(ok, gc.Equals, true)
@@ -78,7 +78,7 @@ func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	validator, err := env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, gc.IsNil)
 	c.Check(validator, gc.NotNil)
 

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -62,7 +62,7 @@ func (s *environInstanceSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(*gc.C) { logger.SetLogLevel(ll) })
 
 	mock.Reset()
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *environInstanceSuite) TearDownTest(c *gc.C) {

--- a/provider/cloudsigma/instance_test.go
+++ b/provider/cloudsigma/instance_test.go
@@ -63,7 +63,7 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 	c.Assert(server, gc.NotNil)
 	s.instWithoutIP = &sigmaInstance{server}
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *instanceSuite) TearDownTest(c *gc.C) {

--- a/provider/common/availabilityzones_test.go
+++ b/provider/common/availabilityzones_test.go
@@ -30,7 +30,7 @@ var _ = gc.Suite(&AvailabilityZoneSuite{})
 func (s *AvailabilityZoneSuite) SetUpSuite(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpSuite(c)
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 	allInstances := make([]instances.Instance, 3)
 	for i := range allInstances {
 		allInstances[i] = &mockInstance{id: fmt.Sprintf("inst%d", i)}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -64,7 +64,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 		return fmt.Errorf("mock connection failure to %s", host)
 	})
 
-	s.callCtx = envcontext.NewCloudCallContext()
+	s.callCtx = envcontext.NewEmptyCloudCallContext()
 }
 
 func (s *BootstrapSuite) TearDownTest(c *gc.C) {

--- a/provider/common/destroy_test.go
+++ b/provider/common/destroy_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&DestroySuite{})
 
 func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *DestroySuite) TestCannotGetInstances(c *gc.C) {

--- a/provider/common/errors_test.go
+++ b/provider/common/errors_test.go
@@ -79,7 +79,7 @@ func (s *ErrorsSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	isAuthF := func(e error) bool {
 		return true
 	}
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
@@ -110,7 +110,7 @@ func (s *ErrorsSuite) checkPermissionHandling(c *gc.C, e error, handled bool) {
 	isAuthF := func(e error) bool {
 		return handled
 	}
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		c.Assert(msg, gc.Matches, "cloud denied access:.*auth failure")

--- a/provider/dummy/config_test.go
+++ b/provider/dummy/config_test.go
@@ -87,7 +87,7 @@ func (s *ConfigSuite) TestFirewallMode(c *gc.C) {
 		}
 		c.Assert(err, jc.ErrorIsNil)
 		env := e.(environs.Environ)
-		defer env.Destroy(context.NewCloudCallContext())
+		defer env.Destroy(context.NewEmptyCloudCallContext())
 
 		firewallMode := env.Config().FirewallMode()
 		c.Assert(firewallMode, gc.Equals, test.firewallMode)

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -107,7 +107,7 @@ func (s *suite) SetUpTest(c *gc.C) {
 	s.MgoSuite.SetUpTest(c)
 	s.Tests.SetUpTest(c)
 	s.PatchValue(&dummy.LogDir, c.MkDir())
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *suite) TearDownTest(c *gc.C) {
@@ -137,7 +137,7 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 	c.Assert(supported, jc.IsTrue)
 
 	err = bootstrap.Bootstrap(envtesting.BootstrapContext(c), netenv,
-		context.NewCloudCallContext(), bootstrap.BootstrapParams{
+		context.NewEmptyCloudCallContext(), bootstrap.BootstrapParams{
 			ControllerConfig: testing.FakeControllerConfig(),
 			Cloud: cloud.Cloud{
 				Name:      "dummy",

--- a/provider/dummy/environs_whitebox_test.go
+++ b/provider/dummy/environs_whitebox_test.go
@@ -21,7 +21,7 @@ var _ = gc.Suite(&environWhiteboxSuite{})
 type environWhiteboxSuite struct{}
 
 func (s *environWhiteboxSuite) TestSupportsContainerAddresses(c *gc.C) {
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewEmptyCloudCallContext()
 	// For now this is a static method so we can use a nil environ
 	var env *environ
 	supported, err := env.SupportsContainerAddresses(callCtx)

--- a/provider/ec2/context_mock_test.go
+++ b/provider/ec2/context_mock_test.go
@@ -7,6 +7,7 @@ package ec2
 import (
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+	time "time"
 )
 
 // MockProviderCallContext is a mock of ProviderCallContext interface
@@ -32,18 +33,47 @@ func (m *MockProviderCallContext) EXPECT() *MockProviderCallContextMockRecorder 
 	return m.recorder
 }
 
-// Dying mocks base method
-func (m *MockProviderCallContext) Dying() <-chan struct{} {
+// Deadline mocks base method
+func (m *MockProviderCallContext) Deadline() (time.Time, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dying")
+	ret := m.ctrl.Call(m, "Deadline")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// Deadline indicates an expected call of Deadline
+func (mr *MockProviderCallContextMockRecorder) Deadline() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deadline", reflect.TypeOf((*MockProviderCallContext)(nil).Deadline))
+}
+
+// Done mocks base method
+func (m *MockProviderCallContext) Done() <-chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Done")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
-// Dying indicates an expected call of Dying
-func (mr *MockProviderCallContextMockRecorder) Dying() *gomock.Call {
+// Done indicates an expected call of Done
+func (mr *MockProviderCallContextMockRecorder) Done() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dying", reflect.TypeOf((*MockProviderCallContext)(nil).Dying))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockProviderCallContext)(nil).Done))
+}
+
+// Err mocks base method
+func (m *MockProviderCallContext) Err() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Err")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Err indicates an expected call of Err
+func (mr *MockProviderCallContextMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockProviderCallContext)(nil).Err))
 }
 
 // InvalidateCredential mocks base method
@@ -58,4 +88,18 @@ func (m *MockProviderCallContext) InvalidateCredential(arg0 string) error {
 func (mr *MockProviderCallContextMockRecorder) InvalidateCredential(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCredential", reflect.TypeOf((*MockProviderCallContext)(nil).InvalidateCredential), arg0)
+}
+
+// Value mocks base method
+func (m *MockProviderCallContext) Value(arg0 interface{}) interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Value", arg0)
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// Value indicates an expected call of Value
+func (mr *MockProviderCallContextMockRecorder) Value(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockProviderCallContext)(nil).Value), arg0)
 }

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -62,7 +62,7 @@ func (s *ebsSuite) SetUpTest(c *gc.C) {
 	restoreEC2Patching := patchEC2ForTesting(c, s.srv.region)
 	s.AddCleanup(func(c *gc.C) { restoreEC2Patching() })
 
-	s.cloudCallCtx = context.NewCloudCallContext()
+	s.cloudCallCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *ebsSuite) ebsProvider(c *gc.C) storage.Provider {

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -136,7 +136,7 @@ func (e *environ) Name() string {
 
 // PrepareForBootstrap is part of the Environ interface.
 func (e *environ) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewCloudCallContext(ctx.Context())
 	// Cannot really invalidate a credential here since nothing is bootstrapped yet.
 	callCtx.InvalidateCredentialFunc = func(string) error { return nil }
 	if ctx.ShouldVerifyCredentials() {

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -191,7 +191,7 @@ func (*Suite) TestSupportsNetworking(c *gc.C) {
 }
 
 func (*Suite) TestSupportsSpaces(c *gc.C) {
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewEmptyCloudCallContext()
 	var env *environ
 	supported, err := env.SupportsSpaces(callCtx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -201,7 +201,7 @@ func (*Suite) TestSupportsSpaces(c *gc.C) {
 
 func (*Suite) TestSupportsSpaceDiscovery(c *gc.C) {
 	var env *environ
-	supported, err := env.SupportsSpaceDiscovery(context.NewCloudCallContext())
+	supported, err := env.SupportsSpaceDiscovery(context.NewEmptyCloudCallContext())
 	// TODO(jam): 2016-02-01 the comment on the interface says the error should
 	// conform to IsNotSupported, but all of the implementations just return
 	// nil for error and 'false' for supported.
@@ -210,7 +210,7 @@ func (*Suite) TestSupportsSpaceDiscovery(c *gc.C) {
 }
 
 func (*Suite) TestSupportsContainerAddresses(c *gc.C) {
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewEmptyCloudCallContext()
 	var env *environ
 	supported, err := env.SupportsContainerAddresses(callCtx)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)

--- a/provider/ec2/environ_vpc_test.go
+++ b/provider/ec2/environ_vpc_test.go
@@ -32,7 +32,7 @@ func (s *vpcSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
 	s.stubAPI = &stubVPCAPIClient{Stub: &testing.Stub{}}
-	s.cloudCallCtx = context.NewCloudCallContext()
+	s.cloudCallCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *vpcSuite) TestValidateBootstrapVPCUnexpectedError(c *gc.C) {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -41,7 +41,7 @@ func InstanceSDKEC2(inst instances.Instance) *ec2.Instance {
 }
 
 func TerminatedInstances(e environs.Environ) ([]instances.Instance, error) {
-	return e.(*environ).allInstancesByState(context.NewCloudCallContext(), "shutting-down", "terminated")
+	return e.(*environ).allInstancesByState(context.NewEmptyCloudCallContext(), "shutting-down", "terminated")
 }
 
 func InstanceSecurityGroups(e environs.Environ, ctx context.ProviderCallContext, ids []instance.Id, states ...string) ([]amzec2.SecurityGroup, error) {

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -110,7 +110,7 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.BaseSuite.SetUpTest(c)
 	t.LiveTests.SetUpTest(c)
 
-	t.callCtx = context.NewCloudCallContext()
+	t.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (t *LiveTests) TearDownTest(c *gc.C) {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -277,7 +277,7 @@ func (t *localServerSuite) SetUpTest(c *gc.C) {
 	t.AddCleanup(func(c *gc.C) { restoreEC2Patching() })
 	t.Tests.SetUpTest(c)
 
-	t.callCtx = context.NewCloudCallContext()
+	t.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (t *localServerSuite) TearDownTest(c *gc.C) {

--- a/provider/ec2/provider_test.go
+++ b/provider/ec2/provider_test.go
@@ -138,13 +138,13 @@ func (s *ProviderSuite) TestVerifyCredentialsErrs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 
-	err = ec2.VerifyCredentials(env, context.NewCloudCallContext())
+	err = ec2.VerifyCredentials(env, context.NewEmptyCloudCallContext())
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 	c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
 }
 
 func (s *ProviderSuite) TestMaybeConvertCredentialErrorIgnoresNil(c *gc.C) {
-	err := ec2.MaybeConvertCredentialError(nil, context.NewCloudCallContext())
+	err := ec2.MaybeConvertCredentialError(nil, context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -158,7 +158,7 @@ func (s *ProviderSuite) TestMaybeConvertCredentialErrorConvertsCredentialRelated
 		"PendingVerification",
 		"SignatureDoesNotMatch",
 	} {
-		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code}, context.NewCloudCallContext())
+		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code}, context.NewEmptyCloudCallContext())
 		c.Assert(err, gc.NotNil)
 		c.Assert(err, jc.Satisfies, common.IsCredentialNotValid)
 	}
@@ -169,7 +169,7 @@ func (s *ProviderSuite) TestMaybeConvertCredentialErrorNotInvalidCredential(c *g
 		"OptInRequired",
 		"UnauthorizedOperation",
 	} {
-		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code}, context.NewCloudCallContext())
+		err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: code}, context.NewEmptyCloudCallContext())
 		c.Assert(err, gc.NotNil)
 		c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
 	}
@@ -177,14 +177,14 @@ func (s *ProviderSuite) TestMaybeConvertCredentialErrorNotInvalidCredential(c *g
 
 func (s *ProviderSuite) TestMaybeConvertCredentialErrorHandlesOtherProviderErrors(c *gc.C) {
 	// Any other ec2.Error is returned unwrapped.
-	err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: "DryRunOperation"}, context.NewCloudCallContext())
+	err := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: "DryRunOperation"}, context.NewEmptyCloudCallContext())
 	c.Assert(err, gc.Not(jc.ErrorIsNil))
 	c.Assert(err, gc.Not(jc.Satisfies), common.IsCredentialNotValid)
 }
 
 func (s *ProviderSuite) TestConvertedCredentialError(c *gc.C) {
 	// Trace() will keep error type
-	inner := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: "Blocked"}, context.NewCloudCallContext())
+	inner := ec2.MaybeConvertCredentialError(&ec2cloud.Error{Code: "Blocked"}, context.NewEmptyCloudCallContext())
 	traced := errors.Trace(inner)
 	c.Assert(traced, gc.NotNil)
 	c.Assert(traced, jc.Satisfies, common.IsCredentialNotValid)
@@ -195,13 +195,13 @@ func (s *ProviderSuite) TestConvertedCredentialError(c *gc.C) {
 	c.Assert(annotated, jc.Satisfies, common.IsCredentialNotValid)
 
 	// Running a CredentialNotValid through conversion call again is a no-op.
-	again := ec2.MaybeConvertCredentialError(inner, context.NewCloudCallContext())
+	again := ec2.MaybeConvertCredentialError(inner, context.NewEmptyCloudCallContext())
 	c.Assert(again, gc.NotNil)
 	c.Assert(again, jc.Satisfies, common.IsCredentialNotValid)
 	c.Assert(again.Error(), jc.Contains, "\nYour Amazon account is currently blocked.:  (Blocked)")
 
 	// Running an annotated CredentialNotValid through conversion call again is a no-op too.
-	againAnotated := ec2.MaybeConvertCredentialError(annotated, context.NewCloudCallContext())
+	againAnotated := ec2.MaybeConvertCredentialError(annotated, context.NewEmptyCloudCallContext())
 	c.Assert(againAnotated, gc.NotNil)
 	c.Assert(againAnotated, jc.Satisfies, common.IsCredentialNotValid)
 	c.Assert(againAnotated.Error(), jc.Contains, "\nYour Amazon account is currently blocked.:  (Blocked)")

--- a/provider/ec2/securitygroups_test.go
+++ b/provider/ec2/securitygroups_test.go
@@ -41,7 +41,7 @@ func (s *SecurityGroupSuite) SetUpTest(c *gc.C) {
 			return nil, nil
 		},
 	}
-	s.cloudCallCtx = context.NewCloudCallContext()
+	s.cloudCallCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *SecurityGroupSuite) TestDeleteSecurityGroupSuccess(c *gc.C) {

--- a/provider/gce/google/errors_test.go
+++ b/provider/gce/google/errors_test.go
@@ -40,7 +40,7 @@ func (s *ErrorSuite) TestNilContext(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
@@ -49,7 +49,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		c.Assert(msg, gc.Matches,
@@ -81,7 +81,7 @@ func (s *ErrorSuite) TestAuthRelatedStatusCodes(c *gc.C) {
 }
 
 func (*ErrorSuite) TestNilGoogleError(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		called = true
@@ -93,7 +93,7 @@ func (*ErrorSuite) TestNilGoogleError(c *gc.C) {
 }
 
 func (*ErrorSuite) TestAnyOtherError(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		called = true

--- a/provider/lxd/environ_instance_test.go
+++ b/provider/lxd/environ_instance_test.go
@@ -35,7 +35,7 @@ func (s *environInstSuite) TestInstancesOkay(c *gc.C) {
 	}
 	s.Client.Containers = containers
 
-	insts, err := s.Env.Instances(context.NewCloudCallContext(), ids)
+	insts, err := s.Env.Instances(context.NewEmptyCloudCallContext(), ids)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(insts, jc.DeepEquals, expected)
@@ -43,7 +43,7 @@ func (s *environInstSuite) TestInstancesOkay(c *gc.C) {
 
 func (s *environInstSuite) TestInstancesAPI(c *gc.C) {
 	ids := []instance.Id{"spam", "eggs", "ham"}
-	s.Env.Instances(context.NewCloudCallContext(), ids)
+	s.Env.Instances(context.NewEmptyCloudCallContext(), ids)
 
 	s.Stub.CheckCalls(c, []gitjujutesting.StubCall{{
 		FuncName: "AliveContainers",
@@ -54,7 +54,7 @@ func (s *environInstSuite) TestInstancesAPI(c *gc.C) {
 }
 
 func (s *environInstSuite) TestInstancesEmptyArg(c *gc.C) {
-	insts, err := s.Env.Instances(context.NewCloudCallContext(), nil)
+	insts, err := s.Env.Instances(context.NewEmptyCloudCallContext(), nil)
 
 	c.Check(insts, gc.HasLen, 0)
 	c.Check(errors.Cause(err), gc.Equals, environs.ErrNoInstances)
@@ -65,7 +65,7 @@ func (s *environInstSuite) TestInstancesInstancesFailed(c *gc.C) {
 	s.Stub.SetErrors(failure)
 
 	ids := []instance.Id{"spam"}
-	insts, err := s.Env.Instances(context.NewCloudCallContext(), ids)
+	insts, err := s.Env.Instances(context.NewEmptyCloudCallContext(), ids)
 
 	c.Check(insts, jc.DeepEquals, []instances.Instance{nil})
 	c.Check(errors.Cause(err), gc.Equals, failure)
@@ -77,7 +77,7 @@ func (s *environInstSuite) TestInstancesPartialMatch(c *gc.C) {
 	s.Client.Containers = []containerlxd.Container{*container}
 
 	ids := []instance.Id{"spam", "eggs"}
-	insts, err := s.Env.Instances(context.NewCloudCallContext(), ids)
+	insts, err := s.Env.Instances(context.NewEmptyCloudCallContext(), ids)
 
 	c.Check(insts, jc.DeepEquals, []instances.Instance{expected, nil})
 	c.Check(errors.Cause(err), gc.Equals, environs.ErrPartialInstances)
@@ -88,7 +88,7 @@ func (s *environInstSuite) TestInstancesNoMatch(c *gc.C) {
 	s.Client.Containers = []containerlxd.Container{*container}
 
 	ids := []instance.Id{"eggs"}
-	insts, err := s.Env.Instances(context.NewCloudCallContext(), ids)
+	insts, err := s.Env.Instances(context.NewEmptyCloudCallContext(), ids)
 
 	c.Check(insts, jc.DeepEquals, []instances.Instance{nil})
 	c.Check(errors.Cause(err), gc.Equals, environs.ErrNoInstances)
@@ -114,7 +114,7 @@ func (s *environInstSuite) TestInstancesInvalidCredentials(c *gc.C) {
 func (s *environInstSuite) TestControllerInstancesOkay(c *gc.C) {
 	s.Client.Containers = []containerlxd.Container{*s.Container}
 
-	ids, err := s.Env.ControllerInstances(context.NewCloudCallContext(), coretesting.ControllerTag.Id())
+	ids, err := s.Env.ControllerInstances(context.NewEmptyCloudCallContext(), coretesting.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})
@@ -125,7 +125,7 @@ func (s *environInstSuite) TestControllerInstancesOkay(c *gc.C) {
 }
 
 func (s *environInstSuite) TestControllerInstancesNotBootstrapped(c *gc.C) {
-	_, err := s.Env.ControllerInstances(context.NewCloudCallContext(), "not-used")
+	_, err := s.Env.ControllerInstances(context.NewEmptyCloudCallContext(), "not-used")
 
 	c.Check(err, gc.Equals, environs.ErrNotBootstrapped)
 }
@@ -135,7 +135,7 @@ func (s *environInstSuite) TestControllerInstancesMixed(c *gc.C) {
 	s.Client.Containers = []containerlxd.Container{*s.Container}
 	s.Client.Containers = []containerlxd.Container{*s.Container, other}
 
-	ids, err := s.Env.ControllerInstances(context.NewCloudCallContext(), coretesting.ControllerTag.Id())
+	ids, err := s.Env.ControllerInstances(context.NewEmptyCloudCallContext(), coretesting.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(ids, jc.DeepEquals, []instance.Id{"spam"})
@@ -163,7 +163,7 @@ func (s *environInstSuite) TestAdoptResources(c *gc.C) {
 	three := s.NewContainer(c, "tall-dwarfs")
 	s.Client.Containers = []containerlxd.Container{*one, *two, *three}
 
-	err := s.Env.AdoptResources(context.NewCloudCallContext(), "target-uuid", version.MustParse("3.4.5"))
+	err := s.Env.AdoptResources(context.NewEmptyCloudCallContext(), "target-uuid", version.MustParse("3.4.5"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.BaseSuite.Client.Calls(), gc.HasLen, 4)
 	s.BaseSuite.Client.CheckCall(c, 0, "AliveContainers", "juju-f75cba-")
@@ -182,7 +182,7 @@ func (s *environInstSuite) TestAdoptResourcesError(c *gc.C) {
 	s.Client.Containers = []containerlxd.Container{*one, *two, *three}
 	s.Client.SetErrors(nil, nil, errors.New("blammo"))
 
-	err := s.Env.AdoptResources(context.NewCloudCallContext(), "target-uuid", version.MustParse("5.3.3"))
+	err := s.Env.AdoptResources(context.NewEmptyCloudCallContext(), "target-uuid", version.MustParse("5.3.3"))
 	c.Assert(err, gc.ErrorMatches, `failed to update controller for some instances: \[guild-league\]`)
 	c.Assert(s.BaseSuite.Client.Calls(), gc.HasLen, 4)
 	s.BaseSuite.Client.CheckCall(c, 0, "AliveContainers", "juju-f75cba-")

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -32,7 +32,7 @@ func (s *environNetSuite) TestSubnetsForUnknownContainer(c *gc.C) {
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	_, err := env.Subnets(ctx, "bogus", nil)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
@@ -45,7 +45,7 @@ func (s *environNetSuite) TestSubnetsForServersThatLackRequiredAPIExtensions(c *
 	srv.EXPECT().GetNetworkNames().Return(nil, errors.New(`server is missing the required "network" API extension`)).AnyTimes()
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 
 	// Space support and by extension, subnet detection is not available.
 	supportsSpaces, err := env.SupportsSpaces(ctx)
@@ -116,7 +116,7 @@ func (s *environNetSuite) TestSubnetsForKnownContainer(c *gc.C) {
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	subnets, err := env.Subnets(ctx, "woot", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -182,7 +182,7 @@ func (s *environNetSuite) TestSubnetsForKnownContainerAndSubnetFiltering(c *gc.C
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
 	// Filter list so we only get a single subnet
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	subnets, err := env.Subnets(ctx, "woot", []network.Id{"subnet-lxdbr0-10.55.158.0/24"})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -275,7 +275,7 @@ func (s *environNetSuite) TestSubnetDiscoveryFallbackForOlderLXDs(c *gc.C) {
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 
 	// Spaces should be supported
 	supportsSpaces, err := env.SupportsSpaces(ctx)
@@ -371,7 +371,7 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot"})
 	c.Assert(err, jc.ErrorIsNil)
 	expInfos := []network.InterfaceInfos{
@@ -449,7 +449,7 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot", "unknown"})
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances, gc.Commentf("expected a partial instances error to be returned if some of the instances were not found"))
 	expInfos := []network.InterfaceInfos{
@@ -486,7 +486,7 @@ func (s *environNetSuite) TestNetworkInterfacesNoResults(c *gc.C) {
 
 	env := s.NewEnviron(c, srv, nil).(*environ)
 
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	_, err := env.NetworkInterfaces(ctx, []instance.Id{"unknown1", "unknown2"})
 	c.Assert(err, gc.Equals, environs.ErrNoInstances, gc.Commentf("expected a no instances error to be returned if none of the requested instances exists"))
 }

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -31,7 +31,7 @@ var _ = gc.Suite(&environPolicySuite{})
 
 func (s *environPolicySuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *environPolicySuite) TestPrecheckInstanceDefaults(c *gc.C) {
@@ -125,7 +125,7 @@ func (s *environPolicySuite) TestConstraintsValidatorEmpty(c *gc.C) {
 func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	validator, err := s.env.ConstraintsValidator(context.NewCloudCallContext())
+	validator, err := s.env.ConstraintsValidator(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse(strings.Join([]string{
@@ -207,7 +207,7 @@ func (s *environPolicySuite) TestSupportNetworks(c *gc.C) {
 
 	isSupported := s.env.(interface {
 		SupportNetworks(context.ProviderCallContext) bool
-	}).SupportNetworks(context.NewCloudCallContext())
+	}).SupportNetworks(context.NewEmptyCloudCallContext())
 
 	c.Check(isSupported, jc.IsFalse)
 }

--- a/provider/lxd/instance_test.go
+++ b/provider/lxd/instance_test.go
@@ -34,14 +34,14 @@ func (s *instanceSuite) TestID(c *gc.C) {
 }
 
 func (s *instanceSuite) TestStatus(c *gc.C) {
-	instanceStatus := s.Instance.Status(context.NewCloudCallContext())
+	instanceStatus := s.Instance.Status(context.NewEmptyCloudCallContext())
 
 	c.Check(instanceStatus.Message, gc.Equals, "Running")
 	s.CheckNoAPI(c)
 }
 
 func (s *instanceSuite) TestAddresses(c *gc.C) {
-	addresses, err := s.Instance.Addresses(context.NewCloudCallContext())
+	addresses, err := s.Instance.Addresses(context.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(addresses, jc.DeepEquals, s.Addresses)

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -484,7 +484,7 @@ func (s *providerSuite) TestPingFailWithNoEndpoint(c *gc.C) {
 
 	p, err := environs.Provider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
-	err = p.Ping(context.NewCloudCallContext(), server.URL)
+	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
 	c.Assert(err, gc.ErrorMatches, "no lxd server running at "+server.URL)
 }
 
@@ -494,7 +494,7 @@ func (s *providerSuite) TestPingFailWithHTTP(c *gc.C) {
 
 	p, err := environs.Provider("lxd")
 	c.Assert(err, jc.ErrorIsNil)
-	err = p.Ping(context.NewCloudCallContext(), server.URL)
+	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
 	c.Assert(err, gc.ErrorMatches, "invalid URL \""+server.URL+"\": only HTTPS is supported")
 }
 

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -204,7 +204,7 @@ var _ = gc.Suite(&MaasPingSuite{})
 
 func (s *MaasPingSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *MaasPingSuite) TestPingNoEndpoint(c *gc.C) {

--- a/provider/maas/errors_test.go
+++ b/provider/maas/errors_test.go
@@ -36,7 +36,7 @@ func (s *ErrorSuite) TestNilContext(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		return errors.New("kaboom")
 	}
@@ -77,7 +77,7 @@ func (s *ErrorSuite) TestGomaasError(c *gc.C) {
 }
 
 func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
-	ctx := context.NewCloudCallContext()
+	ctx := context.NewEmptyCloudCallContext()
 	called := false
 	ctx.InvalidateCredentialFunc = func(msg string) error {
 		c.Assert(msg, gc.Matches, "cloud denied access:.*")

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -35,7 +35,7 @@ func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 type environSuite struct {

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -386,7 +386,7 @@ func (e *environSuite) TestCreate(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidator(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
+	validator, err := e.env.ConstraintsValidator(envcontext.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
@@ -398,7 +398,7 @@ func (e *environSuite) TestConstraintsValidator(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidatorEmpty(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
+	validator, err := e.env.ConstraintsValidator(envcontext.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	unsupported, err := validator.Validate(constraints.Value{})
@@ -408,7 +408,7 @@ func (e *environSuite) TestConstraintsValidatorEmpty(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
+	validator, err := e.env.ConstraintsValidator(envcontext.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
@@ -419,7 +419,7 @@ func (e *environSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 }
 
 func (e *environSuite) TestConstraintsValidatorWrongArch(c *gc.C) {
-	validator, err := e.env.ConstraintsValidator(envcontext.NewCloudCallContext())
+	validator, err := e.env.ConstraintsValidator(envcontext.NewEmptyCloudCallContext())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=ppc64el")

--- a/provider/oci/storage_volumes_test.go
+++ b/provider/oci/storage_volumes_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&storageVolumeSuite{})
 func (s *storageVolumeSuite) SetUpTest(c *gc.C) {
 	s.commonSuite.SetUpTest(c)
 
-	s.environCtx = envcontext.NewCloudCallContext()
+	s.environCtx = envcontext.NewEmptyCloudCallContext()
 	var err error
 	s.provider, err = s.env.StorageProvider(oci.OciStorageProviderType)
 	c.Assert(err, gc.IsNil)

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -193,7 +193,7 @@ func (s *LiveTests) assertStartInstanceDefaultSecurityGroup(c *gc.C, useDefault 
 	s.Destroy(c)
 	s.BootstrapOnce(c)
 
-	inst, _ := jujutesting.AssertStartInstance(c, s.Env, context.NewCloudCallContext(), s.ControllerUUID, "100")
+	inst, _ := jujutesting.AssertStartInstance(c, s.Env, context.NewEmptyCloudCallContext(), s.ControllerUUID, "100")
 	// Check whether the instance has the default security group assigned.
 	novaClient := openstack.GetNovaClient(s.Env)
 	groups, err := novaClient.GetServerSecurityGroups(string(inst.Id()))

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -337,7 +337,7 @@ func (s *localServerSuite) SetUpTest(c *gc.C) {
 	openstack.UseTestImageData(s.imageMetadataStorage, s.cred)
 	s.storageAdapter = makeMockAdapter()
 	overrideCinderProvider(&s.CleanupSuite, s.storageAdapter)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *localServerSuite) TearDownTest(c *gc.C) {
@@ -2094,7 +2094,7 @@ func (s *localHTTPSServerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(environs.Environ)
 	s.attrs = s.env.Config().AllAttrs()
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *localHTTPSServerSuite) TearDownTest(c *gc.C) {
@@ -3216,7 +3216,7 @@ func bootstrapEnv(c *gc.C, env environs.Environ) error {
 
 func bootstrapEnvWithConstraints(c *gc.C, env environs.Environ, cons constraints.Value) error {
 	return bootstrap.Bootstrap(envtesting.BootstrapContext(c), env,
-		context.NewCloudCallContext(),
+		context.NewEmptyCloudCallContext(),
 		bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              testing.AdminSecret,

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -474,7 +474,7 @@ func (localTests) TestPingInvalidHost(c *gc.C) {
 
 	p, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
-	callCtx := context.NewCloudCallContext()
+	callCtx := context.NewEmptyCloudCallContext()
 	for _, t := range tests {
 		err = p.Ping(callCtx, t)
 		if err == nil {
@@ -492,7 +492,7 @@ func (localTests) TestPingNoEndpoint(c *gc.C) {
 	defer server.Close()
 	p, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
-	err = p.Ping(context.NewCloudCallContext(), server.URL)
+	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
 	c.Assert(err, gc.ErrorMatches, "No Openstack server running at "+server.URL)
 }
 
@@ -503,7 +503,7 @@ func (localTests) TestPingInvalidResponse(c *gc.C) {
 	defer server.Close()
 	p, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
-	err = p.Ping(context.NewCloudCallContext(), server.URL)
+	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
 	c.Assert(err, gc.ErrorMatches, "No Openstack server running at "+server.URL)
 }
 
@@ -522,7 +522,7 @@ func (localTests) TestPingOK(c *gc.C) {
 func pingOk(c *gc.C, server *httptest.Server) {
 	p, err := environs.Provider("openstack")
 	c.Assert(err, jc.ErrorIsNil)
-	err = p.Ping(context.NewCloudCallContext(), server.URL)
+	err = p.Ping(context.NewEmptyCloudCallContext(), server.URL)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -519,7 +519,7 @@ var _ = gc.Suite(&environBrokerSuite{})
 func (s *environBrokerSuite) setUpClient(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
-	s.callCtx = callcontext.NewCloudCallContext()
+	s.callCtx = callcontext.NewEmptyCloudCallContext()
 	s.mockClient = mocks.NewMockClient(ctrl)
 	s.provider = vsphere.NewEnvironProvider(vsphere.EnvironProviderConfig{
 		Dial: func(_ context.Context, _ *url.URL, _ string) (vsphere.Client, error) {

--- a/provider/vsphere/fixture_test.go
+++ b/provider/vsphere/fixture_test.go
@@ -38,7 +38,7 @@ func (s *ProviderFixture) SetUpTest(c *gc.C) {
 	s.provider = vsphere.NewEnvironProvider(vsphere.EnvironProviderConfig{
 		Dial: newMockDialFunc(&s.dialStub, s.client),
 	})
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 type EnvironFixture struct {
@@ -69,7 +69,7 @@ func (s *EnvironFixture) SetUpTest(c *gc.C) {
 
 	// Make sure we don't fall back to the public image sources.
 	s.PatchValue(&imagemetadata.DefaultUbuntuBaseURL, "")
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func serveImageMetadata(requests *[]*http.Request) *httptest.Server {

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -32,7 +32,7 @@ type loopSuite struct {
 func (s *loopSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *loopSuite) TearDownTest(c *gc.C) {

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -35,7 +35,7 @@ func (s *managedfsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.blockDevices = make(map[names.VolumeTag]storage.BlockDevice)
 	s.filesystems = make(map[names.FilesystemTag]storage.Filesystem)
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 	s.fakeEtcDir = c.MkDir()
 }
 

--- a/storage/provider/rootfs_test.go
+++ b/storage/provider/rootfs_test.go
@@ -37,7 +37,7 @@ func (s *rootfsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
 	s.fakeEtcDir = c.MkDir()
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *rootfsSuite) TearDownTest(c *gc.C) {

--- a/storage/provider/tmpfs_test.go
+++ b/storage/provider/tmpfs_test.go
@@ -35,7 +35,7 @@ func (s *tmpfsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.storageDir = c.MkDir()
 	s.fakeEtcDir = c.MkDir()
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 func (s *tmpfsSuite) TearDownTest(c *gc.C) {

--- a/worker/common/credentialinvalidator.go
+++ b/worker/common/credentialinvalidator.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/credentialvalidator"
 	"github.com/juju/juju/environs/context"
@@ -19,10 +21,15 @@ func NewCredentialInvalidatorFacade(apiCaller base.APICaller) (CredentialAPI, er
 	return credentialvalidator.NewFacade(apiCaller), nil
 }
 
-// NewCloudCallContext creates a cloud call context to be used by workers.
-func NewCloudCallContext(c CredentialAPI, dying context.Dying) context.ProviderCallContext {
-	return &context.CloudCallContext{
-		DyingFunc:                dying,
-		InvalidateCredentialFunc: c.InvalidateModelCredential,
+// NewCloudCallContextFunc creates a function returning a cloud call context to be used by workers.
+func NewCloudCallContextFunc(c CredentialAPI) CloudCallContextFunc {
+	return func(ctx stdcontext.Context) context.ProviderCallContext {
+		return &context.CloudCallContext{
+			Context:                  ctx,
+			InvalidateCredentialFunc: c.InvalidateModelCredential,
+		}
 	}
 }
+
+// CloudCallContextFunc is a function returning a ProviderCallContext.
+type CloudCallContextFunc func(ctx stdcontext.Context) context.ProviderCallContext

--- a/worker/firewaller/firewaller_test.go
+++ b/worker/firewaller/firewaller_test.go
@@ -71,7 +71,7 @@ type firewallerBaseSuite struct {
 func (s *firewallerBaseSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
 var _ worker.Worker = (*firewaller.Firewaller)(nil)

--- a/worker/firewaller/manifold.go
+++ b/worker/firewaller/manifold.go
@@ -4,6 +4,8 @@
 package firewaller
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
@@ -145,7 +147,7 @@ func (cfg ManifoldConfig) start(context dependency.Context) (worker.Worker, erro
 	var envIPV6CIDRSupport bool
 	if featQuerier, ok := environ.(environs.FirewallFeatureQuerier); ok {
 		var err error
-		cloudCtx := common.NewCloudCallContext(credentialAPI, nil)
+		cloudCtx := common.NewCloudCallContextFunc(credentialAPI)(stdcontext.Background())
 		if envIPV6CIDRSupport, err = featQuerier.SupportsRulesWithIPV6CIDRs(cloudCtx); err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/worker/machineundertaker/undertaker_test.go
+++ b/worker/machineundertaker/undertaker_test.go
@@ -4,6 +4,8 @@
 package machineundertaker_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -100,6 +102,9 @@ func (*undertakerSuite) TestMaybeReleaseAddresses_NoAddresses(c *gc.C) {
 		API:      &api,
 		Releaser: &releaser,
 		Logger:   loggo.GetLogger("test"),
+		CallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	}
 	err := u.MaybeReleaseAddresses(names.NewMachineTag("4/lxd/4"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -121,6 +126,9 @@ func (*undertakerSuite) TestMaybeReleaseAddresses_NotSupported(c *gc.C) {
 		API:      &api,
 		Releaser: &releaser,
 		Logger:   loggo.GetLogger("test"),
+		CallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	}
 	err := u.MaybeReleaseAddresses(names.NewMachineTag("4/lxd/4"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -144,6 +152,9 @@ func (*undertakerSuite) TestMaybeReleaseAddresses_ErrorReleasing(c *gc.C) {
 		API:      &api,
 		Releaser: &releaser,
 		Logger:   loggo.GetLogger("test"),
+		CallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	}
 	err := u.MaybeReleaseAddresses(names.NewMachineTag("4/lxd/4"))
 	c.Assert(err, gc.ErrorMatches, "something unexpected")
@@ -166,6 +177,9 @@ func (*undertakerSuite) TestMaybeReleaseAddresses_Success(c *gc.C) {
 		API:      &api,
 		Releaser: &releaser,
 		Logger:   loggo.GetLogger("test"),
+		CallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	}
 	err := u.MaybeReleaseAddresses(names.NewMachineTag("4/lxd/4"))
 	c.Assert(err, jc.ErrorIsNil)
@@ -189,6 +203,9 @@ func (*undertakerSuite) TestHandle_CompletesRemoval(c *gc.C) {
 		API:      &api,
 		Releaser: &releaser,
 		Logger:   loggo.GetLogger("test"),
+		CallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	}
 	err := u.Handle(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -217,6 +234,9 @@ func (*undertakerSuite) TestHandle_NoRemovalOnErrorReleasing(c *gc.C) {
 		API:      &api,
 		Releaser: &releaser,
 		Logger:   loggo.GetLogger("test"),
+		CallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	}
 	err := u.Handle(nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/worker/common"
 )
 
@@ -66,7 +65,7 @@ type provisioner struct {
 	distributionGroupFinder DistributionGroupFinder
 	toolsFinder             ToolsFinder
 	catacomb                catacomb.Catacomb
-	callContext             context.ProviderCallContext
+	callContextFunc         common.CloudCallContextFunc
 }
 
 // RetryStrategy defines the retry behavior when encountering a retryable
@@ -178,7 +177,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		auth,
 		modelCfg.ImageStream(),
 		RetryStrategy{retryDelay: retryStrategyDelay, retryCount: retryStrategyCount},
-		p.callContext,
+		p.callContextFunc,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -206,7 +205,7 @@ func NewEnvironProvisioner(
 			logger:                  logger,
 			toolsFinder:             getToolsFinder(st),
 			distributionGroupFinder: getDistributionGroupFinder(st),
-			callContext:             common.NewCloudCallContext(credentialAPI, nil),
+			callContextFunc:         common.NewCloudCallContextFunc(credentialAPI),
 		},
 		environ: environ,
 	}
@@ -309,7 +308,7 @@ func NewContainerProvisioner(
 			broker:                  broker,
 			toolsFinder:             toolsFinder,
 			distributionGroupFinder: distributionGroupFinder,
-			callContext:             common.NewCloudCallContext(credentialAPI, nil),
+			callContextFunc:         common.NewCloudCallContextFunc(credentialAPI),
 		},
 		containerType: containerType,
 	}

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -4,6 +4,7 @@
 package provisioner
 
 import (
+	stdcontext "context"
 	"fmt"
 	"sort"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v2"
 	"github.com/juju/version/v2"
@@ -34,13 +36,13 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
 	providercommon "github.com/juju/juju/provider/common"
 	"github.com/juju/juju/storage"
 	coretools "github.com/juju/juju/tools"
+	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/wrench"
 )
 
@@ -85,7 +87,7 @@ func NewProvisionerTask(
 	auth authentication.AuthenticationProvider,
 	imageStream string,
 	retryStartInstanceStrategy RetryStrategy,
-	cloudCallContext context.ProviderCallContext,
+	cloudCallContextFunc common.CloudCallContextFunc,
 ) (ProvisionerTask, error) {
 	machineChanges := machineWatcher.Changes()
 	workers := []worker.Worker{machineWatcher}
@@ -111,7 +113,7 @@ func NewProvisionerTask(
 		availabilityZoneMachines:   make([]*AvailabilityZoneMachine, 0),
 		imageStream:                imageStream,
 		retryStartInstanceStrategy: retryStartInstanceStrategy,
-		cloudCallCtx:               cloudCallContext,
+		cloudCallCtxFunc:           cloudCallContextFunc,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &task.catacomb,
@@ -146,7 +148,7 @@ type provisionerTask struct {
 	machines                 map[string]apiprovisioner.MachineProvisioner
 	machinesMutex            sync.RWMutex
 	availabilityZoneMachines []*AvailabilityZoneMachine
-	cloudCallCtx             context.ProviderCallContext
+	cloudCallCtxFunc         common.CloudCallContextFunc
 }
 
 // Kill implements worker.Worker.Kill.
@@ -250,14 +252,16 @@ func (task *provisionerTask) processMachinesWithTransientErrors() error {
 		task.machinesMutex.Unlock()
 		pending = append(pending, machine)
 	}
-	return task.startMachines(pending)
+	ctx := task.cloudCallCtxFunc(stdcontext.Background())
+	return task.startMachines(ctx, pending)
 }
 
 func (task *provisionerTask) processMachines(ids []string) error {
 	task.logger.Tracef("processMachines(%v)", ids)
 
+	ctx := task.cloudCallCtxFunc(stdcontext.Background())
 	// Populate the tasks maps of current instances and machines.
-	if err := task.populateMachineMaps(ids); err != nil {
+	if err := task.populateMachineMaps(ctx, ids); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -272,7 +276,7 @@ func (task *provisionerTask) processMachines(ids []string) error {
 	}
 
 	// Start an instance for the pending ones.
-	return errors.Trace(task.startMachines(pending))
+	return errors.Trace(task.startMachines(ctx, pending))
 }
 
 func instanceIds(instances []instances.Instance) []string {
@@ -285,10 +289,10 @@ func instanceIds(instances []instances.Instance) []string {
 
 // populateMachineMaps updates task.instances. Also updates
 // task.machines map if a list of IDs is given.
-func (task *provisionerTask) populateMachineMaps(ids []string) error {
+func (task *provisionerTask) populateMachineMaps(ctx context.ProviderCallContext, ids []string) error {
 	task.instances = make(map[instance.Id]instances.Instance)
 
-	allInstances, err := task.broker.AllRunningInstances(task.cloudCallCtx)
+	allInstances, err := task.broker.AllRunningInstances(ctx)
 	if err != nil {
 		return errors.Annotate(err, "failed to get all instances from broker")
 	}
@@ -547,7 +551,7 @@ func (task *provisionerTask) stopInstances(instances []instances.Instance) error
 	for i, inst := range instances {
 		ids[i] = inst.Id()
 	}
-	if err := task.broker.StopInstances(task.cloudCallCtx, ids...); err != nil {
+	if err := task.broker.StopInstances(task.cloudCallCtxFunc(stdcontext.Background()), ids...); err != nil {
 		return errors.Annotate(err, "broker failed to stop instances")
 	}
 	return nil
@@ -774,7 +778,7 @@ func (task *provisionerTask) populateAvailabilityZoneMachines() error {
 	// In this case, AvailabilityZoneAllocations() will return all of the "available"
 	// availability zones and their instance allocations.
 	availabilityZoneInstances, err := providercommon.AvailabilityZoneAllocations(
-		zonedEnv, task.cloudCallCtx, []instance.Id{})
+		zonedEnv, task.cloudCallCtxFunc(stdcontext.Background()), []instance.Id{})
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -913,7 +917,7 @@ func (a azMachineSort) Swap(i, j int) {
 
 // startMachines starts a goroutine for each specified machine to
 // start it.  Errors from individual start machine attempts will be logged.
-func (task *provisionerTask) startMachines(machines []apiprovisioner.MachineProvisioner) error {
+func (task *provisionerTask) startMachines(ctx context.ProviderCallContext, machines []apiprovisioner.MachineProvisioner) error {
 	if len(machines) == 0 {
 		return nil
 	}
@@ -944,7 +948,7 @@ func (task *provisionerTask) startMachines(machines []apiprovisioner.MachineProv
 		wg.Add(1)
 		go func(machine apiprovisioner.MachineProvisioner, dg []string, index int) {
 			defer wg.Done()
-			if err := task.startMachine(machine, dg); err != nil {
+			if err := task.startMachine(ctx, machine, dg); err != nil {
 				task.removeMachineFromAZMap(machine)
 				errMachines[index] = err
 			}
@@ -1023,12 +1027,12 @@ func (task *provisionerTask) setupToStartMachine(machine apiprovisioner.MachineP
 // populateExcludedMachines, translates the results of DeriveAvailabilityZones
 // into availabilityZoneMachines.ExcludedMachineIds for machines not to be used
 // in the given zone.
-func (task *provisionerTask) populateExcludedMachines(machineId string, startInstanceParams environs.StartInstanceParams) error {
+func (task *provisionerTask) populateExcludedMachines(ctx context.ProviderCallContext, machineId string, startInstanceParams environs.StartInstanceParams) error {
 	zonedEnv, ok := task.broker.(providercommon.ZonedEnviron)
 	if !ok {
 		return nil
 	}
-	derivedZones, err := zonedEnv.DeriveAvailabilityZones(task.cloudCallCtx, startInstanceParams)
+	derivedZones, err := zonedEnv.DeriveAvailabilityZones(ctx, startInstanceParams)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1047,6 +1051,7 @@ func (task *provisionerTask) populateExcludedMachines(machineId string, startIns
 }
 
 func (task *provisionerTask) startMachine(
+	ctx context.ProviderCallContext,
 	machine apiprovisioner.MachineProvisioner,
 	distributionGroupMachineIds []string,
 ) error {
@@ -1067,7 +1072,7 @@ func (task *provisionerTask) startMachine(
 	// Figure out if the zones available to use for a new instance are
 	// restricted based on placement, and if so exclude those machines
 	// from being started in any other zone.
-	if err := task.populateExcludedMachines(machine.Id(), startInstanceParams); err != nil {
+	if err := task.populateExcludedMachines(ctx, machine.Id(), startInstanceParams); err != nil {
 		return err
 	}
 
@@ -1092,7 +1097,7 @@ func (task *provisionerTask) startMachine(
 				machine, startInstanceParams.AvailabilityZone)
 		}
 
-		attemptResult, err := task.broker.StartInstance(task.cloudCallCtx, startInstanceParams)
+		attemptResult, err := task.broker.StartInstance(ctx, startInstanceParams)
 		if err == nil {
 			result = attemptResult
 			break
@@ -1187,7 +1192,7 @@ func (task *provisionerTask) startMachine(
 		if err2 := task.setErrorStatus("cannot register instance for machine %v: %v", machine, err); err2 != nil {
 			task.logger.Errorf("%v", errors.Annotate(err2, "cannot set machine's status"))
 		}
-		if err2 := task.broker.StopInstances(task.cloudCallCtx, instanceID); err2 != nil {
+		if err2 := task.broker.StopInstances(ctx, instanceID); err2 != nil {
 			task.logger.Errorf("%v", errors.Annotate(err2, "after failing to set instance info"))
 		}
 		return errors.Annotate(err, "cannot set instance info")

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -98,6 +99,7 @@ func (s *ProvisionerTaskSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.callCtx = &context.CloudCallContext{
+		Context: stdcontext.TODO(),
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -668,7 +670,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithRetry(
 		s.auth,
 		imagemetadata.ReleasedStream,
 		retryStrategy,
-		s.callCtx,
+		func(_ stdcontext.Context) context.ProviderCallContext { return s.callCtx },
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return w
@@ -691,7 +693,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithBroker(
 		s.auth,
 		imagemetadata.ReleasedStream,
 		provisioner.NewRetryStrategy(0*time.Second, 0),
-		s.callCtx,
+		func(_ stdcontext.Context) context.ProviderCallContext { return s.callCtx },
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return task

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"strings"
 	"sync"
@@ -149,7 +150,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.cfg = cfg
 
-	s.callCtx = context.NewCloudCallContext()
+	s.callCtx = context.NewEmptyCloudCallContext()
 
 	// Create a machine for the dummy bootstrap instance,
 	// so the provisioner doesn't destroy it.
@@ -1338,7 +1339,7 @@ func (s *ProvisionerSuite) newProvisionerTaskWithRetryStrategy(
 		auth,
 		imagemetadata.ReleasedStream,
 		retryStrategy,
-		s.callCtx,
+		func(_ stdcontext.Context) context.ProviderCallContext { return s.callCtx },
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return w

--- a/worker/storageprovisioner/blockdevices.go
+++ b/worker/storageprovisioner/blockdevices.go
@@ -4,6 +4,8 @@
 package storageprovisioner
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -121,7 +123,7 @@ func machineBlockDevicesChanged(ctx *context) error {
 		return nil
 	}
 	ctx.config.Logger.Debugf("refreshing mounted filesystems: %#v", toUpdate)
-	_, err = ctx.managedFilesystemSource.AttachFilesystems(ctx.config.CloudCallContext, toUpdate)
+	_, err = ctx.managedFilesystemSource.AttachFilesystems(ctx.config.CloudCallContextFunc(stdcontext.Background()), toUpdate)
 	return err
 }
 

--- a/worker/storageprovisioner/caasworker_test.go
+++ b/worker/storageprovisioner/caasworker_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -46,17 +47,17 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	s.lifeGetter = &mockLifecycleManager{}
 
 	s.config = storageprovisioner.Config{
-		Model:            coretesting.ModelTag,
-		Scope:            coretesting.ModelTag,
-		Applications:     s.applicationsWatcher,
-		Volumes:          newMockVolumeAccessor(),
-		Filesystems:      newMockFilesystemAccessor(),
-		Life:             s.lifeGetter,
-		Status:           &mockStatusSetter{},
-		Clock:            &mockClock{},
-		Logger:           loggo.GetLogger("test"),
-		Registry:         storage.StaticProviderRegistry{},
-		CloudCallContext: context.NewCloudCallContext(),
+		Model:                coretesting.ModelTag,
+		Scope:                coretesting.ModelTag,
+		Applications:         s.applicationsWatcher,
+		Volumes:              newMockVolumeAccessor(),
+		Filesystems:          newMockFilesystemAccessor(),
+		Life:                 s.lifeGetter,
+		Status:               &mockStatusSetter{},
+		Clock:                &mockClock{},
+		Logger:               loggo.GetLogger("test"),
+		Registry:             storage.StaticProviderRegistry{},
+		CloudCallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext { return context.NewEmptyCloudCallContext() },
 	}
 }
 

--- a/worker/storageprovisioner/config.go
+++ b/worker/storageprovisioner/config.go
@@ -8,8 +8,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	environscontext "github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/worker/common"
 )
 
 // Logger represents the methods used by the worker to log details.
@@ -22,19 +22,19 @@ type Logger interface {
 
 // Config holds configuration and dependencies for a storageprovisioner worker.
 type Config struct {
-	Model            names.ModelTag
-	Scope            names.Tag
-	StorageDir       string
-	Applications     ApplicationWatcher
-	Volumes          VolumeAccessor
-	Filesystems      FilesystemAccessor
-	Life             LifecycleManager
-	Registry         storage.ProviderRegistry
-	Machines         MachineAccessor
-	Status           StatusSetter
-	Clock            clock.Clock
-	Logger           Logger
-	CloudCallContext environscontext.ProviderCallContext
+	Model                names.ModelTag
+	Scope                names.Tag
+	StorageDir           string
+	Applications         ApplicationWatcher
+	Volumes              VolumeAccessor
+	Filesystems          FilesystemAccessor
+	Life                 LifecycleManager
+	Registry             storage.ProviderRegistry
+	Machines             MachineAccessor
+	Status               StatusSetter
+	Clock                clock.Clock
+	Logger               Logger
+	CloudCallContextFunc common.CloudCallContextFunc
 }
 
 // Validate returns an error if the config cannot be relied upon to start a worker.
@@ -84,8 +84,8 @@ func (config Config) Validate() error {
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
 	}
-	if config.CloudCallContext == nil {
-		return errors.NotValidf("nil CloudCallContext")
+	if config.CloudCallContextFunc == nil {
+		return errors.NotValidf("nil CloudCallContextFunc")
 	}
 	return nil
 }

--- a/worker/storageprovisioner/config_test.go
+++ b/worker/storageprovisioner/config_test.go
@@ -4,6 +4,8 @@
 package storageprovisioner_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -136,7 +138,9 @@ func almostValidConfig() storageprovisioner.Config {
 	// gofmt doesn't seem to want to let me one-line any of these
 	// except the last one, so I'm standardising on multi-line.
 	return storageprovisioner.Config{
-		CloudCallContext: context.NewCloudCallContext(),
+		CloudCallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 		Volumes: struct {
 			storageprovisioner.VolumeAccessor
 		}{},

--- a/worker/storageprovisioner/filesystem_ops.go
+++ b/worker/storageprovisioner/filesystem_ops.go
@@ -4,6 +4,7 @@
 package storageprovisioner
 
 import (
+	stdcontext "context"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -58,7 +59,7 @@ func createFilesystems(ctx *context, ops map[names.FilesystemTag]*createFilesyst
 		if len(filesystemParams) == 0 {
 			continue
 		}
-		results, err := filesystemSource.CreateFilesystems(ctx.config.CloudCallContext, filesystemParams)
+		results, err := filesystemSource.CreateFilesystems(ctx.config.CloudCallContextFunc(stdcontext.Background()), filesystemParams)
 		if err != nil {
 			return errors.Annotatef(err, "creating filesystems from source %q", sourceName)
 		}
@@ -142,7 +143,7 @@ func attachFilesystems(ctx *context, ops map[params.MachineStorageId]*attachFile
 	for sourceName, filesystemAttachmentParams := range paramsBySource {
 		ctx.config.Logger.Debugf("attaching filesystems: %+v", filesystemAttachmentParams)
 		filesystemSource := filesystemSources[sourceName]
-		results, err := filesystemSource.AttachFilesystems(ctx.config.CloudCallContext, filesystemAttachmentParams)
+		results, err := filesystemSource.AttachFilesystems(ctx.config.CloudCallContextFunc(stdcontext.Background()), filesystemAttachmentParams)
 		if err != nil {
 			return errors.Annotatef(err, "attaching filesystems from source %q", sourceName)
 		}
@@ -221,7 +222,7 @@ func removeFilesystems(ctx *context, ops map[names.FilesystemTag]*removeFilesyst
 		if len(ids) == 0 {
 			return nil
 		}
-		errs, err := f(ctx.config.CloudCallContext, ids)
+		errs, err := f(ctx.config.CloudCallContextFunc(stdcontext.Background()), ids)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -315,7 +316,7 @@ func detachFilesystems(ctx *context, ops map[params.MachineStorageId]*detachFile
 		if !ok && ctx.isApplicationKind() {
 			continue
 		}
-		errs, err := filesystemSource.DetachFilesystems(ctx.config.CloudCallContext, filesystemAttachmentParams)
+		errs, err := filesystemSource.DetachFilesystems(ctx.config.CloudCallContextFunc(stdcontext.Background()), filesystemAttachmentParams)
 		if err != nil {
 			return errors.Annotatef(err, "detaching filesystems from source %q", sourceName)
 		}

--- a/worker/storageprovisioner/manifold_machine.go
+++ b/worker/storageprovisioner/manifold_machine.go
@@ -54,17 +54,17 @@ func (config MachineManifoldConfig) newWorker(a agent.Agent, apiCaller base.APIC
 
 	storageDir := filepath.Join(cfg.DataDir(), "storage")
 	w, err := NewStorageProvisioner(Config{
-		Scope:            tag,
-		StorageDir:       storageDir,
-		Volumes:          api,
-		Filesystems:      api,
-		Life:             api,
-		Registry:         provider.CommonStorageProviders(),
-		Machines:         api,
-		Status:           api,
-		Clock:            config.Clock,
-		Logger:           config.Logger,
-		CloudCallContext: common.NewCloudCallContext(credentialAPI, nil),
+		Scope:                tag,
+		StorageDir:           storageDir,
+		Volumes:              api,
+		Filesystems:          api,
+		Life:                 api,
+		Registry:             provider.CommonStorageProviders(),
+		Machines:             api,
+		Status:               api,
+		Clock:                config.Clock,
+		Logger:               config.Logger,
+		CloudCallContextFunc: common.NewCloudCallContextFunc(credentialAPI),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/storageprovisioner/manifold_model.go
+++ b/worker/storageprovisioner/manifold_model.go
@@ -54,19 +54,19 @@ func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 			w, err := config.NewWorker(Config{
-				Model:            config.Model,
-				Scope:            config.Model,
-				StorageDir:       config.StorageDir,
-				Applications:     api,
-				Volumes:          api,
-				Filesystems:      api,
-				Life:             api,
-				Registry:         registry,
-				Machines:         api,
-				Status:           api,
-				Clock:            config.Clock,
-				Logger:           config.Logger,
-				CloudCallContext: common.NewCloudCallContext(credentialAPI, nil),
+				Model:                config.Model,
+				Scope:                config.Model,
+				StorageDir:           config.StorageDir,
+				Applications:         api,
+				Volumes:              api,
+				Filesystems:          api,
+				Life:                 api,
+				Registry:             registry,
+				Machines:             api,
+				Status:               api,
+				Clock:                config.Clock,
+				Logger:               config.Logger,
+				CloudCallContextFunc: common.NewCloudCallContextFunc(credentialAPI),
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/clock"
@@ -61,16 +62,18 @@ func (s *storageProvisionerSuite) SetUpTest(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
 	worker, err := storageprovisioner.NewStorageProvisioner(storageprovisioner.Config{
-		Scope:            coretesting.ModelTag,
-		Volumes:          newMockVolumeAccessor(),
-		Filesystems:      newMockFilesystemAccessor(),
-		Life:             &mockLifecycleManager{},
-		Registry:         s.registry,
-		Machines:         newMockMachineAccessor(c),
-		Status:           &mockStatusSetter{},
-		Clock:            &mockClock{},
-		Logger:           loggo.GetLogger("test"),
-		CloudCallContext: context.NewCloudCallContext(),
+		Scope:       coretesting.ModelTag,
+		Volumes:     newMockVolumeAccessor(),
+		Filesystems: newMockFilesystemAccessor(),
+		Life:        &mockLifecycleManager{},
+		Registry:    s.registry,
+		Machines:    newMockMachineAccessor(c),
+		Status:      &mockStatusSetter{},
+		Clock:       &mockClock{},
+		Logger:      loggo.GetLogger("test"),
+		CloudCallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2089,17 +2092,19 @@ func newStorageProvisioner(c *gc.C, args *workerArgs) worker.Worker {
 		args.statusSetter = &mockStatusSetter{}
 	}
 	worker, err := storageprovisioner.NewStorageProvisioner(storageprovisioner.Config{
-		Scope:            args.scope,
-		StorageDir:       storageDir,
-		Volumes:          args.volumes,
-		Filesystems:      args.filesystems,
-		Life:             args.life,
-		Registry:         args.registry,
-		Machines:         args.machines,
-		Status:           args.statusSetter,
-		Clock:            args.clock,
-		Logger:           loggo.GetLogger("test"),
-		CloudCallContext: context.NewCloudCallContext(),
+		Scope:       args.scope,
+		StorageDir:  storageDir,
+		Volumes:     args.volumes,
+		Filesystems: args.filesystems,
+		Life:        args.life,
+		Registry:    args.registry,
+		Machines:    args.machines,
+		Status:      args.statusSetter,
+		Clock:       args.clock,
+		Logger:      loggo.GetLogger("test"),
+		CloudCallContextFunc: func(_ stdcontext.Context) context.ProviderCallContext {
+			return context.NewEmptyCloudCallContext()
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return worker

--- a/worker/storageprovisioner/volume_ops.go
+++ b/worker/storageprovisioner/volume_ops.go
@@ -4,6 +4,8 @@
 package storageprovisioner
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -53,7 +55,7 @@ func createVolumes(ctx *context, ops map[names.VolumeTag]*createVolumeOp) error 
 		if len(volumeParams) == 0 {
 			continue
 		}
-		results, err := volumeSource.CreateVolumes(ctx.config.CloudCallContext, volumeParams)
+		results, err := volumeSource.CreateVolumes(ctx.config.CloudCallContextFunc(stdcontext.Background()), volumeParams)
 		if err != nil {
 			return errors.Annotatef(err, "creating volumes from source %q", sourceName)
 		}
@@ -148,7 +150,7 @@ func attachVolumes(ctx *context, ops map[params.MachineStorageId]*attachVolumeOp
 			// to do here.
 			continue
 		}
-		results, err := volumeSource.AttachVolumes(ctx.config.CloudCallContext, volumeAttachmentParams)
+		results, err := volumeSource.AttachVolumes(ctx.config.CloudCallContextFunc(stdcontext.Background()), volumeAttachmentParams)
 		if err != nil {
 			return errors.Annotatef(err, "attaching volumes from source %q", sourceName)
 		}
@@ -281,7 +283,7 @@ func removeVolumes(ctx *context, ops map[names.VolumeTag]*removeVolumeOp) error 
 		if len(ids) == 0 {
 			return nil
 		}
-		errs, err := f(ctx.config.CloudCallContext, ids)
+		errs, err := f(ctx.config.CloudCallContextFunc(stdcontext.Background()), ids)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -374,7 +376,7 @@ func detachVolumes(ctx *context, ops map[params.MachineStorageId]*detachVolumeOp
 			// to do here.
 			continue
 		}
-		errs, err := volumeSource.DetachVolumes(ctx.config.CloudCallContext, volumeAttachmentParams)
+		errs, err := volumeSource.DetachVolumes(ctx.config.CloudCallContextFunc(stdcontext.Background()), volumeAttachmentParams)
 		if err != nil {
 			return errors.Annotatef(err, "detaching volumes from source %q", sourceName)
 		}

--- a/worker/undertaker/shim.go
+++ b/worker/undertaker/shim.go
@@ -22,7 +22,7 @@ func NewFacade(apiCaller base.APICaller) (Facade, error) {
 	return facade, nil
 }
 
-// NewFacade creates a worker.Worker from a Config, by calling the
+// NewWorker creates a worker.Worker from a Config, by calling the
 // local constructor that returns a more specific type.
 func NewWorker(config Config) (worker.Worker, error) {
 	worker, err := NewUndertaker(config)

--- a/worker/undertaker/undertaker.go
+++ b/worker/undertaker/undertaker.go
@@ -4,6 +4,7 @@
 package undertaker
 
 import (
+	stdcontext "context"
 	"fmt"
 	"sync"
 
@@ -77,7 +78,7 @@ func NewUndertaker(config Config) (*Undertaker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	u.setCallCtx(common.NewCloudCallContext(config.CredentialAPI, u.catacomb.Dying))
+	u.setCallCtx(common.NewCloudCallContextFunc(config.CredentialAPI)(stdcontext.Background()))
 	return u, nil
 }
 

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -327,7 +327,7 @@ func (s *ContextFactorySuite) setupPodSpec(c *gc.C) (*state.State, context.Conte
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo, err := environs.APIInfo(
-		environscontext.NewCloudCallContext(),
+		environscontext.NewEmptyCloudCallContext(),
 		s.ControllerConfig.ControllerUUID(), st.ModelUUID(), coretesting.CACert, s.ControllerConfig.APIPort(), s.Environ)
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.Tag = unit.Tag()
@@ -535,7 +535,7 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo, err := environs.APIInfo(
-		environscontext.NewCloudCallContext(),
+		environscontext.NewEmptyCloudCallContext(),
 		s.ControllerConfig.ControllerUUID(), st.ModelUUID(), coretesting.CACert, s.ControllerConfig.APIPort(), s.Environ)
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.Tag = unit.Tag()


### PR DESCRIPTION
We use a `environs/context.ProviderCallContext` to pass to API calls in the Environ interface. This context instance provides a callback which can be used to report invalid credentials.

This PR embeds a `context.Context` in the above context. This is immediately useful for the Azure provider where the Azure SDK takes a `context.Context` and we were having to create a separate one of those ourselves. Now, we can just use a single context instance.

Most of the churn here is mechanical - a common helper method used by tests was renamed. 
NewCloudCallContext -> NewEmptyCloudCallContext

Also, the workers which use a context got some refactoring to create the context on demand for each API call instead of creating one up front and using that same instance each time.

A followup PR will use this work to provide a context with deadline to the environ.Destroy() call to allow model destroy operations to timeout cleanly.

## QA steps

This is just a refactor. QA can be to bootstrap on a few substrates (including Azure) and deploy a few charms.