### PR TITLE
[2.9] Fix various 'juju refresh --switch' bugs

### DIFF
--- a/api/charms/client.go
+++ b/api/charms/client.go
@@ -43,8 +43,9 @@ func (c *Client) IsMetered(charmURL string) (bool, error) {
 
 // CharmToResolve holds the charm url and it's channel to be resolved.
 type CharmToResolve struct {
-	URL    *charm.URL
-	Origin apicharm.Origin
+	URL         *charm.URL
+	Origin      apicharm.Origin
+	SwitchCharm bool
 }
 
 // ResolvedCharm holds resolved charm data.
@@ -69,8 +70,9 @@ func (c *Client) ResolveCharms(charms []CharmToResolve) ([]ResolvedCharm, error)
 	}
 	for i, ch := range charms {
 		args.Resolve[i] = params.ResolveCharmWithChannel{
-			Reference: ch.URL.String(),
-			Origin:    ch.Origin.ParamsCharmOrigin(),
+			Reference:   ch.URL.String(),
+			Origin:      ch.Origin.ParamsCharmOrigin(),
+			SwitchCharm: ch.SwitchCharm,
 		}
 	}
 	var result params.ResolveCharmWithChannelResults

--- a/apiserver/facades/client/charms/clientnormalize_test.go
+++ b/apiserver/facades/client/charms/clientnormalize_test.go
@@ -85,7 +85,7 @@ func (s *clientValidateOriginSuite) TestValidateOrigin(c *gc.C) {
 	}
 	schema := "ch"
 
-	err := validateOrigin(origin, schema)
+	err := validateOrigin(origin, schema, false)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -96,7 +96,7 @@ func (s *clientValidateOriginSuite) TestValidateOriginWithEmptyArch(c *gc.C) {
 	}
 	schema := "ch"
 
-	err := validateOrigin(origin, schema)
+	err := validateOrigin(origin, schema, false)
 	c.Assert(err, gc.ErrorMatches, "empty architecture not valid")
 }
 
@@ -107,7 +107,7 @@ func (s *clientValidateOriginSuite) TestValidateOriginWithInvalidCharmStoreSourc
 	}
 	schema := "ch"
 
-	err := validateOrigin(origin, schema)
+	err := validateOrigin(origin, schema, false)
 	c.Assert(err, gc.ErrorMatches, `origin source "charm-store" with schema not valid`)
 }
 
@@ -118,6 +118,17 @@ func (s *clientValidateOriginSuite) TestValidateOriginWithInvalidCharmHubSource(
 	}
 	schema := "cs"
 
-	err := validateOrigin(origin, schema)
+	err := validateOrigin(origin, schema, false)
 	c.Assert(err, gc.ErrorMatches, `origin source "charm-hub" with schema not valid`)
+}
+
+func (s *clientValidateOriginSuite) TestValidateOriginWhenSwitchingCharmsFromDifferentStores(c *gc.C) {
+	origin := params.CharmOrigin{
+		Source:       "charm-store",
+		Architecture: "all",
+	}
+	schema := "ch"
+
+	err := validateOrigin(origin, schema, true)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("expected validateOrigin to succeed when switching from charmstore to charmhub"))
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14034,6 +14034,9 @@
                         },
                         "reference": {
                             "type": "string"
+                        },
+                        "switch-charm": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false,

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -639,6 +639,10 @@ type ResolveCharmResults struct {
 type ResolveCharmWithChannel struct {
 	Reference string      `json:"reference"`
 	Origin    CharmOrigin `json:"charm-origin"`
+
+	// SwitchCharm is set to true when the purpose of this resolve request
+	// is to switch a different charm (potentially from a different store).
+	SwitchCharm bool `json:"switch-charm,omitempty"`
 }
 
 // ResolveCharmsWithChannel contains of slice of data on charms to be

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1537,13 +1537,13 @@ func (s *DeploySuite) TestDeployWithChannel(c *gc.C) {
 		Series:       "bionic",
 		Risk:         "beta",
 	}
-	s.fakeAPI.Call("ResolveCharm", curl, origin).Returns(
+	s.fakeAPI.Call("ResolveCharm", curl, origin, false).Returns(
 		curl,
 		origin,
 		[]string{"bionic"}, // Supported series
 		error(nil),
 	)
-	s.fakeAPI.Call("ResolveCharm", curl, originWithSeries).Returns(
+	s.fakeAPI.Call("ResolveCharm", curl, originWithSeries, false).Returns(
 		curl,
 		originWithSeries,
 		[]string{"bionic"}, // Supported series
@@ -2018,7 +2018,7 @@ func (s *FakeStoreStateSuite) setupCharmMaybeAddForce(c *gc.C, url, name, series
 				origin, err := apputils.DeduceOrigin(url, charm.Channel{}, platform)
 				c.Assert(err, jc.ErrorIsNil)
 
-				s.fakeAPI.Call("ResolveCharm", url, origin).Returns(
+				s.fakeAPI.Call("ResolveCharm", url, origin, false).Returns(
 					resolveURL,
 					origin,
 					[]string{series},
@@ -2640,13 +2640,13 @@ func (f *fakeDeployAPI) ModelGet() (map[string]interface{}, error) {
 	return results[0].(map[string]interface{}), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) ResolveCharm(url *charm.URL, preferredChannel commoncharm.Origin) (
+func (f *fakeDeployAPI) ResolveCharm(url *charm.URL, preferredChannel commoncharm.Origin, switchCharm bool) (
 	*charm.URL,
 	commoncharm.Origin,
 	[]string,
 	error,
 ) {
-	results := f.MethodCall(f, "ResolveCharm", url, preferredChannel)
+	results := f.MethodCall(f, "ResolveCharm", url, preferredChannel, switchCharm)
 	if results == nil {
 		if url.Schema == "cs" || url.Schema == "ch" {
 			return nil, commoncharm.Origin{}, nil, errors.Errorf(
@@ -3101,7 +3101,7 @@ func withCharmRepoResolvable(
 				Architecture: arch,
 				Series:       series,
 			}
-			fakeAPI.Call("ResolveCharm", url, origin).Returns(
+			fakeAPI.Call("ResolveCharm", url, origin, false).Returns(
 				&resultURL,
 				origin,
 				[]string{"bionic"}, // Supported series

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -338,7 +338,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		url, origin, _, err := h.bundleResolver.ResolveCharm(ch, origin)
+		url, origin, _, err := h.bundleResolver.ResolveCharm(ch, origin, false) // no --switch possible.
 		if err != nil {
 			return errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
 		}
@@ -408,7 +408,7 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, ch
 		return "", -1, errors.Trace(err)
 	}
 
-	_, origin, _, err = h.bundleResolver.ResolveCharm(ch, origin)
+	_, origin, _, err = h.bundleResolver.ResolveCharm(ch, origin, false) // no --switch possible.
 	if err != nil {
 		return "", -1, errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
 	}
@@ -655,7 +655,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
-	url, resolvedOrigin, _, err := h.bundleResolver.ResolveCharm(ch, origin)
+	url, resolvedOrigin, _, err := h.bundleResolver.ResolveCharm(ch, origin, false) // no --switch possible.
 	if err != nil {
 		return errors.Annotatef(err, "cannot resolve %q", ch.Name)
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -1122,9 +1122,10 @@ func (s *BundleDeployRepositorySuite) expectResolveCharm(err error, times int) {
 	s.bundleResolver.EXPECT().ResolveCharm(
 		gomock.AssignableToTypeOf(&charm.URL{}),
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
+		false,
 	).DoAndReturn(
 		// Ensure the same curl that is provided, is returned.
-		func(curl *charm.URL, origin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error) {
+		func(curl *charm.URL, origin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error) {
 			return curl, origin, []string{"bionic", "focal", "xenial"}, err
 		}).Times(times)
 }
@@ -1360,7 +1361,7 @@ func (s *BundleHandlerResolverSuite) TestResolveCharmChannelAndRevision(c *gc.C)
 	resolvedOrigin := origin
 	resolvedOrigin.Revision = &rev
 
-	resolver.EXPECT().ResolveCharm(charmURL, origin).Return(charmURL, resolvedOrigin, nil, nil)
+	resolver.EXPECT().ResolveCharm(charmURL, origin, false).Return(charmURL, resolvedOrigin, nil, nil)
 
 	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1392,7 +1393,7 @@ func (s *BundleHandlerResolverSuite) TestResolveCharmChannelWithoutRevision(c *g
 	}
 	resolvedOrigin := origin
 
-	resolver.EXPECT().ResolveCharm(charmURL, origin).Return(charmURL, resolvedOrigin, nil, nil)
+	resolver.EXPECT().ResolveCharm(charmURL, origin, false).Return(charmURL, resolvedOrigin, nil, nil)
 
 	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -452,7 +452,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	// Charm or bundle has been supplied as a URL so we resolve and
 	// deploy using the store but pass in the origin command line
 	// argument so users can target a specific origin.
-	storeCharmOrBundleURL, origin, supportedSeries, err := resolver.ResolveCharm(userRequestedURL, c.origin)
+	storeCharmOrBundleURL, origin, supportedSeries, err := resolver.ResolveCharm(userRequestedURL, c.origin, false) // no --switch possible.
 	if charm.IsUnsupportedSeriesError(err) {
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	} else if err != nil {

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -155,7 +155,7 @@ type Bundle interface {
 type Resolver interface {
 	GetBundle(*charm.URL, commoncharm.Origin, string) (charm.Bundle, error)
 	ResolveBundleURL(*charm.URL, commoncharm.Origin) (*charm.URL, commoncharm.Origin, error)
-	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error)
+	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error)
 }
 
 type ModelConfigGetter interface {

--- a/cmd/juju/application/deployer/mocks/resolver_mock.go
+++ b/cmd/juju/application/deployer/mocks/resolver_mock.go
@@ -66,9 +66,9 @@ func (mr *MockResolverMockRecorder) ResolveBundleURL(arg0, arg1 interface{}) *go
 }
 
 // ResolveCharm mocks base method
-func (m *MockResolver) ResolveCharm(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, []string, error) {
+func (m *MockResolver) ResolveCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool) (*charm.URL, charm0.Origin, []string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveCharm", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*charm.URL)
 	ret1, _ := ret[1].(charm0.Origin)
 	ret2, _ := ret[2].([]string)
@@ -77,9 +77,9 @@ func (m *MockResolver) ResolveCharm(arg0 *charm.URL, arg1 charm0.Origin) (*charm
 }
 
 // ResolveCharm indicates an expected call of ResolveCharm
-func (mr *MockResolverMockRecorder) ResolveCharm(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockResolverMockRecorder) ResolveCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveCharm", reflect.TypeOf((*MockResolver)(nil).ResolveCharm), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveCharm", reflect.TypeOf((*MockResolver)(nil).ResolveCharm), arg0, arg1, arg2)
 }
 
 // MockBundle is a mock of Bundle interface

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -402,16 +402,6 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		}
 	}
 
-	if oldOrigin.Source != commoncharm.OriginLocal {
-		// If not upgrading from a local path, display the channel we
-		// are pulling the charm from.
-		var channel string
-		if ch := oldOrigin.CharmChannel().String(); ch != "" {
-			channel = fmt.Sprintf(" from channel %s", ch)
-		}
-		ctx.Infof("Looking up metadata for %s charm %q%s", oldOrigin.Source, oldURL.Name, channel)
-	}
-
 	cfg := refresher.RefresherConfig{
 		ApplicationName: c.ApplicationName,
 		CharmURL:        oldURL,
@@ -441,7 +431,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	if charmID.Origin.Source == corecharm.CharmHub || charmID.Origin.Source == corecharm.CharmStore {
 		channel = fmt.Sprintf(" in channel %s", charmID.Origin.Channel.String())
 	}
-	ctx.Infof("Added %s charm %q, revision %d%s, to the model", oldOrigin.Source, curl.Name, curl.Revision, channel)
+	ctx.Infof("Added %s charm %q, revision %d%s, to the model", charmID.Origin.Source, curl.Name, curl.Revision, channel)
 
 	// Next, upgrade resources.
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -100,7 +100,7 @@ func newRefreshCommand() *refreshCommand {
 // CharmResolver defines methods required to resolve charms, as required
 // by the refresh command.
 type CharmResolver interface {
-	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error)
+	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin, switchCHarm bool) (*charm.URL, commoncharm.Origin, []string, error)
 }
 
 // NewRefreshCommand returns a command which upgrades application's charm.

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -106,7 +106,7 @@ func (s *BaseRefreshSuite) SetUpTest(c *gc.C) {
 
 	s.resolvedChannel = csclientparams.StableChannel
 	s.resolveCharm = mockCharmResolver{
-		resolveFunc: func(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error) {
+		resolveFunc: func(url *charm.URL, preferredOrigin commoncharm.Origin, _ bool) (*charm.URL, commoncharm.Origin, []string, error) {
 			s.AddCall("ResolveCharm", url, preferredOrigin)
 			if err := s.NextErr(); err != nil {
 				return nil, commoncharm.Origin{}, nil, err
@@ -974,11 +974,11 @@ func (m *mockCharmClient) CharmInfo(curl string) (*apicommoncharms.CharmInfo, er
 
 type mockCharmResolver struct {
 	testing.Stub
-	resolveFunc func(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error)
+	resolveFunc func(url *charm.URL, preferredOrigin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error)
 }
 
-func (m *mockCharmResolver) ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error) {
-	return m.resolveFunc(url, preferredOrigin)
+func (m *mockCharmResolver) ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error) {
+	return m.resolveFunc(url, preferredOrigin, switchCharm)
 }
 
 type mockCharmRefreshClient struct {

--- a/cmd/juju/application/refresher/interface.go
+++ b/cmd/juju/application/refresher/interface.go
@@ -40,7 +40,7 @@ type CharmID struct {
 // CharmResolver defines methods required to resolve charms, as required
 // by the upgrade-charm command.
 type CharmResolver interface {
-	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error)
+	ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error)
 }
 
 // CharmRepository defines methods for interaction with a charm repo.

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -129,6 +129,7 @@ func (d *factory) maybeCharmStore(authorizer store.MacaroonGetter, charmAdder st
 				charmRef:        cfg.CharmRef,
 				channel:         cfg.Channel,
 				deployedSeries:  cfg.DeployedSeries,
+				switchCharm:     cfg.Switch,
 				force:           cfg.Force,
 				forceSeries:     cfg.ForceSeries,
 				logger:          cfg.Logger,
@@ -150,6 +151,7 @@ func (d *factory) maybeCharmHub(charmAdder store.CharmAdder, charmResolver Charm
 				charmRef:        cfg.CharmRef,
 				channel:         cfg.Channel,
 				deployedSeries:  cfg.DeployedSeries,
+				switchCharm:     cfg.Switch,
 				force:           cfg.Force,
 				forceSeries:     cfg.ForceSeries,
 				logger:          cfg.Logger,
@@ -223,6 +225,7 @@ type baseRefresher struct {
 	charmRef        string
 	channel         charm.Channel
 	deployedSeries  string
+	switchCharm     bool
 	force           bool
 	forceSeries     bool
 	logger          CommandLogger
@@ -249,7 +252,7 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 	}
 
 	// Charm has been supplied as a URL so we resolve and deploy using the store.
-	newURL, origin, supportedSeries, err := r.charmResolver.ResolveCharm(refURL, destOrigin)
+	newURL, origin, supportedSeries, err := r.charmResolver.ResolveCharm(refURL, destOrigin, r.switchCharm)
 	if err != nil {
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}

--- a/cmd/juju/application/refresher/refresher_mock_test.go
+++ b/cmd/juju/application/refresher/refresher_mock_test.go
@@ -140,9 +140,9 @@ func (m *MockCharmResolver) EXPECT() *MockCharmResolverMockRecorder {
 }
 
 // ResolveCharm mocks base method
-func (m *MockCharmResolver) ResolveCharm(arg0 *v8.URL, arg1 charm.Origin) (*v8.URL, charm.Origin, []string, error) {
+func (m *MockCharmResolver) ResolveCharm(arg0 *v8.URL, arg1 charm.Origin, arg2 bool) (*v8.URL, charm.Origin, []string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveCharm", arg0, arg1)
+	ret := m.ctrl.Call(m, "ResolveCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v8.URL)
 	ret1, _ := ret[1].(charm.Origin)
 	ret2, _ := ret[2].([]string)
@@ -151,9 +151,9 @@ func (m *MockCharmResolver) ResolveCharm(arg0 *v8.URL, arg1 charm.Origin) (*v8.U
 }
 
 // ResolveCharm indicates an expected call of ResolveCharm
-func (mr *MockCharmResolverMockRecorder) ResolveCharm(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCharmResolverMockRecorder) ResolveCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveCharm", reflect.TypeOf((*MockCharmResolver)(nil).ResolveCharm), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveCharm", reflect.TypeOf((*MockCharmResolver)(nil).ResolveCharm), arg0, arg1, arg2)
 }
 
 // MockCharmRepository is a mock of CharmRepository interface

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -170,7 +170,7 @@ func (s *baseRefresherSuite) TestResolveCharm(c *gc.C) {
 		charmRef:        "meshuggah",
 		charmURL:        charm.MustParseURL("meshuggah"),
 		charmResolver:   charmResolver,
-		resolveOriginFn: charmHubResolveOrigin,
+		resolveOriginFn: charmHubOriginResolver,
 		logger:          fakeLogger{},
 	}
 	url, origin, err := refresher.ResolveCharm()
@@ -196,7 +196,7 @@ func (s *baseRefresherSuite) TestResolveCharmWithSeriesError(c *gc.C) {
 		deployedSeries:  "bionic",
 		charmURL:        charm.MustParseURL("meshuggah"),
 		charmResolver:   charmResolver,
-		resolveOriginFn: charmHubResolveOrigin,
+		resolveOriginFn: charmHubOriginResolver,
 		logger:          fakeLogger{},
 	}
 	_, _, err := refresher.ResolveCharm()
@@ -218,7 +218,7 @@ func (s *baseRefresherSuite) TestResolveCharmWithNoCharmURL(c *gc.C) {
 	refresher := baseRefresher{
 		charmRef:        "meshuggah",
 		charmResolver:   charmResolver,
-		resolveOriginFn: charmHubResolveOrigin,
+		resolveOriginFn: charmHubOriginResolver,
 		logger:          fakeLogger{},
 	}
 	_, _, err := refresher.ResolveCharm()
@@ -584,8 +584,9 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithCharmSwitch(c *gc.C) {
 	ref := "ch:aloupi-1"
 	curl := charm.MustParseURL(ref)
 	origin := commoncharm.Origin{
-		Source: commoncharm.OriginCharmHub,
-		Risk:   "beta",
+		Source:       commoncharm.OriginCharmHub,
+		Risk:         "beta",
+		Architecture: "amd64",
 	}
 
 	charmAdder := NewMockCharmAdder(ctrl)
@@ -688,7 +689,7 @@ func (s *charmHubCharmRefresherSuite) TestAllowedError(c *gc.C) {
 func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOriginEmpty(c *gc.C) {
 	origin := corecharm.Origin{}
 	channel := charm.Channel{}
-	result, err := charmHubResolveOrigin(nil, origin, channel)
+	result, err := charmHubOriginResolver(nil, origin, channel)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(origin))
 }
@@ -699,7 +700,7 @@ func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOrigin(c *gc.C) {
 	channel := charm.Channel{
 		Track: track,
 	}
-	result, err := charmHubResolveOrigin(nil, origin, channel)
+	result, err := charmHubOriginResolver(nil, origin, channel)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(corecharm.Origin{
 		Channel: &charm.Channel{
@@ -716,7 +717,7 @@ func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOriginEmptyTrackNonEmpt
 	channel := charm.Channel{
 		Risk: "edge",
 	}
-	result, err := charmHubResolveOrigin(nil, origin, channel)
+	result, err := charmHubOriginResolver(nil, origin, channel)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(corecharm.Origin{
 		Channel: &charm.Channel{
@@ -730,7 +731,7 @@ func (s *charmHubCharmRefresherSuite) TestCharmHubResolveOriginEmptyTrackEmptyCh
 	channel := charm.Channel{
 		Risk: "edge",
 	}
-	result, err := charmHubResolveOrigin(nil, origin, channel)
+	result, err := charmHubOriginResolver(nil, origin, channel)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, commoncharm.CoreCharmOrigin(corecharm.Origin{
 		Channel: &charm.Channel{},

--- a/cmd/juju/application/store/charmadapter.go
+++ b/cmd/juju/application/store/charmadapter.go
@@ -71,8 +71,8 @@ func NewCharmAdaptor(charmsAPI CharmsAPI, charmStoreRepoFunc CharmStoreRepoFunc,
 // and a slice of supported series are returned.
 // Resolving a CharmHub charm is only supported if the controller has a
 // Charms API version of 3 or greater.
-func (c *CharmAdaptor) ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, []string, error) {
-	resolved, err := c.charmsAPI.ResolveCharms([]apicharm.CharmToResolve{{URL: url, Origin: preferredOrigin}})
+func (c *CharmAdaptor) ResolveCharm(url *charm.URL, preferredOrigin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error) {
+	resolved, err := c.charmsAPI.ResolveCharms([]apicharm.CharmToResolve{{URL: url, Origin: preferredOrigin, SwitchCharm: switchCharm}})
 	if errors.IsNotSupported(err) {
 		if charm.CharmHub.Matches(url.Schema) {
 			return nil, commoncharm.Origin{}, nil, errors.NewNotSupported(nil, "charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+.")
@@ -109,8 +109,9 @@ func (c *CharmAdaptor) resolveCharmFallback(url *charm.URL, preferredOrigin comm
 // checking it, it returns a nil charm URL.
 func (c *CharmAdaptor) ResolveBundleURL(maybeBundle *charm.URL, preferredOrigin commoncharm.Origin) (*charm.URL, commoncharm.Origin, error) {
 	// Charm or bundle has been supplied as a URL so we resolve and
-	// deploy using the store.
-	storeCharmOrBundleURL, origin, _, err := c.ResolveCharm(maybeBundle, preferredOrigin)
+	// deploy using the store. In this case, a --switch is not possible
+	// so we pass "false" to ResolveCharm.
+	storeCharmOrBundleURL, origin, _, err := c.ResolveCharm(maybeBundle, preferredOrigin, false)
 	if err != nil {
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}

--- a/cmd/juju/application/store/charmadapter_test.go
+++ b/cmd/juju/application/store/charmadapter_test.go
@@ -44,7 +44,7 @@ func (s *resolveSuite) TestResolveCharm(c *gc.C) {
 	}, func() (store.DownloadBundleClient, error) {
 		return s.downloadClient, nil
 	})
-	obtainedURL, obtainedOrigin, obtainedSeries, err := charmAdapter.ResolveCharm(curl, origin)
+	obtainedURL, obtainedOrigin, obtainedSeries, err := charmAdapter.ResolveCharm(curl, origin, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin.Risk, gc.Equals, string(csparams.EdgeChannel))
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "focal"})
@@ -67,7 +67,7 @@ func (s *resolveSuite) TestResolveCharmWithFallback(c *gc.C) {
 	}, func() (store.DownloadBundleClient, error) {
 		return s.downloadClient, nil
 	})
-	obtainedURL, obtainedOrigin, obtainedSeries, err := charmAdapter.ResolveCharm(curl, origin)
+	obtainedURL, obtainedOrigin, obtainedSeries, err := charmAdapter.ResolveCharm(curl, origin, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedOrigin.Risk, gc.Equals, string(csparams.EdgeChannel))
 	c.Assert(obtainedSeries, jc.SameContents, []string{"bionic", "focal"})
@@ -87,7 +87,7 @@ func (s *resolveSuite) TestResolveCharmNotCSCharm(c *gc.C) {
 	}, func() (store.DownloadBundleClient, error) {
 		return s.downloadClient, nil
 	})
-	_, obtainedOrigin, _, err := charmAdapter.ResolveCharm(curl, origin)
+	_, obtainedOrigin, _, err := charmAdapter.ResolveCharm(curl, origin, false)
 	c.Assert(err, gc.NotNil)
 	c.Assert(obtainedOrigin.Risk, gc.Equals, string(csparams.NoChannel))
 }
@@ -108,7 +108,7 @@ func (s *resolveSuite) TestResolveCharmFailResolveWithChannel(c *gc.C) {
 	}, func() (store.DownloadBundleClient, error) {
 		return s.downloadClient, nil
 	})
-	_, obtainedOrigin, _, err := charmAdapter.ResolveCharm(curl, origin)
+	_, obtainedOrigin, _, err := charmAdapter.ResolveCharm(curl, origin, false)
 	c.Assert(err, gc.NotNil)
 	c.Assert(obtainedOrigin.Risk, gc.Equals, string(csparams.NoChannel))
 }
@@ -129,7 +129,7 @@ func (s *resolveSuite) TestResolveCharmFailResolveWithChannelWithFallback(c *gc.
 	}, func() (store.DownloadBundleClient, error) {
 		return s.downloadClient, nil
 	})
-	_, obtainedOrigin, _, err := charmAdapter.ResolveCharm(curl, origin)
+	_, obtainedOrigin, _, err := charmAdapter.ResolveCharm(curl, origin, false)
 	c.Assert(err, gc.NotNil)
 	c.Assert(obtainedOrigin.Risk, gc.Equals, string(csparams.NoChannel))
 }

--- a/state/application.go
+++ b/state/application.go
@@ -1470,7 +1470,8 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 	// this check. Newer charms written for multi-series have a URL
 	// with series = "".
 	if cfg.Charm.URL().Series != "" {
-		if cfg.Charm.URL().Series != a.doc.Series {
+		// Allow series change when switching to charmhub charms.
+		if cfg.Charm.URL().Schema != "ch" && cfg.Charm.URL().Series != a.doc.Series {
 			return errors.Errorf("cannot change an application's series")
 		}
 	} else if !cfg.ForceSeries {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -679,6 +679,18 @@ func (s *ApplicationSuite) TestClientApplicationSetCharmWrongOS(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "cs:multi-series-windows-1": OS "Ubuntu" not supported by charm`)
 }
 
+func (s *ApplicationSuite) TestSetCharmChangeSeriesWhenMovingFromCharmstoreToCharmhub(c *gc.C) {
+	// Moving from a cs to a ch charm should not prevent us from changing the series.
+	chCharm := state.AddTestingCharmhubCharmForSeries(c, s.State, "quantal", "multi-series")
+	cfg := state.SetCharmConfig{
+		Charm:      chCharm,
+		ForceUnits: true,
+	}
+
+	err := s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("expected SetCharm to work with different series when switching from a charmstore to a charmhub charm"))
+}
+
 func (s *ApplicationSuite) TestSetCharmPreconditions(c *gc.C) {
 	logging := s.AddTestingCharm(c, "logging")
 	cfg := state.SetCharmConfig{Charm: logging}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -188,6 +188,21 @@ func AddTestingCharmForSeries(c *gc.C, st *State, series, name string) *Charm {
 	return addCharm(c, st, series, getCharmRepo(series).CharmDir(name))
 }
 
+func AddTestingCharmhubCharmForSeries(c *gc.C, st *State, series, name string) *Charm {
+	ch := getCharmRepo(series).CharmDir(name)
+	ident := fmt.Sprintf("amd64/%s/%s-%d", series, name, ch.Revision())
+	curl := charm.MustParseURL("ch:" + ident)
+	info := CharmInfo{
+		Charm:       ch,
+		ID:          curl,
+		StoragePath: "dummy-path",
+		SHA256:      ident + "-sha256",
+	}
+	sch, err := st.AddCharm(info)
+	c.Assert(err, jc.ErrorIsNil)
+	return sch
+}
+
 func AddTestingCharmMultiSeries(c *gc.C, st *State, name string) *Charm {
 	ch := testcharms.Repo.CharmDir(name)
 	ident := fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())


### PR DESCRIPTION
This PR fixes a few refresh-related bugs and attempts to improve the end-user experience when using the 2.9 client against 2.8 controllers.

The first fix ensures that the origin validation rules (origin switches not allowed) are bypassed when resolving a charm due to a `juju refresh --switch` request. This enables users to switch from a charmstore charm into its charmhub equivalent. The implementation augments the ResolveCharm API payload with an optional `SwitchCharm` boolean value to indicate whether the intent is to switch or simply refresh the charm. As the field is optional (has `omitempty`) no facade bump is needed. _However, we must make sure to regenerate the pylibjuju facades before the 2.9 lib release_.

In addition, the client origin resolution logic has been tweaked so that the cs -> ch transition (due to a switch) can work properly. More specifically, the charm**store** origin resolver (renamed to `stdOriginResolver`) is used as the origin resolver for charmhub charms **only when switching**. This is required as the origin inference logic can inspect the schema and generate a suitable origin for the cs -> ch  switch.

Finally, the refresh command output has been updated to ensure that it always displays correct information (the _right_ charm source) when running the `juju refresh` command with `--switch`.

## Checklist

 - [x ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change

## QA steps

# Test 2.9 client against a 2.8 controller

```console
# Use the 2.8 snap
$ /snap/bin/juju version
2.8.10-focal-amd64

$ /snap/bin/juju bootstrap lxd test28 --no-gui

# Run the following steps with the 2.9.1 client from this PR
$ juju version
2.9.1-ubuntu-amd64

# The client introspects the controller version and assumes "cs" as the default prefix for the deploy
$ juju deploy ceph-mon
Located charm "ceph-mon" in charm-store, revision 55
Deploying "ceph-mon" from charm-store charm "ceph-mon", revision 55 in channel stable

$ juju deploy ch:ceph-mon
ERROR charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+.

# The client introspects the controller version and assumes "cs" as the default prefix for the switch
$ juju refresh ceph-mon --switch influxdb
Added charm-store charm "influxdb", revision 23 in channel stable, to the model
Adding endpoint "grafana-source" to default space "alpha"
Adding endpoint "query" to default space "alpha"
Leaving endpoints in "alpha": admin, nrpe-external-master

$ juju refresh ceph-mon --switch ch:influxdb
ERROR charmhub charms are not supported by the current controller; if you wish to use charmhub consider upgrading your controller to 2.9+.
```

# Test 2.9 client against a 2.9 controller

```console
$ juju bootstrap lxd test29 --no-gui

# The client introspects the controller version and assumes "ch" as the default prefix for the deploy
$ juju deploy wordpress
Located charm "wordpress" in charm-hub, revision 0
Deploying "wordpress" from charm-hub charm "wordpress", revision 0 in channel stable

$ juju deploy cs:ceph-mon
juju deploy cs:ceph-mon
Located charm "ceph-mon" in charm-store, revision 55
Deploying "ceph-mon" from charm-store charm "ceph-mon", revision 55 in channel stable

# The client introspects the controller version and assumes "ch" as the default prefix for the switch
$ juju refresh ceph-mon --switch ceph-mon
Added charm-hub charm "ceph-mon", revision 66 in channel stable, to the model
Leaving endpoints in "alpha": admin, bootstrap-source, client, cluster, mds, mon, nrpe-external-master, osd, prometheus, public, radosgw, rbd-mirror

# Verify that the switch was successful
$ juju status | grep charmhub
ceph-mon            maintenance      1  ceph-mon   charmhub  stable    66  ubuntu  installing charm software
wordpress           error            1  wordpress  charmhub  stable     0  ubuntu  hook failed: "install"

# Switch back to a cs charm (because we can!) 
# NOTE: we should probably block this but this is out of the scope of this PR
$ juju refresh ceph-mon --switch cs:ceph-mon
Added charm-store charm "ceph-mon", revision 55 in channel stable, to the model
Leaving endpoints in "alpha": admin, bootstrap-source, client, cluster, mds, mon, nrpe-external-master, osd, prometheus, public, radosgw, rbd-mirror

# Verify that the switch was successful
$ juju status | grep charmstore
ceph-mon   15.2.8   error       1  ceph-mon   charmstore  stable    55  ubuntu  hook failed: "upgrade-charm"
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1925803
