### PR TITLE
Fix upgrade of operator mode charms

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -46,7 +46,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/storage"
@@ -613,13 +612,6 @@ func caasPrecheck(
 	registry storage.ProviderRegistry,
 	caasBroker caasBrokerInterface,
 ) error {
-	if ch.Meta().Deployment != nil && ch.Meta().Deployment.DeploymentMode == charm.ModeOperator {
-		if !controllerCfg.Features().Contains(feature.K8sOperators) {
-			return errors.Errorf(
-				"feature flag %q is required for deploying container operator charms", feature.K8sOperators,
-			)
-		}
-	}
 	if len(args.AttachStorage) > 0 {
 		return errors.Errorf(
 			"AttachStorage may not be specified for container models",

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -369,32 +369,6 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 	c.Assert(msg, gc.Matches, "Juju on containers does not support updating deployment info.*")
 }
 
-func (s *ApplicationSuite) TestDeployCAASOperatorProtectedByFlag(c *gc.C) {
-	s.model.modelType = state.ModelTypeCAAS
-	s.setAPIUser(c, names.NewUserTag("admin"))
-	s.backend.charm = &mockCharm{
-		meta: &charm.Meta{
-			Deployment: &charm.Deployment{
-				DeploymentMode: charm.ModeOperator,
-			},
-		},
-	}
-	args := params.ApplicationsDeploy{
-		Applications: []params.ApplicationDeploy{{
-			ApplicationName: "foo",
-			CharmURL:        "local:foo-0",
-			CharmOrigin:     &params.CharmOrigin{Source: "local"},
-			NumUnits:        1,
-		}},
-	}
-	result, err := s.api.Deploy(args)
-	c.Assert(err, jc.ErrorIsNil)
-	err = result.OneError()
-	c.Assert(err, gc.NotNil)
-	msg := strings.Replace(err.Error(), "\n", "", -1)
-	c.Assert(msg, gc.Matches, `feature flag "k8s-operators" is required for deploying container operator charms`)
-}
-
 func (s *ApplicationSuite) TestUpdateCAASApplicationSettings(c *gc.C) {
 	s.model.modelType = state.ModelTypeCAAS
 	s.setAPIUser(c, names.NewUserTag("admin"))

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -45,9 +45,6 @@ const MongoDbSnap = "mongodb-snap"
 // MongoDbSnap is not also enabled.
 const MongoDbSSTXN = "mongodb-sstxn"
 
-// K8sOperators indicates that it's allowed to deploy charms with mode=operator
-const K8sOperators = "k8s-operators"
-
 // RawK8sSpec indicates that it's allowed to set k8s spec using raw yaml format.
 const RawK8sSpec = "raw-k8s-spec"
 

--- a/state/podspec_ops.go
+++ b/state/podspec_ops.go
@@ -81,7 +81,7 @@ func (op *setPodSpecOperation) buildTxn(_ int) ([]txn.Op, error) {
 	ch, _, err := app.Charm()
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
-	} else if err == nil {
+	} else if err == nil && (op.spec != nil || op.rawSpec != nil) {
 		if ch.Meta().Deployment != nil && ch.Meta().Deployment.DeploymentMode == charm.ModeOperator {
 			return nil, errors.New("cannot set k8s spec on an operator charm")
 		}

--- a/state/podspec_test.go
+++ b/state/podspec_test.go
@@ -144,6 +144,10 @@ func (s *PodSpecSuite) TestSetPodSpecApplicationOperator(c *gc.C) {
 
 	err := s.Model.SetPodSpec(nil, s.application.ApplicationTag(), strPtr("foo"))
 	c.Assert(err, gc.ErrorMatches, "cannot set k8s spec on an operator charm")
+
+	// Nil spec allowed.
+	err = s.Model.SetPodSpec(nil, s.application.ApplicationTag(), nil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *PodSpecSuite) TestSetPodSpecApplicationDying(c *gc.C) {


### PR DESCRIPTION
v1 k8s charms can have mode=operator. These charms could not be upgraded due to a bug in pod-spec-set. We still need to allow pod-spec-set with nil so that charm modified version is incremented.
This fixes that bug and also removes the feature flag so such charms can be deployed as needed.

## QA steps

Deploy https://github.com/davigar15/kdu-proxy-operator
juju upgrade-charm

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928074
