### PR TITLE
Ignore headless services when reporting k8s addresses

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -586,28 +586,29 @@ func (k *kubernetesClient) getStorageClass(name string) (*k8sstorage.StorageClas
 	return storageClasses.Get(name, v1.GetOptions{})
 }
 
-func getLoadBalancerAddress(svc *core.Service) string {
+func getLoadBalancerAddresses(svc *core.Service) []string {
 	// different cloud providers have a different way to report back the Load Balancer address.
 	// This covers the cases we know about so far.
+	var addr []string
 	lpAdd := svc.Spec.LoadBalancerIP
 	if lpAdd != "" {
-		return lpAdd
+		addr = append(addr, lpAdd)
 	}
 
 	ing := svc.Status.LoadBalancer.Ingress
 	if len(ing) == 0 {
-		return ""
+		return addr
 	}
 
-	// It usually has only one record.
-	firstOne := ing[0]
-	if firstOne.IP != "" {
-		return firstOne.IP
+	for _, ingressAddr := range ing {
+		if ingressAddr.IP != "" {
+			addr = append(addr, ingressAddr.IP)
+		}
+		if ingressAddr.Hostname != "" {
+			addr = append(addr, ingressAddr.Hostname)
+		}
 	}
-	if firstOne.Hostname != "" {
-		return firstOne.Hostname
-	}
-	return lpAdd
+	return addr
 }
 
 func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.ProviderAddress {
@@ -623,7 +624,7 @@ func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.Provide
 	}
 	appendUniqueAddrs := func(scope network.Scope, addrs ...string) {
 		for _, v := range addrs {
-			if v != "" && !addressExist(v) {
+			if v != "" && v != "None" && !addressExist(v) {
 				netAddrs = append(netAddrs, network.NewScopedProviderAddress(v, scope))
 			}
 		}
@@ -639,7 +640,7 @@ func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.Provide
 	case core.ServiceTypeNodePort:
 		appendUniqueAddrs(network.ScopePublic, svc.Spec.ExternalIPs...)
 	case core.ServiceTypeLoadBalancer:
-		appendUniqueAddrs(network.ScopePublic, getLoadBalancerAddress(svc))
+		appendUniqueAddrs(network.ScopePublic, getLoadBalancerAddresses(svc)...)
 	}
 	if includeClusterIP {
 		// append clusterIP as a fixed internal address.
@@ -657,12 +658,23 @@ func (k *kubernetesClient) GetService(appName string, mode caas.DeploymentMode, 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	var result caas.Service
+	var (
+		result caas.Service
+		svc    *core.Service
+	)
 	// We may have the stateful set or deployment but service not done yet.
 	if len(servicesList.Items) > 0 {
-		service := servicesList.Items[0]
-		result.Id = string(service.GetUID())
-		result.Addresses = getSvcAddresses(&service, includeClusterIP)
+		for _, s := range servicesList.Items {
+			// Ignore any headless service for this app.
+			if !strings.HasSuffix(s.Name, "-endpoints") {
+				svc = &s
+				break
+			}
+		}
+		if svc != nil {
+			result.Id = string(svc.GetUID())
+			result.Addresses = getSvcAddresses(svc, includeClusterIP)
+		}
 	}
 
 	if mode == caas.ModeOperator {

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -139,10 +139,8 @@ func buildCloudServiceOps(st *State, doc cloudServiceDoc) ([]txn.Op, error) {
 	addField := func(elm bson.DocElem) {
 		patchFields = append(patchFields, elm)
 	}
-	providerIdToAssert := existing.ProviderId
 	if doc.ProviderId != "" {
 		addField(bson.DocElem{"provider-id", doc.ProviderId})
-		providerIdToAssert = doc.ProviderId
 	}
 	if len(doc.Addresses) > 0 {
 		addField(bson.DocElem{"addresses", doc.Addresses})
@@ -157,8 +155,7 @@ func buildCloudServiceOps(st *State, doc cloudServiceDoc) ([]txn.Op, error) {
 		C:  cloudServicesC,
 		Id: existing.DocID,
 		Assert: bson.D{{"$or", []bson.D{
-			{{"provider-id", providerIdToAssert}},
-			{{"provider-id", ""}},
+			{{"provider-id", existing.ProviderId}},
 			{{"provider-id", bson.D{{"$exists", false}}}},
 		}}},
 		Update: bson.D{

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1494,7 +1494,7 @@ func (s *StateSuite) TestSaveCloudServiceChangeAddressesAllGood(c *gc.C) {
 	c.Assert(svc.Addresses(), gc.DeepEquals, network.NewSpaceAddresses("2.2.2.2"))
 }
 
-func (s *StateSuite) TestSaveCloudServiceChangeProviderIdFailed(c *gc.C) {
+func (s *StateSuite) TestSaveCloudServiceChangeProviderId(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State, func() {
 		_, err := s.State.SaveCloudService(
 			state.SaveCloudServiceArgs{
@@ -1505,16 +1505,18 @@ func (s *StateSuite) TestSaveCloudServiceChangeProviderIdFailed(c *gc.C) {
 		)
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
-	_, err := s.State.SaveCloudService(
+	svc, err := s.State.SaveCloudService(
 		state.SaveCloudServiceArgs{
 			Id:         "cloud-svc-ID",
 			ProviderId: "provider-id-new", // ProviderId is immutable, changing this will get assert error.
 			Addresses:  network.NewSpaceAddresses("1.1.1.1"),
 		},
 	)
-	c.Assert(err, gc.ErrorMatches,
-		`cannot add cloud service "provider-id-new": failed to save cloud service: state changing too quickly; try again soon`,
-	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(svc.Refresh(), jc.ErrorIsNil)
+	c.Assert(svc.Id(), gc.Equals, "a#cloud-svc-ID")
+	c.Assert(svc.ProviderId(), gc.Equals, "provider-id-new")
+	c.Assert(svc.Addresses(), gc.DeepEquals, network.NewSpaceAddresses("1.1.1.1"))
 }
 
 func (s *StateSuite) TestAddApplication(c *gc.C) {


### PR DESCRIPTION
As reported here
https://discourse.charmhub.io/t/how-does-juju-collect-ingress-address/4521

Juju was sometimes reporting the service address(es) of the headless service for an application, depending on the order of the services in the ListServices k8 API call. When this happened, if no record was yet stored in mongo, the reported address would be None. If there was already an address recorded, there would be a txn conflict because the UID had changed.

The fix here is twofold. First, allow last write wins on the service record update. The UID is not expected to change, but if it does, retry the txn. Second, filter out the headless services when querying the cluster. Also, a service could have an IP and a hostname - record both as juju assigns them different types.

## QA steps

bootstrap k8s
As per https://gitlab.com/endikap100/charmbugloadbalancernone
deploy
```
description: test loadbalancer in juju
bundle: kubernetes
applications:
  nginx1:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx2:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx3:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx4:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx5:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx6:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx7:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx8:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx9:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx10:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx11:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx12:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx13:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx14:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
  nginx15:
    charm: '../charms/nginx/nginx.charm'
    scale: 1
```

juju status will report either the loadbalancer ip addresses or nothing (not None).
logs will not have any txn conflict errors

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928282
