### PR TITLE
Upgrade-steps worker does not care about controller primary-vs-secondary

### DIFF
--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -65,8 +65,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.oldVersion.Minor = 1
 
 	// Don't wait so long in tests.
-	s.PatchValue(&upgradesteps.UpgradeStartTimeoutPrimary, time.Millisecond*50)
-	s.PatchValue(&upgradesteps.UpgradeStartTimeoutSecondary, time.Millisecond*60)
+	s.PatchValue(&upgradesteps.UpgradeStartTimeoutController, time.Millisecond*50)
 
 	// Ensure we don't fail disk space check.
 	s.PatchValue(&upgrades.MinDiskSpaceMib, uint64(0))

--- a/state/database.go
+++ b/state/database.go
@@ -71,7 +71,7 @@ type Database interface {
 	// used in almost all cases.
 	GetRawCollection(name string) (*mgo.Collection, SessionCloser)
 
-	// TransactionRunner() returns a runner responsible for making changes to
+	// TransactionRunner returns a runner responsible for making changes to
 	// the database, and a func that must be called when the runner is no longer
 	// needed. The returned Runner might or might not have its own session,
 	// depending on the Database; the closer must always be called regardless.
@@ -86,7 +86,7 @@ type Database interface {
 	// transaction.
 	RunTransaction(ops []txn.Op) error
 
-	// RunTransaction is a convenience method for running a single
+	// RunTransactionFor is a convenience method for running a single
 	// transaction for the model specified.
 	RunTransactionFor(modelUUID string, ops []txn.Op) error
 
@@ -143,7 +143,7 @@ func Apply(db Database, change Change) error {
 	return nil
 }
 
-// collectionInfo describes important features of a collection.
+// CollectionInfo describes important features of a collection.
 type CollectionInfo struct {
 
 	// explicitCreate, if non-nil, will cause the collection to be explicitly
@@ -178,7 +178,7 @@ type CollectionInfo struct {
 	rawAccess bool
 }
 
-// collectionSchema defines the set of collections used in juju.
+// CollectionSchema defines the set of collections used in juju.
 type CollectionSchema map[string]CollectionInfo
 
 // Create causes all recorded collections to be created and indexed as specified

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -264,12 +264,7 @@ func (info *UpgradeInfo) SetStatus(status UpgradeStatus) error {
 		return append(ops, extraOps...), nil
 	}
 
-	err := info.st.db().Run(buildTxn)
-	if err == txn.ErrAborted {
-		return errors.Errorf("cannot set upgrade status to %q: Another "+
-			"status change may have occurred concurrently", status)
-	}
-	return errors.Annotate(err, "setting upgrade status")
+	return errors.Annotatef(info.st.db().Run(buildTxn), "setting upgrade status to %q", status)
 }
 
 // EnsureUpgradeInfo returns an UpgradeInfo describing a current upgrade between the

--- a/worker/upgradedatabase/worker.go
+++ b/worker/upgradedatabase/worker.go
@@ -284,11 +284,11 @@ func (w *upgradeDB) watchUpgrade() {
 	}
 
 	for {
-		// If the primary has already run the database steps then the status will
-		// be "db-complete", however if it has finished all its upgrade steps, the status
-		// will be "finishing". We need to check against both of these statuses.
+		// If the primary has already run the database steps then the status
+		// will be "db-complete", however it may have progressed further on to
+		// upgrade steps, so we check for that status too.
 		switch w.upgradeInfo.Status() {
-		case state.UpgradeDBComplete, state.UpgradeFinishing:
+		case state.UpgradeDBComplete, state.UpgradeRunning:
 			w.logger.Infof("finished waiting - database upgrade steps completed on mongodb primary")
 			w.setStatus(status.Started, fmt.Sprintf("confirmed primary database upgrade for %v", w.toVersion))
 			w.upgradeComplete.Unlock()

--- a/worker/upgradedatabase/worker_test.go
+++ b/worker/upgradedatabase/worker_test.go
@@ -210,7 +210,7 @@ func (s *workerSuite) TestNotPrimaryWatchForCompletionSuccess(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *workerSuite) TestNotPrimaryWatchForCompletionSuccessFinishing(c *gc.C) {
+func (s *workerSuite) TestNotPrimaryWatchForCompletionSuccessRunning(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.ignoreLogging(c)
 
@@ -229,8 +229,9 @@ func (s *workerSuite) TestNotPrimaryWatchForCompletionSuccessFinishing(c *gc.C) 
 	// Initial state is UpgradePending
 	s.upgradeInfo.EXPECT().Refresh().Return(nil).MinTimes(1)
 	s.upgradeInfo.EXPECT().Status().Return(state.UpgradePending)
-	// After the first change is retrieved from the channel above, we then say the upgrade is complete
-	s.upgradeInfo.EXPECT().Status().Return(state.UpgradeFinishing)
+	// After the first change is retrieved from the channel above,
+	// we then say the upgrade has moved on to running (non-db) steps.
+	s.upgradeInfo.EXPECT().Status().Return(state.UpgradeRunning)
 
 	s.pool.EXPECT().SetStatus("0", status.Started, statusConfirmed)
 

--- a/worker/upgradesteps/worker.go
+++ b/worker/upgradesteps/worker.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/api"
 	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
@@ -30,27 +29,15 @@ import (
 var logger = loggo.GetLogger("juju.worker.upgradesteps")
 
 // TODO (manadart 2021-05-18): These are exported for tests and in the case of
-// the timeouts, for feature tests. Those especially should dependencies of the
+// the timeout, for feature tests. That especially should be a dependency of the
 // worker.
 var (
 	PerformUpgrade = upgrades.PerformUpgrade
 
-	// UpgradeStartTimeoutPrimary the maximum time a primary controller will
-	// wait for other controllers to come up and indicate they are ready to
-	// begin running upgrade steps.
-	UpgradeStartTimeoutPrimary = time.Minute * 15
-
-	// UpgradeStartTimeoutSecondary is the maximum time a secondary controller
-	// will wait for other controllers to come up and indicate they are ready
+	// UpgradeStartTimeoutController the maximum time a controller will
+	// wait for other controllers to come up and indicate they are ready
 	// to begin running upgrade steps.
-	//
-	// This is effectively "forever" because we don't really want secondaries
-	// to ever give up once they have indicated that they are ready to upgrade.
-	// It is up to the primary to abort the upgrade if required.
-	//
-	// This should get reduced when/if primary re-elections are introduced in
-	// for case that a primary is failing to come up for upgrade.
-	UpgradeStartTimeoutSecondary = time.Hour * 4
+	UpgradeStartTimeoutController = time.Minute * 15
 )
 
 // NewLock creates a gate.Lock to be used to synchronise workers which
@@ -126,7 +113,6 @@ type upgradeSteps struct {
 	fromVersion version.Number
 	toVersion   version.Number
 	tag         names.Tag
-	isPrimary   bool
 	// If the agent is a machine agent for a controller, flag that state
 	// needs to be opened before running upgrade steps
 	isController bool
@@ -200,13 +186,6 @@ func (w *upgradeSteps) run() error {
 			return errors.Trace(err)
 		}
 		w.isCaas = model.Type() == state.ModelTypeCAAS
-		w.isPrimary = w.isCaas
-		if !w.isCaas {
-			// TODO(caas) - will need fixing when we support HA controllers
-			if w.isPrimary, err = IsMachinePrimary(w.pool, w.tag.Id()); err != nil {
-				return errors.Trace(err)
-			}
-		}
 	}
 
 	if err := w.runUpgrades(); err != nil {
@@ -310,10 +289,8 @@ func (w *upgradeSteps) waitForOtherControllers(info *state.UpgradeInfo) error {
 				return errors.Trace(info.SetStatus(state.UpgradeRunning))
 			}
 		case <-timeout:
-			if w.isPrimary {
-				if err := info.Abort(); err != nil {
-					return errors.Annotate(err, "unable to abort upgrade")
-				}
+			if err := info.Abort(); err != nil {
+				return errors.Annotate(err, "unable to abort upgrade")
 			}
 			return errors.Errorf("timed out after %s", maxWait)
 		case <-w.tomb.Dying():
@@ -391,35 +368,7 @@ func (w *upgradeSteps) getUpgradeStartTimeout() time.Duration {
 		// timeout is triggered.
 		return time.Minute
 	}
-
-	if w.isPrimary {
-		return UpgradeStartTimeoutPrimary
-	}
-	return UpgradeStartTimeoutSecondary
-}
-
-var IsMachinePrimary = func(pool *state.StatePool, machineId string) (bool, error) {
-	if pool == nil {
-		// If there is no state pool, we aren't a primary.
-		return false, nil
-	}
-	// Not calling the agent openState method as it does other checks
-	// we really don't care about here.  All we need here is the machine
-	// so we can determine if we are the primary or not.
-	st := pool.SystemState()
-	machine, err := st.Machine(machineId)
-	if err != nil {
-		// This shouldn't happen, and if it does, the state worker will have
-		// found out before us, and already errored, or is likely to error out
-		// very shortly.  All we do here is return the error. The state worker
-		// returns an error that will cause the agent to be terminated.
-		return false, errors.Trace(err)
-	}
-	isPrimary, err := mongo.IsMaster(st.MongoSession(), machine)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	return isPrimary, nil
+	return UpgradeStartTimeoutController
 }
 
 // TODO(katco): 2016-08-09: lp:1611427


### PR DESCRIPTION
The `upgradesteps` worker used to run state-based steps before those were split out into the separate `upgradedatabase` worker. Because of this the logic was to:
- Determine the controller running the Mongo primary and have it commence the upgrade.
- Have the secondaries wait for the primary.
- Once the primary indicated completion, the secondaries would run their (non-state) steps.

Now that we no longer run state-based steps in this worker, there is no need to coordinate around the primary:
- Controllers just wait until everyone is ready.
- They all run their upgrade steps.
- When everyone is done, the upgrade is complete.

## QA steps

- Deploy a 2.8 controller and some workloads.
- Upgrade the controller using this patch and `--build-agent`.
- Upgrade the workload model.

Comprehensive HA upgrade QA will accompany https://github.com/juju/juju/pull/13047 once it is rebased with these changes.

## Documentation changes

None.

## Bug reference

In service of https://bugs.launchpad.net/juju/+bug/1927732.
