### PR TITLE
Use stable cookie URL for controller client connections

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -237,6 +237,15 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		fallback:    http.DefaultTransport,
 	}
 
+	// Prefer the SNI hostname or controller name for the cookie URL
+	// so that it is stable when used with a HA controller cluster.
+	host := info.SNIHostName
+	if host == "" && info.ControllerUUID != "" {
+		host = info.ControllerUUID
+	}
+	if host == "" {
+		host = dialResult.addr
+	}
 	st := &state{
 		ctx:    context.Background(),
 		client: client,
@@ -246,7 +255,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		ipAddr: dialResult.ipAddr,
 		cookieURL: &url.URL{
 			Scheme: "https",
-			Host:   dialResult.addr,
+			Host:   host,
 			Path:   "/",
 		},
 		pingerFacadeVersion: facadeVersions["Pinger"],

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -264,6 +264,28 @@ func (s *apiclientSuite) TestOpen(c *gc.C) {
 	remoteVersion, versionSet := st.ServerVersion()
 	c.Assert(versionSet, jc.IsTrue)
 	c.Assert(remoteVersion, gc.Equals, jujuversion.Current)
+
+	c.Assert(api.CookieURL(st).String(), gc.Equals, "https://deadbeef-1bad-500d-9000-4b1d0d06f00d/")
+}
+
+func (s *apiclientSuite) TestOpenCookieURLUsesSNIHost(c *gc.C) {
+	info := s.APIInfo(c)
+	info.SNIHostName = "somehost"
+	st, err := api.Open(info, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+
+	c.Assert(api.CookieURL(st).String(), gc.Equals, "https://somehost/")
+}
+
+func (s *apiclientSuite) TestOpenCookieURLDefaultsToAddress(c *gc.C) {
+	info := s.APIInfo(c)
+	info.ControllerUUID = ""
+	st, err := api.Open(info, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Close()
+
+	c.Assert(api.CookieURL(st).String(), gc.Matches, "https://localhost:.*/")
 }
 
 func (s *apiclientSuite) TestOpenHonorsModelTag(c *gc.C) {

--- a/api/export_test.go
+++ b/api/export_test.go
@@ -61,6 +61,11 @@ func UnderlyingConn(c Connection) jsoncodec.JSONConn {
 	return c.(*state).conn
 }
 
+// CookieURL returns the cookie URL of the connection.
+func CookieURL(c Connection) *url.URL {
+	return c.(*state).cookieURL
+}
+
 // TestingStateParams is the parameters for NewTestingState, so that you can
 // only set the bits that you actually want to test.
 type TestingStateParams struct {

--- a/api/interface.go
+++ b/api/interface.go
@@ -41,6 +41,9 @@ type Info struct {
 	// Addrs holds the addresses of the controllers.
 	Addrs []string
 
+	// ControllerUUID is the UUID of the controller.
+	ControllerUUID string
+
 	// SNIHostName optionally holds the host name to use for
 	// server name indication (SNI) when connecting
 	// to the addresses in Addrs above. If CACert is non-empty,

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -59,7 +59,7 @@ type authContext struct {
 	_macaroonAuthError error
 }
 
-// OpenAuthorizer authorises any login operation presented to it.
+// OpenLoginAuthorizer authorises any login operation presented to it.
 type OpenLoginAuthorizer struct{}
 
 // AuthorizeOps implements OpsAuthorizer.AuthorizeOps.
@@ -158,7 +158,7 @@ func (ctxt *authContext) CheckLocalLoginRequest(ctx context.Context, req *http.R
 	return authentication.CheckLocalLoginRequest(ctx, ctxt.localUserThirdPartyBakery.Checker, req)
 }
 
-// Discharge caveats returns the caveats to add to a login discharge macaroon.
+// DischargeCaveats returns the caveats to add to a login discharge macaroon.
 func (ctxt *authContext) DischargeCaveats(tag names.UserTag) []checkers.Caveat {
 	return authentication.DischargeCaveats(tag, ctxt.clock)
 }

--- a/juju/api.go
+++ b/juju/api.go
@@ -79,9 +79,10 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 		// Copy the API info because it's possible that the
 		// apiConfigConnect is still using it concurrently.
 		apiInfo = &api.Info{
-			ModelTag: apiInfo.ModelTag,
-			Addrs:    usableHostPorts(redirErr.Servers).Strings(),
-			CACert:   redirErr.CACert,
+			ModelTag:       apiInfo.ModelTag,
+			Addrs:          usableHostPorts(redirErr.Servers).Strings(),
+			CACert:         redirErr.CACert,
+			ControllerUUID: apiInfo.ControllerUUID,
 		}
 		st, err = args.OpenAPI(apiInfo, args.DialOpts)
 		if err != nil {
@@ -167,8 +168,9 @@ func connectionInfo(args NewAPIConnectionParams) (*api.Info, *jujuclient.Control
 	}
 
 	apiInfo := &api.Info{
-		Addrs:  controller.APIEndpoints,
-		CACert: controller.CACert,
+		Addrs:          controller.APIEndpoints,
+		CACert:         controller.CACert,
+		ControllerUUID: controller.ControllerUUID,
 	}
 	if args.ModelUUID != "" {
 		apiInfo.ModelTag = names.NewModelTag(args.ModelUUID)

--- a/juju/api_test.go
+++ b/juju/api_test.go
@@ -140,6 +140,7 @@ func (s *NewAPIClientSuite) TestUpdatesLastKnownAccess(c *gc.C) {
 
 func (s *NewAPIClientSuite) TestUpdatesPublicDNSName(c *gc.C) {
 	apiOpen := func(apiInfo *api.Info, opts api.DialOpts) (api.Connection, error) {
+		c.Assert(apiInfo.ControllerUUID, gc.Equals, fakeUUID)
 		conn := mockedAPIState(noFlags)
 		conn.publicDNSName = "somewhere.invalid"
 		conn.addr = "0.1.2.3:1234"
@@ -184,6 +185,7 @@ func (s *NewAPIClientSuite) TestWithRedirect(c *gc.C) {
 
 	openCount := 0
 	redirOpen := func(apiInfo *api.Info, opts api.DialOpts) (api.Connection, error) {
+		c.Check(apiInfo.ControllerUUID, gc.Equals, fakeUUID)
 		c.Check(apiInfo.ModelTag.Id(), gc.Equals, fakeUUID)
 		openCount++
 		switch openCount {

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -356,6 +356,7 @@ func (s *JujuConnSuite) APIInfo(c *gc.C) *api.Info {
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.Tag = s.AdminUserTag(c)
 	apiInfo.Password = "dummy-secret"
+	apiInfo.ControllerUUID = s.ControllerConfig.ControllerUUID()
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	apiInfo.ModelTag = model.ModelTag()

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -45,7 +45,7 @@ var ModelTag = names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 // ControllerTag is a defined known valid UUID that can be used in testing.
 var ControllerTag = names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 
-// FakeControllerConfig() returns an environment configuration
+// FakeControllerConfig returns an environment configuration
 // that is expected to be found in state for a fake controller.
 func FakeControllerConfig() controller.Config {
 	return controller.Config{
@@ -65,7 +65,7 @@ func FakeControllerConfig() controller.Config {
 	}
 }
 
-// FakeConfig() returns an environment configuration for a
+// FakeConfig returns an environment configuration for a
 // fake provider with all required attributes set.
 func FakeConfig() Attrs {
 	return Attrs{


### PR DESCRIPTION
When the Juju CLI logs in using a macaroon, it stores the macaroon in a local cookie jar. The cookie is tied to the controller IP address. However, for HA controllers, the controller IP address is one of 3 so we end up forcing the user to login to each controller and store the macaroon 3 times.

This PR instead uses the SNI host as the cookie URL (if set). If not set, it uses the controller name. This means that the user logs in once to the controller cluster and then the macaroon can be correctly queried from the cookie jar next time, even if the CLI randomly selects a different controller IP address to use.

We also add extra trace logging to allow better diagnosis of macaroon auth issues.

## QA steps

bootstrap and enable ha
add a user and give permission to read a model
from a separate terminal with different juju home, login as that user
run juju status repeatedly and see that login is only asked for once

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929351
