### PR TITLE
Fixes controller correlation for pre 2.9

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -24,7 +24,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
@@ -41,6 +43,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
+	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/mongo"
 )
 
@@ -152,22 +155,61 @@ type controllerStacker interface {
 	Deploy() error
 }
 
-func controllerCorelation(broker *kubernetesClient) (string, error) {
-	// ensure controller specific annotations.
-	controllerUUIDKey := k8sutils.AnnotationControllerIsControllerKey(false)
-	_ = broker.addAnnotations(controllerUUIDKey, "true")
+// findControllerNamespace is used for finding a controller's namespace based on
+// its model name and controller uuid. This function really shouldn't exist
+// and should be removed in 3.0. We have it here as we are still trying to use
+// Kubernetes annotations as database selectors in some parts of Juju.
+func findControllerNamespace(
+	client kubernetes.Interface,
+	controllerUUID string,
+) (*core.Namespace, error) {
+	// First we are going to start off by listing namespaces that are not using
+	// legacy labels as that is the direction we are moving towards and hence
+	// should be the quickest operation
+	namespaces, err := client.CoreV1().Namespaces().List(
+		context.TODO(),
+		v1.ListOptions{
+			LabelSelector: labels.Set{
+				constants.LabelJujuModelName: environsbootstrap.ControllerModelName,
+			}.String(),
+		},
+	)
 
-	ns, err := broker.listNamespacesByAnnotations(broker.GetAnnotations())
-	if errors.IsNotFound(err) || ns == nil {
-		// No existing controller found on the cluster.
-		// A controller must be bootstrapping now.
-		// It will reply on setControllerNamespace in controller stack to set namespace name.
-		return "", errors.NewNotFound(err, "controller")
-	}
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Annotate(err, "finding controller namespace with non legacy labels")
 	}
-	return ns[0].GetName(), nil
+
+	for _, ns := range namespaces.Items {
+		if ns.Annotations[k8sutils.AnnotationControllerUUIDKey(false)] == controllerUUID {
+			return &ns, nil
+		}
+	}
+
+	// We didn't find anything using new labels so lets try the old ones.
+	namespaces, err = client.CoreV1().Namespaces().List(
+		context.TODO(),
+		v1.ListOptions{
+			LabelSelector: labels.Set{
+				constants.LegacyLabelModelName: environsbootstrap.ControllerModelName,
+			}.String(),
+		},
+	)
+
+	if err != nil {
+		return nil, errors.Annotate(err, "finding controller namespace with legacy labels")
+	}
+
+	for _, ns := range namespaces.Items {
+		if ns.Annotations[k8sutils.AnnotationControllerUUIDKey(true)] == controllerUUID {
+			return &ns, nil
+		}
+	}
+
+	return nil, errors.NotFoundf(
+		"controller namespace not found for model %q and controller uuid %q",
+		environsbootstrap.ControllerModelName,
+		controllerUUID,
+	)
 }
 
 // DecideControllerNamespace decides the namespace name to use for a new controller.

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -31,7 +31,7 @@ var (
 	OperatorPod               = operatorPod
 	ExtractRegistryURL        = extractRegistryURL
 	CreateDockerConfigJSON    = createDockerConfigJSON
-	ControllerCorelation      = controllerCorelation
+	FindControllerNamespace   = findControllerNamespace
 	GetLocalMicroK8sConfig    = getLocalMicroK8sConfig
 	AttemptMicroK8sCloud      = attemptMicroK8sCloud
 	AttemptMicroK8sCredential = attemptMicroK8sCredential

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -154,7 +154,8 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 		return broker, nil
 	}
 
-	ns, err := controllerCorelation(broker)
+	ns, err := findControllerNamespace(
+		broker.client(), args.ControllerUUID)
 	if errors.IsNotFound(err) {
 		return broker, nil
 	} else if err != nil {
@@ -162,7 +163,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 	}
 
 	return newK8sBroker(
-		args.ControllerUUID, k8sRestConfig, args.Config, ns,
+		args.ControllerUUID, k8sRestConfig, args.Config, ns.Name,
 		NewK8sClients, newRestClient, k8swatcher.NewKubernetesNotifyWatcher, k8swatcher.NewKubernetesStringsWatcher,
 		utils.RandomPrefix, jujuclock.WallClock)
 }


### PR DESCRIPTION
During upgrades to 2.9 Juju cannot find controller namespaces that are pre 2.9

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run unit tests as 2.8 -> 2.9 upgrading for k8s is still not 100%
