### PR TITLE
Only run upgrade-charm hook once when k8s charm upgraded

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -508,6 +508,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				Abort:         u.catacomb.Dying(),
 				OnIdle:        onIdle,
 				CharmDirGuard: u.charmDirGuard,
+				CharmDir:      u.paths.State.CharmDir,
 				Logger:        u.logger.Child("resolver"),
 			}, &localState)
 
@@ -642,22 +643,6 @@ func (u *Uniter) charmState() (bool, *corecharm.URL, int, error) {
 	app, err := u.unit.Application()
 	if err != nil {
 		return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
-	}
-
-	if _, err := corecharm.ReadCharmDir(u.paths.State.CharmDir); err != nil {
-		// use appCharmURL to avoid double upgrade.
-		appCharmURL, _, err := app.CharmURL()
-		if err != nil {
-			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
-		}
-		u.logger.Debugf("start to re-download charm because charm dir has gone which is usually caused by operator pod re-scheduling")
-		op, err := u.operationFactory.NewUpgrade(appCharmURL)
-		if err != nil {
-			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
-		}
-		if err := u.operationExecutor.Run(op, nil); err != nil {
-			return canApplyCharmProfile, charmURL, charmModifiedVersion, errors.Trace(err)
-		}
 	}
 
 	// TODO (hml) 25-09-2020 - investigate

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -218,6 +218,7 @@ func (s *UniterSuite) TestUniterRestartWithCharmDirInvalidThenRecover(c *gc.C) {
 				charm:  1,
 			},
 			waitHooks{"upgrade-charm", "config-changed"},
+			waitHooks{},
 			verifyCharm{revision: 1},
 			verifyRunning{},
 		),


### PR DESCRIPTION
When a k8s charm is upgraded, the provisioner rewrites the pod spec causing a rolling update. As each unit agent starts up, it needs to detect this has happened so it can run the upgrade hook. It does this by seeing if the charm dir exists. But it was being done in the wrong place, and the upgrade operation was not properly wrapped by a `resolverOpFactory`. This meant that the local state charm url was not set, and so the next pass through the resolve loop thought an upgrade was needed and ran the hook a second time. We already have a checkCharmUpgrade() method so the charm dir check just needs to be moved there.

## QA steps

deploy snappass-test
juju upgrade-charm
juju status-log to check that only one upgrade-charm hook is run

do the same for a pod spec charm like mariadb-k8s

## Bug reference

https://bugs.launchpad.net/juju/+bug/1928776
