### PR TITLE
Charmhub: Expose http.Client option

### DIFF
--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"net/http"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -22,7 +24,7 @@ type ConfigModel interface {
 }
 
 // CharmhubClient creates a new charmhub Client based on this model's config.
-func CharmhubClient(mg ModelGetter, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
+func CharmhubClient(mg ModelGetter, httpClient *http.Client, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
 	model, err := mg.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -33,7 +35,10 @@ func CharmhubClient(mg ModelGetter, logger loggo.Logger, metadata map[string]str
 	}
 	url, _ := modelConfig.CharmHubURL()
 
-	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"), charmhub.WithMetadataHeaders(metadata))
+	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"),
+		charmhub.WithMetadataHeaders(metadata),
+		charmhub.WithHTTPClient(httpClient),
+	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -4,8 +4,6 @@
 package common
 
 import (
-	"net/http"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -24,7 +22,7 @@ type ConfigModel interface {
 }
 
 // CharmhubClient creates a new charmhub Client based on this model's config.
-func CharmhubClient(mg ModelGetter, httpClient *http.Client, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
+func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
 	model, err := mg.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -37,7 +35,9 @@ func CharmhubClient(mg ModelGetter, httpClient *http.Client, logger loggo.Logger
 
 	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"),
 		charmhub.WithMetadataHeaders(metadata),
-		charmhub.WithHTTPClient(httpClient),
+		charmhub.WithHTTPTransport(func(charmhub.Logger) charmhub.Transport {
+			return httpClient
+		}),
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -277,17 +277,18 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		return nil, errors.Trace(err)
 	}
 
+	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
-		// TODO (stickupkid): Get the httpClient from the facade context
-		charmhub.WithHTTPClient(charmhub.DefaultHTTPTransport()),
+		// TODO (stickupkid): Get the http transport from the facade context
+		charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
 	}
 
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"), options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"), options...)
+		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -276,12 +276,18 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	options := []charmhub.Option{
+		// TODO (stickupkid): Get the httpClient from the facade context
+		charmhub.WithHTTPClient(charmhub.DefaultHTTPTransport()),
+	}
+
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"), options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"), options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -5,7 +5,6 @@ package charmhub
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/juju/errors"
@@ -61,10 +60,9 @@ func NewFacade(ctx facade.Context) (*CharmHubAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// TODO (stickupkid): Get the httpClient from the facade context
-	httpClient := charmhub.DefaultHTTPTransport()
+	// TODO (stickupkid): Get the http transport from the facade context
 	return newCharmHubAPI(m, ctx.Auth(), charmHubClientFactory{
-		httpClient: httpClient,
+		httpTransport: charmhub.DefaultHTTPTransport,
 	})
 }
 
@@ -135,12 +133,12 @@ func (api *CharmHubAPI) Find(ctx context.Context, arg params.Query) (params.Char
 }
 
 type charmHubClientFactory struct {
-	httpClient *http.Client
+	httpTransport func(charmhub.Logger) charmhub.Transport
 }
 
 func (f charmHubClientFactory) Client(url string) (Client, error) {
 	cfg, err := charmhub.CharmHubConfigFromURL(url, logger.Child("client"),
-		charmhub.WithHTTPClient(f.httpClient),
+		charmhub.WithHTTPTransport(f.httpTransport),
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -102,17 +102,18 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
+	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
-		// TODO (stickupkid): Get the httpClient from the facade context
-		charmhub.WithHTTPClient(charmhub.DefaultHTTPTransport()),
+		// TODO (stickupkid): Get the http transport from the facade context
+		charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
 	}
 
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"), options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"), options...)
+		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -101,12 +101,18 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	options := []charmhub.Option{
+		// TODO (stickupkid): Get the httpClient from the facade context
+		charmhub.WithHTTPClient(charmhub.DefaultHTTPTransport()),
+	}
+
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"), options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfig(logger.Child("client"), options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -80,17 +80,18 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 		switch {
 		case charm.CharmHub.Matches(schema):
 
+			clientLogger := logger.Child("client")
 			options := []charmhub.Option{
 				// TODO (stickupkid): Get the httpClient from the facade context
-				charmhub.WithHTTPClient(charmhub.DefaultHTTPTransport()),
+				charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
 			}
 
 			var chCfg charmhub.Config
 			chURL, ok := modelCfg.CharmHubURL()
 			if ok {
-				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"), options...)
+				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
 			} else {
-				chCfg, err = charmhub.CharmHubConfig(logger.Child("client"), options...)
+				chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
 			}
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -79,12 +79,18 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 		schema := chID.URL.Schema
 		switch {
 		case charm.CharmHub.Matches(schema):
+
+			options := []charmhub.Option{
+				// TODO (stickupkid): Get the httpClient from the facade context
+				charmhub.WithHTTPClient(charmhub.DefaultHTTPTransport()),
+			}
+
 			var chCfg charmhub.Config
 			chURL, ok := modelCfg.CharmHubURL()
 			if ok {
-				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"))
+				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger.Child("client"), options...)
 			} else {
-				chCfg, err = charmhub.CharmHubConfig(logger.Child("client"))
+				chCfg, err = charmhub.CharmHubConfig(logger.Child("client"), options...)
 			}
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -96,7 +102,10 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 			return newCharmHubClient(chClient, chID), nil
 
 		case charm.CharmStore.Matches(schema):
-			cl, err := charmstore.NewCachingClient(state.MacaroonCache{st}, controllerCfg.CharmStoreURL())
+
+			cl, err := charmstore.NewCachingClient(state.MacaroonCache{
+				MacaroonCacheState: st,
+			}, controllerCfg.CharmStoreURL())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -57,9 +57,9 @@ func NewCharmRevisionUpdaterAPI(ctx facade.Context) (*CharmRevisionUpdaterAPI, e
 		return charmstore.NewCachingClient(state.MacaroonCache{MacaroonCacheState: st}, controllerCfg.CharmStoreURL())
 	}
 	newCharmhubClient := func(st State, metadata map[string]string) (CharmhubRefreshClient, error) {
-		// TODO (stickupkid): Get the httpClient from the facade context
-		httpClient := charmhub.DefaultHTTPTransport()
-		return common.CharmhubClient(charmhubClientStateShim{state: st}, httpClient, logger, metadata)
+		// TODO (stickupkid): Get the http transport from the facade context
+		transport := charmhub.DefaultHTTPTransport(logger)
+		return common.CharmhubClient(charmhubClientStateShim{state: st}, transport, logger, metadata)
 	}
 	return NewCharmRevisionUpdaterAPIState(
 		StateShim{State: ctx.State()},

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -17,6 +17,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
@@ -56,7 +57,9 @@ func NewCharmRevisionUpdaterAPI(ctx facade.Context) (*CharmRevisionUpdaterAPI, e
 		return charmstore.NewCachingClient(state.MacaroonCache{MacaroonCacheState: st}, controllerCfg.CharmStoreURL())
 	}
 	newCharmhubClient := func(st State, metadata map[string]string) (CharmhubRefreshClient, error) {
-		return common.CharmhubClient(charmhubClientStateShim{state: st}, logger, metadata)
+		// TODO (stickupkid): Get the httpClient from the facade context
+		httpClient := charmhub.DefaultHTTPTransport()
+		return common.CharmhubClient(charmhubClientStateShim{state: st}, httpClient, logger, metadata)
 	}
 	return NewCharmRevisionUpdaterAPIState(
 		StateShim{State: ctx.State()},

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	charmhubpath "github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
@@ -59,6 +60,8 @@ type Logger interface {
 	Errorf(string, ...interface{})
 	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
+
+	Child(string) loggo.Logger
 }
 
 // Config holds configuration for creating a new charm hub client.
@@ -162,7 +165,7 @@ func CharmHubConfig(logger Logger, options ...Option) (Config, error) {
 		Version:   CharmHubServerVersion,
 		Entity:    CharmHubServerEntity,
 		Headers:   headers,
-		Transport: opts.transportFunc(logger),
+		Transport: opts.transportFunc(logger.Child("transport")),
 		Logger:    logger,
 	}, nil
 }

--- a/charmhub/client_mock_test.go
+++ b/charmhub/client_mock_test.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	path "github.com/juju/juju/charmhub/path"
+	loggo "github.com/juju/loggo"
 	http "net/http"
 	os "os"
 	reflect "reflect"
@@ -165,6 +166,20 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
+// Child mocks base method
+func (m *MockLogger) Child(arg0 string) loggo.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Child", arg0)
+	ret0, _ := ret[0].(loggo.Logger)
+	return ret0
+}
+
+// Child indicates an expected call of Child
+func (mr *MockLoggerMockRecorder) Child(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Child", reflect.TypeOf((*MockLogger)(nil).Child), arg0)
+}
+
 // Debugf mocks base method
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
@@ -180,6 +195,23 @@ func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
+}
+
+// Errorf mocks base method
+func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Errorf", varargs...)
+}
+
+// Errorf indicates an expected call of Errorf
+func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
 }
 
 // IsTraceEnabled mocks base method

--- a/charmhub/fake_test.go
+++ b/charmhub/fake_test.go
@@ -3,6 +3,8 @@
 
 package charmhub
 
+import "github.com/juju/loggo"
+
 type FakeLogger struct {
 }
 
@@ -15,3 +17,7 @@ func (l *FakeLogger) Errorf(format string, args ...interface{}) {}
 func (l *FakeLogger) Debugf(format string, args ...interface{}) {}
 
 func (l *FakeLogger) Tracef(format string, args ...interface{}) {}
+
+func (l *FakeLogger) Child(string) loggo.Logger {
+	return loggo.Logger{}
+}

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -175,7 +175,7 @@ func (s *FindSuite) TestFindRequestPayload(c *gc.C) {
 	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(&FakeLogger{}), &FakeLogger{})
 	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewFindClient(findPath, restClient, &FakeLogger{})
@@ -212,7 +212,7 @@ func (s *FindSuite) TestFindErrorPayload(c *gc.C) {
 	findPath, err := basePath.Join("find")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(&FakeLogger{}), &FakeLogger{})
 	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewFindClient(findPath, restClient, &FakeLogger{})

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils"
 	"gopkg.in/httprequest.v1"
 
 	"github.com/juju/juju/charmhub/path"
@@ -36,7 +37,7 @@ type Transport interface {
 
 // DefaultHTTPTransport creates a new HTTPTransport.
 func DefaultHTTPTransport() *http.Client {
-	return &http.Client{}
+	return utils.GetHTTPClient(utils.VerifySSLHostnames)
 }
 
 // APIRequester creates a wrapper around the transport to allow for better

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
+	jujuhttp "github.com/juju/http"
 	"gopkg.in/httprequest.v1"
 
 	"github.com/juju/juju/charmhub/path"
@@ -36,8 +36,10 @@ type Transport interface {
 }
 
 // DefaultHTTPTransport creates a new HTTPTransport.
-func DefaultHTTPTransport() *http.Client {
-	return utils.GetHTTPClient(utils.VerifySSLHostnames)
+func DefaultHTTPTransport(logger Logger) Transport {
+	return jujuhttp.NewClient(jujuhttp.Config{
+		Logger: logger,
+	})
 }
 
 // APIRequester creates a wrapper around the transport to allow for better

--- a/charmhub/info_test.go
+++ b/charmhub/info_test.go
@@ -252,7 +252,7 @@ func (s *InfoSuite) TestInfoRequestPayload(c *gc.C) {
 	infoPath, err := basePath.Join("info")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(&FakeLogger{}), &FakeLogger{})
 	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewInfoClient(infoPath, restClient, &FakeLogger{})

--- a/charmhub/resources_test.go
+++ b/charmhub/resources_test.go
@@ -101,7 +101,7 @@ func (s *ResourcesSuite) TestListResourceRevisionsRequestPayload(c *gc.C) {
 	resourcesPath, err := basePath.Join("resources")
 	c.Assert(err, jc.ErrorIsNil)
 
-	apiRequester := NewAPIRequester(DefaultHTTPTransport(), &FakeLogger{})
+	apiRequester := NewAPIRequester(DefaultHTTPTransport(&FakeLogger{}), &FakeLogger{})
 	restClient := NewHTTPRESTClient(apiRequester, nil)
 
 	client := NewResourcesClient(resourcesPath, restClient, &FakeLogger{})

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
 	"github.com/juju/os/v2/series"
 
 	"github.com/juju/juju/charmhub"
@@ -422,6 +423,10 @@ func (d downloadLogger) Debugf(msg string, args ...interface{}) {
 }
 
 func (d downloadLogger) Tracef(msg string, args ...interface{}) {}
+
+func (d downloadLogger) Child(name string) loggo.Logger {
+	return loggo.Logger{}
+}
 
 type stdoutFileSystem struct{}
 


### PR DESCRIPTION
The following changes intends to allow the hoisting of the http.Client away
from the edge and up into the facade stack. The change is required, to
prevent the creation of an http.Client every time we instantiate a charmhub
client.

The code is very mechanical and is the first step in a long line of changes
towards the following bugs:

 - https://bugs.launchpad.net/juju/+bug/1928182
 - https://bugs.launchpad.net/juju/+bug/1899793

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy postgresql
```

## Bug reference

 - https://bugs.launchpad.net/juju/+bug/1928182
 - https://bugs.launchpad.net/juju/+bug/1899793
