### PR TITLE
Improve add-relation error message for terminated offers

### DIFF
--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -98,6 +98,19 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationFailure(c *gc.C) {
 	s.mockAPI.CheckCallNames(c, "BestAPIVersion", "GetConsumeDetails", "Consume", "Close", "AddRelation", "Close")
 }
 
+func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationTerminated(c *gc.C) {
+	msg := "remote offer applicationname is terminated"
+	s.mockAPI.addRelation = func(endpoints, viaCIDRs []string) (*params.AddRelationResults, error) {
+		return nil, errors.New(msg)
+	}
+
+	err := s.runAddRelation(c, "applicationname2", "applicationname")
+	c.Assert(err, gc.ErrorMatches, `
+Offer "applicationname" has been removed from the remote model.
+To relate to a new offer with the same name, first run
+'juju remove-saas applicationname' to remove the SAAS record from this model.`[1:])
+}
+
 func (s *AddRemoteRelationSuiteNewAPI) TestAddedRelationVia(c *gc.C) {
 	err := s.runAddRelation(c, "othermodel.applicationname2", "applicationname", "--via", "192.168.1.0/16, 10.0.0.0/16")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -166,7 +166,7 @@ func (c *destroyCommand) Init(args []string) error {
 	if c.destroyStorage && c.releaseStorage {
 		return errors.New("--destroy-storage and --release-storage cannot both be specified")
 	}
-	if c.timeout <= 0 {
+	if c.timeout < 0 {
 		return errors.New("timeout must be zero or greater")
 	}
 


### PR DESCRIPTION
When a consumed offer is terminated on the offering side, attempts to relate to that SAAS application rightly fail.
This PR improves the error message.

Also a driveby fix for destroy model timeout.

## QA steps

See bug. Relate to an offer and then remove it from the offering model.
Then attempt to relate again.

```
$ juju relate mediawiki:db mariadb
ERROR Offer "mariadb" has been removed from the remote model.
To relate to a new offer with the same name, first run
'juju remove-saas mariadb' to remove the SAAS record from this model.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928020
