### PR TITLE
Integration tests: Manual test charm selection

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -44,11 +44,13 @@ manual_deploy() {
 
 	juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
 
-	juju deploy percona-cluster
+	machine_series=$(juju machines --format=json | jq -r '.machines | .["0"] | .series')
 
-	wait_for "percona-cluster" "$(idle_condition "percona-cluster" 0 0)"
+	juju deploy ubuntu --to=0 --series="${machine_series}"
 
-	juju remove-application percona-cluster
+	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 0)"
+
+	juju remove-application ubuntu
 
 	destroy_controller "test-${name}"
 

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -27,7 +27,7 @@ run_deploy_manual_aws() {
 		--filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-${series}-?????-amd64-server-????????" 'Name=state,Values=available' \
 		--query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
 		--output text)
-	if [ -z "${OUT}" ]; then
+	if [[ -z ${OUT} ]]; then
 		echo "No image available: unknown state."
 		exit 1
 	fi
@@ -37,7 +37,7 @@ run_deploy_manual_aws() {
 
 	OUT=$(aws ec2 describe-vpcs | jq '.Vpcs[] | select(.Tags[]? | select((.Key=="Name") and (.Value=="manual-deploy")))' || true)
 	vpc_id=$(echo "${OUT}" | jq -r '.VpcId' || true)
-	if [ -z "${vpc_id}" ]; then
+	if [[ -z ${vpc_id} ]]; then
 		# VPC doesn't exist, create one along with all the required setup.
 		vpc_id=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --output text)
 		aws ec2 wait vpc-available --vpc-ids "${vpc_id}"
@@ -65,7 +65,7 @@ run_deploy_manual_aws() {
 		aws ec2 authorize-security-group-egress --group-id "${sg_id}" --protocol udp --port 0-65535 --cidr 0.0.0.0/0
 	else
 		OUT=$(aws ec2 describe-subnets | jq '.Subnets[] | select(.Tags[]? | select((.Key=="Name") and (.Value=="manual-deploy")))' || true)
-		if [ -z "${OUT}" ]; then
+		if [[ -z ${OUT} ]]; then
 			echo "Subnet not found: unknown state."
 			echo "Delete VPC and start again."
 			exit 1
@@ -73,7 +73,7 @@ run_deploy_manual_aws() {
 		subnet_id=$(echo "${OUT}" | jq -r '.SubnetId')
 
 		OUT=$(aws ec2 describe-security-groups | jq ".SecurityGroups[] | select(.VpcId==\"${vpc_id}\" and .GroupName==\"ci-manual-deploy\")" || true)
-		if [ -z "${OUT}" ]; then
+		if [[ -z ${OUT} ]]; then
 			echo "Security group not found: unknown state."
 			echo "Delete VPC and start again."
 			exit 1

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -117,6 +117,9 @@ run_deploy_manual_lxd() {
 	launch_and_wait_addr "${model1}" addr_m1
 	launch_and_wait_addr "${model2}" addr_m2
 
+	mkdir -p "${HOME}/.ssh"
+	touch "${HOME}/.ssh/known_hosts"
+
 	# shellcheck disable=SC2154
 	for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
 		ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -12,7 +12,7 @@ EOF
 	echo "${PROFILE}" >"${TEST_DIR}/profile-privileged.yaml"
 
 	OUT=$(lxc profile show profile-privileged || true)
-	if [ -z "${OUT}" ]; then
+	if [[ -z ${OUT} ]]; then
 		lxc profile create profile-privileged
 		lxc profile edit profile-privileged <"${TEST_DIR}/profile-privileged.yaml"
 	fi
@@ -55,7 +55,7 @@ delete_user_profile() {
 
 	set +e
 	OUT=$(lxc profile show profile-privileged || true)
-	if [ -n "${OUT}" ]; then
+	if [[ -n ${OUT} ]]; then
 		lxc profile delete "${profile_name}"
 	fi
 	set_verbosity
@@ -97,7 +97,7 @@ run_deploy_manual_lxd() {
 		local address=""
 
 		attempt=0
-		while [ ${attempt} -lt 30 ]; do
+		while [[ ${attempt} -lt 30 ]]; do
 			address=$(lxc list "$1" --format json |
 				jq --raw-output '.[0].state.network.eth0.addresses | map(select( .family == "inet")) | .[0].address')
 
@@ -109,6 +109,11 @@ run_deploy_manual_lxd() {
 			attempt=$((attempt + 1))
 		done
 
+		if [[ -z ${address} ]]; then
+			echo "Address is empty"
+			exit 1
+		fi
+
 		# shellcheck disable=SC2086
 		eval $addr_result="'${address}'"
 	}
@@ -117,15 +122,18 @@ run_deploy_manual_lxd() {
 	launch_and_wait_addr "${model1}" addr_m1
 	launch_and_wait_addr "${model2}" addr_m2
 
-	mkdir -p "${HOME}/.ssh"
-	touch "${HOME}/.ssh/known_hosts"
+	if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
+		mkdir -p "${HOME}/.ssh"
+		touch "${HOME}/.ssh/known_hosts"
+		chmod 600 "${HOME}/.ssh/known_hosts"
+	fi
 
 	# shellcheck disable=SC2154
 	for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
 		ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
 
 		attempt=0
-		while [ ${attempt} -lt 10 ]; do
+		while [[ ${attempt} -lt 10 ]]; do
 			OUT=$(ssh -T -n -i "${TEST_DIR}/${name}" \
 				-o IdentitiesOnly=yes \
 				-o StrictHostKeyChecking=no \

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -46,7 +46,7 @@ run_spaces_manual_aws() {
 		--filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-${series}-?????-amd64-server-????????" 'Name=state,Values=available' \
 		--query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
 		--output text)
-	if [ -z "${OUT}" ]; then
+	if [[ -z ${OUT} ]]; then
 		echo "No image available: unknown state."
 		exit 1
 	fi
@@ -57,7 +57,7 @@ run_spaces_manual_aws() {
 	# See https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html#default-vpc-components
 	OUT=$(aws ec2 describe-subnets | jq -r '.Subnets[] | select(.DefaultForAz==true) | .SubnetId')
 	len=$(echo "$OUT" | wc -w)
-	if [ "${len}" -ne "3" ]; then
+	if [[ ${len} -ne "3" ]]; then
 		echo "Expected 3 subnets from default VPC; got: ${OUT}"
 		exit 1
 	fi
@@ -65,7 +65,7 @@ run_spaces_manual_aws() {
 
 	# Ensure we have a security group allowing SSH and controller access.
 	OUT=$(aws ec2 describe-security-groups | jq '.SecurityGroups[] | select(.GroupName=="ci-spaces-manual-ssh")' || true)
-	if [ -z "${OUT}" ]; then
+	if [[ -z ${OUT} ]]; then
 		sg_id=$(aws ec2 create-security-group --group-name "ci-spaces-manual-ssh" --description "SSH access for manual spaces test" --query 'GroupId' --output text)
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 22 --cidr 0.0.0.0/0
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 17070 --cidr 0.0.0.0/0

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -32,6 +32,9 @@ launch_and_wait_addr_ec2() {
 }
 
 ensure_valid_ssh_hosts() {
+	mkdir -p "${HOME}/.ssh"
+	touch "${HOME}/.ssh/known_hosts"
+
 	# shellcheck disable=SC2154
 	for addr in "$@"; do
 		ssh-keygen -f "${HOME}/.ssh/known_hosts" -R ubuntu@"${addr}"

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -32,15 +32,18 @@ launch_and_wait_addr_ec2() {
 }
 
 ensure_valid_ssh_hosts() {
-	mkdir -p "${HOME}/.ssh"
-	touch "${HOME}/.ssh/known_hosts"
+	if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
+		mkdir -p "${HOME}/.ssh"
+		touch "${HOME}/.ssh/known_hosts"
+		chmod 600 "${HOME}/.ssh/known_hosts"
+	fi
 
 	# shellcheck disable=SC2154
 	for addr in "$@"; do
 		ssh-keygen -f "${HOME}/.ssh/known_hosts" -R ubuntu@"${addr}"
 
 		attempt=0
-		while [ ${attempt} -lt 10 ]; do
+		while [[ ${attempt} -lt 10 ]]; do
 			OUT=$(ssh -T -n -i ~/.ssh/"${name}".pem \
 				-o IdentitiesOnly=yes \
 				-o StrictHostKeyChecking=no \
@@ -56,7 +59,7 @@ ensure_valid_ssh_hosts() {
 			attempt=$((attempt + 1))
 		done
 
-		if [ "${attempt}" -ge 10 ]; then
+		if [[ ${attempt} -ge 10 ]]; then
 			echo "Failed to add key to ${addr}"
 			exit 1
 		fi
@@ -66,14 +69,14 @@ ensure_valid_ssh_hosts() {
 run_cleanup_deploy_manual_aws() {
 	set +e
 
-	if [ -f "${TEST_DIR}/ec2-instances" ]; then
+	if [[ -f "${TEST_DIR}/ec2-instances" ]]; then
 		echo "====> Cleaning up EC2 instances"
 		while read -r ec2_instance; do
 			aws ec2 terminate-instances --instance-ids="${ec2_instance}" >>"${TEST_DIR}/aws_cleanup"
 		done <"${TEST_DIR}/ec2-instances"
 	fi
 
-	if [ -f "${TEST_DIR}/ec2-key-pairs" ]; then
+	if [[ -f "${TEST_DIR}/ec2-key-pairs" ]]; then
 		echo "====> Cleaning up EC2 key-pairs"
 		while read -r ec2_keypair; do
 			aws ec2 delete-key-pair --key-name="${ec2_keypair}" >>"${TEST_DIR}/aws_cleanup"


### PR DESCRIPTION
The manual deployment integration tests failed due to picking the wrong
charm and series for the machine added.

Changing the charm to one that has generally the most LTS support will
make this test more trustworthy and most likely to work long term.

## QA steps

```sh
(cd tests && ./main.sh manual)
```
