### PR TITLE
state: Add UserConnections to the all watcher

### DIFF
--- a/apiserver/params/multiwatcher.go
+++ b/apiserver/params/multiwatcher.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/juju/charm/v9"
@@ -109,6 +110,8 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 		d.Entity = new(RemoteApplicationUpdate)
 	case "unit":
 		d.Entity = new(UnitInfo)
+	case "userConnection":
+		d.Entity = new(UserConnectionInfo)
 	default:
 		return errors.Errorf("Unexpected entity name %q", entityKind)
 	}
@@ -445,5 +448,19 @@ func (i *BranchInfo) EntityId() EntityId {
 		Kind:      "branch",
 		ModelUUID: i.ModelUUID,
 		Id:        i.Id,
+	}
+}
+
+type UserConnectionInfo struct {
+	ModelUUID      string    `json:"model-uuid"`
+	Username       string    `json:"user-name"`
+	LastConnection time.Time `json:"last-connection,omitempty"`
+}
+
+func (i *UserConnectionInfo) EntityId() EntityId {
+	return EntityId{
+		Kind:      "userConnection",
+		ModelUUID: i.ModelUUID,
+		Id:        strings.ToLower(i.Username),
 	}
 }

--- a/apiserver/params/multiwatcher_internal_test.go
+++ b/apiserver/params/multiwatcher_internal_test.go
@@ -16,4 +16,5 @@ var (
 	_ EntityInfo = (*ActionInfo)(nil)
 	_ EntityInfo = (*ModelUpdate)(nil)
 	_ EntityInfo = (*BranchInfo)(nil)
+	_ EntityInfo = (*UserConnectionInfo)(nil)
 )

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -125,6 +125,8 @@ func (aw *SrvAllWatcher) translate(deltas []multiwatcher.Delta) []params.Delta {
 			converted = aw.translateAction(delta.Entity)
 		case multiwatcher.ApplicationOfferKind:
 			converted = aw.translateApplicationOffer(delta.Entity)
+		case multiwatcher.UserConnectionKind:
+			converted = aw.translateUserConnection(delta.Entity)
 		default:
 			// converted stays nil
 		}
@@ -511,6 +513,19 @@ func isAgent(auth facade.Authorizer) bool {
 
 func isAgentOrUser(auth facade.Authorizer) bool {
 	return isAgent(auth) || auth.AuthClient()
+}
+
+func (aw *SrvAllWatcher) translateUserConnection(info multiwatcher.EntityInfo) params.EntityInfo {
+	orig, ok := info.(*multiwatcher.UserConnectionInfo)
+	if !ok {
+		logger.Criticalf("consistency error: %s", pretty.Sprint(info))
+		return nil
+	}
+	return &params.UserConnectionInfo{
+		ModelUUID:      orig.ModelUUID,
+		Username:       orig.Username,
+		LastConnection: orig.LastConnection,
+	}
 }
 
 func newNotifyWatcher(context facade.Context) (facade.Facade, error) {

--- a/core/multiwatcher/store.go
+++ b/core/multiwatcher/store.go
@@ -80,7 +80,7 @@ type Logger interface {
 	Criticalf(string, ...interface{})
 }
 
-// NewStore returns an Store instance holding information about the
+// NewStore returns a Store instance holding information about the
 // current state of all entities in the model.
 // It is only exposed here for testing purposes.
 func NewStore(logger Logger) Store {

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -4,6 +4,7 @@
 package multiwatcher
 
 import (
+	"strings"
 	"time"
 
 	"github.com/juju/juju/core/constraints"
@@ -29,6 +30,7 @@ const (
 	RelationKind          = "relation"
 	RemoteApplicationKind = "remoteApplication"
 	UnitKind              = "unit"
+	UserConnectionKind    = "user-connection"
 )
 
 // Factory is used to create multiwatchers.
@@ -670,4 +672,27 @@ func (i *BranchInfo) Clone() EntityInfo {
 		}
 	}
 	return &clone
+}
+
+// UserConnectionInfo holds data about the connections users make to
+// models.
+type UserConnectionInfo struct {
+	ModelUUID      string
+	Username       string
+	LastConnection time.Time
+}
+
+// EntityID returns a unique identifier for a user in a model.
+func (i *UserConnectionInfo) EntityID() EntityID {
+	return EntityID{
+		Kind:      UserConnectionKind,
+		ModelUUID: i.ModelUUID,
+		ID:        strings.ToLower(i.Username),
+	}
+}
+
+// Clone returns a clone of the EntityInfo.
+func (i *UserConnectionInfo) Clone() EntityInfo {
+	ei := *i
+	return &ei
 }

--- a/state/user.go
+++ b/state/user.go
@@ -57,8 +57,8 @@ func (st *State) AddUser(name, displayName, password, creator string) (*User, er
 
 // AddUserWithSecretKey adds the user with the specified name, and assigns it
 // a randomly generated secret key. This secret key may be used for the user
-// and controller to mutually authenticate one another, without without relying
-// on TLS certificates.
+// and controller to mutually authenticate one another, without relying on TLS
+// certificates.
 //
 // The new user will not have a password. A password must be set, clearing the
 // secret key in the process, before the user can login normally.


### PR DESCRIPTION
Add all watcher events for notifying on user connections. This implements
the feature requested in https://bugs.launchpad.net/juju/+bug/1929524.

## QA steps

 1. Create a controller with this code version.
 2. Connect a client that calls `WatchAllModels` on the `Controller` facade and displays the results.
 3. Connect to a model on the controller (juju status)
 4. Verify the event stream includes a userConnection event with the connection time around step 3.

## Documentation changes

This adds a new event type into the AllWatcher event stream. The "userConnection" events will be fired every time a user connects to a model.

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1929524
