### PR TITLE
[2.9] Prevent contention error when switching charms that drop peer relations

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -855,8 +855,16 @@ func (s *ApplicationSuite) TestSetCharmChecksEndpointsWithoutRelations(c *gc.C) 
 	revno := 2
 	ms := s.AddMetaCharm(c, "mysql", metaBase, revno)
 	app := s.AddTestingApplication(c, "fakemysql", ms)
+
+	// Add two units so that peer relations get established and we can
+	// check that errors are raised when trying to break a peer relation.
+	_, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
 	cfg := state.SetCharmConfig{Charm: ms}
-	err := app.SetCharm(cfg)
+	err = app.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for i, t := range setCharmEndpointsTests {
@@ -2102,6 +2110,10 @@ const onePeerMeta = `
 peers:
   cluster: mysql
 `
+const onePeerAltMeta = `
+peers:
+  minion: helper
+`
 const twoPeersMeta = `
 peers:
   cluster: mysql
@@ -2140,6 +2152,46 @@ func (s *ApplicationSuite) TestNewPeerRelationsAddedOnUpgrade(c *gc.C) {
 	err = s.mysql.SetCharm(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	rels := s.assertApplicationRelations(c, s.mysql, "mysql:cluster", "mysql:loadbalancer")
+
+	// Check state consistency by attempting to destroy the application.
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	assertRemoved(c, s.mysql)
+
+	// Check the peer relations got destroyed as well.
+	for _, rel := range rels {
+		err = rel.Refresh()
+		c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	}
+}
+
+func (s *ApplicationSuite) TestStalePeerRelationsRemovedOnUpgrade(c *gc.C) {
+	// Original mysql charm has no peer relations.
+	// oldCh is mysql + the peer relation "mysql:cluster"
+	// newCh is mysql + the peer relation "mysql:minion"
+	oldCh := s.AddMetaCharm(c, "mysql", mysqlBaseMeta+onePeerMeta, 2)
+	newCh := s.AddMetaCharm(c, "mysql", mysqlBaseMeta+onePeerAltMeta, 42)
+
+	// No relations joined yet.
+	s.assertApplicationRelations(c, s.mysql)
+
+	cfg := state.SetCharmConfig{Charm: oldCh}
+	err := s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertApplicationRelations(c, s.mysql, "mysql:cluster")
+
+	// Since the two charms have different URLs, the following SetCharm call
+	// emulates a "juju refresh --switch" request. We expect that any prior
+	// peer relations that are not referenced by the new charm metadata
+	// to be dropped and any new peer relations to be created.
+	cfg = state.SetCharmConfig{
+		Charm:      newCh,
+		ForceUnits: true,
+	}
+	err = s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rels := s.assertApplicationRelations(c, s.mysql, "mysql:minion")
 
 	// Check state consistency by attempting to destroy the application.
 	err = s.mysql.Destroy()


### PR DESCRIPTION
Juju allows switching to a charm that would otherwise break an existing peer relation as long as there is only one unit present. However, doing so leaves stale documents in the relations collection.

As a result, if deployed a single-unit application, then switched to a charm without peer relations and then tried to switch back to a charm with peer relations we would get in a state where the SetCharm call would attempt to insert a new document into the relations collection but its DocMissing assertion would fail since the doc was still there. As a result the txn runner would eventually give up and return a "contention error".

To address this, this commit first modifies the check-if-relations-will-be-broken logic so that it allows us to change the charm 
even if that means that an existing **peer** relation will be broken. Note that the upgrade will still be blocked if any established **non-peer** relation would be broken (the second commit in this PR relaxes the check based on @jameinel's feedback below).

Secondly, an extra check has been added to the changeCharmOps method which performs a diff between the existing peer relations and the peer relations that the new charm defines and removes any stale relations that were previously left behind after the switch.

The issue also affects 2.8 (with a 2.9 client) so we should back-port the fix just in case we release another 2.8 in the future.

## QA steps

```console
$ juju deploy ceph-mon

# Login to mongo and check that "db.relations.find().pretty()" shows a single document

# Then, switch to a charm that does not define any peer relations
$ juju refresh ceph-mon --switch influxdb

# Login to mongo and check that "db.relations.find().pretty()" shows NO documents

# Then, switch back to the original charm
$ juju refresh ceph-mon --switch ceph-mon

# Login to mongo and check that "db.relations.find().pretty()" shows NO documents

# Add a second unit so now we have a peer relation with > 1 members and try to switch again
# This should work as expected
$ juju add-unit ceph-mon
$ juju refresh ceph-mon --switch influxdb

# Then relate the app to another app and try to switch again. This time you should get an error
$ juju refresh ceph-mon --switch ceph-mon
$ juju relate ceph-mon $something-compatible
$ juju refresh ceph-mon --switch influxdb
Added charm-hub charm "influxdb", revision 23 in channel stable, to the model
ERROR cannot upgrade application "ceph-mon" to charm "ch:amd64/xenial/influxdb-23": would break relation "ceph-mon:$non-peer-endpoint"
```