### PR TITLE
fix lp:1884794: vsphere values for show-cloud --include-config

### DIFF
--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -34,7 +34,7 @@ var (
 			Type:        environschema.Tstring,
 		},
 		cfgPrimaryNetwork: {
-			Description: "The primary network that VMs will be connected to. If this is not specified, Juju will look for a network named VM Network.",
+			Description: "The primary network that VMs will be connected to. If this is not specified, Juju will look for a network named \"VM Network\".",
 			Type:        environschema.Tstring,
 		},
 		cfgForceVMHardwareVersion: {

--- a/provider/vsphere/config.go
+++ b/provider/vsphere/config.go
@@ -6,6 +6,7 @@ package vsphere
 import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/provider/vsphere/internal/vsphereclient"
@@ -23,13 +24,31 @@ const (
 
 // configFields is the spec for each vmware config value's type.
 var (
-	configFields = schema.Fields{
-		cfgExternalNetwork:        schema.String(),
-		cfgDatastore:              schema.String(),
-		cfgPrimaryNetwork:         schema.String(),
-		cfgForceVMHardwareVersion: schema.ForceInt(),
-		cfgEnableDiskUUID:         schema.Bool(),
-		cfgDiskProvisioningType:   schema.String(),
+	configSchema = environschema.Fields{
+		cfgExternalNetwork: {
+			Description: "An external network that VMs will be connected to. The resulting IP address for a VM will be used as its public address.",
+			Type:        environschema.Tstring,
+		},
+		cfgDatastore: {
+			Description: "The datastore in which to create VMs. If this is not specified, the process will abort unless there is only one datastore available.",
+			Type:        environschema.Tstring,
+		},
+		cfgPrimaryNetwork: {
+			Description: "The primary network that VMs will be connected to. If this is not specified, Juju will look for a network named VM Network.",
+			Type:        environschema.Tstring,
+		},
+		cfgForceVMHardwareVersion: {
+			Description: "The HW compatibility version to use when cloning a VM template to create a VM. The version must be supported by the remote compute resource, and greater or equal to the template’s version.",
+			Type:        environschema.Tint,
+		},
+		cfgEnableDiskUUID: {
+			Description: "Expose consistent disk UUIDs to the VM, equivalent to disk.EnableUUID. The default is True.",
+			Type:        environschema.Tbool,
+		},
+		cfgDiskProvisioningType: {
+			Description: "Specify how the disk should be provisioned when cloning the VM template. Allowed values are: thickEagerZero (default), thick and thin.",
+			Type:        environschema.Tstring,
+		},
 	}
 
 	configDefaults = schema.Defaults{
@@ -58,6 +77,14 @@ func newConfig(cfg *config.Config) *environConfig {
 		attrs:  cfg.UnknownAttrs(),
 	}
 }
+
+var configFields = func() schema.Fields {
+	fs, _, err := configSchema.ValidationSchema()
+	if err != nil {
+		panic(err)
+	}
+	return fs
+}()
 
 // newValidConfig builds a new environConfig from the provided Config
 // and returns it. The resulting config values are validated.
@@ -137,6 +164,27 @@ func (c *environConfig) diskProvisioningType() vsphereclient.DiskProvisioningTyp
 	}
 
 	return vsphereclient.DiskProvisioningType(provTypeStr)
+}
+
+// Schema returns the configuration schema for an environment.
+func (environProvider) Schema() environschema.Fields {
+	fields, err := config.Schema(configSchema)
+	if err != nil {
+		panic(err)
+	}
+	return fields
+}
+
+// ConfigSchema returns extra config attributes specific
+// to this provider only.
+func (p environProvider) ConfigSchema() schema.Fields {
+	return configFields
+}
+
+// ConfigDefaults returns the default values for the
+// provider specific config attributes.
+func (p environProvider) ConfigDefaults() schema.Defaults {
+	return configDefaults
 }
 
 // validate checks vmware-specific config values.

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -254,3 +254,16 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 		}
 	}
 }
+
+func (s *ConfigSuite) TestSchema(c *gc.C) {
+	ps, ok := s.provider.(environs.ProviderSchema)
+	c.Assert(ok, jc.IsTrue)
+
+	fields := ps.Schema()
+
+	globalFields, err := config.Schema(nil)
+	c.Assert(err, gc.IsNil)
+	for name, field := range globalFields {
+		c.Check(fields[name], jc.DeepEquals, field)
+	}
+}

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -39,7 +39,7 @@ type EnvironProviderConfig struct {
 }
 
 // NewEnvironProvider returns a new environs.EnvironProvider that will
-// dial vSphere connectons with the given dial function.
+// dial vSphere connections with the given dial function.
 func NewEnvironProvider(config EnvironProviderConfig) environs.CloudEnvironProvider {
 	return &environProvider{
 		dial: config.Dial,

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -32,6 +32,8 @@ type environProvider struct {
 	dial DialFunc
 }
 
+var _ config.ConfigSchemaSource = (*environProvider)(nil)
+
 // EnvironProviderConfig contains configuration for the EnvironProvider.
 type EnvironProviderConfig struct {
 	// Dial is a function used for dialing connections to vCenter/ESXi.

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,6 +1,6 @@
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [[ ${VER} != "1.36" ]]; then
+	if [[ ${VER} != "1.36" ]] && [[ ${VER} != "v1.36" ]]; then
 		(echo >&2 -e '\nError: golangci-lint version does not match 1.36. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi


### PR DESCRIPTION
Implement the ConfigSchemaSource interfaced use by show-cloud --include-config in the vSphere provider.  The config key descriptions are new also.

## QA steps

```sh
# Configure a vsphere cloud.  Bootstrap is not necessary for this command to run.
$ juju show-cloud <vsphere-cloud> --include-config

Client cloud "vsphere":

defined: local
type: vsphere
auth-types: [userpass]
endpoint: x.x.x.x
credential-count: 1
regions:
  QA: {}
config:
  datastore: datastore1


The available config options specific to vsphere clouds are:
datastore:
  type: string
  description: The datastore in which to create VMs. If this is not specified, the
    process will abort unless there is only one datastore available.
disk-provisioning-type:
  type: string
  description: 'Specify how the disk should be provisioned when cloning the VM template.
    Allowed values are: thickEagerZero (default), thick and thin.'
enable-disk-uuid:
  type: bool
  description: Expose consistent disk UUIDs to the VM, equivalent to disk.EnableUUID.
    The default is True.
external-network:
  type: string
  description: An external network that VMs will be connected to. The resulting IP
    address for a VM will be used as its public address.
force-vm-hardware-version:
  type: int
  description: The HW compatibility version to use when cloning a VM template to create
    a VM. The version must be supported by the remote compute resource, and greater
    or equal to the template’s version.
primary-network:
  type: string
  description: The primary network that VMs will be connected to. If this is not specified,
    Juju will look for a network named VM Network.
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1884794
