### PR TITLE
add centos8 to deploy integration test

### DIFF
--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -11,7 +11,12 @@ test_deploy_os() {
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"ec2" | "aws")
-			run "run_deploy_centos"
+		#
+		# A handy place to find the current AMIs for centos
+		# https://wiki.centos.org/Cloud/AWS
+		#
+			run "run_deploy_centos7"
+			run "run_deploy_centos8"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_centos - tests for AWS only"
@@ -20,13 +25,13 @@ test_deploy_os() {
 	)
 }
 
-run_deploy_centos() {
+run_deploy_centos7() {
 	echo
 
 	echo "==> Checking for dependencies"
 	check_juju_dependencies metadata
 
-	name="test-deploy-centos"
+	name="test-deploy-centos7"
 	file="${TEST_DIR}/${name}.log"
 
 	ensure "${name}" "${file}"
@@ -53,4 +58,35 @@ run_deploy_centos() {
 
 	destroy_model "${name}"
 	destroy_model "test-deploy-centos-west2"
+}
+
+run_deploy_centos8() {
+	echo
+
+	echo "==> Checking for dependencies"
+	check_juju_dependencies metadata
+
+	name="test-deploy-centos8"
+	file="${TEST_DIR}/${name}.log"
+
+	ensure "${name}" "${file}"
+
+	#
+	# Images have been setup and and subscribed for juju-qa aws
+	# in us-east-1.  Take care editing the details.
+	#
+	juju metadata add-image --series centos8 ami-0d6e9a57f6259ba3a
+
+	#
+	# The disk size must be >= 10G to cover the image above.
+	# Ensure we use an instance with enough disk space.
+	#
+	juju deploy ./tests/suites/deploy/charms/centos-dummy-sink --series centos8 --constraints root-disk=10G
+
+	series=$(juju status --format=json | jq '.applications."dummy-sink".series')
+	echo "$series" | check "centos8"
+
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
+
+	destroy_model "${name}"
 }


### PR DESCRIPTION
Centos deploys seem to need special cases with instances or disk space.

## QA steps

The test will fail: https://bugs.launchpad.net/juju/+bug/1931157
However a machine should be created.

```sh
(cd tests ; ./main.sh -v  deploy test_deploy_os )
```

