### PR TITLE
Fix how default app constraint it set

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -404,7 +404,7 @@ func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		},
 	}
 
-	cons := constraints.MustParse("arch=amd64")
+	var cons constraints.Value
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -485,7 +485,7 @@ func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64")
+	var cons constraints.Value
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -518,7 +518,7 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64")
+	var cons constraints.Value
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),
@@ -684,7 +684,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64")
+	var cons constraints.Value
 	config := map[string]string{"trust": "true"}
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
@@ -722,7 +722,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		URL: curl.String(),
 	}, s.openRepo)
 	c.Assert(err, jc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64")
+	var cons constraints.Value
 	args := params.ApplicationDeploy{
 		ApplicationName: "application",
 		CharmURL:        curl.String(),

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -57,7 +57,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, app, s.charm.URL())
 	s.assertSettings(c, app, charm.Settings{})
 	s.assertApplicationConfig(c, app, coreapplication.ConfigAttributes(nil))
-	s.assertConstraints(c, app, constraints.MustParse("arch=amd64"))
+	s.assertConstraints(c, app, constraints.Value{})
 	s.assertMachines(c, app, constraints.Value{})
 }
 
@@ -306,7 +306,7 @@ func (s *DeployLocalSuite) TestDeployWithApplicationConfig(c *gc.C) {
 func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 	err := s.State.SetModelConstraints(constraints.MustParse("mem=2G"))
 	c.Assert(err, jc.ErrorIsNil)
-	applicationCons := constraints.MustParse("arch=amd64 cores=2")
+	applicationCons := constraints.MustParse("cores=2")
 	app, err := application.DeployApplication(stateDeployer{s.State},
 		application.DeployApplicationParams{
 			ApplicationName: "bob",

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -92,7 +92,6 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
-		Constraints: constraints.MustParse("arch=amd64"),
 		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     true,
@@ -129,7 +128,6 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
-		Constraints: constraints.MustParse("arch=amd64"),
 		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     "My Title",
@@ -151,7 +149,6 @@ func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.ApplicationGetResults{
 		Application: "wordpress",
 		Charm:       "wordpress",
-		Constraints: constraints.MustParse("arch=amd64"),
 		CharmConfig: map[string]interface{}{
 			"blog-title": map[string]interface{}{
 				"default":     "My Title",
@@ -359,9 +356,8 @@ var getTests = []struct {
 		},
 	},
 }, {
-	about:       "deployed application  #2",
-	charm:       "dummy",
-	constraints: "arch=amd64",
+	about: "deployed application  #2",
+	charm: "dummy",
 	config: charm.Settings{
 		// Set title to default.
 		"title": nil,

--- a/apiserver/testing/application.go
+++ b/apiserver/testing/application.go
@@ -14,9 +14,9 @@ import (
 )
 
 func AssertPrincipalApplicationDeployed(c *gc.C, st *state.State, applicationName string, curl *charm.URL, forced bool, bundle charm.Charm, cons constraints.Value) *state.Application {
-	service, err := st.Application(applicationName)
+	app, err := st.Application(applicationName)
 	c.Assert(err, jc.ErrorIsNil)
-	charm, force, err := service.Charm()
+	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(force, gc.Equals, forced)
 	c.Assert(charm.URL(), gc.DeepEquals, curl)
@@ -33,12 +33,12 @@ func AssertPrincipalApplicationDeployed(c *gc.C, st *state.State, applicationNam
 	c.Assert(charm.Meta(), jc.DeepEquals, bundle.Meta())
 	c.Assert(charm.Config(), jc.DeepEquals, bundle.Config())
 
-	serviceCons, err := service.Constraints()
+	appCons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(serviceCons, gc.DeepEquals, cons)
+	c.Assert(appCons, gc.DeepEquals, cons)
 
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		units, err := service.AllUnits()
+		units, err := app.AllUnits()
 		c.Assert(err, jc.ErrorIsNil)
 		for _, unit := range units {
 			mid, err := unit.AssignedMachineId()
@@ -55,5 +55,5 @@ func AssertPrincipalApplicationDeployed(c *gc.C, st *state.State, applicationNam
 		}
 		break
 	}
-	return service
+	return app
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -146,14 +146,12 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleEndpointBindingsSuccess(c 
 
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"mysql": {
-			charm:       "cs:xenial/mysql-42",
-			config:      mysqlch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/mysql-42",
+			config: mysqlch.Config().DefaultSettings(),
 		},
 		"wordpress-extra-bindings": {
-			charm:       "cs:xenial/wordpress-extra-bindings-47",
-			config:      wpch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/wordpress-extra-bindings-47",
+			config: wpch.Config().DefaultSettings(),
 		},
 	})
 	s.assertDeployedApplicationBindings(c, map[string]applicationInfo{
@@ -216,14 +214,10 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleTwice(c *gc.C) {
 	stdOut, stdErr, err = s.runDeployWithOutput(c, "cs:bundle/wordpress-simple")
 	c.Assert(err, jc.ErrorIsNil)
 	// Nothing to do... not quite...
-	c.Check(stdOut, gc.Equals, ""+
-		"Executing changes:\n"+
-		"- set constraints for mysql to \"\"\n"+
-		"- set constraints for wordpress to \"\"",
-	)
+	c.Check(stdOut, gc.Equals, "")
 	c.Check(stdErr, gc.Equals, ""+
 		"Located bundle \"wordpress-simple\" in charm-store, revision 1\n"+
-		"Deploy of bundle completed.",
+		"No changes to apply.",
 	)
 
 	s.assertCharmsUploaded(c, "cs:xenial/mysql-42", "cs:xenial/wordpress-47")
@@ -289,9 +283,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"dummy": {
-			charm:       "local:xenial/dummy-1",
-			config:      ch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "local:xenial/dummy-1",
+			config: ch.Config().DefaultSettings(),
 		},
 	})
 }
@@ -332,9 +325,8 @@ func (s *BundleDeployCharmStoreSuite) assertDeployBundleLocalPathInvalidSeriesWi
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"dummy": {
-			charm:       "local:quantal/dummy-1",
-			config:      ch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "local:quantal/dummy-1",
+			config: ch.Config().DefaultSettings(),
 		},
 	})
 }
@@ -362,9 +354,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"dummy-resource": {
-			charm:       "local:bionic/dummy-resource-0",
-			config:      ch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "local:bionic/dummy-resource-0",
+			config: ch.Config().DefaultSettings(),
 		},
 	})
 }
@@ -389,9 +380,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNoSeriesInCharmURL(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"dummy": {
-			charm:       "cs:~who/multi-series-0",
-			config:      ch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:~who/multi-series-0",
+			config: ch.Config().DefaultSettings(),
 		},
 	})
 }
@@ -764,9 +754,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentLXDProfile(
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"lxd-profile": {
-			charm:       "local:bionic/lxd-profile-0",
-			config:      lxdProfile.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "local:bionic/lxd-profile-0",
+			config: lxdProfile.Config().DefaultSettings(),
 		},
 	})
 	s.assertUnitsCreated(c, map[string]string{
@@ -888,14 +877,12 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalAndCharmStoreCharms(c
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"mysql": {
-			charm:       "local:xenial/mysql-1",
-			config:      mysqlch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "local:xenial/mysql-1",
+			config: mysqlch.Config().DefaultSettings(),
 		},
 		"wordpress": {
-			charm:       "cs:xenial/wordpress-42",
-			config:      wpch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/wordpress-42",
+			config: wpch.Config().DefaultSettings(),
 		},
 	})
 	s.assertRelationsEstablished(c, "wordpress:db mysql:server")
@@ -926,14 +913,12 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationOptions(c *gc.C
 	s.assertCharmsUploaded(c, "cs:bionic/dummy-0", "cs:xenial/wordpress-42")
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"customized": {
-			charm:       "cs:bionic/dummy-0",
-			config:      s.combinedSettings(dch, charm.Settings{"username": "who", "skill-level": int64(47)}),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:bionic/dummy-0",
+			config: s.combinedSettings(dch, charm.Settings{"username": "who", "skill-level": int64(47)}),
 		},
 		"wordpress": {
-			charm:       "cs:xenial/wordpress-42",
-			config:      s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/wordpress-42",
+			config: s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
 		},
 	})
 	s.assertUnitsCreated(c, map[string]string{
@@ -966,7 +951,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationDefaultArchCons
 		},
 		"wordpress": {
 			charm:       "cs:xenial/wordpress-42",
-			constraints: constraints.MustParse("arch=amd64 mem=4G cores=2"),
+			constraints: constraints.MustParse("mem=4G cores=2"),
 			config:      wpch.Config().DefaultSettings(),
 		},
 	})
@@ -999,7 +984,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationConstraints(c *
 		},
 		"wordpress": {
 			charm:       "cs:xenial/wordpress-42",
-			constraints: constraints.MustParse("arch=amd64 mem=4G cores=2"),
+			constraints: constraints.MustParse("mem=4G cores=2"),
 			config:      wpch.Config().DefaultSettings(),
 		},
 	})
@@ -1069,7 +1054,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleApplicationUpgrade(c *gc.C
 		"Executing changes:\n"+
 		"- upload charm upgrade from charm-store for series trusty with architecture=amd64\n"+
 		"- upgrade up from charm-store using charm upgrade for series trusty\n"+
-		"- set constraints for up to \"mem=8G\"\n"+
 		"- set application options for wordpress\n"+
 		`- set constraints for wordpress to "spaces=new cores=8"`,
 	)
@@ -1150,9 +1134,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleNewRelations(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- set constraints for mysql to \"\"\n"+
-		"- set constraints for varnish to \"\"\n"+
-		"- set constraints for wp to \"\"\n"+
 		"- add relation varnish:webcache - wp:cache",
 	)
 	s.assertRelationsEstablished(c, "wp:db mysql:server", "wp:cache varnish:webcache")
@@ -1192,14 +1173,12 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachinesUnitsPlacement(c *
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"sql": {
-			charm:       "cs:xenial/mysql-2",
-			config:      mysqlch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/mysql-2",
+			config: mysqlch.Config().DefaultSettings(),
 		},
 		"wp": {
-			charm:       "cs:xenial/wordpress-0",
-			config:      s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/wordpress-0",
+			config: s.combinedSettings(wpch, charm.Settings{"blog-title": "these are the voyages"}),
 		},
 	})
 	s.assertRelationsEstablished(c)
@@ -1297,9 +1276,8 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMachineAttributes(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertApplicationsDeployed(c, map[string]applicationInfo{
 		"django": {
-			charm:       "cs:xenial/django-42",
-			config:      ch.Config().DefaultSettings(),
-			constraints: constraints.MustParse("arch=amd64"),
+			charm:  "cs:xenial/django-42",
+			config: ch.Config().DefaultSettings(),
 		},
 	})
 	s.assertRelationsEstablished(c)
@@ -1486,7 +1464,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleSwitch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- set constraints for django to \"\"\n"+
 		"- deploy application node from charm-store on bionic using django\n"+
 		"- add unit node/0 to new machine 2",
 	)
@@ -1569,8 +1546,6 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(stdOut, gc.Equals, ""+
 		"Executing changes:\n"+
-		"- set constraints for django to \"\"\n"+
-		"- set constraints for memcached to \"\"\n"+
 		"- deploy application node from charm-store on bionic using django\n"+
 		"- add unit node/0 to 0/lxd/0 to satisfy [lxd:memcached]",
 	)
@@ -1578,10 +1553,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleMassiveUnitColocation(c *g
 	// Redeploy the same bundle again and check that nothing happens.
 	stdOut, _, err = s.DeployBundleYAMLWithOutput(c, content)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stdOut, gc.Equals, ""+
-		"Executing changes:\n"+
-		"- set constraints for node to \"\"",
-	)
+	c.Assert(stdOut, gc.Equals, "")
 	s.assertUnitsCreated(c, map[string]string{
 		"django/0":    "0",
 		"django/1":    "0/lxd/0",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -618,7 +618,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	app, _ := s.AssertApplication(c, "multi-series", curl, 1, 0)
 	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.MustParse("arch=amd64 mem=2G cores=2"))
+	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2"))
 }
 
 func (s *DeploySuite) TestResources(c *gc.C) {

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -69,8 +69,6 @@ func (s *cmdApplicationSuite) TestShowApplicationOne(c *gc.C) {
 wordpress:
   charm: wordpress
   series: quantal
-  constraints:
-    arch: amd64
   principal: true
   exposed: false
   remote: false
@@ -108,8 +106,6 @@ logging:
 wordpress:
   charm: wordpress
   series: quantal
-  constraints:
-    arch: amd64
   principal: true
   exposed: false
   remote: false

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -78,7 +78,6 @@ applications:
       logging-directory: alpha
   wordpress:
     charm: cs:quantal/wordpress-23
-    constraints: arch=amd64
     bindings:
       "": alpha
       admin-api: alpha

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -187,7 +187,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	c.Assert(err, jc.ErrorIsNil)
 	err = wordpress.SetMinUnits(units)
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpress.SetConstraints(constraints.MustParse("arch=amd64 mem=100M"))
+	err = wordpress.SetConstraints(constraints.MustParse("mem=100M"))
 	c.Assert(err, jc.ErrorIsNil)
 	setApplicationConfigAttr(c, wordpress, "blog-title", "boring")
 	pairs := map[string]string{"x": "12", "y": "99"}
@@ -198,7 +198,7 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 		CharmURL:    applicationCharmURL(wordpress).String(),
 		Life:        life.Alive,
 		MinUnits:    units,
-		Constraints: constraints.MustParse("arch=amd64 mem=100M"),
+		Constraints: constraints.MustParse("mem=100M"),
 		Annotations: pairs,
 		Config:      charm.Settings{"blog-title": "boring"},
 		Subordinate: false,
@@ -382,12 +382,11 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	mysql := AddTestingApplication(c, st, "mysql", AddTestingCharm(c, st, "mysql"))
 	curl := applicationCharmURL(mysql)
 	add(&multiwatcher.ApplicationInfo{
-		ModelUUID:   modelUUID,
-		Name:        "mysql",
-		CharmURL:    curl.String(),
-		Life:        life.Alive,
-		Config:      charm.Settings{},
-		Constraints: constraints.MustParse("arch=amd64"),
+		ModelUUID: modelUUID,
+		Name:      "mysql",
+		CharmURL:  curl.String(),
+		Life:      life.Alive,
+		Config:    charm.Settings{},
 		Status: multiwatcher.StatusInfo{
 			Current: "unset",
 			Message: "",
@@ -2117,14 +2116,13 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ApplicationInfo{
-						ModelUUID:   st.ModelUUID(),
-						Name:        "wordpress",
-						Exposed:     true,
-						CharmURL:    "local:quantal/quantal-wordpress-3",
-						Life:        life.Alive,
-						MinUnits:    42,
-						Config:      charm.Settings{},
-						Constraints: constraints.MustParse("arch=amd64"),
+						ModelUUID: st.ModelUUID(),
+						Name:      "wordpress",
+						Exposed:   true,
+						CharmURL:  "local:quantal/quantal-wordpress-3",
+						Life:      life.Alive,
+						MinUnits:  42,
+						Config:    charm.Settings{},
 						Status: multiwatcher.StatusInfo{
 							Current: "unset",
 							Message: "",

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3225,12 +3225,10 @@ func uint64p(val uint64) *uint64 {
 }
 
 func (s *ApplicationSuite) TestConstraints(c *gc.C) {
-	amdArch := "amd64"
+	// Constraints are initially empty (for now).
 	cons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.Value{
-		Arch: &amdArch,
-	})
+	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
 
 	// Constraints can be set.
 	cons2 := constraints.Value{Mem: uint64p(4096)}
@@ -3261,30 +3259,15 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons6, jc.DeepEquals, constraints.Value{
-		Arch: &amdArch,
-	})
+	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
 }
 
 func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
 	amdArch := "amd64"
-	cons, err := s.mysql.Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.Value{
-		Arch: &amdArch,
-	})
-
-	// Constraints can not be set if it already exists and is different than
-	// the default architecture.
 	armArch := "arm64"
-	cons1 := constraints.Value{Arch: &armArch}
-	err = s.mysql.SetConstraints(cons1)
-	c.Assert(err, gc.ErrorMatches, "changing architecture \\(amd64\\) not supported")
-
-	// Constraints can be set.
 
 	cons2 := constraints.Value{Arch: &amdArch}
-	err = s.mysql.SetConstraints(cons2)
+	err := s.mysql.SetConstraints(cons2)
 	c.Assert(err, jc.ErrorIsNil)
 	cons3, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3308,9 +3291,7 @@ func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons6, jc.DeepEquals, constraints.Value{
-		Arch: &amdArch,
-	})
+	c.Assert(constraints.IsEmpty(&cons6), jc.IsTrue)
 }
 
 func (s *ApplicationSuite) TestSetInvalidConstraints(c *gc.C) {
@@ -3352,11 +3333,7 @@ func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 
 	scons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-
-	amdArch := "amd64"
-	c.Assert(scons, jc.DeepEquals, constraints.Value{
-		Arch: &amdArch,
-	})
+	c.Assert(&scons, jc.Satisfies, constraints.IsEmpty)
 
 	// Removed (== Dead, for a application).
 	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -403,7 +403,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineSetsConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	mcons, err := machine.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	expect := constraints.MustParse("mem=2G cores=2 cpu-power=400")
+	expect := constraints.MustParse("arch=amd64 mem=2G cores=2 cpu-power=400")
 	c.Assert(mcons, gc.DeepEquals, expect)
 }
 
@@ -841,7 +841,7 @@ var assignUsingConstraintsTests = []struct {
 }{
 	{
 		// 0
-		unitConstraints:         "arch=amd64",
+		unitConstraints:         "",
 		hardwareCharacteristics: "arch=amd64",
 		assignOk:                true,
 	}, {
@@ -856,7 +856,7 @@ var assignUsingConstraintsTests = []struct {
 		assignOk:                false,
 	}, {
 		// 3
-		unitConstraints:         "arch=amd64",
+		unitConstraints:         "",
 		hardwareCharacteristics: "arch=i386",
 		assignOk:                false,
 	}, {
@@ -877,8 +877,8 @@ var assignUsingConstraintsTests = []struct {
 	}, {
 		// 7
 		unitConstraints:         "mem=4G",
-		hardwareCharacteristics: "mem=4G",
-		assignOk:                false,
+		hardwareCharacteristics: "arch=amd64 mem=4G",
+		assignOk:                true,
 	}, {
 		// 8
 		unitConstraints:         "arch=amd64 mem=4G",
@@ -897,8 +897,8 @@ var assignUsingConstraintsTests = []struct {
 	}, {
 		// 11
 		unitConstraints:         "cores=2",
-		hardwareCharacteristics: "cores=2",
-		assignOk:                false,
+		hardwareCharacteristics: "arch=amd64 cores=2",
+		assignOk:                true,
 	}, {
 		// 12
 		unitConstraints:         "arch=amd64 cores=2",
@@ -927,8 +927,8 @@ var assignUsingConstraintsTests = []struct {
 	}, {
 		// 17
 		unitConstraints:         "cpu-power=50",
-		hardwareCharacteristics: "cpu-power=50",
-		assignOk:                false,
+		hardwareCharacteristics: "arch=amd64 cpu-power=50",
+		assignOk:                true,
 	}, {
 		// 18
 		unitConstraints:         "arch=amd64 cpu-power=100",
@@ -977,8 +977,8 @@ var assignUsingConstraintsTests = []struct {
 	}, {
 		// 27
 		unitConstraints:         "root-disk=8192",
-		hardwareCharacteristics: "root-disk=8192",
-		assignOk:                false,
+		hardwareCharacteristics: "arch=amd64 root-disk=8192",
+		assignOk:                true,
 	}, {
 		// 28
 		unitConstraints:         "root-disk-source=place1",

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -53,13 +53,13 @@ var setConstraintsTests = []struct {
 	effectiveUnitCons        string // unit constraints after setting consToSet on the application
 	effectiveMachineCons     string // machine constraints after setting consToSet
 }{{
-	about:        "(implictly) empty constraints are OK and stored as empty",
+	about:        "(implicitly) empty constraints are OK and stored as empty",
 	consToSet:    "",
 	consFallback: "",
 
 	effectiveModelCons:       "",
 	effectiveApplicationCons: "",
-	effectiveUnitCons:        "",
+	effectiveUnitCons:        "arch=amd64",
 	effectiveMachineCons:     "",
 }, {
 	about:        "(implicitly) empty fallback constraints never override set constraints",
@@ -91,7 +91,7 @@ var setConstraintsTests = []struct {
 
 	effectiveModelCons:       "",
 	effectiveApplicationCons: "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
-	effectiveUnitCons:        "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveUnitCons:        "arch=amd64 cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	effectiveMachineCons:     "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:        "(explicitly) empty fallback constraints are OK and stored as given",
@@ -100,7 +100,7 @@ var setConstraintsTests = []struct {
 
 	effectiveModelCons:       "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	effectiveApplicationCons: "",
-	effectiveUnitCons:        "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
+	effectiveUnitCons:        "arch=amd64 cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	effectiveMachineCons:     "cores= cpu-power= instance-type= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:                    "(explicitly) empty constraints and fallbacks are OK and stored as given",
@@ -108,7 +108,7 @@ var setConstraintsTests = []struct {
 	consFallback:             "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	effectiveModelCons:       "cores= cpu-power= root-disk= instance-type= container= tags= spaces=",
 	effectiveApplicationCons: "arch= mem= cores= container=",
-	effectiveUnitCons:        "arch= container= cores= cpu-power= mem= root-disk= tags= spaces=",
+	effectiveUnitCons:        "arch=amd64 container= cores= cpu-power= mem= root-disk= tags= spaces=",
 	effectiveMachineCons:     "arch= cores= cpu-power= mem= root-disk= tags= spaces=", // container= is dropped
 }, {
 	about:        "(explicitly) empty constraints override set fallbacks for deployment and provisioning",
@@ -117,7 +117,7 @@ var setConstraintsTests = []struct {
 
 	effectiveModelCons:       "cores=42 arch=amd64 tags=foo spaces=default,^dmz mem=4G",
 	effectiveApplicationCons: "cores= arch= spaces= cpu-power=",
-	effectiveUnitCons:        "arch= cores= cpu-power= mem=4G tags=foo spaces=",
+	effectiveUnitCons:        "arch=amd64 cores= cpu-power= mem=4G tags=foo spaces=",
 	effectiveMachineCons:     "arch= cores= cpu-power= mem=4G tags=foo spaces=",
 	// we're also checking if m.SetConstraints() does the same with
 	// regards to the effective constraints as AddMachine(), because
@@ -162,7 +162,7 @@ var setConstraintsTests = []struct {
 	// constraints when it comes to effective values.
 	effectiveModelCons:       "tags=foo cpu-power=42",
 	effectiveApplicationCons: "cpu-power= tags= spaces=bar",
-	effectiveUnitCons:        "cpu-power= tags= spaces=bar",
+	effectiveUnitCons:        "arch=amd64 cpu-power= tags= spaces=bar",
 	effectiveMachineCons:     "cpu-power= tags= spaces=bar",
 }, {
 	about:        "container type can only be used for deployment, not provisioning",
@@ -188,7 +188,7 @@ var setConstraintsTests = []struct {
 	// to ensure consistency in scalability.
 	effectiveModelCons:       "",
 	effectiveApplicationCons: "virt-type=kvm",
-	effectiveUnitCons:        "virt-type=kvm",
+	effectiveUnitCons:        "arch=amd64 virt-type=kvm",
 	effectiveMachineCons:     "virt-type=kvm",
 }, {
 	about:        "ensure model and application constraints are separate",
@@ -200,7 +200,7 @@ var setConstraintsTests = []struct {
 	// to ensure consistency in scalability.
 	effectiveModelCons:       "mem=2G",
 	effectiveApplicationCons: "virt-type=kvm",
-	effectiveUnitCons:        "mem=2G virt-type=kvm",
+	effectiveUnitCons:        "arch=amd64 mem=2G virt-type=kvm",
 	effectiveMachineCons:     "mem=2G virt-type=kvm",
 }}
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v3"
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
@@ -1511,7 +1512,7 @@ func getApplicationArchConstraint(a description.Application) string {
 	if arch := cons.Architecture(); arch != "" {
 		return arch
 	}
-	return ""
+	return arch.DefaultArchitecture
 }
 
 func (i *importer) relationCount(application string) int {

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -261,7 +261,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationNoPlacement(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": failed for some reason`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
 		Series:      "quantal",
-		Constraints: constraints.MustParse("arch=amd64 root-disk=20G"),
+		Constraints: constraints.MustParse("root-disk=20G"),
 	})
 }
 
@@ -310,8 +310,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationMixedPlacement(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": hey now`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
-		Series:      "precise",
-		Placement:   "somewhere",
-		Constraints: constraints.MustParse("arch=amd64"),
+		Series:    "precise",
+		Placement: "somewhere",
 	})
 }

--- a/state/state.go
+++ b/state/state.go
@@ -31,7 +31,6 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/application"
-	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -1104,16 +1103,8 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return nil, errors.Trace(err)
 	}
 
-	switch model.Type() {
-	case ModelTypeIAAS:
-		// CAAS doesn't support architecture in every scenario.
-		args.Constraints, err = st.deriveApplicationConstraints(args.Constraints, args.Charm.Meta().Subordinate)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-	case ModelTypeCAAS:
-		// CAAS charms don't support volume/block storage yet.
+	// CAAS charms don't support volume/block storage yet.
+	if model.Type() == ModelTypeCAAS {
 		for name, charmStorage := range args.Charm.Meta().Storage {
 			if storageKind(charmStorage.Type) != storage.StorageKindBlock {
 				continue
@@ -1359,26 +1350,6 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return app, nil
 	}
 	return nil, errors.Trace(err)
-}
-
-func (st *State) deriveApplicationConstraints(cons constraints.Value, subordinate bool) (constraints.Value, error) {
-	if subordinate {
-		return cons, nil
-	}
-
-	var modelConstraints *constraints.Value
-	if !cons.HasArch() {
-		c, err := st.ModelConstraints()
-		if err != nil {
-			return constraints.Value{}, errors.Trace(err)
-		}
-		modelConstraints = &c
-	}
-
-	result := cons
-	a := arch.ConstraintArch(cons, modelConstraints)
-	result.Arch = &a
-	return result, nil
 }
 
 func (st *State) processCommonModelApplicationArgs(args *AddApplicationArgs) error {

--- a/state/unit.go
+++ b/state/unit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/mgo/v2/bson"
@@ -1975,6 +1976,21 @@ func (u *Unit) Constraints() (*constraints.Value, error) {
 		return nil, errors.NotFoundf("unit")
 	} else if err != nil {
 		return nil, err
+	}
+	if !cons.HasArch() && !cons.HasInstanceType() {
+		app, err := u.Application()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if origin := app.CharmOrigin(); origin != nil && origin.Platform != nil {
+			if origin.Platform.Architecture != "" {
+				cons.Arch = &origin.Platform.Architecture
+			}
+		}
+		if !cons.HasArch() {
+			a := arch.DefaultArchitecture
+			cons.Arch = &a
+		}
 	}
 	return &cons, nil
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2155,6 +2155,51 @@ func (s *UnitSuite) TestPrincipalName(c *gc.C) {
 	c.Assert(principal, gc.Equals, "")
 }
 
+func (s *UnitSuite) TestConstraintsDefaultArchNotRelevant(c *gc.C) {
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "app",
+		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{
+			Architecture: "arm64",
+		}},
+	})
+	err := app.SetConstraints(constraints.MustParse("instance-type=big"))
+	c.Assert(err, jc.ErrorIsNil)
+	unit0, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	cons, err := unit0.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons.String(), gc.Equals, "instance-type=big")
+
+	app = s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "app2",
+		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{
+			Architecture: "arm64",
+		}},
+		Constraints: constraints.MustParse("arch=s390x"),
+	})
+	unit1, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	cons, err = unit1.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons.String(), gc.Equals, "arch=s390x")
+}
+
+func (s *UnitSuite) TestConstraintsDefaultArch(c *gc.C) {
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "app",
+		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{
+			Architecture: "arm64",
+		}},
+	})
+	err := app.SetConstraints(constraints.MustParse("mem=4G"))
+	c.Assert(err, jc.ErrorIsNil)
+	unit0, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	cons, err := unit0.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons.String(), gc.Equals, "arch=arm64 mem=4096M")
+}
+
 func (s *UnitSuite) TestRelations(c *gc.C) {
 	wordpress0 := s.unit
 	mysql := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))


### PR DESCRIPTION
During 2.9 release candidate stages, a change was made to, at the time of deploying an app, set the app arch constraint to "amd64" if not otherwise set. This was the wrong place to do it. We should only record user intent and fill in any defaults at the appropriate time. The approach used broke constraints handling: arch is not compatible with instance-type and because we were setting arch to "amd64", if the user had specified "instance-type=foo", juju complained about ambiguous constraints (see bug).

The app constraint is only used to inform a unit constraint if none is other wise specified when adding a unit. And the unit constraint is only used to set up the machine constraint when provisioning a machine. So this PR moves the default arch logic to the Constraints() method on unit; moreover, it only fills in default arch if instance-type is not set, since instance type fixes the arch anyway. If we do need to fill in a default constraint to use to provision a machine, we actually look at the unit's charm manifest and use the platform arch if there is one. This ensures the correct machine is provisioned.

Also, there were some bundle deploy tests that appeared to be quite wrong, meaning we were testing for incorrect behaviour. Specifically, lines like this in the test output are wrong:
```
- set constraints for mysql to ""
- set constraints for wordpress to ""
```

The other thing is that apps from migrated models do not get this special treatment as far as I can see so they would be missing this added default arch.

We can still improve error messaging though. Consider an amd64 only charm deployed to an arm64 instance type

`juju deploy somecharm --constraints="instance-type=a1.medium"`

deploy "succeeds" but status subsequently shows

```
failed to start machine 0 (chosen architecture arm64 for image "ami-0ca133384d447f902" not present in [amd64]), retrying in 10s (9 more attempts)
```

which is not very inormative

## QA steps

As per bug, bootstrap azure and
`juju deploy mysql --constraints="instance-type=Standard_D4_v4"`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931504
