### PR TITLE
Embedded CLI returns an error is macaroon is invalid

### DIFF
--- a/api/authentication/interactor.go
+++ b/api/authentication/interactor.go
@@ -17,7 +17,7 @@ import (
 
 const authMethod = "juju_userpass"
 
-// Visitor is a httpbakery.Visitor that will login directly
+// Interactor is a httpbakery.Interactor that will login directly
 // to the Juju controller using password authentication. This
 // only applies when logging in as a local user.
 type Interactor struct {
@@ -117,4 +117,23 @@ func (i *Interactor) LegacyInteract(ctx context.Context, client *httpbakery.Clie
 		return errors.Annotate(err, "unmarshalling error")
 	}
 	return &jsonError
+}
+
+// NewNotSupportedInteractor returns an interactor that does
+// not support any discharge workflow.
+func NewNotSupportedInteractor() httpbakery.Interactor {
+	return &notSupportedInteractor{}
+}
+
+type notSupportedInteractor struct {
+}
+
+// Kind implements httpbakery.Interactor for the Interactor.
+func (i notSupportedInteractor) Kind() string {
+	return authMethod
+}
+
+// Interact implements httpbakery.Interactor for the Interactor.
+func (i notSupportedInteractor) Interact(_ context.Context, _ *httpbakery.Client, location string, _ *httpbakery.Error) (*httpbakery.DischargeToken, error) {
+	return nil, errors.NotSupportedf("interaction for %s", location)
 }

--- a/api/authentication/interactor_test.go
+++ b/api/authentication/interactor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery/form"
+	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -44,6 +45,13 @@ func (s *InteractorSuite) SetUpTest(c *gc.C) {
 		s.handler.ServeHTTP(w, r)
 	}))
 	s.AddCleanup(func(c *gc.C) { s.server.Close() })
+}
+
+func (s *InteractorSuite) TestNotSupportedInteract(c *gc.C) {
+	v := authentication.NewNotSupportedInteractor()
+	c.Assert(v.Kind(), gc.Equals, "juju_userpass")
+	_, err := v.Interact(context.TODO(), nil, "", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *InteractorSuite) TestLegacyInteract(c *gc.C) {

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -173,9 +173,14 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 				fmt.Fprintf(ctx.Stderr, err.Error())
 				return 1
 			}
-			cmdStr := fmt.Sprintf("%s@%s:%s -> %s", ad.User, ctrl, model, cmdPlusArgs)
-			fmt.Fprintf(ctx.Stdout, cmdStr)
-			fmt.Fprintf(ctx.Stdout, "\n")
+			if strings.Contains(cmdPlusArgs, "macaroon error") {
+				fmt.Fprintf(ctx.Stderr, "ERROR: cannot get discharge from https://controller")
+				fmt.Fprintf(ctx.Stderr, "\n")
+			} else {
+				cmdStr := fmt.Sprintf("%s@%s:%s -> %s", ad.User, ctrl, model, cmdPlusArgs)
+				fmt.Fprintf(ctx.Stdout, cmdStr)
+				fmt.Fprintf(ctx.Stdout, "\n")
+			}
 			return 0
 		},
 	}
@@ -422,6 +427,16 @@ func (s *apiserverSuite) TestEmbeddedCommandInvalidUser(c *gc.C) {
 		Commands: []string{"status --color"},
 	}
 	s.assertEmbeddedCommand(c, cmdArgs, "", &params.Error{Message: `user name "123@" not valid`})
+}
+
+func (s *apiserverSuite) TestEmbeddedCommandInvalidMacaroon(c *gc.C) {
+	cmdArgs := params.CLICommands{
+		User:     "fred",
+		Commands: []string{"status macaroon error"},
+	}
+	s.assertEmbeddedCommand(c, cmdArgs, "", &params.Error{
+		Code:    params.CodeDischargeRequired,
+		Message: `macaroon discharge required: cannot get discharge from https://controller`})
 }
 
 func (s *apiserverSuite) assertEmbeddedCommand(c *gc.C, cmdArgs params.CLICommands, expected string, resultErr *params.Error) {

--- a/cmd/modelcmd/apicontext.go
+++ b/cmd/modelcmd/apicontext.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/idmclient/v2/ussologin"
 	"gopkg.in/juju/environschema.v1/form"
 
+	"github.com/juju/juju/api/authentication"
 	"github.com/juju/juju/jujuclient"
 )
 
@@ -65,9 +66,12 @@ func newAPIContext(ctxt *cmd.Context, opts *AuthOpts, store jujuclient.CookieSto
 	}
 	var interactor httpbakery.Interactor
 	embedded := ctxt != nil && opts != nil && opts.Embedded
-	noBrowser := ctxt != nil && opts != nil && opts.NoBrowser
-	if !embedded {
+	if embedded {
+		// Embedded commands don't yet support macaroon discharge workflow.
+		interactor = authentication.NewNotSupportedInteractor()
+	} else {
 		// Only support discharge interactions if command is not embedded.
+		noBrowser := ctxt != nil && opts != nil && opts.NoBrowser
 		if noBrowser {
 			filler := &form.IOFiller{
 				In:  ctxt.Stdin,

--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -4,12 +4,14 @@
 package modelcmd_test
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/cmd"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -101,7 +103,10 @@ func (s *APIContextSuite) TestNewAPIContextEmbedded(c *gc.C) {
 	opts := modelcmd.AuthOpts{Embedded: true}
 	ctx, err := modelcmd.NewAPIContext(cmdCtx, &opts, store, "testcontroller")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelcmd.Interactor(ctx), gc.IsNil)
+	interactor := modelcmd.Interactor(ctx)
+	c.Assert(interactor, gc.Not(gc.IsNil))
+	_, err = interactor.Interact(context.TODO(), nil, "", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }
 
 func (s *APIContextSuite) TestNewAPIContextNoBrowser(c *gc.C) {


### PR DESCRIPTION
When the dashboard uses the embedded CLI, and the macaroon is invalid, we need to handle that better. This PR exposes the error via the json status result. In future, we may want to consider implementing the full discharge workflow.

## QA steps

Use the test CLI client in https://gist.github.com/wallyworld/4e8de75d5a439bd511e27d9bf5046c31
Delete the user macaroon and run something like status.
The CLICommandStatus Error will contain the macaroon discharge error string.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1915429
