### PR TITLE
Fixes error with ensure ClusterRole

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -908,9 +908,9 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 
 		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), controllerServiceAccount, v1.CreateOptions{}).
 			Return(controllerServiceAccount, nil),
-		s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "model.juju.is/name=controller"}).
-			Return(&rbacv1.ClusterRoleBindingList{}, nil),
-		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), controllerServiceCRB, v1.CreateOptions{}).
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), controllerServiceCRB.Name, gomock.Any()).
+			Return(controllerServiceCRB, nil),
+		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), controllerServiceCRB, gomock.Any()).
 			Return(controllerServiceCRB, nil),
 
 		// Check the operator storage exists.

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -3945,10 +3945,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), svcAccount, v1.CreateOptions{}).Return(svcAccount, nil),
-		s.mockClusterRoles.EXPECT().Create(gomock.Any(), cr, v1.CreateOptions{}).Return(cr, nil),
-		s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
-			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb, v1.CreateOptions{}).Return(crb, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), cr.Name, gomock.Any()).Return(cr, nil),
+		s.mockClusterRoles.EXPECT().Update(gomock.Any(), cr, gomock.Any()).Return(cr, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb.Name, gomock.Any()).Return(crb, nil),
+		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb, gomock.Any()).Return(crb, nil),
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
@@ -4115,7 +4115,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			},
 		},
 	}
-	crbUID := crb.GetUID()
 
 	secretArg := s.getOCIImageSecret(c, map[string]string{"fred": "mary"})
 	gomock.InOrder(
@@ -4125,16 +4124,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 		s.mockServiceAccounts.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name"}).
 			Return(&core.ServiceAccountList{Items: []core.ServiceAccount{*svcAccount}}, nil),
 		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), svcAccount, v1.UpdateOptions{}).Return(svcAccount, nil),
-		s.mockClusterRoles.EXPECT().Create(gomock.Any(), cr, v1.CreateOptions{}).Return(nil, s.k8sAlreadyExistsError()),
-		s.mockClusterRoles.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
-			Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*cr}}, nil),
-		s.mockClusterRoles.EXPECT().Update(gomock.Any(), cr, v1.UpdateOptions{}).Return(cr, nil),
-		s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
-			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*crb}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Delete(gomock.Any(), "app-name-test-app-name", s.deleteOptions(v1.DeletePropagationForeground, crbUID)).Return(nil),
-		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "app-name-test-app-name", v1.GetOptions{}).Return(crb, nil),
-		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "app-name-test-app-name", v1.GetOptions{}).Return(nil, s.k8sNotFoundError()),
-		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb, v1.CreateOptions{}).Return(crb, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), cr.Name, gomock.Any()).Return(cr, nil),
+		s.mockClusterRoles.EXPECT().Update(gomock.Any(), cr, gomock.Any()).Return(cr, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "app-name-test-app-name", gomock.Any()).Return(crb, nil),
+		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb, gomock.Any()).Return(crb, nil),
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
@@ -4170,8 +4163,6 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
 		})
 	}()
-	err = s.clock.WaitAdvance(2*time.Second, testing.LongWait, 1)
-	c.Assert(err, jc.ErrorIsNil)
 
 	select {
 	case err := <-errChan:
@@ -4661,10 +4652,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		s.mockRoleBindings.EXPECT().Create(gomock.Any(), rb1, v1.CreateOptions{}).Return(rb1, nil),
 
 		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), svcAccount2, v1.CreateOptions{}).Return(svcAccount2, nil),
-		s.mockClusterRoles.EXPECT().Create(gomock.Any(), clusterrole2, v1.CreateOptions{}).Return(clusterrole2, nil),
-		s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
-			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb2, v1.CreateOptions{}).Return(crb2, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), clusterrole2.Name, gomock.Any()).Return(clusterrole2, nil),
+		s.mockClusterRoles.EXPECT().Update(gomock.Any(), clusterrole2, gomock.Any()).Return(clusterrole2, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb2.Name, gomock.Any()).Return(crb2, nil),
+		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb2, gomock.Any()).Return(crb2, nil),
 
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
@@ -4983,10 +4974,10 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		s.mockRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name"}).
 			Return(&rbacv1.RoleBindingList{Items: []rbacv1.RoleBinding{}}, nil),
 		s.mockRoleBindings.EXPECT().Create(gomock.Any(), rb2, v1.CreateOptions{}).Return(rb2, nil),
-		s.mockClusterRoles.EXPECT().Create(gomock.Any(), clusterrole2, v1.CreateOptions{}).Return(clusterrole2, nil),
-		s.mockClusterRoleBindings.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name,model.juju.is/name=test"}).
-			Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{}}, nil),
-		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb2, v1.CreateOptions{}).Return(crb2, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), clusterrole2.Name, gomock.Any()).Return(clusterrole2, nil),
+		s.mockClusterRoles.EXPECT().Update(gomock.Any(), clusterrole2, gomock.Any()).Return(clusterrole2, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb2.Name, gomock.Any()).Return(crb2, nil),
+		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb2, gomock.Any()).Return(crb2, nil),
 
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).

--- a/caas/kubernetes/provider/resources/claim.go
+++ b/caas/kubernetes/provider/resources/claim.go
@@ -1,0 +1,113 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+)
+
+// Claim represents an assertion over a generic Kubernetes object to assert
+// ownership. These are used in Juju for cluster scoped resources to assert that
+// that Juju is not going to take ownership of an object that was not created by
+// itself.
+type Claim interface {
+	// Assert defines the assertion to run. Returns true if a claim is asserted
+	// over the provided object or if an error occurred where a claim can not be
+	// made.
+	Assert(obj interface{}) (bool, error)
+}
+
+// ClaimFn is a helper type for making Claim types out of functions. See Claim
+type ClaimFn func(obj interface{}) (bool, error)
+
+var (
+	// ClaimJujuOwnership asserts that the Kubernetes object has labels that
+	// in line with Juju management "ownership".
+	ClaimJujuOwnership = ClaimAggregateOr(
+		ClaimFn(claimIsManagedByJuju),
+		ClaimFn(claimHasJujuLabel),
+	)
+)
+
+func (c ClaimFn) Assert(obj interface{}) (bool, error) {
+	return c(obj)
+}
+
+// ClaimAggregateOr runs multiple claims looking for the first true condition.
+// If no claims are provided or no claim returns true false is returned. The
+// first claim to error stops execution.
+func ClaimAggregateOr(claims ...Claim) Claim {
+	return ClaimFn(func(obj interface{}) (bool, error) {
+		for _, claim := range claims {
+			if r, err := claim.Assert(obj); err != nil {
+				return r, err
+			} else if r {
+				return r, err
+			}
+		}
+		return false, nil
+	})
+}
+
+// claimHasAJujuLabel is a throw everything against the wall and see what sticks
+// assertion. It itterates all labels of the object trying to find a key that
+// has the lowercase word "juju". We use this because our labeling at one stage
+// is a bit hit and miss and no consitancy to fall back on.
+// TODO: Remove in Juju 3.0
+func claimHasJujuLabel(obj interface{}) (bool, error) {
+	if obj == nil {
+		return false, errors.NewNotValid(nil, "obj for claim cannot be nil")
+	}
+
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return false, errors.Annotate(err, "asserting Kubernetes object has Juju labels")
+	}
+	for k := range metaObj.GetLabels() {
+		if strings.Contains(k, "juju") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// claimIsManagedByJuju is a check to assert that the Kubernetes object provied
+// is managed by Juju by having the label key and value of
+// app.kubernetes.io/managed-by: juju.
+func claimIsManagedByJuju(obj interface{}) (bool, error) {
+	if obj == nil {
+		return false, errors.NewNotValid(nil, "obj for claim cannot be nil")
+	}
+
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return false, errors.Annotate(err, "asserting Kubernetes object has managed by juju label")
+	}
+
+	val, has := metaObj.GetLabels()[constants.LabelKubernetesAppManaged]
+	if !has {
+		return false, nil
+	}
+	return val == "juju", nil
+}
+
+// RunClaims runs the provided claims until the first true condition is found or
+// the first error occurs. If no claims are provided then true is returned.
+func RunClaims(claims ...Claim) Claim {
+	return ClaimFn(func(obj interface{}) (bool, error) {
+		for _, claim := range claims {
+			if r, err := claim.Assert(obj); err != nil {
+				return r, err
+			} else if r {
+				return r, err
+			}
+		}
+		return true, nil
+	})
+}

--- a/caas/kubernetes/provider/resources/claim_test.go
+++ b/caas/kubernetes/provider/resources/claim_test.go
@@ -1,0 +1,381 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/juju/errors"
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClaimHasJujuLabel(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Obj    interface{}
+		Result bool
+	}{
+		{
+			Name: "Test that object has a single juju label",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"juju.io/something": "some-value",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test that object has no juju labels",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"does-not-mention-secret-keys": "foo",
+					},
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "Test many labels with juju key",
+			Obj: &rbac.ClusterRole{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"label1":     "foo",
+						"label2":     "foo",
+						"label3":     "foo",
+						"label4":     "foo",
+						"label5":     "foo",
+						"label6":     "foo",
+						"label7":     "foo",
+						"label8":     "foo",
+						"label9":     "foo",
+						"juju-model": "AA==",
+					},
+				},
+			},
+			Result: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			r, err := claimHasJujuLabel(test.Obj)
+			if err != nil {
+				t.Errorf("unexpected error testing claim has juju label %w", err)
+			}
+			if r != test.Result {
+				t.Errorf("unexpected result for claim has juju label, weanted %t got %t",
+					test.Result, r)
+			}
+		})
+	}
+}
+
+func TestClaimHasJujuLabelBadData(t *testing.T) {
+	r, err := claimHasJujuLabel(map[string]string{})
+	if r {
+		t.Error("expected claim has juju label with bad data returns false")
+	}
+
+	if err == nil {
+		t.Error("expected claim has juju label with bad data returns an error")
+	}
+}
+
+func TestClaimHasJujuLabelNilData(t *testing.T) {
+	r, err := claimHasJujuLabel(nil)
+	if r {
+		t.Error("expected claim has juju label with nil data returns false")
+	}
+
+	if !errors.IsNotValid(err) {
+		t.Error("expected claim has juju label with nil to be a not valid error")
+	}
+}
+
+func TestClaimIsManagedByJuju(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Obj    interface{}
+		Result bool
+	}{
+		{
+			Name: "Test that object is not managed by juju",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"juju.io/something": "some-value",
+					},
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "Test that object is managed by juju",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "juju",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test many labels with is managed by juju",
+			Obj: &rbac.ClusterRole{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"label1":                       "foo",
+						"label2":                       "foo",
+						"label3":                       "foo",
+						"label4":                       "foo",
+						"label5":                       "foo",
+						"label6":                       "foo",
+						"label7":                       "foo",
+						"label8":                       "foo",
+						"label9":                       "foo",
+						"app.kubernetes.io/managed-by": "juju",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test not managed by Juju",
+			Obj: &rbac.ClusterRole{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"label1":                       "foo",
+						"label2":                       "foo",
+						"label3":                       "foo",
+						"label4":                       "foo",
+						"label5":                       "foo",
+						"label6":                       "foo",
+						"label7":                       "foo",
+						"label8":                       "foo",
+						"label9":                       "foo",
+						"app.kubernetes.io/managed-by": "notjuju",
+					},
+				},
+			},
+			Result: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			r, err := claimIsManagedByJuju(test.Obj)
+			if err != nil {
+				t.Errorf("unexpected error testing is managed by juju %w", err)
+			}
+			if r != test.Result {
+				t.Errorf("unexpected result for claim is managed by juju, weanted %t got %t",
+					test.Result, r)
+			}
+		})
+	}
+}
+
+func TestClaimIsManagedByJujuBadData(t *testing.T) {
+	r, err := claimHasJujuLabel(map[string]string{})
+	if r {
+		t.Error("expected claim is managed by juju with bad data returns false")
+	}
+
+	if err == nil {
+		t.Error("expected claim is managed by juju with bad data returns an error")
+	}
+}
+
+func TestClaimIsManagedByJujuNilData(t *testing.T) {
+	r, err := claimHasJujuLabel(nil)
+	if r {
+		t.Error("expected claim is managed by juju with nil data returns false")
+	}
+
+	if !errors.IsNotValid(err) {
+		t.Error("expected claim is managed by juju with nil to be a not valid error")
+	}
+}
+
+func TestClaimOrAggregateWithEmptyClaimsReturnsFalse(t *testing.T) {
+	r, err := ClaimAggregateOr().Assert(nil)
+	if err != nil {
+		t.Errorf("unexpected error for empty claim aggregate or %w", err)
+	}
+	if r {
+		t.Errorf("expected empty claim aggregate or to return false")
+	}
+}
+
+func TestClaimAggregateOrReturnsTrue(t *testing.T) {
+	r, err := ClaimAggregateOr(
+		ClaimFn(func(_ interface{}) (bool, error) {
+			return false, nil
+		}),
+		ClaimFn(func(_ interface{}) (bool, error) {
+			return true, nil
+		}),
+	).Assert(nil)
+	if err != nil {
+		t.Errorf("unexpected error for claim aggregate or %w", err)
+	}
+	if !r {
+		t.Errorf("expected claim aggregate or to return true")
+	}
+}
+
+func TestClaimAggregateOrReturnsFalse(t *testing.T) {
+	r, err := ClaimAggregateOr(
+		ClaimFn(func(_ interface{}) (bool, error) {
+			return false, nil
+		}),
+		ClaimFn(func(_ interface{}) (bool, error) {
+			return false, nil
+		}),
+	).Assert(nil)
+	if err != nil {
+		t.Errorf("unexpected error for claim aggregate or %w", err)
+	}
+	if r {
+		t.Errorf("expected claim aggregate or to return false")
+	}
+}
+
+func TestClaimAggregateOrReturnsError(t *testing.T) {
+	r, err := ClaimAggregateOr(
+		ClaimFn(func(_ interface{}) (bool, error) {
+			return false, nil
+		}),
+		ClaimFn(func(_ interface{}) (bool, error) {
+			return false, errors.New("some-error")
+		}),
+	).Assert(nil)
+	if err == nil {
+		t.Error("expected claim aggregate or to return error")
+	}
+	if r {
+		t.Errorf("expected claim aggregate or to return false")
+	}
+}
+
+func TestClaimJujuOwnership(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Obj    interface{}
+		Result bool
+	}{
+		{
+			Name: "Test that object has a single juju label",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"juju.io/something": "some-value",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test that object has no juju labels",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"does-not-mention-secret-keys": "foo",
+					},
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "Test many labels with juju key",
+			Obj: &rbac.ClusterRole{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"label1":     "foo",
+						"label2":     "foo",
+						"label3":     "foo",
+						"label4":     "foo",
+						"label5":     "foo",
+						"label6":     "foo",
+						"label7":     "foo",
+						"label8":     "foo",
+						"label9":     "foo",
+						"juju-model": "AA==",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test that object is managed by juju",
+			Obj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "juju",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test many labels with is managed by juju",
+			Obj: &rbac.ClusterRole{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"label1":                       "foo",
+						"label2":                       "foo",
+						"label3":                       "foo",
+						"label4":                       "foo",
+						"label5":                       "foo",
+						"label6":                       "foo",
+						"label7":                       "foo",
+						"label8":                       "foo",
+						"label9":                       "foo",
+						"app.kubernetes.io/managed-by": "juju",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test not managed by Juju",
+			Obj: &rbac.ClusterRole{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{
+						"label1":                       "foo",
+						"label2":                       "foo",
+						"label3":                       "foo",
+						"label4":                       "foo",
+						"label5":                       "foo",
+						"label6":                       "foo",
+						"label7":                       "foo",
+						"label8":                       "foo",
+						"label9":                       "foo",
+						"app.kubernetes.io/managed-by": "notjuju",
+					},
+				},
+			},
+			Result: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			r, err := ClaimJujuOwnership.Assert(test.Obj)
+			if err != nil {
+				t.Errorf("unexpected error testing claim juju ownership %w", err)
+			}
+			if r != test.Result {
+				t.Errorf("unexpected result for claim juju ownership, weanted %t got %t",
+					test.Result, r)
+			}
+		})
+	}
+}

--- a/caas/kubernetes/provider/resources/clusterrole.go
+++ b/caas/kubernetes/provider/resources/clusterrole.go
@@ -90,6 +90,47 @@ func (r *ClusterRole) Delete(ctx context.Context, client kubernetes.Interface) e
 	return nil
 }
 
+// Ensure ensures this cluster role exists in it's desired form inside the
+// cluster. If the object does not exist it's updated and if the object exists
+// it's updated. The method also takes an optional set of claims to test the
+// exisiting Kubernetes object with to assert ownership before overwriting it.
+func (r *ClusterRole) Ensure(
+	ctx context.Context,
+	client kubernetes.Interface,
+	claims ...Claim,
+) ([]func(), error) {
+	cleanups := []func(){}
+	hasClaim := true
+
+	existing := ClusterRole{r.ClusterRole}
+	err := existing.Get(ctx, client)
+	if err == nil {
+		hasClaim, err = RunClaims(claims...).Assert(&existing.ClusterRole)
+	}
+	if err != nil && !errors.IsNotFound(err) {
+		return cleanups, errors.Annotatef(
+			err,
+			"checking for existing cluster role %q",
+			r.Name,
+		)
+	}
+
+	if !hasClaim {
+		return cleanups, errors.AlreadyExistsf(
+			"cluster role %q not controlled by juju", r.Name)
+	}
+
+	cleanups = append(cleanups, func() { _ = r.Delete(ctx, client) })
+	if errors.IsNotFound(err) {
+		return cleanups, r.Apply(ctx, client)
+	}
+
+	if err := r.Update(ctx, client); err != nil {
+		return cleanups, err
+	}
+	return cleanups, nil
+}
+
 // Events emitted by the resource.
 func (r *ClusterRole) Events(ctx context.Context, client kubernetes.Interface) ([]corev1.Event, error) {
 	return ListEventsForObject(ctx, client, r.Namespace, r.Name, "ClusterRole")
@@ -101,4 +142,22 @@ func (r *ClusterRole) ComputeStatus(_ context.Context, _ kubernetes.Interface, n
 		return "", status.Terminated, r.DeletionTimestamp.Time, nil
 	}
 	return "", status.Active, now, nil
+}
+
+// Update updates the object in the Kubernetes cluster to the new representation
+func (r *ClusterRole) Update(ctx context.Context, client kubernetes.Interface) error {
+	out, err := client.RbacV1().ClusterRoles().Update(
+		ctx,
+		&r.ClusterRole,
+		metav1.UpdateOptions{
+			FieldManager: JujuFieldManager,
+		},
+	)
+	if k8serrors.IsNotFound(err) {
+		return errors.Annotatef(err, "updating cluster role %q", r.Name)
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	r.ClusterRole = *out
+	return nil
 }


### PR DESCRIPTION
When ensuring a cluster role if the labels had changed then update would
fail with an already exists error. As reported in lp1929909.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Upgrade from 2.8 to 2.9 or use regression test added with this PR. See the bug below for more information.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929909
