### PR TITLE
Locate container and machine units regression

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -281,19 +281,19 @@ func (c *upgradeSeriesCommand) retrieveUnits() ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 
-	instanceID, err := getInstanceID(fullStatus, c.machineNumber)
+	machineID, err := getMachineID(fullStatus, c.machineNumber)
 	if err != nil {
 		return nil, errors.Annotatef(err, "unable to locate instance")
 	}
 	var units []string
 	for _, application := range fullStatus.Applications {
 		for name, unit := range application.Units {
-			if unit.Machine == instanceID {
+			if unit.Machine == machineID {
 				units = append(units, name)
 			}
 			for subName, subordinate := range unit.Subordinates {
-				if subordinate.Machine != "" && subordinate.Machine != instanceID {
-					return nil, errors.Errorf("subordinate %q machine has unexpected instance id %s", subName, instanceID)
+				if subordinate.Machine != "" && subordinate.Machine != machineID {
+					return nil, errors.Errorf("subordinate %q machine has unexpected instance id %s", subName, machineID)
 				}
 				units = append(units, subName)
 			}
@@ -305,7 +305,7 @@ func (c *upgradeSeriesCommand) retrieveUnits() ([]string, error) {
 	return units, nil
 }
 
-func getInstanceID(fullStatus *params.FullStatus, id string) (string, error) {
+func getMachineID(fullStatus *params.FullStatus, id string) (string, error) {
 	if machine, ok := fullStatus.Machines[id]; ok {
 		return machine.Id, nil
 	}

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -281,19 +281,19 @@ func (c *upgradeSeriesCommand) retrieveUnits() ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 
-	var units []string
-	machine, ok := fullStatus.Machines[c.machineNumber]
-	if !ok {
-		return nil, errors.NotFoundf("machine %q", c.machineNumber)
+	instanceID, err := getInstanceID(fullStatus, c.machineNumber)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unable to locate instance")
 	}
+	var units []string
 	for _, application := range fullStatus.Applications {
 		for name, unit := range application.Units {
-			if unit.Machine == machine.Id {
+			if unit.Machine == instanceID {
 				units = append(units, name)
 			}
 			for subName, subordinate := range unit.Subordinates {
-				if subordinate.Machine != "" && subordinate.Machine != machine.Id {
-					return nil, errors.Errorf("subordinate %q machine has unexpected machine id %s", subName, machine.Id)
+				if subordinate.Machine != "" && subordinate.Machine != instanceID {
+					return nil, errors.Errorf("subordinate %q machine has unexpected instance id %s", subName, instanceID)
 				}
 				units = append(units, subName)
 			}
@@ -303,6 +303,18 @@ func (c *upgradeSeriesCommand) retrieveUnits() ([]string, error) {
 	sort.Strings(units)
 
 	return units, nil
+}
+
+func getInstanceID(fullStatus *params.FullStatus, id string) (string, error) {
+	if machine, ok := fullStatus.Machines[id]; ok {
+		return machine.Id, nil
+	}
+	for _, machine := range fullStatus.Machines {
+		if container, ok := machine.Containers[id]; ok {
+			return container.Id, nil
+		}
+	}
+	return "", errors.NotFoundf("instance %q", id)
 }
 
 // Display any progress information from the error. If there isn't any info

--- a/cmd/juju/machine/upgradeseries_test.go
+++ b/cmd/juju/machine/upgradeseries_test.go
@@ -36,11 +36,18 @@ func (s *UpgradeSeriesSuite) SetUpTest(c *gc.C) {
 		status: &params.FullStatus{
 			Machines: map[string]params.MachineStatus{
 				"1": {Id: "1"},
+				"2": {
+					Id: "2",
+					Containers: map[string]params.MachineStatus{
+						"2/lxd/0": {Id: "2/lxd/0"},
+					},
+				},
 			},
 			Applications: map[string]params.ApplicationStatus{
 				"foo": {
 					Units: map[string]params.UnitStatus{
 						"foo/1": {Machine: "1"},
+						"foo/2": {Machine: "2/lxd/0"},
 					},
 				},
 			},
@@ -50,8 +57,12 @@ func (s *UpgradeSeriesSuite) SetUpTest(c *gc.C) {
 	s.completeExpectation = &upgradeSeriesCompleteExpectation{gomock.Any()}
 }
 
-const machineArg = "1"
-const seriesArg = "xenial"
+const (
+	machineArg   = "1"
+	containerArg = "2/lxd/0"
+
+	seriesArg = "xenial"
+)
 
 func (s *UpgradeSeriesSuite) runUpgradeSeriesCommand(c *gc.C, args ...string) error {
 	_, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", args...)
@@ -95,9 +106,15 @@ func (s *UpgradeSeriesSuite) runUpgradeSeriesCommandWithConfirmation(
 	return ctx, nil
 }
 
-func (s *UpgradeSeriesSuite) TestPrepareCommand(c *gc.C) {
+func (s *UpgradeSeriesSuite) TestPrepareCommandMachines(c *gc.C) {
 	s.prepareExpectation = &upgradeSeriesPrepareExpectation{machineArg, seriesArg, gomock.Eq(false)}
 	err := s.runUpgradeSeriesCommand(c, machineArg, machine.PrepareCommand, seriesArg)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpgradeSeriesSuite) TestPrepareCommandContainers(c *gc.C) {
+	s.prepareExpectation = &upgradeSeriesPrepareExpectation{containerArg, seriesArg, gomock.Eq(false)}
+	err := s.runUpgradeSeriesCommand(c, containerArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
The following was a regression when attempting to locate the right units
for a given container. Only machines where checked which caused issues
when attempting to upgrade a container based instance.

The fix is really easy, as it just looks through the machine containers
as well.

It is expected that performing an upgrade series, the model and in turn
the status has quiesced before proceeding.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --lxd --series=xenial
$ # wait for idle
$ juju upgrade-series 0/lxd/0 prepare bionic 
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928468
