### PR TITLE
Fix upgrade-model agent lookup for k8s controllers

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -134,7 +134,7 @@ func NewProvisionerAPI(ctx facade.Context) (*ProvisionerAPI, error) {
 		return nil, errors.Annotate(err, "instantiating network config API")
 	}
 
-	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
+	urlGetter := common.NewToolsURLGetter(model.UUID(), ctx.StatePool().SystemState())
 	callCtx := context.CallContext(st)
 	resources := ctx.Resources()
 	api := &ProvisionerAPI{

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1502,17 +1502,27 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 }
 
 func (s *withoutControllerSuite) TestFindTools(c *gc.C) {
+	otherSt := s.Factory.MakeModel(c, nil)
+	defer otherSt.Close()
+	provisionerAPI, err := provisioner.NewProvisionerAPI(facadetest.Context{
+		Auth_:      s.authorizer,
+		State_:     otherSt,
+		StatePool_: s.StatePool,
+		Resources_: s.resources,
+	},
+	)
+	c.Assert(err, jc.ErrorIsNil)
 	args := params.FindToolsParams{
 		MajorVersion: -1,
 		MinorVersion: -1,
 	}
-	result, err := s.provisioner.FindTools(args)
+	result, err := provisionerAPI.FindTools(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.List, gc.Not(gc.HasLen), 0)
 	for _, tools := range result.List {
 		url := fmt.Sprintf("https://%s/model/%s/tools/%s",
-			s.APIState.Addr(), coretesting.ModelTag.Id(), tools.Version)
+			s.APIState.Addr(), otherSt.ModelUUID(), tools.Version)
 		c.Assert(tools.URL, gc.Equals, url)
 	}
 }

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -178,7 +178,7 @@ func newFacade(ctx facade.Context) (*Client, error) {
 
 	modelUUID := model.UUID()
 
-	urlGetter := common.NewToolsURLGetter(modelUUID, st)
+	urlGetter := common.NewToolsURLGetter(modelUUID, ctx.StatePool().SystemState())
 	statusSetter := common.NewStatusSetter(st, common.AuthAlways())
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
 	blockChecker := common.NewBlockChecker(st)

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facade/facadetest"
@@ -47,6 +48,7 @@ import (
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	toolstesting "github.com/juju/juju/environs/tools/testing"
+	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -1269,27 +1271,44 @@ func (s *clientSuite) TestClientPrivateAddressUnit(c *gc.C) {
 }
 
 func (s *clientSuite) TestClientFindTools(c *gc.C) {
-	result, err := s.APIState.Client().FindTools(99, -1, "", "", "")
+	s.assertClientFindTools(c, s.APIState)
+}
+
+func (s *clientSuite) TestClientFindToolsCAAS(c *gc.C) {
+	otherSt := s.Factory.MakeCAASModel(c, nil)
+	defer otherSt.Close()
+
+	apiInfo, err := environs.APIInfo(s.ProviderCallContext, s.ControllerConfig.ControllerUUID(), coretesting.ModelTag.Id(), coretesting.CACert, s.ControllerConfig.APIPort(), s.Environ)
+	c.Assert(err, jc.ErrorIsNil)
+	apiInfo.Tag = s.AdminUserTag(c)
+	apiInfo.Password = jujutesting.AdminSecret
+	apiCaller, err := api.Open(apiInfo, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.assertClientFindTools(c, apiCaller)
+}
+
+func (s *clientSuite) assertClientFindTools(c *gc.C, apiCaller api.Connection) {
+	result, err := apiCaller.Client().FindTools(99, -1, "", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, jc.Satisfies, params.IsCodeNotFound)
 	toolstesting.UploadToStorage(c, s.DefaultToolsStorage, "released", version.MustParseBinary("2.99.0-ubuntu-amd64"))
-	result, err = s.APIState.Client().FindTools(2, 99, "ubuntu", "amd64", "")
+	result, err = apiCaller.Client().FindTools(2, 99, "ubuntu", "amd64", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.List, gc.HasLen, 1)
 	c.Assert(result.List[0].Version, gc.Equals, version.MustParseBinary("2.99.0-ubuntu-amd64"))
 	url := fmt.Sprintf("https://%s/model/%s/tools/%s",
-		s.APIState.Addr(), coretesting.ModelTag.Id(), result.List[0].Version)
+		apiCaller.Addr(), coretesting.ModelTag.Id(), result.List[0].Version)
 	c.Assert(result.List[0].URL, gc.Equals, url)
 
 	toolstesting.UploadToStorage(c, s.DefaultToolsStorage, "pretend", version.MustParseBinary("3.0.1-ubuntu-amd64"))
-	result, err = s.APIState.Client().FindTools(3, 0, "ubuntu", "amd64", "pretend")
+	result, err = apiCaller.Client().FindTools(3, 0, "ubuntu", "amd64", "pretend")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.List, gc.HasLen, 1)
 	c.Assert(result.List[0].Version, gc.Equals, version.MustParseBinary("3.0.1-ubuntu-amd64"))
 	url = fmt.Sprintf("https://%s/model/%s/tools/%s",
-		s.APIState.Addr(), coretesting.ModelTag.Id(), result.List[0].Version)
+		apiCaller.Addr(), coretesting.ModelTag.Id(), result.List[0].Version)
 	c.Assert(result.List[0].URL, gc.Equals, url)
 }
 

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -55,7 +55,7 @@ func InstanceConfig(ctrlSt *state.State, st *state.State, machineId, nonce, data
 	if !ok {
 		return nil, errors.New("no agent version set in model configuration")
 	}
-	urlGetter := common.NewToolsURLGetter(model.UUID(), st)
+	urlGetter := common.NewToolsURLGetter(model.UUID(), ctrlSt)
 	configGetter := stateenvirons.EnvironConfigGetter{Model: model}
 	newEnviron := func() (environs.BootstrapEnviron, error) {
 		return environs.GetEnviron(configGetter, environs.New)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -338,7 +338,7 @@ func NewModelManagerAPI(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), st)
+	urlGetter := common.NewToolsURLGetter(st.ModelUUID(), ctlrSt)
 
 	model, err := st.Model()
 	if err != nil {

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 	"github.com/juju/version/v2"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	envtools "github.com/juju/juju/environs/tools"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/tools"
 	jujuversion "github.com/juju/juju/version"
@@ -296,7 +298,7 @@ func (c *baseUpgradeCommand) initCAASVersions(
 		// Only include a docker image if we've published simple streams
 		// metadata for that version.
 		vers.Build = 0
-		if streamsVersions.Size() > 0 {
+		if !featureflag.Enabled(feature.DeveloperMode) && streamsVersions.Size() > 0 {
 			if !streamsVersions.Contains(vers.String()) {
 				continue
 			}


### PR DESCRIPTION
When upgrading a k8s model, the juju upgrade-model CLI would make a call to the controller to check what agent binaries are there. The call failed because the returned agent metadata includes a URL used to stream the binaries, and this URL is the controller `host:port`. The lookup of the controller URL needs to be done using the system state, but only the model state was being used. So we fix that here. 

Also, the jujud docker image selection requires that there be simplestreams metadata as a safety check so that only official images are used. We add bypass so that if the `developer-mode` feature flag is on, this additional check is no longer done, making it trivial to test upgrades for developers.

## QA steps

push the 2.8.10 juju-operator image and a 2.9 image built off this PR to a docker namespace eg `foo`
docker login
make push-release-operator-image

juju bootstrap microk8s --config caas-image-repo=foo
juju add-model test
juju deploy <a charm>
juju upgrade-controller --verbose
juju upgrade-model --verbose

The controller and model should upgrade to 2.9.4. Previously the model upgrade would fail.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929887
