### PR TITLE
Stops including all host vars in hook context.

### DIFF
--- a/worker/meterstatus/context_test.go
+++ b/worker/meterstatus/context_test.go
@@ -46,8 +46,17 @@ func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 				c.Errorf("unexpected get env call for %q", k)
 			}
 			return ""
-		}),
-	)
+		},
+		func(k string) (string, bool) {
+			switch k {
+			case "PATH", "Path":
+				return "pathy", true
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return "", false
+		},
+	))
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -80,8 +89,17 @@ func (s *ContextSuite) TestHookContextSetEnv(c *gc.C) {
 				c.Errorf("unexpected get env call for %q", k)
 			}
 			return ""
-		}),
-	)
+		},
+		func(k string) (string, bool) {
+			switch k {
+			case "PATH", "Path":
+				return "pathy", true
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return "", false
+		},
+	))
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/metrics/collect/context_test.go
+++ b/worker/metrics/collect/context_test.go
@@ -76,8 +76,17 @@ func (s *ContextSuite) TestHookContextEnv(c *gc.C) {
 				c.Errorf("unexpected get env call for %q", k)
 			}
 			return ""
-		}),
-	)
+		},
+		func(k string) (string, bool) {
+			switch k {
+			case "PATH", "Path":
+				return "pathy", true
+			default:
+				c.Errorf("unexpected get env call for %q", k)
+			}
+			return "", false
+		},
+	))
 	c.Assert(err, jc.ErrorIsNil)
 	varMap, err := keyvalues.Parse(vars, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -977,11 +977,7 @@ func (ctx *HookContext) HookVars(
 	env Environmenter,
 ) ([]string, error) {
 	vars := ctx.legacyProxySettings.AsEnvironmentValues()
-
-	// We add all the host env's here because hooks are starting to expect that
-	// they can see this. This in response to lp1892255. We are doing this early
-	// so our overrides come out on top.
-	vars = append(vars, env.Environ()...)
+	vars = append(vars, ContextDependentEnvVars(env)...)
 
 	// TODO(thumper): as work on proxies progress, there will be additional
 	// proxy settings to be added.

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -263,8 +263,15 @@ func (s *FactorySuite) TestNewActionRunnerGood(c *gc.C) {
 					return "pathy"
 				}
 				return ""
-			}),
-		)
+			},
+			func(k string) (string, bool) {
+				switch k {
+				case "PATH", "Path":
+					return "pathy", true
+				}
+				return "", false
+			},
+		))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(len(vars) > 0, jc.IsTrue, gc.Commentf("expected HookVars but found none"))
 		combined := strings.Join(vars, "|")
@@ -367,8 +374,15 @@ func (s *FactorySuite) TestNewActionRunnerWithCancel(c *gc.C) {
 				return "pathy"
 			}
 			return ""
-		}),
-	)
+		},
+		func(k string) (string, bool) {
+			switch k {
+			case "PATH", "Path":
+				return "pathy", true
+			}
+			return "", false
+		},
+	))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(vars) > 0, jc.IsTrue, gc.Commentf("expected HookVars but found none"))
 	combined := strings.Join(vars, "|")

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -238,6 +238,10 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 				v, _ := env[k]
 				return v
 			},
+			func(k string) (string, bool) {
+				v, t := env[k]
+				return v, t
+			},
 		)
 	}
 	env, err := runner.context.HookVars(runner.paths, rMode == runOnRemote, environmenter)
@@ -418,6 +422,10 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 			func(k string) string {
 				v, _ := env[k]
 				return v
+			},
+			func(k string) (string, bool) {
+				v, t := env[k]
+				return v, t
 			},
 		)
 	}


### PR DESCRIPTION
This is to fix a bug previously introduced in juju 2.9. We now are back
to selectivly adding env vars that make sense in a hook context.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

See bug: https://bugs.launchpad.net/juju/+bug/1928486 &&
https://bugs.launchpad.net/juju/+bug/1892255

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928486
