### PR TITLE
Fixes proxy address bug in controllers.yaml

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -160,10 +160,10 @@ type state struct {
 	// authorize macaroon based login requests.
 	bakeryClient *httpbakery.Client
 
-	// proxy is the proxy used for this connection when not nil. If's expected
+	// proxier is the proxier used for this connection when not nil. If's expected
 	// the proxy has already been started when placing in this var. This struct
 	// will take the responsibility of closing the proxy.
-	proxy jujuproxy.Proxier
+	proxier jujuproxy.Proxier
 }
 
 // RedirectError is returned from Open when the controller
@@ -216,22 +216,6 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		ctx1, cancel := utils.ContextWithTimeout(dialCtx, opts.Clock, opts.Timeout)
 		defer cancel()
 		dialCtx = ctx1
-	}
-
-	if info.Proxier != nil {
-		if err := info.Proxier.Start(); err != nil {
-			return nil, errors.Annotate(err, "starting proxy for api connection")
-		}
-
-		switch p := info.Proxier.(type) {
-		case jujuproxy.TunnelProxier:
-			info.Addrs = []string{
-				fmt.Sprintf("%s:%s", p.Host(), p.Port()),
-			}
-		default:
-			info.Proxier.Stop()
-			return nil, errors.New("unknown proxier provided")
-		}
 	}
 
 	dialResult, err := dialAPI(dialCtx, info, opts)
@@ -288,6 +272,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		tlsConfig:    dialResult.tlsConfig,
 		bakeryClient: bakeryClient,
 		modelTag:     info.ModelTag,
+		proxier:      dialResult.proxier,
 	}
 	if !info.SkipLogin {
 		if err := loginWithContext(dialCtx, st, info); err != nil {
@@ -582,6 +567,7 @@ type dialResult struct {
 	addr      string
 	urlStr    string
 	ipAddr    string
+	proxier   jujuproxy.Proxier
 	tlsConfig *tls.Config
 }
 
@@ -613,6 +599,27 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	if len(info.Addrs) == 0 {
 		return nil, errors.New("no API addresses to connect to")
 	}
+
+	addrs := info.Addrs[:]
+
+	if info.Proxier != nil {
+		if err := info.Proxier.Start(); err != nil {
+			return nil, errors.Annotate(err, "starting proxy for api connection")
+		}
+		logger.Debugf("starting proxier for connection")
+
+		switch p := info.Proxier.(type) {
+		case jujuproxy.TunnelProxier:
+			logger.Debugf("tunnel proxy in use at %s on port %s", p.Host(), p.Port())
+			addrs = []string{
+				fmt.Sprintf("%s:%s", p.Host(), p.Port()),
+			}
+		default:
+			info.Proxier.Stop()
+			return nil, errors.New("unknown proxier provided")
+		}
+	}
+
 	opts := dialOpts{
 		DialOpts:    opts0,
 		sniHostName: info.SNIHostName,
@@ -642,8 +649,8 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	// Encourage load balancing by shuffling controller addresses.
-	addrs := info.Addrs[:]
 	rand.Shuffle(len(addrs), func(i, j int) { addrs[i], addrs[j] = addrs[j], addrs[i] })
 
 	if opts.VerifyCA != nil {
@@ -662,6 +669,7 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 		return nil, errors.Trace(err)
 	}
 	logger.Infof("connection established to %q", dialInfo.urlStr)
+	dialInfo.proxier = info.Proxier
 	return dialInfo, nil
 }
 
@@ -1258,8 +1266,8 @@ func (s *state) Close() error {
 		close(s.closed)
 	}
 	<-s.broken
-	if s.proxy != nil {
-		s.proxy.Stop()
+	if s.proxier != nil {
+		s.proxier.Stop()
 	}
 	return err
 }
@@ -1297,6 +1305,11 @@ func (s *state) Addr() string {
 // connect to the API server.
 func (s *state) IPAddr() string {
 	return s.ipAddr
+}
+
+// IsProxied indicates if this connection was proxied
+func (s *state) IsProxied() bool {
+	return s.proxier != nil
 }
 
 // ModelTag implements base.APICaller.ModelTag.

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/network"
+	jujuproxy "github.com/juju/juju/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
 )
 
@@ -73,6 +74,7 @@ type TestingStateParams struct {
 	RPCConnection  RPCConnection
 	Clock          clock.Clock
 	Broken, Closed chan struct{}
+	Proxier        jujuproxy.Proxier
 }
 
 // NewTestingState creates an api.State object that can be used for testing. It
@@ -98,6 +100,7 @@ func NewTestingState(params TestingStateParams) Connection {
 		serverRootAddress: params.ServerRoot,
 		broken:            params.Broken,
 		closed:            params.Closed,
+		proxier:           params.Proxier,
 	}
 	return st
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -260,6 +260,9 @@ type Connection interface {
 	// ping.
 	IsBroken() bool
 
+	// IsProxied returns weather the connection is proxied.
+	IsProxied() bool
+
 	// PublicDNSName returns the host name for which an officially
 	// signed certificate will be used for TLS connection to the server.
 	// If empty, the private Juju CA certificate must be used to verify

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/modelmanager"
 	"github.com/juju/juju/api/usermanager"
+	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
 	jujutesting "github.com/juju/juju/juju/testing"
+	proxytest "github.com/juju/juju/proxy/testing"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
@@ -89,6 +91,45 @@ func (s *stateSuite) TestAPIHostPortsAlwaysIncludesTheConnection(c *gc.C) {
 		serverhostports,
 		{*hp},
 	})
+}
+
+func (s *stateSuite) TestAPIHostPortsDoesNotIncludeConnectionProxy(c *gc.C) {
+	info := s.APIInfo(c)
+	conn := newRPCConnection()
+	conn.response = &params.LoginResult{
+		ControllerTag: "controller-" + s.ControllerConfig.ControllerUUID(),
+		ServerVersion: "2.3-rc2",
+		Servers: [][]params.HostPort{
+			{
+				params.HostPort{
+					Address: params.Address{
+						Value: "fe80:abcd::1",
+						CIDR:  "128",
+					},
+					Port: 1234,
+				},
+			},
+		},
+	}
+
+	broken := make(chan struct{})
+	close(broken)
+	testState := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: conn,
+		Clock:         &fakeClock{},
+		Address:       "localhost:1234",
+		Broken:        broken,
+		Closed:        make(chan struct{}),
+		Proxier:       proxytest.NewMockTunnelProxier(),
+	})
+	err := testState.Login(info.Tag, info.Password, "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	hostPortList := testState.APIHostPorts()
+	c.Assert(len(hostPortList), gc.Equals, 1)
+	c.Assert(len(hostPortList[0]), gc.Equals, 1)
+	c.Assert(hostPortList[0][0].NetPort, gc.Equals, network.NetPort(1234))
+	c.Assert(hostPortList[0][0].MachineAddress.Value, gc.Equals, "fe80:abcd::1")
 }
 
 func (s *stateSuite) TestTags(c *gc.C) {

--- a/proxy/testing/proxy.go
+++ b/proxy/testing/proxy.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+type MockProxier struct {
+	// See Proxier interface
+	StartFn func() error
+
+	// See Proxier interface
+	StopFn func()
+
+	// See Proxier interface
+	TypeFn func() string
+}
+
+type MockTunnelProxier struct {
+	*MockProxier
+
+	// See TunnelProxier interface
+	HostFn func() string
+
+	// See TunnelProxier interface
+	PortFn func() string
+}
+
+func NewMockTunnelProxier() *MockTunnelProxier {
+	return &MockTunnelProxier{
+		MockProxier: &MockProxier{},
+	}
+}
+
+func (mp *MockProxier) Start() error {
+	if mp.StartFn == nil {
+		return nil
+	}
+	return mp.StartFn()
+}
+
+func (mp *MockProxier) Stop() {
+	if mp.StopFn != nil {
+		mp.StopFn()
+	}
+}
+
+func (mp *MockProxier) Type() string {
+	if mp.TypeFn == nil {
+		return "mock-proxier"
+	}
+	return mp.TypeFn()
+}
+
+func (mtp *MockTunnelProxier) Host() string {
+	if mtp.HostFn == nil {
+		return ""
+	}
+	return mtp.HostFn()
+}
+
+func (mtp *MockTunnelProxier) Port() string {
+	if mtp.PortFn == nil {
+		return ""
+	}
+	return mtp.PortFn()
+}


### PR DESCRIPTION
With the introduction of the Kubernetes proxy our update controllers
yaml logic was including the temp proxy address in the endpoints list.
This is not ideal because it's temporary. This change fixes that by not
inlcuding the connected address as part of the output anymore.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

1. Bootstrap a Kubernetes controller that requires proxying. (Minikube, Microk8s).
2. Check the controllers.yaml file created to make sure there is no mention of localhost and a random port in the endpoints list
3. Run auxiliary Juju commands to make sure that subsequent logins don't add this extra information.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1926595
