### PR TITLE
CLI: Fix panic in upgrade-series with older controllers

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -321,7 +321,15 @@ func getMachineID(fullStatus *params.FullStatus, id string) (string, error) {
 // or the info was malformed, we will fall back to the underlying error
 // and not provide any hints.
 func (c *upgradeSeriesCommand) displayProgressFromError(ctx *cmd.Context, err error) error {
-	errResp := errors.Cause(err).(*params.Error)
+	if errors.IsNotSupported(err) {
+		return errors.Wrap(err, errors.Errorf(`upgrade-series is not supported.
+Please upgrade your controller to perform the operation.`))
+	}
+
+	errResp, ok := errors.Cause(err).(*params.Error)
+	if !ok {
+		return errors.Trace(err)
+	}
 	var info params.UpgradeSeriesValidationErrorInfo
 	if unmarshalErr := errResp.UnmarshalInfo(&info); unmarshalErr == nil && info.Status != "" {
 		// Lift the raw status into a upgrade series status type. Then perform


### PR DESCRIPTION
The upgrade-series command expected that all controllers would return a
`*params.Error`. This isn't always the case, so the code here assumes that
we correctly handle that case.

## QA steps

```sh
$ snap install juju --classic --channel=2.3
$ juju bootstrap lxd test
$ juju deploy ubuntu --series=xenial
```
Build this PR:

```sh
$ juju upgrade-series 0 prepare bionic
...
ERROR upgrade-series is not supported.
Please upgrade your controller to perform the operation.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929100
