### PR TITLE
Integration tests: Fix upgrade tests

### DIFF
--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -3,10 +3,13 @@ start_server() {
 
 	path=${1}
 
-	python3 -m http.server --directory "${path}" 8666 >"${TEST_DIR}/server.log" 2>&1 &
-	SERVER_PID=$!
+	(
+		cd "${path}"
+		python3 -m http.server 8666 >"${TEST_DIR}/server.log" 2>&1 &
+		SERVER_PID=$!
 
-	echo "${SERVER_PID}" >"${TEST_DIR}/server.pid"
+		echo "${SERVER_PID}" >"${TEST_DIR}/server.pid"
+	)
 }
 
 kill_server() {

--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -4,7 +4,7 @@ start_server() {
 	path=${1}
 
 	(
-		cd "${path}"
+		cd "${path}" || exit 1
 		python3 -m http.server 8666 >"${TEST_DIR}/server.log" 2>&1 &
 		SERVER_PID=$!
 


### PR DESCRIPTION
The directory is a non-standard flag and has been removed. Instead, create a
sub-shell and change to the path there and then launch the python http
server.

## QA steps

**Note**: root is required if you're snap installing an old juju version.

```sh
$ (cd tests && ./main.sh upgrade)
```
