### PR TITLE
Static analysis wasn't exiting correctly

### DIFF
--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,18 +1,26 @@
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [ "${VER}" != "1.36" ]; then
+	if [[ ${VER} != "1.36" ]]; then
 		(echo >&2 -e '\nError: golangci-lint version does not match 1.36. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi
-	golangci-lint run -c .github/golangci-lint.config.yaml
-	golangci-lint run -c .github/golangci-lint.config.experimental.yaml
+	OUT=$(golangci-lint run -c .github/golangci-lint.config.yaml 2>&1)
+	if [[ -n ${OUT} ]]; then
+		(echo >&2 "\\nError: linter has issues:\\n\\n${OUT}")
+		exit 1
+	fi
+	OUT=$(golangci-lint run -c .github/golangci-lint.config.experimental.yaml 2>&1)
+	if [[ -n ${OUT} ]]; then
+		(echo >&2 "\\nError: experimental linter has issues:\\n\\n${OUT}")
+		exit 1
+	fi
 }
 
 run_go_tidy() {
 	CUR_SHA=$(git show HEAD:go.sum | shasum -a 1 | awk '{ print $1 }')
 	go mod tidy 2>&1
 	NEW_SHA=$(cat go.sum | shasum -a 1 | awk '{ print $1 }')
-	if [ "${CUR_SHA}" != "${NEW_SHA}" ]; then
+	if [[ ${CUR_SHA} != "${NEW_SHA}" ]]; then
 		git diff >&2
 		(echo >&2 -e "\\nError: go mod sum is out of sync. Run 'go mod tidy' and commit source.")
 		exit 1


### PR DESCRIPTION
The golangci-lint isn't always exiting correctly and I'm not entirely
sure why. The fix, for now, is to read the output of the command and
determine if it has text, if it does then exit hard.

## QA steps

Apply this diff:

```diff
diff --git a/apiserver/facades/client/action/operation.go b/apiserver/facades/client/action/operation.go
index e85a412038..3e2a93098e 100644
--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -122,8 +122,8 @@ func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, e
                // If we failed to enqueue the action, record the error on the operation.
                if !errorRecorded {
                        errorRecorded = true
-                       err := a.model.FailOperation(operationID, actionErr)
-                       logger.Errorf("unable to log the error on the operation: %v", err)
+                       err = a.model.FailOperation(operationID, actionErr)
+                       //logger.Errorf("unable to log the error on the operation: %v", err)
                }
                currentResult.Error = apiservererrors.ServerError(actionErr)
        }
```

Then run:

```sh
$ make static-analysis
```

Should fail like:

```sh
==> Checking for dependencies
==> TEST BEGIN: test_static_analysis (tmp.CnE)
===> [ ✔ ] Success: copyright (0s)
===> [ x ] Fail: go (10s)
==> Cleaning up
====> Completed cleaning up jujus

==> TESTS DONE: test_static_analysis
==> RUN OUTPUT: test_static_analysis
    |
    | Error: linter has issues:
    |
    | apiserver/facades/client/action/operation.go:21:5: `logger` is unused (deadcode)
    | var logger = loggo.GetLogger("juju.apiserver.action")
    | ^
    | apiserver/facades/client/action/operation.go:125:4: ineffectual assignment to `err` (ineffassign)
    | err = a.model.FailOperation(operationID, actionErr)
    | ^

==> Test result: failure
==> TEST COMPLETE
make: *** [Makefile:278: static-analysis] Error 1
```
