### PR TITLE
LeadershipContext: Embed a leadership context

### DIFF
--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -23,8 +23,8 @@ type Facade interface{}
 // Factory is a callback used to create a Facade.
 type Factory func(Context) (Facade, error)
 
-// LeadershipContext represents all the leadership methods that can be performed
-// on a given modelUUID.
+// LeadershipContext describes factory methods for objects that deliver
+// specific lease-related capabilities
 type LeadershipContext interface {
 
 	// LeadershipClaimer returns a leadership.Claimer tied to a
@@ -46,6 +46,10 @@ type LeadershipContext interface {
 	// LeadershipReader returns a leadership.Reader for this
 	// context's model.
 	LeadershipReader(modelUUID string) (leadership.Reader, error)
+
+	// SingularClaimer returns a lease.Claimer for singular leases for
+	// this context's model.
+	SingularClaimer() (lease.Claimer, error)
 }
 
 // Context exposes useful capabilities to a Facade.
@@ -132,10 +136,6 @@ type Context interface {
 	// into Resources to get the watcher in play. This is not really
 	// a good idea; see Resources.
 	ID() string
-
-	// SingularClaimer returns a lease.Claimer for singular leases for
-	// this context's model.
-	SingularClaimer() (lease.Claimer, error)
 }
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/facade_mock.go github.com/juju/juju/apiserver/facade Resources,Authorizer

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -23,8 +23,39 @@ type Facade interface{}
 // Factory is a callback used to create a Facade.
 type Factory func(Context) (Facade, error)
 
+// LeadershipContext represents all the leadership methods that can be performed
+// on a given modelUUID.
+type LeadershipContext interface {
+
+	// LeadershipClaimer returns a leadership.Claimer tied to a
+	// specific model.
+	LeadershipClaimer(modelUUID string) (leadership.Claimer, error)
+
+	// LeadershipRevoker returns a leadership.Revoker tied to a
+	// specific model.
+	LeadershipRevoker(modelUUID string) (leadership.Revoker, error)
+
+	// LeadershipChecker returns a leadership.Checker for this
+	// context's model.
+	LeadershipChecker() (leadership.Checker, error)
+
+	// LeadershipPinner returns a leadership.Pinner for this
+	// context's model.
+	LeadershipPinner(modelUUID string) (leadership.Pinner, error)
+
+	// LeadershipReader returns a leadership.Reader for this
+	// context's model.
+	LeadershipReader(modelUUID string) (leadership.Reader, error)
+}
+
 // Context exposes useful capabilities to a Facade.
 type Context interface {
+	// TODO (stickupkid): This shouldn't be embedded, instead this should be
+	// in the form of `context.Leadership() Leadership`, which returns the
+	// contents of the LeadershipContext.
+	// Context should have a single responsibility, and that's access to other
+	// types/objects.
+	LeadershipContext
 
 	// Cancel channel represents an indication from the API server that
 	// all interruptable calls should stop. The channel is only ever
@@ -101,26 +132,6 @@ type Context interface {
 	// into Resources to get the watcher in play. This is not really
 	// a good idea; see Resources.
 	ID() string
-
-	// LeadershipClaimer returns a leadership.Claimer tied to a
-	// specific model.
-	LeadershipClaimer(modelUUID string) (leadership.Claimer, error)
-
-	// LeadershipRevoker returns a leadership.Revoker tied to a
-	// specific model.
-	LeadershipRevoker(modelUUID string) (leadership.Revoker, error)
-
-	// LeadershipChecker returns a leadership.Checker for this
-	// context's model.
-	LeadershipChecker() (leadership.Checker, error)
-
-	// LeadershipPinner returns a leadership.Pinner for this
-	// context's model.
-	LeadershipPinner(modelUUID string) (leadership.Pinner, error)
-
-	// LeadershipReader returns a leadership.Reader for this
-	// context's model.
-	LeadershipReader(modelUUID string) (leadership.Reader, error)
 
 	// SingularClaimer returns a lease.Claimer for singular leases for
 	// this context's model.

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -17,18 +17,13 @@ import (
 )
 
 const (
-	// FacadeName is the string-representation of this API used both
-	// to register the service, and for the client to resolve the
-	// service endpoint.
-	FacadeName = "LeadershipService"
-
-	// MinLeaseRequest is the shortest duration for which we will accept
+	// minLeaseRequest is the shortest duration for which we will accept
 	// a leadership claim.
-	MinLeaseRequest = 5 * time.Second
+	minLeaseRequest = 5 * time.Second
 
-	// MaxLeaseRequest is the longest duration for which we will accept
+	// maxLeaseRequest is the longest duration for which we will accept
 	// a leadership claim.
-	MaxLeaseRequest = 5 * time.Minute
+	maxLeaseRequest = 5 * time.Minute
 )
 
 // NewLeadershipServiceFacade constructs a new LeadershipService and presents
@@ -76,7 +71,7 @@ func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParam
 			continue
 		}
 		duration := time.Duration(p.DurationSeconds * float64(time.Second))
-		if duration > MaxLeaseRequest || duration < MinLeaseRequest {
+		if duration > maxLeaseRequest || duration < minLeaseRequest {
 			result.Error = apiservererrors.ServerError(errors.New("invalid duration"))
 			continue
 		}
@@ -101,7 +96,7 @@ func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParam
 		}
 	}
 
-	return params.ClaimLeadershipBulkResults{results}, nil
+	return params.ClaimLeadershipBulkResults{Results: results}, nil
 }
 
 // BlockUntilLeadershipReleased implements the LeadershipService interface.


### PR DESCRIPTION
The following is a very simple mechanical patch with the aim of updating
the facade context in the future. The facade context should be a gateway
to types/objects.

The context becomes:

```
type Context interface {
    Leadership() Leadership
}

type Leadership interface {

    ...
}
```

Although it's close to what we currently have, it becomes more of a
single responsibility proposal.

## QA steps

Tests pass.
