### PR TITLE
Introduces a new portforward verb for k8s proxy.

### DIFF
--- a/caas/kubernetes/provider/proxy/setup.go
+++ b/caas/kubernetes/provider/proxy/setup.go
@@ -68,10 +68,12 @@ func CreateControllerProxy(
 				Resources: []string{"services"},
 				Verbs:     []string{"get"},
 			},
+			// The get verb below is not used directly by juju but is for
+			// the python lib
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods/portforward"},
-				Verbs:     []string{"create"},
+				Verbs:     []string{"create", "get"},
 			},
 		},
 	}

--- a/caas/kubernetes/provider/proxy/setup_test.go
+++ b/caas/kubernetes/provider/proxy/setup_test.go
@@ -69,7 +69,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	c.Assert(role.Rules[1].Resources, jc.DeepEquals, []string{"services"})
 	c.Assert(role.Rules[1].Verbs, jc.DeepEquals, []string{"get"})
 	c.Assert(role.Rules[2].Resources, jc.DeepEquals, []string{"pods/portforward"})
-	c.Assert(role.Rules[2].Verbs, jc.DeepEquals, []string{"create"})
+	c.Assert(role.Rules[2].Verbs, jc.DeepEquals, []string{"create", "get"})
 
 	sa, err := s.client.CoreV1().ServiceAccounts(testNamespace).Get(
 		context.TODO(),


### PR DESCRIPTION
The get verb is being added for the k8s rbac proxy permissions. This is needed for the python library to proxy onto k8s.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap to a k8s cluster that Juju would need to proxy through. For example microk8s or minikube.

Check the role created in the controller namespace 'controller-proxy' to make sure the new get verb appears.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1926595
