### PR TITLE
Lp1920820 dashboard proxy support

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1312,6 +1312,11 @@ func (s *state) IsProxied() bool {
 	return s.proxier != nil
 }
 
+// Proxy returns the proxy being used with this connection if one is being used.
+func (s *state) Proxy() jujuproxy.Proxier {
+	return s.proxier
+}
+
 // ModelTag implements base.APICaller.ModelTag.
 func (s *state) ModelTag() (names.ModelTag, bool) {
 	return s.modelTag, s.modelTag.Id() != ""

--- a/api/interface.go
+++ b/api/interface.go
@@ -263,6 +263,11 @@ type Connection interface {
 	// IsProxied returns weather the connection is proxied.
 	IsProxied() bool
 
+	// Proxy returns the Proxier used to establish the connection if one was
+	// used at all. If no Proxier was used then it's expected that returned
+	// Proxier will be nil. Use IsProxied() to test for the presence of a proxy.
+	Proxy() proxy.Proxier
+
 	// PublicDNSName returns the host name for which an officially
 	// signed certificate will be used for TLS connection to the server.
 	// If empty, the private Juju CA certificate must be used to verify


### PR DESCRIPTION
With this change juju dashboard command can now hold open proxy connections for use with the juju dashboard.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap a Kubernetes controller that requires proxying minikube, microk8s or kind

Run `juju dashboard` and check the connection is held open till an interrupt is received. 

Check the dashboard connection works.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1920820
