### PR TITLE
Reset back the start-timeout to 3m;

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ apps:
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
-    start-timeout: 1m
+    start-timeout: 3m
     stop-timeout: 35s
 
 parts:


### PR DESCRIPTION
The `start-timeout` was wrongly reverted to the old value when we bring forward from 2.8.
