### PR TITLE
Download charm even if not started

### DIFF
--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -290,9 +290,9 @@ func (s *LoopSuite) TestCheckCharmUpgradeUpgradeCharmHook(c *gc.C) {
 		Executor: nil,
 		Stub:     envtesting.Stub{},
 		st: operation.State{
-			Started: true,
-			Kind:    operation.Continue,
-			Hook:    &hook.Info{Kind: hooks.UpgradeCharm},
+			Installed: true,
+			Kind:      operation.Continue,
+			Hook:      &hook.Info{Kind: hooks.UpgradeCharm},
 		},
 		run: nil,
 	}
@@ -304,8 +304,8 @@ func (s *LoopSuite) TestCheckCharmUpgradeSameURL(c *gc.C) {
 		Executor: nil,
 		Stub:     envtesting.Stub{},
 		st: operation.State{
-			Started: true,
-			Kind:    operation.Continue,
+			Installed: true,
+			Kind:      operation.Continue,
 		},
 		run: nil,
 	}
@@ -318,13 +318,32 @@ func (s *LoopSuite) TestCheckCharmUpgradeSameURL(c *gc.C) {
 	s.testCheckCharmUpgradeDoesNothing(c)
 }
 
+func (s *LoopSuite) TestCheckCharmUpgradeNotInstalled(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Kind: operation.Continue,
+		},
+		run: nil,
+	}
+	s.watcher = &mockRemoteStateWatcher{
+		snapshot: remotestate.Snapshot{
+			CharmURL: charm.MustParseURL("cs:trusty/mysql-2"),
+		},
+	}
+	s.charmDir = testcharms.Repo.CharmDirPath("mysql")
+	s.testCheckCharmUpgradeDoesNothing(c)
+}
+
 func (s *LoopSuite) TestCheckCharmUpgradeIncorrectLXDProfile(c *gc.C) {
 	s.executor = &mockOpExecutor{
 		Executor: nil,
 		Stub:     envtesting.Stub{},
 		st: operation.State{
-			Started: true,
-			Kind:    operation.Continue,
+			Installed: true,
+			Started:   true,
+			Kind:      operation.Continue,
 		},
 		run: nil,
 	}
@@ -360,8 +379,8 @@ func (s *LoopSuite) TestCheckCharmUpgrade(c *gc.C) {
 		Executor: nil,
 		Stub:     envtesting.Stub{},
 		st: operation.State{
-			Started: true,
-			Kind:    operation.Continue,
+			Installed: true,
+			Kind:      operation.Continue,
 		},
 		run: nil,
 	}
@@ -378,8 +397,8 @@ func (s *LoopSuite) TestCheckCharmUpgradeMissingCharmDir(c *gc.C) {
 		Executor: nil,
 		Stub:     envtesting.Stub{},
 		st: operation.State{
-			Started: true,
-			Kind:    operation.Continue,
+			Installed: true,
+			Kind:      operation.Continue,
 		},
 		run: nil,
 	}
@@ -396,8 +415,9 @@ func (s *LoopSuite) TestCheckCharmUpgradeLXDProfile(c *gc.C) {
 		Executor: nil,
 		Stub:     envtesting.Stub{},
 		st: operation.State{
-			Started: true,
-			Kind:    operation.Continue,
+			Installed: true,
+			Started:   true,
+			Kind:      operation.Continue,
 		},
 		run: nil,
 	}

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -68,7 +68,7 @@ var (
 // will fail the test. Raising this value should
 // not affect the overall running time of the tests
 // unless they fail.
-const worstCase = coretesting.LongWait
+const worstCase = 100 * coretesting.LongWait
 
 // Assign the unit to a provisioned machine with dummy addresses set.
 func assertAssignUnit(c *gc.C, st *state.State, u *state.Unit) {


### PR DESCRIPTION
When checking to see if the charm needs to be downloaded and unpacked, the unit agent was assuming that if a charm is not started, the charm has been downloaded. For k8s charms, this might not be the case, since the charm might update the statefulset in the install hook. This is the case for the [k8s dashboard charm](https://charmhub.io/jnsgruk-kubernetes-dashboard).

This PR simply allows the unit agent to check to see if the charm needs downloading any time after install rather than waiting for the start hook.

## QA steps

bootstrap k8s
juju add-model test
juju deploy jnsgruk-kubernetes-dashboard --channel=edge
juju trust jnsgruk-kubernetes-dashboard --scope=cluster

Check status goes green and logs for test model do not contain errors like referenced in the bug

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929566
