### PR TITLE
Use Addresses member when sending machine link-layer data

### DIFF
--- a/api/common/network.go
+++ b/api/common/network.go
@@ -31,9 +31,6 @@ var logger = loggo.GetLogger("juju.api.common")
 //   have their type forced to bridge and their virtual port type set to
 //   OvsPort.
 // * TODO: IPv6 link-local addresses will be ignored and treated as empty ATM.
-//
-// Result entries will be grouped by InterfaceName, in the same order they are
-// returned by the given source.
 func GetObservedNetworkConfig(source network.ConfigSource) ([]params.NetworkConfig, error) {
 	logger.Tracef("discovering observed machine network config...")
 
@@ -50,151 +47,134 @@ func GetObservedNetworkConfig(source network.ConfigSource) ([]params.NetworkConf
 	if err != nil {
 		// NOTE(achilleasa): we will only get an error here if we do
 		// locate the OVS cli tools and get an error executing them.
-		return nil, errors.Annotate(err, "cannot query list of OVS bridges")
+		return nil, errors.Annotate(err, "querying OVS bridges")
 	}
 
 	defaultRoute, defaultRouteDevice, err := source.DefaultRoute()
 	if err != nil {
-		return nil, errors.Annotate(err, "cannot get default route")
+		return nil, errors.Annotate(err, "retrieving default route")
 	}
-	var namesOrder []string
-	nameToConfigs := make(map[string][]params.NetworkConfig)
+
+	var configs []params.NetworkConfig
+	var bridgeNames []string
+
 	for _, nic := range interfaces {
 		virtualPortType := network.NonVirtualPort
 		if knownOVSBridges.Contains(nic.Name()) {
 			virtualPortType = network.OvsPort
 		}
 
-		nicType := nic.Type()
-		nicConfig := interfaceToNetworkConfig(nic, nicType, virtualPortType, network.OriginMachine)
+		nicConfig := interfaceToNetworkConfig(nic, virtualPortType)
 
 		if nicConfig.InterfaceName == defaultRouteDevice {
 			nicConfig.IsDefaultGateway = true
 			nicConfig.GatewayAddress = defaultRoute.String()
 		}
 
-		if nicType == network.BridgeDevice {
-			updateParentForBridgePorts(source, nic.Name(), nameToConfigs)
+		// Collect all the bridge device names. We will use these to update all
+		// the parent device names for the bridge's port devices at the end.
+		if nic.Type() == network.BridgeDevice {
+			bridgeNames = append(bridgeNames, nic.Name())
 		}
 
-		seenSoFar := false
-		if existing, ok := nameToConfigs[nic.Name()]; ok {
-			nicConfig.ParentInterfaceName = existing[0].ParentInterfaceName
-			// If only ParentInterfaceName was set in a previous iteration (e.g.
-			// if the bridge appeared before the port), treat the interface as
-			// not yet seen.
-			seenSoFar = existing[0].InterfaceName != ""
-		}
-
-		if !seenSoFar {
-			nameToConfigs[nic.Name()] = []params.NetworkConfig(nil)
-			namesOrder = append(namesOrder, nic.Name())
-		}
-
-		addrs, err := nic.Addresses()
+		nicAddrs, err := nic.Addresses()
 		if err != nil {
 			return nil, errors.Annotatef(err, "detecting addresses for %q", nic.Name())
 		}
 
-		if len(addrs) == 0 {
-			logger.Infof("no addresses observed on interface %q", nic.Name())
-			nameToConfigs[nic.Name()] = append(nameToConfigs[nic.Name()], nicConfig)
-			continue
-		}
+		if len(nicAddrs) > 0 {
+			// TODO (manadart 2021-05-07): This preserves prior behaviour,
+			// but is incorrect for DHCP configured devices.
+			// At present we do not store a config type against the device,
+			// only the addresses (which incorrectly default to static too).
+			// This could be corrected by interrogating the DHCP leases for
+			// the device, should we ever need that detail.
+			// At present we do not - we only use it to determine if an address
+			// has a configuration method of "loopback".
+			if nic.Type() != network.LoopbackDevice {
+				nicConfig.ConfigType = string(network.ConfigStatic)
+			}
 
-		for _, addr := range addrs {
-			addressConfig, err := interfaceAddressToNetworkConfig(nic.Name(), nicConfig.ConfigType, addr)
+			nicConfig.Addresses, err = addressesToConfig(nicConfig, nicAddrs)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-
-			// Need to copy nicConfig so only the fields relevant for the
-			// current address are updated.
-			nicConfigCopy := nicConfig
-			nicConfigCopy.Address = addressConfig.Address
-			nicConfigCopy.CIDR = addressConfig.CIDR
-			nicConfigCopy.ConfigType = addressConfig.ConfigType
-			nameToConfigs[nic.Name()] = append(nameToConfigs[nic.Name()], nicConfigCopy)
+		} else {
+			logger.Infof("no addresses observed on interface %q", nic.Name())
 		}
+
+		configs = append(configs, nicConfig)
 	}
 
-	// Return all interfaces configs in input order.
-	var observedConfig []params.NetworkConfig
-	for _, name := range namesOrder {
-		observedConfig = append(observedConfig, nameToConfigs[name]...)
-	}
-	logger.Tracef("observed network config: %+v", observedConfig)
-	return observedConfig, nil
+	updateParentsForBridgePorts(configs, bridgeNames, source)
+	return configs, nil
 }
 
 func interfaceToNetworkConfig(nic network.ConfigSourceNIC,
-	nicType network.LinkLayerDeviceType,
 	virtualPortType network.VirtualPortType,
-	networkOrigin network.Origin,
 ) params.NetworkConfig {
 	configType := network.ConfigManual
-	if nicType == network.LoopbackDevice {
+	if nic.Type() == network.LoopbackDevice {
 		configType = network.ConfigLoopback
 	}
 
 	isUp := nic.IsUp()
 
+	// TODO (dimitern): Add DNS servers and search domains.
 	return params.NetworkConfig{
 		DeviceIndex:     nic.Index(),
 		MACAddress:      nic.HardwareAddr().String(),
 		ConfigType:      string(configType),
 		MTU:             nic.MTU(),
 		InterfaceName:   nic.Name(),
-		InterfaceType:   string(nicType),
+		InterfaceType:   string(nic.Type()),
 		NoAutoStart:     !isUp,
 		Disabled:        !isUp,
 		VirtualPortType: string(virtualPortType),
-		NetworkOrigin:   params.NetworkOrigin(networkOrigin),
+		NetworkOrigin:   params.NetworkOrigin(network.OriginMachine),
 	}
 }
 
-func updateParentForBridgePorts(
-	source network.ConfigSource, bridgeName string, nameToConfigs map[string][]params.NetworkConfig,
-) {
-	for _, portName := range source.GetBridgePorts(bridgeName) {
-		portConfigs, ok := nameToConfigs[portName]
-		if ok {
-			portConfigs[0].ParentInterfaceName = bridgeName
-		} else {
-			portConfigs = []params.NetworkConfig{{ParentInterfaceName: bridgeName}}
+func addressesToConfig(nic params.NetworkConfig, nicAddrs []network.ConfigSourceAddr) ([]params.Address, error) {
+	var res []params.Address
+
+	for _, nicAddr := range nicAddrs {
+		if nicAddr == nil {
+			return nil, errors.Errorf("cannot parse nil address on interface %q", nic.InterfaceName)
 		}
-		nameToConfigs[portName] = portConfigs
+
+		ip := nicAddr.IP()
+
+		// TODO (macgreagoir): Skip IPv6 link-local until we decide how to handle them.
+		if ip.To4() == nil && ip.IsLinkLocalUnicast() {
+			logger.Tracef("skipping observed IPv6 link-local address %q on %q", ip, nic.InterfaceName)
+			continue
+		}
+
+		addr := params.Address{
+			Value:      ip.String(),
+			ConfigType: nic.ConfigType,
+		}
+
+		if ipNet := nicAddr.IPNet(); ipNet != nil && ipNet.Mask != nil {
+			addr.CIDR = network.NetworkCIDRFromIPAndMask(ip, ipNet.Mask)
+		}
+
+		res = append(res, addr)
 	}
+
+	return res, nil
 }
 
-func interfaceAddressToNetworkConfig(
-	interfaceName, configType string, addr network.ConfigSourceAddr,
-) (params.NetworkConfig, error) {
-	config := params.NetworkConfig{
-		ConfigType: configType,
+func updateParentsForBridgePorts(config []params.NetworkConfig, bridgeNames []string, source network.ConfigSource) {
+	for _, bridgeName := range bridgeNames {
+		for _, portName := range source.GetBridgePorts(bridgeName) {
+			for i := range config {
+				if config[i].InterfaceName == portName {
+					config[i].ParentInterfaceName = bridgeName
+					break
+				}
+			}
+		}
 	}
-
-	if addr == nil {
-		return config, errors.Errorf("cannot parse nil address on interface %q", interfaceName)
-	}
-
-	ip := addr.IP()
-	if ip.To4() == nil && ip.IsLinkLocalUnicast() {
-		// TODO(macgreagoir) IPv6. Skip link-local for now until we decide how to handle them.
-		logger.Tracef("skipping observed IPv6 link-local address %q on %q", ip, interfaceName)
-		return config, nil
-	}
-
-	if ipNet := addr.IPNet(); ipNet != nil && ipNet.Mask != nil {
-		config.CIDR = network.NetworkCIDRFromIPAndMask(ip, ipNet.Mask)
-	}
-
-	config.Address = ip.String()
-	if configType != string(network.ConfigLoopback) {
-		config.ConfigType = string(network.ConfigStatic)
-	}
-
-	// TODO(dimitern): Add DNS servers, search domains, and gateway.
-
-	return config, nil
 }

--- a/api/common/network_test.go
+++ b/api/common/network_test.go
@@ -57,7 +57,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigInterfaceAddressesError
 	nic := NewMockConfigSourceNIC(ctrl)
 	exp := nic.EXPECT()
 	exp.Name().Return("eth0").MinTimes(1)
-	exp.Type().Return(network.EthernetDevice)
+	exp.Type().Return(network.EthernetDevice).MinTimes(1)
 	exp.IsUp().Return(true)
 	exp.Index().Return(2)
 	exp.HardwareAddr().Return(net.HardwareAddr{})
@@ -78,7 +78,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigNilAddressError(c *gc.C
 	nic := NewMockConfigSourceNIC(ctrl)
 	exp := nic.EXPECT()
 	exp.Name().Return("eth1").MinTimes(1)
-	exp.Type().Return(network.EthernetDevice)
+	exp.Type().Return(network.EthernetDevice).MinTimes(1)
 	exp.IsUp().Return(true)
 	exp.Index().Return(2)
 	exp.HardwareAddr().Return(parseMAC(c, "aa:bb:cc:dd:ee:ff"))
@@ -101,7 +101,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigNoInterfaceAddresses(c 
 
 	// Note that eth1 is not the default gateway.
 	exp.Name().Return("eth1").MinTimes(1)
-	exp.Type().Return(network.EthernetDevice)
+	exp.Type().Return(network.EthernetDevice).MinTimes(1)
 	exp.IsUp().Return(true)
 	exp.Index().Return(2)
 	exp.HardwareAddr().Return(parseMAC(c, "aa:bb:cc:dd:ee:ff"))
@@ -145,7 +145,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigDefaultGatewayWithAddre
 
 	// eth0 matches the device returned as the default gateway.
 	exp.Name().Return("eth0").MinTimes(1)
-	exp.Type().Return(network.EthernetDevice)
+	exp.Type().Return(network.EthernetDevice).MinTimes(1)
 	exp.IsUp().Return(true)
 	exp.Index().Return(2)
 	exp.HardwareAddr().Return(parseMAC(c, "aa:bb:cc:dd:ee:ff"))
@@ -167,21 +167,17 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigDefaultGatewayWithAddre
 			ConfigType:       "static",
 			IsDefaultGateway: true,
 			GatewayAddress:   "1.2.3.4",
-			Address:          "1.2.3.4",
-			CIDR:             "1.2.3.0/24",
 			NetworkOrigin:    "machine",
-		},
-		{
-			DeviceIndex:      2,
-			MACAddress:       "aa:bb:cc:dd:ee:ff",
-			MTU:              1500,
-			InterfaceName:    "eth0",
-			InterfaceType:    "ethernet",
-			ConfigType:       "static",
-			IsDefaultGateway: true,
-			GatewayAddress:   "1.2.3.4",
-			Address:          "559c:f8c5:812a:fa1f:21fe:5613:3f20:b081",
-			NetworkOrigin:    "machine",
+			Addresses: []params.Address{
+				{
+					Value:      "1.2.3.4",
+					CIDR:       "1.2.3.0/24",
+					ConfigType: "static",
+				}, {
+					Value:      "559c:f8c5:812a:fa1f:21fe:5613:3f20:b081",
+					ConfigType: "static",
+				},
+			},
 		},
 	})
 }
@@ -196,7 +192,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigForOVSDevice(c *gc.C) {
 	exp := nic.EXPECT()
 
 	exp.Name().Return("ovsbr0").MinTimes(1)
-	exp.Type().Return(network.BridgeDevice)
+	exp.Type().Return(network.BridgeDevice).MinTimes(1)
 	exp.IsUp().Return(true)
 	exp.Index().Return(2)
 	exp.HardwareAddr().Return(parseMAC(c, "aa:bb:cc:dd:ee:ff"))
@@ -230,7 +226,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSe
 	exp1 := nic1.EXPECT()
 
 	exp1.Name().Return("eth1").MinTimes(1)
-	exp1.Type().Return(network.EthernetDevice)
+	exp1.Type().Return(network.EthernetDevice).MinTimes(1)
 	exp1.IsUp().Return(true)
 	exp1.Index().Return(2)
 	exp1.HardwareAddr().Return(parseMAC(c, "aa:bb:cc:dd:ee:ff"))
@@ -241,7 +237,7 @@ func (s *networkConfigSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSe
 	exp2 := nic2.EXPECT()
 
 	exp2.Name().Return("br-eth1").MinTimes(1)
-	exp2.Type().Return(network.BridgeDevice)
+	exp2.Type().Return(network.BridgeDevice).MinTimes(1)
 	exp2.IsUp().Return(true)
 	exp2.Index().Return(3)
 	exp2.HardwareAddr().Return(parseMAC(c, "aa:bb:cc:dd:ee:ff"))
@@ -300,102 +296,3 @@ func parseMAC(c *gc.C, val string) net.HardwareAddr {
 	c.Assert(err, jc.ErrorIsNil)
 	return mac
 }
-
-/*
-
-func (s *NetworkSuite) TestGetObservedNetworkConfigBridgePortsHaveParentSet(c *gc.C) {
-	s.stubConfigSource.interfaces = exampleObservedInterfaces[1:5] // eth0, br-eth0, br-eth1, eth1
-	br0Path := s.stubConfigSource.makeSysClassNetInterfacePath(c, "br-eth0", "bridge")
-	// "extra" added below to verify bridge ports which are discovered, but not
-	// found as interfaces from the source will be ignored.
-	s.stubConfigSource.makeSysClassNetBridgePorts(c, br0Path, "eth0", "extra")
-	br1Path := s.stubConfigSource.makeSysClassNetInterfacePath(c, "br-eth1", "bridge")
-	s.stubConfigSource.makeSysClassNetBridgePorts(c, br1Path, "eth1")
-
-	observedConfig, err := common.GetObservedNetworkConfig(s.stubConfigSource)
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(observedConfig, jc.DeepEquals, []params.NetworkConfig{{
-		DeviceIndex:         2,
-		MACAddress:          "aa:bb:cc:dd:ee:f0",
-		MTU:                 1500,
-		InterfaceName:       "eth0",
-		InterfaceType:       "ethernet",
-		ParentInterfaceName: "br-eth0",
-		ConfigType:          "manual",
-		NetworkOrigin:       "machine",
-	}, {
-		DeviceIndex:   10,
-		CIDR:          "10.20.19.0/24",
-		Address:       "10.20.19.100",
-		MACAddress:    "aa:bb:cc:dd:ee:f0",
-		MTU:           1500,
-		InterfaceName: "br-eth0",
-		InterfaceType: "bridge",
-		ConfigType:    "static",
-		NetworkOrigin: "machine",
-	}, {
-		DeviceIndex:   10,
-		CIDR:          "10.20.19.0/24",
-		Address:       "10.20.19.123",
-		MACAddress:    "aa:bb:cc:dd:ee:f0",
-		MTU:           1500,
-		InterfaceName: "br-eth0",
-		InterfaceType: "bridge",
-		ConfigType:    "static",
-		NetworkOrigin: "machine",
-	}, {
-		DeviceIndex:   10,
-		MACAddress:    "aa:bb:cc:dd:ee:f0",
-		MTU:           1500,
-		InterfaceName: "br-eth0",
-		InterfaceType: "bridge",
-		ConfigType:    "manual",
-		NetworkOrigin: "machine",
-	}, {
-		DeviceIndex:   11,
-		CIDR:          "10.20.19.0/24",
-		Address:       "10.20.19.105",
-		MACAddress:    "aa:bb:cc:dd:ee:f1",
-		MTU:           1500,
-		InterfaceName: "br-eth1",
-		InterfaceType: "bridge",
-		ConfigType:    "static",
-		NetworkOrigin: "machine",
-	}, {
-		DeviceIndex:   11,
-		MACAddress:    "aa:bb:cc:dd:ee:f1",
-		MTU:           1500,
-		InterfaceName: "br-eth1",
-		InterfaceType: "bridge",
-		ConfigType:    "manual",
-		NetworkOrigin: "machine",
-	}, {
-		DeviceIndex:         3,
-		MACAddress:          "aa:bb:cc:dd:ee:f1",
-		MTU:                 1500,
-		InterfaceName:       "eth1",
-		InterfaceType:       "ethernet",
-		ParentInterfaceName: "br-eth1",
-		ConfigType:          "manual",
-		GatewayAddress:      "1.2.3.4",
-		IsDefaultGateway:    true,
-		NetworkOrigin:       "machine",
-	}})
-
-	s.stubConfigSource.CheckCallNames(c,
-		"Interfaces",
-		"OvsManagedBridges",
-		"DefaultRoute",
-		"SysClassNetPath",
-		"InterfaceAddresses", // eth0
-		"InterfaceAddresses", // br-eth0
-		"InterfaceAddresses", // br-eth1
-		"InterfaceAddresses", // eth1
-	)
-	s.stubConfigSource.CheckCall(c, 4, "InterfaceAddresses", "eth0")
-	s.stubConfigSource.CheckCall(c, 5, "InterfaceAddresses", "br-eth0")
-	s.stubConfigSource.CheckCall(c, 6, "InterfaceAddresses", "br-eth1")
-	s.stubConfigSource.CheckCall(c, 7, "InterfaceAddresses", "eth1")
-}
-
-*/


### PR DESCRIPTION
Past patches ensured that we can transport `params.NetworkConfig` with `Addresses` members correctly populated with data that used to go against the device itself.

Now we send can `pararms.NetworkConfig` with the correct cardinality for machine-discovered NICs.

Accordingly, this change ensures that a network config is sent just once per detected NIC instead of repeating the config for each detected address.

This will allow us to do some nice clean-up in the next minor version release. 

## QA steps

- Bootstrap to MAAS.
- Add a machine.
- Add a LXD machine to this machine with network space constraints.
- Check that Mongo has devices recorded in the `linklayerdevices` collection including bridges and corresponding parent names.
- Check that Mongo has addresses in the `ip.addresses` collection.

## Documentation changes

None.

## Bug reference

N/A
