### PR TITLE
[2.8] Prevent contention error when switching charms that drop peer relations

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -768,7 +768,8 @@ func (a *Application) checkRelationsOps(ch *Charm, relations []*Relation) ([]txn
 
 	isPeerToItself := func(ep Endpoint) bool {
 		// We do not want to prevent charm upgrade when endpoint relation is
-		// peer-scoped and there is only one unit of this application.
+		// peer-scoped and there is only one unit of this application or no
+		// units at all.
 		// Essentially, this is the corner case when a unit relates to itself.
 		// For example, in this case, we want to allow charm upgrade, for e.g.
 		// interface name change does not affect anything.
@@ -778,7 +779,7 @@ func (a *Application) checkRelationsOps(ch *Charm, relations []*Relation) ([]txn
 			// We are only interested in thinking further if we can get units.
 			return false
 		}
-		return len(units) == 1 && isPeer(ep)
+		return len(units) <= 1 && isPeer(ep)
 	}
 
 	// All relations must still exist and their endpoints are implemented by the charm.
@@ -1015,12 +1016,26 @@ func (a *Application) changeCharmOps(
 
 	ops = append(ops, incCharmModifiedVersionOps(a.doc.DocID)...)
 
-	// Add any extra peer relations that need creation.
-	newPeers := a.extraPeerRelations(ch.Meta())
-	peerOps, err := a.st.addPeerRelationsOps(a.doc.Name, newPeers)
+	// Get all relations - we need to check them later.
+	relations, err := a.Relations()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// Remove any stale peer relation entries when switching charms
+	removeStalePeerOps, err := a.st.removeStalePeerRelationsOps(a.doc.Name, relations, ch.Meta())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, removeStalePeerOps...)
+
+	// Add any extra peer relations that need creation.
+	newPeers := a.extraPeerRelations(ch.Meta())
+	addPeerOps, err := a.st.addPeerRelationsOps(a.doc.Name, newPeers)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, addPeerOps...)
 
 	if len(resourceIDs) > 0 {
 		// Collect pending resource resolution operations.
@@ -1031,15 +1046,9 @@ func (a *Application) changeCharmOps(
 		ops = append(ops, resOps...)
 	}
 
-	// Get all relations - we need to check them later.
-	relations, err := a.Relations()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	// Make sure the relation count does not change.
 	sameRelCount := bson.D{{"relationcount", len(relations)}}
 
-	ops = append(ops, peerOps...)
 	// Update the relation count as well.
 	ops = append(ops, txn.Op{
 		C:      applicationsC,

--- a/state/application.go
+++ b/state/application.go
@@ -766,28 +766,18 @@ func (a *Application) extraPeerRelations(newMeta *charm.Meta) map[string]charm.R
 func (a *Application) checkRelationsOps(ch *Charm, relations []*Relation) ([]txn.Op, error) {
 	asserts := make([]txn.Op, 0, len(relations))
 
-	isPeerToItself := func(ep Endpoint) bool {
-		// We do not want to prevent charm upgrade when endpoint relation is
-		// peer-scoped and there is only one unit of this application or no
-		// units at all.
-		// Essentially, this is the corner case when a unit relates to itself.
-		// For example, in this case, we want to allow charm upgrade, for e.g.
-		// interface name change does not affect anything.
-		units, err := a.AllUnits()
-		if err != nil {
-			// Whether we could get application units does not matter.
-			// We are only interested in thinking further if we can get units.
-			return false
-		}
-		return len(units) <= 1 && isPeer(ep)
-	}
-
 	// All relations must still exist and their endpoints are implemented by the charm.
 	for _, rel := range relations {
 		if ep, err := rel.Endpoint(a.doc.Name); err != nil {
 			return nil, err
 		} else if !ep.ImplementedBy(ch) {
-			if !isPeerToItself(ep) {
+			// When switching charms, we should allow peer
+			// relations to be broken (e.g. because a newer charm
+			// version removes a particular peer relation) even if
+			// they are already established as those particular
+			// relations will become irrelevant once the upgrade is
+			// complete.
+			if !isPeer(ep) {
 				return nil, errors.Errorf("would break relation %q", rel)
 			}
 		}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -678,6 +678,13 @@ func (s *ApplicationSuite) TestSetCharmUpdatesBindings(c *gc.C) {
 	})
 }
 
+var metaRelationConsumer = `
+name: sqlvampire
+summary: "connects to an sql server"
+description: "lorem ipsum"
+requires:
+  server: mysql
+`
 var metaBase = `
 name: mysql
 summary: "Fake MySQL Database engine"
@@ -707,6 +714,7 @@ name: mysql
 description: none
 summary: none
 provides:
+  server: mysql
   kludge: mysql
 requires:
   client: mysql
@@ -734,6 +742,15 @@ requires:
   client: mysql
 peers:
   kludge: mysql
+`
+var metaRemoveNonPeerRelation = `
+name: mysql
+summary: "Fake MySQL Database engine"
+description: "Complete with nonsense relations"
+requires:
+  client: mysql
+peers:
+  cluster: mysql
 `
 var metaExtraEndpoints = `
 name: mysql
@@ -768,7 +785,10 @@ var setCharmEndpointsTests = []struct {
 }, {
 	summary: "different peer",
 	meta:    metaDifferentPeer,
-	err:     `cannot upgrade application "fakemysql" to charm "local:quantal/quantal-mysql-5": would break relation "fakemysql:cluster"`,
+}, {
+	summary: "attempt to break existing non-peer relations",
+	meta:    metaRemoveNonPeerRelation,
+	err:     `.*would break relation "fakeother:server fakemysql:server"`,
 }, {
 	summary: "same relations ok",
 	meta:    metaBase,
@@ -781,12 +801,25 @@ func (s *ApplicationSuite) TestSetCharmChecksEndpointsWithoutRelations(c *gc.C) 
 	revno := 2
 	ms := s.AddMetaCharm(c, "mysql", metaBase, revno)
 	app := s.AddTestingApplication(c, "fakemysql", ms)
+	appServerEP, err := app.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
 
-	// Add two units so that peer relations get established and we can
-	// check that errors are raised when trying to break a peer relation.
-	_, err := app.AddUnit(state.AddUnitParams{})
+	otherCharm := s.AddMetaCharm(c, "dummy", metaRelationConsumer, 42)
+	otherApp := s.AddTestingApplication(c, "fakeother", otherCharm)
+	otherServerEP, err := otherApp.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add two mysql units so that peer relations get established and we
+	// can check that we are allowed to break them when we upgrade.
+	_, err = app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a unit for the other application and establish a relation.
+	_, err = otherApp.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.AddRelation(appServerEP, otherServerEP)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := state.SetCharmConfig{Charm: ms}
@@ -3690,6 +3723,7 @@ func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 
 	oldCharm := s.AddMetaCharm(c, "mysql", metaDifferentProvider, 42)
 	oldBindings := map[string]string{
+		"server": dbSpace.Id(),
 		"kludge": dbSpace.Id(),
 		"client": dbSpace.Id(),
 	}
@@ -3698,6 +3732,7 @@ func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	effectiveOld := map[string]string{
 		"":        network.AlphaSpaceId,
+		"server":  dbSpace.Id(),
 		"kludge":  dbSpace.Id(),
 		"client":  dbSpace.Id(),
 		"cluster": network.AlphaSpaceId,
@@ -3713,11 +3748,11 @@ func (s *ApplicationSuite) TestSetCharmExtraBindingsUseDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	effectiveNew := map[string]string{
 		"": network.AlphaSpaceId,
-		// These two should be preserved from oldCharm.
+		// These three should be preserved from oldCharm.
 		"client":  dbSpace.Id(),
+		"server":  dbSpace.Id(),
 		"cluster": network.AlphaSpaceId,
-		// "kludge" is missing in newMeta, "server" is new and gets the default.
-		"server": network.AlphaSpaceId,
+		// "kludge" is missing in newMeta
 		// All the remaining are new and use the empty default.
 		"foo":  network.AlphaSpaceId,
 		"baz":  network.AlphaSpaceId,
@@ -3798,9 +3833,9 @@ func (s *ApplicationSuite) TestRenamePeerRelationOnUpgradeWithOneUnit(c *gc.C) {
 func (s *ApplicationSuite) TestRenamePeerRelationOnUpgradeWithMoreThanOneUnit(c *gc.C) {
 	obtainedV, err := s.setupApplicationWithUnitsForUpgradeCharmScenario(c, 2)
 
-	// ensure upgrade did not happen
-	c.Assert(err, gc.ErrorMatches, `*would break relation "mysql:replication"*`)
-	c.Assert(s.mysql.CharmModifiedVersion() == obtainedV, jc.IsTrue)
+	// ensure upgrade happened
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mysql.CharmModifiedVersion() == obtainedV+1, jc.IsTrue)
 }
 
 func (s *ApplicationSuite) TestWatchCharmConfig(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -952,9 +952,75 @@ func (st *State) tagToCollectionAndId(tag names.Tag) (string, interface{}, error
 	return coll, id, nil
 }
 
+// removeStalePeerRelationsOps returns the operations necessary to remove any
+// stale peer relation docs that may have been left behind after switching to
+// a different charm.
+func (st *State) removeStalePeerRelationsOps(applicationName string, relations []*Relation, newCharmMeta *charm.Meta) ([]txn.Op, error) {
+	if len(relations) == 0 {
+		return nil, nil // nothing to do
+	}
+
+	// Construct set of keys for existing peer relations.
+	oldPeerRelKeySet := set.NewStrings()
+nextRel:
+	for _, rel := range relations {
+		for _, ep := range rel.Endpoints() {
+			if ep.Role == charm.RolePeer {
+				oldPeerRelKeySet.Add(ep.String())
+				continue nextRel
+			}
+		}
+	}
+
+	// Construct set of keys for any peer relations defined by the new charm.
+	newPeerRelKeySet := set.NewStrings()
+	for _, rel := range newCharmMeta.Peers {
+		newPeerRelKeySet.Add(
+			relationKey(
+				[]Endpoint{{
+					ApplicationName: applicationName,
+					Relation:        rel,
+				}},
+			),
+		)
+	}
+
+	// Remove any stale peer relation docs
+	var ops []txn.Op
+	for peerRelKey := range oldPeerRelKeySet.Difference(newPeerRelKeySet) {
+		ops = append(ops,
+			txn.Op{
+				C:      relationsC,
+				Id:     st.docID(peerRelKey),
+				Assert: txn.DocExists,
+				Remove: true,
+			},
+		)
+	}
+
+	// If any peer relation docs are to be removed, we need to adjust the
+	// relationcount field for the application document accordingly.
+	if removals := len(ops); removals > 0 {
+		ops = append(ops,
+			txn.Op{
+				C:      applicationsC,
+				Id:     st.docID(applicationName),
+				Assert: txn.DocExists,
+				Update: bson.M{
+					"$inc": bson.M{
+						"relationcount": -removals,
+					},
+				},
+			},
+		)
+	}
+
+	return ops, nil
+}
+
 // addPeerRelationsOps returns the operations necessary to add the
 // specified application peer relations to the state.
-func (st *State) addPeerRelationsOps(applicationname string, peers map[string]charm.Relation) ([]txn.Op, error) {
+func (st *State) addPeerRelationsOps(applicationName string, peers map[string]charm.Relation) ([]txn.Op, error) {
 	now := st.clock().Now()
 	var ops []txn.Op
 	for _, rel := range peers {
@@ -963,7 +1029,7 @@ func (st *State) addPeerRelationsOps(applicationname string, peers map[string]ch
 			return nil, errors.Trace(err)
 		}
 		eps := []Endpoint{{
-			ApplicationName: applicationname,
+			ApplicationName: applicationName,
 			Relation:        rel,
 		}}
 		relKey := relationKey(eps)
@@ -1277,11 +1343,11 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		//
 		// TODO(dimitern): Ensure each st.Endpoint has a space name associated in a
 		// follow-up.
-		peerOps, err := st.addPeerRelationsOps(args.Name, peers)
+		addPeerOps, err := st.addPeerRelationsOps(args.Name, peers)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ops = append(ops, peerOps...)
+		ops = append(ops, addPeerOps...)
 
 		if len(args.Resources) > 0 {
 			// Collect pending resource resolution operations.


### PR DESCRIPTION
This is a back-port of #12986 to the 2.8 branch.

## QA steps

Repeat the QA steps from #12986 using a 2.8/2.9 client and a controller bootstrapped from the code from this PR.