### PR TITLE
Facades: Update charm facade to consume all bases

### DIFF
--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -170,14 +170,14 @@ func (c *chRepo) retryResolveWithPreferredChannel(curl *charm.URL, origin corech
 	case transport.ErrorCodeInvalidCharmPlatform, transport.ErrorCodeInvalidCharmBase:
 		logger.Tracef("Invalid charm platform %q %v - Default Base: %v", curl, origin, resErr.Extra.DefaultBases)
 
-		if bases, err = c.selectNextBase(resErr.Extra.DefaultBases, origin); err != nil {
+		if bases, err = c.selectNextBases(resErr.Extra.DefaultBases, origin); err != nil {
 			return nil, errors.Annotatef(err, "selecting next bases")
 		}
 
 	case transport.ErrorCodeRevisionNotFound:
 		logger.Tracef("Revision not found %q %v - Releases: %v", curl, origin, resErr.Extra.Releases)
 
-		if bases, err = c.selectNextReleases(resErr.Extra.Releases, origin); err != nil {
+		if bases, err = c.selectNextBasesFromReleases(resErr.Extra.Releases, origin); err != nil {
 			return nil, errors.Annotatef(err, "selecting releases")
 		}
 
@@ -306,7 +306,7 @@ func (c *chRepo) refreshOne(curl *charm.URL, origin corecharm.Origin) (transport
 	return result[0], nil
 }
 
-func (c *chRepo) selectNextBase(bases []transport.Base, origin corecharm.Origin) ([]corecharm.Platform, error) {
+func (c *chRepo) selectNextBases(bases []transport.Base, origin corecharm.Origin) ([]corecharm.Platform, error) {
 	if len(bases) == 0 {
 		return nil, errors.Errorf("no bases available")
 	}
@@ -347,7 +347,7 @@ func (c *chRepo) selectNextBase(bases []transport.Base, origin corecharm.Origin)
 	return results, nil
 }
 
-func (c *chRepo) selectNextReleases(releases []transport.Release, origin corecharm.Origin) ([]corecharm.Platform, error) {
+func (c *chRepo) selectNextBasesFromReleases(releases []transport.Release, origin corecharm.Origin) ([]corecharm.Platform, error) {
 	if len(releases) == 0 {
 		return nil, errors.Errorf("no releases available")
 	}

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -560,13 +560,13 @@ var _ = gc.Suite(&selectNextBaseSuite{})
 
 func (selectNextBaseSuite) TestSelectNextBaseWithNoBases(c *gc.C) {
 	repo := &chRepo{}
-	_, err := repo.selectNextBase(nil, corecharm.Origin{})
+	_, err := repo.selectNextBases(nil, corecharm.Origin{})
 	c.Assert(err, gc.ErrorMatches, `no bases available`)
 }
 
 func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBases(c *gc.C) {
 	repo := &chRepo{}
-	_, err := repo.selectNextBase([]transport.Base{{
+	_, err := repo.selectNextBases([]transport.Base{{
 		Architecture: "all",
 	}}, corecharm.Origin{
 		Platform: corecharm.Platform{
@@ -578,7 +578,7 @@ func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBases(c *gc.C) {
 
 func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBaseChannel(c *gc.C) {
 	repo := &chRepo{}
-	_, err := repo.selectNextBase([]transport.Base{{
+	_, err := repo.selectNextBases([]transport.Base{{
 		Architecture: "amd64",
 	}}, corecharm.Origin{
 		Platform: corecharm.Platform{
@@ -590,7 +590,7 @@ func (selectNextBaseSuite) TestSelectNextBaseWithInvalidBaseChannel(c *gc.C) {
 
 func (selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *gc.C) {
 	repo := &chRepo{}
-	platform, err := repo.selectNextBase([]transport.Base{{
+	platform, err := repo.selectNextBases([]transport.Base{{
 		Architecture: "amd64",
 		Name:         "ubuntu",
 		Channel:      "20.04",

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -602,11 +602,11 @@ func (selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(platform, gc.DeepEquals, corecharm.Platform{
+	c.Assert(platform, gc.DeepEquals, []corecharm.Platform{{
 		Architecture: "amd64",
 		OS:           "ubuntu",
 		Series:       "focal",
-	})
+	}})
 }
 
 type composeSuggestionsSuite struct {
@@ -748,10 +748,11 @@ func (selectReleaseByChannelSuite) TestSelection(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(release, gc.DeepEquals, Release{
-		OS:     "os",
-		Series: "focal",
-	})
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "arch",
+		OS:           "os",
+		Series:       "focal",
+	}})
 }
 
 func (selectReleaseByChannelSuite) TestAllSelection(c *gc.C) {
@@ -771,10 +772,61 @@ func (selectReleaseByChannelSuite) TestAllSelection(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(release, gc.DeepEquals, Release{
-		OS:     "os",
-		Series: "xenial",
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "arch",
+		OS:           "os",
+		Series:       "xenial",
+	}})
+}
+
+func (selectReleaseByChannelSuite) TestMultipleSelectionMultipleReturned(c *gc.C) {
+	release, err := selectReleaseByArchAndChannel([]transport.Release{{
+		Base: transport.Base{
+			Name:         "a",
+			Channel:      "14.04",
+			Architecture: "c",
+		},
+		Channel: "1.0/edge",
+	}, {
+		Base: transport.Base{
+			Name:         "d",
+			Channel:      "16.04",
+			Architecture: "all",
+		},
+		Channel: "2.0/stable",
+	}, {
+		Base: transport.Base{
+			Name:         "f",
+			Channel:      "18.04",
+			Architecture: "h",
+		},
+		Channel: "3.0/stable",
+	}, {
+		Base: transport.Base{
+			Name:         "g",
+			Channel:      "20.04",
+			Architecture: "h",
+		},
+		Channel: "3.0/stable",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "h",
+		},
+		Channel: &charm.Channel{
+			Track: "3.0",
+			Risk:  "stable",
+		},
 	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "h",
+		OS:           "f",
+		Series:       "bionic",
+	}, {
+		Architecture: "h",
+		OS:           "g",
+		Series:       "focal",
+	}})
 }
 
 func (selectReleaseByChannelSuite) TestMultipleSelection(c *gc.C) {
@@ -809,10 +861,11 @@ func (selectReleaseByChannelSuite) TestMultipleSelection(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(release, gc.DeepEquals, Release{
-		OS:     "f",
-		Series: "bionic",
-	})
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "h",
+		OS:           "f",
+		Series:       "bionic",
+	}})
 }
 
 type channelTrackSuite struct {

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -236,7 +236,7 @@ func (s *charmHubRepositoriesSuite) TestResolveRevisionNotFoundErrorWithNoSeries
 
 	resolver := &chRepo{client: s.client}
 	_, _, _, err := resolver.ResolveWithPreferredChannel(curl, origin)
-	c.Assert(err, gc.ErrorMatches, `refresh: no charm or bundle matching channel or platform; suggestions: stable with focal`)
+	c.Assert(err, gc.ErrorMatches, `resolving with preferred channel: selecting releases: no charm or bundle matching channel or platform; suggestions: stable with focal`)
 }
 
 func (s *charmHubRepositoriesSuite) TestResolveRevisionNotFoundError(c *gc.C) {
@@ -715,8 +715,9 @@ type selectReleaseByChannelSuite struct {
 var _ = gc.Suite(&selectReleaseByChannelSuite{})
 
 func (selectReleaseByChannelSuite) TestNoReleases(c *gc.C) {
-	_, err := selectReleaseByArchAndChannel([]transport.Release{}, corecharm.Origin{})
-	c.Assert(err, gc.ErrorMatches, `release not found`)
+	release, err := selectReleaseByArchAndChannel([]transport.Release{}, corecharm.Origin{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform(nil))
 }
 
 func (selectReleaseByChannelSuite) TestInvalidChannel(c *gc.C) {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1508,6 +1508,7 @@ func (s *DeploySuite) TestDeployWithTermsNotSigned(c *gc.C) {
 	origin := commoncharm.Origin{
 		Source:       commoncharm.OriginCharmStore,
 		Architecture: arch.DefaultArchitecture,
+		Series:       "bionic",
 	}
 	s.fakeAPI.Call("AddCharm", &deployURL, origin, false).Returns(origin, error(termsRequiredError))
 	s.fakeAPI.Call("CharmInfo", deployURL.String()).Returns(
@@ -1559,7 +1560,7 @@ func (s *DeploySuite) TestDeployWithChannel(c *gc.C) {
 		Series:          "bionic",
 		NumUnits:        1,
 	}).Returns(error(nil))
-	s.fakeAPI.Call("AddCharm", curl, origin, false).Returns(originWithSeries, error(nil))
+	s.fakeAPI.Call("AddCharm", curl, originWithSeries, false).Returns(originWithSeries, error(nil))
 	withCharmDeployable(
 		s.fakeAPI, curl, "bionic",
 		&charm.Meta{Name: "dummy", Series: []string{"bionic"}},
@@ -1586,7 +1587,7 @@ func (s *DeploySuite) TestDeployCharmsEndpointNotImplemented(c *gc.C) {
 	series := "bionic"
 
 	fallbackCons := constraints.MustParse("arch=amd64")
-	platform, _ := apputils.DeducePlatform(constraints.Value{}, "", fallbackCons)
+	platform, _ := apputils.DeducePlatform(constraints.Value{}, "bionic", fallbackCons)
 	origin, _ := apputils.DeduceOrigin(meteredCharmURL, charm.Channel{}, platform)
 	s.fakeAPI.Call("AddCharm", meteredCharmURL, origin, false).Returns(origin, error(nil))
 	s.fakeAPI.Call("CharmInfo", meteredCharmURL.String()).Returns(
@@ -1631,7 +1632,7 @@ func (s *DeploySuite) TestAddMetricCredentials(c *gc.C) {
 	charmDir := testcharms.RepoWithSeries("bionic").CharmDir("metered")
 	meteredURL := charm.MustParseURL("cs:bionic/metered-1")
 	s.fakeAPI.planURL = server.URL
-	withCharmDeployable(s.fakeAPI, meteredURL, "", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
+	withCharmDeployable(s.fakeAPI, meteredURL, "bionic", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 	withCharmRepoResolvable(s.fakeAPI, meteredURL, "")
 
 	// `"hello registration"\n` (quotes and newline from json
@@ -1685,7 +1686,7 @@ func (s *DeploySuite) TestAddMetricCredentialsDefaultPlan(c *gc.C) {
 
 	meteredURL := charm.MustParseURL("cs:bionic/metered-1")
 	s.fakeAPI.planURL = server.URL
-	withCharmDeployable(s.fakeAPI, meteredURL, "", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
+	withCharmDeployable(s.fakeAPI, meteredURL, "bionic", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 	withCharmRepoResolvable(s.fakeAPI, meteredURL, "")
 
 	creds := append([]byte(`"aGVsbG8gcmVnaXN0cmF0aW9u"`), 0xA)
@@ -1731,7 +1732,7 @@ func (s *DeploySuite) TestSetMetricCredentialsNotCalledForUnmeteredCharm(c *gc.C
 	charmDir := testcharms.RepoWithSeries("bionic").CharmDir("dummy")
 	charmURL := charm.MustParseURL("cs:bionic/dummy-1")
 	withCharmRepoResolvable(s.fakeAPI, charmURL, "")
-	withCharmDeployable(s.fakeAPI, charmURL, "", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
+	withCharmDeployable(s.fakeAPI, charmURL, "bionic", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	s.fakeAPI.Call("Deploy", application.DeployArgs{
 		CharmID: application.CharmID{
@@ -2178,18 +2179,20 @@ func (s *DeploySuite) TestDeployCharmWithSomeEndpointBindingsSpecifiedSuccess(c 
 	curl := charm.MustParseURL("cs:bionic/wordpress-extra-bindings-1")
 	charmDir := testcharms.RepoWithSeries("bionic").CharmDir("wordpress-extra-bindings")
 	withCharmRepoResolvable(s.fakeAPI, curl, "")
-	withCharmDeployable(s.fakeAPI, curl, "", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
+	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), true, false, 1, nil, nil)
 	s.fakeAPI.Call("Deploy", application.DeployArgs{
 		CharmID: application.CharmID{
 			URL: curl,
 			Origin: commoncharm.Origin{
 				Source:       commoncharm.OriginCharmStore,
 				Architecture: arch.DefaultArchitecture,
+				Series:       "bionic",
 			},
 		},
 		CharmOrigin: commoncharm.Origin{
 			Source:       commoncharm.OriginCharmStore,
 			Architecture: arch.DefaultArchitecture,
+			Series:       "bionic",
 		},
 		ApplicationName: curl.Name,
 		Series:          "bionic",

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -492,7 +492,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// Ensure we save the origin.
-	c.origin = origin
+	c.origin = origin.WithSeries(series)
 
 	// In-order for the url to represent the following updates to the the origin
 	// and machine, we need to ensure that the series is actually correct as

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -428,11 +428,11 @@ func (c *repositoryCharm) String() string {
 // then deploys it.
 func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver, macaroonGetter store.MacaroonGetter) error {
 	userRequestedURL := c.userRequestedURL
-	location := "hub"
+	location := "charmhub"
 	if charm.CharmStore.Matches(userRequestedURL.Schema) {
-		location = "store"
+		location = "charm-store"
 	}
-	ctx.Verbosef("Preparing to deploy %q from the charm-%s", userRequestedURL.Name, location)
+	ctx.Verbosef("Preparing to deploy %q from the %s", userRequestedURL.Name, location)
 
 	// resolver.resolve potentially updates the series of anything
 	// passed in. Store this for use in seriesSelector.
@@ -474,6 +474,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 
 	// Get the series to use.
 	series, err := selector.charmSeries()
+	logger.Tracef("Using series %s from %v to deploy %v", series, supportedSeries, userRequestedURL)
 
 	// Avoid deploying charm if it's not valid for the model.
 	// We check this first before possibly suggesting --force.


### PR DESCRIPTION
The following changes will allow us to collate all bases when no base is
passed. This is possible because of a change to charmhub API; passing
multiple bases back within the error.

Previously the code would select the first base within the error and use
that for the resolution of the charm, dropping any others on the floor.
It wasn't required to do anything more with them at the time.
The change here is that we collate them, so once we've resolved the name
against the API, we can extract the series from them and return them
back. Allowing the client-side logic to see if the model-default value
is set on it, if it is, we can use that for the actual charm download
selection.

The code changes now expect the result from the selection from the error
to return many and not 1. Additional changes to simplify the setting of
the original input charm origin is also used, which makes reading the
code much easier.

Additionally, the way this is implemented will work in a backward
compatible way, as the underlying API hasn't changed the type, just how
much data is returned.

## QA steps

This is kind of a big one, we have to do a lot of regression testing here.

Note: it requires charmhub API to be release to staging/production.

### model-defaults scenario

The following should deploy a `xenial` version of ubuntu.

Note: this currently only works on staging as we require API support.
Considering this is backwards compatible, this is safe to merge and release
to production with the changes anyway.

```sh
$ juju bootstrap lxd test
$ juju add-model other --config="default-series=xenial" --config charmhub-url="https://api.staging.snapcraft.io"
$ juju deploy ubuntu
```

### charmhub deployments

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu # deploys focal
$ juju deploy ubuntu --series=bionic # deploys bionic
```

## Bug reference

https://bugs.launchpad.net/snapstore-server/+bug/1927135
