### PR TITLE
Fixes issue in SNI getter for IP certificates.

### DIFF
--- a/pki/tls/sni.go
+++ b/pki/tls/sni.go
@@ -30,10 +30,11 @@ func AuthoritySNITLSGetter(authority pki.Authority, logger Logger) func(*tls.Cli
 		if hello.ServerName == "" {
 			logger.Debugf("tls client hello server name is empty. Attempting to provide ip address certificate")
 			leaf, err := authority.LeafForGroup(pki.ControllerIPLeafGroup)
-			if err != nil && !errors.IsNotFound(err) {
+			if err == nil {
+				cert = leaf.TLSCertificate()
+			} else if !errors.IsNotFound(err) {
 				return nil, errors.Annotate(err, "fetching ip address certificate")
 			}
-			cert = leaf.TLSCertificate()
 		} else {
 			authority.LeafRange(func(leaf pki.Leaf) bool {
 				if err := hello.SupportsCertificate(leaf.TLSCertificate()); err == nil {


### PR DESCRIPTION
If no ip certificate is defined on the authority it would result in a panic from the function for accessing nil memory.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

1. Bootstrap to microk8s and get the controller's ip and port from the controllers.yaml file
2. Run `openssl s_client -connect  <controller-ip>:<port>` and verify that a Juju certificate is returned and no panics in the logs.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928390
