### PR TITLE
Add option to export-bundle to inlude charm defaults

### DIFF
--- a/api/bundle/client.go
+++ b/api/bundle/client.go
@@ -58,13 +58,18 @@ func (c *Client) GetChangesMapArgs(bundleURL, bundleDataYAML string) (params.Bun
 }
 
 // ExportBundle exports the current model configuration.
-func (c *Client) ExportBundle() (string, error) {
+func (c *Client) ExportBundle(includeDefaults bool) (string, error) {
 	var result params.StringResult
 	if bestVer := c.BestAPIVersion(); bestVer < 2 {
 		return "", errors.Errorf("this controller version does not support bundle export feature.")
+	} else if bestVer < 5 && includeDefaults {
+		return "", errors.Errorf("this controller version does not support bundle export with charm defaults.")
 	}
 
-	if err := c.facade.FacadeCall("ExportBundle", nil, &result); err != nil {
+	arg := params.ExportBundleParams{
+		IncludeCharmDefaults: includeDefaults,
+	}
+	if err := c.facade.FacadeCall("ExportBundle", arg, &result); err != nil {
 		return "", errors.Trace(err)
 	}
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -23,7 +23,7 @@ var facadeVersions = map[string]int{
 	"ApplicationScaler":            1,
 	"Backups":                      2,
 	"Block":                        2,
-	"Bundle":                       4,
+	"Bundle":                       5,
 	"CAASAgent":                    1,
 	"CAASAdmission":                1,
 	"CAASApplication":              1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -171,6 +171,7 @@ func AllFacades() *facade.Registry {
 	reg("Bundle", 2, bundle.NewFacadeV2)
 	reg("Bundle", 3, bundle.NewFacadeV3)
 	reg("Bundle", 4, bundle.NewFacadeV4)
+	reg("Bundle", 5, bundle.NewFacadeV5)
 	reg("CharmHub", 1, charmhub.NewFacade)
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)
 	reg("Charms", 2, charms.NewFacadeV2)

--- a/apiserver/facades/client/bundle/mock_test.go
+++ b/apiserver/facades/client/bundle/mock_test.go
@@ -4,6 +4,7 @@
 package bundle_test
 
 import (
+	"github.com/juju/charm/v8"
 	"github.com/juju/description/v3"
 	"github.com/juju/testing"
 
@@ -12,10 +13,21 @@ import (
 	"github.com/juju/juju/state"
 )
 
+type mockCharm struct {
+	charm.Charm
+}
+
+func (c *mockCharm) Config() *charm.Config {
+	return &charm.Config{Options: map[string]charm.Option{
+		"foo": {Default: "bar"},
+	}}
+}
+
 type mockState struct {
 	testing.Stub
 	bundle.Backend
 	model  description.Model
+	charm  *mockCharm
 	Spaces map[string]string
 }
 
@@ -38,6 +50,10 @@ func (m *mockState) GetExportConfig() state.ExportConfig {
 		SkipStatusHistory:      true,
 		SkipLinkLayerDevices:   true,
 	}
+}
+
+func (m *mockState) Charm(url *charm.URL) (charm.Charm, error) {
+	return m.charm, nil
 }
 
 func (m *mockState) AllSpaceInfos() (network.SpaceInfos, error) {

--- a/apiserver/facades/client/bundle/state.go
+++ b/apiserver/facades/client/bundle/state.go
@@ -4,6 +4,7 @@
 package bundle
 
 import (
+	"github.com/juju/charm/v8"
 	"github.com/juju/description/v3"
 	"github.com/juju/juju/state"
 )
@@ -11,11 +12,16 @@ import (
 type Backend interface {
 	ExportPartial(cfg state.ExportConfig) (description.Model, error)
 	GetExportConfig() state.ExportConfig
+	Charm(url *charm.URL) (charm.Charm, error)
 	state.EndpointBinding
 }
 
 type stateShim struct {
 	*state.State
+}
+
+func (m *stateShim) Charm(url *charm.URL) (charm.Charm, error) {
+	return m.State.Charm(url)
 }
 
 // GetExportConfig implements Backend.GetExportConfig.

--- a/apiserver/facades/client/client/bundles.go
+++ b/apiserver/facades/client/client/bundles.go
@@ -13,8 +13,7 @@ import (
 // GetBundleChanges returns the list of changes required to deploy the given
 // bundle data. The changes are sorted by requirements, so that they can be
 // applied in order.
-// This call is deprecated, clients should use the GetChanges endpoint on the
-// Bundle facade.
+// Deprecated: clients should use the GetChanges endpoint on the Bundle facade.
 // Note: any new feature in the future like devices will never be supported here.
 func (c *Client) GetBundleChanges(args params.BundleChangesParams) (params.BundleChangesResults, error) {
 	st := c.api.state()

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -5810,8 +5810,8 @@
     },
     {
         "Name": "Bundle",
-        "Description": "APIv4 provides the Bundle API facade for version 4. It is otherwise\nidentical to V3 with the exception that the V4 now has GetChangesAsMap, which\nreturns the same data as GetChanges, but with better args data.",
-        "Version": 4,
+        "Description": "APIv5 provides the Bundle API facade for version 5. It is otherwise\nidentical to V4 with the exception that the V5 adds an arg to export\nbundle to control what is exported..",
+        "Version": 5,
         "AvailableTo": [
             "controller-user",
             "model-user"
@@ -5822,6 +5822,9 @@
                 "ExportBundle": {
                     "type": "object",
                     "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ExportBundleParams"
+                        },
                         "Result": {
                             "$ref": "#/definitions/StringResult"
                         }
@@ -5994,6 +5997,15 @@
                         "message",
                         "code"
                     ]
+                },
+                "ExportBundleParams": {
+                    "type": "object",
+                    "properties": {
+                        "include-charm-defaults": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "StringResult": {
                     "type": "object",
@@ -14304,7 +14316,7 @@
                             "$ref": "#/definitions/BundleChangesResults"
                         }
                     },
-                    "description": "GetBundleChanges returns the list of changes required to deploy the given\nbundle data. The changes are sorted by requirements, so that they can be\napplied in order.\nThis call is deprecated, clients should use the GetChanges endpoint on the\nBundle facade.\nNote: any new feature in the future like devices will never be supported here."
+                    "description": "GetBundleChanges returns the list of changes required to deploy the given\nbundle data. The changes are sorted by requirements, so that they can be\napplied in order.\nDeprecated: clients should use the GetChanges endpoint on the Bundle facade.\nNote: any new feature in the future like devices will never be supported here."
                 },
                 "GetModelConstraints": {
                     "type": "object",

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1069,6 +1069,11 @@ type PubSubMessage struct {
 	Data  map[string]interface{} `json:"data"`
 }
 
+// ExportBundleParams holds parameters for exporting Bundles.
+type ExportBundleParams struct {
+	IncludeCharmDefaults bool `json:"include-charm-defaults,omitempty"`
+}
+
 // BundleChangesParams holds parameters for making Bundle.GetChanges calls.
 type BundleChangesParams struct {
 	// BundleDataYAML is the YAML-encoded charm bundle data

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -96,7 +96,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessNoFilename(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store))
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", nil},
+		{"ExportBundle", []interface{}{false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -139,7 +139,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", nil},
+		{"ExportBundle", []interface{}{false}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -173,7 +173,23 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *
 	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store), "--filename", s.fakeBundle.filename)
 	c.Assert(err, jc.ErrorIsNil)
 	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
-		{"ExportBundle", nil},
+		{"ExportBundle", []interface{}{false}},
+	})
+
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
+	output, err := ioutil.ReadFile(s.fakeBundle.filename)
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(string(output), gc.Equals, "fake-data")
+}
+
+func (s *ExportBundleCommandSuite) TestExportBundleIncludeCharmDefaults(c *gc.C) {
+	s.fakeBundle.filename = filepath.Join(c.MkDir(), "mymodel")
+	s.fakeBundle.result = "fake-data"
+	ctx, err := cmdtesting.RunCommand(c, model.NewExportBundleCommandForTest(s.fakeBundle, s.fakeConfig, s.store), "--include-charm-defaults", "--filename", s.fakeBundle.filename)
+	c.Assert(err, jc.ErrorIsNil)
+	s.fakeBundle.CheckCalls(c, []jujutesting.StubCall{
+		{"ExportBundle", []interface{}{true}},
 	})
 
 	out := cmdtesting.Stdout(ctx)
@@ -307,8 +323,8 @@ func (f *fakeExportBundleClient) BestAPIVersion() int { return f.bestAPIVersion 
 
 func (f *fakeExportBundleClient) Close() error { return nil }
 
-func (f *fakeExportBundleClient) ExportBundle() (string, error) {
-	f.MethodCall(f, "ExportBundle")
+func (f *fakeExportBundleClient) ExportBundle(includeDefaults bool) (string, error) {
+	f.MethodCall(f, "ExportBundle", includeDefaults)
 	if err := f.NextErr(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Add an `--include-charm-defaults` option to the `export-bundle` command which will cause all charm config and any defaults to be included in the bundle export, not just config that has been explicitly set by the user.

## QA steps

bootstrap a 2.8 or 2.9.1 controller
deploy a charm with a config item set, eg juju deploy mariadb --config query-cache-size=10000
juju export-bundle --include-charm-defaults
ERROR: this controller version does not support bundle export with charm defaults.

upgrade controller

For a mariadb deploy with query-cache-size set to 10000 and dataset-size = 50%
```
$ juju export-bundle
applications:
  mariadb:
    charm: cs:trusty/mariadb-7
    channel: stable
    series: trusty
    num_units: 1
    to:
    - "0"
    options:
      dataset-size: 50%
      query-cache-size: 10000
    constraints: arch=amd64

$ juju export-bundle --include-charm-defaults
applications:
  mariadb:
    charm: cs:trusty/mariadb-7
    channel: stable
    series: trusty
    num_units: 1
    to:
    - "0"
    options:
      base-url: https://downloads.mariadb.com/enterprise
      base-url-org: http://ftp.osuosl.org/pub/mariadb/repo
      binlog-format: MIXED
      block-size: 5
      ceph-osd-replication-count: 2
      dataset-size: 50%
      enterprise-eula: false
      ha-bindiface: eth0
      ha-mcastport: 5411
      key: "0xce1a3dd5e3c94f49"
      key-org: 0xcbcb082a1bb943db 0xF1656F24C74CD1D8
      max-connections: -1
      preferred-storage-engine: InnoDB
      query-cache-size: 10000
      query-cache-type: "OFF"
      rbd-name: mysql1
      repo-pkg: mariadb-enterprise-repository.deb
      series: "10.1"
      token: ""
      tuning-level: safest
      vip: ""
      vip_cidr: 24
      vip_iface: eth0
    constraints: arch=amd64
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1903607
