### PR TITLE
Merge 2.8

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2929,13 +2929,37 @@ func (s *K8sBrokerSuite) assertGetService(c *gc.C, mode caas.DeploymentMode, exp
 			LoadBalancerIP: "10.0.0.1",
 			ExternalName:   "ext-name",
 		},
+		Status: core.ServiceStatus{
+			LoadBalancer: core.LoadBalancerStatus{
+				Ingress: []core.LoadBalancerIngress{{
+					Hostname: "host.com.au",
+				}},
+			},
+		},
 	}
 	svc.SetUID("uid-xxxxx")
-
+	svcHeadless := core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "app-name-endpoints",
+			Labels: labels,
+			Annotations: map[string]string{
+				"juju.io/controller": testing.ControllerTag.Id(),
+				"fred":               "mary",
+				"a":                  "b",
+			}},
+		Spec: core.ServiceSpec{
+			Selector: labels,
+			Type:     core.ServiceTypeClusterIP,
+			Ports: []core.ServicePort{
+				{Port: 80, TargetPort: intstr.FromInt(80), Protocol: "TCP"},
+			},
+			ClusterIP: "192.168.1.1",
+		},
+	}
 	gomock.InOrder(
 		append([]*gomock.Call{
 			s.mockServices.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: selector}).
-				Return(&core.ServiceList{Items: []core.Service{svc}}, nil),
+				Return(&core.ServiceList{Items: []core.Service{svcHeadless, svc}}, nil),
 
 			s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
 				Return(nil, s.k8sNotFoundError()),
@@ -2956,6 +2980,7 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundNoWorkload(c *gc.C) {
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
+				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
 		},
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
@@ -3046,6 +3071,7 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
+				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
 			Scale:      intPtr(2),
 			Generation: int64Ptr(1),
@@ -3137,6 +3163,7 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
+				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
 			Scale:      intPtr(2),
 			Generation: int64Ptr(1),
@@ -3200,6 +3227,7 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 			Id: "uid-xxxxx",
 			Addresses: network.ProviderAddresses{
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
+				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
 			Scale:      intPtr(2),
 			Generation: int64Ptr(1),

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -139,10 +139,8 @@ func buildCloudServiceOps(st *State, doc cloudServiceDoc) ([]txn.Op, error) {
 	addField := func(elm bson.DocElem) {
 		patchFields = append(patchFields, elm)
 	}
-	providerIdToAssert := existing.ProviderId
 	if doc.ProviderId != "" {
 		addField(bson.DocElem{"provider-id", doc.ProviderId})
-		providerIdToAssert = doc.ProviderId
 	}
 	if len(doc.Addresses) > 0 {
 		addField(bson.DocElem{"addresses", doc.Addresses})
@@ -157,8 +155,7 @@ func buildCloudServiceOps(st *State, doc cloudServiceDoc) ([]txn.Op, error) {
 		C:  cloudServicesC,
 		Id: existing.DocID,
 		Assert: bson.D{{"$or", []bson.D{
-			{{"provider-id", providerIdToAssert}},
-			{{"provider-id", ""}},
+			{{"provider-id", existing.ProviderId}},
 			{{"provider-id", bson.D{{"$exists", false}}}},
 		}}},
 		Update: bson.D{

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1498,7 +1498,7 @@ func (s *StateSuite) TestSaveCloudServiceChangeAddressesAllGood(c *gc.C) {
 	c.Assert(svc.Addresses(), gc.DeepEquals, network.NewSpaceAddresses("2.2.2.2"))
 }
 
-func (s *StateSuite) TestSaveCloudServiceChangeProviderIdFailed(c *gc.C) {
+func (s *StateSuite) TestSaveCloudServiceChangeProviderId(c *gc.C) {
 	defer state.SetBeforeHooks(c, s.State, func() {
 		_, err := s.State.SaveCloudService(
 			state.SaveCloudServiceArgs{
@@ -1509,16 +1509,18 @@ func (s *StateSuite) TestSaveCloudServiceChangeProviderIdFailed(c *gc.C) {
 		)
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
-	_, err := s.State.SaveCloudService(
+	svc, err := s.State.SaveCloudService(
 		state.SaveCloudServiceArgs{
 			Id:         "cloud-svc-ID",
 			ProviderId: "provider-id-new", // ProviderId is immutable, changing this will get assert error.
 			Addresses:  network.NewSpaceAddresses("1.1.1.1"),
 		},
 	)
-	c.Assert(err, gc.ErrorMatches,
-		`cannot add cloud service "provider-id-new": failed to save cloud service: state changing too quickly; try again soon`,
-	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(svc.Refresh(), jc.ErrorIsNil)
+	c.Assert(svc.Id(), gc.Equals, "a#cloud-svc-ID")
+	c.Assert(svc.ProviderId(), gc.Equals, "provider-id-new")
+	c.Assert(svc.Addresses(), gc.DeepEquals, network.NewSpaceAddresses("1.1.1.1"))
 }
 
 func (s *StateSuite) TestAddApplication(c *gc.C) {


### PR DESCRIPTION
Merge 2.8

#12974 Ignore headless services when reporting k8s addresses

```
# Conflicts:
#       caas/kubernetes/provider/k8s.go
#       caas/kubernetes/provider/k8s_test.go
```


## QA steps

See PR
