### PR TITLE
Fix display of scale and workload version in status

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1172,8 +1172,8 @@ func paramsJobsFromJobs(jobs []state.MachineJob) []model.MachineJob {
 
 func (context *statusContext) processApplications() map[string]params.ApplicationStatus {
 	applicationsMap := make(map[string]params.ApplicationStatus)
-	for _, s := range context.allAppsUnitsCharmBindings.applications {
-		applicationsMap[s.Name()] = context.processApplication(s)
+	for _, app := range context.allAppsUnitsCharmBindings.applications {
+		applicationsMap[app.Name()] = context.processApplication(app)
 	}
 	return applicationsMap
 }
@@ -1300,17 +1300,17 @@ func (context *statusContext) processApplication(application *state.Application)
 				processedStatus.WorkloadVersion = spec.Containers[0].Image
 			}
 		}
-		serviceInfo, err := application.ServiceInfo()
-		if err == nil {
-			processedStatus.ProviderId = serviceInfo.ProviderId()
-			if len(serviceInfo.Addresses()) > 0 {
-				processedStatus.PublicAddress = serviceInfo.Addresses()[0].Value
-			}
-		} else {
-			logger.Debugf("no service details for %v: %v", application.Name(), err)
-		}
-		processedStatus.Scale = application.GetScale()
 	}
+	serviceInfo, err := application.ServiceInfo()
+	if err == nil {
+		processedStatus.ProviderId = serviceInfo.ProviderId()
+		if len(serviceInfo.Addresses()) > 0 {
+			processedStatus.PublicAddress = serviceInfo.Addresses()[0].Value
+		}
+	} else {
+		logger.Debugf("no service details for %v: %v", application.Name(), err)
+	}
+	processedStatus.Scale = application.GetScale()
 	processedStatus.EndpointBindings = context.allAppsUnitsCharmBindings.endpointBindings[application.Name()]
 	return processedStatus
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -1049,6 +1049,8 @@ func (s *CAASStatusSuite) TestStatusWorkloadVersionSetByCharm(c *gc.C) {
 	client := s.APIState.Client()
 	err := s.app.SetOperatorStatus(status.StatusInfo{Status: status.Active})
 	c.Assert(err, jc.ErrorIsNil)
+	err = s.app.SetScale(1, 1, true)
+	c.Assert(err, jc.ErrorIsNil)
 	u, err := s.app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u, gc.HasLen, 1)
@@ -1057,7 +1059,9 @@ func (s *CAASStatusSuite) TestStatusWorkloadVersionSetByCharm(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status.Applications, gc.HasLen, 1)
-	c.Assert(status.Applications[s.app.Name()].WorkloadVersion, gc.Equals, "666")
+	app := status.Applications[s.app.Name()]
+	c.Assert(app.WorkloadVersion, gc.Equals, "666")
+	c.Assert(app.Scale, gc.Equals, 1)
 }
 
 type filteringBranchesSuite struct {

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/core/instance"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/names/v4"
 )
@@ -267,7 +268,7 @@ func (s *formattedStatus) applicationScale(name string) (string, bool) {
 			match(u)
 		}
 	}
-	if s.Model.Type == "caas" {
+	if s.Model.Type == string(coremodel.CAAS) {
 		desiredUnitCount = app.Scale
 	}
 	if currentUnitCount == desiredUnitCount {

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -122,18 +122,18 @@ func (sf *statusFormatter) format() (formattedStatus, error) {
 	// branch ref numbers provided the map of active branches does not
 	// change.
 	i := 1
-	for _, sn := range naturalsort.Sort(stringKeysFromMap(sf.status.Branches)) {
-		s := sf.status.Branches[sn]
-		isActiveBranch := sn == sf.activeBranch
-		out.Branches[sn] = sf.formatBranch(i, s, isActiveBranch)
+	for _, name := range naturalsort.Sort(stringKeysFromMap(sf.status.Branches)) {
+		s := sf.status.Branches[name]
+		isActiveBranch := name == sf.activeBranch
+		out.Branches[name] = sf.formatBranch(i, s, isActiveBranch)
 		i += 1
 	}
 	sf.formattedBranches = out.Branches
-	for sn, s := range sf.status.Applications {
-		out.Applications[sn] = sf.formatApplication(sn, s)
+	for name, app := range sf.status.Applications {
+		out.Applications[name] = sf.formatApplication(name, app)
 	}
-	for sn, s := range sf.status.RemoteApplications {
-		out.RemoteApplications[sn] = sf.formatRemoteApplication(sn, s)
+	for name, app := range sf.status.RemoteApplications {
+		out.RemoteApplications[name] = sf.formatRemoteApplication(name, app)
 	}
 	for name, offer := range sf.status.Offers {
 		out.Offers[name] = sf.formatOffer(name, offer)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -140,7 +140,8 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	tw.SetColumnAlignRight(7)
 	for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
 		app := fs.Applications[appName]
-		version := app.Version
+		// Workload version might be multi-line; we only want the first line for tabular.
+		version := strings.Split(app.Version, "\n")[0]
 		// CAAS versions may have repo prefix we don't care about.
 		if fs.Model.Type == caasModelType && version != "" {
 			ref, err := reference.ParseNamed(version)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5113,7 +5113,7 @@ func (s *StatusSuite) prepareTabularData(c *gc.C) *context {
 		setAgentStatus{"logging/1", status.Error, "somehow lost in all those logs", nil},
 		setUnitWorkloadVersion{"logging/1", "a bit too long, really"},
 		setUnitWorkloadVersion{"wordpress/0", "4.5.3"},
-		setUnitWorkloadVersion{"mysql/0", "5.7.13"},
+		setUnitWorkloadVersion{"mysql/0", "5.7.13\nanother"},
 		setUnitAsLeader{"mysql/0"},
 		setUnitAsLeader{"logging/1"},
 		setUnitAsLeader{"wordpress/0"},


### PR DESCRIPTION
After workload version is set by the charm, juju status was not setting the scale to display due to a logic error.
Also, if the charm sent in a workload version with a "\n", this messed up status.

Also some drive by fixes for variable names (yet more fallout from rename of service->application).

## QA steps

juju bootstrap k8s
juju deploy redis-k8s --channel=edge
juju status

## Bug reference

https://bugs.launchpad.net/bugs/1930444
https://bugs.launchpad.net/bugs/1930612
