### PR TITLE
Fixes in cluster credentials for juju upgrades.

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -453,7 +453,20 @@ func (c *controllerStack) Deploy() (err error) {
 	}
 
 	// create service account for local cluster/provider connections.
-	if err = c.ensureControllerServiceAccount(); err != nil {
+	_, saCleanUps, err := ensureControllerServiceAccount(
+		c.ctx.Context(),
+		c.broker.client(),
+		c.broker.GetCurrentNamespace(),
+		c.stackLabels,
+		c.stackAnnotations,
+	)
+	c.addCleanUp(func() {
+		logger.Debugf("delete controller service accounts")
+		for _, v := range saCleanUps {
+			v()
+		}
+	})
+	if err != nil {
 		return errors.Annotate(err, "creating service account for controller")
 	}
 	if isDone() {
@@ -721,39 +734,39 @@ func (c *controllerStack) ensureControllerConfigmapAgentConf() error {
 	return errors.Trace(err)
 }
 
-func (c *controllerStack) ensureControllerServiceAccount() error {
-	sa := &core.ServiceAccount{
+// ensureControllerServiceAccount is responsible for making sure the in cluster
+// service account for the controller exists and is upto date. Returns the name
+// of the service account create, cleanup functions and any errors.
+func ensureControllerServiceAccount(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace string,
+	labels map[string]string,
+	annotations map[string]string,
+) (string, []func(), error) {
+	sa := resources.NewServiceAccount("controller", namespace, &core.ServiceAccount{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "controller",
-			Namespace: c.broker.GetCurrentNamespace(),
 			Labels: providerutils.LabelsMerge(
-				c.stackLabels,
+				labels,
 				providerutils.LabelsJujuModelOperatorDisableWebhook,
 			),
-			Annotations: c.stackAnnotations,
+			Annotations: annotations,
 		},
 		AutomountServiceAccountToken: boolPtr(true),
-	}
-
-	logger.Debugf("ensuring controller service account: \n%+v", sa)
-	_, cleanUps, err := c.broker.ensureServiceAccount(sa)
-	c.addCleanUp(func() {
-		logger.Debugf("deleting %q service account", sa.Name)
-		for _, v := range cleanUps {
-			v()
-		}
 	})
+
+	cleanUps, err := sa.Ensure(context.TODO(), client)
 	if err != nil {
-		return errors.Trace(err)
+		return sa.Name, cleanUps, errors.Trace(err)
 	}
 
 	// name cluster role binding after the controller namespace.
-	clusterRoleBindingName := c.broker.GetCurrentNamespace()
+	clusterRoleBindingName := namespace
 	crb := resources.NewClusterRoleBinding(clusterRoleBindingName, &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        clusterRoleBindingName,
 			Labels:      providerutils.LabelsForModel("controller", false),
-			Annotations: c.stackAnnotations,
+			Annotations: annotations,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -763,18 +776,13 @@ func (c *controllerStack) ensureControllerServiceAccount() error {
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
 			Name:      "controller",
-			Namespace: c.broker.GetCurrentNamespace(),
+			Namespace: namespace,
 		}},
 	})
 
-	crbCleanUps, err := crb.Ensure(c.ctx.Context(), c.broker.client())
-	c.addCleanUp(func() {
-		logger.Debugf("deleting %q cluster role binding", crb.Name)
-		for _, v := range crbCleanUps {
-			v()
-		}
-	})
-	return errors.Trace(err)
+	crbCleanUps, err := crb.Ensure(ctx, client)
+	cleanUps = append(cleanUps, crbCleanUps...)
+	return sa.Name, cleanUps, errors.Trace(err)
 }
 
 func (c *controllerStack) createControllerStatefulset() error {

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -906,8 +906,6 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			Return(emptyConfigMap, nil),
 		s.mockConfigMaps.EXPECT().Create(gomock.Any(), configMapWithBootstrapParamsAdded, v1.CreateOptions{}).AnyTimes().
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockConfigMaps.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=juju-controller-test"}).
-			Return(&core.ConfigMapList{Items: []core.ConfigMap{*emptyConfigMap}}, nil),
 		s.mockConfigMaps.EXPECT().Update(gomock.Any(), configMapWithBootstrapParamsAdded, v1.UpdateOptions{}).AnyTimes().
 			Return(configMapWithBootstrapParamsAdded, nil),
 
@@ -916,12 +914,12 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			Return(configMapWithBootstrapParamsAdded, nil),
 		s.mockConfigMaps.EXPECT().Create(gomock.Any(), configMapWithAgentConfAdded, v1.CreateOptions{}).AnyTimes().
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockConfigMaps.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=juju-controller-test"}).
-			Return(&core.ConfigMapList{Items: []core.ConfigMap{*configMapWithBootstrapParamsAdded}}, nil),
 		s.mockConfigMaps.EXPECT().Update(gomock.Any(), configMapWithAgentConfAdded, v1.UpdateOptions{}).AnyTimes().
 			Return(configMapWithAgentConfAdded, nil),
 
-		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), controllerServiceAccount, v1.CreateOptions{}).
+		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), controllerServiceAccount.Name, gomock.Any()).
+			Return(controllerServiceAccount, nil),
+		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), controllerServiceAccount, gomock.Any()).
 			Return(controllerServiceAccount, nil),
 		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), controllerServiceCRB.Name, gomock.Any()).
 			Return(controllerServiceCRB, nil),

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -74,14 +74,6 @@ func (k *kubernetesClient) ensureConfigMap(cm *core.ConfigMap) (func(), error) {
 	if !errors.IsAlreadyExists(err) {
 		return cleanUp, errors.Trace(err)
 	}
-	_, err = k.listConfigMaps(cm.GetLabels())
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// configmap name is already used for an existing secret.
-			return cleanUp, errors.AlreadyExistsf("configmap %q", cm.GetName())
-		}
-		return cleanUp, errors.Trace(err)
-	}
 	err = k.updateConfigMap(cm)
 	logger.Debugf("updating configmap %q", cm.GetName())
 	return cleanUp, errors.Trace(err)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2809,8 +2809,6 @@ password: shhhh`[1:],
 		// ensure configmaps.
 		s.mockConfigMaps.EXPECT().Create(gomock.Any(), cm, v1.CreateOptions{}).
 			Return(nil, s.k8sAlreadyExistsError()),
-		s.mockConfigMaps.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: "app.kubernetes.io/managed-by=juju,app.kubernetes.io/name=app-name"}).
-			Return(&core.ConfigMapList{Items: []core.ConfigMap{*cm}}, nil),
 		s.mockConfigMaps.EXPECT().Update(gomock.Any(), cm, v1.UpdateOptions{}).
 			Return(cm, nil),
 

--- a/caas/kubernetes/provider/resources/clusterrole.go
+++ b/caas/kubernetes/provider/resources/clusterrole.go
@@ -111,7 +111,7 @@ func (r *ClusterRole) Ensure(
 		return cleanups, errors.Annotatef(
 			err,
 			"checking for existing cluster role %q",
-			r.Name,
+			existing.Name,
 		)
 	}
 
@@ -154,7 +154,7 @@ func (r *ClusterRole) Update(ctx context.Context, client kubernetes.Interface) e
 		},
 	)
 	if k8serrors.IsNotFound(err) {
-		return errors.Annotatef(err, "updating cluster role %q", r.Name)
+		return errors.NewNotFound(err, "updating cluster role")
 	} else if err != nil {
 		return errors.Trace(err)
 	}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -94,6 +94,7 @@ type StateBackend interface {
 	TranslateK8sServiceTypes() error
 	UpdateKubernetesCloudCredentials() error
 	UpdateDHCPAddressConfigs() error
+	KubernetesInClusterCredentialSpec() (environscloudspec.CloudSpec, *config.Config, string, error)
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -397,4 +398,9 @@ func (s stateBackend) UpdateKubernetesCloudCredentials() error {
 
 func (s stateBackend) UpdateDHCPAddressConfigs() error {
 	return state.UpdateDHCPAddressConfigs(s.pool)
+}
+
+func (s stateBackend) KubernetesInClusterCredentialSpec() (
+	environscloudspec.CloudSpec, *config.Config, string, error) {
+	return state.KubernetesInClusterCredentialSpec(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -47,6 +47,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.8.9"), stateStepsFor289()},
 		upgradeToVersion{version.MustParse("2.9.0"), stateStepsFor29()},
 		upgradeToVersion{version.MustParse("2.9.5"), stateStepsFor295()},
+		upgradeToVersion{version.MustParse("2.9.6"), stateStepsFor296()},
 	}
 	return steps
 }

--- a/upgrades/steps_295.go
+++ b/upgrades/steps_295.go
@@ -3,7 +3,7 @@
 
 package upgrades
 
-// stateStepsFor295 returns database upgrade steps for Juju 2.9.5.
+// stateStepsFor295 returns upgrade steps for juju 2.9.5
 func stateStepsFor295() []Step {
 	return []Step{
 		&upgradeStep{

--- a/upgrades/steps_296.go
+++ b/upgrades/steps_296.go
@@ -1,0 +1,58 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+import (
+	ctx "context"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/environs"
+)
+
+// upgradeKubernetesClusterCredential is an upgrade step interface that
+// Kubernetes providers need to implement to perform in cluster credential
+// upgrades
+type upgradeKubernetesClusterCredential interface {
+	InClusterCredentialUpgrade() error
+}
+
+// stateStepsFor296 returns upgrade steps for juju 2.9.6
+func stateStepsFor296() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "prepare k8s controller for in cluster credentials",
+			targets:     []Target{DatabaseMaster},
+			run:         controllerInClusterCredentials,
+		},
+	}
+}
+
+// controllerInClusterCredentials performs the upgrade for Kubernetes
+// controllers to us in cluster credentials
+func controllerInClusterCredentials(context Context) error {
+	cloudSpec, modelCfg, uuid, err := context.State().KubernetesInClusterCredentialSpec()
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
+	cloudSpec.IsControllerCloud = false
+	broker, err := caas.New(ctx.TODO(), environs.OpenParams{
+		ControllerUUID: uuid,
+		Cloud:          cloudSpec,
+		Config:         modelCfg,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	upgrader, ok := broker.(upgradeKubernetesClusterCredential)
+	if !ok {
+		return errors.New("caas broker does not implement kubernetes cluster credential upgrader")
+	}
+
+	return upgrader.InClusterCredentialUpgrade()
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -637,6 +637,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.8.9",
 		"2.9.0",
 		"2.9.5",
+		"2.9.6",
 	})
 }
 


### PR DESCRIPTION
In juju 2.9 we migrated the controller pod to using in cluster
credentials when talking to Kubernetes. This change did not apply to
upgrade controllers. This commit changes that with upgrade steps to the
controller.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

See bug. We want to do an upgrade from 2.8 to 2.9 and check that the statefulset for the controller gets it's service account attached and that the controller logs report no provider errors for credentials.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1930798
