### PR TITLE
Do not attempt downgrades in the upgrade-steps worker

### DIFF
--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/names/v4"
 	pacman "github.com/juju/packaging/manager"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
@@ -25,10 +24,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/addons"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	"github.com/juju/juju/cmd/jujud/agent/agenttest"
-	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
-	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/context"
-	envtesting "github.com/juju/juju/environs/testing"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 
@@ -46,12 +42,6 @@ const (
 	FullAPIExposed       = true
 	RestrictedAPIExposed = false
 )
-
-// TODO(katco): 2016-08-09: lp:1611427
-var ShortAttempt = &utils.AttemptStrategy{
-	Total: time.Second * 10,
-	Delay: time.Millisecond * 200,
-}
 
 type upgradeSuite struct {
 	agenttest.AgentSuite
@@ -155,74 +145,6 @@ func (s *upgradeSuite) TestLoginsDuringUpgrade(c *gc.C) {
 	s.checkLoginToAPIAsUser(c, machine0Conf, FullAPIExposed)
 	c.Assert(canLoginToAPIAsMachine(c, machine0Conf, machine0Conf), jc.IsTrue)
 	c.Assert(canLoginToAPIAsMachine(c, machine1Conf, machine0Conf), jc.IsTrue)
-}
-
-func (s *upgradeSuite) TestDowngradeOnMasterWhenOtherControllerDoesntStartUpgrade(c *gc.C) {
-	coretesting.SkipIfWindowsBug(c, "lp:1446885")
-
-	// This test checks that the master triggers a downgrade if one of
-	// the other controller fails to signal it is ready for upgrade.
-	//
-	// This test is functional, ensuring that the upgrader worker
-	// terminates the machine agent with the UpgradeReadyError which
-	// makes the downgrade happen.
-
-	// Provide (fake) tools so that the upgrader has something to downgrade to.
-	envtesting.AssertUploadFakeToolsVersions(
-		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), s.oldVersion)
-
-	// Create 3 controllers
-	machineA, _ := s.makeStateAgentVersion(c, s.oldVersion)
-	// We're not going to start the agents for machines A or B - we
-	// need to make sure the API port is still set to the one picked
-	// for this machine after we create the other machines.
-	apiPort := s.ControllerConfig.APIPort()
-
-	changes, err := s.State.EnableHA(3, constraints.Value{}, "quantal", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(len(changes.Added), gc.Equals, 2)
-	machineB, _, _ := s.configureMachine(c, changes.Added[0], s.oldVersion)
-	s.configureMachine(c, changes.Added[1], s.oldVersion)
-
-	s.SetControllerConfigAPIPort(c, apiPort)
-
-	// One of the other controllers is ready for upgrade (but machine C isn't).
-	info, err := s.State.EnsureUpgradeInfo(machineB.Id(), s.oldVersion.Number, jujuversion.Current)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Ensure the agent will think it's the master controller.
-	fakeIsMachineMaster := func(*state.StatePool, string) (bool, error) {
-		return true, nil
-	}
-	s.PatchValue(&upgradesteps.IsMachinePrimary, fakeIsMachineMaster)
-
-	// Start the agent
-	agent := s.newAgent(c, machineA)
-	defer agent.Stop()
-	agentDone := make(chan error)
-	ctx := cmdtesting.Context(c)
-	go func() {
-		agentDone <- agent.Run(ctx)
-	}()
-
-	select {
-	case agentErr := <-agentDone:
-		upgradeReadyErr, ok := agentErr.(*agenterrors.UpgradeReadyError)
-		if !ok {
-			c.Fatalf("didn't see UpgradeReadyError, instead got: %v", agentErr)
-		}
-		// Confirm that the downgrade is back to the previous version.
-		current := coretesting.CurrentVersion(c)
-		c.Assert(upgradeReadyErr.OldTools, gc.Equals, current)
-		c.Assert(upgradeReadyErr.NewTools, gc.Equals, s.oldVersion)
-
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("machine agent did not exit as expected")
-	}
-
-	// UpgradeInfo doc should now be archived.
-	err = info.Refresh()
-	c.Assert(err, gc.ErrorMatches, "current upgrade info not found")
 }
 
 // TODO(mjs) - the following should maybe be part of AgentSuite

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -279,19 +279,10 @@ func (w *upgradeSteps) prepareControllerForUpgrade() (*state.UpgradeInfo, error)
 	logger.Infof("waiting for other controllers to be ready for upgrade")
 	if err := w.waitForOtherControllers(info); err != nil {
 		if err == tomb.ErrDying {
-			logger.Warningf(`stopped waiting for other controllers: %v`, err)
+			logger.Warningf("stopped waiting for other controllers: %v", err)
 			return nil, err
 		}
-		logger.Errorf(`aborted wait for other controllers: %v`, err)
-		// If primary, trigger a rollback to the previous agent version.
-		if w.isPrimary {
-			logger.Errorf("downgrading model agent version to %v due to aborted upgrade",
-				w.fromVersion)
-			if rollbackErr := st.SetModelAgentVersion(w.fromVersion, true); rollbackErr != nil {
-				logger.Errorf("rollback failed: %v", rollbackErr)
-				return nil, errors.Annotate(rollbackErr, "failed to roll back desired agent version")
-			}
-		}
+		logger.Errorf("aborted wait for other controllers: %v", err)
 		return nil, errors.Annotate(err, "aborted wait for other controllers")
 	}
 	if w.isPrimary {

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -261,7 +261,7 @@ func (s *UpgradeSuite) TestAPIConnectionFailure(c *gc.C) {
 	c.Assert(doneLock.IsUnlocked(), jc.IsFalse)
 }
 
-func (s *UpgradeSuite) TestAbortWhenOtherControllerDoesntStartUpgrade(c *gc.C) {
+func (s *UpgradeSuite) TestAbortWhenOtherControllerDoesNotStartUpgrade(c *gc.C) {
 	// This test checks when a controller is upgrading and one of
 	// the other controllers doesn't signal it is ready in time.
 


### PR DESCRIPTION
Historically, when all upgrade logic was in the `upgradesteps` worker, we would downgrade the agent version if we could not coordinate readiness across controllers in a HA plane.

Since we split out the `upgradedatabase` worker to execute Mongo-based upgrade steps, and execute those before other upgrade steps, we can no longer guarantee that we have a state that is compatible with the old version.

Here we remove the downgrade logic so that an error leaves the controllers in a semi-suspended state, relying on user intervention to proceed.

## QA steps

Check for regression:
- Bootstrap a 2.8 controller.
- `juju enable-ha`.
- Upgrade the controller using this patch and `--build-agent`.

## Documentation changes

None.

## Bug reference

N/A
