### PR TITLE
lxd models can be added to k8s controller

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -1049,7 +1049,7 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 		return apiservererrors.ServerError(apiservererrors.ErrPerm)
 	}
 
-	if cloudArgs.Cloud.Type != string(k8sconstants.CAASProviderType) {
+	if cloudArgs.Cloud.Type != k8sconstants.CAASProviderType {
 		// All non-k8s cloud need to go through whitelist.
 		controllerInfo, err := api.backend.ControllerInfo()
 		if err != nil {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -274,6 +274,7 @@ func (s *cloudSuite) TestAddCloudNotWhitelisted(c *gc.C) {
 	err := s.api.AddCloud(createAddCloudParam(""))
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`
 controller cloud type "dummy" is not whitelisted, current whitelist: 
+ - controller cloud type "kubernetes" supports [lxd maas openstack]
  - controller cloud type "lxd" supports [lxd maas openstack]
  - controller cloud type "maas" supports [maas openstack]
  - controller cloud type "openstack" supports [openstack]`[1:]))

--- a/cloud/whitelist.go
+++ b/cloud/whitelist.go
@@ -53,6 +53,7 @@ func (w *WhiteList) Check(existing, new string) error {
 // CurrentWhiteList returns current clouds whitelist supported by Juju.
 func CurrentWhiteList() *WhiteList {
 	return &WhiteList{map[string]set.Strings{
+		"kubernetes":          set.NewStrings(lxdnames.ProviderType, "maas", "openstack"),
 		lxdnames.ProviderType: set.NewStrings(lxdnames.ProviderType, "maas", "openstack"),
 		"maas":                set.NewStrings("maas", "openstack"),
 		"openstack":           set.NewStrings("openstack"),

--- a/cloud/whitelist_test.go
+++ b/cloud/whitelist_test.go
@@ -13,6 +13,7 @@ import (
 func (s *cloudSuite) TestWhitelistString(c *gc.C) {
 	c.Assert((&cloud.WhiteList{}).String(), gc.Equals, "empty whitelist")
 	c.Assert(cloud.CurrentWhiteList().String(), gc.Equals, `
+ - controller cloud type "kubernetes" supports [lxd maas openstack]
  - controller cloud type "lxd" supports [lxd maas openstack]
  - controller cloud type "maas" supports [maas openstack]
  - controller cloud type "openstack" supports [openstack]`[1:])
@@ -25,6 +26,7 @@ func (s *cloudSuite) TestCheckWhitelistSuccess(c *gc.C) {
 func (s *cloudSuite) TestCheckWhitelistFail(c *gc.C) {
 	c.Assert(cloud.CurrentWhiteList().Check("ec2", "maas"), gc.ErrorMatches, `
 controller cloud type "ec2" is not whitelisted, current whitelist: 
+ - controller cloud type "kubernetes" supports \[lxd maas openstack\]
  - controller cloud type "lxd" supports \[lxd maas openstack\]
  - controller cloud type "maas" supports \[maas openstack\]
  - controller cloud type "openstack" supports \[openstack\]`[1:])

--- a/go.sum
+++ b/go.sum
@@ -428,7 +428,6 @@ github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41/go.mod h1:RI/7Oj7RFK3hzCr
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7LYjAfMZm+i6+VzOUBGhku+iOYeh0ohjIy7N9zd7JR4=
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible/go.mod h1:YQBneJkXlAAye6yHFYH8CabVID+0Oq2by8DDKGj5OIU=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f/go.mod h1:+7K7MqWi5xWI+s1LyB2g0Di71jZo27y+XOlmhNtV1Y0=
-github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208 h1:/WiCm+Vpj87e4QWuWwPD/bNE9kDrWCLvPBHOQNcG2+A=
 github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
 github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f h1:/Wj+9vztEkhkudRz596GbOu3x6FmftHk2vurf4yaaxw=
 github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
@@ -522,7 +521,6 @@ github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KV
 github.com/juju/utils v0.0.0-20200423035217-b0a7da72a5fa/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20200604140309-9d78121a29e0 h1:4XlJ/Wj/bH3zGa2GU+Us72FgtmL1n3dwjP7LW7+TF/o=
 github.com/juju/utils v0.0.0-20200604140309-9d78121a29e0/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
-github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1 h1:3y/lDs71xT7YIYtlfODytPNGEF4XVvUUZhFe3s5kkQQ=
 github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1/go.mod h1:fdlDtQlzundleLLz/ggoYinEt/LmnrpNKcNTABQATNI=
 github.com/juju/utils/v2 v2.0.0-20210305225158-eedbe7b6b3e2 h1:E7BgV8lczMmMqMtXdOis5BPEDu6bSG1D6K7SHEq7hEw=
 github.com/juju/utils/v2 v2.0.0-20210305225158-eedbe7b6b3e2/go.mod h1:p35YIk2Pj1lxjhWuYsYbKvMpJ/iX9F8DBgJkNbGF0nQ=
@@ -868,7 +866,6 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed h1:p9UgmWI9wKpfYmgaV/IZKGdXc5qEK45tDwwwDyjS26I=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -147,10 +147,9 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 	if err != nil && !errors.IsNotImplemented(err) {
 		return nil, err
 	}
-	tag := p.agentConfig.Tag()
-	machineTag, ok := tag.(names.MachineTag)
-	if !ok {
-		return nil, errors.Errorf("expected names.MachineTag, got %T", tag)
+	hostTag := p.agentConfig.Tag()
+	if kind := hostTag.Kind(); kind != names.ControllerAgentTagKind && kind != names.MachineTagKind {
+		return nil, errors.Errorf("agent's tag is not a machine or controller agent tag, got %T", hostTag)
 	}
 
 	modelCfg, err := p.st.ModelConfig()
@@ -165,7 +164,7 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 
 	task, err := NewProvisionerTask(
 		controllerCfg.ControllerUUID(),
-		machineTag,
+		hostTag,
 		p.logger,
 		harvestMode,
 		p.st,

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -75,7 +75,7 @@ type ToolsFinder interface {
 
 func NewProvisionerTask(
 	controllerUUID string,
-	machineTag names.MachineTag,
+	hostTag names.Tag,
 	logger Logger,
 	harvestMode config.HarvestMode,
 	machineGetter MachineGetter,
@@ -98,7 +98,7 @@ func NewProvisionerTask(
 	}
 	task := &provisionerTask{
 		controllerUUID:             controllerUUID,
-		machineTag:                 machineTag,
+		hostTag:                    hostTag,
 		logger:                     logger,
 		machineGetter:              machineGetter,
 		distributionGroupFinder:    distributionGroupFinder,
@@ -128,7 +128,7 @@ func NewProvisionerTask(
 
 type provisionerTask struct {
 	controllerUUID             string
-	machineTag                 names.MachineTag
+	hostTag                    names.Tag
 	logger                     Logger
 	machineGetter              MachineGetter
 	distributionGroupFinder    DistributionGroupFinder
@@ -182,7 +182,7 @@ func (task *provisionerTask) loop() error {
 	for {
 		select {
 		case <-task.catacomb.Dying():
-			task.logger.Infof("Shutting down provisioner task %s", task.machineTag)
+			task.logger.Infof("Shutting down provisioner task %s", task.hostTag)
 			return task.catacomb.ErrDying()
 		case ids, ok := <-task.machineChanges:
 			if !ok {
@@ -576,7 +576,7 @@ func (task *provisionerTask) constructInstanceConfig(
 		return nil, errors.Annotate(err, "failed to generate a nonce for machine "+machine.Id())
 	}
 
-	nonce := fmt.Sprintf("%s:%s", task.machineTag, uuid)
+	nonce := fmt.Sprintf("%s:%s", task.hostTag, uuid)
 	instanceConfig, err := instancecfg.NewInstanceConfig(
 		names.NewControllerTag(controller.Config(pInfo.ControllerConfig).ControllerUUID()),
 		machine.Id(),


### PR DESCRIPTION
Adding a lxd cloud and then a model to a k8s controller failed because the provisioner worker was assuming the host controller tag is a machine. However, we are moving towards using controller agent tags (which is what we use for k8s) so both need to be allowed. The tag is just used to generate a nonce so there's nothing restricting what it can be.

Also, add lxd, mass, openstack clouds to the k8s whitelist so --force is not needed.

## QA steps

As per the bug, bootstrap microk8s and add a lxd cloud and then a lxd model.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1927193
