### PR TITLE
Fix panic in remove-unit

### DIFF
--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -142,15 +142,18 @@ func (c *removeUnitCommand) validateCAASRemoval() error {
 		// TODO(caas): enable --destroy-storage for caas model.
 		return errors.New("k8s models only support --num-units")
 	}
+	if len(c.EntityNames) == 0 {
+		return errors.Errorf("no application specified")
+	}
+	if len(c.EntityNames) != 1 {
+		return errors.Errorf("only single application supported")
+	}
 	if names.IsValidUnit(c.EntityNames[0]) {
 		msg := `
 k8s models do not support removing named units.
 Instead specify an application with --num-units.
 `[1:]
 		return errors.Errorf(msg)
-	}
-	if len(c.EntityNames) != 1 {
-		return errors.Errorf("only single application supported")
 	}
 	if !names.IsValidApplication(c.EntityNames[0]) {
 		return errors.NotValidf("application name %q", c.EntityNames[0])

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -196,6 +196,9 @@ func (s *RemoveUnitSuite) TestCAASAllowsNumUnitsOnly(c *gc.C) {
 	_, err := s.runRemoveUnit(c, "some-application-name")
 	c.Assert(err, gc.ErrorMatches, `specify the number of units \(> 0\) to remove using --num-units`)
 
+	_, err = s.runRemoveUnit(c)
+	c.Assert(err, gc.ErrorMatches, `no application specified`)
+
 	_, err = s.runRemoveUnit(c, "some-application-name", "--destroy-storage")
 	c.Assert(err, gc.ErrorMatches, "k8s models only support --num-units")
 


### PR DESCRIPTION
juju remove-unit without args on a k8s model would panic.

## QA steps

bootstrap k8s model
```
$ juju remove-unit
ERROR no application specified
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928192
