### PR TITLE
Handle SIGTERM and stop hook on sidecar deploys.

### DIFF
--- a/api/caasapplication/client.go
+++ b/api/caasapplication/client.go
@@ -49,3 +49,30 @@ func (c *Client) UnitIntroduction(podName string, podUUID string) (*UnitConfig, 
 		AgentConf: result.Result.AgentConf,
 	}, nil
 }
+
+// UnitTermination holds the result from calling UnitTerminating.
+type UnitTermination struct {
+	// WillRestart is true when the unit agent should restart.
+	// It will be false when the unit is dying and should shutdown normally.
+	WillRestart bool
+}
+
+// UnitTerminating is to be called by the CAASUnitTerminationWorker when the uniter is
+// shutting down.
+func (c *Client) UnitTerminating(unit names.UnitTag) (UnitTermination, error) {
+	var result params.CAASUnitTerminationResult
+	args := params.Entity{
+		Tag: unit.String(),
+	}
+	err := c.facade.FacadeCall("UnitTerminating", args, &result)
+	if err != nil {
+		return UnitTermination{}, err
+	}
+	if err := result.Error; err != nil {
+		return UnitTermination{}, err
+	}
+	term := UnitTermination{
+		WillRestart: result.WillRestart,
+	}
+	return term, nil
+}

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasapplication")
@@ -35,15 +36,26 @@ type Facade struct {
 	state     State
 	model     Model
 	clock     clock.Clock
+	broker    Broker
 }
 
 // NewStateFacade provides the signature required for facade registration.
 func NewStateFacade(ctx facade.Context) (*Facade, error) {
 	authorizer := ctx.Auth()
 	resources := ctx.Resources()
+	st := ctx.State()
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(model)
+	if err != nil {
+		return nil, errors.Annotate(err, "getting caas client")
+	}
 	return NewFacade(resources, authorizer,
 		ctx.StatePool().SystemState(),
-		&stateShim{ctx.State()},
+		&stateShim{st},
+		broker,
 		ctx.StatePool().Clock())
 }
 
@@ -53,9 +65,10 @@ func NewFacade(
 	authorizer facade.Authorizer,
 	ctrlSt ControllerState,
 	st State,
+	broker Broker,
 	clock clock.Clock,
 ) (*Facade, error) {
-	if !authorizer.AuthApplicationAgent() {
+	if !authorizer.AuthApplicationAgent() && !authorizer.AuthUnitAgent() {
 		return nil, apiservererrors.ErrPerm
 	}
 	model, err := st.Model()
@@ -69,6 +82,7 @@ func NewFacade(
 		state:     st,
 		model:     model,
 		clock:     clock,
+		broker:    broker,
 	}, nil
 }
 
@@ -298,4 +312,64 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 		},
 	}
 	return res, nil
+}
+
+// UnitTerminating should be called by the CAASUnitTerminationWorker when
+// the agent receives a signal to exit. UnitTerminating will return how
+// the agent should shutdown.
+func (f *Facade) UnitTerminating(args params.Entity) (params.CAASUnitTerminationResult, error) {
+	tag, ok := f.auth.GetAuthTag().(names.UnitTag)
+	if !ok {
+		return params.CAASUnitTerminationResult{}, apiservererrors.ErrPerm
+	}
+
+	errResp := func(err error) (params.CAASUnitTerminationResult, error) {
+		return params.CAASUnitTerminationResult{Error: apiservererrors.ServerError(err)}, nil
+	}
+
+	unitTag, err := names.ParseUnitTag(args.Tag)
+	if err != nil {
+		return errResp(err)
+	}
+	if unitTag != tag {
+		return params.CAASUnitTerminationResult{}, apiservererrors.ErrPerm
+	}
+
+	unit, err := f.state.Unit(unitTag.Id())
+	if err != nil {
+		return errResp(err)
+	}
+	if unit.Life() != state.Alive {
+		return params.CAASUnitTerminationResult{WillRestart: false}, nil
+	}
+
+	// TODO(sidecar): handle deployment other than statefulset
+	deploymentType := caas.DeploymentStateful
+	restart := true
+
+	switch deploymentType {
+	case caas.DeploymentStateful:
+		application, err := f.state.Application(unit.ApplicationName())
+		if err != nil {
+			return errResp(err)
+		}
+		caasApp := f.broker.Application(unit.ApplicationName(), caas.DeploymentStateful)
+		appState, err := caasApp.State()
+		if err != nil {
+			return errResp(err)
+		}
+		n := unitTag.Number()
+		if n >= application.GetScale() || n >= appState.DesiredReplicas {
+			restart = false
+		}
+	case caas.DeploymentStateless, caas.DeploymentDaemon:
+		// Both handled the same way.
+		restart = true
+	default:
+		return errResp(errors.NotSupportedf("unknown deployment type"))
+	}
+
+	return params.CAASUnitTerminationResult{
+		WillRestart: restart,
+	}, nil
 }

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/caasapplication"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -33,6 +34,7 @@ type CAASApplicationSuite struct {
 	facade     *caasapplication.Facade
 	st         *mockState
 	clock      *testclock.Clock
+	broker     *mockBroker
 }
 
 func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
@@ -48,8 +50,9 @@ func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
+	s.broker = &mockBroker{}
 
-	facade, err := caasapplication.NewFacade(s.resources, s.authorizer, s.st, s.st, s.clock)
+	facade, err := caasapplication.NewFacade(s.resources, s.authorizer, s.st, s.st, s.broker, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	s.facade = facade
 }
@@ -224,6 +227,68 @@ func (s *CAASApplicationSuite) TestMissingArgName(c *gc.C) {
 	results, err := s.facade.UnitIntroduction(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `pod-name not valid`)
+}
+
+func (s *CAASApplicationSuite) TestUnitTerminatingAgentWillRestart(c *gc.C) {
+	s.authorizer.Tag = names.NewUnitTag("gitlab/0")
+
+	s.broker.app = &mockCAASApplication{
+		state: caas.ApplicationState{
+			DesiredReplicas: 1,
+		},
+	}
+
+	s.st.app.scale = 1
+
+	s.st.units = map[string]*mockUnit{
+		"gitlab/0": {
+			life: state.Alive,
+			containerInfo: &mockCloudContainer{
+				providerID: "gitlab-0",
+				unit:       "gitlab/0",
+			},
+			updateOp: nil,
+		},
+	}
+
+	args := params.Entity{
+		Tag: "unit-gitlab-0",
+	}
+	results, err := s.facade.UnitTerminating(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Error, gc.IsNil)
+	c.Assert(results.WillRestart, jc.IsTrue)
+}
+
+func (s *CAASApplicationSuite) TestUnitTerminatingAgentDying(c *gc.C) {
+	s.authorizer.Tag = names.NewUnitTag("gitlab/0")
+
+	s.broker.app = &mockCAASApplication{
+		state: caas.ApplicationState{
+			DesiredReplicas: 0,
+		},
+	}
+
+	s.st.app.scale = 0
+
+	s.st.units = map[string]*mockUnit{
+		"gitlab/0": {
+			life: state.Alive,
+			containerInfo: &mockCloudContainer{
+				providerID: "gitlab-0",
+				unit:       "gitlab/0",
+			},
+			updateOp: nil,
+		},
+	}
+
+	args := params.Entity{
+		Tag: "unit-gitlab-0",
+	}
+	results, err := s.facade.UnitTerminating(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Error, gc.IsNil)
+	c.Assert(results.WillRestart, jc.IsFalse)
 }
 
 func strPtr(s string) *string {

--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/agent/caasapplication"
+	"github.com/juju/juju/caas"
 	_ "github.com/juju/juju/caas/kubernetes/provider"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
-	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/state"
 	jtesting "github.com/juju/juju/testing"
 )
@@ -154,6 +154,7 @@ type mockApplication struct {
 	name         string
 	newUnit      caasapplication.Unit
 	units        map[string]*mockUnit
+	scale        int
 }
 
 func (*mockApplication) Tag() names.Tag {
@@ -203,6 +204,11 @@ func (a *mockApplication) AddUnit(args state.AddUnitParams) (unit caasapplicatio
 	return a.newUnit, nil
 }
 
+func (a *mockApplication) GetScale() int {
+	a.MethodCall(a, "GetScale")
+	return a.scale
+}
+
 type mockUnit struct {
 	testing.Stub
 	life          state.Life
@@ -242,6 +248,11 @@ func (u *mockUnit) SetPassword(password string) error {
 	return u.NextErr()
 }
 
+func (u *mockUnit) ApplicationName() string {
+	u.MethodCall(u, "ApplicationName")
+	return "gitlab"
+}
+
 type mockCharm struct {
 	url      *charm.URL
 	sha256   string
@@ -267,12 +278,12 @@ func (ch *mockCharm) Manifest() *charm.Manifest {
 
 type mockBroker struct {
 	testing.Stub
-	watcher corewatcher.StringsWatcher
+	app *mockCAASApplication
 }
 
-func (b *mockBroker) WatchContainerStart(appName string, containerName string) (corewatcher.StringsWatcher, error) {
-	b.MethodCall(b, "WatchContainerStart", appName, containerName)
-	return b.watcher, b.NextErr()
+func (b *mockBroker) Application(appName string, deploymentType caas.DeploymentType) caas.Application {
+	b.MethodCall(b, "Application", appName, deploymentType)
+	return b.app
 }
 
 type mockCloudContainer struct {
@@ -303,4 +314,16 @@ type mockLeadershipRevoker struct {
 func (s *mockLeadershipRevoker) RevokeLeadership(applicationId, unitId string) error {
 	s.revoked.Add(unitId)
 	return nil
+}
+
+type mockCAASApplication struct {
+	testing.Stub
+	caas.Application
+
+	state caas.ApplicationState
+}
+
+func (a *mockCAASApplication) State() (caas.ApplicationState, error) {
+	a.MethodCall(a, "State")
+	return a.state, a.NextErr()
 }

--- a/apiserver/facades/agent/caasapplication/state.go
+++ b/apiserver/facades/agent/caasapplication/state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/version/v2"
 
+	"github.com/juju/juju/caas"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
@@ -46,6 +47,7 @@ type Application interface {
 	AllUnits() ([]Unit, error)
 	UpdateUnits(unitsOp *state.UpdateUnitsOperation) error
 	AddUnit(args state.AddUnitParams) (unit Unit, err error)
+	GetScale() int
 }
 
 // Charm provides the subset of charm state required by the
@@ -117,4 +119,10 @@ type Unit interface {
 	Refresh() error
 	UpdateOperation(props state.UnitUpdateProperties) *state.UpdateUnitOperation
 	SetPassword(string) error
+	ApplicationName() string
+}
+
+// Broker contains methods from the caas.Broker interface used by the caasapplication facade.
+type Broker interface {
+	Application(string, caas.DeploymentType) caas.Application
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6538,6 +6538,18 @@
                         }
                     },
                     "description": "UnitIntroduction sets the status of each given entity."
+                },
+                "UnitTerminating": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CAASUnitTerminationResult"
+                        }
+                    },
+                    "description": "UnitTerminating should be called by the CAASUnitTerminationWorker when\nthe agent receives a signal to exit. UnitTerminating will return how\nthe agent should shutdown."
                 }
             },
             "definitions": {
@@ -6587,6 +6599,34 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "CAASUnitTerminationResult": {
+                    "type": "object",
+                    "properties": {
+                        "Error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "WillRestart": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "WillRestart",
+                        "Error"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
                 },
                 "Error": {
                     "type": "object",

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -32,6 +32,13 @@ type CAASApplicationProvisioningInfoResults struct {
 	Results []CAASApplicationProvisioningInfo `json:"results"`
 }
 
+// CAASUnitTerminationResult holds result to UnitTerminating call.
+type CAASUnitTerminationResult struct {
+	// WillRestart is true if the termination of the unit is temporary.
+	WillRestart bool
+	Error       *Error
+}
+
 // CAASApplicationProvisioningInfo holds info needed to provision a caas application.
 type CAASApplicationProvisioningInfo struct {
 	ImagePath            string                       `json:"image-path"`

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 	"github.com/juju/juju/worker/apiconfigwatcher"
 	"github.com/juju/juju/worker/caasprober"
+	"github.com/juju/juju/worker/caasunitterminationworker"
 	"github.com/juju/juju/worker/caasupgrader"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/gate"
@@ -300,6 +301,15 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			EnforcedCharmModifiedVersion: config.CharmModifiedVersion,
 			ContainerNames:               config.ContainerNames,
 		})),
+
+		// The CAAS unit termination worker handles SIGTERM from the container runtime.
+		caasUnitTerminationWorker: ifNotMigrating(caasunitterminationworker.Manifold(caasunitterminationworker.ManifoldConfig{
+			AgentName:     agentName,
+			APICallerName: apiCallerName,
+			Clock:         config.Clock,
+			Logger:        loggo.GetLogger("juju.worker.caasunitterminationworker"),
+			UniterName:    uniterName,
+		})),
 	}
 }
 
@@ -336,6 +346,8 @@ const (
 	proxyConfigUpdaterName   = "proxy-config-updater"
 	loggingConfigUpdaterName = "logging-config-updater"
 	apiAddressUpdaterName    = "api-address-updater"
+
+	caasUnitTerminationWorker = "caas-unit-termination-worker"
 )
 
 type noopStatusSetter struct{}

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -62,6 +62,8 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 		"upgrade-steps-runner",
 		"upgrade-steps-gate",
 		"upgrade-steps-flag",
+
+		"caas-unit-termination-worker",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -217,5 +219,17 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"api-caller",
 		"api-config-watcher",
 		"upgrade-steps-gate",
+	},
+
+	"caas-unit-termination-worker": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"charm-dir",
+		"hook-retry-strategy",
+		"leadership-tracker",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"uniter",
 	},
 }

--- a/worker/caasunitterminationworker/manifold.go
+++ b/worker/caasunitterminationworker/manifold.go
@@ -1,0 +1,80 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitterminationworker
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/worker/v2"
+	"github.com/juju/worker/v2/dependency"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/caasapplication"
+	"github.com/juju/juju/worker/uniter"
+)
+
+// Logger for logging messages.
+type Logger interface {
+	Infof(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// ManifoldConfig defines the names of the manifolds on which a
+// Manifold will depend.
+type ManifoldConfig struct {
+	AgentName     string
+	APICallerName string
+	UniterName    string
+	Clock         clock.Clock
+	Logger        Logger
+}
+
+// Validate ensures all the required values for the config are set.
+func (config *ManifoldConfig) Validate() error {
+	if config.Clock == nil {
+		return errors.NotValidf("missing Clock")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("missing Logger")
+	}
+	return nil
+}
+
+// Manifold returns a manifold whose worker returns ErrTerminateAgent
+// if a termination signal is received by the process it's running in.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.APICallerName,
+			config.UniterName,
+		},
+		Start: func(context dependency.Context) (worker.Worker, error) {
+			if err := config.Validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			var agent agent.Agent
+			if err := context.Get(config.AgentName, &agent); err != nil {
+				return nil, err
+			}
+			var apiConn api.Connection
+			if err := context.Get(config.APICallerName, &apiConn); err != nil {
+				return nil, err
+			}
+			var uniter *uniter.Uniter
+			if err := context.Get(config.UniterName, &uniter); err != nil {
+				return nil, err
+			}
+			state := caasapplication.NewClient(apiConn)
+			return NewWorker(Config{
+				Agent:          agent,
+				State:          state,
+				UnitTerminator: uniter,
+				Logger:         config.Logger,
+				Clock:          config.Clock,
+			}), nil
+		},
+	}
+}

--- a/worker/caasunitterminationworker/manifold_test.go
+++ b/worker/caasunitterminationworker/manifold_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitterminationworker_test
+
+import (
+	"time"
+
+	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/caasunitterminationworker"
+)
+
+type ManifoldSuite struct {
+	config caasunitterminationworker.ManifoldConfig
+}
+
+var _ = gc.Suite(&ManifoldSuite{})
+
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.config = caasunitterminationworker.ManifoldConfig{
+		Clock:  testclock.NewClock(time.Now()),
+		Logger: loggo.GetLogger("test"),
+	}
+}
+
+func (s *ManifoldSuite) TestConfigValidation(c *gc.C) {
+	err := s.config.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingClock(c *gc.C) {
+	s.config.Clock = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Clock not valid")
+}
+
+func (s *ManifoldSuite) TestConfigValidationMissingLogger(c *gc.C) {
+	s.config.Logger = nil
+	err := s.config.Validate()
+	c.Check(err, jc.Satisfies, errors.IsNotValid)
+	c.Check(err, gc.ErrorMatches, "missing Logger not valid")
+}

--- a/worker/caasunitterminationworker/worker.go
+++ b/worker/caasunitterminationworker/worker.go
@@ -1,0 +1,101 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitterminationworker
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/worker/v2"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/caasapplication"
+)
+
+// TerminationSignal is SIGTERM which is sent by most container runtimes when
+// a container should terminate gracefully.
+const TerminationSignal = syscall.SIGTERM
+
+type terminationWorker struct {
+	tomb tomb.Tomb
+
+	agent          agent.Agent
+	state          State
+	unitTerminator UnitTerminator
+	logger         Logger
+	clock          clock.Clock
+}
+
+type Config struct {
+	Agent          agent.Agent
+	State          State
+	UnitTerminator UnitTerminator
+	Logger         Logger
+	Clock          clock.Clock
+}
+
+type State interface {
+	UnitTerminating(tag names.UnitTag) (caasapplication.UnitTermination, error)
+}
+
+type UnitTerminator interface {
+	Terminate() error
+}
+
+// NewWorker returns a worker that waits for a
+// TerminationSignal signal, and then exits
+// with worker.ErrTerminateAgent.
+func NewWorker(config Config) worker.Worker {
+	w := terminationWorker{
+		agent:          config.Agent,
+		state:          config.State,
+		unitTerminator: config.UnitTerminator,
+		logger:         config.Logger,
+		clock:          config.Clock,
+	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, TerminationSignal)
+	w.tomb.Go(func() error {
+		defer signal.Stop(c)
+		return w.loop(c)
+	})
+	return &w
+}
+
+func (w *terminationWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *terminationWorker) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *terminationWorker) loop(c <-chan os.Signal) (err error) {
+	select {
+	case <-c:
+		w.logger.Infof("terminating due to SIGTERM")
+		term, err := w.state.UnitTerminating(w.agent.CurrentConfig().Tag().(names.UnitTag))
+		if err != nil {
+			w.logger.Errorf("error while terminating unit: %v", err)
+			return err
+		}
+		if !term.WillRestart {
+			// Lifecycle watcher will handle termination of the unit.
+			return nil
+		}
+		err = w.unitTerminator.Terminate()
+		if err != nil {
+			w.logger.Errorf("error while terminating unit: %v", err)
+			return errors.Annotatef(err, "failed to terminate unit agent worker")
+		}
+		return nil
+	case <-w.tomb.Dying():
+		return tomb.ErrDying
+	}
+}

--- a/worker/caasunitterminationworker/worker_test.go
+++ b/worker/caasunitterminationworker/worker_test.go
@@ -1,0 +1,128 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasunitterminationworker_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/juju/clock"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/caasapplication"
+	"github.com/juju/juju/worker/caasunitterminationworker"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+var _ = gc.Suite(&TerminationWorkerSuite{})
+
+type TerminationWorkerSuite struct {
+	state      *mockState
+	terminator *mockTerminator
+}
+
+func (s *TerminationWorkerSuite) newWorker(c *gc.C) worker.Worker {
+	s.state = &mockState{}
+	s.terminator = &mockTerminator{}
+	config := caasunitterminationworker.Config{
+		Agent:          &mockAgent{},
+		Logger:         loggo.GetLogger("test"),
+		Clock:          clock.WallClock,
+		State:          s.state,
+		UnitTerminator: s.terminator,
+	}
+	return caasunitterminationworker.NewWorker(config)
+}
+
+func (s *TerminationWorkerSuite) TestStartStop(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("not supported")
+	}
+	w := s.newWorker(c)
+	w.Kill()
+	err := w.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *TerminationWorkerSuite) TestAgentWillRestart(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("not supported")
+	}
+	w := s.newWorker(c)
+	s.state.termination.WillRestart = true
+	proc, err := os.FindProcess(os.Getpid())
+	c.Assert(err, jc.ErrorIsNil)
+	defer proc.Release()
+	err = proc.Signal(caasunitterminationworker.TerminationSignal)
+	c.Assert(err, jc.ErrorIsNil)
+	err = w.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	s.state.CheckCallNames(c, "UnitTerminating")
+	c.Assert(s.state.Calls()[0].Args[0], gc.DeepEquals, names.NewUnitTag("gitlab/0"))
+	s.terminator.CheckCallNames(c, "Terminate")
+}
+
+func (s *TerminationWorkerSuite) TestAgentDying(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("not supported")
+	}
+	w := s.newWorker(c)
+	s.state.termination.WillRestart = false
+	proc, err := os.FindProcess(os.Getpid())
+	c.Assert(err, jc.ErrorIsNil)
+	defer proc.Release()
+	err = proc.Signal(caasunitterminationworker.TerminationSignal)
+	c.Assert(err, jc.ErrorIsNil)
+	err = w.Wait()
+	c.Assert(err, jc.ErrorIsNil)
+	s.state.CheckCallNames(c, "UnitTerminating")
+	c.Assert(s.state.Calls()[0].Args[0], gc.DeepEquals, names.NewUnitTag("gitlab/0"))
+	s.terminator.CheckCallNames(c)
+}
+
+type mockAgent struct {
+	agent.Agent
+}
+
+func (a *mockAgent) CurrentConfig() agent.Config {
+	return &mockAgentConfig{}
+}
+
+type mockAgentConfig struct {
+	agent.Config
+}
+
+func (c *mockAgentConfig) Tag() names.Tag {
+	return names.NewUnitTag("gitlab/0")
+}
+
+type mockState struct {
+	jujutesting.Stub
+
+	termination caasapplication.UnitTermination
+}
+
+func (s *mockState) UnitTerminating(tag names.UnitTag) (caasapplication.UnitTermination, error) {
+	s.MethodCall(s, "UnitTerminating", tag)
+	return s.termination, s.NextErr()
+}
+
+type mockTerminator struct {
+	jujutesting.Stub
+}
+
+func (t *mockTerminator) Terminate() error {
+	t.MethodCall(t, "Terminate")
+	return t.NextErr()
+}

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -154,6 +154,19 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			return uniter, nil
 		},
+		Output: func(in worker.Worker, out interface{}) error {
+			uniter, _ := in.(*Uniter)
+			if uniter == nil {
+				return errors.Errorf("expected Uniter in")
+			}
+			switch outPtr := out.(type) {
+			case **Uniter:
+				*outPtr = uniter
+			default:
+				return errors.Errorf("unknown out type")
+			}
+			return nil
+		},
 	}
 }
 

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -296,8 +296,10 @@ func (rh *runHook) Commit(state State) (*State, error) {
 	switch rh.info.Kind {
 	case hooks.Install:
 		newState.Installed = true
+		newState.Removed = false
 	case hooks.Start:
 		newState.Started = true
+		newState.Stopped = false
 	case hooks.Stop:
 		newState.Stopped = true
 	case hooks.Remove:

--- a/worker/uniter/reboot/resolver.go
+++ b/worker/uniter/reboot/resolver.go
@@ -21,8 +21,8 @@ type Logger interface {
 
 // NewResolver returns a resolver that runs the start hook to notify install
 // charms that the machine has been rebooted.
-func NewResolver(logger Logger, rebootDetected bool, modelType model.ModelType) resolver.Resolver {
-	if modelType != model.IAAS || !rebootDetected {
+func NewResolver(logger Logger, rebootDetected bool) resolver.Resolver {
+	if !rebootDetected {
 		return nopResolver{}
 	}
 
@@ -60,6 +60,11 @@ func (r *rebootResolver) NextOp(localState resolver.LocalState, remoteState remo
 	// can safely skip the start hook.
 	if !localState.Started {
 		r.rebootDetected = false
+		return nil, resolver.ErrNoOperation
+	}
+
+	// If there is another hook currently, wait until they are done.
+	if localState.Kind == operation.RunHook {
 		return nil, resolver.ErrNoOperation
 	}
 

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -107,6 +107,10 @@ type Snapshot struct {
 	// WorkloadEvents is a list of IDs of workload events that need to be
 	// processed.
 	WorkloadEvents []string
+
+	// Shutdown is true on CAAS sidecar applications when SIGTERM is recevied
+	// but the unit isn't going to die, just a uniter restart/pod reschedule.
+	Shutdown bool
 }
 
 // RelationSnapshot tracks the state of a relationship from the viewpoint of the local unit.

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -107,7 +107,7 @@ func (s *baseResolverSuite) SetUpTest(c *gc.C, modelType model.ModelType, reboot
 		StopRetryHookTimer:  func() { s.stub.AddCall("StopRetryHookTimer") },
 		ShouldRetryHooks:    true,
 		UpgradeSeries:       upgradeseries.NewResolver(logger),
-		Reboot:              reboot.NewResolver(logger, rebootDetected, modelType),
+		Reboot:              reboot.NewResolver(logger, rebootDetected),
 		Leadership:          leadership.NewResolver(logger),
 		Actions:             uniteractions.NewResolver(logger),
 		VerifyCharmProfile:  verifycharmprofile.NewResolver(logger, modelType),

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1507,3 +1507,15 @@ func executorFunc(c *gc.C) uniter.NewOperationExecutorFunc {
 		return &mockExecutor{e}, nil
 	}
 }
+
+func (s *UniterSuite) TestShutdown(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"shutdown",
+			quickStart{},
+			triggerShutdown{},
+			waitHooks{"stop"},
+			expectError{"agent should be terminated"},
+		),
+	})
+}

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1680,3 +1680,11 @@ func (s injectTestContainer) step(c *gc.C, ctx *testContext) {
 		err: errors.BadRequestf("not ready yet"),
 	}
 }
+
+type triggerShutdown struct {
+}
+
+func (t triggerShutdown) step(c *gc.C, ctx *testContext) {
+	err := ctx.uniter.Terminate()
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
Add the caasunitterminationworker to the caas sidecar unit agent manifold to handle receiving SIGTERM when running in
a container environment (k8s).

In the event a Pod is simply dying (expectation the unit will get a new Pod), then the worker will ask the uniter to shutdown, running the stop hook first before terminating the agent process.

In the event a Pod is dying because the Unit has reached the end of its life, then the termination worker just eats the SIGTERM allowing the Uniter to exit normally.

## QA steps

Deploy sidecar charm.
Install hook should run and start hook.
Delete pod.
Stop hook should run.
On restart the upgrade-charm hook should run then possibly config-changed hook then start hook.
Use juju to scale the application to 0.
Stop hook should run then the remove hook should run.

## Documentation changes

Task created to update/create documentation.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1926568
