### PR TITLE
GCE: Allow injection of global http client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
 	github.com/juju/gomaasapi/v2 v2.0.0-20210323144809-92beddd020fe
 	github.com/juju/http v0.0.0-20201019013536-69ae1d429836
+	github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076
 	github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcM
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
+github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076 h1:Y9skx/w7NYVMj5N7t+rV66BYEMItpoSDG+Stb8beRuU=
+github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076/go.mod h1:y1PngvubGWeSpDBI4kxdaTc9f3HEThd2A5mv0MKBi74=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v1.0.1/go.mod h1:K+CyYVHU/NcfbMpK7YIVobh4U4Fci3EUB2AqIRtl+xs=

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils"
+	jujuhttp "github.com/juju/http/v2"
 	"google.golang.org/api/compute/v1"
 
 	jujucloud "github.com/juju/juju/cloud"
@@ -153,18 +153,15 @@ func (e *environ) SetCloudSpec(spec environscloudspec.CloudSpec) error {
 		PrivateKey:  []byte(credAttrs[credAttrPrivateKey]),
 	}
 
-	sslVerification := utils.VerifySSLHostnames
-	if spec.SkipTLSVerify {
-		sslVerification = utils.NoVerifySSLHostnames
-	}
-
 	connectionConfig := google.ConnectionConfig{
 		Region:    spec.Region,
 		ProjectID: credential.ProjectID,
 
 		// TODO (Stickupkid): Pass the http.Client through on the construction
 		// of the environ.
-		HTTPClient: utils.GetHTTPClient(sslVerification),
+		HTTPClient: jujuhttp.NewClient(
+			jujuhttp.WithSkipHostnameVerification(spec.SkipTLSVerify),
+		),
 	}
 
 	// TODO (stickupkid): Pass the context through the method call.

--- a/provider/gce/google/auth.go
+++ b/provider/gce/google/auth.go
@@ -5,9 +5,9 @@ package google
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/juju/errors"
+	jujuhttp "github.com/juju/http/v2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/compute/v1"
@@ -29,7 +29,7 @@ var scopes = []string{
 // which is then used by the Environ.
 // This should also be relocated alongside its wrapper,
 // rather than this "auth.go" file.
-func newComputeService(ctx context.Context, creds *Credentials, httpClient *http.Client) (*compute.Service, error) {
+func newComputeService(ctx context.Context, creds *Credentials, httpClient *jujuhttp.Client) (*compute.Service, error) {
 	cfg, err := newJWTConfig(creds)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -37,10 +37,10 @@ func newComputeService(ctx context.Context, creds *Credentials, httpClient *http
 
 	// We're substituting the transport, with a wrapped GCE specific version of
 	// the original http.Client.
-	newClient := *httpClient
+	newClient := *httpClient.Client()
 
 	tsOpt := option.WithTokenSource(cfg.TokenSource(ctx))
-	if newClient.Transport, err = transporthttp.NewTransport(ctx, httpClient.Transport, tsOpt); err != nil {
+	if newClient.Transport, err = transporthttp.NewTransport(ctx, newClient.Transport, tsOpt); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/provider/gce/google/auth_test.go
+++ b/provider/gce/google/auth_test.go
@@ -4,6 +4,9 @@
 package google
 
 import (
+	"context"
+	"net/http"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -15,7 +18,7 @@ type authSuite struct {
 var _ = gc.Suite(&authSuite{})
 
 func (s *authSuite) TestNewComputeService(c *gc.C) {
-	_, err := newComputeService(s.Credentials)
+	_, err := newComputeService(context.TODO(), s.Credentials, http.DefaultClient)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/gce/google/auth_test.go
+++ b/provider/gce/google/auth_test.go
@@ -5,8 +5,8 @@ package google
 
 import (
 	"context"
-	"net/http"
 
+	jujuhttp "github.com/juju/http/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -18,7 +18,7 @@ type authSuite struct {
 var _ = gc.Suite(&authSuite{})
 
 func (s *authSuite) TestNewComputeService(c *gc.C) {
-	_, err := newComputeService(context.TODO(), s.Credentials, http.DefaultClient)
+	_, err := newComputeService(context.TODO(), s.Credentials, jujuhttp.NewClient())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -7,10 +7,10 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"net/mail"
 
 	"github.com/juju/errors"
+	jujuhttp "github.com/juju/http/v2"
 )
 
 // The names of OS environment variables related to GCE.
@@ -191,7 +191,7 @@ type ConnectionConfig struct {
 	ProjectID string
 
 	// HTTPClient is the client to use for all GCE connections.
-	HTTPClient *http.Client
+	HTTPClient *jujuhttp.Client
 }
 
 // Validate checks the connection's fields for invalid values.

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/mail"
 
 	"github.com/juju/errors"
@@ -188,6 +189,9 @@ type ConnectionConfig struct {
 	// ProjectID is the project ID to use in all GCE API requests for
 	// the connection.
 	ProjectID string
+
+	// HTTPClient is the client to use for all GCE connections.
+	HTTPClient *http.Client
 }
 
 // Validate checks the connection's fields for invalid values.
@@ -203,6 +207,9 @@ func (gc ConnectionConfig) Validate() error {
 	}
 	if gc.ProjectID == "" {
 		return NewMissingConfigValue(OSEnvProjectID, "ProjectID")
+	}
+	if gc.HTTPClient == nil {
+		return errors.NotFoundf("connection config http.Client")
 	}
 	return nil
 }

--- a/provider/gce/google/config_connection_test.go
+++ b/provider/gce/google/config_connection_test.go
@@ -4,8 +4,7 @@
 package google_test
 
 import (
-	"net/http"
-
+	jujuhttp "github.com/juju/http/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -22,7 +21,7 @@ func (*connConfigSuite) TestValidateValid(c *gc.C) {
 	cfg := google.ConnectionConfig{
 		Region:     "spam",
 		ProjectID:  "eggs",
-		HTTPClient: http.DefaultClient,
+		HTTPClient: jujuhttp.NewClient(),
 	}
 	err := cfg.Validate()
 

--- a/provider/gce/google/config_connection_test.go
+++ b/provider/gce/google/config_connection_test.go
@@ -4,6 +4,8 @@
 package google_test
 
 import (
+	"net/http"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,8 +20,9 @@ var _ = gc.Suite(&connConfigSuite{})
 
 func (*connConfigSuite) TestValidateValid(c *gc.C) {
 	cfg := google.ConnectionConfig{
-		Region:    "spam",
-		ProjectID: "eggs",
+		Region:     "spam",
+		ProjectID:  "eggs",
+		HTTPClient: http.DefaultClient,
 	}
 	err := cfg.Validate()
 

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -5,9 +5,9 @@ package google
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/juju/errors"
+	jujuhttp "github.com/juju/http/v2"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -154,7 +154,7 @@ func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) 
 	return conn, nil
 }
 
-var newService = func(ctx context.Context, creds *Credentials, httpClient *http.Client) (*compute.Service, error) {
+var newService = func(ctx context.Context, creds *Credentials, httpClient *jujuhttp.Client) (*compute.Service, error) {
 	return newComputeService(ctx, creds, httpClient)
 }
 

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -4,6 +4,9 @@
 package google
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/juju/errors"
 	"google.golang.org/api/compute/v1"
 )
@@ -137,8 +140,8 @@ type Connection struct {
 // Connect after a successful connection has already been made will
 // result in an error. All errors that happen while authenticating and
 // connecting are returned by Connect.
-func Connect(connCfg ConnectionConfig, creds *Credentials) (*Connection, error) {
-	raw, err := newService(creds)
+func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) (*Connection, error) {
+	raw, err := newService(ctx, creds, connCfg.HTTPClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -151,8 +154,8 @@ func Connect(connCfg ConnectionConfig, creds *Credentials) (*Connection, error) 
 	return conn, nil
 }
 
-var newService = func(creds *Credentials) (*compute.Service, error) {
-	return newComputeService(creds)
+var newService = func(ctx context.Context, creds *Credentials, httpClient *http.Client) (*compute.Service, error) {
+	return newComputeService(ctx, creds, httpClient)
 }
 
 // VerifyCredentials ensures that the authentication credentials used

--- a/provider/gce/google/conn_test.go
+++ b/provider/gce/google/conn_test.go
@@ -5,9 +5,9 @@ package google_test
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/juju/errors"
+	jujuhttp "github.com/juju/http/v2"
 	jc "github.com/juju/testing/checkers"
 	"google.golang.org/api/compute/v1"
 	gc "gopkg.in/check.v1"
@@ -24,7 +24,7 @@ var _ = gc.Suite(&connSuite{})
 func (s *connSuite) TestConnect(c *gc.C) {
 	google.SetRawConn(s.Conn, nil)
 	service := &compute.Service{}
-	s.PatchValue(google.NewService, func(ctx context.Context, creds *google.Credentials, httpClient *http.Client) (*compute.Service, error) {
+	s.PatchValue(google.NewService, func(ctx context.Context, creds *google.Credentials, httpClient *jujuhttp.Client) (*compute.Service, error) {
 		return service, nil
 	})
 

--- a/provider/gce/google/conn_test.go
+++ b/provider/gce/google/conn_test.go
@@ -4,6 +4,9 @@
 package google_test
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"google.golang.org/api/compute/v1"
@@ -14,8 +17,6 @@ import (
 
 type connSuite struct {
 	google.BaseSuite
-
-	conn *google.Connection
 }
 
 var _ = gc.Suite(&connSuite{})
@@ -23,11 +24,11 @@ var _ = gc.Suite(&connSuite{})
 func (s *connSuite) TestConnect(c *gc.C) {
 	google.SetRawConn(s.Conn, nil)
 	service := &compute.Service{}
-	s.PatchValue(google.NewService, func(auth *google.Credentials) (*compute.Service, error) {
+	s.PatchValue(google.NewService, func(ctx context.Context, creds *google.Credentials, httpClient *http.Client) (*compute.Service, error) {
 		return service, nil
 	})
 
-	conn, err := google.Connect(s.ConnCfg, s.Credentials)
+	conn, err := google.Connect(context.TODO(), s.ConnCfg, s.Credentials)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(google.ExposeRawService(conn), gc.Equals, service)

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -4,8 +4,7 @@
 package google
 
 import (
-	"net/http"
-
+	jujuhttp "github.com/juju/http/v2"
 	"google.golang.org/api/compute/v1"
 	gc "gopkg.in/check.v1"
 
@@ -55,7 +54,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	s.ConnCfg = ConnectionConfig{
 		Region:     "a",
 		ProjectID:  "spam",
-		HTTPClient: http.DefaultClient,
+		HTTPClient: jujuhttp.NewClient(),
 	}
 	fake := &fakeConn{}
 	s.Conn = &Connection{

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -4,6 +4,8 @@
 package google
 
 import (
+	"net/http"
+
 	"google.golang.org/api/compute/v1"
 	gc "gopkg.in/check.v1"
 
@@ -51,8 +53,9 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 }`[1:]),
 	}
 	s.ConnCfg = ConnectionConfig{
-		Region:    "a",
-		ProjectID: "spam",
+		Region:     "a",
+		ProjectID:  "spam",
+		HTTPClient: http.DefaultClient,
 	}
 	fake := &fakeConn{}
 	s.Conn = &Connection{

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -4,6 +4,7 @@
 package gce
 
 import (
+	stdcontext "context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -328,7 +329,7 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 
 	// Patch out all expensive external deps.
 	s.Env.gce = s.FakeConn
-	s.PatchValue(&newConnection, func(google.ConnectionConfig, *google.Credentials) (gceConnection, error) {
+	s.PatchValue(&newConnection, func(stdcontext.Context, google.ConnectionConfig, *google.Credentials) (gceConnection, error) {
 		return s.FakeConn, nil
 	})
 	s.PatchValue(&bootstrap, s.FakeCommon.Bootstrap)


### PR DESCRIPTION
The following code changes starts to lift the http client out from the
edge and into the constructor of the environ. Future commits should
allow us to pass in a http client on the construction of the environ
from the dependency engine. This is just the first step of many to do
that.

## See

 - https://github.com/juju/juju/pull/13023

## QA steps

```sh
$ juju bootstrap google test 
```

## Bug reference

 - https://bugs.launchpad.net/juju/+bug/1928182
 - https://bugs.launchpad.net/juju/+bug/1899793
