### PR TITLE
Sort NetworkInfo bind addresses

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -262,26 +262,6 @@ func (n *NetworkInfoBase) resolveResultInfoHostNames(netInfo params.NetworkInfoR
 	return netInfo
 }
 
-// resolveResultIngressHostNames returns a new NetworkInfoResult with host names
-// in the `IngressAddresses` member resolved to IP addresses where possible.
-// This is slightly different to the `Info` addresses above in that we do not
-// include anything that does not resolve to a usable address.
-func (n *NetworkInfoBase) resolveResultIngressHostNames(netInfo params.NetworkInfoResult) params.NetworkInfoResult {
-	var newIngress []string
-	for _, addr := range netInfo.IngressAddresses {
-		if ip := net.ParseIP(addr); ip != nil {
-			newIngress = append(newIngress, addr)
-			continue
-		}
-		if ipAddr := n.resolveHostAddress(addr); ipAddr != "" {
-			newIngress = append(newIngress, ipAddr)
-		}
-	}
-	netInfo.IngressAddresses = newIngress
-
-	return netInfo
-}
-
 func (n *NetworkInfoBase) resolveHostAddress(hostName string) string {
 	resolved, err := n.lookupHost(hostName)
 	if err != nil {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4434,7 +4434,7 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 	s.PatchValue(&provider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 
 	net := map[string][]string{
-		"public":     {"8.8.0.0/16", "1.0.0.0/12"},
+		"public":     {"8.8.0.0/16", "240.0.0.0/12"},
 		"internal":   {"10.0.0.0/24"},
 		"wp-default": {"100.64.0.0/16"},
 		"database":   {"192.168.1.0/24"},
@@ -4597,7 +4597,7 @@ func (s *uniterNetworkInfoSuite) makeMachineDevicesAndAddressesArgs(addrSuffix i
 		}, {
 			DeviceName:   "fan-1",
 			ConfigMethod: network.ConfigStatic,
-			CIDRAddress:  fmt.Sprintf("1.1.1.%d/12", addrSuffix),
+			CIDRAddress:  fmt.Sprintf("240.1.1.%d/12", addrSuffix),
 		}}
 }
 
@@ -4710,13 +4710,6 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 	expectedConfigWithExtraBindingName := params.NetworkInfoResult{
 		Info: []params.NetworkInfo{
 			{
-				MACAddress:    "00:11:22:33:10:50",
-				InterfaceName: "eth0",
-				Addresses: []params.InterfaceAddress{
-					{Address: "8.8.8.10", CIDR: "8.8.0.0/16"},
-				},
-			},
-			{
 				MACAddress:    "00:11:22:33:10:51",
 				InterfaceName: "eth1",
 				Addresses: []params.InterfaceAddress{
@@ -4725,17 +4718,24 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForExplicitlyBoundEndpointAndDef
 				},
 			},
 			{
+				MACAddress:    "00:11:22:33:10:50",
+				InterfaceName: "eth0",
+				Addresses: []params.InterfaceAddress{
+					{Address: "8.8.8.10", CIDR: "8.8.0.0/16"},
+				},
+			},
+			{
 				MACAddress:    "00:11:22:33:10:55",
 				InterfaceName: "fan-1",
 				Addresses: []params.InterfaceAddress{
-					{Address: "1.1.1.10", CIDR: "1.0.0.0/12"},
+					{Address: "240.1.1.10", CIDR: "240.0.0.0/12"},
 				},
 			},
 		},
 		// Egress is based on the first ingress address.
 		// Addresses are sorted, with fan always last.
 		EgressSubnets:    []string{"8.8.4.10/32"},
-		IngressAddresses: []string{"8.8.4.10", "8.8.4.11", "8.8.8.10", "1.1.1.10"},
+		IngressAddresses: []string{"8.8.4.10", "8.8.4.11", "8.8.8.10", "240.1.1.10"},
 	}
 
 	// For the "db-client" extra-binding we expect to see interfaces from default

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -309,7 +309,7 @@ func (s *ipAddressesStateSuite) TestMachineAllAddressesSuccess(c *gc.C) {
 	c.Assert(allAddresses, jc.DeepEquals, addedAddresses)
 }
 
-func (s *ipAddressesStateSuite) TestMachineAllNetworkAddresses(c *gc.C) {
+func (s *ipAddressesStateSuite) TestMachineAllDeviceSpaceAddresses(c *gc.C) {
 	addrs := s.addTwoDevicesWithTwoAddressesEach(c)
 	expected := make(network.SpaceAddresses, len(addrs))
 	for i, addr := range addrs {
@@ -319,6 +319,7 @@ func (s *ipAddressesStateSuite) TestMachineAllNetworkAddresses(c *gc.C) {
 				network.WithCIDR(addr.SubnetCIDR()),
 				network.WithConfigType(addr.ConfigMethod()),
 			),
+			SpaceID: network.AlphaSpaceId,
 		}
 	}
 

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -865,16 +865,34 @@ func (m *Machine) AllAddresses() ([]*Address, error) {
 // AllDeviceSpaceAddresses returns the SpaceAddress representation of all known
 // addresses assigned to link-layer devices on the machine.
 func (m *Machine) AllDeviceSpaceAddresses() (corenetwork.SpaceAddresses, error) {
+	subnets, err := m.st.AllSubnets()
+	if err != nil {
+		return nil, errors.Annotate(err, "retrieving subnets")
+	}
+
 	var allAddresses corenetwork.SpaceAddresses
 	callbackFunc := func(doc *ipAddressDoc) {
-		allAddresses = append(allAddresses, corenetwork.SpaceAddress{
+		addr := corenetwork.SpaceAddress{
 			MachineAddress: corenetwork.NewMachineAddress(
 				doc.Value,
 				corenetwork.WithConfigType(doc.ConfigMethod),
 				corenetwork.WithCIDR(doc.SubnetCIDR),
 				corenetwork.WithSecondary(doc.IsSecondary),
 			),
-		})
+		}
+
+		// If this is not a loopback device, attempt to
+		// set the space ID based on the subnet.
+		if doc.ConfigMethod != corenetwork.ConfigLoopback && doc.SubnetCIDR != "" {
+			for _, sub := range subnets {
+				if sub.CIDR() == doc.SubnetCIDR {
+					addr.SpaceID = sub.spaceID
+					break
+				}
+			}
+		}
+
+		allAddresses = append(allAddresses, addr)
 	}
 
 	findQuery := findAddressesQuery(m.doc.Id, "")
@@ -898,7 +916,7 @@ func (m *Machine) AllSpaces() (set.Strings, error) {
 	spaces := set.NewStrings()
 	callback := func(doc *ipAddressDoc) {
 		// Don't bother with these. They are not in a space.
-		if doc.ConfigMethod == corenetwork.ConfigLoopback {
+		if doc.ConfigMethod == corenetwork.ConfigLoopback || doc.SubnetCIDR == "" {
 			return
 		}
 

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -862,8 +862,10 @@ func (m *Machine) AllAddresses() ([]*Address, error) {
 	return allAddresses, nil
 }
 
-// AllDeviceSpaceAddresses returns the SpaceAddress representation of all known
-// addresses assigned to link-layer devices on the machine.
+// AllDeviceSpaceAddresses returns the SpaceAddress representation of
+// all known addresses assigned to link-layer devices on the machine.
+// These addresses are populated with sufficient detail to be accurately
+// sortable by network.SortAddresses.
 func (m *Machine) AllDeviceSpaceAddresses() (corenetwork.SpaceAddresses, error) {
 	subnets, err := m.st.AllSubnets()
 	if err != nil {


### PR DESCRIPTION
This addresses the linked bug by ensuring that the order in which addresses are processed by `network-get` for IAAS models reflects the sorting rules for `SpaceAddresses`.

In particular, addresses are retrieved using `AllDeviceSpaceAddresses`, which now populates space IDs, allowing grouping by this characteristic.

Because we need characteristics of the interface, we still call `AllAddresses`, but we iterate them based on the sorted space addresses above.

This patch will probably be followed by another that allows us to sort both the bind addresses and the ingress addresses with the same logic, doing away with the artificial scoping done by `spaceAddressesFromNetworkInfo`. A comment is added regarding this, but it is eschewed here for brevity.

## QA steps

Exactly the same as for #12961, which did not _actually_ fix the issue.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1863916
