### PR TITLE
Update pre-upgrade-steps function signature

### DIFF
--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -77,7 +78,7 @@ type manifoldsConfig struct {
 	// PreUpgradeSteps is a function that is used by the upgradesteps
 	// worker to ensure that conditions are OK for an upgrade to
 	// proceed.
-	PreUpgradeSteps func(*state.StatePool, coreagent.Config, bool, bool, bool) error
+	PreUpgradeSteps upgrades.PreUpgradeStepsFunc
 
 	// PrometheusRegisterer is a prometheus.Registerer that may be used
 	// by workers to register Prometheus metric collectors.

--- a/cmd/jujud/agent/caasoperator/manifolds.go
+++ b/cmd/jujud/agent/caasoperator/manifolds.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/utils/proxy"
 	"github.com/juju/juju/worker/agent"
 	"github.com/juju/juju/worker/apiaddressupdater"
@@ -86,7 +87,7 @@ type ManifoldsConfig struct {
 	// PreUpgradeSteps is a function that is used by the upgradesteps
 	// worker to ensure that conditions are OK for an upgrade to
 	// proceed.
-	PreUpgradeSteps func(*state.StatePool, coreagent.Config, bool, bool, bool) error
+	PreUpgradeSteps upgrades.PreUpgradeStepsFunc
 
 	// MachineLock is a central source for acquiring the machine lock.
 	// This is used by a number of workers to ensure serialisation of actions

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/core/raftlease"
 	"github.com/juju/juju/pubsub/lease"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/upgrades"
 	proxyconfig "github.com/juju/juju/utils/proxy"
 	jworker "github.com/juju/juju/worker"
 	"github.com/juju/juju/worker/agent"
@@ -165,7 +166,7 @@ type ManifoldsConfig struct {
 	// PreUpgradeSteps is a function that is used by the upgradesteps
 	// worker to ensure that conditions are OK for an upgrade to
 	// proceed.
-	PreUpgradeSteps func(*state.StatePool, coreagent.Config, bool, bool, bool) error
+	PreUpgradeSteps upgrades.PreUpgradeStepsFunc
 
 	// LogSource defines the channel type used to send log message
 	// structs within the machine agent.

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -171,7 +171,7 @@ func NewTestMachineAgentFactory(
 	bufferedLogger *logsender.BufferedLogWriter,
 	rootDir string,
 ) machineAgentFactoryFnType {
-	preUpgradeSteps := func(_ *state.StatePool, _ agent.Config, isController, isMaster, isCaas bool) error {
+	preUpgradeSteps := func(_ *state.StatePool, _ agent.Config, isController, isCaas bool) error {
 		return nil
 	}
 	return func(agentTag names.Tag, isCAAS bool) (*MachineAgent, error) {

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -165,7 +165,7 @@ func (s *upgradeSuite) newAgent(c *gc.C, m *state.Machine) *agentcmd.MachineAgen
 	return a
 }
 
-func noPreUpgradeSteps(_ *state.StatePool, _ agent.Config, isController, isMaster, isCaas bool) error {
+func noPreUpgradeSteps(_ *state.StatePool, _ agent.Config, isController, isCaas bool) error {
 	return nil
 }
 

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -17,11 +17,11 @@ import (
 // PreUpgradeStepsFunc is the function type of PreUpgradeSteps. This may be
 // used to provide an alternative to PreUpgradeSteps to the upgrade steps
 // worker.
-type PreUpgradeStepsFunc func(_ *state.StatePool, _ agent.Config, isController, isMaster, isCaas bool) error
+type PreUpgradeStepsFunc = func(_ *state.StatePool, _ agent.Config, isController, isCaas bool) error
 
 // PreUpgradeSteps runs various checks and prepares for performing an upgrade.
 // If any check fails, an error is returned which aborts the upgrade.
-func PreUpgradeSteps(_ *state.StatePool, agentConf agent.Config, isController, isMaster, isCaas bool) error {
+func PreUpgradeSteps(_ *state.StatePool, agentConf agent.Config, isController, isCaas bool) error {
 	if isCaas {
 		logger.Debugf("skipping disk space checks for k8s controllers")
 		return nil

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -24,7 +24,7 @@ var _ = gc.Suite(&preupgradechecksSuite{})
 func (s *preupgradechecksSuite) TestCheckFreeDiskSpace(c *gc.C) {
 	// Expect an impossibly large amount of free disk.
 	s.PatchValue(&upgrades.MinDiskSpaceMib, uint64(humanize.PiByte/humanize.MiByte))
-	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false, false, false)
+	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, false, false)
 	c.Assert(err, gc.ErrorMatches, `not enough free disk space on "/" for upgrade: .* available, require 1073741824MiB`)
 }
 
@@ -36,7 +36,7 @@ func (s *preupgradechecksSuite) TestUpdateDistroInfo(c *gc.C) {
 	}
 
 	commandChan := s.HookCommandOutput(&pkgmgr.CommandOutput, nil, nil)
-	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, true, false, false)
+	err := upgrades.PreUpgradeSteps(nil, &mockAgentConfig{dataDir: "/"}, true, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var commands []*exec.Cmd

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -253,6 +253,7 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 	s.patchVersion(newTools.Version)
 	err := envtools.MergeAndWriteMetadata(stor, "released", "released", coretools.List{newTools}, envtools.DoNotWriteMirrors)
 	c.Assert(err, jc.ErrorIsNil)
+
 	ugErr := &agenterrors.UpgradeReadyError{
 		AgentName: "anAgent",
 		OldTools:  oldTools.Version,
@@ -261,6 +262,7 @@ func (s *UpgraderSuite) TestChangeAgentTools(c *gc.C) {
 	}
 	err = ugErr.ChangeAgentTools(loggo.GetLogger("test"))
 	c.Assert(err, jc.ErrorIsNil)
+
 	target := agenttools.ToolsDir(s.DataDir(), newToolsBinary)
 	link, err := symlink.Read(agenttools.ToolsDir(s.DataDir(), "anAgent"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/upgradesteps/manifold.go
+++ b/worker/upgradesteps/manifold.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api"
 	apiagent "github.com/juju/juju/api/agent"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/worker/gate"
 )
 
@@ -23,7 +24,7 @@ type ManifoldConfig struct {
 	APICallerName        string
 	UpgradeStepsGateName string
 	OpenStateForUpgrade  func() (*state.StatePool, error)
-	PreUpgradeSteps      func(*state.StatePool, agent.Config, bool, bool, bool) error
+	PreUpgradeSteps      upgrades.PreUpgradeStepsFunc
 	NewAgentStatusSetter func(apiConn api.Connection) (StatusSetter, error)
 }
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -430,7 +430,7 @@ func (s *UpgradeSuite) openStateForUpgrade() (*state.StatePool, error) {
 	return pool, nil
 }
 
-func (s *UpgradeSuite) preUpgradeSteps(pool *state.StatePool, agentConf agent.Config, isController, isMaster, isCaas bool) error {
+func (s *UpgradeSuite) preUpgradeSteps(pool *state.StatePool, agentConf agent.Config, isController, isCaas bool) error {
 	if s.preUpgradeError {
 		return errors.New("preupgrade error")
 	}


### PR DESCRIPTION
Here, we remove the unused `isMaster` argument from the function signature. The function is changed from a type to a type alias, which is what it is used as.

All sites declaring an explicit function signature type now use the type alias.

## QA steps

No functional changes - unit tests pass.

## Documentation changes

None.

## Bug reference

N/A
