### PR TITLE
cmd/juju: add links to remove-saas from related commands

### DIFF
--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -34,7 +34,8 @@ Examples:
 
 See also:
     add-relation
-    offer`[1:]
+    offer
+    remove-saas`[1:]
 
 // NewConsumeCommand returns a command to add remote offers to
 // the model.

--- a/cmd/juju/application/removesaas.go
+++ b/cmd/juju/application/removesaas.go
@@ -53,7 +53,11 @@ in a non-functional state.
 
 Examples:
     juju remove-saas hosted-mysql
-    juju remove-saas -m test-model hosted-mariadb`[1:]
+    juju remove-saas -m test-model hosted-mariadb
+
+See also:
+    consume
+    offer`[1:]
 
 func (c *removeSaasCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{

--- a/cmd/juju/crossmodel/offer.go
+++ b/cmd/juju/crossmodel/offer.go
@@ -36,6 +36,7 @@ $ juju offer db2:db,log hosted-db2
 See also:
     consume
     relate
+    remove-saas
 `
 )
 


### PR DESCRIPTION
Update the help on the offer and consume commands to add remove-saas to
the "see also" section.

## QA steps

```sh
juju help consume
juju help offer
juju help remove-saas
```

## Documentation changes

It is easier to find the remove-saas command.


