### PR TITLE
Sidecar charms do not need operator storage

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -647,12 +647,11 @@ func caasPrecheck(
 	}
 
 	// For older charms, operator-storage model config is mandatory.
-	minver := ch.Meta().MinJujuVersion
-	if k8s.RequireOperatorStorage(minver) {
+	if k8s.RequireOperatorStorage(ch) {
 		storageClassName, _ := cfg.AllAttrs()[k8sconstants.OperatorStorageKey].(string)
 		if storageClassName == "" {
 			return errors.New(
-				"deploying a Kubernetes application requires a suitable storage class.\n" +
+				"deploying this Kubernetes application requires a suitable storage class.\n" +
 					"None have been configured. Set the operator-storage model config to " +
 					"specify which storage class should be used to allocate operator storage.\n" +
 					"See https://discourse.jujucharms.com/t/getting-started/152.",

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1119,7 +1119,7 @@ func (s *ApplicationSuite) TestDeployCAASModelNoOperatorStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	msg := result.OneError().Error()
-	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, `deploying a Kubernetes application requires a suitable storage class.*`)
+	c.Assert(strings.Replace(msg, "\n", "", -1), gc.Matches, `deploying this Kubernetes application requires a suitable storage class.*`)
 }
 
 func (s *ApplicationSuite) TestDeployCAASModelCharmNeedsNoOperatorStorage(c *gc.C) {
@@ -1130,6 +1130,28 @@ func (s *ApplicationSuite) TestDeployCAASModelCharmNeedsNoOperatorStorage(c *gc.
 		meta: &charm.Meta{
 			MinJujuVersion: version.MustParse("2.8.0"),
 		},
+	}
+
+	args := params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{{
+			ApplicationName: "foo",
+			CharmURL:        "local:foo-0",
+			CharmOrigin:     &params.CharmOrigin{Source: "local"},
+			NumUnits:        1,
+		}},
+	}
+	result, err := s.api.Deploy(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 1)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+}
+
+func (s *ApplicationSuite) TestDeployCAASModelSidecarCharmNeedsNoOperatorStorage(c *gc.C) {
+	s.model.modelType = state.ModelTypeCAAS
+	delete(s.model.cfg, "operator-storage")
+	s.backend.charm = &mockCharm{
+		meta:     &charm.Meta{},
+		manifest: &charm.Manifest{Bases: []charm.Base{{}}},
 	}
 
 	args := params.ApplicationsDeploy{

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -63,12 +63,18 @@ type mockCharm struct {
 	charm.Charm
 	config     *charm.Config
 	meta       *charm.Meta
+	manifest   *charm.Manifest
 	lxdProfile *charm.LXDProfile
 }
 
 func (c *mockCharm) Meta() *charm.Meta {
 	c.MethodCall(c, "Meta")
 	return c.meta
+}
+
+func (c *mockCharm) Manifest() *charm.Manifest {
+	c.MethodCall(c, "Manifest")
+	return c.manifest
 }
 
 func (c *mockCharm) Config() *charm.Config {

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -128,7 +128,7 @@ type mockApplication struct {
 	state.Authenticator
 	tag      names.Tag
 	password string
-	charm    caasoperatorprovisioner.Charm
+	charm    charm.CharmMeta
 }
 
 func (m *mockApplication) Tag() names.Tag {
@@ -144,16 +144,21 @@ func (a *mockApplication) Life() state.Life {
 	return state.Alive
 }
 
-func (a *mockApplication) Charm() (caasoperatorprovisioner.Charm, bool, error) {
+func (a *mockApplication) Charm() (charm.CharmMeta, bool, error) {
 	return a.charm, false, nil
 }
 
 type mockCharm struct {
-	meta *charm.Meta
+	meta     *charm.Meta
+	manifest *charm.Manifest
 }
 
 func (ch *mockCharm) Meta() *charm.Meta {
 	return ch.meta
+}
+
+func (ch *mockCharm) Manifest() *charm.Manifest {
+	return ch.manifest
 }
 
 type mockWatcher struct {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -190,8 +190,7 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		minVer := ch.Meta().MinJujuVersion
-		needStorage := provider.RequireOperatorStorage(minVer)
+		needStorage := provider.RequireOperatorStorage(ch)
 		logger.Debugf("application %s has min-juju-version=%v, so charm storage is %v",
 			appName.String(), ch.Meta().MinJujuVersion, needStorage)
 		result.Results[i] = oneProvisioningInfo(needStorage)

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -194,6 +194,27 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStorage(c *gc.C) {
 	})
 }
 
+func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoSidecarNoStorage(c *gc.C) {
+	s.st.operatorRepo = "somerepo"
+	s.st.app = &mockApplication{
+		charm: &mockCharm{
+			meta:     &charm.Meta{},
+			manifest: &charm.Manifest{Bases: []charm.Base{{}}}},
+	}
+	result, err := s.api.OperatorProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.OperatorProvisioningInfoResults{
+		Results: []params.OperatorProvisioningInfo{{
+			ImagePath:    s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3.666",
+			Version:      version.MustParse("2.6-beta3"),
+			APIAddresses: []string{"10.0.0.1:1"},
+			Tags: map[string]string{
+				"juju-model-uuid":      coretesting.ModelTag.Id(),
+				"juju-controller-uuid": coretesting.ControllerTag.Id()},
+		}},
+	})
+}
+
 func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C) {
 	s.storagePoolManager.SetErrors(errors.NotFoundf("pool"))
 	s.st.operatorRepo = "somerepo"

--- a/apiserver/facades/controller/caasoperatorprovisioner/state.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/state.go
@@ -36,11 +36,7 @@ type Model interface {
 }
 
 type Application interface {
-	Charm() (ch Charm, force bool, err error)
-}
-
-type Charm interface {
-	Meta() *charm.Meta
+	Charm() (ch charm.CharmMeta, force bool, err error)
 }
 
 type stateShim struct {
@@ -67,6 +63,6 @@ type applicationShim struct {
 	*state.Application
 }
 
-func (a *applicationShim) Charm() (Charm, bool, error) {
+func (a *applicationShim) Charm() (charm.CharmMeta, bool, error) {
 	return a.Application.Charm()
 }

--- a/caas/kubernetes/provider/providerconfig.go
+++ b/caas/kubernetes/provider/providerconfig.go
@@ -6,11 +6,13 @@ package provider
 import (
 	"fmt"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/schema"
 	"github.com/juju/version/v2"
 	"gopkg.in/juju/environschema.v1"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -22,8 +24,12 @@ var (
 
 // RequireOperatorStorage returns true if the specified min-juju-version
 // defined by a charm is such that the charm requires operator storage.
-func RequireOperatorStorage(charmMinJujuVersion version.Number) bool {
-	return charmMinJujuVersion.Compare(jujuVersionForControllerStorage) < 0
+func RequireOperatorStorage(ch charm.CharmMeta) bool {
+	if corecharm.Format(ch) == corecharm.FormatV2 {
+		return false
+	}
+	minVers := ch.Meta().MinJujuVersion
+	return minVers.Compare(jujuVersionForControllerStorage) < 0
 }
 
 var configSchema = environschema.Fields{

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -24,10 +24,10 @@ import (
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/statusapi_mock.go github.com/juju/juju/cmd/juju/commands StatusAPI
 
 var usageSSHSummary = `
-Initiates an SSH session or executes a command on a Juju machine.`[1:]
+Initiates an SSH session or executes a command on a Juju machine or container.`[1:]
 
 var usageSSHDetails = `
-The machine is identified by the <target> argument which is either a 'unit
+The ssh target is identified by the <target> argument which is either a 'unit
 name' or a 'machine id'. Both can be obtained by examining the output to "juju
 status".
 
@@ -59,6 +59,11 @@ where it is available. This is done by inserting them between the target and
 a possible remote command. Refer to the ssh man page for an explanation 
 of those options.
 
+For k8s charms, the --container argument is used to identity a specific
+container in the pod. For charms which run the workload in a separate pod
+to that of the charm, the default ssh target is the charm operator pod.
+The workload pod may be specified using the --remote argument.
+
 Examples:
 Connect to machine 0:
 
@@ -84,15 +89,25 @@ Connect to a mysql unit with an identity not known to juju (ssh option -i):
 
     juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
-Connect to a k8s unit targeting the operator pod by default:
+For k8s charms running the workload in a separate pod:
+  Connect to a k8s unit targeting the operator pod by default:
 
 	juju ssh mysql/0
 	juju ssh mysql/0 bash
 	
-Connect to a k8s unit targeting the workload pod by specifying --remote:
+  Connect to a k8s unit targeting the workload pod by specifying --remote:
 
 	juju ssh --remote mysql/0
-	
+
+For k8s charms using the sidecar pattern:
+  Connect to a k8s unit targeting the charm container (the default):
+
+	juju ssh --container charm snappass/0
+
+  Connect to a k8s unit targeting the redis container:
+
+	juju ssh --container redis snappass/0
+
 See also: 
     scp`
 


### PR DESCRIPTION
When deploying a k8s charm, juju checks to see if the cluster supports storage in case the charm needs it. Charms for juju 2.8 or greater do not need it. Neither do new sidecar charms, but we were not accounting for that.

Also a  driveby fix to the juju ssh help text.

## QA steps

bootstrap microk8s, add a model
```
$ juju model-config operator-storage=""
$ juju deploy snappass-test
$
$ juju deploy cs:~juju/mariadb-k8s
Located charm "mariadb-k8s" in charm-store, revision 3
Deploying "mariadb-k8s" from charm-store charm "mariadb-k8s", revision 3 in channel stable
ERROR deploying this Kubernetes application requires a suitable storage class.
None have been configured. Set the operator-storage model config to specify which storage class should be used to allocate operator storage.
See https://discourse.jujucharms.com/t/getting-started/152.
```

## Bug reference

https://bugs.launchpad.net/bugs/1927027
https://bugs.launchpad.net/juju/+bug/1927743
