### PR TITLE
Charmhub: Download error should include status

### DIFF
--- a/charmhub/download.go
+++ b/charmhub/download.go
@@ -209,5 +209,5 @@ func (c *DownloadClient) downloadFromURL(ctx context.Context, resourceURL *url.U
 
 	// Server error, nothing we can do other than inform the user that the
 	// archive was unaviable.
-	return nil, errors.Errorf("unable to locate archive with status: %s", resp.Status)
+	return nil, errors.Errorf("unable to locate archive (store API responded with status: %s)", resp.Status)
 }

--- a/charmhub/download.go
+++ b/charmhub/download.go
@@ -209,5 +209,5 @@ func (c *DownloadClient) downloadFromURL(ctx context.Context, resourceURL *url.U
 
 	// Server error, nothing we can do other than inform the user that the
 	// archive was unaviable.
-	return nil, errors.Errorf("unable to locate archive")
+	return nil, errors.Errorf("unable to locate archive with status: %s", resp.Status)
 }

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -106,7 +106,8 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 	transport := NewMockTransport(ctrl)
 	transport.EXPECT().Do(gomock.Any()).DoAndReturn(func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
-			StatusCode: 500,
+			Status:     http.StatusText(http.StatusInternalServerError),
+			StatusCode: http.StatusInternalServerError,
 			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 		}, nil
 	})
@@ -116,7 +117,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 
 	client := NewDownloadClient(transport, fileSystem, &FakeLogger{})
 	_, err = client.DownloadAndRead(context.TODO(), serverURL, tmpFile.Name())
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive`)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive with status: Internal Server Error`)
 }
 
 func (s *DownloadSuite) createCharmArchieve(c *gc.C) []byte {

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -117,7 +117,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 
 	client := NewDownloadClient(transport, fileSystem, &FakeLogger{})
 	_, err = client.DownloadAndRead(context.TODO(), serverURL, tmpFile.Name())
-	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive with status: Internal Server Error`)
+	c.Assert(err, gc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive \(store API responded with status: Internal Server Error\)`)
 }
 
 func (s *DownloadSuite) createCharmArchieve(c *gc.C) []byte {


### PR DESCRIPTION
To help understand why something failed to download, it might help if we
always include the status code message. That way it becomes easier to
diagnose the underlying error without the need to hit debug-log every time.

## QA steps

See tests.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929058