### PR TITLE
Make sidecar unit IP address visible immediately.

### DIFF
--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -321,9 +321,15 @@ type mockCAASApplication struct {
 	caas.Application
 
 	state caas.ApplicationState
+	units []caas.Unit
 }
 
 func (a *mockCAASApplication) State() (caas.ApplicationState, error) {
 	a.MethodCall(a, "State")
 	return a.state, a.NextErr()
+}
+
+func (a *mockCAASApplication) Units() ([]caas.Unit, error) {
+	a.MethodCall(a, "Units")
+	return a.units, a.NextErr()
 }


### PR DESCRIPTION
During UnitIntroduction call, store the PodIP and Ports in state.

## QA steps

See repro steps on bug.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929364
