### PR TITLE
[2.9] Also resolve subordinate leaders when using juju ssh app/leader syntax

### DIFF
--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -285,5 +285,18 @@ func maybeResolveLeaderUnit(statusAPIGetter func() (StatusAPI, error), target st
 		}
 	}
 
+	// Check if we are trying to look up a subordinate leader. Unfortunately,
+	// this means we have to iterate each principal unit's subordinate list.
+	subordinateAppPrefix := app + "/"
+	for _, appInfo := range res.Applications {
+		for _, unitStatus := range appInfo.Units {
+			for subordinateUnitName, subordinateUnitStatus := range unitStatus.Subordinates {
+				if strings.HasPrefix(subordinateUnitName, subordinateAppPrefix) && subordinateUnitStatus.Leader {
+					return subordinateUnitName, nil
+				}
+			}
+		}
+	}
+
 	return "", errors.Errorf("unable to resolve leader unit for application %q", app)
 }

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -337,25 +337,40 @@ func (s *SSHSuite) TestMaybeResolveLeaderUnit(c *gc.C) {
 	defer ctrl.Finish()
 
 	statusAPI := mocks.NewMockStatusAPI(ctrl)
-	statusAPI.EXPECT().Close().Return(nil)
-	statusAPI.EXPECT().Status([]string{"loop"}).Return(&params.FullStatus{
+	statusAPI.EXPECT().Close().AnyTimes().Return(nil)
+	statusAPI.EXPECT().Status(gomock.Any()).AnyTimes().Return(&params.FullStatus{
 		Applications: map[string]params.ApplicationStatus{
 			"loop": {
 				Units: map[string]params.UnitStatus{
-					"loop/0": {},
+					"loop/0": {
+						Subordinates: map[string]params.UnitStatus{
+							"wormhole/0": {},
+						},
+					},
 					"loop/1": {
 						Leader: true,
+						Subordinates: map[string]params.UnitStatus{
+							"wormhole/1": {Leader: true},
+						},
 					},
 				},
 			},
 		},
 	}, nil)
 
+	// Resolve principal application leader.
 	resolvedUnit, err := maybeResolveLeaderUnit(func() (StatusAPI, error) {
 		return statusAPI, nil
 	}, "loop/leader")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resolvedUnit, gc.Equals, "loop/1", gc.Commentf("expected leader to resolve to loop/1"))
+	c.Assert(resolvedUnit, gc.Equals, "loop/1", gc.Commentf("expected leader to resolve to loop/1 for principal application"))
+
+	// Resolve subordinate application leader.
+	resolvedUnit, err = maybeResolveLeaderUnit(func() (StatusAPI, error) {
+		return statusAPI, nil
+	}, "wormhole/leader")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resolvedUnit, gc.Equals, "wormhole/1", gc.Commentf("expected leader to resolve to wormhole/1 for subordinate application"))
 }
 
 type callbackAttemptStarter struct {


### PR DESCRIPTION
This PR allows `juju ssh` to target subordinate leaders using the ` juju ssh $app/leader` syntax.

## QA steps

```sh
juju deploy mysql -n 2
juju deploy rsyslog-forwarder
juju add-relation mysql rsyslog-forwarder
juju deploy mysql foosql -n 2
juju add-relation foosql rsyslog-forwarder

# The following commands should ssh to the machine that corresponds to the leader as shown in `juju status`
$ juju ssh mysql/leader
$ juju ssh rsyslog-forwarder/leader
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931721