### PR TITLE
Updated the show-action command to include the default value of action parameters

### DIFF
--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -80,12 +80,16 @@ var someCharmActions = map[string]actionapi.ActionSpec{
 				"name": map[string]interface{}{
 					"type":        "string",
 					"description": "snapshot name",
-					"default":     nil,
 				},
 				"full": map[string]interface{}{
 					"type":        "boolean",
 					"description": "take a full backup",
 					"default":     true,
+				},
+				"prefix": map[string]interface{}{
+					"type":        "string",
+					"description": "prefix to snapshot name",
+					"default":     "",
 				},
 			},
 			"baz": "bar",

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -80,10 +80,12 @@ var someCharmActions = map[string]actionapi.ActionSpec{
 				"name": map[string]interface{}{
 					"type":        "string",
 					"description": "snapshot name",
+					"default":     nil,
 				},
 				"full": map[string]interface{}{
 					"type":        "boolean",
 					"description": "take a full backup",
+					"default":     true,
 				},
 			},
 			"baz": "bar",

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -102,21 +102,11 @@ func (c *showCommand) Run(ctx *cmd.Context) error {
 			if !ok {
 				continue
 			}
-
-			if infoMap["default"] != nil {
-				args[argName] = actionArg{
-					Type:        infoMap["type"],
-					Description: infoMap["description"],
-					Default:     infoMap["default"],
-				}
-			} else {
-				// Don't include the default value if it's unspecified
-				args[argName] = actionArg{
-					Type:        infoMap["type"],
-					Description: infoMap["description"],
-				}
+			args[argName] = actionArg{
+				Type:        infoMap["type"],
+				Description: infoMap["description"],
+				Default:     infoMap["default"],
 			}
-
 		}
 	}
 

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -102,11 +102,21 @@ func (c *showCommand) Run(ctx *cmd.Context) error {
 			if !ok {
 				continue
 			}
-			args[argName] = actionArg{
-				Type:        infoMap["type"],
-				Description: infoMap["description"],
-				Default:     infoMap["default"],
+
+			if infoMap["default"] != nil {
+				args[argName] = actionArg{
+					Type:        infoMap["type"],
+					Description: infoMap["description"],
+					Default:     infoMap["default"],
+				}
+			} else {
+				// Don't include the default value if it's unspecified
+				args[argName] = actionArg{
+					Type:        infoMap["type"],
+					Description: infoMap["description"],
+				}
 			}
+
 		}
 	}
 

--- a/cmd/juju/action/show.go
+++ b/cmd/juju/action/show.go
@@ -105,6 +105,7 @@ func (c *showCommand) Run(ctx *cmd.Context) error {
 			args[argName] = actionArg{
 				Type:        infoMap["type"],
 				Description: infoMap["description"],
+				Default:     infoMap["default"],
 			}
 		}
 	}
@@ -121,4 +122,5 @@ type actionArg struct {
 	// Use a struct so we can control the order of the printed values.
 	Type        interface{} `yaml:"type"`
 	Description interface{} `yaml:"description"`
+	Default     interface{} `yaml:"default,omitempty"`
 }

--- a/cmd/juju/action/show_test.go
+++ b/cmd/juju/action/show_test.go
@@ -87,6 +87,7 @@ Arguments
 full:
   type: boolean
   description: take a full backup
+  default: true
 name:
   type: string
   description: snapshot name

--- a/cmd/juju/action/show_test.go
+++ b/cmd/juju/action/show_test.go
@@ -91,6 +91,10 @@ full:
 name:
   type: string
   description: snapshot name
+prefix:
+  type: string
+  description: prefix to snapshot name
+  default: ""
 
 `[1:]
 


### PR DESCRIPTION
This pull request adds the ability for the `juju show-action` command to also display the default value for any parameters where they are specified/non-empty.

## QA steps

```sh
$ juju bootstrap microk8s micro
$ juju deploy jnsgruk-test
$ juju show-action jnsgruk-test example-action
An example action with some parameters.

Arguments
param-blank-default:
  type: string
  description: this parameter has a blank default value.
  default: ""
param-default-value:
  type: string
  description: this parameter has a default value.
  default: somevalue
param-no-default:
  type: string
  description: this parameter has no default.
```

Note that the `jnsgruk-test` charm essentially does nothing but [specify some actions](https://github.com/jnsgruk/test-charm/blob/show-action-test/actions.yaml) and start a blank ubuntu container.
## Bug reference

https://bugs.launchpad.net/juju/+bug/1908714
