### PR TITLE
Use the address CIDRs when populating machine addresses in the instance-poller

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -213,7 +213,7 @@ func mapNetworkConfigsToProviderAddresses(
 		// Private addresses use the same CIDR; try to resolve them
 		// to a space and create a scoped network address
 		for _, addr := range params.ToProviderAddresses(cfg.Addresses...) {
-			spaceInfo, err := spaceInfoForAddress(spaceInfos, cfg.CIDR, cfg.ProviderSubnetId, addr.Value)
+			spaceInfo, err := spaceInfoForAddress(spaceInfos, addr.CIDR, cfg.ProviderSubnetId, addr.Value)
 			if err != nil {
 				// If we were unable to infer the space using the
 				// currently available subnet information, use


### PR DESCRIPTION
In a prior patch we changed `params.NetworkConfig` and associated logic to consider the `CIDR` transported with each address instead of the deprecated one supplied on the address` device.

Here we correct the instance-poller to consider the address CIDRs instead of the device CIDR.

## QA steps

The change is red/green for instance-poller unit tests (see review comment). For regression:

- Bootstrap to AWS.
- `juju add-space beta 172.31.0.0/20`.
- `juju add-machine --constraints spaces=beta`.
- Connect to Mongo and see that the provider addresses are in the correct space. For example:
```
        "preferredprivateaddress" : {
                "value" : "172.31.11.254",
                "addresstype" : "ipv4",
                "networkscope" : "local-cloud",
                "origin" : "provider",
                "spaceid" : "1"
        },
```

## Documentation changes

None.

## Bug reference

N/A
