### PR TITLE
EC2: Use juju/http client

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -4,6 +4,7 @@
 package agentbootstrap
 
 import (
+	stdcontext "context"
 	"fmt"
 	"path/filepath"
 
@@ -390,9 +391,9 @@ func getEnviron(
 		Config:         modelConfig,
 	}
 	if cloudSpec.Type == cloud.CloudTypeCAAS {
-		return caas.Open(provider, openParams)
+		return caas.Open(stdcontext.TODO(), provider, openParams)
 	}
-	return environs.Open(provider, openParams)
+	return environs.Open(stdcontext.TODO(), provider, openParams)
 }
 
 func initRaft(agentConfig agent.Config) error {

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -4,6 +4,7 @@
 package agentbootstrap_test
 
 import (
+	stdcontext "context"
 	"io/ioutil"
 	"net"
 	"path/filepath"
@@ -522,7 +523,7 @@ func (p *fakeProvider) Validate(newCfg, oldCfg *config.Config) (*config.Config, 
 	return newCfg, p.NextErr()
 }
 
-func (p *fakeProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p *fakeProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	p.MethodCall(p, "Open", args)
 	p.environ = &fakeEnviron{Stub: &p.Stub, provider: p}
 	return p.environ, p.NextErr()

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -76,7 +76,7 @@ func checkCAASModelCredential(brokerParams environs.OpenParams) (params.ErrorRes
 }
 
 func checkIAASModelCredential(openParams environs.OpenParams, backend PersistentBackend, callCtx context.ProviderCallContext, checkCloudInstances bool) (params.ErrorResults, error) {
-	env, err := newEnv(openParams)
+	env, err := newEnv(callCtx, openParams)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}

--- a/apiserver/common/credentialcommon/modelcredential.go
+++ b/apiserver/common/credentialcommon/modelcredential.go
@@ -4,6 +4,8 @@
 package credentialcommon
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -63,7 +65,7 @@ func ValidateNewModelCredential(backend PersistentBackend, callCtx context.Provi
 }
 
 func checkCAASModelCredential(brokerParams environs.OpenParams) (params.ErrorResults, error) {
-	broker, err := newCAASBroker(brokerParams)
+	broker, err := newCAASBroker(stdcontext.TODO(), brokerParams)
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}

--- a/apiserver/common/credentialcommon/modelcredential_test.go
+++ b/apiserver/common/credentialcommon/modelcredential_test.go
@@ -4,6 +4,8 @@
 package credentialcommon_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -347,7 +349,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialInvalidCredent
 }
 
 func (s *ModelCredentialSuite) TestOpeningProviderFails(c *gc.C) {
-	s.PatchValue(credentialcommon.NewEnv, func(environs.OpenParams) (environs.Environ, error) {
+	s.PatchValue(credentialcommon.NewEnv, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return nil, errors.New("explosive")
 	})
 	results, err := credentialcommon.CheckIAASModelCredential(environs.OpenParams{}, s.backend, s.callContext, false)
@@ -370,7 +372,7 @@ func (s *ModelCredentialSuite) TestValidateExistingModelCredentialForIAASModel(c
 }
 
 func (s *ModelCredentialSuite) TestOpeningCAASBrokerFails(c *gc.C) {
-	s.PatchValue(credentialcommon.NewCAASBroker, func(environs.OpenParams) (caas.Broker, error) {
+	s.PatchValue(credentialcommon.NewCAASBroker, func(stdcontext.Context, environs.OpenParams) (caas.Broker, error) {
 		return nil, errors.New("explosive")
 	})
 	results, err := credentialcommon.CheckCAASModelCredential(environs.OpenParams{})
@@ -379,7 +381,7 @@ func (s *ModelCredentialSuite) TestOpeningCAASBrokerFails(c *gc.C) {
 }
 
 func (s *ModelCredentialSuite) TestCAASCredentialCheckFailed(c *gc.C) {
-	s.PatchValue(credentialcommon.NewCAASBroker, func(environs.OpenParams) (caas.Broker, error) {
+	s.PatchValue(credentialcommon.NewCAASBroker, func(stdcontext.Context, environs.OpenParams) (caas.Broker, error) {
 		return &mockCaasBroker{
 			namespacesFunc: func() ([]string, error) { return nil, errors.New("fail auth") },
 		}, nil
@@ -390,7 +392,7 @@ func (s *ModelCredentialSuite) TestCAASCredentialCheckFailed(c *gc.C) {
 }
 
 func (s *ModelCredentialSuite) TestCAASCredentialCheckSucceeds(c *gc.C) {
-	s.PatchValue(credentialcommon.NewCAASBroker, func(environs.OpenParams) (caas.Broker, error) {
+	s.PatchValue(credentialcommon.NewCAASBroker, func(stdcontext.Context, environs.OpenParams) (caas.Broker, error) {
 		return &mockCaasBroker{
 			namespacesFunc: func() ([]string, error) { return []string{}, nil },
 		}, nil
@@ -420,7 +422,7 @@ func (s *ModelCredentialSuite) ensureEnvForCAASModel(c *gc.C) {
 	s.backend.modelFunc = func() (credentialcommon.Model, error) {
 		return caasModel, nil
 	}
-	s.PatchValue(credentialcommon.NewCAASBroker, func(environs.OpenParams) (caas.Broker, error) {
+	s.PatchValue(credentialcommon.NewCAASBroker, func(stdcontext.Context, environs.OpenParams) (caas.Broker, error) {
 		return &mockCaasBroker{
 			namespacesFunc: func() ([]string, error) { return []string{}, nil },
 		}, nil
@@ -428,7 +430,7 @@ func (s *ModelCredentialSuite) ensureEnvForCAASModel(c *gc.C) {
 }
 
 func (s *ModelCredentialSuite) ensureEnvForIAASModel(c *gc.C) {
-	s.PatchValue(credentialcommon.NewEnv, func(environs.OpenParams) (environs.Environ, error) {
+	s.PatchValue(credentialcommon.NewEnv, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return &mockEnviron{
 			mockProvider: &mockProvider{
 				Stub: &testing.Stub{},

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"time"
 
@@ -5514,7 +5515,7 @@ func (s *cloudSpecUniterSuite) TestCloudAPIVersion(c *gc.C) {
 	_, cm, _, _ := s.setupCAASModel(c)
 
 	uniterAPI := s.newUniterAPI(c, cm.State(), s.authorizer)
-	uniter.SetNewContainerBrokerFunc(uniterAPI, func(environs.OpenParams) (caas.Broker, error) {
+	uniter.SetNewContainerBrokerFunc(uniterAPI, func(stdcontext.Context, environs.OpenParams) (caas.Broker, error) {
 		return &fakeBroker{}, nil
 	})
 

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -4,6 +4,7 @@
 package controller_test
 
 import (
+	stdcontext "context"
 	"encoding/json"
 	"regexp"
 	"time"
@@ -241,7 +242,7 @@ func (s *controllerSuite) TestHostedModelConfigs_CanOpenEnviron(c *gc.C) {
 		cfg, err := config.New(config.NoDefaults, model.Config)
 		c.Assert(err, jc.ErrorIsNil)
 		spec := s.makeCloudSpec(c, model.CloudSpec)
-		_, err = environs.New(environs.OpenParams{
+		_, err = environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  spec,
 			Config: cfg,
 		})

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -8,6 +8,7 @@
 package modelmanager
 
 import (
+	stdcontext "context"
 	"fmt"
 	"sort"
 	"time"
@@ -686,7 +687,7 @@ func (m *ModelManagerAPI) newModel(
 	}
 
 	// Create the Environ.
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		ControllerUUID: controllerCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         newConfig,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -121,7 +121,7 @@ type ModelManagerV2 interface {
 	ModelStatus(req params.Entities) (params.ModelStatusResults, error)
 }
 
-type newCaasBrokerFunc func(args environs.OpenParams) (caas.Broker, error)
+type newCaasBrokerFunc func(_ stdcontext.Context, args environs.OpenParams) (caas.Broker, error)
 
 // StatePool represents a point of use interface for getting the state from the
 // pool.
@@ -622,7 +622,7 @@ func (m *ModelManagerAPI) newCAASModel(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting controller config")
 	}
-	broker, err := m.getBroker(environs.OpenParams{
+	broker, err := m.getBroker(stdcontext.TODO(), environs.OpenParams{
 		ControllerUUID: controllerConfig.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         newConfig,

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	stdcontext "context"
 	"regexp"
 	"time"
 
@@ -206,7 +207,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 
 	s.callContext = context.NewEmptyCloudCallContext()
 
-	newBroker := func(args environs.OpenParams) (caas.Broker, error) {
+	newBroker := func(_ stdcontext.Context, args environs.OpenParams) (caas.Broker, error) {
 		s.caasBroker = &mockCaasBroker{namespace: args.Config.Name()}
 		return s.caasBroker, nil
 	}
@@ -221,7 +222,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 
 func (s *modelManagerSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
-	newBroker := func(args environs.OpenParams) (caas.Broker, error) {
+	newBroker := func(_ stdcontext.Context, args environs.OpenParams) (caas.Broker, error) {
 		return s.caasBroker, nil
 	}
 	mm, err := modelmanager.NewModelManagerAPI(s.st, s.ctlrSt, nil, nil, newBroker, s.authoriser, s.st.model, s.callContext)

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -5,6 +5,8 @@
 package spaces
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
 	networkingcommon "github.com/juju/juju/apiserver/common/networkingcommon"
@@ -19,34 +21,33 @@ import (
 	space "github.com/juju/juju/environs/space"
 	state "github.com/juju/juju/state"
 	txn "github.com/juju/mgo/v2/txn"
-	v4 "github.com/juju/names/v4"
-	reflect "reflect"
+	names "github.com/juju/names/v4"
 )
 
-// MockBacking is a mock of Backing interface
+// MockBacking is a mock of Backing interface.
 type MockBacking struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackingMockRecorder
 }
 
-// MockBackingMockRecorder is the mock recorder for MockBacking
+// MockBackingMockRecorder is the mock recorder for MockBacking.
 type MockBackingMockRecorder struct {
 	mock *MockBacking
 }
 
-// NewMockBacking creates a new mock instance
+// NewMockBacking creates a new mock instance.
 func NewMockBacking(ctrl *gomock.Controller) *MockBacking {
 	mock := &MockBacking{ctrl: ctrl}
 	mock.recorder = &MockBackingMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBacking) EXPECT() *MockBackingMockRecorder {
 	return m.recorder
 }
 
-// AddSpace mocks base method
+// AddSpace mocks base method.
 func (m *MockBacking) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3 bool) (networkingcommon.BackingSpace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3)
@@ -55,13 +56,13 @@ func (m *MockBacking) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3
 	return ret0, ret1
 }
 
-// AddSpace indicates an expected call of AddSpace
+// AddSpace indicates an expected call of AddSpace.
 func (mr *MockBackingMockRecorder) AddSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockBacking)(nil).AddSpace), arg0, arg1, arg2, arg3)
 }
 
-// AllConstraints mocks base method
+// AllConstraints mocks base method.
 func (m *MockBacking) AllConstraints() ([]Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllConstraints")
@@ -70,13 +71,13 @@ func (m *MockBacking) AllConstraints() ([]Constraints, error) {
 	return ret0, ret1
 }
 
-// AllConstraints indicates an expected call of AllConstraints
+// AllConstraints indicates an expected call of AllConstraints.
 func (mr *MockBackingMockRecorder) AllConstraints() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllConstraints", reflect.TypeOf((*MockBacking)(nil).AllConstraints))
 }
 
-// AllEndpointBindings mocks base method
+// AllEndpointBindings mocks base method.
 func (m *MockBacking) AllEndpointBindings() (map[string]Bindings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllEndpointBindings")
@@ -85,13 +86,13 @@ func (m *MockBacking) AllEndpointBindings() (map[string]Bindings, error) {
 	return ret0, ret1
 }
 
-// AllEndpointBindings indicates an expected call of AllEndpointBindings
+// AllEndpointBindings indicates an expected call of AllEndpointBindings.
 func (mr *MockBackingMockRecorder) AllEndpointBindings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllEndpointBindings", reflect.TypeOf((*MockBacking)(nil).AllEndpointBindings))
 }
 
-// AllMachines mocks base method
+// AllMachines mocks base method.
 func (m *MockBacking) AllMachines() ([]Machine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllMachines")
@@ -100,13 +101,13 @@ func (m *MockBacking) AllMachines() ([]Machine, error) {
 	return ret0, ret1
 }
 
-// AllMachines indicates an expected call of AllMachines
+// AllMachines indicates an expected call of AllMachines.
 func (mr *MockBackingMockRecorder) AllMachines() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachines", reflect.TypeOf((*MockBacking)(nil).AllMachines))
 }
 
-// AllSpaceInfos mocks base method
+// AllSpaceInfos mocks base method.
 func (m *MockBacking) AllSpaceInfos() (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaceInfos")
@@ -115,13 +116,13 @@ func (m *MockBacking) AllSpaceInfos() (network.SpaceInfos, error) {
 	return ret0, ret1
 }
 
-// AllSpaceInfos indicates an expected call of AllSpaceInfos
+// AllSpaceInfos indicates an expected call of AllSpaceInfos.
 func (mr *MockBackingMockRecorder) AllSpaceInfos() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaceInfos", reflect.TypeOf((*MockBacking)(nil).AllSpaceInfos))
 }
 
-// AllSpaces mocks base method
+// AllSpaces mocks base method.
 func (m *MockBacking) AllSpaces() ([]networkingcommon.BackingSpace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
@@ -130,13 +131,13 @@ func (m *MockBacking) AllSpaces() ([]networkingcommon.BackingSpace, error) {
 	return ret0, ret1
 }
 
-// AllSpaces indicates an expected call of AllSpaces
+// AllSpaces indicates an expected call of AllSpaces.
 func (mr *MockBackingMockRecorder) AllSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockBacking)(nil).AllSpaces))
 }
 
-// ApplyOperation mocks base method
+// ApplyOperation mocks base method.
 func (m *MockBacking) ApplyOperation(arg0 state.ModelOperation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyOperation", arg0)
@@ -144,13 +145,13 @@ func (m *MockBacking) ApplyOperation(arg0 state.ModelOperation) error {
 	return ret0
 }
 
-// ApplyOperation indicates an expected call of ApplyOperation
+// ApplyOperation indicates an expected call of ApplyOperation.
 func (mr *MockBackingMockRecorder) ApplyOperation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyOperation", reflect.TypeOf((*MockBacking)(nil).ApplyOperation), arg0)
 }
 
-// CloudSpec mocks base method
+// CloudSpec mocks base method.
 func (m *MockBacking) CloudSpec() (cloudspec.CloudSpec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudSpec")
@@ -159,13 +160,13 @@ func (m *MockBacking) CloudSpec() (cloudspec.CloudSpec, error) {
 	return ret0, ret1
 }
 
-// CloudSpec indicates an expected call of CloudSpec
+// CloudSpec indicates an expected call of CloudSpec.
 func (mr *MockBackingMockRecorder) CloudSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockBacking)(nil).CloudSpec))
 }
 
-// ConstraintsBySpaceName mocks base method
+// ConstraintsBySpaceName mocks base method.
 func (m *MockBacking) ConstraintsBySpaceName(arg0 string) ([]Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsBySpaceName", arg0)
@@ -174,13 +175,13 @@ func (m *MockBacking) ConstraintsBySpaceName(arg0 string) ([]Constraints, error)
 	return ret0, ret1
 }
 
-// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName
+// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName.
 func (mr *MockBackingMockRecorder) ConstraintsBySpaceName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockBacking)(nil).ConstraintsBySpaceName), arg0)
 }
 
-// ControllerConfig mocks base method
+// ControllerConfig mocks base method.
 func (m *MockBacking) ControllerConfig() (controller.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
@@ -189,13 +190,13 @@ func (m *MockBacking) ControllerConfig() (controller.Config, error) {
 	return ret0, ret1
 }
 
-// ControllerConfig indicates an expected call of ControllerConfig
+// ControllerConfig indicates an expected call of ControllerConfig.
 func (mr *MockBackingMockRecorder) ControllerConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockBacking)(nil).ControllerConfig))
 }
 
-// IsController mocks base method
+// IsController mocks base method.
 func (m *MockBacking) IsController() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsController")
@@ -203,13 +204,13 @@ func (m *MockBacking) IsController() bool {
 	return ret0
 }
 
-// IsController indicates an expected call of IsController
+// IsController indicates an expected call of IsController.
 func (mr *MockBackingMockRecorder) IsController() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsController", reflect.TypeOf((*MockBacking)(nil).IsController))
 }
 
-// ModelConfig mocks base method
+// ModelConfig mocks base method.
 func (m *MockBacking) ModelConfig() (*config.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelConfig")
@@ -218,27 +219,27 @@ func (m *MockBacking) ModelConfig() (*config.Config, error) {
 	return ret0, ret1
 }
 
-// ModelConfig indicates an expected call of ModelConfig
+// ModelConfig indicates an expected call of ModelConfig.
 func (mr *MockBackingMockRecorder) ModelConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfig", reflect.TypeOf((*MockBacking)(nil).ModelConfig))
 }
 
-// ModelTag mocks base method
-func (m *MockBacking) ModelTag() v4.ModelTag {
+// ModelTag mocks base method.
+func (m *MockBacking) ModelTag() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(v4.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
-// ModelTag indicates an expected call of ModelTag
+// ModelTag indicates an expected call of ModelTag.
 func (mr *MockBackingMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockBacking)(nil).ModelTag))
 }
 
-// MovingSubnet mocks base method
+// MovingSubnet mocks base method.
 func (m *MockBacking) MovingSubnet(arg0 string) (MovingSubnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MovingSubnet", arg0)
@@ -247,13 +248,13 @@ func (m *MockBacking) MovingSubnet(arg0 string) (MovingSubnet, error) {
 	return ret0, ret1
 }
 
-// MovingSubnet indicates an expected call of MovingSubnet
+// MovingSubnet indicates an expected call of MovingSubnet.
 func (mr *MockBackingMockRecorder) MovingSubnet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MovingSubnet", reflect.TypeOf((*MockBacking)(nil).MovingSubnet), arg0)
 }
 
-// SpaceByName mocks base method
+// SpaceByName mocks base method.
 func (m *MockBacking) SpaceByName(arg0 string) (networkingcommon.BackingSpace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpaceByName", arg0)
@@ -262,13 +263,13 @@ func (m *MockBacking) SpaceByName(arg0 string) (networkingcommon.BackingSpace, e
 	return ret0, ret1
 }
 
-// SpaceByName indicates an expected call of SpaceByName
+// SpaceByName indicates an expected call of SpaceByName.
 func (mr *MockBackingMockRecorder) SpaceByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceByName", reflect.TypeOf((*MockBacking)(nil).SpaceByName), arg0)
 }
 
-// SubnetByCIDR mocks base method
+// SubnetByCIDR mocks base method.
 func (m *MockBacking) SubnetByCIDR(arg0 string) (networkingcommon.BackingSubnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubnetByCIDR", arg0)
@@ -277,36 +278,36 @@ func (m *MockBacking) SubnetByCIDR(arg0 string) (networkingcommon.BackingSubnet,
 	return ret0, ret1
 }
 
-// SubnetByCIDR indicates an expected call of SubnetByCIDR
+// SubnetByCIDR indicates an expected call of SubnetByCIDR.
 func (mr *MockBackingMockRecorder) SubnetByCIDR(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetByCIDR", reflect.TypeOf((*MockBacking)(nil).SubnetByCIDR), arg0)
 }
 
-// MockBlockChecker is a mock of BlockChecker interface
+// MockBlockChecker is a mock of BlockChecker interface.
 type MockBlockChecker struct {
 	ctrl     *gomock.Controller
 	recorder *MockBlockCheckerMockRecorder
 }
 
-// MockBlockCheckerMockRecorder is the mock recorder for MockBlockChecker
+// MockBlockCheckerMockRecorder is the mock recorder for MockBlockChecker.
 type MockBlockCheckerMockRecorder struct {
 	mock *MockBlockChecker
 }
 
-// NewMockBlockChecker creates a new mock instance
+// NewMockBlockChecker creates a new mock instance.
 func NewMockBlockChecker(ctrl *gomock.Controller) *MockBlockChecker {
 	mock := &MockBlockChecker{ctrl: ctrl}
 	mock.recorder = &MockBlockCheckerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBlockChecker) EXPECT() *MockBlockCheckerMockRecorder {
 	return m.recorder
 }
 
-// ChangeAllowed mocks base method
+// ChangeAllowed mocks base method.
 func (m *MockBlockChecker) ChangeAllowed() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeAllowed")
@@ -314,13 +315,13 @@ func (m *MockBlockChecker) ChangeAllowed() error {
 	return ret0
 }
 
-// ChangeAllowed indicates an expected call of ChangeAllowed
+// ChangeAllowed indicates an expected call of ChangeAllowed.
 func (mr *MockBlockCheckerMockRecorder) ChangeAllowed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeAllowed", reflect.TypeOf((*MockBlockChecker)(nil).ChangeAllowed))
 }
 
-// RemoveAllowed mocks base method
+// RemoveAllowed mocks base method.
 func (m *MockBlockChecker) RemoveAllowed() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllowed")
@@ -328,36 +329,36 @@ func (m *MockBlockChecker) RemoveAllowed() error {
 	return ret0
 }
 
-// RemoveAllowed indicates an expected call of RemoveAllowed
+// RemoveAllowed indicates an expected call of RemoveAllowed.
 func (mr *MockBlockCheckerMockRecorder) RemoveAllowed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllowed", reflect.TypeOf((*MockBlockChecker)(nil).RemoveAllowed))
 }
 
-// MockMachine is a mock of Machine interface
+// MockMachine is a mock of Machine interface.
 type MockMachine struct {
 	ctrl     *gomock.Controller
 	recorder *MockMachineMockRecorder
 }
 
-// MockMachineMockRecorder is the mock recorder for MockMachine
+// MockMachineMockRecorder is the mock recorder for MockMachine.
 type MockMachineMockRecorder struct {
 	mock *MockMachine
 }
 
-// NewMockMachine creates a new mock instance
+// NewMockMachine creates a new mock instance.
 func NewMockMachine(ctrl *gomock.Controller) *MockMachine {
 	mock := &MockMachine{ctrl: ctrl}
 	mock.recorder = &MockMachineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 	return m.recorder
 }
 
-// AllAddresses mocks base method
+// AllAddresses mocks base method.
 func (m *MockMachine) AllAddresses() ([]Address, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllAddresses")
@@ -366,13 +367,13 @@ func (m *MockMachine) AllAddresses() ([]Address, error) {
 	return ret0, ret1
 }
 
-// AllAddresses indicates an expected call of AllAddresses
+// AllAddresses indicates an expected call of AllAddresses.
 func (mr *MockMachineMockRecorder) AllAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockMachine)(nil).AllAddresses))
 }
 
-// AllSpaces mocks base method
+// AllSpaces mocks base method.
 func (m *MockMachine) AllSpaces() (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
@@ -381,13 +382,13 @@ func (m *MockMachine) AllSpaces() (set.Strings, error) {
 	return ret0, ret1
 }
 
-// AllSpaces indicates an expected call of AllSpaces
+// AllSpaces indicates an expected call of AllSpaces.
 func (mr *MockMachineMockRecorder) AllSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockMachine)(nil).AllSpaces))
 }
 
-// Units mocks base method
+// Units mocks base method.
 func (m *MockMachine) Units() ([]Unit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units")
@@ -396,36 +397,36 @@ func (m *MockMachine) Units() ([]Unit, error) {
 	return ret0, ret1
 }
 
-// Units indicates an expected call of Units
+// Units indicates an expected call of Units.
 func (mr *MockMachineMockRecorder) Units() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockMachine)(nil).Units))
 }
 
-// MockRenameSpace is a mock of RenameSpace interface
+// MockRenameSpace is a mock of RenameSpace interface.
 type MockRenameSpace struct {
 	ctrl     *gomock.Controller
 	recorder *MockRenameSpaceMockRecorder
 }
 
-// MockRenameSpaceMockRecorder is the mock recorder for MockRenameSpace
+// MockRenameSpaceMockRecorder is the mock recorder for MockRenameSpace.
 type MockRenameSpaceMockRecorder struct {
 	mock *MockRenameSpace
 }
 
-// NewMockRenameSpace creates a new mock instance
+// NewMockRenameSpace creates a new mock instance.
 func NewMockRenameSpace(ctrl *gomock.Controller) *MockRenameSpace {
 	mock := &MockRenameSpace{ctrl: ctrl}
 	mock.recorder = &MockRenameSpaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRenameSpace) EXPECT() *MockRenameSpaceMockRecorder {
 	return m.recorder
 }
 
-// Id mocks base method
+// Id mocks base method.
 func (m *MockRenameSpace) Id() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
@@ -433,13 +434,13 @@ func (m *MockRenameSpace) Id() string {
 	return ret0
 }
 
-// Id indicates an expected call of Id
+// Id indicates an expected call of Id.
 func (mr *MockRenameSpaceMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockRenameSpace)(nil).Id))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockRenameSpace) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -447,13 +448,13 @@ func (m *MockRenameSpace) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockRenameSpaceMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockRenameSpace)(nil).Name))
 }
 
-// Refresh mocks base method
+// Refresh mocks base method.
 func (m *MockRenameSpace) Refresh() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
@@ -461,13 +462,13 @@ func (m *MockRenameSpace) Refresh() error {
 	return ret0
 }
 
-// Refresh indicates an expected call of Refresh
+// Refresh indicates an expected call of Refresh.
 func (mr *MockRenameSpaceMockRecorder) Refresh() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockRenameSpace)(nil).Refresh))
 }
 
-// RenameSpaceOps mocks base method
+// RenameSpaceOps mocks base method.
 func (m *MockRenameSpace) RenameSpaceOps(arg0 string) []txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenameSpaceOps", arg0)
@@ -475,36 +476,36 @@ func (m *MockRenameSpace) RenameSpaceOps(arg0 string) []txn.Op {
 	return ret0
 }
 
-// RenameSpaceOps indicates an expected call of RenameSpaceOps
+// RenameSpaceOps indicates an expected call of RenameSpaceOps.
 func (mr *MockRenameSpaceMockRecorder) RenameSpaceOps(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameSpaceOps", reflect.TypeOf((*MockRenameSpace)(nil).RenameSpaceOps), arg0)
 }
 
-// MockRenameSpaceState is a mock of RenameSpaceState interface
+// MockRenameSpaceState is a mock of RenameSpaceState interface.
 type MockRenameSpaceState struct {
 	ctrl     *gomock.Controller
 	recorder *MockRenameSpaceStateMockRecorder
 }
 
-// MockRenameSpaceStateMockRecorder is the mock recorder for MockRenameSpaceState
+// MockRenameSpaceStateMockRecorder is the mock recorder for MockRenameSpaceState.
 type MockRenameSpaceStateMockRecorder struct {
 	mock *MockRenameSpaceState
 }
 
-// NewMockRenameSpaceState creates a new mock instance
+// NewMockRenameSpaceState creates a new mock instance.
 func NewMockRenameSpaceState(ctrl *gomock.Controller) *MockRenameSpaceState {
 	mock := &MockRenameSpaceState{ctrl: ctrl}
 	mock.recorder = &MockRenameSpaceStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRenameSpaceState) EXPECT() *MockRenameSpaceStateMockRecorder {
 	return m.recorder
 }
 
-// ConstraintsBySpaceName mocks base method
+// ConstraintsBySpaceName mocks base method.
 func (m *MockRenameSpaceState) ConstraintsBySpaceName(arg0 string) ([]Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsBySpaceName", arg0)
@@ -513,13 +514,13 @@ func (m *MockRenameSpaceState) ConstraintsBySpaceName(arg0 string) ([]Constraint
 	return ret0, ret1
 }
 
-// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName
+// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName.
 func (mr *MockRenameSpaceStateMockRecorder) ConstraintsBySpaceName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockRenameSpaceState)(nil).ConstraintsBySpaceName), arg0)
 }
 
-// ControllerConfig mocks base method
+// ControllerConfig mocks base method.
 func (m *MockRenameSpaceState) ControllerConfig() (controller.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
@@ -528,36 +529,36 @@ func (m *MockRenameSpaceState) ControllerConfig() (controller.Config, error) {
 	return ret0, ret1
 }
 
-// ControllerConfig indicates an expected call of ControllerConfig
+// ControllerConfig indicates an expected call of ControllerConfig.
 func (mr *MockRenameSpaceStateMockRecorder) ControllerConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockRenameSpaceState)(nil).ControllerConfig))
 }
 
-// MockSettings is a mock of Settings interface
+// MockSettings is a mock of Settings interface.
 type MockSettings struct {
 	ctrl     *gomock.Controller
 	recorder *MockSettingsMockRecorder
 }
 
-// MockSettingsMockRecorder is the mock recorder for MockSettings
+// MockSettingsMockRecorder is the mock recorder for MockSettings.
 type MockSettingsMockRecorder struct {
 	mock *MockSettings
 }
 
-// NewMockSettings creates a new mock instance
+// NewMockSettings creates a new mock instance.
 func NewMockSettings(ctrl *gomock.Controller) *MockSettings {
 	mock := &MockSettings{ctrl: ctrl}
 	mock.recorder = &MockSettingsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSettings) EXPECT() *MockSettingsMockRecorder {
 	return m.recorder
 }
 
-// DeltaOps mocks base method
+// DeltaOps mocks base method.
 func (m *MockSettings) DeltaOps(arg0 string, arg1 settings.ItemChanges) ([]txn.Op, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeltaOps", arg0, arg1)
@@ -566,36 +567,36 @@ func (m *MockSettings) DeltaOps(arg0 string, arg1 settings.ItemChanges) ([]txn.O
 	return ret0, ret1
 }
 
-// DeltaOps indicates an expected call of DeltaOps
+// DeltaOps indicates an expected call of DeltaOps.
 func (mr *MockSettingsMockRecorder) DeltaOps(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeltaOps", reflect.TypeOf((*MockSettings)(nil).DeltaOps), arg0, arg1)
 }
 
-// MockOpFactory is a mock of OpFactory interface
+// MockOpFactory is a mock of OpFactory interface.
 type MockOpFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockOpFactoryMockRecorder
 }
 
-// MockOpFactoryMockRecorder is the mock recorder for MockOpFactory
+// MockOpFactoryMockRecorder is the mock recorder for MockOpFactory.
 type MockOpFactoryMockRecorder struct {
 	mock *MockOpFactory
 }
 
-// NewMockOpFactory creates a new mock instance
+// NewMockOpFactory creates a new mock instance.
 func NewMockOpFactory(ctrl *gomock.Controller) *MockOpFactory {
 	mock := &MockOpFactory{ctrl: ctrl}
 	mock.recorder = &MockOpFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOpFactory) EXPECT() *MockOpFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewMoveSubnetsOp mocks base method
+// NewMoveSubnetsOp mocks base method.
 func (m *MockOpFactory) NewMoveSubnetsOp(arg0 string, arg1 []MovingSubnet) (MoveSubnetsOp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewMoveSubnetsOp", arg0, arg1)
@@ -604,13 +605,13 @@ func (m *MockOpFactory) NewMoveSubnetsOp(arg0 string, arg1 []MovingSubnet) (Move
 	return ret0, ret1
 }
 
-// NewMoveSubnetsOp indicates an expected call of NewMoveSubnetsOp
+// NewMoveSubnetsOp indicates an expected call of NewMoveSubnetsOp.
 func (mr *MockOpFactoryMockRecorder) NewMoveSubnetsOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMoveSubnetsOp", reflect.TypeOf((*MockOpFactory)(nil).NewMoveSubnetsOp), arg0, arg1)
 }
 
-// NewRemoveSpaceOp mocks base method
+// NewRemoveSpaceOp mocks base method.
 func (m *MockOpFactory) NewRemoveSpaceOp(arg0 string) (state.ModelOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRemoveSpaceOp", arg0)
@@ -619,13 +620,13 @@ func (m *MockOpFactory) NewRemoveSpaceOp(arg0 string) (state.ModelOperation, err
 	return ret0, ret1
 }
 
-// NewRemoveSpaceOp indicates an expected call of NewRemoveSpaceOp
+// NewRemoveSpaceOp indicates an expected call of NewRemoveSpaceOp.
 func (mr *MockOpFactoryMockRecorder) NewRemoveSpaceOp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoveSpaceOp", reflect.TypeOf((*MockOpFactory)(nil).NewRemoveSpaceOp), arg0)
 }
 
-// NewRenameSpaceOp mocks base method
+// NewRenameSpaceOp mocks base method.
 func (m *MockOpFactory) NewRenameSpaceOp(arg0, arg1 string) (state.ModelOperation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRenameSpaceOp", arg0, arg1)
@@ -634,36 +635,36 @@ func (m *MockOpFactory) NewRenameSpaceOp(arg0, arg1 string) (state.ModelOperatio
 	return ret0, ret1
 }
 
-// NewRenameSpaceOp indicates an expected call of NewRenameSpaceOp
+// NewRenameSpaceOp indicates an expected call of NewRenameSpaceOp.
 func (mr *MockOpFactoryMockRecorder) NewRenameSpaceOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRenameSpaceOp", reflect.TypeOf((*MockOpFactory)(nil).NewRenameSpaceOp), arg0, arg1)
 }
 
-// MockRemoveSpace is a mock of RemoveSpace interface
+// MockRemoveSpace is a mock of RemoveSpace interface.
 type MockRemoveSpace struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoveSpaceMockRecorder
 }
 
-// MockRemoveSpaceMockRecorder is the mock recorder for MockRemoveSpace
+// MockRemoveSpaceMockRecorder is the mock recorder for MockRemoveSpace.
 type MockRemoveSpaceMockRecorder struct {
 	mock *MockRemoveSpace
 }
 
-// NewMockRemoveSpace creates a new mock instance
+// NewMockRemoveSpace creates a new mock instance.
 func NewMockRemoveSpace(ctrl *gomock.Controller) *MockRemoveSpace {
 	mock := &MockRemoveSpace{ctrl: ctrl}
 	mock.recorder = &MockRemoveSpaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoveSpace) EXPECT() *MockRemoveSpaceMockRecorder {
 	return m.recorder
 }
 
-// Refresh mocks base method
+// Refresh mocks base method.
 func (m *MockRemoveSpace) Refresh() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
@@ -671,13 +672,13 @@ func (m *MockRemoveSpace) Refresh() error {
 	return ret0
 }
 
-// Refresh indicates an expected call of Refresh
+// Refresh indicates an expected call of Refresh.
 func (mr *MockRemoveSpaceMockRecorder) Refresh() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockRemoveSpace)(nil).Refresh))
 }
 
-// RemoveSpaceOps mocks base method
+// RemoveSpaceOps mocks base method.
 func (m *MockRemoveSpace) RemoveSpaceOps() []txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSpaceOps")
@@ -685,36 +686,36 @@ func (m *MockRemoveSpace) RemoveSpaceOps() []txn.Op {
 	return ret0
 }
 
-// RemoveSpaceOps indicates an expected call of RemoveSpaceOps
+// RemoveSpaceOps indicates an expected call of RemoveSpaceOps.
 func (mr *MockRemoveSpaceMockRecorder) RemoveSpaceOps() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSpaceOps", reflect.TypeOf((*MockRemoveSpace)(nil).RemoveSpaceOps))
 }
 
-// MockSubnet is a mock of Subnet interface
+// MockSubnet is a mock of Subnet interface.
 type MockSubnet struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubnetMockRecorder
 }
 
-// MockSubnetMockRecorder is the mock recorder for MockSubnet
+// MockSubnetMockRecorder is the mock recorder for MockSubnet.
 type MockSubnetMockRecorder struct {
 	mock *MockSubnet
 }
 
-// NewMockSubnet creates a new mock instance
+// NewMockSubnet creates a new mock instance.
 func NewMockSubnet(ctrl *gomock.Controller) *MockSubnet {
 	mock := &MockSubnet{ctrl: ctrl}
 	mock.recorder = &MockSubnetMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubnet) EXPECT() *MockSubnetMockRecorder {
 	return m.recorder
 }
 
-// UpdateSpaceOps mocks base method
+// UpdateSpaceOps mocks base method.
 func (m *MockSubnet) UpdateSpaceOps(arg0 string) []txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSpaceOps", arg0)
@@ -722,36 +723,36 @@ func (m *MockSubnet) UpdateSpaceOps(arg0 string) []txn.Op {
 	return ret0
 }
 
-// UpdateSpaceOps indicates an expected call of UpdateSpaceOps
+// UpdateSpaceOps indicates an expected call of UpdateSpaceOps.
 func (mr *MockSubnetMockRecorder) UpdateSpaceOps(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSpaceOps", reflect.TypeOf((*MockSubnet)(nil).UpdateSpaceOps), arg0)
 }
 
-// MockConstraints is a mock of Constraints interface
+// MockConstraints is a mock of Constraints interface.
 type MockConstraints struct {
 	ctrl     *gomock.Controller
 	recorder *MockConstraintsMockRecorder
 }
 
-// MockConstraintsMockRecorder is the mock recorder for MockConstraints
+// MockConstraintsMockRecorder is the mock recorder for MockConstraints.
 type MockConstraintsMockRecorder struct {
 	mock *MockConstraints
 }
 
-// NewMockConstraints creates a new mock instance
+// NewMockConstraints creates a new mock instance.
 func NewMockConstraints(ctrl *gomock.Controller) *MockConstraints {
 	mock := &MockConstraints{ctrl: ctrl}
 	mock.recorder = &MockConstraintsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConstraints) EXPECT() *MockConstraintsMockRecorder {
 	return m.recorder
 }
 
-// ChangeSpaceNameOps mocks base method
+// ChangeSpaceNameOps mocks base method.
 func (m *MockConstraints) ChangeSpaceNameOps(arg0, arg1 string) []txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeSpaceNameOps", arg0, arg1)
@@ -759,13 +760,13 @@ func (m *MockConstraints) ChangeSpaceNameOps(arg0, arg1 string) []txn.Op {
 	return ret0
 }
 
-// ChangeSpaceNameOps indicates an expected call of ChangeSpaceNameOps
+// ChangeSpaceNameOps indicates an expected call of ChangeSpaceNameOps.
 func (mr *MockConstraintsMockRecorder) ChangeSpaceNameOps(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeSpaceNameOps", reflect.TypeOf((*MockConstraints)(nil).ChangeSpaceNameOps), arg0, arg1)
 }
 
-// ID mocks base method
+// ID mocks base method.
 func (m *MockConstraints) ID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
@@ -773,13 +774,13 @@ func (m *MockConstraints) ID() string {
 	return ret0
 }
 
-// ID indicates an expected call of ID
+// ID indicates an expected call of ID.
 func (mr *MockConstraintsMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockConstraints)(nil).ID))
 }
 
-// Value mocks base method
+// Value mocks base method.
 func (m *MockConstraints) Value() constraints.Value {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value")
@@ -787,36 +788,36 @@ func (m *MockConstraints) Value() constraints.Value {
 	return ret0
 }
 
-// Value indicates an expected call of Value
+// Value indicates an expected call of Value.
 func (mr *MockConstraintsMockRecorder) Value() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConstraints)(nil).Value))
 }
 
-// MockMovingSubnet is a mock of MovingSubnet interface
+// MockMovingSubnet is a mock of MovingSubnet interface.
 type MockMovingSubnet struct {
 	ctrl     *gomock.Controller
 	recorder *MockMovingSubnetMockRecorder
 }
 
-// MockMovingSubnetMockRecorder is the mock recorder for MockMovingSubnet
+// MockMovingSubnetMockRecorder is the mock recorder for MockMovingSubnet.
 type MockMovingSubnetMockRecorder struct {
 	mock *MockMovingSubnet
 }
 
-// NewMockMovingSubnet creates a new mock instance
+// NewMockMovingSubnet creates a new mock instance.
 func NewMockMovingSubnet(ctrl *gomock.Controller) *MockMovingSubnet {
 	mock := &MockMovingSubnet{ctrl: ctrl}
 	mock.recorder = &MockMovingSubnetMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMovingSubnet) EXPECT() *MockMovingSubnetMockRecorder {
 	return m.recorder
 }
 
-// CIDR mocks base method
+// CIDR mocks base method.
 func (m *MockMovingSubnet) CIDR() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CIDR")
@@ -824,13 +825,13 @@ func (m *MockMovingSubnet) CIDR() string {
 	return ret0
 }
 
-// CIDR indicates an expected call of CIDR
+// CIDR indicates an expected call of CIDR.
 func (mr *MockMovingSubnetMockRecorder) CIDR() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CIDR", reflect.TypeOf((*MockMovingSubnet)(nil).CIDR))
 }
 
-// FanLocalUnderlay mocks base method
+// FanLocalUnderlay mocks base method.
 func (m *MockMovingSubnet) FanLocalUnderlay() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FanLocalUnderlay")
@@ -838,13 +839,13 @@ func (m *MockMovingSubnet) FanLocalUnderlay() string {
 	return ret0
 }
 
-// FanLocalUnderlay indicates an expected call of FanLocalUnderlay
+// FanLocalUnderlay indicates an expected call of FanLocalUnderlay.
 func (mr *MockMovingSubnetMockRecorder) FanLocalUnderlay() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FanLocalUnderlay", reflect.TypeOf((*MockMovingSubnet)(nil).FanLocalUnderlay))
 }
 
-// ID mocks base method
+// ID mocks base method.
 func (m *MockMovingSubnet) ID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
@@ -852,13 +853,13 @@ func (m *MockMovingSubnet) ID() string {
 	return ret0
 }
 
-// ID indicates an expected call of ID
+// ID indicates an expected call of ID.
 func (mr *MockMovingSubnetMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockMovingSubnet)(nil).ID))
 }
 
-// Refresh mocks base method
+// Refresh mocks base method.
 func (m *MockMovingSubnet) Refresh() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
@@ -866,13 +867,13 @@ func (m *MockMovingSubnet) Refresh() error {
 	return ret0
 }
 
-// Refresh indicates an expected call of Refresh
+// Refresh indicates an expected call of Refresh.
 func (mr *MockMovingSubnetMockRecorder) Refresh() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockMovingSubnet)(nil).Refresh))
 }
 
-// SpaceID mocks base method
+// SpaceID mocks base method.
 func (m *MockMovingSubnet) SpaceID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpaceID")
@@ -880,13 +881,13 @@ func (m *MockMovingSubnet) SpaceID() string {
 	return ret0
 }
 
-// SpaceID indicates an expected call of SpaceID
+// SpaceID indicates an expected call of SpaceID.
 func (mr *MockMovingSubnetMockRecorder) SpaceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceID", reflect.TypeOf((*MockMovingSubnet)(nil).SpaceID))
 }
 
-// SpaceName mocks base method
+// SpaceName mocks base method.
 func (m *MockMovingSubnet) SpaceName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpaceName")
@@ -894,13 +895,13 @@ func (m *MockMovingSubnet) SpaceName() string {
 	return ret0
 }
 
-// SpaceName indicates an expected call of SpaceName
+// SpaceName indicates an expected call of SpaceName.
 func (mr *MockMovingSubnetMockRecorder) SpaceName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceName", reflect.TypeOf((*MockMovingSubnet)(nil).SpaceName))
 }
 
-// UpdateSpaceOps mocks base method
+// UpdateSpaceOps mocks base method.
 func (m *MockMovingSubnet) UpdateSpaceOps(arg0 string) []txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSpaceOps", arg0)
@@ -908,36 +909,36 @@ func (m *MockMovingSubnet) UpdateSpaceOps(arg0 string) []txn.Op {
 	return ret0
 }
 
-// UpdateSpaceOps indicates an expected call of UpdateSpaceOps
+// UpdateSpaceOps indicates an expected call of UpdateSpaceOps.
 func (mr *MockMovingSubnetMockRecorder) UpdateSpaceOps(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSpaceOps", reflect.TypeOf((*MockMovingSubnet)(nil).UpdateSpaceOps), arg0)
 }
 
-// MockMoveSubnetsOp is a mock of MoveSubnetsOp interface
+// MockMoveSubnetsOp is a mock of MoveSubnetsOp interface.
 type MockMoveSubnetsOp struct {
 	ctrl     *gomock.Controller
 	recorder *MockMoveSubnetsOpMockRecorder
 }
 
-// MockMoveSubnetsOpMockRecorder is the mock recorder for MockMoveSubnetsOp
+// MockMoveSubnetsOpMockRecorder is the mock recorder for MockMoveSubnetsOp.
 type MockMoveSubnetsOpMockRecorder struct {
 	mock *MockMoveSubnetsOp
 }
 
-// NewMockMoveSubnetsOp creates a new mock instance
+// NewMockMoveSubnetsOp creates a new mock instance.
 func NewMockMoveSubnetsOp(ctrl *gomock.Controller) *MockMoveSubnetsOp {
 	mock := &MockMoveSubnetsOp{ctrl: ctrl}
 	mock.recorder = &MockMoveSubnetsOpMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMoveSubnetsOp) EXPECT() *MockMoveSubnetsOpMockRecorder {
 	return m.recorder
 }
 
-// Build mocks base method
+// Build mocks base method.
 func (m *MockMoveSubnetsOp) Build(arg0 int) ([]txn.Op, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", arg0)
@@ -946,13 +947,13 @@ func (m *MockMoveSubnetsOp) Build(arg0 int) ([]txn.Op, error) {
 	return ret0, ret1
 }
 
-// Build indicates an expected call of Build
+// Build indicates an expected call of Build.
 func (mr *MockMoveSubnetsOpMockRecorder) Build(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockMoveSubnetsOp)(nil).Build), arg0)
 }
 
-// Done mocks base method
+// Done mocks base method.
 func (m *MockMoveSubnetsOp) Done(arg0 error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Done", arg0)
@@ -960,13 +961,13 @@ func (m *MockMoveSubnetsOp) Done(arg0 error) error {
 	return ret0
 }
 
-// Done indicates an expected call of Done
+// Done indicates an expected call of Done.
 func (mr *MockMoveSubnetsOpMockRecorder) Done(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockMoveSubnetsOp)(nil).Done), arg0)
 }
 
-// GetMovedSubnets mocks base method
+// GetMovedSubnets mocks base method.
 func (m *MockMoveSubnetsOp) GetMovedSubnets() []MovedSubnet {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMovedSubnets")
@@ -974,36 +975,36 @@ func (m *MockMoveSubnetsOp) GetMovedSubnets() []MovedSubnet {
 	return ret0
 }
 
-// GetMovedSubnets indicates an expected call of GetMovedSubnets
+// GetMovedSubnets indicates an expected call of GetMovedSubnets.
 func (mr *MockMoveSubnetsOpMockRecorder) GetMovedSubnets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovedSubnets", reflect.TypeOf((*MockMoveSubnetsOp)(nil).GetMovedSubnets))
 }
 
-// MockAddress is a mock of Address interface
+// MockAddress is a mock of Address interface.
 type MockAddress struct {
 	ctrl     *gomock.Controller
 	recorder *MockAddressMockRecorder
 }
 
-// MockAddressMockRecorder is the mock recorder for MockAddress
+// MockAddressMockRecorder is the mock recorder for MockAddress.
 type MockAddressMockRecorder struct {
 	mock *MockAddress
 }
 
-// NewMockAddress creates a new mock instance
+// NewMockAddress creates a new mock instance.
 func NewMockAddress(ctrl *gomock.Controller) *MockAddress {
 	mock := &MockAddress{ctrl: ctrl}
 	mock.recorder = &MockAddressMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAddress) EXPECT() *MockAddressMockRecorder {
 	return m.recorder
 }
 
-// ConfigMethod mocks base method
+// ConfigMethod mocks base method.
 func (m *MockAddress) ConfigMethod() network.AddressConfigType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigMethod")
@@ -1011,13 +1012,13 @@ func (m *MockAddress) ConfigMethod() network.AddressConfigType {
 	return ret0
 }
 
-// ConfigMethod indicates an expected call of ConfigMethod
+// ConfigMethod indicates an expected call of ConfigMethod.
 func (mr *MockAddressMockRecorder) ConfigMethod() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigMethod", reflect.TypeOf((*MockAddress)(nil).ConfigMethod))
 }
 
-// SubnetCIDR mocks base method
+// SubnetCIDR mocks base method.
 func (m *MockAddress) SubnetCIDR() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubnetCIDR")
@@ -1025,13 +1026,13 @@ func (m *MockAddress) SubnetCIDR() string {
 	return ret0
 }
 
-// SubnetCIDR indicates an expected call of SubnetCIDR
+// SubnetCIDR indicates an expected call of SubnetCIDR.
 func (mr *MockAddressMockRecorder) SubnetCIDR() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetCIDR", reflect.TypeOf((*MockAddress)(nil).SubnetCIDR))
 }
 
-// Value mocks base method
+// Value mocks base method.
 func (m *MockAddress) Value() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value")
@@ -1039,36 +1040,36 @@ func (m *MockAddress) Value() string {
 	return ret0
 }
 
-// Value indicates an expected call of Value
+// Value indicates an expected call of Value.
 func (mr *MockAddressMockRecorder) Value() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockAddress)(nil).Value))
 }
 
-// MockUnit is a mock of Unit interface
+// MockUnit is a mock of Unit interface.
 type MockUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockUnitMockRecorder
 }
 
-// MockUnitMockRecorder is the mock recorder for MockUnit
+// MockUnitMockRecorder is the mock recorder for MockUnit.
 type MockUnitMockRecorder struct {
 	mock *MockUnit
 }
 
-// NewMockUnit creates a new mock instance
+// NewMockUnit creates a new mock instance.
 func NewMockUnit(ctrl *gomock.Controller) *MockUnit {
 	mock := &MockUnit{ctrl: ctrl}
 	mock.recorder = &MockUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUnit) EXPECT() *MockUnitMockRecorder {
 	return m.recorder
 }
 
-// ApplicationName mocks base method
+// ApplicationName mocks base method.
 func (m *MockUnit) ApplicationName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationName")
@@ -1076,13 +1077,13 @@ func (m *MockUnit) ApplicationName() string {
 	return ret0
 }
 
-// ApplicationName indicates an expected call of ApplicationName
+// ApplicationName indicates an expected call of ApplicationName.
 func (mr *MockUnitMockRecorder) ApplicationName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockUnit)(nil).ApplicationName))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockUnit) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -1090,36 +1091,36 @@ func (m *MockUnit) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockUnitMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockUnit)(nil).Name))
 }
 
-// MockReloadSpaces is a mock of ReloadSpaces interface
+// MockReloadSpaces is a mock of ReloadSpaces interface.
 type MockReloadSpaces struct {
 	ctrl     *gomock.Controller
 	recorder *MockReloadSpacesMockRecorder
 }
 
-// MockReloadSpacesMockRecorder is the mock recorder for MockReloadSpaces
+// MockReloadSpacesMockRecorder is the mock recorder for MockReloadSpaces.
 type MockReloadSpacesMockRecorder struct {
 	mock *MockReloadSpaces
 }
 
-// NewMockReloadSpaces creates a new mock instance
+// NewMockReloadSpaces creates a new mock instance.
 func NewMockReloadSpaces(ctrl *gomock.Controller) *MockReloadSpaces {
 	mock := &MockReloadSpaces{ctrl: ctrl}
 	mock.recorder = &MockReloadSpacesMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReloadSpaces) EXPECT() *MockReloadSpacesMockRecorder {
 	return m.recorder
 }
 
-// ReloadSpaces mocks base method
+// ReloadSpaces mocks base method.
 func (m *MockReloadSpaces) ReloadSpaces() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReloadSpaces")
@@ -1127,36 +1128,36 @@ func (m *MockReloadSpaces) ReloadSpaces() error {
 	return ret0
 }
 
-// ReloadSpaces indicates an expected call of ReloadSpaces
+// ReloadSpaces indicates an expected call of ReloadSpaces.
 func (mr *MockReloadSpacesMockRecorder) ReloadSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadSpaces", reflect.TypeOf((*MockReloadSpaces)(nil).ReloadSpaces))
 }
 
-// MockReloadSpacesState is a mock of ReloadSpacesState interface
+// MockReloadSpacesState is a mock of ReloadSpacesState interface.
 type MockReloadSpacesState struct {
 	ctrl     *gomock.Controller
 	recorder *MockReloadSpacesStateMockRecorder
 }
 
-// MockReloadSpacesStateMockRecorder is the mock recorder for MockReloadSpacesState
+// MockReloadSpacesStateMockRecorder is the mock recorder for MockReloadSpacesState.
 type MockReloadSpacesStateMockRecorder struct {
 	mock *MockReloadSpacesState
 }
 
-// NewMockReloadSpacesState creates a new mock instance
+// NewMockReloadSpacesState creates a new mock instance.
 func NewMockReloadSpacesState(ctrl *gomock.Controller) *MockReloadSpacesState {
 	mock := &MockReloadSpacesState{ctrl: ctrl}
 	mock.recorder = &MockReloadSpacesStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReloadSpacesState) EXPECT() *MockReloadSpacesStateMockRecorder {
 	return m.recorder
 }
 
-// AddSpace mocks base method
+// AddSpace mocks base method.
 func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3 bool) (space.Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3)
@@ -1165,13 +1166,13 @@ func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []st
 	return ret0, ret1
 }
 
-// AddSpace indicates an expected call of AddSpace
+// AddSpace indicates an expected call of AddSpace.
 func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2, arg3)
 }
 
-// AllEndpointBindingsSpaceNames mocks base method
+// AllEndpointBindingsSpaceNames mocks base method.
 func (m *MockReloadSpacesState) AllEndpointBindingsSpaceNames() (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllEndpointBindingsSpaceNames")
@@ -1180,13 +1181,13 @@ func (m *MockReloadSpacesState) AllEndpointBindingsSpaceNames() (set.Strings, er
 	return ret0, ret1
 }
 
-// AllEndpointBindingsSpaceNames indicates an expected call of AllEndpointBindingsSpaceNames
+// AllEndpointBindingsSpaceNames indicates an expected call of AllEndpointBindingsSpaceNames.
 func (mr *MockReloadSpacesStateMockRecorder) AllEndpointBindingsSpaceNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllEndpointBindingsSpaceNames", reflect.TypeOf((*MockReloadSpacesState)(nil).AllEndpointBindingsSpaceNames))
 }
 
-// AllSpaces mocks base method
+// AllSpaces mocks base method.
 func (m *MockReloadSpacesState) AllSpaces() ([]space.Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
@@ -1195,13 +1196,13 @@ func (m *MockReloadSpacesState) AllSpaces() ([]space.Space, error) {
 	return ret0, ret1
 }
 
-// AllSpaces indicates an expected call of AllSpaces
+// AllSpaces indicates an expected call of AllSpaces.
 func (mr *MockReloadSpacesStateMockRecorder) AllSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockReloadSpacesState)(nil).AllSpaces))
 }
 
-// ConstraintsBySpaceName mocks base method
+// ConstraintsBySpaceName mocks base method.
 func (m *MockReloadSpacesState) ConstraintsBySpaceName(arg0 string) ([]space.Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsBySpaceName", arg0)
@@ -1210,13 +1211,13 @@ func (m *MockReloadSpacesState) ConstraintsBySpaceName(arg0 string) ([]space.Con
 	return ret0, ret1
 }
 
-// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName
+// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName.
 func (mr *MockReloadSpacesStateMockRecorder) ConstraintsBySpaceName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockReloadSpacesState)(nil).ConstraintsBySpaceName), arg0)
 }
 
-// DefaultEndpointBindingSpace mocks base method
+// DefaultEndpointBindingSpace mocks base method.
 func (m *MockReloadSpacesState) DefaultEndpointBindingSpace() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
@@ -1225,13 +1226,13 @@ func (m *MockReloadSpacesState) DefaultEndpointBindingSpace() (string, error) {
 	return ret0, ret1
 }
 
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace
+// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
 func (mr *MockReloadSpacesStateMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).DefaultEndpointBindingSpace))
 }
 
-// SaveProviderSubnets mocks base method
+// SaveProviderSubnets mocks base method.
 func (m *MockReloadSpacesState) SaveProviderSubnets(arg0 []network.SubnetInfo, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveProviderSubnets", arg0, arg1)
@@ -1239,36 +1240,36 @@ func (m *MockReloadSpacesState) SaveProviderSubnets(arg0 []network.SubnetInfo, a
 	return ret0
 }
 
-// SaveProviderSubnets indicates an expected call of SaveProviderSubnets
+// SaveProviderSubnets indicates an expected call of SaveProviderSubnets.
 func (mr *MockReloadSpacesStateMockRecorder) SaveProviderSubnets(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveProviderSubnets", reflect.TypeOf((*MockReloadSpacesState)(nil).SaveProviderSubnets), arg0, arg1)
 }
 
-// MockReloadSpacesEnviron is a mock of ReloadSpacesEnviron interface
+// MockReloadSpacesEnviron is a mock of ReloadSpacesEnviron interface.
 type MockReloadSpacesEnviron struct {
 	ctrl     *gomock.Controller
 	recorder *MockReloadSpacesEnvironMockRecorder
 }
 
-// MockReloadSpacesEnvironMockRecorder is the mock recorder for MockReloadSpacesEnviron
+// MockReloadSpacesEnvironMockRecorder is the mock recorder for MockReloadSpacesEnviron.
 type MockReloadSpacesEnvironMockRecorder struct {
 	mock *MockReloadSpacesEnviron
 }
 
-// NewMockReloadSpacesEnviron creates a new mock instance
+// NewMockReloadSpacesEnviron creates a new mock instance.
 func NewMockReloadSpacesEnviron(ctrl *gomock.Controller) *MockReloadSpacesEnviron {
 	mock := &MockReloadSpacesEnviron{ctrl: ctrl}
 	mock.recorder = &MockReloadSpacesEnvironMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReloadSpacesEnviron) EXPECT() *MockReloadSpacesEnvironMockRecorder {
 	return m.recorder
 }
 
-// CloudSpec mocks base method
+// CloudSpec mocks base method.
 func (m *MockReloadSpacesEnviron) CloudSpec() (cloudspec.CloudSpec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudSpec")
@@ -1277,13 +1278,13 @@ func (m *MockReloadSpacesEnviron) CloudSpec() (cloudspec.CloudSpec, error) {
 	return ret0, ret1
 }
 
-// CloudSpec indicates an expected call of CloudSpec
+// CloudSpec indicates an expected call of CloudSpec.
 func (mr *MockReloadSpacesEnvironMockRecorder) CloudSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockReloadSpacesEnviron)(nil).CloudSpec))
 }
 
-// GetEnviron mocks base method
+// GetEnviron mocks base method.
 func (m *MockReloadSpacesEnviron) GetEnviron(arg0 environs.EnvironConfigGetter, arg1 environs.NewEnvironFunc) (environs.Environ, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEnviron", arg0, arg1)
@@ -1292,13 +1293,13 @@ func (m *MockReloadSpacesEnviron) GetEnviron(arg0 environs.EnvironConfigGetter, 
 	return ret0, ret1
 }
 
-// GetEnviron indicates an expected call of GetEnviron
+// GetEnviron indicates an expected call of GetEnviron.
 func (mr *MockReloadSpacesEnvironMockRecorder) GetEnviron(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnviron", reflect.TypeOf((*MockReloadSpacesEnviron)(nil).GetEnviron), arg0, arg1)
 }
 
-// ModelConfig mocks base method
+// ModelConfig mocks base method.
 func (m *MockReloadSpacesEnviron) ModelConfig() (*config.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelConfig")
@@ -1307,36 +1308,36 @@ func (m *MockReloadSpacesEnviron) ModelConfig() (*config.Config, error) {
 	return ret0, ret1
 }
 
-// ModelConfig indicates an expected call of ModelConfig
+// ModelConfig indicates an expected call of ModelConfig.
 func (mr *MockReloadSpacesEnvironMockRecorder) ModelConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfig", reflect.TypeOf((*MockReloadSpacesEnviron)(nil).ModelConfig))
 }
 
-// MockEnvironSpaces is a mock of EnvironSpaces interface
+// MockEnvironSpaces is a mock of EnvironSpaces interface.
 type MockEnvironSpaces struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvironSpacesMockRecorder
 }
 
-// MockEnvironSpacesMockRecorder is the mock recorder for MockEnvironSpaces
+// MockEnvironSpacesMockRecorder is the mock recorder for MockEnvironSpaces.
 type MockEnvironSpacesMockRecorder struct {
 	mock *MockEnvironSpaces
 }
 
-// NewMockEnvironSpaces creates a new mock instance
+// NewMockEnvironSpaces creates a new mock instance.
 func NewMockEnvironSpaces(ctrl *gomock.Controller) *MockEnvironSpaces {
 	mock := &MockEnvironSpaces{ctrl: ctrl}
 	mock.recorder = &MockEnvironSpacesMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnvironSpaces) EXPECT() *MockEnvironSpacesMockRecorder {
 	return m.recorder
 }
 
-// ReloadSpaces mocks base method
+// ReloadSpaces mocks base method.
 func (m *MockEnvironSpaces) ReloadSpaces(arg0 context.ProviderCallContext, arg1 ReloadSpacesState, arg2 environs.BootstrapEnviron) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReloadSpaces", arg0, arg1, arg2)
@@ -1344,73 +1345,73 @@ func (m *MockEnvironSpaces) ReloadSpaces(arg0 context.ProviderCallContext, arg1 
 	return ret0
 }
 
-// ReloadSpaces indicates an expected call of ReloadSpaces
+// ReloadSpaces indicates an expected call of ReloadSpaces.
 func (mr *MockEnvironSpacesMockRecorder) ReloadSpaces(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadSpaces", reflect.TypeOf((*MockEnvironSpaces)(nil).ReloadSpaces), arg0, arg1, arg2)
 }
 
-// MockAuthorizerState is a mock of AuthorizerState interface
+// MockAuthorizerState is a mock of AuthorizerState interface.
 type MockAuthorizerState struct {
 	ctrl     *gomock.Controller
 	recorder *MockAuthorizerStateMockRecorder
 }
 
-// MockAuthorizerStateMockRecorder is the mock recorder for MockAuthorizerState
+// MockAuthorizerStateMockRecorder is the mock recorder for MockAuthorizerState.
 type MockAuthorizerStateMockRecorder struct {
 	mock *MockAuthorizerState
 }
 
-// NewMockAuthorizerState creates a new mock instance
+// NewMockAuthorizerState creates a new mock instance.
 func NewMockAuthorizerState(ctrl *gomock.Controller) *MockAuthorizerState {
 	mock := &MockAuthorizerState{ctrl: ctrl}
 	mock.recorder = &MockAuthorizerStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAuthorizerState) EXPECT() *MockAuthorizerStateMockRecorder {
 	return m.recorder
 }
 
-// ModelTag mocks base method
-func (m *MockAuthorizerState) ModelTag() v4.ModelTag {
+// ModelTag mocks base method.
+func (m *MockAuthorizerState) ModelTag() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelTag")
-	ret0, _ := ret[0].(v4.ModelTag)
+	ret0, _ := ret[0].(names.ModelTag)
 	return ret0
 }
 
-// ModelTag indicates an expected call of ModelTag
+// ModelTag indicates an expected call of ModelTag.
 func (mr *MockAuthorizerStateMockRecorder) ModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockAuthorizerState)(nil).ModelTag))
 }
 
-// MockBindings is a mock of Bindings interface
+// MockBindings is a mock of Bindings interface.
 type MockBindings struct {
 	ctrl     *gomock.Controller
 	recorder *MockBindingsMockRecorder
 }
 
-// MockBindingsMockRecorder is the mock recorder for MockBindings
+// MockBindingsMockRecorder is the mock recorder for MockBindings.
 type MockBindingsMockRecorder struct {
 	mock *MockBindings
 }
 
-// NewMockBindings creates a new mock instance
+// NewMockBindings creates a new mock instance.
 func NewMockBindings(ctrl *gomock.Controller) *MockBindings {
 	mock := &MockBindings{ctrl: ctrl}
 	mock.recorder = &MockBindingsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBindings) EXPECT() *MockBindingsMockRecorder {
 	return m.recorder
 }
 
-// Map mocks base method
+// Map mocks base method.
 func (m *MockBindings) Map() map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Map")
@@ -1418,7 +1419,7 @@ func (m *MockBindings) Map() map[string]string {
 	return ret0
 }
 
-// Map indicates an expected call of Map
+// Map indicates an expected call of Map.
 func (mr *MockBindingsMockRecorder) Map() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockBindings)(nil).Map))

--- a/apiserver/facades/client/spaces/package_test.go
+++ b/apiserver/facades/client/spaces/package_test.go
@@ -86,7 +86,7 @@ func (s *APISuite) SetupMocks(c *gc.C, supportSpaces bool, providerSpaces bool) 
 	mockNetworkEnviron.EXPECT().SupportsSpaceDiscovery(gomock.Any()).Return(providerSpaces, nil).AnyTimes()
 
 	mockProvider := environmocks.NewMockCloudEnvironProvider(ctrl)
-	mockProvider.EXPECT().Open(gomock.Any()).Return(mockNetworkEnviron, nil).AnyTimes()
+	mockProvider.EXPECT().Open(gomock.Any(), gomock.Any()).Return(mockNetworkEnviron, nil).AnyTimes()
 
 	unReg := environs.RegisterProvider("mock-provider", mockProvider)
 

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	stdcontext "context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -626,7 +627,7 @@ type StubProvider struct {
 
 var _ environs.EnvironProvider = (*StubProvider)(nil)
 
-func (sp *StubProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (sp *StubProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	sp.MethodCall(sp, "Open", args.Config)
 	if err := sp.NextErr(); err != nil {
 		return nil, err

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -4,6 +4,7 @@
 package caas
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -49,17 +50,17 @@ func RegisterContainerProvider(name string, p ContainerEnvironProvider, alias ..
 }
 
 // New returns a new broker based on the provided configuration.
-func New(args environs.OpenParams) (Broker, error) {
+func New(ctx context.Context, args environs.OpenParams) (Broker, error) {
 	p, err := environs.Provider(args.Cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return Open(p, args)
+	return Open(ctx, p, args)
 }
 
 // Open creates a Broker instance and errors if the provider is not for
 // a container substrate.
-func Open(p environs.EnvironProvider, args environs.OpenParams) (Broker, error) {
+func Open(ctx context.Context, p environs.EnvironProvider, args environs.OpenParams) (Broker, error) {
 	if envProvider, ok := p.(ContainerEnvironProvider); !ok {
 		return nil, errors.NotValidf("container environ provider %T", p)
 	} else {
@@ -68,7 +69,7 @@ func Open(p environs.EnvironProvider, args environs.OpenParams) (Broker, error) 
 }
 
 // NewContainerBrokerFunc returns a Container Broker.
-type NewContainerBrokerFunc func(args environs.OpenParams) (Broker, error)
+type NewContainerBrokerFunc func(ctx context.Context, args environs.OpenParams) (Broker, error)
 
 // StatusCallbackFunc represents a function that can be called to report a status.
 type StatusCallbackFunc func(appName string, settableStatus status.Status, info string, data map[string]interface{}) error

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -300,7 +300,7 @@ func (k *kubernetesClient) SetConfig(cfg *config.Config) error {
 }
 
 // SetCloudSpec is specified in the environs.Environ interface.
-func (k *kubernetesClient) SetCloudSpec(spec environscloudspec.CloudSpec) error {
+func (k *kubernetesClient) SetCloudSpec(_ context.Context, spec environscloudspec.CloudSpec) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	stdcontext "context"
 	"net/url"
 
 	jujuclock "github.com/juju/clock"
@@ -44,7 +45,7 @@ var providerInstance = kubernetesEnvironProvider{
 	cmdRunner:          defaultRunner{},
 	builtinCloudGetter: attemptMicroK8sCloud,
 	brokerGetter: func(args environs.OpenParams) (caas.ClusterMetadataChecker, error) {
-		return caas.New(args)
+		return caas.New(stdcontext.TODO(), args)
 	},
 }
 

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -5,6 +5,7 @@ package caas
 
 import (
 	"bytes"
+	stdcontext "context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -718,7 +719,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credential j
 		}
 		openParams.ControllerUUID = ctrlUUID
 	}
-	return caas.New(openParams)
+	return caas.New(stdcontext.TODO(), openParams)
 }
 
 func getCloudAndRegionFromOptions(cloudOption, regionOption string) (string, string, error) {

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -4,6 +4,7 @@
 package caas
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/cmd"
@@ -159,7 +160,7 @@ func (c *UpdateCAASCommand) newK8sClusterBroker(cloud jujucloud.Cloud, credentia
 		}
 		openParams.ControllerUUID = ctrlUUID
 	}
-	return caas.New(openParams)
+	return caas.New(stdcontext.TODO(), openParams)
 }
 
 // maybeBuiltInCloud returns a built in cloud (eg microk8s) and the relevant credential

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1343,7 +1343,7 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	cfg, err := provider.PrepareConfig(*params)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  params.Cloud,
 		Config: cfg,
 	})

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"bufio"
+	stdcontext "context"
 	stderrors "errors"
 	"fmt"
 	"io"
@@ -632,7 +633,7 @@ var getCAASBroker = func(getter environs.EnvironConfigGetter) (caas.Broker, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	env, err := caas.New(environs.OpenParams{
+	env, err := caas.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
 	})

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -581,9 +581,9 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 		Config:         cfg,
 	}
 	if bootstrapConfig.CloudType == cloud.CloudTypeCAAS {
-		return caas.New(openParams)
+		return caas.New(stdcontext.TODO(), openParams)
 	}
-	return environs.New(openParams)
+	return environs.New(stdcontext.TODO(), openParams)
 }
 
 func (c *destroyCommandBase) getControllerEnvironFromAPI(
@@ -611,7 +611,7 @@ func (c *destroyCommandBase) getControllerEnvironFromAPI(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting controller config from API")
 	}
-	return environs.New(environs.OpenParams{
+	return environs.New(stdcontext.TODO(), environs.OpenParams{
 		ControllerUUID: ctrlCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	stdcontext "context"
 	"fmt"
 	"time"
 
@@ -226,9 +227,9 @@ func (c *killCommand) DirectDestroyRemaining(ctx *cmd.Context, api destroyContro
 			}
 			var env environs.CloudDestroyer
 			if model.CloudSpec.Type == cloud.CloudTypeCAAS {
-				env, err = caas.Open(cloudProvider, openParams)
+				env, err = caas.Open(stdcontext.TODO(), cloudProvider, openParams)
 			} else {
-				env, err = environs.Open(cloudProvider, openParams)
+				env, err = environs.Open(stdcontext.TODO(), cloudProvider, openParams)
 			}
 			if err != nil {
 				logger.Errorf(err.Error())

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -182,11 +182,14 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		Cloud:          cloudSpec,
 		Config:         args.ControllerModelConfig,
 	}
+
+	ctx := stdcontext.TODO()
+
 	var env environs.BootstrapEnviron
 	if isCAAS {
-		env, err = environsNewCAAS(openParams)
+		env, err = environsNewCAAS(ctx, openParams)
 	} else {
-		env, err = environsNewIAAS(openParams)
+		env, err = environsNewIAAS(ctx, openParams)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	stdcontext "context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -633,7 +634,7 @@ func (s *BootstrapSuite) TestInitializeStateMinSocketTimeout(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapWithInvalidCredentialLogs(c *gc.C) {
 	called := false
-	newEnviron := func(ps environs.OpenParams) (environs.Environ, error) {
+	newEnviron := func(_ stdcontext.Context, ps environs.OpenParams) (environs.Environ, error) {
 		called = true
 		env, _ := environs.New(context.TODO(), ps)
 		return &mockDummyEnviron{env}, nil

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -635,7 +635,7 @@ func (s *BootstrapSuite) TestBootstrapWithInvalidCredentialLogs(c *gc.C) {
 	called := false
 	newEnviron := func(ps environs.OpenParams) (environs.Environ, error) {
 		called = true
-		env, _ := environs.New(ps)
+		env, _ := environs.New(context.TODO(), ps)
 		return &mockDummyEnviron{env}, nil
 	}
 	s.PatchValue(&environsNewIAAS, newEnviron)
@@ -792,7 +792,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		Config: cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.Open(provider, environs.OpenParams{
+	env, err := environs.Open(context.TODO(), provider, environs.OpenParams{
 		Cloud:  dummy.SampleCloudSpec(),
 		Config: cfg,
 	})

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"bufio"
 	"bytes"
+	stdcontext "context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -1053,7 +1054,7 @@ func (s *MachineSuite) TestHostedModelWorkers(c *gc.C) {
 	// The dummy provider blows up in the face of multi-model
 	// scenarios so patch in a minimal environs.Environ that's good
 	// enough to allow the model workers to run.
-	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
+	s.PatchValue(&newEnvirons, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return &minModelWorkersEnviron{}, nil
 	})
 
@@ -1078,7 +1079,7 @@ func (s *MachineSuite) TestWorkersForHostedModelWithInvalidCredential(c *gc.C) {
 	// scenarios so patch in a minimal environs.Environ that's good
 	// enough to allow the model workers to run.
 	loggo.GetLogger("juju.worker.dependency").SetLogLevel(loggo.TRACE)
-	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
+	s.PatchValue(&newEnvirons, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return &minModelWorkersEnviron{}, nil
 	})
 
@@ -1123,7 +1124,7 @@ func (s *MachineSuite) TestWorkersForHostedModelWithDeletedCredential(c *gc.C) {
 	// scenarios so patch in a minimal environs.Environ that's good
 	// enough to allow the model workers to run.
 	loggo.GetLogger("juju.worker.dependency").SetLogLevel(loggo.TRACE)
-	s.PatchValue(&newEnvirons, func(environs.OpenParams) (environs.Environ, error) {
+	s.PatchValue(&newEnvirons, func(stdcontext.Context, environs.OpenParams) (environs.Environ, error) {
 		return &minModelWorkersEnviron{}, nil
 	})
 

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,12 +27,12 @@ import (
 	"github.com/juju/juju/version"
 )
 
-func prepare(context *cmd.Context, controllerName string, store jujuclient.ClientStore) (environs.Environ, error) {
+func prepare(ctx *cmd.Context, controllerName string, store jujuclient.ClientStore) (environs.Environ, error) {
 	// NOTE(axw) this is a work-around for the TODO below. This
 	// means that the command will only work if you've bootstrapped
 	// the specified environment.
 	bootstrapConfig, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
-		context, store, environs.GlobalProviderRegistry(),
+		ctx, store, environs.GlobalProviderRegistry(),
 	)(controllerName)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -53,7 +54,7 @@ func prepare(context *cmd.Context, controllerName string, store jujuclient.Clien
 	// identify region and endpoint info that we need. Not sure what
 	// we'll do about simplestreams.MetadataValidator yet. Probably
 	// move it to the EnvironProvider interface.
-	return environs.New(environs.OpenParams{
+	return environs.New(context.TODO(), environs.OpenParams{
 		Cloud:  params.Cloud,
 		Config: cfg,
 	})

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -122,16 +122,22 @@ type BootstrapResult struct {
 	CaasBootstrapFinalizer
 }
 
+// BootstrapLogger defines the logger used during a bootstrap.
+type BootstrapLogger interface {
+	GetStdin() io.Reader
+	GetStdout() io.Writer
+	GetStderr() io.Writer
+
+	Infof(format string, params ...interface{})
+	Verbosef(format string, params ...interface{})
+}
+
 // BootstrapContext is an interface that is passed to
 // Environ.Bootstrap, providing a means of obtaining
 // information about and manipulating the context in which
 // it is being invoked.
 type BootstrapContext interface {
-	GetStdin() io.Reader
-	GetStdout() io.Writer
-	GetStderr() io.Writer
-	Infof(format string, params ...interface{})
-	Verbosef(format string, params ...interface{})
+	BootstrapLogger
 
 	// InterruptNotify starts watching for interrupt signals
 	// on behalf of the caller, sending them to the supplied

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -122,7 +122,7 @@ func PrepareController(
 	}
 	if isCAASController {
 		details.ModelType = model.CAAS
-		env, err = caas.Open(p, openParams)
+		env, err = caas.Open(ctx.Context(), p, openParams)
 	} else {
 		details.ModelType = model.IAAS
 		env, err = environs.Open(ctx.Context(), p, openParams)

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -125,7 +125,7 @@ func PrepareController(
 		env, err = caas.Open(p, openParams)
 	} else {
 		details.ModelType = model.IAAS
-		env, err = environs.Open(p, openParams)
+		env, err = environs.Open(ctx.Context(), p, openParams)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -4,6 +4,8 @@
 package environs
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -18,7 +20,7 @@ type EnvironConfigGetter interface {
 
 // NewEnvironFunc is the type of a function that, given a model config,
 // returns an Environ. This will typically be environs.New.
-type NewEnvironFunc func(OpenParams) (Environ, error)
+type NewEnvironFunc func(context.Context, OpenParams) (Environ, error)
 
 // GetEnviron returns the environs.Environ ("provider") associated
 // with the model.
@@ -38,7 +40,7 @@ func GetEnvironAndCloud(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Envi
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	env, err := newEnviron(OpenParams{
+	env, err := newEnviron(context.TODO(), OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
 	})

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -4,6 +4,7 @@
 package environs
 
 import (
+	stdcontext "context"
 	"io"
 
 	"github.com/juju/jsonschema"
@@ -65,7 +66,7 @@ type CloudEnvironProvider interface {
 	//
 	// Open should not perform any expensive operations, such as querying
 	// the cloud API, as it will be called frequently.
-	Open(OpenParams) (Environ, error)
+	Open(stdcontext.Context, OpenParams) (Environ, error)
 }
 
 // OpenParams contains the parameters for EnvironProvider.Open.
@@ -280,7 +281,7 @@ type ConfigSetter interface {
 // CloudSpecSetter implements access to an environment's cloud spec.
 type CloudSpecSetter interface {
 	// SetConfig updates the Environ's configuration.
-	SetCloudSpec(spec environscloudspec.CloudSpec) error
+	SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.CloudSpec) error
 }
 
 // Bootstrapper provides the way for bootstrapping controller.

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -136,14 +136,15 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
 	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, nil))
-	t.ProviderCallContext = context.NewCloudCallContext(stdcontext.Background())
 
+	// Setup the simplestreams bootstrap context.
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 
 	ctx := stdcontext.TODO()
 	ctx = stdcontext.WithValue(ctx, bootstrap.SimplestreamsFetcherContextKey, ss)
 
 	t.BootstrapContext = envtesting.BootstrapContext(ctx, c)
+	t.ProviderCallContext = context.NewCloudCallContext(ctx)
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -109,6 +109,9 @@ type LiveTests struct {
 	// calls to a cloud provider.
 	ProviderCallContext context.ProviderCallContext
 
+	// BootstrapContext holds the context to bootstrap a test environment.
+	BootstrapContext environs.BootstrapContext
+
 	prepared     bool
 	bootstrapped bool
 	toolsStorage storage.Storage
@@ -134,6 +137,13 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.toolsStorage = stor
 	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, nil))
 	t.ProviderCallContext = context.NewCloudCallContext(stdcontext.Background())
+
+	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
+
+	ctx := stdcontext.TODO()
+	ctx = stdcontext.WithValue(ctx, bootstrap.SimplestreamsFetcherContextKey, ss)
+
+	t.BootstrapContext = envtesting.BootstrapContext(ctx, c)
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
@@ -155,7 +165,7 @@ func (t *LiveTests) PrepareOnce(c *gc.C) {
 	}
 
 	args := t.prepareForBootstrapParams(c)
-	e, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c), t.ControllerStore, args)
+	e, err := bootstrap.PrepareController(false, t.BootstrapContext, t.ControllerStore, args)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", t.TestConfig))
 	c.Assert(e, gc.NotNil)
 	t.Env = e.(environs.Environ)
@@ -217,6 +227,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	if t.bootstrapped {
 		return
 	}
+
 	t.PrepareOnce(c)
 	// We only build and upload tools if there will be a state agent that
 	// we could connect to (actual live tests, rather than local-only)
@@ -230,10 +241,7 @@ func (t *LiveTests) BootstrapOnce(c *gc.C) {
 	args.BootstrapConstraints = cons
 	args.ModelConstraints = cons
 
-	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	ctx := stdcontext.WithValue(stdcontext.TODO(), bootstrap.SimplestreamsFetcherContextKey, ss)
-
-	err := bootstrap.Bootstrap(envtesting.BootstrapContext(ctx, c), t.Env, t.ProviderCallContext, args)
+	err := bootstrap.Bootstrap(t.BootstrapContext, t.Env, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 	t.bootstrapped = true
 }
@@ -961,7 +969,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 	})
 	args := t.prepareForBootstrapParams(c)
 	args.ModelConfig = dummyCfg
-	e, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c),
+	e, err := bootstrap.PrepareController(false, t.BootstrapContext,
 		jujuclient.NewMemStore(),
 		args,
 	)
@@ -975,13 +983,13 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		"default-series": "quantal",
 	})
 	args.ModelConfig = attrs
-	env, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c),
+	env, err := bootstrap.PrepareController(false, t.BootstrapContext,
 		t.ControllerStore,
 		args)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = environs.Destroy("livetests", env, t.ProviderCallContext, t.ControllerStore) }()
 
-	err = bootstrap.Bootstrap(envtesting.BootstrapContext(stdcontext.TODO(), c), env, t.ProviderCallContext, t.bootstrapParams())
+	err = bootstrap.Bootstrap(t.BootstrapContext, env, t.ProviderCallContext, t.bootstrapParams())
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := t.Env.(jujutesting.GetStater).GetStateInAPIServer()

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -122,6 +122,15 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.TestDataSuite.SetUpSuite(c)
 	t.ControllerStore = jujuclient.NewMemStore()
 	t.PatchValue(&keys.JujuPublicKey, sstesting.SignedMetadataPublicKey)
+
+	// Setup the simplestreams bootstrap context.
+	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
+
+	ctx := stdcontext.TODO()
+	ctx = stdcontext.WithValue(ctx, bootstrap.SimplestreamsFetcherContextKey, ss)
+
+	t.BootstrapContext = envtesting.BootstrapContext(ctx, c)
+	t.ProviderCallContext = context.NewCloudCallContext(ctx)
 }
 
 func (t *LiveTests) SetUpTest(c *gc.C) {
@@ -136,15 +145,6 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
 	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, nil))
-
-	// Setup the simplestreams bootstrap context.
-	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-
-	ctx := stdcontext.TODO()
-	ctx = stdcontext.WithValue(ctx, bootstrap.SimplestreamsFetcherContextKey, ss)
-
-	t.BootstrapContext = envtesting.BootstrapContext(ctx, c)
-	t.ProviderCallContext = context.NewCloudCallContext(ctx)
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -102,6 +102,7 @@ func (t *Tests) Prepare(c *gc.C) environs.Environ {
 
 // PrepareWithParams prepares an instance of the testing environment.
 func (t *Tests) PrepareWithParams(c *gc.C, params bootstrap.PrepareParams) environs.Environ {
+	panic("X")
 	e, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c), t.ControllerStore, params)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", params.ModelConfig))
 	c.Assert(e, gc.NotNil)
@@ -110,6 +111,7 @@ func (t *Tests) PrepareWithParams(c *gc.C, params bootstrap.PrepareParams) envir
 }
 
 func (t *Tests) AssertPrepareFailsWithConfig(c *gc.C, badConfig coretesting.Attrs, errorMatches string) error {
+	panic("Y")
 	args := t.PrepareParams(c)
 	args.ModelConfig = coretesting.Attrs(args.ModelConfig).Merge(badConfig)
 

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -53,11 +53,14 @@ type Tests struct {
 	// ProviderCallContext holds the context to be used to make
 	// calls to a cloud provider.
 	ProviderCallContext context.ProviderCallContext
+
+	// BootstrapContext holds the context to bootstrap a test environment.
+	BootstrapContext environs.BootstrapContext
 }
 
 // Open opens an instance of the testing environment.
-func (t *Tests) Open(c *gc.C, cfg *config.Config) environs.Environ {
-	e, err := environs.New(environs.OpenParams{
+func (t *Tests) Open(c *gc.C, ctx stdcontext.Context, cfg *config.Config) environs.Environ {
+	e, err := environs.New(ctx, environs.OpenParams{
 		Cloud:  t.CloudSpec(),
 		Config: cfg,
 	})
@@ -102,8 +105,7 @@ func (t *Tests) Prepare(c *gc.C) environs.Environ {
 
 // PrepareWithParams prepares an instance of the testing environment.
 func (t *Tests) PrepareWithParams(c *gc.C, params bootstrap.PrepareParams) environs.Environ {
-	panic("X")
-	e, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c), t.ControllerStore, params)
+	e, err := bootstrap.PrepareController(false, t.BootstrapContext, t.ControllerStore, params)
 	c.Assert(err, gc.IsNil, gc.Commentf("preparing environ %#v", params.ModelConfig))
 	c.Assert(e, gc.NotNil)
 	t.Env = e.(environs.Environ)
@@ -111,11 +113,10 @@ func (t *Tests) PrepareWithParams(c *gc.C, params bootstrap.PrepareParams) envir
 }
 
 func (t *Tests) AssertPrepareFailsWithConfig(c *gc.C, badConfig coretesting.Attrs, errorMatches string) error {
-	panic("Y")
 	args := t.PrepareParams(c)
 	args.ModelConfig = coretesting.Attrs(args.ModelConfig).Merge(badConfig)
 
-	e, err := bootstrap.PrepareController(false, envtesting.BootstrapContext(stdcontext.TODO(), c), t.ControllerStore, args)
+	e, err := bootstrap.PrepareController(false, t.BootstrapContext, t.ControllerStore, args)
 	c.Assert(err, gc.ErrorMatches, errorMatches)
 	c.Assert(e, gc.IsNil)
 	return err
@@ -132,7 +133,11 @@ func (t *Tests) SetUpTest(c *gc.C) {
 	t.toolsStorage = stor
 	t.ControllerStore = jujuclient.NewMemStore()
 	t.ControllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
-	t.ProviderCallContext = context.NewCloudCallContext(stdcontext.Background())
+
+	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
+	ctx := stdcontext.WithValue(stdcontext.TODO(), bootstrap.SimplestreamsFetcherContextKey, ss)
+	t.BootstrapContext = envtesting.BootstrapContext(ctx, c)
+	t.ProviderCallContext = context.NewCloudCallContext(ctx)
 }
 
 func (t *Tests) TearDownTest(c *gc.C) {
@@ -221,14 +226,14 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	}
 
 	e := t.Prepare(c)
-	err := bootstrap.Bootstrap(bootstrapContext(c), e, t.ProviderCallContext, args)
+	err := bootstrap.Bootstrap(t.BootstrapContext, e, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerInstances, err := e.ControllerInstances(t.ProviderCallContext, t.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerInstances, gc.Not(gc.HasLen), 0)
 
-	e2 := t.Open(c, e.Config())
+	e2 := t.Open(c, t.BootstrapContext.Context(), e.Config())
 	controllerInstances2, err := e2.ControllerInstances(t.ProviderCallContext, t.ControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(controllerInstances2, gc.Not(gc.HasLen), 0)
@@ -240,15 +245,9 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 	// Prepare again because Destroy invalidates old environments.
 	e3 := t.Prepare(c)
 
-	err = bootstrap.Bootstrap(bootstrapContext(c), e3, t.ProviderCallContext, args)
+	err = bootstrap.Bootstrap(t.BootstrapContext, e3, t.ProviderCallContext, args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = environs.Destroy(e3.Config().Name(), e3, t.ProviderCallContext, t.ControllerStore)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func bootstrapContext(c *gc.C) environs.BootstrapContext {
-	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	ctx := stdcontext.WithValue(stdcontext.TODO(), bootstrap.SimplestreamsFetcherContextKey, ss)
-	return envtesting.BootstrapContext(ctx, c)
 }

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -15,7 +16,7 @@ import (
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
@@ -46,7 +47,7 @@ func (m *MockNetworkingEnviron) EXPECT() *MockNetworkingEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method.
-func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockNetworkingEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -60,7 +61,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 int
 }
 
 // AllInstances mocks base method.
-func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -75,7 +76,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gom
 }
 
 // AllRunningInstances mocks base method.
-func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -90,7 +91,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method.
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(network.InterfaceInfos)
@@ -105,7 +106,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 }
 
 // AreSpacesRoutable mocks base method.
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
+func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context0.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -120,7 +121,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 
 }
 
 // Bootstrap mocks base method.
-func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context0.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
@@ -149,7 +150,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method.
-func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -164,7 +165,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ConstraintsValidator(arg0 interface
 }
 
 // ControllerInstances mocks base method.
-func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockNetworkingEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -179,7 +180,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ControllerInstances(arg0, arg1 inte
 }
 
 // Create mocks base method.
-func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockNetworkingEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -193,7 +194,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Create(arg0, arg1 interface{}) *gom
 }
 
 // Destroy mocks base method.
-func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockNetworkingEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -207,7 +208,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.C
 }
 
 // DestroyController mocks base method.
-func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockNetworkingEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -221,7 +222,7 @@ func (mr *MockNetworkingEnvironMockRecorder) DestroyController(arg0, arg1 interf
 }
 
 // InstanceTypes mocks base method.
-func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockNetworkingEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -236,7 +237,7 @@ func (mr *MockNetworkingEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{
 }
 
 // Instances mocks base method.
-func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -251,7 +252,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Instances(arg0, arg1 interface{}) *
 }
 
 // NetworkInterfaces mocks base method.
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
 	ret0, _ := ret[0].([]network.InterfaceInfos)
@@ -266,7 +267,7 @@ func (mr *MockNetworkingEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interf
 }
 
 // PrecheckInstance mocks base method.
-func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -308,7 +309,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // ProviderSpaceInfo mocks base method.
-func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context0.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderSpaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(*environs.ProviderSpaceInfo)
@@ -323,7 +324,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method.
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context0.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -337,7 +338,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SSHAddresses mocks base method.
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
+func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
 	ret0, _ := ret[0].(network.SpaceAddresses)
@@ -366,7 +367,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method.
-func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
 	ret0, _ := ret[0].([]network.SpaceInfo)
@@ -381,7 +382,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Spaces(arg0 interface{}) *gomock.Ca
 }
 
 // StartInstance mocks base method.
-func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockNetworkingEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -396,7 +397,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StartInstance(arg0, arg1 interface{
 }
 
 // StopInstances mocks base method.
-func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockNetworkingEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -445,7 +446,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StorageProviderTypes() *gomock.Call
 }
 
 // Subnets mocks base method.
-func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]network.SubnetInfo)
@@ -460,7 +461,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 interface{
 }
 
 // SuperSubnets mocks base method.
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) ([]string, error) {
+func (m *MockNetworkingEnviron) SuperSubnets(arg0 context0.ProviderCallContext) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
 	ret0, _ := ret[0].([]string)
@@ -475,7 +476,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 interface{}) *gom
 }
 
 // SupportsContainerAddresses mocks base method.
-func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsContainerAddresses", arg0)
 	ret0, _ := ret[0].(bool)
@@ -490,7 +491,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsContainerAddresses(arg0 int
 }
 
 // SupportsSpaceDiscovery mocks base method.
-func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaceDiscovery", arg0)
 	ret0, _ := ret[0].(bool)
@@ -505,7 +506,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaceDiscovery(arg0 interfa
 }
 
 // SupportsSpaces mocks base method.
-func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaces", arg0)
 	ret0, _ := ret[0].(bool)
@@ -601,22 +602,22 @@ func (mr *MockCloudEnvironProviderMockRecorder) FinalizeCredential(arg0, arg1 in
 }
 
 // Open mocks base method.
-func (m *MockCloudEnvironProvider) Open(arg0 environs.OpenParams) (environs.Environ, error) {
+func (m *MockCloudEnvironProvider) Open(arg0 context.Context, arg1 environs.OpenParams) (environs.Environ, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", arg0)
+	ret := m.ctrl.Call(m, "Open", arg0, arg1)
 	ret0, _ := ret[0].(environs.Environ)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Open indicates an expected call of Open.
-func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0 interface{}) *gomock.Call {
+func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0, arg1)
 }
 
 // Ping mocks base method.
-func (m *MockCloudEnvironProvider) Ping(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockCloudEnvironProvider) Ping(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/environs/open.go
+++ b/environs/open.go
@@ -4,6 +4,8 @@
 package environs
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs/context"
@@ -14,20 +16,20 @@ import (
 const AdminUser = "admin"
 
 // New returns a new environment based on the provided configuration.
-func New(args OpenParams) (Environ, error) {
+func New(ctx stdcontext.Context, args OpenParams) (Environ, error) {
 	p, err := Provider(args.Cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return Open(p, args)
+	return Open(ctx, p, args)
 }
 
 // Open creates an Environ instance and errors if the provider is not for a cloud.
-func Open(p EnvironProvider, args OpenParams) (Environ, error) {
+func Open(ctx stdcontext.Context, p EnvironProvider, args OpenParams) (Environ, error) {
 	if envProvider, ok := p.(CloudEnvironProvider); !ok {
 		return nil, errors.NotValidf("cloud environ provider %T", p)
 	} else {
-		return envProvider.Open(args)
+		return envProvider.Open(ctx, args)
 	}
 }
 

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -118,7 +118,7 @@ func (s *OpenSuite) TestUpdateEnvInfo(c *gc.C) {
 }
 
 func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud: environscloudspec.CloudSpec{
 			Type: "wondercloud",
 		},
@@ -135,7 +135,7 @@ func (*OpenSuite) TestNew(c *gc.C) {
 		},
 	))
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(environs.OpenParams{
+	e, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  dummy.SampleCloudSpec(),
 		Config: cfg,
 	})

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -5,6 +5,7 @@
 package testing
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -17,7 +18,7 @@ import (
 	firewall "github.com/juju/juju/core/network/firewall"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
-	context "github.com/juju/juju/environs/context"
+	context0 "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
@@ -107,7 +108,7 @@ func (mr *MockEnvironProviderMockRecorder) FinalizeCredential(arg0, arg1 interfa
 }
 
 // Ping mocks base method.
-func (m *MockEnvironProvider) Ping(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockEnvironProvider) Ping(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -246,22 +247,22 @@ func (mr *MockCloudEnvironProviderMockRecorder) FinalizeCredential(arg0, arg1 in
 }
 
 // Open mocks base method.
-func (m *MockCloudEnvironProvider) Open(arg0 environs.OpenParams) (environs.Environ, error) {
+func (m *MockCloudEnvironProvider) Open(arg0 context.Context, arg1 environs.OpenParams) (environs.Environ, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", arg0)
+	ret := m.ctrl.Call(m, "Open", arg0, arg1)
 	ret0, _ := ret[0].(environs.Environ)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Open indicates an expected call of Open.
-func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0 interface{}) *gomock.Call {
+func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0, arg1)
 }
 
 // Ping mocks base method.
-func (m *MockCloudEnvironProvider) Ping(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockCloudEnvironProvider) Ping(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -727,7 +728,7 @@ func (m *MockCloudDestroyer) EXPECT() *MockCloudDestroyerMockRecorder {
 }
 
 // Destroy mocks base method.
-func (m *MockCloudDestroyer) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockCloudDestroyer) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -764,7 +765,7 @@ func (m *MockEnviron) EXPECT() *MockEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method.
-func (m *MockEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -778,7 +779,7 @@ func (mr *MockEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) 
 }
 
 // AllInstances mocks base method.
-func (m *MockEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -793,7 +794,7 @@ func (mr *MockEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 }
 
 // AllRunningInstances mocks base method.
-func (m *MockEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -808,7 +809,7 @@ func (mr *MockEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock
 }
 
 // Bootstrap mocks base method.
-func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context0.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
@@ -837,7 +838,7 @@ func (mr *MockEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method.
-func (m *MockEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -852,7 +853,7 @@ func (mr *MockEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomoc
 }
 
 // ControllerInstances mocks base method.
-func (m *MockEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -867,7 +868,7 @@ func (mr *MockEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *
 }
 
 // Create mocks base method.
-func (m *MockEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -881,7 +882,7 @@ func (mr *MockEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Destroy mocks base method.
-func (m *MockEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -895,7 +896,7 @@ func (mr *MockEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 }
 
 // DestroyController mocks base method.
-func (m *MockEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -909,7 +910,7 @@ func (mr *MockEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *go
 }
 
 // InstanceTypes mocks base method.
-func (m *MockEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -924,7 +925,7 @@ func (mr *MockEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock
 }
 
 // Instances mocks base method.
-func (m *MockEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -939,7 +940,7 @@ func (mr *MockEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Cal
 }
 
 // PrecheckInstance mocks base method.
-func (m *MockEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -995,7 +996,7 @@ func (mr *MockEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
 }
 
 // StartInstance mocks base method.
-func (m *MockEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -1010,7 +1011,7 @@ func (mr *MockEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock
 }
 
 // StopInstances mocks base method.
-func (m *MockEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -1082,7 +1083,7 @@ func (m *MockInstancePrechecker) EXPECT() *MockInstancePrecheckerMockRecorder {
 }
 
 // PrecheckInstance mocks base method.
-func (m *MockInstancePrechecker) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockInstancePrechecker) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1119,7 +1120,7 @@ func (m *MockFirewaller) EXPECT() *MockFirewallerMockRecorder {
 }
 
 // ClosePorts mocks base method.
-func (m *MockFirewaller) ClosePorts(arg0 context.ProviderCallContext, arg1 firewall.IngressRules) error {
+func (m *MockFirewaller) ClosePorts(arg0 context0.ProviderCallContext, arg1 firewall.IngressRules) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClosePorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1133,7 +1134,7 @@ func (mr *MockFirewallerMockRecorder) ClosePorts(arg0, arg1 interface{}) *gomock
 }
 
 // IngressRules mocks base method.
-func (m *MockFirewaller) IngressRules(arg0 context.ProviderCallContext) (firewall.IngressRules, error) {
+func (m *MockFirewaller) IngressRules(arg0 context0.ProviderCallContext) (firewall.IngressRules, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IngressRules", arg0)
 	ret0, _ := ret[0].(firewall.IngressRules)
@@ -1148,7 +1149,7 @@ func (mr *MockFirewallerMockRecorder) IngressRules(arg0 interface{}) *gomock.Cal
 }
 
 // OpenPorts mocks base method.
-func (m *MockFirewaller) OpenPorts(arg0 context.ProviderCallContext, arg1 firewall.IngressRules) error {
+func (m *MockFirewaller) OpenPorts(arg0 context0.ProviderCallContext, arg1 firewall.IngressRules) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenPorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1185,7 +1186,7 @@ func (m *MockInstanceTagger) EXPECT() *MockInstanceTaggerMockRecorder {
 }
 
 // TagInstance mocks base method.
-func (m *MockInstanceTagger) TagInstance(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 map[string]string) error {
+func (m *MockInstanceTagger) TagInstance(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagInstance", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1222,7 +1223,7 @@ func (m *MockInstanceTypesFetcher) EXPECT() *MockInstanceTypesFetcherMockRecorde
 }
 
 // InstanceTypes mocks base method.
-func (m *MockInstanceTypesFetcher) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockInstanceTypesFetcher) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -1260,7 +1261,7 @@ func (m *MockUpgrader) EXPECT() *MockUpgraderMockRecorder {
 }
 
 // UpgradeOperations mocks base method.
-func (m *MockUpgrader) UpgradeOperations(arg0 context.ProviderCallContext, arg1 environs.UpgradeOperationsParams) []environs.UpgradeOperation {
+func (m *MockUpgrader) UpgradeOperations(arg0 context0.ProviderCallContext, arg1 environs.UpgradeOperationsParams) []environs.UpgradeOperation {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeOperations", arg0, arg1)
 	ret0, _ := ret[0].([]environs.UpgradeOperation)
@@ -1311,7 +1312,7 @@ func (mr *MockUpgradeStepMockRecorder) Description() *gomock.Call {
 }
 
 // Run mocks base method.
-func (m *MockUpgradeStep) Run(arg0 context.ProviderCallContext) error {
+func (m *MockUpgradeStep) Run(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0)
 	ret0, _ := ret[0].(error)
@@ -1460,7 +1461,7 @@ func (m *MockNetworkingEnviron) EXPECT() *MockNetworkingEnvironMockRecorder {
 }
 
 // AdoptResources mocks base method.
-func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
+func (m *MockNetworkingEnviron) AdoptResources(arg0 context0.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -1474,7 +1475,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 int
 }
 
 // AllInstances mocks base method.
-func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -1489,7 +1490,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gom
 }
 
 // AllRunningInstances mocks base method.
-func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context0.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -1504,7 +1505,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{
 }
 
 // AllocateContainerAddresses mocks base method.
-func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(network.InterfaceInfos)
@@ -1519,7 +1520,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, ar
 }
 
 // AreSpacesRoutable mocks base method.
-func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
+func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context0.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -1534,7 +1535,7 @@ func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 
 }
 
 // Bootstrap mocks base method.
-func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
+func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context0.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*environs.BootstrapResult)
@@ -1563,7 +1564,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Config() *gomock.Call {
 }
 
 // ConstraintsValidator mocks base method.
-func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
+func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context0.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
 	ret0, _ := ret[0].(constraints.Validator)
@@ -1578,7 +1579,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ConstraintsValidator(arg0 interface
 }
 
 // ControllerInstances mocks base method.
-func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
+func (m *MockNetworkingEnviron) ControllerInstances(arg0 context0.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
 	ret0, _ := ret[0].([]instance.Id)
@@ -1593,7 +1594,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ControllerInstances(arg0, arg1 inte
 }
 
 // Create mocks base method.
-func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
+func (m *MockNetworkingEnviron) Create(arg0 context0.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1607,7 +1608,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Create(arg0, arg1 interface{}) *gom
 }
 
 // Destroy mocks base method.
-func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error {
+func (m *MockNetworkingEnviron) Destroy(arg0 context0.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
@@ -1621,7 +1622,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.C
 }
 
 // DestroyController mocks base method.
-func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
+func (m *MockNetworkingEnviron) DestroyController(arg0 context0.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1635,7 +1636,7 @@ func (mr *MockNetworkingEnvironMockRecorder) DestroyController(arg0, arg1 interf
 }
 
 // InstanceTypes mocks base method.
-func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
+func (m *MockNetworkingEnviron) InstanceTypes(arg0 context0.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
 	ret0, _ := ret[0].(instances.InstanceTypesWithCostMetadata)
@@ -1650,7 +1651,7 @@ func (mr *MockNetworkingEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{
 }
 
 // Instances mocks base method.
-func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
+func (m *MockNetworkingEnviron) Instances(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
 	ret0, _ := ret[0].([]instances.Instance)
@@ -1665,7 +1666,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Instances(arg0, arg1 interface{}) *
 }
 
 // NetworkInterfaces mocks base method.
-func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
+func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context0.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
 	ret0, _ := ret[0].([]network.InterfaceInfos)
@@ -1680,7 +1681,7 @@ func (mr *MockNetworkingEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interf
 }
 
 // PrecheckInstance mocks base method.
-func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
+func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context0.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1722,7 +1723,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // ProviderSpaceInfo mocks base method.
-func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
+func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context0.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderSpaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(*environs.ProviderSpaceInfo)
@@ -1737,7 +1738,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interf
 }
 
 // ReleaseContainerAddresses mocks base method.
-func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
+func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context0.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1751,7 +1752,7 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SSHAddresses mocks base method.
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
+func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
 	ret0, _ := ret[0].(network.SpaceAddresses)
@@ -1780,7 +1781,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method.
-func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
 	ret0, _ := ret[0].([]network.SpaceInfo)
@@ -1795,7 +1796,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Spaces(arg0 interface{}) *gomock.Ca
 }
 
 // StartInstance mocks base method.
-func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (m *MockNetworkingEnviron) StartInstance(arg0 context0.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
 	ret0, _ := ret[0].(*environs.StartInstanceResult)
@@ -1810,7 +1811,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StartInstance(arg0, arg1 interface{
 }
 
 // StopInstances mocks base method.
-func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
+func (m *MockNetworkingEnviron) StopInstances(arg0 context0.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
@@ -1859,7 +1860,7 @@ func (mr *MockNetworkingEnvironMockRecorder) StorageProviderTypes() *gomock.Call
 }
 
 // Subnets mocks base method.
-func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 context0.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]network.SubnetInfo)
@@ -1874,7 +1875,7 @@ func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 interface{
 }
 
 // SuperSubnets mocks base method.
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) ([]string, error) {
+func (m *MockNetworkingEnviron) SuperSubnets(arg0 context0.ProviderCallContext) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
 	ret0, _ := ret[0].([]string)
@@ -1889,7 +1890,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 interface{}) *gom
 }
 
 // SupportsContainerAddresses mocks base method.
-func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsContainerAddresses", arg0)
 	ret0, _ := ret[0].(bool)
@@ -1904,7 +1905,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsContainerAddresses(arg0 int
 }
 
 // SupportsSpaceDiscovery mocks base method.
-func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaceDiscovery", arg0)
 	ret0, _ := ret[0].(bool)
@@ -1919,7 +1920,7 @@ func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaceDiscovery(arg0 interfa
 }
 
 // SupportsSpaces mocks base method.
-func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext) (bool, error) {
+func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context0.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaces", arg0)
 	ret0, _ := ret[0].(bool)

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -323,7 +323,7 @@ func openEnviron(
 		makeResourceGroupNotFoundSender(fmt.Sprintf(".*/resourcegroups/juju-%s-model-deadbeef-.*", cfg.Name())),
 		makeSender(fmt.Sprintf(".*/resourcegroups/juju-%s-.*", cfg.Name()), makeResourceGroupResult()),
 	}
-	env, err := environs.Open(provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: cfg,
 	})
@@ -360,7 +360,7 @@ func prepareForBootstrap(
 		makeResourceGroupNotFoundSender(".*/resourcegroups/juju-testmodel-model-deadbeef-.*"),
 		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
 	}
-	env, err := environs.Open(provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: cfg,
 	})

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -4,6 +4,8 @@
 package azure
 
 import (
+	stdcontext "context"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -121,7 +123,7 @@ func (prov *azureEnvironProvider) Version() int {
 }
 
 // Open is part of the EnvironProvider interface.
-func (prov *azureEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (prov *azureEnvironProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	stdcontext "context"
 	"net/http"
 	"time"
 
@@ -78,7 +79,7 @@ func (s *environProviderSuite) TestOpen(c *gc.C) {
 		makeResourceGroupNotFoundSender(".*/resourcegroups/juju-testmodel-model-deadbeef-.*"),
 		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
 	}
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: makeTestModelConfig(c),
 	})
@@ -102,7 +103,7 @@ func (s *environProviderSuite) testOpenError(c *gc.C, spec environscloudspec.Clo
 		makeResourceGroupNotFoundSender(".*/resourcegroups/juju-testmodel-model-deadbeef-.*"),
 		makeSender(".*/resourcegroups/juju-testmodel-.*", makeResourceGroupResult()),
 	}
-	_, err := environs.Open(s.provider, environs.OpenParams{
+	_, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: makeTestModelConfig(c),
 	})

--- a/provider/cloudsigma/config_test.go
+++ b/provider/cloudsigma/config_test.go
@@ -4,6 +4,8 @@
 package cloudsigma
 
 import (
+	stdcontext "context"
+
 	"github.com/altoros/gosigma/mock"
 	gc "gopkg.in/check.v1"
 
@@ -82,7 +84,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 		attrs := validAttrs().Merge(test.insert).Delete(test.remove...)
 		testConfig := newConfig(c, attrs)
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  fakeCloudSpec(),
 			Config: testConfig,
 		})
@@ -151,7 +153,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs())
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  fakeCloudSpec(),
 			Config: baseConfig,
 		})

--- a/provider/cloudsigma/environ_test.go
+++ b/provider/cloudsigma/environ_test.go
@@ -4,6 +4,8 @@
 package cloudsigma
 
 import (
+	stdcontext "context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -47,7 +49,7 @@ func (s *environSuite) TearDownTest(c *gc.C) {
 
 func (s *environSuite) TestBase(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: baseConfig,
 	})
@@ -72,7 +74,7 @@ func (s *environSuite) TestBase(c *gc.C) {
 
 func (s *environSuite) TestUnsupportedConstraints(c *gc.C) {
 	baseConfig := newConfig(c, validAttrs().Merge(testing.Attrs{"name": "testname"}))
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: baseConfig,
 	})

--- a/provider/cloudsigma/environinstance_test.go
+++ b/provider/cloudsigma/environinstance_test.go
@@ -4,6 +4,7 @@
 package cloudsigma
 
 import (
+	stdcontext "context"
 	"time"
 
 	"github.com/altoros/gosigma/mock"
@@ -81,7 +82,7 @@ func (s *environInstanceSuite) createEnviron(c *gc.C, cfg *config.Config) enviro
 		cfg = s.baseConfig
 	}
 
-	environ, err := environs.New(environs.OpenParams{
+	environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  s.cloud,
 		Config: cfg,
 	})

--- a/provider/cloudsigma/provider.go
+++ b/provider/cloudsigma/provider.go
@@ -6,6 +6,7 @@
 package cloudsigma
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -66,7 +67,7 @@ func (environProvider) Version() int {
 // Open opens the environment and returns it.
 // The configuration must have come from a previously
 // prepared environment.
-func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")

--- a/provider/cloudsigma/provider_test.go
+++ b/provider/cloudsigma/provider_test.go
@@ -4,6 +4,7 @@
 package cloudsigma
 
 import (
+	stdcontext "context"
 	stdtesting "testing"
 
 	"github.com/juju/testing"
@@ -38,7 +39,7 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: newConfig(c, nil),
 	})
@@ -63,7 +64,7 @@ func (s *providerSuite) TestOpenUnsupportedCredential(c *gc.C) {
 }
 
 func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec, expect string) {
-	_, err := environs.Open(s.provider, environs.OpenParams{
+	_, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: newConfig(c, nil),
 	})

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -19,6 +19,7 @@
 package dummy
 
 import (
+	stdcontext "context"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
@@ -704,7 +705,7 @@ func (*environProvider) Version() int {
 	return 0
 }
 
-func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	ecfg, err := p.newConfig(args.Config)

--- a/provider/ec2/client.go
+++ b/provider/ec2/client.go
@@ -50,7 +50,6 @@ type Client interface {
 
 // EC2Session returns a session with the given credentials.
 func clientFunc(region, accessKey, secretKey string, clientOptions ...ClientOption) Client {
-	panic("Z")
 	opts := newOptions()
 	for _, option := range clientOptions {
 		option(opts)

--- a/provider/ec2/client.go
+++ b/provider/ec2/client.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// ClientOption to be passed into the transport construction to customize the
+// default transport.
+type ClientOption func(*clientOptions)
+
+type clientOptions struct {
+	httpClient *http.Client
+}
+
+// WithHTTPClient allows to define the http.Client to use.
+func WithHTTPClient(value *http.Client) ClientOption {
+	return func(opt *clientOptions) {
+		opt.httpClient = value
+	}
+}
+
+// Create a clientOptions instance with default values.
+func newOptions() *clientOptions {
+	defaultCopy := *http.DefaultClient
+	return &clientOptions{
+		httpClient: &defaultCopy,
+	}
+}
+
+type ClientFunc = func(string, string, string, ...ClientOption) Client
+
+// The subset of *ec2.EC2 methods that we currently use.
+type Client interface {
+	DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
+	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+	DescribeInstanceTypeOfferings(*ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
+	DescribeInstanceTypes(*ec2.DescribeInstanceTypesInput) (*ec2.DescribeInstanceTypesOutput, error)
+	DescribeSpotPriceHistory(*ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error)
+}
+
+// EC2Session returns a session with the given credentials.
+func clientFunc(region, accessKey, secretKey string, clientOptions ...ClientOption) Client {
+	panic("Z")
+	opts := newOptions()
+	for _, option := range clientOptions {
+		option(opts)
+	}
+
+	sess := session.Must(session.NewSession())
+	config := &aws.Config{
+		HTTPClient: opts.httpClient,
+		Retryer: client.DefaultRetryer{ // these roughly match retry params in gopkg.in/amz.v3/ec2/ec2.go:EC2.query
+			NumMaxRetries:    10,
+			MinRetryDelay:    time.Second,
+			MinThrottleDelay: time.Second,
+			MaxRetryDelay:    time.Minute,
+			MaxThrottleDelay: time.Minute,
+		},
+		Region: aws.String(region),
+		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
+			AccessKeyID:     accessKey,
+			SecretAccessKey: secretKey,
+		}),
+	}
+
+	// Enable request and response logging, but only if TRACE is enabled (as
+	// they're probably fairly expensive to produce).
+	if logger.IsTraceEnabled() {
+		config.Logger = awsLogger{sess}
+		config.LogLevel = aws.LogLevel(aws.LogDebug | aws.LogDebugWithRequestErrors | aws.LogDebugWithRequestRetries)
+	}
+
+	return ec2.New(sess, config)
+}

--- a/provider/ec2/config_test.go
+++ b/provider/ec2/config_test.go
@@ -6,6 +6,7 @@ package ec2
 // TODO: Clean this up so it matches environs/openstack/config_test.go.
 
 import (
+	stdcontext "context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -67,7 +68,7 @@ func (t configTest) check(c *gc.C) {
 	}).Merge(t.config)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	e, err := environs.New(environs.OpenParams{
+	e, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: cfg,
 	})

--- a/provider/ec2/credentials.go
+++ b/provider/ec2/credentials.go
@@ -64,7 +64,7 @@ func (e environProviderCredentials) DetectCredentials(cloudName string) (*cloud.
 		AuthCredentials: make(map[string]cloud.Credential),
 	}
 	for _, credName := range credInfo.SectionStrings() {
-		if credName == ini.DEFAULT_SECTION {
+		if credName == ini.DefaultSection {
 			// No credentials at top level.
 			continue
 		}

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -405,8 +405,8 @@ func (v *ebsVolumeSource) createVolume(ctx context.ProviderCallContext, p storag
 	}
 
 	volume := storage.Volume{
-		p.Tag,
-		storage.VolumeInfo{
+		Tag: p.Tag,
+		VolumeInfo: storage.VolumeInfo{
 			VolumeId:   volumeId,
 			Size:       gibToMib(uint64(resp.Size)),
 			Persistent: true,
@@ -758,9 +758,9 @@ func (v *ebsVolumeSource) AttachVolumes(ctx context.ProviderCallContext, attachP
 		attachmentInfo.DeviceName = deviceName
 
 		results[i].VolumeAttachment = &storage.VolumeAttachment{
-			params.Volume,
-			params.Machine,
-			attachmentInfo,
+			Volume:               params.Volume,
+			Machine:              params.Machine,
+			VolumeAttachmentInfo: attachmentInfo,
 		}
 	}
 	return results, nil

--- a/provider/ec2/ebs_test.go
+++ b/provider/ec2/ebs_test.go
@@ -5,6 +5,7 @@ package ec2_test
 
 import (
 	"bytes"
+	stdcontext "context"
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
@@ -76,7 +77,7 @@ func (s *ebsSuite) ebsProvider(c *gc.C) storage.Provider {
 			"secret-key": "x",
 		},
 	)
-	env, err := environs.Open(provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), provider, environs.OpenParams{
 		Cloud: environscloudspec.CloudSpec{
 			Type:       "ec2",
 			Name:       "ec2test",

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2540,6 +2540,16 @@ func (e *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.Cl
 	// Allow the passing of a client func through the context. This allows
 	// passing the client from outside of the environ, one that allows for
 	// custom http.Clients.
+	//
+	// This isn't in it's final form. It is expected that eventually the ec2
+	// client will be passed in via the constructor of the environ. That can
+	// then be passed in via the environProvider. Unfortunately the provider
+	// (factory) is registered in an init function and makes it VERY hard to
+	// override. The solution to all of this is to remove the global registry
+	// and construct that within the main (or provide sane defaults). The
+	// provider/all package can then be removed and the black magic for provider
+	// registration can then vanish and plain old dependency management can
+	// then be used.
 	if value := ctx.Value(AWSClientContextKey); value == nil {
 		e.ec2ClientFunc = clientFunc
 	} else if s, ok := value.(ClientFunc); ok {

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -14,8 +14,6 @@ import (
 	jujustorage "github.com/juju/juju/storage"
 )
 
-type EC2Client = ec2Client
-
 func StorageEC2(vs jujustorage.VolumeSource) *amzec2.EC2 {
 	return vs.(*ebsVolumeSource).env.ec2
 }

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/juju/os/v2/series"
 	jc "github.com/juju/testing/checkers"
@@ -23,7 +22,6 @@ import (
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/jujutest"
 	"github.com/juju/juju/juju/testing"
-	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/provider/ec2"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -85,20 +83,8 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return version.DefaultSupportedLTS(), nil })
-	// Use the real ec2 session if we are running with real creds.
-	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-	if accessKey == "" {
-		t.BaseSuite.PatchValue(&ec2.EC2Session, func(region, accessKey, secretKey string) ec2.EC2Client {
-			c.Assert(region, gc.Equals, "test")
-			c.Assert(accessKey, gc.Equals, "x")
-			c.Assert(secretKey, gc.Equals, "x")
-			return &mockEC2Session{
-				newInstancesClient: func() *amzec2.EC2 {
-					return ec2.EnvironEC2(t.Env)
-				},
-			}
-		})
-	}
+
+	t.BootstrapContext = bootstrapLiveContext(c, liveEnvGetter{t: t.LiveTests})
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
@@ -118,6 +104,14 @@ func (t *LiveTests) TearDownTest(c *gc.C) {
 	t.BaseSuite.TearDownTest(c)
 }
 
+type liveEnvGetter struct {
+	t jujutest.LiveTests
+}
+
+func (e liveEnvGetter) Env() environs.Environ {
+	return e.t.Env
+}
+
 // TODO(niemeyer): Looks like many of those tests should be moved to jujutest.LiveTests.
 
 func (t *LiveTests) TestInstanceAttributes(c *gc.C) {
@@ -130,7 +124,7 @@ func (t *LiveTests) TestInstanceAttributes(c *gc.C) {
 	c.Assert(hc.RootDisk, gc.NotNil)
 	c.Assert(hc.CpuCores, gc.NotNil)
 	c.Assert(hc.CpuPower, gc.NotNil)
-	addresses, err := jujutesting.WaitInstanceAddresses(t.Env, t.callCtx, inst.Id())
+	addresses, err := testing.WaitInstanceAddresses(t.Env, t.callCtx, inst.Id())
 	// TODO(niemeyer): This assert sometimes fails with "no instances found"
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addresses, gc.Not(gc.HasLen), 0)

--- a/provider/ec2/live_test.go
+++ b/provider/ec2/live_test.go
@@ -83,8 +83,6 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	t.BaseSuite.PatchValue(&version.Current, coretesting.FakeVersionNumber)
 	t.BaseSuite.PatchValue(&arch.HostArch, func() string { return arch.AMD64 })
 	t.BaseSuite.PatchValue(&series.HostSeries, func() (string, error) { return version.DefaultSupportedLTS(), nil })
-
-	t.BootstrapContext = bootstrapLiveContext(c, liveEnvGetter{t: t.LiveTests})
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
@@ -97,6 +95,8 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	t.LiveTests.SetUpTest(c)
 
 	t.callCtx = context.NewEmptyCloudCallContext()
+	t.LiveTests.BootstrapContext = bootstrapLiveContext(c, liveEnvGetter{t: t})
+	t.LiveTests.ProviderCallContext = context.NewCloudCallContext(t.LiveTests.BootstrapContext.Context())
 }
 
 func (t *LiveTests) TearDownTest(c *gc.C) {
@@ -105,7 +105,7 @@ func (t *LiveTests) TearDownTest(c *gc.C) {
 }
 
 type liveEnvGetter struct {
-	t jujutest.LiveTests
+	t *LiveTests
 }
 
 func (e liveEnvGetter) Env() environs.Environ {

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -40,7 +40,7 @@ func (environProvider) Version() int {
 func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", args.Config.Name())
 
-	e := new(environ)
+	e := newEnviron()
 	e.name = args.Config.Name()
 
 	if err := e.SetCloudSpec(args.Cloud); err != nil {

--- a/provider/ec2/provider.go
+++ b/provider/ec2/provider.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	stdcontext "context"
 	"fmt"
 	"strings"
 
@@ -37,13 +38,13 @@ func (environProvider) Version() int {
 }
 
 // Open is specified in the EnvironProvider interface.
-func (p environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", args.Config.Name())
 
 	e := newEnviron()
 	e.name = args.Config.Name()
 
-	if err := e.SetCloudSpec(args.Cloud); err != nil {
+	if err := e.SetCloudSpec(ctx, args.Cloud); err != nil {
 		return nil, err
 	}
 
@@ -190,7 +191,7 @@ var verifyCredentials = func(e *environ, ctx context.ProviderCallContext) error 
 
 // maybeConvertCredentialError examines the error received from the provider.
 // Authentication related errors are wrapped in common.CredentialNotValid.
-// Authorisation related errors are annotated with an additional
+// Authorization related errors are annotated with an additional
 // user-friendly explanation.
 // All other errors are returned un-wrapped and not annotated.
 var maybeConvertCredentialError = func(err error, ctx context.ProviderCallContext) error {

--- a/provider/ec2/provider_test.go
+++ b/provider/ec2/provider_test.go
@@ -4,6 +4,8 @@
 package ec2_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +53,7 @@ func (s *ProviderSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ProviderSuite) TestOpen(c *gc.C) {
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: coretesting.ModelConfig(c),
 	})
@@ -64,7 +66,7 @@ func (s *ProviderSuite) TestOpenUnknownRegion(c *gc.C) {
 	// anything in the client. That means that when new regions are
 	// added to AWS, we'll be able to support them.
 	s.spec.Region = "foobar"
-	_, err := environs.Open(s.provider, environs.OpenParams{
+	_, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: coretesting.ModelConfig(c),
 	})
@@ -79,7 +81,7 @@ func (s *ProviderSuite) TestOpenKnownRegionInvalidEndpoint(c *gc.C) {
 	})
 	s.spec.Endpoint = "https://us-east-1.aws.amazon.com/v1.2/"
 
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: coretesting.ModelConfig(c),
 	})
@@ -101,7 +103,7 @@ func (s *ProviderSuite) TestOpenKnownRegionValidEndpoint(c *gc.C) {
 	})
 	s.spec.Endpoint = "https://ec2.us-east-1.amazonaws.com"
 
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: coretesting.ModelConfig(c),
 	})
@@ -123,7 +125,7 @@ func (s *ProviderSuite) TestOpenUnsupportedCredential(c *gc.C) {
 }
 
 func (s *ProviderSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec, expect string) {
-	_, err := environs.Open(s.provider, environs.OpenParams{
+	_, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: coretesting.ModelConfig(c),
 	})
@@ -131,7 +133,7 @@ func (s *ProviderSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 }
 
 func (s *ProviderSuite) TestVerifyCredentialsErrs(c *gc.C) {
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: coretesting.ModelConfig(c),
 	})

--- a/provider/gce/config_test.go
+++ b/provider/gce/config_test.go
@@ -4,6 +4,8 @@
 package gce_test
 
 import (
+	stdcontext "context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -99,7 +101,7 @@ func (s *ConfigSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  gce.MakeTestCloudSpec(),
 			Config: testConfig,
 		})
@@ -177,7 +179,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  gce.MakeTestCloudSpec(),
 			Config: s.config,
 		})

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -124,14 +124,14 @@ func newEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config) (*environ
 		ecfg:      ecfg,
 		namespace: namespace,
 	}
-	if err = e.SetCloudSpec(cloud); err != nil {
+	if err = e.SetCloudSpec(stdcontext.TODO(), cloud); err != nil {
 		return nil, err
 	}
 	return e, nil
 }
 
 // SetCloudSpec is specified in the environs.Environ interface.
-func (e *environ) SetCloudSpec(spec environscloudspec.CloudSpec) error {
+func (e *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.CloudSpec) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 

--- a/provider/gce/provider.go
+++ b/provider/gce/provider.go
@@ -4,6 +4,8 @@
 package gce
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/schema"
@@ -36,7 +38,7 @@ func (environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/provider/gce/provider_test.go
+++ b/provider/gce/provider_test.go
@@ -4,6 +4,8 @@
 package gce_test
 
 import (
+	stdcontext "context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -37,7 +39,7 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 }
 
 func (s *providerSuite) TestOpen(c *gc.C) {
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: s.Config,
 	})
@@ -64,7 +66,7 @@ func (s *providerSuite) TestOpenUnsupportedCredential(c *gc.C) {
 }
 
 func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec, expect string) {
-	_, err := environs.Open(s.provider, environs.OpenParams{
+	_, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: s.Config,
 	})

--- a/provider/lxd/config_test.go
+++ b/provider/lxd/config_test.go
@@ -4,6 +4,8 @@
 package lxd_test
 
 import (
+	stdcontext "context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
@@ -138,7 +140,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  lxdCloudSpec(),
 			Config: testConfig,
 		})
@@ -231,7 +233,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  lxdCloudSpec(),
 			Config: s.config,
 		})

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	stdcontext "context"
 	"strings"
 	"sync"
 
@@ -76,7 +77,7 @@ func newEnviron(
 	}
 	env.base = common.DefaultProvider{Env: env}
 
-	err = env.SetCloudSpec(spec)
+	err = env.SetCloudSpec(stdcontext.TODO(), spec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -148,7 +149,7 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 }
 
 // SetCloudSpec is specified in the environs.Environ interface.
-func (env *environ) SetCloudSpec(spec environscloudspec.CloudSpec) error {
+func (env *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.CloudSpec) error {
 	env.lock.Lock()
 	defer env.lock.Unlock()
 

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -5,6 +5,7 @@ package lxd_test
 
 import (
 	"context"
+	stdcontext "context"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/cmdtesting"
@@ -393,7 +394,7 @@ func (s *environCloudProfileSuite) TestSetCloudSpecCreateProfile(c *gc.C) {
 	s.expectHasProfileFalse("juju-controller")
 	s.expectCreateProfile("juju-controller", nil)
 
-	err := s.cloudSpecEnv.SetCloudSpec(lxdCloudSpec())
+	err := s.cloudSpecEnv.SetCloudSpec(stdcontext.TODO(), lxdCloudSpec())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -402,7 +403,7 @@ func (s *environCloudProfileSuite) TestSetCloudSpecCreateProfileErrorSucceeds(c 
 	s.expectForProfileCreateRace("juju-controller")
 	s.expectCreateProfile("juju-controller", errors.New("The profile already exists"))
 
-	err := s.cloudSpecEnv.SetCloudSpec(lxdCloudSpec())
+	err := s.cloudSpecEnv.SetCloudSpec(stdcontext.TODO(), lxdCloudSpec())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	stdcontext "context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -137,7 +138,7 @@ func (*environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := p.validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/provider/lxd/provider_test.go
+++ b/provider/lxd/provider_test.go
@@ -4,6 +4,7 @@
 package lxd_test
 
 import (
+	stdcontext "context"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -536,7 +537,7 @@ func (s *ProviderFunctionalSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  lxdCloudSpec(),
 		Config: s.Config,
 	})

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	stdcontext "context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -127,7 +128,7 @@ func NewEnviron(cloud environscloudspec.CloudSpec, cfg *config.Config, getCaps M
 	if err := env.SetConfig(cfg); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := env.SetCloudSpec(cloud); err != nil {
+	if err := env.SetCloudSpec(stdcontext.TODO(), cloud); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -272,7 +273,7 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 }
 
 // SetCloudSpec is specified in the environs.Environ interface.
-func (env *maasEnviron) SetCloudSpec(spec environscloudspec.CloudSpec) error {
+func (env *maasEnviron) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.CloudSpec) error {
 	env.ecfgMutex.Lock()
 	defer env.ecfgMutex.Unlock()
 

--- a/provider/maas/environprovider.go
+++ b/provider/maas/environprovider.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	stdcontext "context"
 	"fmt"
 	"net/url"
 
@@ -59,7 +60,7 @@ func (MaasEnvironProvider) Version() int {
 	return 0
 }
 
-func (MaasEnvironProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (MaasEnvironProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q.", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	stdcontext "context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -136,7 +137,7 @@ func (suite *EnvironProviderSuite) testMAASServerFromEndpoint(c *gc.C, endpoint 
 
 	cloudSpec := suite.cloudSpec()
 	cloudSpec.Endpoint = endpoint
-	env, err := providerInstance.Open(environs.OpenParams{
+	env, err := providerInstance.Open(stdcontext.TODO(), environs.OpenParams{
 		Config: config,
 		Cloud:  cloudSpec,
 	})
@@ -166,7 +167,7 @@ func (suite *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.
 	spec := suite.cloudSpec()
 	cred := oauthCredential("wrongly-formatted-oauth-string")
 	spec.Credential = &cred
-	env, err := providerInstance.Open(environs.OpenParams{
+	env, err := providerInstance.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  spec,
 		Config: config,
 	})

--- a/provider/manual/environ_test.go
+++ b/provider/manual/environ_test.go
@@ -4,6 +4,7 @@
 package manual
 
 import (
+	stdcontext "context"
 	"os"
 
 	"github.com/juju/errors"
@@ -29,7 +30,7 @@ type baseEnvironSuite struct {
 
 func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	env, err := ManualProvider{}.Open(environs.OpenParams{
+	env, err := ManualProvider{}.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  CloudSpec(),
 		Config: MinimalConfig(c),
 	})

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -5,6 +5,7 @@ package manual
 
 import (
 	"bytes"
+	stdcontext "context"
 	"fmt"
 	"strings"
 
@@ -124,7 +125,7 @@ func (ManualProvider) Version() int {
 	return 0
 }
 
-func (p ManualProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p ManualProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -5,6 +5,7 @@ package manual_test
 
 import (
 	"context"
+	stdcontext "context"
 	"fmt"
 	"io"
 
@@ -69,7 +70,7 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	if err != nil {
 		return nil, err
 	}
-	env, err := manual.ProviderInstance.Open(environs.OpenParams{
+	env, err := manual.ProviderInstance.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: testConfig,
 	})

--- a/provider/oci/common_test.go
+++ b/provider/oci/common_test.go
@@ -5,6 +5,7 @@ package oci_test
 
 import (
 	"context"
+	stdcontext "context"
 	"fmt"
 	"time"
 
@@ -295,7 +296,7 @@ func (s *commonSuite) SetUpTest(c *gc.C) {
 	s.spec = fakeCloudSpec()
 
 	config := newConfig(c, jujutesting.Attrs{"compartment-id": s.testCompartment})
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: config,
 	})

--- a/provider/oci/provider.go
+++ b/provider/oci/provider.go
@@ -4,6 +4,7 @@
 package oci
 
 import (
+	stdcontext "context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -220,7 +221,7 @@ func (e EnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*conf
 }
 
 // Open implements environs.EnvironProvider.
-func (e *EnvironProvider) Open(params environs.OpenParams) (environs.Environ, error) {
+func (e *EnvironProvider) Open(_ stdcontext.Context, params environs.OpenParams) (environs.Environ, error) {
 	logger.Infof("opening model %q", params.Config.Name())
 
 	if err := validateCloudSpec(params.Cloud); err != nil {

--- a/provider/oci/provider_test.go
+++ b/provider/oci/provider_test.go
@@ -4,6 +4,7 @@
 package oci_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -204,14 +205,14 @@ func (s *credentialsSuite) TestDetectCredentialsMultiSectionInvalidConfig(c *gc.
 }
 
 func (s *credentialsSuite) TestOpen(c *gc.C) {
-	env, err := environs.Open(s.provider, environs.OpenParams{
+	env, err := environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: newConfig(c, jujutesting.Attrs{"compartment-id": "fake"}),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 
-	env, err = environs.Open(s.provider, environs.OpenParams{
+	env, err = environs.Open(stdcontext.TODO(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: newConfig(c, nil),
 	})

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -97,7 +97,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	})
 	t.LiveTests.SetUpSuite(c)
 	// For testing, we create a storage instance to which is uploaded tools and image metadata.
-	t.PrepareOnce(envtesting.BootstrapTODOContext(c), c)
+	t.PrepareOnce(c)
 	t.metadataStorage = openstack.MetadataStorage(t.Env)
 	// Put some fake tools metadata in place so that tests that are simply
 	// starting instances without any need to check if those instances
@@ -128,7 +128,7 @@ func (t *LiveTests) TearDownTest(c *gc.C) {
 }
 
 func (t *LiveTests) TestSetupGlobalGroupExposesCorrectPorts(c *gc.C) {
-	t.PrepareOnce(envtesting.BootstrapTODOContext(c), c)
+	t.PrepareOnce(c)
 	groupName := "juju-test-group-" + randomName()
 	// Make sure things are clean before we start, and will be clean when we finish
 	cleanup := func() {

--- a/provider/openstack/live_test.go
+++ b/provider/openstack/live_test.go
@@ -97,7 +97,7 @@ func (t *LiveTests) SetUpSuite(c *gc.C) {
 	})
 	t.LiveTests.SetUpSuite(c)
 	// For testing, we create a storage instance to which is uploaded tools and image metadata.
-	t.PrepareOnce(c)
+	t.PrepareOnce(envtesting.BootstrapTODOContext(c), c)
 	t.metadataStorage = openstack.MetadataStorage(t.Env)
 	// Put some fake tools metadata in place so that tests that are simply
 	// starting instances without any need to check if those instances
@@ -128,7 +128,7 @@ func (t *LiveTests) TearDownTest(c *gc.C) {
 }
 
 func (t *LiveTests) TestSetupGlobalGroupExposesCorrectPorts(c *gc.C) {
-	t.PrepareOnce(c)
+	t.PrepareOnce(envtesting.BootstrapTODOContext(c), c)
 	groupName := "juju-test-group-" + randomName()
 	// Make sure things are clean before we start, and will be clean when we finish
 	cleanup := func() {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -5,6 +5,7 @@ package openstack_test
 
 import (
 	"bytes"
+	stdcontext "context"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -185,7 +186,7 @@ func (s *localHTTPSServerSuite) envUsingCertificate(c *gc.C) environs.Environ {
 	cloudSpec.CACertificates, err = s.srv.openstackCertificate(c)
 	c.Assert(err, jc.ErrorIsNil)
 
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: cfg,
 	})
@@ -355,7 +356,7 @@ func (s *localServerSuite) TearDownTest(c *gc.C) {
 func (s *localServerSuite) openEnviron(c *gc.C, attrs coretesting.Attrs) environs.Environ {
 	cfg, err := config.New(config.NoDefaults, s.TestConfig.Merge(attrs))
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  s.CloudSpec(),
 		Config: cfg,
 	})
@@ -1342,7 +1343,7 @@ func (s *localServerSuite) TestGetImageMetadataSourcesNoProductStreams(c *gc.C) 
 	s.PatchValue(openstack.MakeServiceURL, func(client.AuthenticatingClient, string, string, []string) (string, error) {
 		return "", errors.New("cannae do it captain")
 	})
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	sources, err := environs.ImageMetadataSources(env, ss)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sources, gc.HasLen, 2)
@@ -1356,7 +1357,7 @@ func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
 	s.PatchValue(&tools.DefaultBaseURL, "")
 
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	sources, err := tools.GetMetadataSources(env, ss)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sources, gc.HasLen, 2)
@@ -1374,13 +1375,13 @@ func (s *localServerSuite) TestGetToolsMetadataSources(c *gc.C) {
 }
 
 func (s *localServerSuite) TestSupportsNetworking(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	_, ok := environs.SupportsNetworking(env)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (s *localServerSuite) prepareNetworkingEnviron(c *gc.C, cfg *config.Config) environs.NetworkingEnviron {
-	env := s.Open(c, cfg)
+	env := s.Open(c, stdcontext.TODO(), cfg)
 	netenv, supported := environs.SupportsNetworking(env)
 	c.Assert(supported, jc.IsTrue)
 	return netenv
@@ -1513,7 +1514,7 @@ func (s *localServerSuite) TestSuperSubnets(c *gc.C) {
 
 func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 
 	// An error occurs if no suitable image is found.
 	_, err := openstack.FindInstanceSpec(env, "saucy", "amd64", "mem=1G", nil)
@@ -1521,7 +1522,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 }
 
 func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=lxd")
@@ -1531,7 +1532,7 @@ func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
 }
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1545,7 +1546,7 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 }
 
 func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	validator, err := env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	consA := constraints.MustParse("arch=amd64 mem=1G root-disk=10G")
@@ -1557,7 +1558,7 @@ func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {
 }
 
 func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	imageMetadata := []*imagemetadata.ImageMetadata{{
 		Id:   "image-id",
 		Arch: "amd64",
@@ -1573,7 +1574,7 @@ func (s *localServerSuite) TestFindImageInstanceConstraint(c *gc.C) {
 
 func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
 	testVirtType := "qemu"
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	imageMetadata := []*imagemetadata.ImageMetadata{{
 		Id:       "image-id",
 		Arch:     "amd64",
@@ -1592,7 +1593,7 @@ func (s *localServerSuite) TestFindInstanceImageConstraintHypervisor(c *gc.C) {
 
 func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc.C) {
 	testVirtType := "qemu"
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	imageMetadata := []*imagemetadata.ImageMetadata{{
 		Id:       "image-id",
 		Arch:     "amd64",
@@ -1610,7 +1611,7 @@ func (s *localServerSuite) TestFindInstanceImageWithHypervisorNoConstraint(c *gc
 }
 
 func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	imageMetadata := []*imagemetadata.ImageMetadata{{
 		Id:   "image-id",
 		Arch: "amd64",
@@ -1626,7 +1627,7 @@ func (s *localServerSuite) TestFindInstanceNoConstraint(c *gc.C) {
 }
 
 func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	imageMetadata := []*imagemetadata.ImageMetadata{{
 		Id:   "image-id",
 		Arch: "amd64",
@@ -1639,21 +1640,21 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 }
 
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small")
 	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.large")
 	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `invalid Openstack flavour "m1.large" specified`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskConstraint(c *gc.C) {
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small root-disk=10G")
 	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Series: jujuversion.DefaultSupportedLTS(), Constraints: cons})
 	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless constraint root-disk-source=volume`)
@@ -1869,7 +1870,7 @@ func (s *localServerSuite) TestDeriveAvailabilityZonesConflictsVolume(c *gc.C) {
 
 func (s *localServerSuite) TestValidateImageMetadata(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	params, err := env.(simplestreams.ImageMetadataValidator).ImageMetadataLookupParams("some-region")
 	c.Assert(err, jc.ErrorIsNil)
 	params.Sources, err = environs.ImageMetadataSources(env, ss)
@@ -1890,7 +1891,7 @@ func (s *localServerSuite) TestImageMetadataSourceOrder(c *gc.C) {
 			Priority:             simplestreams.CUSTOM_CLOUD_DATA}), nil
 	}
 	environs.RegisterUserImageDataSourceFunc("my func", src)
-	env := s.Open(c, s.env.Config())
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	sources, err := environs.ImageMetadataSources(env, ss)
 	c.Assert(err, jc.ErrorIsNil)
 	var sourceIds []string
@@ -2134,7 +2135,7 @@ func (s *localHTTPSServerSuite) TestMustDisableSSLVerify(c *gc.C) {
 	newattrs["ssl-hostname-verification"] = true
 	cfg, err := config.New(config.NoDefaults, newattrs)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = environs.New(environs.OpenParams{
+	_, err = environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  makeCloudSpec(s.cred),
 		Config: cfg,
 	})
@@ -2834,7 +2835,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 		"uuid": hostedModelUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  makeCloudSpec(s.cred),
 		Config: cfg,
 	})
@@ -2880,7 +2881,7 @@ func (s *localServerSuite) TestAdoptResourcesNoStorage(c *gc.C) {
 		"uuid": hostedModelUUID,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := environs.New(environs.OpenParams{
+	env, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  makeCloudSpec(s.cred),
 		Config: cfg,
 	})
@@ -3019,7 +3020,6 @@ type noNeutronSuite struct {
 	coretesting.BaseSuite
 	cred *identity.Credentials
 	srv  localServer
-	env  environs.Environ
 }
 
 func (s *noNeutronSuite) SetUpSuite(c *gc.C) {

--- a/provider/rackspace/provider.go
+++ b/provider/rackspace/provider.go
@@ -4,6 +4,7 @@
 package rackspace
 
 import (
+	stdcontext "context"
 	"strings"
 
 	"github.com/juju/errors"
@@ -39,9 +40,9 @@ func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*con
 }
 
 // Open is part of the EnvironProvider interface.
-func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	args.Cloud = transformCloudSpec(args.Cloud)
-	return p.CloudEnvironProvider.Open(args)
+	return p.CloudEnvironProvider.Open(ctx, args)
 }
 
 func transformCloudSpec(spec environscloudspec.CloudSpec) environscloudspec.CloudSpec {

--- a/provider/rackspace/provider_test.go
+++ b/provider/rackspace/provider_test.go
@@ -4,6 +4,8 @@
 package rackspace_test
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/testing"
@@ -68,7 +70,7 @@ func (p *fakeProvider) Version() int {
 	return 0
 }
 
-func (p *fakeProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p *fakeProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	p.MethodCall(p, "Open", args)
 	return nil, nil
 }

--- a/provider/vsphere/config_test.go
+++ b/provider/vsphere/config_test.go
@@ -4,6 +4,8 @@
 package vsphere_test
 
 import (
+	stdcontext "context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -145,7 +147,7 @@ func (*ConfigSuite) TestNewModelConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		fakeConfig := test.newConfig(c)
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  fakeCloudSpec(),
 			Config: fakeConfig,
 		})
@@ -236,7 +238,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 	for i, test := range changeConfigTests {
 		c.Logf("test %d: %s", i, test.info)
 
-		environ, err := environs.New(environs.OpenParams{
+		environ, err := environs.New(stdcontext.TODO(), environs.OpenParams{
 			Cloud:  fakeCloudSpec(),
 			Config: s.config,
 		})

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -5,6 +5,7 @@ package vsphere_test
 
 import (
 	"context"
+	stdcontext "context"
 	"fmt"
 	"net/url"
 	"path"
@@ -176,7 +177,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstance(c *gc.C) {
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceNetwork(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"primary-network":    "foo",
@@ -198,7 +199,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceNetwork(c *gc.C) {
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningMissingModelConfigOption(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url": s.imageServer.URL,
@@ -216,7 +217,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningMissingModel
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningDefaultOption(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url":     s.imageServer.URL,
@@ -235,7 +236,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningDefaultOptio
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThinDisk(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url":     s.imageServer.URL,
@@ -254,7 +255,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThinDisk(c *
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickDisk(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url":     s.imageServer.URL,
@@ -273,7 +274,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickDisk(c 
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickEagerZeroDisk(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url":     s.imageServer.URL,
@@ -292,7 +293,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickEagerZe
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"name":               "supercalifragilisticexpialidocious",
@@ -314,7 +315,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
 }
 
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskUUIDDisabled(c *gc.C) {
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"enable-disk-uuid":   false,
@@ -526,7 +527,7 @@ func (s *environBrokerSuite) setUpClient(c *gc.C) *gomock.Controller {
 			return s.mockClient, nil
 		},
 	})
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url": s.imageServerURL,

--- a/provider/vsphere/fixture_test.go
+++ b/provider/vsphere/fixture_test.go
@@ -4,6 +4,7 @@
 package vsphere_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -58,7 +59,7 @@ func (s *EnvironFixture) SetUpTest(c *gc.C) {
 		s.imageServer.Close()
 	})
 
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud: fakeCloudSpec(),
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url": s.imageServer.URL,

--- a/provider/vsphere/provider.go
+++ b/provider/vsphere/provider.go
@@ -4,6 +4,7 @@
 package vsphere
 
 import (
+	stdcontext "context"
 	"net/url"
 
 	"github.com/juju/errors"
@@ -54,7 +55,7 @@ func (p *environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (p *environProvider) Open(args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/provider/vsphere/provider_test.go
+++ b/provider/vsphere/provider_test.go
@@ -4,6 +4,7 @@
 package vsphere_test
 
 import (
+	stdcontext "context"
 	"errors"
 	"net/url"
 
@@ -32,7 +33,7 @@ func (s *providerSuite) TestRegistered(c *gc.C) {
 
 func (s *providerSuite) TestOpen(c *gc.C) {
 	config := fakeConfig(c)
-	env, err := s.provider.Open(environs.OpenParams{
+	env, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: config,
 	})
@@ -62,7 +63,7 @@ func (s *providerSuite) TestOpenUnsupportedCredential(c *gc.C) {
 }
 
 func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec, expect string) {
-	_, err := s.provider.Open(environs.OpenParams{
+	_, err := s.provider.Open(stdcontext.TODO(), environs.OpenParams{
 		Cloud:  spec,
 		Config: fakeConfig(c),
 	})

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -4,6 +4,8 @@
 package stateenvirons
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -54,7 +56,7 @@ func (g EnvironConfigGetter) CloudAPIVersion(spec environscloudspec.CloudSpec) (
 	if newBroker == nil {
 		newBroker = caas.New
 	}
-	broker, err := newBroker(environs.OpenParams{
+	broker, err := newBroker(context.TODO(), environs.OpenParams{
 		ControllerUUID: g.Model.ControllerUUID(),
 		Cloud:          spec,
 		Config:         cfg,
@@ -143,7 +145,7 @@ func GetNewCAASBrokerFunc(newBroker caas.NewContainerBrokerFunc) NewCAASBrokerFu
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return newBroker(environs.OpenParams{
+		return newBroker(context.TODO(), environs.OpenParams{
 			ControllerUUID: m.ControllerUUID(),
 			Cloud:          cloudSpec,
 			Config:         cfg,

--- a/state/stateenvirons/config_test.go
+++ b/state/stateenvirons/config_test.go
@@ -4,6 +4,8 @@
 package stateenvirons_test
 
 import (
+	"context"
+
 	"github.com/juju/juju/caas"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -26,7 +28,7 @@ var _ = gc.Suite(&environSuite{})
 func (s *environSuite) TestGetNewEnvironFunc(c *gc.C) {
 	var calls int
 	var callArgs environs.OpenParams
-	newEnviron := func(args environs.OpenParams) (environs.Environ, error) {
+	newEnviron := func(_ context.Context, args environs.OpenParams) (environs.Environ, error) {
 		calls++
 		callArgs = args
 		return nil, nil
@@ -110,7 +112,7 @@ func (s *environSuite) TestCloudSpecForModel(c *gc.C) {
 func (s *environSuite) TestGetNewCAASBrokerFunc(c *gc.C) {
 	var calls int
 	var callArgs environs.OpenParams
-	newBroker := func(args environs.OpenParams) (caas.Broker, error) {
+	newBroker := func(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
 		calls++
 		callArgs = args
 		return nil, nil
@@ -142,7 +144,7 @@ func (s *environSuite) TestCloudAPIVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred := cloud.NewNamedCredential("dummy-credential", "userpass", nil, false)
-	newBrokerFunc := func(args environs.OpenParams) (caas.Broker, error) {
+	newBrokerFunc := func(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
 		c.Assert(args.Cloud, jc.DeepEquals, environscloudspec.CloudSpec{
 			Name:       "caascloud",
 			Type:       "kubernetes",

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -1928,7 +1929,7 @@ func updateKubernetesStorageConfig(st *State) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		broker, err := NewBroker(environs.OpenParams{Cloud: cloudSpec, Config: cfg})
+		broker, err := NewBroker(context.TODO(), environs.OpenParams{Cloud: cloudSpec, Config: cfg})
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	stdcontext "context"
 	"fmt"
 	"sort"
 	"time"
@@ -2801,7 +2802,7 @@ func (s *upgradesSuite) TestUpdateKubernetesStorageConfig(c *gc.C) {
 	err := s.state.UpdateCloudCredential(tag, cloud.NewEmptyCredential())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.PatchValue(&NewBroker, func(args environs.OpenParams) (caas.Broker, error) {
+	s.PatchValue(&NewBroker, func(_ stdcontext.Context, args environs.OpenParams) (caas.Broker, error) {
 		return &fakeBroker{}, nil
 	})
 
@@ -2835,7 +2836,7 @@ func (s *upgradesSuite) TestUpdateKubernetesStorageConfigWithDyingModel(c *gc.C)
 	err := s.state.UpdateCloudCredential(tag, cloud.NewEmptyCredential())
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.PatchValue(&NewBroker, func(args environs.OpenParams) (caas.Broker, error) {
+	s.PatchValue(&NewBroker, func(_ stdcontext.Context, args environs.OpenParams) (caas.Broker, error) {
 		return &fakeBroker{}, nil
 	})
 

--- a/worker/caasbroker/broker.go
+++ b/worker/caasbroker/broker.go
@@ -88,7 +88,7 @@ func NewTracker(config Config) (*Tracker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	broker, err := config.NewContainerBrokerFunc(environs.OpenParams{
+	broker, err := config.NewContainerBrokerFunc(context.TODO(), environs.OpenParams{
 		ControllerUUID: ctrlCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,

--- a/worker/caasbroker/broker.go
+++ b/worker/caasbroker/broker.go
@@ -4,6 +4,7 @@
 package caasbroker
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -176,7 +177,7 @@ func (t *Tracker) loop() error {
 				continue
 			}
 			logger.Debugf("reloading cloud config")
-			if err = cloudSpecSetter.SetCloudSpec(cloudSpec); err != nil {
+			if err = cloudSpecSetter.SetCloudSpec(context.TODO(), cloudSpec); err != nil {
 				return errors.Annotate(err, "cannot update broker cloud spec")
 			}
 			t.currentCloudSpec = cloudSpec

--- a/worker/caasbroker/fixture_test.go
+++ b/worker/caasbroker/fixture_test.go
@@ -234,7 +234,7 @@ func (e *mockBroker) CloudSpec() environscloudspec.CloudSpec {
 	return e.spec
 }
 
-func (e *mockBroker) SetCloudSpec(spec environscloudspec.CloudSpec) error {
+func (e *mockBroker) SetCloudSpec(_ context.Context, spec environscloudspec.CloudSpec) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.MethodCall(e, "SetCloudSpec", spec)

--- a/worker/caasbroker/fixture_test.go
+++ b/worker/caasbroker/fixture_test.go
@@ -4,6 +4,7 @@
 package caasbroker_test
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/names/v4"
@@ -223,7 +224,7 @@ type mockBroker struct {
 	mu        sync.Mutex
 }
 
-func newMockBroker(args environs.OpenParams) (caas.Broker, error) {
+func newMockBroker(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
 	return &mockBroker{spec: args.Cloud, namespace: args.Config.Name(), cfg: args.Config}, nil
 }
 

--- a/worker/environ/environ.go
+++ b/worker/environ/environ.go
@@ -4,6 +4,7 @@
 package environ
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/juju/errors"
@@ -155,7 +156,7 @@ func (t *Tracker) loop() error {
 				continue
 			}
 			logger.Debugf("reloading cloud config")
-			if err = cloudSpecSetter.SetCloudSpec(cloudSpec); err != nil {
+			if err = cloudSpecSetter.SetCloudSpec(context.TODO(), cloudSpec); err != nil {
 				return errors.Annotate(err, "cannot update environ cloud spec")
 			}
 			t.currentCloudSpec = cloudSpec

--- a/worker/environ/fixture_test.go
+++ b/worker/environ/fixture_test.go
@@ -4,6 +4,7 @@
 package environ_test
 
 import (
+	"context"
 	"sync"
 
 	"github.com/juju/names/v4"
@@ -246,6 +247,6 @@ func (e *mockEnviron) SetCloudSpec(spec environscloudspec.CloudSpec) error {
 	return nil
 }
 
-func newMockEnviron(args environs.OpenParams) (environs.Environ, error) {
+func newMockEnviron(_ context.Context, args environs.OpenParams) (environs.Environ, error) {
 	return &mockEnviron{cfg: args.Config, spec: args.Cloud}, nil
 }

--- a/worker/environ/fixture_test.go
+++ b/worker/environ/fixture_test.go
@@ -236,7 +236,7 @@ func (e *mockEnviron) CloudSpec() environscloudspec.CloudSpec {
 	return e.spec
 }
 
-func (e *mockEnviron) SetCloudSpec(spec environscloudspec.CloudSpec) error {
+func (e *mockEnviron) SetCloudSpec(_ context.Context, spec environscloudspec.CloudSpec) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.MethodCall(e, "SetCloudSpec", spec)


### PR DESCRIPTION
The following updates the ec2 client factory to use the juju/http
client instead of the one offered by the library. We can reduce a lot of
the client boilerplate by just surfacing the only client.

More work is required to lift it out of the provider into a manifold,
but that work can be done at a later PR.

## QA steps

### Tests should pass.

```sh
go test -v ./provider/ec2/...
```

### Bootstrap to ec2

```sh
$ juju bootstrap aws test
```

## Bug reference

 - https://bugs.launchpad.net/juju/+bug/1928182
 - https://bugs.launchpad.net/juju/+bug/1899793
