### PR TITLE
Fixes a panic with Juju ssh k8s proxy.

### DIFF
--- a/caas/kubernetes/tunnel.go
+++ b/caas/kubernetes/tunnel.go
@@ -52,7 +52,11 @@ const (
 
 // Close disconnects a tunnel connection
 func (t *Tunnel) Close() {
-	close(t.stopChan)
+	select {
+	case <-t.stopChan:
+	default:
+		close(t.stopChan)
+	}
 }
 
 // findSuitablePodForService when tunneling to a kubernetes service we need to


### PR DESCRIPTION
The panic was happening because of a double close event on the k8s proxy
channel. This is due to Close being called more then once on the
underlying juju connection.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

1. Bootstrap a microk8s controller. 
2. Deploy a charmed workload
3. ssh to one of the workloads unit's
4. crtl+d on the ssh connection and check for no panic on the client at the end.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928165
