### PR TITLE
Simplify bootstrap logging

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -213,7 +213,7 @@ func InitializeState(
 
 	var controllerNode bootstrapController
 	if isCAAS {
-		if controllerNode, err = initBootstrapNode(c, st, args); err != nil {
+		if controllerNode, err = initBootstrapNode(st, args); err != nil {
 			return nil, errors.Annotate(err, "cannot initialize bootstrap controller")
 		}
 		if err := initControllerCloudService(cloudSpec, provider, st, args); err != nil {
@@ -425,11 +425,7 @@ func initMongo(info mongo.Info, dialOpts mongo.DialOpts, password string) (*mgo.
 
 // initBootstrapMachine initializes the initial bootstrap machine in state.
 func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstrapController, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Infof("initialising bootstrap machine for %q model with config: %+v", model.Type(), args)
+	logger.Infof("initialising bootstrap machine with config: %+v", args)
 
 	jobs := make([]state.MachineJob, len(args.BootstrapMachineJobs))
 	for i, job := range args.BootstrapMachineJobs {
@@ -471,15 +467,10 @@ func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstra
 
 // initBootstrapNode initializes the initial caas bootstrap controller in state.
 func initBootstrapNode(
-	c agent.ConfigSetter,
 	st *state.State,
 	args InitializeStateParams,
 ) (bootstrapController, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("initialising bootstrap node for %q model with config: %+v", model.Type(), args)
+	logger.Debugf("initialising bootstrap node for with config: %+v", args)
 
 	node, err := st.AddControllerNode()
 	if err != nil {


### PR DESCRIPTION
Looking at CI integration test output we see lines like this:
```
2021-06-14 04:34:55 INFO juju.agent.agentbootstrap bootstrap.go:432 initialising bootstrap machine for "iaas" model with config: ...
```

The terms "iaas" and "caas" are of no value here. Not only will the user know the estate they are bootstrapping on to, but these acronyms are not common knowledge.

Omitting them allows us to drop the state access that retrieves the model type.

## QA steps

Bootstrap a controller and observe that the logging output does not include "iaas" or "caas".

## Documentation changes

None.

## Bug reference

N/A
