### PR TITLE
Report service address for sidecar k8s charms

### DIFF
--- a/caas/application.go
+++ b/caas/application.go
@@ -33,7 +33,11 @@ type Application interface {
 	Trust(bool) error
 
 	State() (ApplicationState, error)
+
+	// Units of the application fetched from kubernetes by matching pod labels.
 	Units() ([]Unit, error)
+	// Service returns the service associated with the application.
+	Service() (*Service, error)
 
 	// Upgrade upgrades the app to the specified version.
 	Upgrade(version.Number) error

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -51,7 +51,6 @@ import (
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -546,69 +545,6 @@ func (k *kubernetesClient) getStorageClass(name string) (*storagev1.StorageClass
 	return storageClasses.Get(context.TODO(), name, v1.GetOptions{})
 }
 
-func getLoadBalancerAddresses(svc *core.Service) []string {
-	// different cloud providers have a different way to report back the Load Balancer address.
-	// This covers the cases we know about so far.
-	var addr []string
-	lpAdd := svc.Spec.LoadBalancerIP
-	if lpAdd != "" {
-		addr = append(addr, lpAdd)
-	}
-
-	ing := svc.Status.LoadBalancer.Ingress
-	if len(ing) == 0 {
-		return addr
-	}
-
-	for _, ingressAddr := range ing {
-		if ingressAddr.IP != "" {
-			addr = append(addr, ingressAddr.IP)
-		}
-		if ingressAddr.Hostname != "" {
-			addr = append(addr, ingressAddr.Hostname)
-		}
-	}
-	return addr
-}
-
-func getSvcAddresses(svc *core.Service, includeClusterIP bool) []network.ProviderAddress {
-	var netAddrs []network.ProviderAddress
-
-	addressExist := func(addr string) bool {
-		for _, v := range netAddrs {
-			if addr == v.Value {
-				return true
-			}
-		}
-		return false
-	}
-	appendUniqueAddrs := func(scope network.Scope, addrs ...string) {
-		for _, v := range addrs {
-			if v != "" && v != "None" && !addressExist(v) {
-				netAddrs = append(netAddrs, network.NewProviderAddress(v, network.WithScope(scope)))
-			}
-		}
-	}
-
-	t := svc.Spec.Type
-	clusterIP := svc.Spec.ClusterIP
-	switch t {
-	case core.ServiceTypeClusterIP:
-		appendUniqueAddrs(network.ScopeCloudLocal, clusterIP)
-	case core.ServiceTypeExternalName:
-		appendUniqueAddrs(network.ScopePublic, svc.Spec.ExternalName)
-	case core.ServiceTypeNodePort:
-		appendUniqueAddrs(network.ScopePublic, svc.Spec.ExternalIPs...)
-	case core.ServiceTypeLoadBalancer:
-		appendUniqueAddrs(network.ScopePublic, getLoadBalancerAddresses(svc)...)
-	}
-	if includeClusterIP {
-		// append clusterIP as a fixed internal address.
-		appendUniqueAddrs(network.ScopeCloudLocal, clusterIP)
-	}
-	return netAddrs
-}
-
 // GetService returns the service for the specified application.
 func (k *kubernetesClient) GetService(appName string, mode caas.DeploymentMode, includeClusterIP bool) (*caas.Service, error) {
 	services := k.client().CoreV1().Services(k.namespace)
@@ -641,7 +577,7 @@ func (k *kubernetesClient) GetService(appName string, mode caas.DeploymentMode, 
 		}
 		if svc != nil {
 			result.Id = string(svc.GetUID())
-			result.Addresses = getSvcAddresses(svc, includeClusterIP)
+			result.Addresses = utils.GetSvcAddresses(svc, includeClusterIP)
 		}
 	}
 

--- a/caas/kubernetes/provider/utils/address.go
+++ b/caas/kubernetes/provider/utils/address.go
@@ -1,0 +1,74 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	core "k8s.io/api/core/v1"
+
+	"github.com/juju/juju/core/network"
+)
+
+// GetSvcAddresses returns the network addresses for the given service.
+func GetSvcAddresses(svc *core.Service, includeClusterIP bool) []network.ProviderAddress {
+	var netAddrs []network.ProviderAddress
+
+	addressExist := func(addr string) bool {
+		for _, v := range netAddrs {
+			if addr == v.Value {
+				return true
+			}
+		}
+		return false
+	}
+	appendUniqueAddrs := func(scope network.Scope, addrs ...string) {
+		for _, v := range addrs {
+			if v != "" && v != "None" && !addressExist(v) {
+				netAddrs = append(netAddrs, network.NewProviderAddress(v, network.WithScope(scope)))
+			}
+		}
+	}
+
+	t := svc.Spec.Type
+	clusterIP := svc.Spec.ClusterIP
+	switch t {
+	case core.ServiceTypeClusterIP:
+		appendUniqueAddrs(network.ScopeCloudLocal, clusterIP)
+	case core.ServiceTypeExternalName:
+		appendUniqueAddrs(network.ScopePublic, svc.Spec.ExternalName)
+	case core.ServiceTypeNodePort:
+		appendUniqueAddrs(network.ScopePublic, svc.Spec.ExternalIPs...)
+	case core.ServiceTypeLoadBalancer:
+		appendUniqueAddrs(network.ScopePublic, getLoadBalancerAddresses(svc)...)
+	}
+	if includeClusterIP {
+		// append clusterIP as a fixed internal address.
+		appendUniqueAddrs(network.ScopeCloudLocal, clusterIP)
+	}
+	return netAddrs
+}
+
+func getLoadBalancerAddresses(svc *core.Service) []string {
+	// different cloud providers have a different way to report back the Load Balancer address.
+	// This covers the cases we know about so far.
+	var addr []string
+	lpAdd := svc.Spec.LoadBalancerIP
+	if lpAdd != "" {
+		addr = append(addr, lpAdd)
+	}
+
+	ing := svc.Status.LoadBalancer.Ingress
+	if len(ing) == 0 {
+		return addr
+	}
+
+	for _, ingressAddr := range ing {
+		if ingressAddr.IP != "" {
+			addr = append(addr, ingressAddr.IP)
+		}
+		if ingressAddr.Hostname != "" {
+			addr = append(addr, ingressAddr.Hostname)
+		}
+	}
+	return addr
+}

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -92,6 +92,21 @@ func (mr *MockApplicationMockRecorder) Scale(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scale", reflect.TypeOf((*MockApplication)(nil).Scale), arg0)
 }
 
+// Service mocks base method
+func (m *MockApplication) Service() (*caas.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Service")
+	ret0, _ := ret[0].(*caas.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Service indicates an expected call of Service
+func (mr *MockApplicationMockRecorder) Service() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockApplication)(nil).Service))
+}
+
 // State mocks base method
 func (m *MockApplication) State() (caas.ApplicationState, error) {
 	m.ctrl.T.Helper()

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/caas"
 	caasmocks "github.com/juju/juju/caas/mocks"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -189,6 +191,17 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 				Replicas:        []string{"test-0"},
 			}, nil
 		}),
+		brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+			return &caas.Service{
+				Id:        "deadbeef",
+				Addresses: network.NewProviderAddresses("10.6.6.6"),
+			}, nil
+		}),
+		unitFacade.EXPECT().UpdateApplicationService(params.UpdateApplicationServiceArg{
+			ApplicationTag: "application-test",
+			ProviderId:     "deadbeef",
+			Addresses:      params.FromProviderAddresses(network.NewProviderAddress("10.6.6.6")),
+		}).Return(nil),
 		facade.EXPECT().GarbageCollect("test", []names.Tag{names.NewUnitTag("test/0")}, 1, []string{"test-0"}, false).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
 			return nil
 		}),
@@ -281,6 +294,17 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 				Replicas:        []string(nil),
 			}, nil
 		}),
+		brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+			return &caas.Service{
+				Id:        "deadbeef",
+				Addresses: network.NewProviderAddresses("10.6.6.6"),
+			}, nil
+		}),
+		unitFacade.EXPECT().UpdateApplicationService(params.UpdateApplicationServiceArg{
+			ApplicationTag: "application-test",
+			ProviderId:     "deadbeef",
+			Addresses:      params.FromProviderAddresses(network.NewProviderAddress("10.6.6.6")),
+		}).Return(nil),
 		facade.EXPECT().GarbageCollect("test", []names.Tag{names.NewUnitTag("test/0")}, 0, []string(nil), false).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
 			notifyReady <- struct{}{}
 			return nil
@@ -328,6 +352,9 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 				DesiredReplicas: 0,
 				Replicas:        []string(nil),
 			}, nil
+		}),
+		brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+			return nil, errors.NotFoundf("test")
 		}),
 		facade.EXPECT().GarbageCollect("test", []names.Tag(nil), 0, []string(nil), true).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
 			close(done)

--- a/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	params "github.com/juju/juju/apiserver/params"
 	watcher "github.com/juju/juju/core/watcher"
 	reflect "reflect"
 )
@@ -61,6 +62,20 @@ func (m *MockCAASUnitProvisionerFacade) ApplicationTrust(arg0 string) (bool, err
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationTrust(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTrust", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationTrust), arg0)
+}
+
+// UpdateApplicationService mocks base method
+func (m *MockCAASUnitProvisionerFacade) UpdateApplicationService(arg0 params.UpdateApplicationServiceArg) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateApplicationService", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateApplicationService indicates an expected call of UpdateApplicationService
+func (mr *MockCAASUnitProvisionerFacadeMockRecorder) UpdateApplicationService(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplicationService", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).UpdateApplicationService), arg0)
 }
 
 // WatchApplicationScale mocks base method

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -34,6 +34,7 @@ type CAASUnitProvisionerFacade interface {
 	WatchApplicationScale(string) (watcher.NotifyWatcher, error)
 	ApplicationTrust(string) (bool, error)
 	WatchApplicationTrustHash(string) (watcher.StringsWatcher, error)
+	UpdateApplicationService(arg params.UpdateApplicationServiceArg) error
 }
 
 // CAASProvisionerFacade exposes CAAS provisioning functionality to a worker.


### PR DESCRIPTION
When a sidecar k8s charm is deployed, ensure that the ip address of the service and also the service status are reported back to juju so these are properly recorded in the juju model.

## QA steps

juju bootstrap microk8s
juju deploy snappass-test
juju status

there will now be an application address in status after the k8s service has been created


## Bug reference

https://bugs.launchpad.net/bugs/1930649
