### PR TITLE
Integration tests: Server IP address

### DIFF
--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -9,6 +9,10 @@ start_server() {
 		SERVER_PID=$!
 
 		echo "${SERVER_PID}" >"${TEST_DIR}/server.pid"
+
+		# Sleep to ensure the python server is up and running correctly, as it's
+		# a daemon service (&) we can't actually see if it's up easily.
+		sleep 5
 	)
 }
 

--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -15,13 +15,22 @@ run_simplestream_metadata() {
 	add_clean_func "kill_server"
 	start_server "./tests/suites/bootstrap/streams/tools"
 
-	ip_address=$(ip -4 -o addr show scope global | awk '{gsub(/\/.*/,"",$4); print $4}' | head -n 1)
+	# Find a routable address to the server that isn't the loopback address.
+	# Unfortunately, you can't cleanly look at the addresses and select the
+	# right one.
+	addresses=$(hostname -I)
+	server_address=""
+	for address in $(echo "${addresses}" | tr ' ' '\n'); do
+		# shellcheck disable=SC2015
+		curl "http://${address}:8666" >/dev/null 2>&1 && server_address="${address}" && break || true
+	done
 
 	name="test-bootstrap-stream"
 
 	file="${TEST_DIR}/test-bootstrap-stream.log"
 	juju bootstrap "lxd" "${name}" \
-		--config agent-metadata-url="http://${ip_address}:8666/" \
+		--show-log \
+		--config agent-metadata-url="http://${server_address}:8666/" \
 		--config test-mode=true \
 		--agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"


### PR DESCRIPTION
The server IP address for the metadata service has to be routable, but
not the loopback one to work in every scenario. In this case we just
make this more robust by iterating over the `hostname -I` command and
finding the first one that works correctly.

This should be enough for juju to correctly bootstrap from a local file
system.


## QA steps

```sh
(cd tests && ./main.sh bootstrap)
```
