### PR TITLE
Extend timeout for fetch-oci;

### DIFF
--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -38,10 +38,9 @@ mongo_image="docker.io/jujusolutions/juju-db:4.0"
 echo "Going to cache images: $oci_image and $mongo_image."
 
 # It's not an install/refresh blocker if we can't get the images.
-timeout 2m sh <<EOT || echo "Timed out waiting to install microk8s image."
+timeout 90s sh <<EOT || echo "Timed out waiting to install microk8s image."
 echo "Pulling: $oci_image."
 $container_cmd $image_arg list | grep $oci_image || $container_cmd $image_arg pull $oci_image || true
-
 echo "Pulling: $mongo_image."
 $container_cmd $image_arg list | grep $mongo_image || $container_cmd $image_arg pull $mongo_image || true
 EOT

--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -25,7 +25,7 @@ if ! which $container_cmd; then
 fi
 
 echo "Wait for microk8s to be ready if needed."
-wait_result=$(microk8s.status --wait-ready --timeout 15 2>&1)
+wait_result=$(microk8s.status --wait-ready --timeout 30 2>&1)
 if [ $? -ne 0 ]; then
     echo "${wait_result}"
     exit 0
@@ -38,7 +38,7 @@ mongo_image="docker.io/jujusolutions/juju-db:4.0"
 echo "Going to cache images: $oci_image and $mongo_image."
 
 # It's not an install/refresh blocker if we can't get the images.
-timeout 40s sh <<EOT || echo "Timed out waiting to install microk8s image."
+timeout 2m sh <<EOT || echo "Timed out waiting to install microk8s image."
 echo "Pulling: $oci_image."
 $container_cmd $image_arg list | grep $oci_image || $container_cmd $image_arg pull $oci_image || true
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,8 @@ apps:
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
+    start-timeout: 3m
+    stop-timeout: 35s
 
 parts:
   wrappers:


### PR DESCRIPTION
Extend timeout for snap.juju.fetch-oci.service to 3m and restore timeout for microk8s.status and images pulling;

```console
$ systemctl cat snap.juju.fetch-oci.service | grep TimeoutStartSec
TimeoutStartSec=180

$ sudo snap connect juju:peers microk8s:microk8s

$ systemctl status snap.juju.fetch-oci.service
● snap.juju.fetch-oci.service - Service for snap application juju.fetch-oci
     Loaded: loaded (/etc/systemd/system/snap.juju.fetch-oci.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Wed 2021-05-26 06:12:53 UTC; 36s ago
    Process: 421504 ExecStart=/usr/bin/snap run juju.fetch-oci (code=exited, status=0/SUCCESS)
   Main PID: 421504 (code=exited, status=0/SUCCESS)

May 26 06:11:22 ip-172-31-10-193 juju.fetch-oci[421527]: /usr/bin/timeout
May 26 06:11:22 ip-172-31-10-193 juju.fetch-oci[421528]: /snap/bin/microk8s.ctr
May 26 06:11:22 ip-172-31-10-193 juju.fetch-oci[421504]: Wait for microk8s to be ready if needed.
May 26 06:11:23 ip-172-31-10-193 juju.fetch-oci[421504]: Going to cache images: docker.io/jujusolutions/jujud-operator:2.8.11 and docker.io/jujusolutions/juju-db:4.0.
May 26 06:11:23 ip-172-31-10-193 juju.fetch-oci[421694]: Pulling: docker.io/jujusolutions/jujud-operator:2.8.11.
May 26 06:11:23 ip-172-31-10-193 juju.fetch-oci[421696]: docker.io/jujusolutions/jujud-operator:2.8.11                                                               application/vnd.dock>
May 26 06:11:23 ip-172-31-10-193 juju.fetch-oci[421694]: sleeping 130s...
May 26 06:12:53 ip-172-31-10-193 juju.fetch-oci[421504]: Timed out waiting to install microk8s image.
May 26 06:12:53 ip-172-31-10-193 systemd[1]: snap.juju.fetch-oci.service: Succeeded.
May 26 06:12:53 ip-172-31-10-193 systemd[1]: Finished Service for snap application juju.fetch-oci.

```