### PR TITLE
Remove upgrade steps gate as an input to the caas-upgrader

### DIFF
--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -158,7 +158,6 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
 			AgentName:            agentName,
 			APICallerName:        apiCallerName,
-			UpgradeStepsGateName: upgradeStepsGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 		}),
 

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -216,6 +216,5 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
-		"upgrade-steps-gate",
 	},
 }

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -162,7 +162,6 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
 			AgentName:            agentName,
 			APICallerName:        apiCallerName,
-			UpgradeStepsGateName: upgradeStepsGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 		}),
 

--- a/cmd/jujud/agent/caasoperator/manifolds_test.go
+++ b/cmd/jujud/agent/caasoperator/manifolds_test.go
@@ -204,7 +204,6 @@ var expectedOperatorManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
-		"upgrade-steps-gate",
 	},
 
 	"clock": {},

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -1002,7 +1002,6 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
 			AgentName:            agentName,
 			APICallerName:        apiCallerName,
-			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 		}),

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -127,7 +127,6 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
 			AgentName:            agentName,
 			APICallerName:        apiCallerName,
-			UpgradeStepsGateName: upgradeStepsGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 		}),
 

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -51,7 +51,6 @@ type Config struct {
 	CAASOperatorUpgrader        CAASOperatorUpgrader
 	AgentTag                    names.Tag
 	OrigAgentVersion            version.Number
-	UpgradeStepsWaiter          gate.Waiter
 	InitialUpgradeCheckComplete gate.Unlocker
 }
 
@@ -87,7 +86,8 @@ func (u *Upgrader) Wait() error {
 }
 
 func (u *Upgrader) loop() error {
-	// Only controllers and sidecar unit agents set their version here - application agents do it in the main agent worker loop.
+	// Only controllers and sidecar unit agents set their version here.
+	// Application agents do it in the main agent worker loop.
 	hostOSType := coreos.HostOSTypeName()
 	if agent.IsAllowedControllerTag(u.tag.Kind()) || u.tag.Kind() == names.UnitTagKind {
 		if err := u.upgraderClient.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostOSType)); err != nil {

--- a/worker/caasupgrader/upgrader_test.go
+++ b/worker/caasupgrader/upgrader_test.go
@@ -27,7 +27,6 @@ type UpgraderSuite struct {
 	operatorUpgrader *mockOperatorUpgrader
 	ch               chan struct{}
 
-	upgradeStepsComplete gate.Lock
 	initialCheckComplete gate.Lock
 }
 
@@ -36,7 +35,6 @@ var _ = gc.Suite(&UpgraderSuite{})
 func (s *UpgraderSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	s.upgradeStepsComplete = gate.NewLock()
 	s.initialCheckComplete = gate.NewLock()
 	s.ch = make(chan struct{})
 	s.upgraderClient = &mockUpgraderClient{
@@ -57,7 +55,6 @@ func (s *UpgraderSuite) makeUpgrader(c *gc.C, agent names.Tag) *caasupgrader.Upg
 		CAASOperatorUpgrader:        s.operatorUpgrader,
 		AgentTag:                    agent,
 		OrigAgentVersion:            s.confVersion,
-		UpgradeStepsWaiter:          s.upgradeStepsComplete,
 		InitialUpgradeCheckComplete: s.initialCheckComplete,
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This patch concerns the dependency engine.

The upgrade-steps gate was passed as an input to the `caasupgrader` manifold, but never used by the worker. Seeing as there is no need to restart the worker based on changes to the gate, it can be removed.

## Checklist

TBC

## QA steps

TBC

## Documentation changes

None.

## Bug reference

TBC
