### PR TITLE
NetworkInfo - Add Machine Indirection

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -60,7 +60,7 @@ func NewNetworkInfo(st *state.State, tag names.UnitTag) (NetworkInfo, error) {
 	return n, errors.Trace(err)
 }
 
-// NewNetworkInfoWithBehaviour initialises and returns a new NetworkInfo
+// NewNetworkInfoForStrategy initialises and returns a new NetworkInfo
 // based on the input state and unit tag, allowing further specification of
 // behaviour via the input retry factory and host resolver.
 func NewNetworkInfoForStrategy(

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/params"
@@ -16,11 +17,35 @@ import (
 	"github.com/juju/juju/state"
 )
 
+// Machine describes methods required for interrogating
+// the addresses of a machine in state.
+type Machine interface {
+	// Id returns the machine's model-unique identifier.
+	Id() string
+
+	// MachineTag returns the machine's tag, specifically typed.
+	MachineTag() names.MachineTag
+
+	// PrivateAddress returns the machine's preferred private address.
+	PrivateAddress() (network.SpaceAddress, error)
+
+	// AllAddresses returns the state representation of a machine's addresses.
+	// TODO (manadart 2021-06-15): Indirect this too.
+	AllAddresses() ([]*state.Address, error)
+
+	// AllDeviceSpaceAddresses returns all known addresses
+	// from the machine's link-layer devices.
+	AllDeviceSpaceAddresses() (network.SpaceAddresses, error)
+}
+
 // NetworkInfoIAAS is used to provide network info for IAAS units.
 type NetworkInfoIAAS struct {
 	*NetworkInfoBase
 
-	// machineNetworkInfos container network info for the unit's machine,
+	// machine is where the unit resides.
+	machine Machine
+
+	// machineNetworkInfos contains network info for the unit's machine,
 	// keyed by space ID.
 	machineNetworkInfos map[string]params.NetworkInfoResult
 }
@@ -32,9 +57,14 @@ func newNetworkInfoIAAS(base *NetworkInfoBase) (*NetworkInfoIAAS, error) {
 	}
 
 	netInfo := &NetworkInfoIAAS{NetworkInfoBase: base}
+
+	if err := netInfo.populateUnitMachine(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if err := netInfo.populateMachineNetworkInfos(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	return netInfo, nil
 }
 
@@ -173,18 +203,18 @@ func (n *NetworkInfoIAAS) resolveResultIngressHostNames(netInfo params.NetworkIn
 	return netInfo
 }
 
-// populateMachineNetworkInfos sets network info for the unit's machine
-// based on devices with addresses in the unit's bound spaces.
-func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
+func (n *NetworkInfoIAAS) populateUnitMachine() error {
 	machineID, err := n.unit.AssignedMachineId()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	machine, err := n.st.Machine(machineID)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	n.machine, err = n.st.Machine(machineID)
+	return errors.Trace(err)
+}
 
+// populateMachineNetworkInfos sets network info for the unit's machine
+// based on devices with addresses in the unit's bound spaces.
+func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 	spaceSet := set.NewStrings()
 	for _, binding := range n.bindings {
 		spaceSet.Add(binding)
@@ -195,10 +225,10 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 
 	if spaceSet.Contains(network.AlphaSpaceId) {
 		var err error
-		privateMachineAddress, err := n.pollForAddress(machine.PrivateAddress)
+		privateMachineAddress, err := n.pollForAddress(n.machine.PrivateAddress)
 		if err != nil {
 			n.machineNetworkInfos[network.AlphaSpaceId] = params.NetworkInfoResult{Error: apiservererrors.ServerError(
-				errors.Annotatef(err, "getting machine %q preferred private address", machine.MachineTag()))}
+				errors.Annotatef(err, "getting machine %q preferred private address", n.machine.MachineTag()))}
 
 			// Remove this ID to prevent further processing.
 			spaceSet.Remove(network.AlphaSpaceId)
@@ -212,7 +242,7 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 	// can be sorted for scope and primary/secondary status.
 	// We create a map for the information we need to return, and a separate
 	// sorted slice for iteration in the correct order.
-	addrs, err := machine.AllAddresses()
+	addrs, err := n.machine.AllAddresses()
 	if err != nil {
 		n.populateMachineNetworkInfoErrors(spaceSet, err)
 		return nil
@@ -222,7 +252,7 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 		addrByIP[addr.Value()] = addr
 	}
 
-	spaceAddrs, err := machine.AllDeviceSpaceAddresses()
+	spaceAddrs, err := n.machine.AllDeviceSpaceAddresses()
 	if err != nil {
 		n.populateMachineNetworkInfoErrors(spaceSet, err)
 		return nil
@@ -294,7 +324,7 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 	for _, id := range spaceSet.Values() {
 		if _, ok := n.machineNetworkInfos[id]; !ok {
 			n.machineNetworkInfos[id] = params.NetworkInfoResult{Error: apiservererrors.ServerError(
-				errors.Errorf("machine %q has no addresses in space %q", machineID, id))}
+				errors.Errorf("machine %q has no addresses in space %q", n.machine.Id(), id))}
 		}
 	}
 


### PR DESCRIPTION
This is the beginning of some work to make the machine-based `NetworkInfo` less brittle.

We need to allow address sorting before materialising results into wire-types, losing the domain-type capability.

This simply adds an indirection for the unit's machine and populates it separately from address acquisition.

## QA steps

Non-functional changes; unit tests pass.
