### PR TITLE
Integration tests: Bootstrap series

### DIFF
--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -32,6 +32,7 @@ run_simplestream_metadata() {
 		--show-log \
 		--config agent-metadata-url="http://${server_address}:8666/" \
 		--config test-mode=true \
+		--bootstrap-series="${BOOTSTRAP_SERIES}" \
 		--agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"
 

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -11,10 +11,10 @@ test_deploy_os() {
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"ec2" | "aws")
-		#
-		# A handy place to find the current AMIs for centos
-		# https://wiki.centos.org/Cloud/AWS
-		#
+			#
+			# A handy place to find the current AMIs for centos
+			# https://wiki.centos.org/Cloud/AWS
+			#
 			run "run_deploy_centos7"
 			run "run_deploy_centos8"
 			;;

--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -74,6 +74,7 @@ exec_simplestream_metadata() {
 	file="${TEST_DIR}/test-upgrade-${test_name}-stream.log"
 	/snap/bin/juju bootstrap "lxd" "${name}" \
 		--show-log \
+		--bootstrap-series="${BOOTSTRAP_SERIES}" \
 		--config agent-metadata-url="http://${server_address}:8666/" \
 		--config test-mode=true 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"


### PR DESCRIPTION
The natural bootstrap series for the integration tests are focal.
Unfortunately for us, focal can't be used inside multiple nested
containers, we have to resort to using bionic.
With this in mind, we allow the setting of a bootstrap-series for the
main deployments, when not using that flow, we need to ensure that we
also, pass that through to the new cases.

The change although simple should be enough to get some of the
integration tests working in the CI infra.

## QA steps

```sh
(cd tests && ./main.sh bootstrap)
```
