### PR TITLE
Integration tests: Fix intermittent failure

### DIFF
--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -27,13 +27,15 @@ cloudinit-userdata: |
 EOF
 
 	juju model-config "${FILE}"
-	juju model-config cloudinit-userdata | grep -q "shellcheck"
+	OUT=$(juju model-config cloudinit-userdata)
+	echo "${OUT}" | grep -q "shellcheck"
 
 	# cloudinit-userdata is not present from the default tabluar output
 	! juju model-config cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
 
 	# cloudinit-userdata is hidden in the normal output
-	juju model-config | grep -q "<value set, see juju model-config cloudinit-userdata>"
+	OUT=$(juju model-config)
+	echo "${OUT}" | grep -q "<value set, see juju model-config cloudinit-userdata>"
 
 	destroy_model "model-config-cloudinit-userdata"
 }


### PR DESCRIPTION
Ensure we capture all the output from stdout before streaming to grep
via pipe. This shouldn't happen, but does happen. Because of newlines
(\n) we can end up not capturing all of the output. The fix is to send
it to a variable and then check that information.

## QA steps

```sh
(cd tests && ./main.sh cli)
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931587