### PR TITLE
Update Pebble: enable "pebble run --verbose" logging and starting services as different user/group

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1224,6 +1224,7 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				"run",
 				"--create-dirs",
 				"--hold",
+				"--verbose",
 			},
 			Env: []corev1.EnvVar{{
 				Name:  "JUJU_CONTAINER_NAME",

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -350,7 +350,7 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Image:           "gitlab-image:latest",
 			Command:         []string{"/charm/bin/pebble"},
-			Args:            []string{"run", "--create-dirs", "--hold"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--verbose"},
 			Env: []corev1.EnvVar{
 				{
 					Name:  "JUJU_CONTAINER_NAME",

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 	github.com/aws/aws-sdk-go v1.29.8
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20210418225304-713a473474b7
+	github.com/canonical/pebble v0.0.0-20210523225630-645d2ba3f000
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/dnaeon/go-vcr v1.1.0 // indirect
@@ -144,8 +144,6 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml v0.0.0-20200420012109-12a32b78d
 replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0.0.0-20141228071148-145fabdb1ab7
 
 replace github.com/hashicorp/raft-boltdb => github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5
-
-replace github.com/canonical/pebble => github.com/benhoyt/pebble v0.0.0-20210521043823-48d13055770d
 
 replace (
 	k8s.io/api v0.0.0 => k8s.io/api v0.19.6

--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,8 @@ replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0
 
 replace github.com/hashicorp/raft-boltdb => github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5
 
+replace github.com/canonical/pebble => github.com/benhoyt/pebble v0.0.0-20210521043823-48d13055770d
+
 replace (
 	k8s.io/api v0.0.0 => k8s.io/api v0.19.6
 	k8s.io/apiextensions-apiserver v0.0.0 => k8s.io/apiextensions-apiserver v0.19.6

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.29.8 h1:Kma1ikL7MHs/XH5Q4Aqj53AAhgttW6UFykc8Qj16HGo=
 github.com/aws/aws-sdk-go v1.29.8/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
+github.com/benhoyt/pebble v0.0.0-20210521043823-48d13055770d h1:ucueolfSbLmrUEmOAsZXukwK1XegimJB5ShMa3uiWGs=
+github.com/benhoyt/pebble v0.0.0-20210521043823-48d13055770d/go.mod h1:Glkg6kOpPMNw1BDDzRHH0U9i3pnc6Y+zV+pHwdX4SU0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -93,8 +95,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20210418225304-713a473474b7 h1:wHNTSsq2tCTPs9jUhUBsJugZ0pJoAvRW/oHo4IUrJhY=
-github.com/canonical/pebble v0.0.0-20210418225304-713a473474b7/go.mod h1:Glkg6kOpPMNw1BDDzRHH0U9i3pnc6Y+zV+pHwdX4SU0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,6 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.29.8 h1:Kma1ikL7MHs/XH5Q4Aqj53AAhgttW6UFykc8Qj16HGo=
 github.com/aws/aws-sdk-go v1.29.8/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/benhoyt/pebble v0.0.0-20210521043823-48d13055770d h1:ucueolfSbLmrUEmOAsZXukwK1XegimJB5ShMa3uiWGs=
-github.com/benhoyt/pebble v0.0.0-20210521043823-48d13055770d/go.mod h1:Glkg6kOpPMNw1BDDzRHH0U9i3pnc6Y+zV+pHwdX4SU0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -95,6 +93,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/canonical/pebble v0.0.0-20210523225630-645d2ba3f000 h1:36iiZ+qIA4HOkoKzUnld9Gf2FmxSwGcTjap2D/dSv5E=
+github.com/canonical/pebble v0.0.0-20210523225630-645d2ba3f000/go.mod h1:Glkg6kOpPMNw1BDDzRHH0U9i3pnc6Y+zV+pHwdX4SU0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
This enables the new `--verbose` flag on the `pebble run` command used by Juju for sidecar charms, which forwards service stdout and stderr through to Pebble's stdout (and adds timestamps and service name).

The latest version of Pebble also supports the user/user-id/group/group-id fields in the Pebble layer configuration for a service, allowing charmers to start services as a non-root user.

Specifically, it includes these three Pebble PRs:

* https://github.com/canonical/pebble/pull/29: Foundation work for service log buffers with pebble run -v
* https://github.com/canonical/pebble/pull/45: Don't log requests to /v1/system-info to avoid noise from health checks
* https://github.com/canonical/pebble/pull/35: Allow starting services as another user

## QA steps

Below are QA steps (for just the logging feature):

```
# Bootstrap and deploy a sidecar charm
$ juju bootstrap microk8s
$ juju add-model snappass
$ juju deploy snappass-test

# View logs using kubectl logs on the workload containers
$ microk8s.kubectl logs -n snappass snappass-test-0 redis
2021-05-21T05:02:17.373Z [pebble] Started daemon.
2021-05-21T05:02:22.268Z [pebble] GET /v1/services?names=redis 120.548µs 200
2021-05-21T05:02:22.822Z [pebble] GET /v1/services?names=redis 40.28µs 200
2021-05-21T05:02:22.823Z [pebble] POST /v1/layers 158.323µs 200
2021-05-21T05:02:22.832Z [pebble] POST /v1/services 8.953673ms 202
2021-05-21T05:02:22.868Z [redis] 15:C 21 May 2021 05:02:22.867 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
2021-05-21T05:02:22.868Z [redis] 15:C 21 May 2021 05:02:22.867 # Redis version=6.2.1, bits=64, commit=00000000, modified=0, pid=15, just started
2021-05-21T05:02:22.868Z [redis] 15:C 21 May 2021 05:02:22.867 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
2021-05-21T05:02:22.870Z [redis] 15:M 21 May 2021 05:02:22.870 * monotonic clock: POSIX clock_gettime
2021-05-21T05:02:22.871Z [redis] 15:M 21 May 2021 05:02:22.871 * Running mode=standalone, port=6379.
2021-05-21T05:02:22.871Z [redis] 15:M 21 May 2021 05:02:22.871 # Server initialized
2021-05-21T05:02:22.872Z [redis] 15:M 21 May 2021 05:02:22.872 * Ready to accept connections

$ microk8s.kubectl logs -n snappass snappass-test-0 snappass
2021-05-21T05:02:17.575Z [pebble] Started daemon.
2021-05-21T05:02:23.934Z [pebble] GET /v1/services?names=snappass 301.57µs 200
2021-05-21T05:02:23.937Z [pebble] POST /v1/layers 470.062µs 200
2021-05-21T05:02:23.950Z [pebble] POST /v1/services 11.297726ms 202
2021-05-21T05:02:24.490Z [snappass]  * Serving Flask app "snappass.main" (lazy loading)
2021-05-21T05:02:24.490Z [snappass]  * Environment: production
2021-05-21T05:02:24.490Z [snappass]    WARNING: This is a development server. Do not use it in a production deployment.
2021-05-21T05:02:24.490Z [snappass]    Use a production WSGI server instead.
2021-05-21T05:02:24.490Z [snappass]  * Debug mode: off
2021-05-21T05:02:24.503Z [snappass]  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```

To ensure the user/group feature was in place, I made some local edits to the snappass-test charm to add a user and group. The user/group didn't exist in the redis container, but it was clear that Pebble was trying to set the UID/GID.