### PR TITLE
Database upgrade logging

### DIFF
--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -75,7 +75,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.oldVersion.Minor = 1
 
 	// Don't wait so long in tests.
-	s.PatchValue(&upgradesteps.UpgradeStartTimeoutMaster, time.Millisecond*50)
+	s.PatchValue(&upgradesteps.UpgradeStartTimeoutPrimary, time.Millisecond*50)
 	s.PatchValue(&upgradesteps.UpgradeStartTimeoutSecondary, time.Millisecond*60)
 
 	// Ensure we don't fail disk space check.
@@ -194,7 +194,7 @@ func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrad
 	fakeIsMachineMaster := func(*state.StatePool, string) (bool, error) {
 		return true, nil
 	}
-	s.PatchValue(&upgradesteps.IsMachineMaster, fakeIsMachineMaster)
+	s.PatchValue(&upgradesteps.IsMachinePrimary, fakeIsMachineMaster)
 
 	// Start the agent
 	agent := s.newAgent(c, machineA)

--- a/worker/upgradedatabase/worker.go
+++ b/worker/upgradedatabase/worker.go
@@ -205,7 +205,7 @@ func (w *upgradeDB) upgradeDone() bool {
 	w.fromVersion = w.agent.CurrentConfig().UpgradedToVersion()
 	w.toVersion = jujuversion.Current
 	if w.fromVersion == w.toVersion {
-		w.logger.Debugf("database upgrade to %v already completed", w.toVersion)
+		w.logger.Infof("database upgrade for %v already completed", w.toVersion)
 		w.upgradeComplete.Unlock()
 		return true
 	}
@@ -214,7 +214,8 @@ func (w *upgradeDB) upgradeDone() bool {
 }
 
 func (w *upgradeDB) runUpgrade() {
-	w.setStatus(status.Started, fmt.Sprintf("upgrading database to %v", w.toVersion))
+	w.logger.Infof("running database upgrade for %v on mongodb primary", w.toVersion)
+	w.setStatus(status.Started, fmt.Sprintf("upgrading database for %v", w.toVersion))
 
 	if err := w.agent.ChangeConfig(w.runUpgradeSteps); err == nil {
 		// Update the upgrade status document to unlock the other controllers.
@@ -224,7 +225,7 @@ func (w *upgradeDB) runUpgrade() {
 			return
 		}
 
-		w.logger.Infof("database upgrade to %v completed successfully.", w.toVersion)
+		w.logger.Infof("database upgrade for %v completed successfully.", w.toVersion)
 		w.setStatus(status.Started, fmt.Sprintf("database upgrade to %v completed", w.toVersion))
 		w.upgradeComplete.Unlock()
 	}
@@ -259,6 +260,7 @@ func (w *upgradeDB) contextGetter(agentConfig agent.ConfigSetter) func() upgrade
 }
 
 func (w *upgradeDB) watchUpgrade() {
+	w.logger.Infof("waiting for database upgrade on mongodb primary")
 	w.setStatus(status.Started, fmt.Sprintf("waiting on primary database upgrade to %v", w.toVersion))
 
 	if wrench.IsActive("upgrade-database", "watch-upgrade") {
@@ -287,6 +289,7 @@ func (w *upgradeDB) watchUpgrade() {
 		// will be "finishing". We need to check against both of these statuses.
 		switch w.upgradeInfo.Status() {
 		case state.UpgradeDBComplete, state.UpgradeFinishing:
+			w.logger.Infof("finished waiting - database upgrade steps completed on mongodb primary")
 			w.setStatus(status.Started, fmt.Sprintf("confirmed primary database upgrade to %v", w.toVersion))
 			w.upgradeComplete.Unlock()
 			return

--- a/worker/upgradedatabase/worker.go
+++ b/worker/upgradedatabase/worker.go
@@ -226,7 +226,7 @@ func (w *upgradeDB) runUpgrade() {
 		}
 
 		w.logger.Infof("database upgrade for %v completed successfully.", w.toVersion)
-		w.setStatus(status.Started, fmt.Sprintf("database upgrade to %v completed", w.toVersion))
+		w.setStatus(status.Started, fmt.Sprintf("database upgrade for %v completed", w.toVersion))
 		w.upgradeComplete.Unlock()
 	}
 }
@@ -261,7 +261,7 @@ func (w *upgradeDB) contextGetter(agentConfig agent.ConfigSetter) func() upgrade
 
 func (w *upgradeDB) watchUpgrade() {
 	w.logger.Infof("waiting for database upgrade on mongodb primary")
-	w.setStatus(status.Started, fmt.Sprintf("waiting on primary database upgrade to %v", w.toVersion))
+	w.setStatus(status.Started, fmt.Sprintf("waiting on primary database upgrade for %v", w.toVersion))
 
 	if wrench.IsActive("upgrade-database", "watch-upgrade") {
 		// Simulate an error causing the upgrade to fail.
@@ -290,7 +290,7 @@ func (w *upgradeDB) watchUpgrade() {
 		switch w.upgradeInfo.Status() {
 		case state.UpgradeDBComplete, state.UpgradeFinishing:
 			w.logger.Infof("finished waiting - database upgrade steps completed on mongodb primary")
-			w.setStatus(status.Started, fmt.Sprintf("confirmed primary database upgrade to %v", w.toVersion))
+			w.setStatus(status.Started, fmt.Sprintf("confirmed primary database upgrade for %v", w.toVersion))
 			w.upgradeComplete.Unlock()
 			return
 		default:
@@ -326,7 +326,7 @@ func (w *upgradeDB) reportUpgradeFailure(err error, willRetry bool) {
 }
 
 func (w *upgradeDB) setFailStatus() {
-	w.setStatus(status.Error, fmt.Sprintf("upgrading database to %v", w.toVersion))
+	w.setStatus(status.Error, fmt.Sprintf("upgrading database for %v", w.toVersion))
 }
 
 func (w *upgradeDB) setStatus(sts status.Status, msg string) {

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -60,7 +60,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			// Get upgradesteps completed lock.
+			// Get upgradeSteps completed lock.
 			var upgradeStepsLock gate.Lock
 			if err := context.Get(config.UpgradeStepsGateName, &upgradeStepsLock); err != nil {
 				return nil, errors.Trace(err)

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -391,7 +391,7 @@ func (s *UpgradeSuite) TestPreUpgradeFail(c *gc.C) {
 	}})
 }
 
-// Run just the upgradesteps worker with a fake machine agent and
+// Run just the upgradeSteps worker with a fake machine agent and
 // fake agent config.
 func (s *UpgradeSuite) runUpgradeWorker(c *gc.C, isController bool) (
 	error, *fakeConfigSetter, []StatusCall, gate.Lock,

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -73,10 +73,10 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	})
 
 	s.machineIsMaster = true
-	fakeIsMachineMaster := func(*state.StatePool, string) (bool, error) {
+	fakeIsMachinePrimary := func(*state.StatePool, string) (bool, error) {
 		return s.machineIsMaster, nil
 	}
-	s.PatchValue(&IsMachineMaster, fakeIsMachineMaster)
+	s.PatchValue(&IsMachinePrimary, fakeIsMachinePrimary)
 
 }
 
@@ -507,20 +507,20 @@ func (s *UpgradeSuite) makeExpectedUpgradeLogs(retryCount int, target string, ex
 
 	if target == "databaseMaster" || target == "controller" {
 		outLogs = append(outLogs, jc.SimpleMessage{
-			loggo.INFO, "waiting for other controllers to be ready for upgrade",
+			Level: loggo.INFO, Message: "waiting for other controllers to be ready for upgrade",
 		})
 		var waitMsg string
 		switch target {
 		case "databaseMaster":
 			waitMsg = "all controllers are ready to run upgrade steps"
 		case "controller":
-			waitMsg = "the master has completed its upgrade steps"
+			waitMsg = "the primary has completed its upgrade steps"
 		}
-		outLogs = append(outLogs, jc.SimpleMessage{loggo.INFO, "finished waiting - " + waitMsg})
+		outLogs = append(outLogs, jc.SimpleMessage{Level: loggo.INFO, Message: "finished waiting - " + waitMsg})
 	}
 
 	outLogs = append(outLogs, jc.SimpleMessage{
-		loggo.INFO, fmt.Sprintf(
+		Level: loggo.INFO, Message: fmt.Sprintf(
 			`starting upgrade from %s to %s for "machine-0"`,
 			s.oldVersion.Number, jujuversion.Current),
 	})
@@ -530,13 +530,13 @@ func (s *UpgradeSuite) makeExpectedUpgradeLogs(retryCount int, target string, ex
 		s.oldVersion.Number, jujuversion.Current, failReason)
 
 	for i := 0; i < retryCount; i++ {
-		outLogs = append(outLogs, jc.SimpleMessage{loggo.ERROR, fmt.Sprintf(failMessage, "will retry")})
+		outLogs = append(outLogs, jc.SimpleMessage{Level: loggo.ERROR, Message: fmt.Sprintf(failMessage, "will retry")})
 	}
 	if expectFail {
-		outLogs = append(outLogs, jc.SimpleMessage{loggo.ERROR, fmt.Sprintf(failMessage, "giving up")})
+		outLogs = append(outLogs, jc.SimpleMessage{Level: loggo.ERROR, Message: fmt.Sprintf(failMessage, "giving up")})
 	} else {
-		outLogs = append(outLogs, jc.SimpleMessage{loggo.INFO,
-			fmt.Sprintf(`upgrade to %s completed successfully.`, jujuversion.Current)})
+		outLogs = append(outLogs, jc.SimpleMessage{Level: loggo.INFO,
+			Message: fmt.Sprintf(`upgrade to %s completed successfully.`, jujuversion.Current)})
 	}
 	return outLogs
 }

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -63,7 +63,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	s.oldVersion.Minor = 16
 
 	// Don't wait so long in tests.
-	s.PatchValue(&UpgradeStartTimeoutMaster, time.Millisecond*50)
+	s.PatchValue(&UpgradeStartTimeoutPrimary, time.Millisecond*50)
 	s.PatchValue(&UpgradeStartTimeoutSecondary, time.Millisecond*60)
 
 	// Allow tests to make the API connection appear to be dead.


### PR DESCRIPTION
The pertinent change for this patch is to add some info-level logging to the database upgrade worker, so that its output resembles the upgrade-steps worker. This will better illustrate what is happening during upgrades.

In addition, there is some renaming to replace the usage of "master" with "primary" in the same code modules, to reflect the company inclusiveness initiatives.

## QA steps

- Bootstrap a 2.8 controller and enable HA.
- With this patch, run `juju upgrade-controller --build-agent`.
- Observe the controller logs for the `upgradedatabase` worker. We should see something like this:
```
machine-1: 10:15:36 INFO juju.worker.upgradedatabase waiting for database upgrade on mongodb primary
machine-1: 10:15:36 INFO juju.worker.upgradedatabase finished waiting - database upgrade steps completed on mongodb primary
machine-0: 10:15:55 INFO juju.worker.upgradedatabase waiting for database upgrade on mongodb primary
machine-0: 10:15:55 INFO juju.worker.upgradedatabase finished waiting - database upgrade steps completed on mongodb primary
machine-2: 10:15:56 INFO juju.worker.upgradedatabase running database upgrade for 2.9.2.1 on mongodb primary
...
```

## Documentation changes

None.

## Bug reference

N/A
