### PR TITLE
Integration tests: Extend timeout

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -10,7 +10,7 @@ run_charmhub_download() {
 	check_contains "${output}" 'Fetching charm "mysql"'
 
 	juju deploy "${TEST_DIR}/mysql.charm" mysql
-	juju wait-for application mysql
+	juju wait-for application --timeout=15m mysql
 }
 
 run_charmstore_download() {


### PR DESCRIPTION
We seem to be failing a lot waiting for a machine to provision or an
application to reach idle. Either way, we're struggling to reach the
goal state. I don't think waiting longer than 15minutes is advisable,
so let's set that for now.

## QA steps

```sh
(cd test && ./main.sh charmhub)
```
