### PR TITLE
Set the statefulset service name for sidecar charms

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -362,6 +362,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 						Spec: *podSpec,
 					},
 					PodManagementPolicy: appsv1.ParallelPodManagement,
+					ServiceName:         headlessServiceName(a.name),
 				},
 			},
 		}

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -474,6 +474,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 						},
 					},
 					PodManagementPolicy: appsv1.ParallelPodManagement,
+					ServiceName:         "gitlab-endpoints",
 				},
 			})
 		},
@@ -1873,6 +1874,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 						},
 					},
 					PodManagementPolicy: appsv1.ParallelPodManagement,
+					ServiceName:         "gitlab-endpoints",
 				},
 			})
 		},


### PR DESCRIPTION
k8s v1 charms set the statefulset service name.
This PR ensures that it is also set for sidecar charms as well.

## QA steps

deploy snappass-test
inspect the statefulset to see the service name is set

## Bug reference

https://bugs.launchpad.net/bugs/1928822
