### PR TITLE
Charmhub: Request recorder collector

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -127,6 +127,9 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 		a.srv.facades,
 		a.root.resources,
 		a.root,
+		httpRequestRecorderWrapper{
+			collector: a.srv.metricsCollector,
+		},
 	)
 	if err != nil {
 		return fail, errors.Trace(err)

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -129,6 +129,7 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 		a.root,
 		httpRequestRecorderWrapper{
 			collector: a.srv.metricsCollector,
+			modelUUID: a.root.model.UUID(),
 		},
 	)
 	if err != nil {

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -122,10 +122,7 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 	var apiRoot rpc.Root
 	apiRoot, err = newAPIRoot(
 		a.srv.clock,
-		a.root.state,
-		a.root.shared,
 		a.srv.facades,
-		a.root.resources,
 		a.root,
 		httpRequestRecorderWrapper{
 			collector: a.srv.metricsCollector,
@@ -534,7 +531,7 @@ func setupPingTimeoutDisconnect(clock clock.Clock, root *apiHandler, entity stat
 		}
 	}
 	pingTimeout := newPingTimeout(action, clock, maxClientPingInterval)
-	return root.getResources().RegisterNamed("pingTimeout", pingTimeout)
+	return root.Resources().RegisterNamed("pingTimeout", pingTimeout)
 }
 
 // errRoot implements the API that a client first sees

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -22,7 +23,6 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/pubsub"
 	"github.com/juju/ratelimit"
-	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/tomb.v2"
@@ -70,7 +70,6 @@ type Server struct {
 	tag                    names.Tag
 	dataDir                string
 	logDir                 string
-	limiter                utils.Limiter
 	facades                *facade.Registry
 	authenticator          httpcontext.LocalMacaroonAuthenticator
 	offerAuthCtxt          *crossmodel.AuthContext
@@ -502,6 +501,22 @@ func (w logsinkMetricsCollectorWrapper) LogWriteCount(modelUUID, state string) p
 
 func (w logsinkMetricsCollectorWrapper) LogReadCount(modelUUID, state string) prometheus.Counter {
 	return w.collector.LogReadCount.WithLabelValues(modelUUID, state)
+}
+
+// httpRequestRecorderWrapper defines a wrapper from exposing the
+// essentials for the http request recorder.
+type httpRequestRecorderWrapper struct {
+	collector *Collector
+}
+
+// Record an outgoing request which produced an http.Response.
+func (w httpRequestRecorderWrapper) Record(method string, url *url.URL, res *http.Response, rtt time.Duration) {
+
+}
+
+// Record an outgoing request which returned back an error.
+func (w httpRequestRecorderWrapper) RecordError(method string, url *url.URL, err error) {
+
 }
 
 // loop is the main loop for the server.

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -917,7 +917,7 @@ func (srv *Server) trackRequests(handler http.Handler) http.Handler {
 			// but after the tomb was killed. As we're in the process of
 			// shutting down, do not consider this request as in progress,
 			// just send a 503 and return.
-			http.Error(w, "apiserver shutdown in progress", 503)
+			http.Error(w, "apiserver shutdown in progress", http.StatusServiceUnavailable)
 		default:
 			// If we get here then the tomb was not killed therefore the
 			// listener is still open. It is safe to increment the

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 	"github.com/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/modelcache"
 	"github.com/juju/juju/worker/multiwatcher"
@@ -68,8 +67,6 @@ type apiserverConfigFixture struct {
 	mux           *apiserverhttp.Mux
 	tlsConfig     *tls.Config
 	config        apiserver.ServerConfig
-
-	controller *cache.Controller
 }
 
 func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
@@ -80,13 +77,13 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 	s.authenticator = authenticator
 	s.mux = apiserverhttp.NewMux()
 
-	certPool, err := api.CreateCertPool(coretesting.CACert)
+	certPool, err := api.CreateCertPool(testing.CACert)
 	if err != nil {
 		panic(err)
 	}
 	s.tlsConfig = api.NewTLSConfig(certPool)
 	s.tlsConfig.ServerName = "juju-apiserver"
-	s.tlsConfig.Certificates = []tls.Certificate{*coretesting.ServerTLSCert}
+	s.tlsConfig.Certificates = []tls.Certificate{*testing.ServerTLSCert}
 	s.mux = apiserverhttp.NewMux()
 
 	multiWatcherWorker, err := multiwatcher.NewWorker(multiwatcher.Config{
@@ -160,17 +157,17 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 			}
 			ctrl, err := store.CurrentController()
 			if err != nil {
-				fmt.Fprintf(ctx.Stderr, err.Error())
+				fmt.Fprintf(ctx.Stderr, "%s", err.Error())
 				return 1
 			}
 			model, err := store.CurrentModel(ctrl)
 			if err != nil {
-				fmt.Fprintf(ctx.Stderr, err.Error())
+				fmt.Fprintf(ctx.Stderr, "%s", err.Error())
 				return 1
 			}
 			ad, err := store.AccountDetails(ctrl)
 			if err != nil {
-				fmt.Fprintf(ctx.Stderr, err.Error())
+				fmt.Fprintf(ctx.Stderr, "%s", err.Error())
 				return 1
 			}
 			if strings.Contains(cmdPlusArgs, "macaroon error") {
@@ -178,7 +175,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 				fmt.Fprintf(ctx.Stderr, "\n")
 			} else {
 				cmdStr := fmt.Sprintf("%s@%s:%s -> %s", ad.User, ctrl, model, cmdPlusArgs)
-				fmt.Fprintf(ctx.Stdout, cmdStr)
+				fmt.Fprintf(ctx.Stdout, "%s", cmdStr)
 				fmt.Fprintf(ctx.Stdout, "\n")
 			}
 			return 0
@@ -271,7 +268,7 @@ func (s *apiserverBaseSuite) APIInfo(server *apiserver.Server) *api.Info {
 	address := s.server.Listener.Addr().String()
 	return &api.Info{
 		Addrs:  []string{address},
-		CACert: coretesting.CACert,
+		CACert: testing.CACert,
 	}
 }
 
@@ -325,7 +322,7 @@ func dialWebsocketFromURL(c *gc.C, server string, header http.Header) (*websocke
 	}
 	header.Set("Origin", "http://localhost/")
 	caCerts := x509.NewCertPool()
-	c.Assert(caCerts.AppendCertsFromPEM([]byte(coretesting.CACert)), jc.IsTrue)
+	c.Assert(caCerts.AppendCertsFromPEM([]byte(testing.CACert)), jc.IsTrue)
 	tlsConfig := jujuhttp.SecureTLSConfig()
 	tlsConfig.RootCAs = caCerts
 	tlsConfig.ServerName = "juju-apiserver"
@@ -477,7 +474,7 @@ func (s *apiserverSuite) assertEmbeddedCommand(c *gc.C, cmdArgs params.CLIComman
 
 	select {
 	case <-done:
-	case <-time.After(coretesting.LongWait):
+	case <-time.After(testing.LongWait):
 		c.Fatalf("no command result")
 	}
 

--- a/apiserver/apiservermetrics_test.go
+++ b/apiserver/apiservermetrics_test.go
@@ -36,7 +36,7 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 	for desc := range ch {
 		descs = append(descs, desc)
 	}
-	c.Assert(descs, gc.HasLen, 7)
+	c.Assert(descs, gc.HasLen, 10)
 	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connections_total".*`)
 	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connections".*`)
 	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_active_login_attempts".*`)
@@ -44,6 +44,10 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 	c.Assert(descs[4].String(), gc.Matches, `.*fqName: "juju_apiserver_ping_failure_count".*`)
 	c.Assert(descs[5].String(), gc.Matches, `.*fqName: "juju_apiserver_log_write_count".*`)
 	c.Assert(descs[6].String(), gc.Matches, `.*fqName: "juju_apiserver_log_read_count".*`)
+
+	c.Assert(descs[7].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_requests_total".*`)
+	c.Assert(descs[8].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_request_errors_total".*`)
+	c.Assert(descs[9].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_request_duration_seconds".*`)
 }
 
 func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
@@ -81,6 +85,16 @@ func (s *apiservermetricsSuite) TestLabelNames(c *gc.C) {
 		{
 			name:    "log failure label names",
 			labels:  apiserver.MetricLogLabelNames,
+			checker: jc.IsTrue,
+		},
+		{
+			name:    "total requests with status label names",
+			labels:  apiserver.MetricTotalRequestsWithStatusLabelNames,
+			checker: jc.IsTrue,
+		},
+		{
+			name:    "total requests label names",
+			labels:  apiserver.MetricTotalRequestsLabelNames,
 			checker: jc.IsTrue,
 		},
 		{

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -44,7 +44,7 @@ func NewErrRoot(err error) *errRoot {
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	root, err := newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil)
+	root, err := newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil, nil)
 	if err != nil {
 		// While not ideal, this is only in test code, and there are a bunch of other functions
 		// that depend on this one that don't return errors either.

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -40,11 +40,29 @@ func NewErrRoot(err error) *errRoot {
 	return &errRoot{err}
 }
 
+type testingAPIRootHandler struct{}
+
+func (testingAPIRootHandler) State() *state.State {
+	return nil
+}
+
+func (testingAPIRootHandler) SharedContext() *sharedServerContext {
+	return nil
+}
+
+func (testingAPIRootHandler) Authorizer() facade.Authorizer {
+	return nil
+}
+
+func (testingAPIRootHandler) Resources() *common.Resources {
+	return common.NewResources()
+}
+
 // TestingAPIRoot gives you an APIRoot as a rpc.Methodfinder that is
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	root, err := newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil, nil)
+	root, err := newAPIRoot(clock.WallClock, facades, testingAPIRootHandler{}, nil)
 	if err != nil {
 		// While not ideal, this is only in test code, and there are a bunch of other functions
 		// that depend on this one that don't return errors either.
@@ -68,7 +86,7 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHan
 	}
 	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), 6543, "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
-	return h, h.getResources()
+	return h, h.Resources()
 }
 
 // TestingAPIHandlerWithEntity gives you the sane kind of APIHandler as

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -25,6 +25,7 @@ type Context struct {
 	Controller_          *cache.Controller
 	MultiwatcherFactory_ multiwatcher.Factory
 	ID_                  string
+	RequestRecorder_     facade.RequestRecorder
 	Cancel_              <-chan struct{}
 
 	LeadershipClaimer_ leadership.Claimer
@@ -91,6 +92,11 @@ func (context Context) StatePool() *state.StatePool {
 // ID is part of the facade.Context interface.
 func (context Context) ID() string {
 	return context.ID_
+}
+
+// RequestRecorder defines a metrics collector for outbound requests.
+func (context Context) RequestRecorder() facade.RequestRecorder {
+	return context.RequestRecorder_
 }
 
 // Presence implements facade.Context.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -4,6 +4,10 @@
 package facade
 
 import (
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/cache"
@@ -136,6 +140,19 @@ type Context interface {
 	// into Resources to get the watcher in play. This is not really
 	// a good idea; see Resources.
 	ID() string
+
+	// RequestRecorder defines a metrics collector for outbound requests.
+	RequestRecorder() RequestRecorder
+}
+
+// RequestRecorder is implemented by types that can record information about
+// successful and unsuccessful http requests.
+type RequestRecorder interface {
+	// Record an outgoing request which produced an http.Response.
+	Record(method string, url *url.URL, res *http.Response, rtt time.Duration)
+
+	// Record an outgoing request which returned back an error.
+	RecordError(method string, url *url.URL, err error)
 }
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/facade_mock.go github.com/juju/juju/apiserver/facade Resources,Authorizer

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -48,9 +48,8 @@ type Client interface {
 
 // CharmHubAPI API provides the CharmHub API facade for version 1.
 type CharmHubAPI struct {
-	backend Backend
-	auth    facade.Authorizer
-	client  Client
+	auth   facade.Authorizer
+	client Client
 }
 
 // NewFacade creates a new CharmHubAPI facade.
@@ -60,9 +59,8 @@ func NewFacade(ctx facade.Context) (*CharmHubAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// TODO (stickupkid): Get the http transport from the facade context
 	return newCharmHubAPI(m, ctx.Auth(), charmHubClientFactory{
-		httpTransport: charmhub.DefaultHTTPTransport,
+		httpTransport: charmhub.RequestRecorderHTTPTransport(ctx.RequestRecorder()),
 	})
 }
 

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -125,6 +125,8 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 		return nil, errors.Trace(err)
 	}
 
+	httpTransport := charmhub.RequestRecorderHTTPTransport(ctx.RequestRecorder())
+
 	return &API{
 		CharmsAPI:            commonCharmsAPI,
 		authorizer:           authorizer,
@@ -134,11 +136,13 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 		getStrategyFunc:      getStrategyFunc,
 		newStorage:           storage.NewStorage,
 		tag:                  m.ModelTag(),
-		// TODO (stickupkid): Get the http transport from the facade context
-		httpClient: charmhub.DefaultHTTPTransport(logger),
+		httpClient:           httpTransport(logger),
 	}, nil
 }
 
+// NewCharmsAPI is only used for testing.
+// TODO (stickupkid): We should use the latest NewFacadeV4 to better exercise
+// the API.
 func NewCharmsAPI(
 	authorizer facade.Authorizer,
 	st charmsinterfaces.BackendState,
@@ -155,8 +159,7 @@ func NewCharmsAPI(
 		getStrategyFunc:      getStrategyFunc,
 		newStorage:           newStorage,
 		tag:                  m.ModelTag(),
-		// TODO (stickupkid): Get the http transport from the facade context
-		httpClient: charmhub.DefaultHTTPTransport(logger),
+		httpClient:           charmhub.DefaultHTTPTransport(logger),
 	}, nil
 }
 

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -57,6 +57,7 @@ func (ctx *charmsSuiteContext) Resources() facade.Resources                   { 
 func (ctx *charmsSuiteContext) State() *state.State                           { return ctx.cs.State }
 func (ctx *charmsSuiteContext) StatePool() *state.StatePool                   { return nil }
 func (ctx *charmsSuiteContext) ID() string                                    { return "" }
+func (ctx *charmsSuiteContext) RequestRecorder() facade.RequestRecorder       { return nil }
 func (ctx *charmsSuiteContext) Presence() facade.Presence                     { return nil }
 func (ctx *charmsSuiteContext) Hub() facade.Hub                               { return nil }
 func (ctx *charmsSuiteContext) Controller() *cache.Controller                 { return nil }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -596,6 +596,7 @@ func (s *charmsMockSuite) api(c *gc.C) *charms.API {
 	storageFunc := func(modelUUID string, session *mgo.Session) storage.Storage {
 		return s.storage
 	}
+
 	api, err := charms.NewCharmsAPI(
 		s.authorizer,
 		s.state,
@@ -688,10 +689,6 @@ func (s *charmsMockSuite) expectRun(download corecharm.DownloadResult, already b
 
 func (s *charmsMockSuite) expectValidate() {
 	s.strategy.EXPECT().Validate().Return(nil)
-}
-
-func (s *charmsMockSuite) expectPrepareCharmUpload(curl *charm.URL) {
-	s.state.EXPECT().PrepareCharmUpload(curl).Return(s.charm, nil)
 }
 
 func (s *charmsMockSuite) expectCharmURL(curl *charm.URL) {

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -235,7 +235,8 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 	config.Logger.Tracef("NewClient to %q", config.URL)
 
 	apiRequester := NewAPIRequester(config.Transport, config.Logger)
-	restClient := NewHTTPRESTClient(apiRequester, config.Headers)
+	apiRequestLogger := NewAPIRequesterLogger(apiRequester, config.Logger)
+	restClient := NewHTTPRESTClient(apiRequestLogger, config.Headers)
 
 	return &Client{
 		url:           base.String(),

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -40,7 +40,7 @@ type Transport interface {
 // DefaultHTTPTransport creates a new HTTPTransport.
 func DefaultHTTPTransport(logger Logger) Transport {
 	return RequestRecorderHTTPTransport(loggingRequestRecorder{
-		logger: logger,
+		logger: logger.Child("request-recorder"),
 	})(logger)
 }
 
@@ -50,12 +50,20 @@ type loggingRequestRecorder struct {
 
 // Record an outgoing request which produced an http.Response.
 func (r loggingRequestRecorder) Record(method string, url *url.URL, res *http.Response, rtt time.Duration) {
-
+	status := "unknown"
+	if res != nil {
+		status = res.Status
+	}
+	if r.logger.IsTraceEnabled() {
+		r.logger.Tracef("request (method: %q, url: %q, status: %q, duration: %s)", method, url, status, rtt)
+	}
 }
 
 // Record an outgoing request which returned back an error.
 func (r loggingRequestRecorder) RecordError(method string, url *url.URL, err error) {
-
+	if r.logger.IsTraceEnabled() {
+		r.logger.Tracef("request error (method: %q, url: %q, err: %s)", method, url, err)
+	}
 }
 
 // RequestRecorderHTTPTransport creates a new HTTPTransport that records the
@@ -87,35 +95,13 @@ func NewAPIRequester(transport Transport, logger Logger) *APIRequester {
 // Do performs the *http.Request and returns a *http.Response or an error
 // if it fails to construct the transport.
 func (t *APIRequester) Do(req *http.Request) (*http.Response, error) {
-	if t.logger.IsTraceEnabled() {
-		if data, err := httputil.DumpRequest(req, true); err == nil {
-			t.logger.Tracef("%s request %s", req.Method, data)
-		} else {
-			t.logger.Tracef("%s request DumpRequest error %s", req.Method, err.Error())
-		}
-	}
-
 	resp, err := t.transport.Do(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	if t.logger.IsTraceEnabled() {
-		if data, err := httputil.DumpResponse(resp, true); err == nil {
-			t.logger.Tracef("%s response %s", req.Method, data)
-		} else {
-			t.logger.Tracef("%s response DumpResponse error %s", req.Method, err.Error())
-		}
-	}
-
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode <= http.StatusNoContent {
 		return resp, nil
-	}
-
-	if data, err := httputil.DumpResponse(resp, true); err == nil {
-		t.logger.Errorf("Response %s", data)
-	} else {
-		t.logger.Errorf("Response DumpResponse error %s", err.Error())
 	}
 
 	var potentialInvalidURL bool
@@ -146,6 +132,49 @@ func (t *APIRequester) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, nil
+}
+
+// APIRequestLogger creates a wrapper around the transport to allow for better
+// logging.
+type APIRequestLogger struct {
+	transport Transport
+	logger    Logger
+}
+
+// NewAPIRequesterLogger creates a new Transport that allows logging of requests
+// for every request.
+func NewAPIRequesterLogger(transport Transport, logger Logger) *APIRequestLogger {
+	return &APIRequestLogger{
+		transport: transport,
+		logger:    logger,
+	}
+}
+
+// Do performs the *http.Request and returns a *http.Response or an error
+// if it fails to construct the transport.
+func (t *APIRequestLogger) Do(req *http.Request) (*http.Response, error) {
+	if t.logger.IsTraceEnabled() {
+		if data, err := httputil.DumpRequest(req, true); err == nil {
+			t.logger.Tracef("%s request %s", req.Method, data)
+		} else {
+			t.logger.Tracef("%s request DumpRequest error %s", req.Method, err.Error())
+		}
+	}
+
+	resp, err := t.transport.Do(req)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if t.logger.IsTraceEnabled() {
+		if data, err := httputil.DumpResponse(resp, true); err == nil {
+			t.logger.Tracef("%s response %s", req.Method, data)
+		} else {
+			t.logger.Tracef("%s response DumpResponse error %s", req.Method, err.Error())
+		}
+	}
+
+	return resp, err
 }
 
 // RESTResponse abstracts away the underlying response from the implementation.

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -50,19 +50,15 @@ type loggingRequestRecorder struct {
 
 // Record an outgoing request which produced an http.Response.
 func (r loggingRequestRecorder) Record(method string, url *url.URL, res *http.Response, rtt time.Duration) {
-	status := "unknown"
-	if res != nil {
-		status = res.Status
-	}
 	if r.logger.IsTraceEnabled() {
-		r.logger.Tracef("request (method: %q, url: %q, status: %q, duration: %s)", method, url, status, rtt)
+		r.logger.Tracef("request (method: %q, host: %q, path: %q, status: %q, duration: %s)", method, url.Host, url.Path, res.Status, rtt)
 	}
 }
 
 // Record an outgoing request which returned back an error.
 func (r loggingRequestRecorder) RecordError(method string, url *url.URL, err error) {
 	if r.logger.IsTraceEnabled() {
-		r.logger.Tracef("request error (method: %q, url: %q, err: %s)", method, url, err)
+		r.logger.Tracef("request error (method: %q, host: %q, path: %q, err: %s)", method, url.Host, url.Path, err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
 	github.com/juju/gomaasapi/v2 v2.0.0-20210323144809-92beddd020fe
-	github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076
+	github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a
 	github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcM
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
-github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076 h1:Y9skx/w7NYVMj5N7t+rV66BYEMItpoSDG+Stb8beRuU=
-github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076/go.mod h1:y1PngvubGWeSpDBI4kxdaTc9f3HEThd2A5mv0MKBi74=
+github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a h1:Moqm99huPhL1lffDs8uNZ6VJ3kAPDxPPu/kbZlMAy98=
+github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a/go.mod h1:y1PngvubGWeSpDBI4kxdaTc9f3HEThd2A5mv0MKBi74=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v1.0.1/go.mod h1:K+CyYVHU/NcfbMpK7YIVobh4U4Fci3EUB2AqIRtl+xs=


### PR DESCRIPTION
The following wires up the outbound total requests API metrics. It uses
the juju/http request recorder.

We have to be extra careful about what we want to use as labels, we
don't want to log the path or the complete URL for a couple of reasons:

 1. Security around what can be in a URL; auth tokens et al
 2. We don't want to balloon the cardinality of the database.

With this in mind, we want to just request the hostnames for now, which
keeps the cardinality low.

Additionally, we have single responsibility for logging when performing 
API requests.

The default HTTP transport will also give you a logging request
recorder, this should aid with always having a request recorder for
making charmhub requests.

As all the above is handled only when trace is enabled shouldn't impact
performance.

## QA steps

### Setup

```sh
$ juju bootstrap lxd test
$ juju switch controller
$ juju add-user prom
$ juju change-user-password prom
# you need the password for later!
$ juju grant prom read controller
```

### Query

Note: you need to query first to show any outbound information. The metrics
are lazily created.

```sh
$ juju info mattermost
$ juju info badname
$ juju show-controller test --format=json | jq '.test.details."api-endpoints"[0]' | xargs -I % echo "https://%/introspection/metrics" | xargs curl -k -s -u user-prom:$PASSWORD | grep outbound_
```

## Bug reference

 - https://bugs.launchpad.net/juju/+bug/1928182
 - https://bugs.launchpad.net/juju/+bug/1899793
