### PR TITLE
Use mongo storage for external identity macaroon keys

### DIFF
--- a/apiserver/bakeryutil/service.go
+++ b/apiserver/bakeryutil/service.go
@@ -24,7 +24,7 @@ type BakeryThirdPartyLocator struct {
 	PublicKey bakery.PublicKey
 }
 
-// PublicKeyForLocation implements bakery.PublicKeyLocator.
+// ThirdPartyInfo implements bakery.PublicKeyLocator.
 func (b BakeryThirdPartyLocator) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
 	return bakery.ThirdPartyInfo{
 		PublicKey: b.PublicKey,

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
@@ -235,7 +236,7 @@ func (a authenticator) localUserAuth() *authentication.UserAuthenticator {
 // logins for external users. If it fails once, it will always fail.
 func (ctxt *authContext) externalMacaroonAuth(identClient identchecker.IdentityClient) (authentication.EntityAuthenticator, error) {
 	ctxt.macaroonAuthOnce.Do(func() {
-		ctxt._macaroonAuth, ctxt._macaroonAuthError = newExternalMacaroonAuth(ctxt.st, ctxt.clock, identClient)
+		ctxt._macaroonAuth, ctxt._macaroonAuthError = newExternalMacaroonAuth(ctxt.st, ctxt.clock, externalLoginExpiryTime, identClient)
 	})
 	if ctxt._macaroonAuth == nil {
 		return nil, errors.Trace(ctxt._macaroonAuthError)
@@ -245,10 +246,15 @@ func (ctxt *authContext) externalMacaroonAuth(identClient identchecker.IdentityC
 
 var errMacaroonAuthNotConfigured = errors.New("macaroon authentication is not configured")
 
+const (
+	// TODO make this configurable via model config.
+	externalLoginExpiryTime = 24 * time.Hour
+)
+
 // newExternalMacaroonAuth returns an authenticator that can authenticate
 // macaroon-based logins for external users. This is just a helper function
 // for authCtxt.externalMacaroonAuth.
-func newExternalMacaroonAuth(st *state.State, clock clock.Clock, identClient identchecker.IdentityClient) (*authentication.ExternalMacaroonAuthenticator, error) {
+func newExternalMacaroonAuth(st *state.State, clock clock.Clock, expiryTime time.Duration, identClient identchecker.IdentityClient) (*authentication.ExternalMacaroonAuthenticator, error) {
 	controllerCfg, err := st.ControllerConfig()
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get model config")
@@ -278,17 +284,20 @@ func newExternalMacaroonAuth(st *state.State, clock clock.Clock, identClient ide
 		IdentityLocation: idURL,
 	}
 
-	// We pass in nil for the storage, which leads to in-memory storage
-	// being used. We only use in-memory storage for now, since we never
-	// expire the keys, and don't want garbage to accumulate.
+	store, err := st.NewBakeryStorage()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	store = store.ExpireAfter(expiryTime)
 	if identClient == nil {
 		identClient = &auth
 	}
-	indentBakery := identchecker.NewBakery(identchecker.BakeryParams{
+	identBakery := identchecker.NewBakery(identchecker.BakeryParams{
 		Checker:        httpbakery.NewChecker(),
 		Locator:        pkLocator,
 		Key:            key,
 		IdentityClient: identClient,
+		RootKeyStore:   store,
 		Authorizer: identchecker.ACLAuthorizer{
 			GetACL: func(ctx context.Context, op bakery.Op) ([]string, bool, error) {
 				return []string{identchecker.Everyone}, false, nil
@@ -296,6 +305,6 @@ func newExternalMacaroonAuth(st *state.State, clock clock.Clock, identClient ide
 		},
 		Location: idURL,
 	})
-	auth.Bakery = indentBakery
+	auth.Bakery = identBakery
 	return &auth, nil
 }

--- a/apiserver/stateauthenticator/export_test.go
+++ b/apiserver/stateauthenticator/export_test.go
@@ -23,3 +23,11 @@ func ServerBakery(a *Authenticator, identClient identchecker.IdentityClient) (*i
 	}
 	return auth.(*authentication.ExternalMacaroonAuthenticator).Bakery, nil
 }
+
+func ServerBakeryExpiresImmediately(a *Authenticator, identClient identchecker.IdentityClient) (*identchecker.Bakery, error) {
+	auth, err := newExternalMacaroonAuth(a.authContext.st, a.authContext.clock, 0, identClient)
+	if err != nil {
+		return nil, err
+	}
+	return auth.Bakery, nil
+}


### PR DESCRIPTION
The external macaroon authenticator was using in-memory storage for macaroons keys. This PR instead wires up a mongo root key store with an expiry time of 24 hours (local login macaroons also expire after 24 hours).

## QA steps

Needs to be tested in a set up with a public controller.

## Bug

https://bugs.launchpad.net/juju/+bug/1930319