### PR TITLE
Upgrade step for dynamic address configs

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3482,3 +3482,10 @@ func TranslateK8sServiceTypes(pool *StatePool) error {
 	}
 	return nil
 }
+
+// UpdateDHCPAddressConfigs ensures that any addresses in the ip.addresses
+// collection with the removed "dynamic" address configuration method are
+// updated to indicate the "dhcp" configuration method.
+func UpdateDHCPAddressConfigs(pool *StatePool) error {
+	return nil
+}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3487,5 +3487,30 @@ func TranslateK8sServiceTypes(pool *StatePool) error {
 // collection with the removed "dynamic" address configuration method are
 // updated to indicate the "dhcp" configuration method.
 func UpdateDHCPAddressConfigs(pool *StatePool) error {
+	st := pool.SystemState()
+
+	col, closer := st.db().GetRawCollection(ipAddressesC)
+	defer closer()
+
+	iter := col.Find(bson.M{"config-method": "dynamic"}).Iter()
+
+	var ops []txn.Op
+	var doc bson.M
+	for iter.Next(&doc) {
+		ops = append(ops, txn.Op{
+			C:      ipAddressesC,
+			Id:     doc["_id"],
+			Assert: txn.DocExists,
+			Update: bson.M{"$set": bson.M{"config-method": network.ConfigDHCP}},
+		})
+	}
+
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(ops) > 0 {
+		return errors.Trace(st.runRawTransaction(ops))
+	}
 	return nil
 }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -93,6 +93,7 @@ type StateBackend interface {
 	RemoveUnusedLinkLayerDeviceProviderIDs() error
 	TranslateK8sServiceTypes() error
 	UpdateKubernetesCloudCredentials() error
+	UpdateDHCPAddressConfigs() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -392,4 +393,8 @@ func (s stateBackend) TranslateK8sServiceTypes() error {
 
 func (s stateBackend) UpdateKubernetesCloudCredentials() error {
 	return state.UpdateLegacyKubernetesCloudCredentials(s.pool.SystemState())
+}
+
+func (s stateBackend) UpdateDHCPAddressConfigs() error {
+	return state.UpdateDHCPAddressConfigs(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -46,6 +46,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.6"), stateStepsFor286()},
 		upgradeToVersion{version.MustParse("2.8.9"), stateStepsFor289()},
 		upgradeToVersion{version.MustParse("2.9.0"), stateStepsFor29()},
+		upgradeToVersion{version.MustParse("2.9.5"), stateStepsFor295()},
 	}
 	return steps
 }

--- a/upgrades/steps_295.go
+++ b/upgrades/steps_295.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor295 returns database upgrade steps for Juju 2.9.5.
+func stateStepsFor295() []Step {
+	return []Step{
+		&upgradeStep{
+			description: `change "dynamic" link-layer address configs to "dhcp"`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateDHCPAddressConfigs()
+			},
+		},
+	}
+}

--- a/upgrades/steps_295_test.go
+++ b/upgrades/steps_295_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v295 = version.MustParse("2.9.5")
+
+type steps295Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps295Suite{})
+
+func (s *steps295Suite) TestAddOriginToIPAddresses(c *gc.C) {
+	step := findStateStep(c, v295, `change "dynamic" link-layer address configs to "dhcp"`)
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -636,6 +636,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.6",
 		"2.8.9",
 		"2.9.0",
+		"2.9.5",
 	})
 }
 


### PR DESCRIPTION
In a prior patch we unified the type for address configuration method. This meant that prior usage of "dynamic" from the the removed type values was replaced with "dhcp" under the unified values.

This upgrade step replaces _config-method_ "dynamic" with "dhcp" in the _ip.addresses_ collection.

Beyond integrity of data, no behaviour is changed - _config-method_ is currently only ever compared with "loopback".

## QA steps

- Bootstrap < 2.9.5 to LXD.
- `juju add-machine`.
- When the machine comes up, `juju ssh 0` and stop it's agent so we don't get updated link-layer data: `systemctl stop jujud-machine-0`.
- Connect to Mongo. There should only be one address in the workload model that is not for a loopback device. Update it's config method to be "dynamic" for example:
```
db.ip.addresses.updateOne({"_id" : "cfd25afa-af5c-4de2-8a7e-ba6ca5c0a397:m#0#d#eth0#ip#10.161.87.115"}, {$set: {"config-method": "dynamic"}})
```
- Upgrade to this patch and observe that the config method is changed to "dhcp".

## Documentation changes

None.

## Bug reference

N/A
