### PR TITLE
Fix bash completion Python detection

### DIFF
--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -485,7 +485,8 @@ fi
 
 # Select python3, else python2
 export _juju_cmd_PYTHON
-for _juju_cmd_PYTHON in /usr/bin/python{3,2};do
+for _python_version in {3,2};do
+  _juju_cmd_PYTHON=$(which python${_python_version})
   [ -x ${_juju_cmd_PYTHON?} ] && break
 done
 


### PR DESCRIPTION
PR #11993 broke bash completion (Python version detection).

This PR fixes it.

## QA steps

install juju snap on new focal machine
juju <tab> doesn't work
source the file in this PR
juju <tab> works

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928286
