### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -213,7 +213,7 @@ func InitializeState(
 
 	var controllerNode bootstrapController
 	if isCAAS {
-		if controllerNode, err = initBootstrapNode(c, st, args); err != nil {
+		if controllerNode, err = initBootstrapNode(st, args); err != nil {
 			return nil, errors.Annotate(err, "cannot initialize bootstrap controller")
 		}
 		if err := initControllerCloudService(cloudSpec, provider, st, args); err != nil {
@@ -425,11 +425,7 @@ func initMongo(info mongo.Info, dialOpts mongo.DialOpts, password string) (*mgo.
 
 // initBootstrapMachine initializes the initial bootstrap machine in state.
 func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstrapController, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Infof("initialising bootstrap machine for %q model with config: %+v", model.Type(), args)
+	logger.Infof("initialising bootstrap machine with config: %+v", args)
 
 	jobs := make([]state.MachineJob, len(args.BootstrapMachineJobs))
 	for i, job := range args.BootstrapMachineJobs {
@@ -471,15 +467,10 @@ func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstra
 
 // initBootstrapNode initializes the initial caas bootstrap controller in state.
 func initBootstrapNode(
-	c agent.ConfigSetter,
 	st *state.State,
 	args InitializeStateParams,
 ) (bootstrapController, error) {
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	logger.Debugf("initialising bootstrap node for %q model with config: %+v", model.Type(), args)
+	logger.Debugf("initialising bootstrap node for with config: %+v", args)
 
 	node, err := st.AddControllerNode()
 	if err != nil {

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -32,7 +32,7 @@ var (
 	OperatorPod               = operatorPod
 	ExtractRegistryURL        = extractRegistryURL
 	CreateDockerConfigJSON    = createDockerConfigJSON
-	ControllerCorelation      = controllerCorelation
+	FindControllerNamespace   = findControllerNamespace
 	GetLocalMicroK8sConfig    = getLocalMicroK8sConfig
 	AttemptMicroK8sCloud      = attemptMicroK8sCloud
 	AttemptMicroK8sCredential = attemptMicroK8sCredential

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -164,7 +164,8 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 		return broker, nil
 	}
 
-	ns, err := controllerCorelation(broker)
+	ns, err := findControllerNamespace(
+		broker.client(), args.ControllerUUID)
 	if errors.IsNotFound(err) {
 		return broker, nil
 	} else if err != nil {
@@ -172,7 +173,7 @@ func (p kubernetesEnvironProvider) Open(args environs.OpenParams) (caas.Broker, 
 	}
 
 	return newK8sBroker(
-		args.ControllerUUID, k8sRestConfig, args.Config, ns,
+		args.ControllerUUID, k8sRestConfig, args.Config, ns.Name,
 		NewK8sClients, newRestClient, k8swatcher.NewKubernetesNotifyWatcher, k8swatcher.NewKubernetesStringsWatcher,
 		utils.RandomPrefix, jujuclock.WallClock)
 }

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -285,5 +285,18 @@ func maybeResolveLeaderUnit(statusAPIGetter func() (StatusAPI, error), target st
 		}
 	}
 
+	// Check if we are trying to look up a subordinate leader. Unfortunately,
+	// this means we have to iterate each principal unit's subordinate list.
+	subordinateAppPrefix := app + "/"
+	for _, appInfo := range res.Applications {
+		for _, unitStatus := range appInfo.Units {
+			for subordinateUnitName, subordinateUnitStatus := range unitStatus.Subordinates {
+				if strings.HasPrefix(subordinateUnitName, subordinateAppPrefix) && subordinateUnitStatus.Leader {
+					return subordinateUnitName, nil
+				}
+			}
+		}
+	}
+
 	return "", errors.Errorf("unable to resolve leader unit for application %q", app)
 }

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -337,25 +337,40 @@ func (s *SSHSuite) TestMaybeResolveLeaderUnit(c *gc.C) {
 	defer ctrl.Finish()
 
 	statusAPI := mocks.NewMockStatusAPI(ctrl)
-	statusAPI.EXPECT().Close().Return(nil)
-	statusAPI.EXPECT().Status([]string{"loop"}).Return(&params.FullStatus{
+	statusAPI.EXPECT().Close().AnyTimes().Return(nil)
+	statusAPI.EXPECT().Status(gomock.Any()).AnyTimes().Return(&params.FullStatus{
 		Applications: map[string]params.ApplicationStatus{
 			"loop": {
 				Units: map[string]params.UnitStatus{
-					"loop/0": {},
+					"loop/0": {
+						Subordinates: map[string]params.UnitStatus{
+							"wormhole/0": {},
+						},
+					},
 					"loop/1": {
 						Leader: true,
+						Subordinates: map[string]params.UnitStatus{
+							"wormhole/1": {Leader: true},
+						},
 					},
 				},
 			},
 		},
 	}, nil)
 
+	// Resolve principal application leader.
 	resolvedUnit, err := maybeResolveLeaderUnit(func() (StatusAPI, error) {
 		return statusAPI, nil
 	}, "loop/leader")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resolvedUnit, gc.Equals, "loop/1", gc.Commentf("expected leader to resolve to loop/1"))
+	c.Assert(resolvedUnit, gc.Equals, "loop/1", gc.Commentf("expected leader to resolve to loop/1 for principal application"))
+
+	// Resolve subordinate application leader.
+	resolvedUnit, err = maybeResolveLeaderUnit(func() (StatusAPI, error) {
+		return statusAPI, nil
+	}, "wormhole/leader")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resolvedUnit, gc.Equals, "wormhole/1", gc.Commentf("expected leader to resolve to wormhole/1 for subordinate application"))
 }
 
 type callbackAttemptStarter struct {

--- a/tests/includes/server.sh
+++ b/tests/includes/server.sh
@@ -9,6 +9,10 @@ start_server() {
 		SERVER_PID=$!
 
 		echo "${SERVER_PID}" >"${TEST_DIR}/server.pid"
+
+		# Sleep to ensure the python server is up and running correctly, as it's
+		# a daemon service (&) we can't actually see if it's up easily.
+		sleep 5
 	)
 }
 

--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -15,13 +15,22 @@ run_simplestream_metadata() {
 	add_clean_func "kill_server"
 	start_server "./tests/suites/bootstrap/streams/tools"
 
-	ip_address=$(ip -4 -o addr show scope global | awk '{gsub(/\/.*/,"",$4); print $4}' | head -n 1)
+	# Find a routable address to the server that isn't the loopback address.
+	# Unfortunately, you can't cleanly look at the addresses and select the
+	# right one.
+	addresses=$(hostname -I)
+	server_address=""
+	for address in $(echo "${addresses}" | tr ' ' '\n'); do
+		# shellcheck disable=SC2015
+		curl "http://${address}:8666" >/dev/null 2>&1 && server_address="${address}" && break || true
+	done
 
 	name="test-bootstrap-stream"
 
 	file="${TEST_DIR}/test-bootstrap-stream.log"
 	juju bootstrap "lxd" "${name}" \
-		--config agent-metadata-url="http://${ip_address}:8666/" \
+		--show-log \
+		--config agent-metadata-url="http://${server_address}:8666/" \
 		--config test-mode=true \
 		--agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -27,13 +27,15 @@ cloudinit-userdata: |
 EOF
 
 	juju model-config "${FILE}"
-	juju model-config cloudinit-userdata | grep -q "shellcheck"
+	OUT=$(juju model-config cloudinit-userdata)
+	echo "${OUT}" | grep -q "shellcheck"
 
 	# cloudinit-userdata is not present from the default tabluar output
 	! juju model-config cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
 
 	# cloudinit-userdata is hidden in the normal output
-	juju model-config | grep -q "<value set, see juju model-config cloudinit-userdata>"
+	OUT=$(juju model-config)
+	echo "${OUT}" | grep -q "<value set, see juju model-config cloudinit-userdata>"
 
 	destroy_model "model-config-cloudinit-userdata"
 }

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -475,6 +475,13 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 	err := statetesting.SetAgentVersion(s.State, newTools.Version.Number)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// We want to wait for the model to settle so that we get a single event
+	// from the version watcher.
+	// If we start the worker too quickly after setting the new tools,
+	// it is possible to get 2 watcher changes - the guaranteed initial event
+	// and *then* the one for the change.
+	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())
+
 	var diskSpaceStub testing.Stub
 	diskSpaceStub.SetErrors(nil, errors.Errorf("full-up"))
 	diskSpaceChecked := make(chan struct{}, 1)
@@ -489,7 +496,15 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 		InitialUpgradeCheckComplete: s.initialCheckComplete,
 		CheckDiskSpace: func(dir string, size uint64) error {
 			diskSpaceStub.AddCall("CheckDiskSpace", dir, size)
-			diskSpaceChecked <- struct{}{}
+
+			// CheckDiskSpace is called twice in checkForSpace.
+			// We only care that we arrived there, so if we've already buffered
+			// a write, just proceed.
+			select {
+			case diskSpaceChecked <- struct{}{}:
+			default:
+			}
+
 			return diskSpaceStub.NextErr()
 		},
 	})
@@ -497,14 +512,13 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 
 	select {
 	case <-diskSpaceChecked:
+		workertest.CleanKill(c, u)
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for disk space check.")
 	}
-	err = worker.Stop(u)
 
 	s.expectInitialUpgradeCheckNotDone(c)
 
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(diskSpaceStub.Calls(), gc.HasLen, 2)
 	diskSpaceStub.CheckCall(c, 0, "CheckDiskSpace", s.DataDir(), upgrades.MinDiskSpaceMib)
 	diskSpaceStub.CheckCall(c, 1, "CheckDiskSpace", os.TempDir(), upgrades.MinDiskSpaceMib)


### PR DESCRIPTION
Zero-conflict merge from 2.9 to bring forward:
- #13071 from manadart/2.9-no-bootstrap-type-logging
- #13069 from manadart/2.9-fix-upgrader-space-check-test
- #13054 from SimonRichardson/integration-tests-bootstrap
- #13067 from achilleasa/2.9-resolve-subordinate-leaders-for-juju-ssh
- #13068 from SimonRichardson/mode-config-cloudinit-userdata
- #13064 from tlm/controller-namespace-finding