### PR TITLE
Add relation error

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -3361,7 +3361,7 @@ func (s *applicationSuite) TestAddAlreadyAddedRelation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// And try to add it again.
 	_, err = s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server`)
 }
 
 func (s *applicationSuite) setupRemoteApplication(c *gc.C) {
@@ -3420,7 +3420,7 @@ func (s *applicationSuite) TestAlreadyAddedRemoteRelation(c *gc.C) {
 
 	// And try to add it again.
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`cannot add relation "wordpress:db hosted-mysql:server": relation wordpress:db hosted-mysql:server already exists`))
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`cannot add relation "wordpress:db hosted-mysql:server": relation wordpress:db hosted-mysql:server`))
 }
 
 func (s *applicationSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -292,10 +292,12 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 		common.PermissionsMessage(ctx.Stderr, "add a relation")
 	}
 	if params.IsCodeAlreadyExists(err) {
-		// It's not a real error, mention about it, log it and move along
-		logger.Infof("%s", err)
-		ctx.Infof("%s", err)
-		err = nil
+		splitError := strings.Join(strings.Split(err.Error(), ": "), "\n")
+		infoErr := errors.Errorf(`
+
+Use 'juju status --relations' to view the current relations
+for %q.`, strings.Join(c.endpoints, ", "))
+		return errors.Annotatef(infoErr, splitError)
 	}
 	if err != nil && offerTerminatedRegexp.MatchString(err.Error()) {
 		offerName := offerTerminatedRegexp.ReplaceAllString(err.Error(), "$offer")

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -295,8 +295,7 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 		splitError := strings.Join(strings.Split(err.Error(), ": "), "\n")
 		infoErr := errors.Errorf(`
 
-Use 'juju status --relations' to view the current relations
-for %q.`, strings.Join(c.endpoints, ", "))
+Use 'juju status --relations' to view the current relations.`)
 		return errors.Annotatef(infoErr, splitError)
 	}
 	if err != nil && offerTerminatedRegexp.MatchString(err.Error()) {

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -37,8 +37,12 @@ func (s *CmdRelationSuite) TestAddRelationSuccess(c *gc.C) {
 func (s *CmdRelationSuite) TestAddRelationSuccessOnAlreadyExists(c *gc.C) {
 	runCommandExpectSuccess(c, "add-relation", s.apps...)
 	context, err := runCommand(c, append([]string{"add-relation"}, s.apps...)...)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(cmdtesting.Stderr(context), jc.Contains, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
+	c.Assert(err, gc.NotNil)
+	c.Check(cmdtesting.Stderr(context), jc.Contains, `ERROR cannot add relation "wordpress:db mysql:server"
+relation wordpress:db mysql:server (already exists): 
+
+Use 'juju status --relations' to view the current relations.
+`)
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -53,6 +53,7 @@ const (
 	GUISettingsC      = guisettingsC
 	GlobalSettingsC   = globalSettingsC
 	SettingsC         = settingsC
+	UnitsC            = unitsC
 )
 
 var (
@@ -78,6 +79,10 @@ type (
 	StorageBackend         = storageBackend
 	DeviceBackend          = deviceBackend
 	ControllerNodeInstance = controllerNode
+)
+
+var (
+	IsDying = isDying
 )
 
 func NewStateSettingsForCollection(backend modelBackend, collection string) *StateSettings {

--- a/state/life.go
+++ b/state/life.go
@@ -97,6 +97,16 @@ func isNotDeadWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 	return checkLifeWithSession(coll, id, bson.DocElem{"life", bson.D{{"$ne", Dead}}})
 }
 
+func isDying(mb modelBackend, collName string, id interface{}) (bool, error) {
+	coll, closer := mb.db().GetCollection(collName)
+	defer closer()
+	return isDyingWithSession(coll, id)
+}
+
+func isDyingWithSession(coll mongo.Collection, id interface{}) (bool, error) {
+	return checkLifeWithSession(coll, id, bson.DocElem{"life", Dying})
+}
+
 func checkLifeWithSession(coll mongo.Collection, id interface{}, sel bson.DocElem) (bool, error) {
 	n, err := coll.Find(bson.D{{"_id", id}, sel}).Count()
 	return n == 1, err

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -82,6 +82,7 @@ var stateChanges = []struct {
 type lifeFixture interface {
 	id() (coll string, id interface{})
 	setup(s *LifeSuite, c *gc.C) state.AgentLiving
+	isDying(s *LifeSuite, c *gc.C) bool
 }
 
 type unitLife struct {
@@ -90,7 +91,7 @@ type unitLife struct {
 }
 
 func (l *unitLife) id() (coll string, id interface{}) {
-	return "units", state.DocID(l.st, l.unit.Name())
+	return state.UnitsC, state.DocID(l.st, l.unit.Name())
 }
 
 func (l *unitLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
@@ -101,13 +102,20 @@ func (l *unitLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
 	return l.unit
 }
 
+func (l *unitLife) isDying(s *LifeSuite, c *gc.C) bool {
+	col, id := l.id()
+	dying, err := state.IsDying(l.st, col, id)
+	c.Assert(err, jc.ErrorIsNil)
+	return dying
+}
+
 type machineLife struct {
 	machine *state.Machine
 	st      *state.State
 }
 
 func (l *machineLife) id() (coll string, id interface{}) {
-	return "machines", state.DocID(l.st, l.machine.Id())
+	return state.MachinesC, state.DocID(l.st, l.machine.Id())
 }
 
 func (l *machineLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
@@ -115,6 +123,13 @@ func (l *machineLife) setup(s *LifeSuite, c *gc.C) state.AgentLiving {
 	l.machine, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	return l.machine
+}
+
+func (l *machineLife) isDying(s *LifeSuite, c *gc.C) bool {
+	col, id := l.id()
+	dying, err := state.IsDying(l.st, col, id)
+	c.Assert(err, jc.ErrorIsNil)
+	return dying
 }
 
 func (s *LifeSuite) prepareFixture(living state.Living, lfix lifeFixture, cached, dbinitial state.Life, c *gc.C) {
@@ -145,6 +160,8 @@ func (s *LifeSuite) TestLifecycleStateChanges(c *gc.C) {
 			case state.Dying:
 				err := living.Destroy()
 				c.Assert(err, jc.ErrorIsNil)
+				ok := lfix.isDying(s, c)
+				c.Assert(ok, jc.IsTrue)
 			case state.Dead:
 				err := living.EnsureDead()
 				c.Assert(err, jc.ErrorIsNil)

--- a/state/life_test.go
+++ b/state/life_test.go
@@ -160,8 +160,13 @@ func (s *LifeSuite) TestLifecycleStateChanges(c *gc.C) {
 			case state.Dying:
 				err := living.Destroy()
 				c.Assert(err, jc.ErrorIsNil)
-				ok := lfix.isDying(s, c)
-				c.Assert(ok, jc.IsTrue)
+
+				// If we're already in the dead state, we can't transition, so
+				// don't test that permutation.
+				if v.dbinitial != state.Dead {
+					ok := lfix.isDying(s, c)
+					c.Assert(ok, jc.IsTrue)
+				}
 			case state.Dead:
 				err := living.EnsureDead()
 				c.Assert(err, jc.ErrorIsNil)

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -181,9 +181,9 @@ func (s *RelationSuite) TestAddRelation(c *gc.C) {
 
 	// Check we cannot re-add the same relation, regardless of endpoint ordering.
 	_, err = s.State.AddRelation(mysqlEP, wordpressEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server`)
 	_, err = s.State.AddRelation(wordpressEP, mysqlEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "wordpress:db mysql:server": relation wordpress:db mysql:server`)
 	assertOneRelation(c, mysql, 0, mysqlEP, wordpressEP)
 	assertOneRelation(c, wordpress, 0, wordpressEP, mysqlEP)
 }
@@ -219,9 +219,9 @@ func (s *RelationSuite) TestAddContainerRelation(c *gc.C) {
 
 	// Check we cannot re-add the same relation, regardless of endpoint ordering.
 	_, err = s.State.AddRelation(loggingEP, wordpressEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation logging:info wordpress:juju-info already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation logging:info wordpress:juju-info`)
 	_, err = s.State.AddRelation(wordpressEP, loggingEP)
-	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation logging:info wordpress:juju-info already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add relation "logging:info wordpress:juju-info": relation logging:info wordpress:juju-info`)
 	assertOneRelation(c, logging, 0, loggingEP, wordpressEP)
 	assertOneRelation(c, wordpress, 0, wordpressEP, loggingEP)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2029,7 +2029,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 			if dying, _ := isDying(st, relationsC, key); dying {
 				return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("relation %v is dying, but not yet removed", key))
 			}
-			return nil, errors.AlreadyExistsf("relation %v", key)
+			return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("relation %v", key))
 		}
 
 		// Collect per-application operations, checking sanity as we go.

--- a/state/state.go
+++ b/state/state.go
@@ -1969,6 +1969,7 @@ func (st *State) endpoints(name string, filter func(ep Endpoint) bool) ([]Endpoi
 func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 	key := relationKey(eps)
 	defer errors.DeferredAnnotatef(&err, "cannot add relation %q", key)
+
 	// Enforce basic endpoint sanity. The epCount restrictions may be relaxed
 	// in the future; if so, this method is likely to need significant rework.
 	if len(eps) != 2 {
@@ -2008,10 +2009,12 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 	} else {
 		compatibleSeries = false
 	}
+
 	// We only get a unique relation id once, to save on roundtrips. If it's
 	// -1, we haven't got it yet (we don't get it at this stage, because we
 	// still don't know whether it's sane to even attempt creation).
 	id := -1
+
 	// If a application's charm is upgraded while we're trying to add a relation,
 	// we'll need to re-validate application sanity.
 	var doc *relationDoc
@@ -2021,8 +2024,14 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		if exists, err := isNotDead(st, relationsC, key); err != nil {
 			return nil, errors.Trace(err)
 		} else if exists {
+			// Ignore the error here, if there is an error, we know that dying
+			// will be false and can fall through to error message below.
+			if dying, _ := isDying(st, relationsC, key); dying {
+				return nil, errors.AlreadyExistsf("relation %v is dying and", key)
+			}
 			return nil, errors.AlreadyExistsf("relation %v", key)
 		}
+
 		// Collect per-application operations, checking sanity as we go.
 		var ops []txn.Op
 		var subordinateCount int

--- a/state/state.go
+++ b/state/state.go
@@ -2027,7 +2027,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 			// Ignore the error here, if there is an error, we know that dying
 			// will be false and can fall through to error message below.
 			if dying, _ := isDying(st, relationsC, key); dying {
-				return nil, errors.AlreadyExistsf("relation %v is dying and", key)
+				return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("relation %v is dying, but not yet removed", key))
 			}
 			return nil, errors.AlreadyExistsf("relation %v", key)
 		}


### PR DESCRIPTION
The following changes in state allow us to see if a relation is dying
whilst it already exists. This way we can inform users of juju when
attempting to add a relation that already exists, but failed to do so
because it failed to remove originally.

**Note**: A subsequent PR will fix the issue where we double wrap
the `already exists (already exists):` in the error message.

## QA steps

This requires forcing a charm into a broken state on departing, so
we can see the error message.

Firstly we need to apply the diff to juju-qa-test charm:

```diff
diff --git a/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml b/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
index 5f485e47d5..6373a29faf 100644
--- a/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
@@ -8,6 +8,7 @@ description: |
   A container-based V2 metadata charm to use in testing juju.
   It has config, actions, resources, and a relation.
 series: [groovy, focal, bionic, xenial]
+subordinate: true
 requires:
   info:
     interface: juju-info
diff --git a/testcharms/charm-hub/charms/juju-qa-test/src/charm.py b/testcharms/charm-hub/charms/juju-qa-test/src/charm.py
index 25d36077c8..39b1d6141d 100755
--- a/testcharms/charm-hub/charms/juju-qa-test/src/charm.py
+++ b/testcharms/charm-hub/charms/juju-qa-test/src/charm.py
@@ -25,6 +25,7 @@ class ApitestUbuntuQaCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.fortune_action, self._on_fortune_action)
         self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.info_relation_departed, self._on_relation_departed)
         self._stored.set_default(things=[])
         self._stored.set_default(foo="")
         self._stored.set_default(status="")
@@ -76,6 +77,9 @@ class ApitestUbuntuQaCharm(CharmBase):
         status = "resource line one: {}".format( line.strip())
         self.unit.status = ActiveStatus(status)

+    def _on_relation_departed(self, event):
+        event.fail("FAIL")
+

 if __name__ == "__main__":
     main(ApitestUbuntuQaCharm)
```

Then we need to build that charm so we can deploy it later

```sh
cd testcharms/charm-hub/charms/juju-qa-test/
charmcraft build
cd -
```

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu
$ juju deploy ./testcharms/charm-hub/charms/juju-qa-test/juju-qa-test.charm
$ juju relate ubuntu juju-qa-test
$ juju remove-relation ubuntu juju-qa-test
$ juju relate ubuntu juju-qa-test
ERROR cannot add relation "juju-qa-test:info ubuntu:juju-info"
relation juju-qa-test:info ubuntu:juju-info is dying and already exists (already exists):

Use 'juju status --relations' to view the current relations.
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1902544