### PR TITLE
Remove churn deploying bundles with default config values

### DIFF
--- a/cmd/juju/application/bundle.go
+++ b/cmd/juju/application/bundle.go
@@ -1518,7 +1518,7 @@ func applicationConfigValue(key string, valueMap interface{}) (interface{}, erro
 	if !found {
 		return nil, errors.Errorf("missing application config value 'source' for key %q", key)
 	}
-	if source != "user" {
+	if source == "unset" {
 		return nil, nil
 	}
 	value, found := vm["value"]

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -400,9 +400,10 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	})
 
 	add(&multiwatcher.CharmInfo{
-		ModelUUID: modelUUID,
-		CharmURL:  applicationCharmURL(mysql).String(),
-		Life:      life.Alive,
+		ModelUUID:     modelUUID,
+		CharmURL:      applicationCharmURL(mysql).String(),
+		Life:          life.Alive,
+		DefaultConfig: map[string]interface{}{"dataset-size": "80%"},
 	})
 
 	// Set up a remote application related to the offer.

--- a/testcharms/charm-repo/bionic/mysql/config.yaml
+++ b/testcharms/charm-repo/bionic/mysql/config.yaml
@@ -1,0 +1,5 @@
+options:
+  dataset-size:
+    default: '80%'
+    description: How much data do you want to keep in memory in the DB.
+    type: string

--- a/testcharms/charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/testcharms/charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -5,5 +5,7 @@ services:
     mysql:
         charm: mysql
         num_units: 1
+        options:
+            dataset-size: 80%
 relations:
     - ["wordpress:db", "mysql:server"]

--- a/testcharms/charm-repo/quantal/mysql/config.yaml
+++ b/testcharms/charm-repo/quantal/mysql/config.yaml
@@ -1,0 +1,5 @@
+options:
+  dataset-size:
+    default: '80%'
+    description: How much data do you want to keep in memory in the DB.
+    type: string


### PR DESCRIPTION
When deploying over the top of an existing model a bundle that contains charm config values set to the charm default, juju would claim that config had changed when it hadn't. Any default charm values were being removed from the model representation to compare, instead of unset values.

## QA steps

juju deploy a simple bundle with a config option set to the charm default
```
applications:
    mariadb:
        charm: cs:mariadb
        num_units: 1
        options:
          dataset-size: 50%
```
`juju export-bundle --filename foo.yaml`
`juju deploy ./foo.yaml --verbose --dry-run --map-machines existing`

There should be no changes printed.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929908
