### PR TITLE
Lazily create storage registry in client storage facade

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/state"
 	jujustorage "github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/poolmanager"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -69,9 +70,9 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 	s.poolsInUse = []string{}
 
 	s.callContext = context.NewCloudCallContext()
-	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
-	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
-	newAPI := storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
+	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
+	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
+	newAPI := storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
 	s.apiv3 = &storage.StorageAPIv3{
 		StorageAPIv4: storage.StorageAPIv4{
 			StorageAPIv5: storage.StorageAPIv5{
@@ -79,6 +80,10 @@ func (s *baseStorageSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
+}
+
+func (s *baseStorageSuite) storageMetadata() (poolmanager.PoolManager, jujustorage.ProviderRegistry, error) {
+	return s.poolManager, s.registry, nil
 }
 
 // TODO(axw) get rid of assertCalls, use stub directly everywhere.

--- a/apiserver/facades/client/storage/poollist_test.go
+++ b/apiserver/facades/client/storage/poollist_test.go
@@ -173,7 +173,7 @@ func (s *poolSuite) TestListNoPools(c *gc.C) {
 }
 
 func (s *poolSuite) TestListFilterEmpty(c *gc.C) {
-	err := apiserverstorage.ValidatePoolListFilter(s.api, params.StoragePoolFilter{})
+	err := apiserverstorage.ValidatePoolListFilter(s.api, s.registry, params.StoragePoolFilter{})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -188,6 +188,7 @@ func (s *poolSuite) TestListFilterValidProviders(c *gc.C) {
 	s.registerProviders(c)
 	err := apiserverstorage.ValidateProviderCriteria(
 		s.api,
+		s.registry,
 		[]string{validProvider})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -195,6 +196,7 @@ func (s *poolSuite) TestListFilterValidProviders(c *gc.C) {
 func (s *poolSuite) TestListFilterUnregisteredProvider(c *gc.C) {
 	err := apiserverstorage.ValidateProviderCriteria(
 		s.api,
+		s.registry,
 		[]string{validProvider})
 	c.Assert(err, gc.ErrorMatches, `storage provider "loop" not found`)
 }
@@ -203,6 +205,7 @@ func (s *poolSuite) TestListFilterUnknownProvider(c *gc.C) {
 	s.registerProviders(c)
 	err := apiserverstorage.ValidateProviderCriteria(
 		s.api,
+		s.registry,
 		[]string{invalidProvider})
 	c.Assert(err, gc.ErrorMatches, `storage provider "invalid" not found`)
 }
@@ -225,6 +228,7 @@ func (s *poolSuite) TestListFilterValidProvidersAndNames(c *gc.C) {
 	s.registerProviders(c)
 	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
+		s.registry,
 		params.StoragePoolFilter{
 			Providers: []string{validProvider},
 			Names:     []string{validName}})
@@ -235,6 +239,7 @@ func (s *poolSuite) TestListFilterValidProvidersAndInvalidNames(c *gc.C) {
 	s.registerProviders(c)
 	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
+		s.registry,
 		params.StoragePoolFilter{
 			Providers: []string{validProvider},
 			Names:     []string{invalidName}})
@@ -244,6 +249,7 @@ func (s *poolSuite) TestListFilterValidProvidersAndInvalidNames(c *gc.C) {
 func (s *poolSuite) TestListFilterInvalidProvidersAndValidNames(c *gc.C) {
 	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
+		s.registry,
 		params.StoragePoolFilter{
 			Providers: []string{invalidProvider},
 			Names:     []string{validName}})
@@ -253,6 +259,7 @@ func (s *poolSuite) TestListFilterInvalidProvidersAndValidNames(c *gc.C) {
 func (s *poolSuite) TestListFilterInvalidProvidersAndNames(c *gc.C) {
 	err := apiserverstorage.ValidatePoolListFilter(
 		s.api,
+		s.registry,
 		params.StoragePoolFilter{
 			Providers: []string{invalidProvider},
 			Names:     []string{invalidName}})

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -838,7 +838,7 @@ func (s *storageSuite) TestListStorageAsAdminOnNotOwnedModel(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("superuserfoo"),
 	}
-	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
+	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
 
 	// Sanity check before running test:
 	// Ensure that the user has NO read access to the model but SuperuserAccess
@@ -860,7 +860,7 @@ func (s *storageSuite) TestListStorageAsNonAdminOnNotOwnedModel(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("userfoo"),
 	}
-	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.registry, s.poolManager, s.authorizer, s.callContext)
+	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.storageMetadata, s.authorizer, s.callContext)
 
 	// Sanity check before running test:
 	// Ensure that the user has NO read access to the model and NO SuperuserAccess

--- a/storage/poolmanager/poolmanager.go
+++ b/storage/poolmanager/poolmanager.go
@@ -7,11 +7,10 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/storage"
-	"github.com/juju/juju/storage/provider"
 )
 
+// Pool configuration attribute names.
 const (
-	// Pool configuration attribute names.
 	Name = "name"
 	Type = "type"
 )
@@ -71,7 +70,7 @@ func (pm *poolManager) validatedConfig(name string, providerType storage.Provide
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := provider.ValidateConfig(p, cfg); err != nil {
+	if err := p.ValidateConfig(cfg); err != nil {
 		return nil, errors.Annotate(err, "validating storage provider config")
 	}
 
@@ -160,7 +159,7 @@ func (pm *poolManager) configFromSettings(settings map[string]interface{}) (*sto
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := provider.ValidateConfig(p, cfg); err != nil {
+	if err := p.ValidateConfig(cfg); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return cfg, nil

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -24,9 +24,3 @@ var (
 func CommonStorageProviders() storage.ProviderRegistry {
 	return storage.StaticProviderRegistry{Providers: commonStorageProviders}
 }
-
-// ValidateConfig performs storage provider config validation, including
-// any common validation.
-func ValidateConfig(p storage.Provider, cfg *storage.Config) error {
-	return p.ValidateConfig(cfg)
-}


### PR DESCRIPTION
The client storage facade was creating the storage pool manager and registry in the constructor. These objects need an instantiated provider instance to work. However, creating a provider instance hits the cloud provider apis. Running status therefore was impacted by these cloud api calls. 

This PR only creates the storage pool manager and registry for those facade calls that need them, eg creating a storage pool. The read only apis used by status now no longer hit the cloud apis.

## QA steps

Regression test storage behaviour.
bootstrap lxd
juju create-storage-pool test tmpfs foo=bar
juju storage-pools
juju storage-pools --name=lxd
juju storage-pools --provider=tmpfs
juju deploy postgresql --storage pgdata=lxd
juju status --storage

## Bug reference

https://bugs.launchpad.net/juju/+bug/1908102
