### PR TITLE
Update apt mirrors on all nodes when model value changes

### DIFF
--- a/api/proxyupdater/proxyupdater.go
+++ b/api/proxyupdater/proxyupdater.go
@@ -80,6 +80,8 @@ type ProxyConfiguration struct {
 	APTProxy    proxy.Settings
 	SnapProxy   proxy.Settings
 
+	AptMirror string
+
 	SnapStoreProxyId         string
 	SnapStoreProxyAssertions string
 	SnapStoreProxyURL        string
@@ -117,6 +119,7 @@ func (api *API) ProxyConfig() (ProxyConfiguration, error) {
 		APTProxy:    proxySettingsParamToProxySettings(result.APTProxySettings),
 		SnapProxy:   proxySettingsParamToProxySettings(result.SnapProxySettings),
 
+		AptMirror:                result.AptMirror,
 		SnapStoreProxyId:         result.SnapStoreProxyId,
 		SnapStoreProxyAssertions: result.SnapStoreProxyAssertions,
 		SnapStoreProxyURL:        result.SnapStoreProxyURL,

--- a/api/proxyupdater/proxyupdater_test.go
+++ b/api/proxyupdater/proxyupdater_test.go
@@ -104,6 +104,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 			HTTP:  "http-snap",
 			HTTPS: "https-snap",
 		},
+		AptMirror: "http://mirror",
 	}
 
 	called, api := newAPI(c, 2, apitesting.APICall{
@@ -138,6 +139,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 		Http:  "http-snap",
 		Https: "https-snap",
 	})
+	c.Check(config.AptMirror, gc.Equals, "http://mirror")
 }
 
 func (s *ProxyUpdaterSuite) TestProxyConfigV1(c *gc.C) {

--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -129,7 +129,7 @@ func (api *APIBase) oneWatch() params.NotifyWatchResult {
 	return result
 }
 
-// WatchForProxyConfigAndAPIHostPortChanges watches for cleanups to be perfomed in state
+// WatchForProxyConfigAndAPIHostPortChanges watches for changes to the proxy and api host port settings.
 func (api *APIBase) WatchForProxyConfigAndAPIHostPortChanges(args params.Entities) params.NotifyWatchResults {
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
@@ -205,6 +205,7 @@ func (api *APIBase) proxyConfig() params.ProxyConfigResult {
 	result.LegacyProxySettings = toParams(legacyProxySettings)
 
 	result.APTProxySettings = toParams(config.AptProxySettings())
+	result.AptMirror = config.AptMirror()
 
 	result.SnapProxySettings = toParams(config.SnapProxySettings())
 	result.SnapStoreProxyId = config.SnapStoreProxy()

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -114,6 +114,21 @@ func (s *ProxyUpdaterSuite) TestProxyConfigV1(c *gc.C) {
 	}
 	c.Assert(cfg.Results[0], jc.DeepEquals, r)
 }
+func (s *ProxyUpdaterSuite) TestMirrorConfig(c *gc.C) {
+	s.state.SetModelConfig(coretesting.Attrs{
+		"apt-mirror": "http://mirror",
+	})
+	// Check that the ProxyConfig combines data from ModelConfig and APIHostPorts
+	cfg := s.facade.ProxyConfig(s.oneEntity())
+
+	s.state.Stub.CheckCallNames(c,
+		"ModelConfig",
+		"APIHostPortsForAgents",
+	)
+
+	c.Assert(cfg.Results, gc.HasLen, 1)
+	c.Assert(cfg.Results[0].AptMirror, gc.Equals, "http://mirror")
+}
 
 func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 	// Check that the ProxyConfig combines data from ModelConfig and APIHostPorts

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -33447,7 +33447,6 @@
                         "snap-store-assertions",
                         "snap-store-proxy-id",
                         "snap-store-proxy-url",
-                        "apt-mirror",
                         "UpdateBehavior"
                     ]
                 },
@@ -35211,7 +35210,7 @@
                             "$ref": "#/definitions/NotifyWatchResults"
                         }
                     },
-                    "description": "WatchForProxyConfigAndAPIHostPortChanges watches for cleanups to be perfomed in state"
+                    "description": "WatchForProxyConfigAndAPIHostPortChanges watches for changes to the proxy and api host port settings."
                 }
             },
             "definitions": {
@@ -35324,6 +35323,9 @@
                 "ProxyConfigResult": {
                     "type": "object",
                     "properties": {
+                        "apt-mirror": {
+                            "type": "string"
+                        },
                         "apt-proxy-settings": {
                             "$ref": "#/definitions/ProxyConfig"
                         },

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -1175,6 +1175,7 @@ type ProxyConfigResult struct {
 	SnapStoreProxyId         string      `json:"snap-store-id,omitempty"`
 	SnapStoreProxyAssertions string      `json:"snap-store-assertions,omitempty"`
 	SnapStoreProxyURL        string      `json:"snap-store-proxy-url,omitempty"`
+	AptMirror                string      `json:"apt-mirror,omitempty"`
 	Error                    *Error      `json:"error,omitempty"`
 }
 

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -767,7 +767,7 @@ type ContainerConfig struct {
 	SnapStoreAssertions        string                 `json:"snap-store-assertions"`
 	SnapStoreProxyID           string                 `json:"snap-store-proxy-id"`
 	SnapStoreProxyURL          string                 `json:"snap-store-proxy-url"`
-	AptMirror                  string                 `json:"apt-mirror"`
+	AptMirror                  string                 `json:"apt-mirror,omitempty"`
 	CloudInitUserData          map[string]interface{} `json:"cloudinit-userdata,omitempty"`
 	ContainerInheritProperties string                 `json:"container-inherit-properties,omitempty"`
 	*UpdateBehavior

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -124,7 +124,7 @@ type PackageMirrorConfig interface {
 	PackageMirror() string
 }
 
-// PackageSourceConfig is the interface for package source settings on a cloudconfig.
+// PackageSourcesConfig is the interface for package source settings on a cloudconfig.
 type PackageSourcesConfig interface {
 	// AddPackageSource adds a new repository and optional key to be
 	// used as a package source by the system's specific package manager.

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -203,7 +203,7 @@ func shquote(p string) string {
 	return utils.ShQuote(p)
 }
 
-// packageManagerProxySettings implements cloudinit.PackageManagerConfig.
+// packageManagerProxySettings implements cloudinit.PackageManagerProxyConfig.
 type packageManagerProxySettings struct {
 	aptProxy            proxy.Settings
 	aptMirror           string
@@ -213,20 +213,20 @@ type packageManagerProxySettings struct {
 	snapStoreProxyURL   string
 }
 
-// AptProxy implements cloudinit.PackageManagerConfig.
+// AptProxy implements cloudinit.PackageManagerProxyConfig.
 func (p packageManagerProxySettings) AptProxy() proxy.Settings { return p.aptProxy }
 
 // AptMirror implements cloudinit.PackageManagerConfig.
 func (p packageManagerProxySettings) AptMirror() string { return p.aptMirror }
 
-// SnapProxy implements cloudinit.PackageManagerConfig.
+// SnapProxy implements cloudinit.PackageManagerProxyConfig.
 func (p packageManagerProxySettings) SnapProxy() proxy.Settings { return p.snapProxy }
 
-// SnapStoreAssertions implements cloudinit.PackageManagerConfig.
+// SnapStoreAssertions implements cloudinit.PackageManagerProxyConfig.
 func (p packageManagerProxySettings) SnapStoreAssertions() string { return p.snapStoreAssertions }
 
-// SnapStoreProxyID implements cloudinit.PackageManagerConfig.
+// SnapStoreProxyID implements cloudinit.PackageManagerProxyConfig.
 func (p packageManagerProxySettings) SnapStoreProxyID() string { return p.snapStoreProxyID }
 
-// SnapStoreProxyURL implements cloudinit.PackageManagerConfig.
+// SnapStoreProxyURL implements cloudinit.PackageManagerProxyConfig.
 func (p packageManagerProxySettings) SnapStoreProxyURL() string { return p.snapStoreProxyURL }

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -217,6 +217,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			WorkerFunc:          proxyupdater.NewWorker,
 			InProcessUpdate:     proxy.DefaultConfig.Set,
 			SupportLegacyValues: false,
+			RunFunc:             proxyupdater.RunWithStdIn,
 		})),
 
 		// The logging config updater is a leaf worker that indirectly

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -221,6 +221,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			WorkerFunc:          proxyupdater.NewWorker,
 			InProcessUpdate:     proxy.DefaultConfig.Set,
 			SupportLegacyValues: false,
+			RunFunc:             proxyupdater.RunWithStdIn,
 		})),
 
 		// The logging config updater is a leaf worker that indirectly

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -898,6 +898,10 @@ var validationTests = []validationTest{{
 	old:   testing.Attrs{"charmhub-url": "http://a.com"},
 	new:   testing.Attrs{"charmhub-url": "http://b.com"},
 	err:   `cannot change charmhub-url from "http://a.com" to "http://b.com"`,
+}, {
+	about: "Can't clear apt-mirror",
+	old:   testing.Attrs{"apt-mirror": "http://mirror"},
+	err:   `cannot clear apt-mirror`,
 }}
 
 func (s *ConfigSuite) TestValidateChange(c *gc.C) {

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
 	github.com/juju/os/v2 v2.1.2
-	github.com/juju/packaging v0.0.0-20200421095529-970596d2622a
+	github.com/juju/packaging v0.0.0-20210602012220-a1d8f0c5acd9
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
 	github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6

--- a/go.sum
+++ b/go.sum
@@ -445,11 +445,12 @@ github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/
 github.com/juju/os/v2 v2.0.0/go.mod h1:S/AadPYIeAZtep7zu519c+eWGWV7dVR+Hb8RTGBR1+I=
 github.com/juju/os/v2 v2.1.2 h1:RZ1mRJ/fx6O6KpLBLaNwMbb+EMI+iEfBPTdb3CWpi7w=
 github.com/juju/os/v2 v2.1.2/go.mod h1:S/AadPYIeAZtep7zu519c+eWGWV7dVR+Hb8RTGBR1+I=
-github.com/juju/packaging v0.0.0-20200421095529-970596d2622a h1:dMBYD9gIFbskcksH9ib+OvmOwwkJTS5ldwvZq3axlbY=
-github.com/juju/packaging v0.0.0-20200421095529-970596d2622a/go.mod h1:Brg98KsCnaxL6UxQ4pbVFlT4MoQO7x0kSzwnuvRbUy8=
+github.com/juju/packaging v0.0.0-20210602012220-a1d8f0c5acd9 h1:TJsa3p04K4RhtTZ91qADfuJmQ2zstEMQWxauR4SW30M=
+github.com/juju/packaging v0.0.0-20210602012220-a1d8f0c5acd9/go.mod h1:IMNHG1GegM098IwRypW5SFXF3ZSK08mGwQhDWz4AZ1g=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93/go.mod h1:zrbmo4nBKaiP/Ez3F67ewkMbzGYfXyMvRtbOfuAwG0w=
 github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSwAjh/uLXDM=
+github.com/juju/proxy v0.0.0-20180516023828-df38202e4713/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4 h1:y2eoq0Uof/dWLAXRyKKGOJuF0TEkauPscQI7Q1XQqvM=
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6 h1:2aARJxmMC2IF9GqVtt5PYcIy4jyuAcR44byqwXKTK0o=


### PR DESCRIPTION
The apt-mirror model config now updates the `/etc/apt/sources.list` whenever it changes. Previously, the only time apt-mirror was used was when the machine instance was started.
As with instance startup, setting the apt-mirror value will update both the apt and security archives.

This change now also allow the apt mirrors to be updated inside k8s containers. In particular, the container running the charm now gets the apt mirror values from the model config.

Instead of making the apt updates scripts manually in juju, we now rely on the juju/package upstream to do that, so there's a bunch of deleted code also.

## QA steps

juju bootstrap aws
juju add-machine 
juju add-machine lxd:0
ssh to both machines
cat /etc/apt/sourcs.list and see the archives mirrors are stock
juju model-config apt-mirror=http://foo
juju add-machine 
juju add-machine lxd:0
ssh to all 4 machines
cat /etc/apt/sourcs.list and see the archives mirrors are set to http://foo

bootstrap k8s
juju model-config apt-mirror=http://foo
deploy snappass-test
ssh to the charm container
cat /etc/apt/sourcs.list and see the archives mirrors are set to http://foo

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929399
