### PR TITLE
CLI: Document juju plans

### DIFF
--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/gosuri/uitable"
+	"github.com/juju/charm/v8"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -61,7 +62,7 @@ func NewListPlansCommand() modelcmd.ControllerCommand {
 func (c *ListPlansCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "plans",
-		Args:    "",
+		Args:    "<charm-url>",
 		Purpose: "List plans.",
 		Doc:     listPlansDoc,
 		Aliases: []string{"list-plans"},
@@ -76,6 +77,13 @@ func (c *ListPlansCommand) Init(args []string) error {
 	charmURL, args := args[0], args[1:]
 	if err := cmd.CheckEmpty(args); err != nil {
 		return errors.Errorf("unknown command line arguments: " + strings.Join(args, ","))
+	}
+	curl, err := charm.ParseURL(charmURL)
+	if err != nil {
+		return errors.Annotatef(err, "unable to parse charm URL")
+	}
+	if !charm.CharmStore.Matches(curl.Schema) {
+		return errors.Errorf("charm-store charm URLs are only supported")
 	}
 	c.CharmURL = charmURL
 	return c.CommandBase.Init(args)

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -83,7 +83,7 @@ func (c *ListPlansCommand) Init(args []string) error {
 		return errors.Annotatef(err, "unable to parse charm URL")
 	}
 	if !charm.CharmStore.Matches(curl.Schema) {
-		return errors.Errorf("charm-store charm URLs are only supported")
+		return errors.NotSupportedf("non charm-store URLs")
 	}
 	c.CharmURL = charmURL
 	return c.CommandBase.Init(args)

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -72,7 +72,7 @@ func (c *ListPlansCommand) Info() *cmd.Info {
 // Init reads and verifies the cli arguments for the ListPlansCommand
 func (c *ListPlansCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return errors.New("missing arguments")
+		return errors.New("missing charm-store charm URL argument")
 	}
 	charmURL, args := args[0], args[1:]
 	if err := cmd.CheckEmpty(args); err != nil {

--- a/cmd/juju/romulus/listplans/list_plans_test.go
+++ b/cmd/juju/romulus/listplans/list_plans_test.go
@@ -181,7 +181,7 @@ func (s *ListPlansCommandSuite) TestGetCommands(c *gc.C) {
 	}, {
 		about:   "missing argument",
 		args:    []string{},
-		err:     `missing arguments`,
+		err:     `missing charm-store charm URL argument`,
 		apiCall: []interface{}{},
 	}, {
 		about:   "invalid charm url",

--- a/cmd/juju/romulus/listplans/list_plans_test.go
+++ b/cmd/juju/romulus/listplans/list_plans_test.go
@@ -68,9 +68,9 @@ func (s *ListPlansCommandSuite) SetUpTest(c *gc.C) {
 
 func (s *ListPlansCommandSuite) TestTabularOutput(c *gc.C) {
 	ctx, err := s.runCommand(c, &mockCharmResolver{
-		ResolvedURL: "series/some-charm-url",
+		ResolvedURL: "cs:series/some-charm-url",
 		Stub:        s.stub,
-	}, "some-charm-url")
+	}, "cs:some-charm-url")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals,
 		`Plan             	Price	Description                                       
@@ -151,37 +151,42 @@ func (s *ListPlansCommandSuite) TestGetCommands(c *gc.C) {
 		apiCall          []interface{}
 	}{{
 		about:            "charm url is resolved",
-		args:             []string{"some-charm-url"},
-		resolvedCharmURL: "series/some-charm-url-1",
-		apiCall:          []interface{}{"series/some-charm-url-1"},
+		args:             []string{"cs:some-charm-url"},
+		resolvedCharmURL: "cs:series/some-charm-url-1",
+		apiCall:          []interface{}{"cs:series/some-charm-url-1"},
 	}, {
 		about:   "everything works - default format",
-		args:    []string{"some-charm-url"},
-		apiCall: []interface{}{"some-charm-url"},
+		args:    []string{"cs:some-charm-url"},
+		apiCall: []interface{}{"cs:some-charm-url"},
 	}, {
 		about:   "everything works - yaml",
-		args:    []string{"some-charm-url", "--format", "yaml"},
-		apiCall: []interface{}{"some-charm-url"},
+		args:    []string{"cs:some-charm-url", "--format", "yaml"},
+		apiCall: []interface{}{"cs:some-charm-url"},
 	}, {
 		about:   "everything works - smart",
-		args:    []string{"some-charm-url", "--format", "smart"},
-		apiCall: []interface{}{"some-charm-url"},
+		args:    []string{"cs:some-charm-url", "--format", "smart"},
+		apiCall: []interface{}{"cs:some-charm-url"},
 	}, {
 		about:   "everything works - json",
-		args:    []string{"some-charm-url", "--format", "json"},
-		apiCall: []interface{}{"some-charm-url"},
+		args:    []string{"cs:some-charm-url", "--format", "json"},
+		apiCall: []interface{}{"cs:some-charm-url"},
 	}, {
 		about:   "everything works - summary",
-		args:    []string{"some-charm-url", "--format", "summary"},
-		apiCall: []interface{}{"some-charm-url"},
+		args:    []string{"cs:some-charm-url", "--format", "summary"},
+		apiCall: []interface{}{"cs:some-charm-url"},
 	}, {
 		about:   "everything works - tabular",
-		args:    []string{"some-charm-url", "--format", "tabular"},
-		apiCall: []interface{}{"some-charm-url"},
+		args:    []string{"cs:some-charm-url", "--format", "tabular"},
+		apiCall: []interface{}{"cs:some-charm-url"},
 	}, {
 		about:   "missing argument",
 		args:    []string{},
 		err:     `missing arguments`,
+		apiCall: []interface{}{},
+	}, {
+		about:   "invalid charm url",
+		args:    []string{"some-url"},
+		err:     `charm-store charm URLs are only supported`,
 		apiCall: []interface{}{},
 	}, {
 		about:   "unknown arguments",

--- a/cmd/juju/romulus/listplans/list_plans_test.go
+++ b/cmd/juju/romulus/listplans/list_plans_test.go
@@ -186,7 +186,7 @@ func (s *ListPlansCommandSuite) TestGetCommands(c *gc.C) {
 	}, {
 		about:   "invalid charm url",
 		args:    []string{"some-url"},
-		err:     `charm-store charm URLs are only supported`,
+		err:     `non charm-store URLs not supported`,
 		apiCall: []interface{}{},
 	}, {
 		about:   "unknown arguments",


### PR DESCRIPTION
Juju plans has undocumented arguments that require you to fail and read
the help. Instead, we can populate the args for the command to get the
correct information.

Additionally, we restrict the list plan command to charm-store to prevent
errors later on when calling against the charmstore.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju plans
ERROR missing charm-store charm URL argument
$ juju plans -h
Usage: juju plans [options] <charm-url>
$ juju plans postgresql
ERROR charm-store charm URLs are only supported
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1912761
