### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -122,11 +122,12 @@ func (a *admin) login(ctx context.Context, req params.LoginRequest, loginVersion
 	var apiRoot rpc.Root
 	apiRoot, err = newAPIRoot(
 		a.srv.clock,
-		a.root.state,
-		a.root.shared,
 		a.srv.facades,
-		a.root.resources,
 		a.root,
+		httpRequestRecorderWrapper{
+			collector: a.srv.metricsCollector,
+			modelUUID: a.root.model.UUID(),
+		},
 	)
 	if err != nil {
 		return fail, errors.Trace(err)
@@ -523,7 +524,7 @@ func setupPingTimeoutDisconnect(clock clock.Clock, root *apiHandler, entity stat
 		}
 	}
 	pingTimeout := newPingTimeout(action, clock, maxClientPingInterval)
-	return root.getResources().RegisterNamed("pingTimeout", pingTimeout)
+	return root.Resources().RegisterNamed("pingTimeout", pingTimeout)
 }
 
 // errRoot implements the API that a client first sees

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -22,7 +24,6 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/pubsub"
 	"github.com/juju/ratelimit"
-	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/tomb.v2"
@@ -70,7 +71,6 @@ type Server struct {
 	tag                    names.Tag
 	dataDir                string
 	logDir                 string
-	limiter                utils.Limiter
 	facades                *facade.Registry
 	authenticator          httpcontext.LocalMacaroonAuthenticator
 	offerAuthCtxt          *crossmodel.AuthContext
@@ -452,21 +452,6 @@ func (srv *Server) getAgentToken() error {
 	return nil
 }
 
-// loggoWrapper is an io.Writer() that forwards the messages to a loggo.Logger.
-// Unfortunately http takes a concrete stdlib log.Logger struct, and not an
-// interface, so we can't just proxy all of the log levels without inspecting
-// the string content. For now, we just want to get the messages into the log
-// file.
-type loggoWrapper struct {
-	logger loggo.Logger
-	level  loggo.Level
-}
-
-func (w *loggoWrapper) Write(content []byte) (int, error) {
-	w.logger.Logf(w.level, "%s", string(content))
-	return len(content), nil
-}
-
 // logsinkMetricsCollectorWrapper defines a wrapper for exposing the essentials
 // for the logsink api handler to interact with the metrics collector.
 type logsinkMetricsCollectorWrapper struct {
@@ -491,6 +476,32 @@ func (w logsinkMetricsCollectorWrapper) LogWriteCount(modelUUID, state string) p
 
 func (w logsinkMetricsCollectorWrapper) LogReadCount(modelUUID, state string) prometheus.Counter {
 	return w.collector.LogReadCount.WithLabelValues(modelUUID, state)
+}
+
+// httpRequestRecorderWrapper defines a wrapper from exposing the
+// essentials for the http request recorder.
+type httpRequestRecorderWrapper struct {
+	collector *Collector
+	modelUUID string
+}
+
+// Record an outgoing request which produced an http.Response.
+func (w httpRequestRecorderWrapper) Record(method string, url *url.URL, res *http.Response, rtt time.Duration) {
+	// Note: Do not log url.Path as REST queries _can_ include the name of the
+	// entities (charms, architectures, etc).
+	w.collector.TotalRequests.WithLabelValues(w.modelUUID, url.Host, strconv.FormatInt(int64(res.StatusCode), 10)).Inc()
+	if res.StatusCode >= 400 {
+		w.collector.TotalRequestErrors.WithLabelValues(w.modelUUID, url.Host).Inc()
+	}
+	w.collector.TotalRequestsDuration.WithLabelValues(w.modelUUID, url.Host).Observe(rtt.Seconds())
+}
+
+// Record an outgoing request which returned back an error.
+func (w httpRequestRecorderWrapper) RecordError(method string, url *url.URL, err error) {
+	// Note: Do not log url.Path as REST queries _can_ include the name of the
+	// entities (charms, architectures, etc).
+	w.collector.TotalRequests.WithLabelValues(w.modelUUID, url.Host, "unknown").Inc()
+	w.collector.TotalRequestErrors.WithLabelValues(w.modelUUID, url.Host).Inc()
 }
 
 // loop is the main loop for the server.
@@ -890,7 +901,7 @@ func (srv *Server) trackRequests(handler http.Handler) http.Handler {
 			// but after the tomb was killed. As we're in the process of
 			// shutting down, do not consider this request as in progress,
 			// just send a 503 and return.
-			http.Error(w, "apiserver shutdown in progress", 503)
+			http.Error(w, "apiserver shutdown in progress", http.StatusServiceUnavailable)
 		default:
 			// If we get here then the tomb was not killed therefore the
 			// listener is still open. It is safe to increment the

--- a/apiserver/apiservermetrics_test.go
+++ b/apiserver/apiservermetrics_test.go
@@ -36,7 +36,7 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 	for desc := range ch {
 		descs = append(descs, desc)
 	}
-	c.Assert(descs, gc.HasLen, 7)
+	c.Assert(descs, gc.HasLen, 10)
 	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connections_total".*`)
 	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connections".*`)
 	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_active_login_attempts".*`)
@@ -44,6 +44,10 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 	c.Assert(descs[4].String(), gc.Matches, `.*fqName: "juju_apiserver_ping_failure_count".*`)
 	c.Assert(descs[5].String(), gc.Matches, `.*fqName: "juju_apiserver_log_write_count".*`)
 	c.Assert(descs[6].String(), gc.Matches, `.*fqName: "juju_apiserver_log_read_count".*`)
+
+	c.Assert(descs[7].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_requests_total".*`)
+	c.Assert(descs[8].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_request_errors_total".*`)
+	c.Assert(descs[9].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_request_duration_seconds".*`)
 }
 
 func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
@@ -81,6 +85,16 @@ func (s *apiservermetricsSuite) TestLabelNames(c *gc.C) {
 		{
 			name:    "log failure label names",
 			labels:  apiserver.MetricLogLabelNames,
+			checker: jc.IsTrue,
+		},
+		{
+			name:    "total requests with status label names",
+			labels:  apiserver.MetricTotalRequestsWithStatusLabelNames,
+			checker: jc.IsTrue,
+		},
+		{
+			name:    "total requests label names",
+			labels:  apiserver.MetricTotalRequestsLabelNames,
 			checker: jc.IsTrue,
 		},
 		{

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -39,11 +39,29 @@ func NewErrRoot(err error) *errRoot {
 	return &errRoot{err}
 }
 
+type testingAPIRootHandler struct{}
+
+func (testingAPIRootHandler) State() *state.State {
+	return nil
+}
+
+func (testingAPIRootHandler) SharedContext() *sharedServerContext {
+	return nil
+}
+
+func (testingAPIRootHandler) Authorizer() facade.Authorizer {
+	return nil
+}
+
+func (testingAPIRootHandler) Resources() *common.Resources {
+	return common.NewResources()
+}
+
 // TestingAPIRoot gives you an APIRoot as a rpc.Methodfinder that is
 // *barely* connected to anything.  Just enough to let you probe some
 // of the interfaces, but not enough to actually do any RPC calls.
 func TestingAPIRoot(facades *facade.Registry) rpc.Root {
-	root, err := newAPIRoot(clock.WallClock, nil, nil, facades, common.NewResources(), nil)
+	root, err := newAPIRoot(clock.WallClock, facades, testingAPIRootHandler{}, nil)
 	if err != nil {
 		// While not ideal, this is only in test code, and there are a bunch of other functions
 		// that depend on this one that don't return errors either.
@@ -67,7 +85,7 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHan
 	}
 	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), 6543, "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
-	return h, h.getResources()
+	return h, h.Resources()
 }
 
 // TestingAPIHandlerWithEntity gives you the sane kind of APIHandler as

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -25,6 +25,7 @@ type Context struct {
 	Controller_          *cache.Controller
 	MultiwatcherFactory_ multiwatcher.Factory
 	ID_                  string
+	RequestRecorder_     facade.RequestRecorder
 	Cancel_              <-chan struct{}
 
 	LeadershipClaimer_ leadership.Claimer
@@ -91,6 +92,11 @@ func (context Context) StatePool() *state.StatePool {
 // ID is part of the facade.Context interface.
 func (context Context) ID() string {
 	return context.ID_
+}
+
+// RequestRecorder defines a metrics collector for outbound requests.
+func (context Context) RequestRecorder() facade.RequestRecorder {
+	return context.RequestRecorder_
 }
 
 // Presence implements facade.Context.

--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -321,9 +321,15 @@ type mockCAASApplication struct {
 	caas.Application
 
 	state caas.ApplicationState
+	units []caas.Unit
 }
 
 func (a *mockCAASApplication) State() (caas.ApplicationState, error) {
 	a.MethodCall(a, "State")
 	return a.state, a.NextErr()
+}
+
+func (a *mockCAASApplication) Units() ([]caas.Unit, error) {
+	a.MethodCall(a, "Units")
+	return a.units, a.NextErr()
 }

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -17,18 +17,13 @@ import (
 )
 
 const (
-	// FacadeName is the string-representation of this API used both
-	// to register the service, and for the client to resolve the
-	// service endpoint.
-	FacadeName = "LeadershipService"
-
-	// MinLeaseRequest is the shortest duration for which we will accept
+	// minLeaseRequest is the shortest duration for which we will accept
 	// a leadership claim.
-	MinLeaseRequest = 5 * time.Second
+	minLeaseRequest = 5 * time.Second
 
-	// MaxLeaseRequest is the longest duration for which we will accept
+	// maxLeaseRequest is the longest duration for which we will accept
 	// a leadership claim.
-	MaxLeaseRequest = 5 * time.Minute
+	maxLeaseRequest = 5 * time.Minute
 )
 
 // NewLeadershipServiceFacade constructs a new LeadershipService and presents
@@ -76,7 +71,7 @@ func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParam
 			continue
 		}
 		duration := time.Duration(p.DurationSeconds * float64(time.Second))
-		if duration > MaxLeaseRequest || duration < MinLeaseRequest {
+		if duration > maxLeaseRequest || duration < minLeaseRequest {
 			result.Error = apiservererrors.ServerError(errors.New("invalid duration"))
 			continue
 		}
@@ -101,7 +96,7 @@ func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParam
 		}
 	}
 
-	return params.ClaimLeadershipBulkResults{results}, nil
+	return params.ClaimLeadershipBulkResults{Results: results}, nil
 }
 
 // BlockUntilLeadershipReleased implements the LeadershipService interface.

--- a/apiserver/facades/agent/uniter/networkinfo.go
+++ b/apiserver/facades/agent/uniter/networkinfo.go
@@ -60,7 +60,7 @@ func NewNetworkInfo(st *state.State, tag names.UnitTag) (NetworkInfo, error) {
 	return n, errors.Trace(err)
 }
 
-// NewNetworkInfoWithBehaviour initialises and returns a new NetworkInfo
+// NewNetworkInfoForStrategy initialises and returns a new NetworkInfo
 // based on the input state and unit tag, allowing further specification of
 // behaviour via the input retry factory and host resolver.
 func NewNetworkInfoForStrategy(

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -48,9 +48,8 @@ type Client interface {
 
 // CharmHubAPI API provides the CharmHub API facade for version 1.
 type CharmHubAPI struct {
-	backend Backend
-	auth    facade.Authorizer
-	client  Client
+	auth   facade.Authorizer
+	client Client
 }
 
 // NewFacade creates a new CharmHubAPI facade.
@@ -60,9 +59,8 @@ func NewFacade(ctx facade.Context) (*CharmHubAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// TODO (stickupkid): Get the http transport from the facade context
 	return newCharmHubAPI(m, ctx.Auth(), charmHubClientFactory{
-		httpTransport: charmhub.DefaultHTTPTransport,
+		httpTransport: charmhub.RequestRecorderHTTPTransport(ctx.RequestRecorder()),
 	})
 }
 

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -125,6 +125,8 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 		return nil, errors.Trace(err)
 	}
 
+	httpTransport := charmhub.RequestRecorderHTTPTransport(ctx.RequestRecorder())
+
 	return &API{
 		CharmsAPI:            commonCharmsAPI,
 		authorizer:           authorizer,
@@ -134,11 +136,13 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 		getStrategyFunc:      getStrategyFunc,
 		newStorage:           storage.NewStorage,
 		tag:                  m.ModelTag(),
-		// TODO (stickupkid): Get the http transport from the facade context
-		httpClient: charmhub.DefaultHTTPTransport(logger),
+		httpClient:           httpTransport(logger),
 	}, nil
 }
 
+// NewCharmsAPI is only used for testing.
+// TODO (stickupkid): We should use the latest NewFacadeV4 to better exercise
+// the API.
 func NewCharmsAPI(
 	authorizer facade.Authorizer,
 	st charmsinterfaces.BackendState,
@@ -155,8 +159,7 @@ func NewCharmsAPI(
 		getStrategyFunc:      getStrategyFunc,
 		newStorage:           newStorage,
 		tag:                  m.ModelTag(),
-		// TODO (stickupkid): Get the http transport from the facade context
-		httpClient: charmhub.DefaultHTTPTransport(logger),
+		httpClient:           charmhub.DefaultHTTPTransport(logger),
 	}, nil
 }
 

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -57,6 +57,7 @@ func (ctx *charmsSuiteContext) Resources() facade.Resources                   { 
 func (ctx *charmsSuiteContext) State() *state.State                           { return ctx.cs.State }
 func (ctx *charmsSuiteContext) StatePool() *state.StatePool                   { return nil }
 func (ctx *charmsSuiteContext) ID() string                                    { return "" }
+func (ctx *charmsSuiteContext) RequestRecorder() facade.RequestRecorder       { return nil }
 func (ctx *charmsSuiteContext) Presence() facade.Presence                     { return nil }
 func (ctx *charmsSuiteContext) Hub() facade.Hub                               { return nil }
 func (ctx *charmsSuiteContext) Controller() *cache.Controller                 { return nil }
@@ -595,6 +596,7 @@ func (s *charmsMockSuite) api(c *gc.C) *charms.API {
 	storageFunc := func(modelUUID string, session *mgo.Session) storage.Storage {
 		return s.storage
 	}
+
 	api, err := charms.NewCharmsAPI(
 		s.authorizer,
 		s.state,
@@ -687,10 +689,6 @@ func (s *charmsMockSuite) expectRun(download corecharm.DownloadResult, already b
 
 func (s *charmsMockSuite) expectValidate() {
 	s.strategy.EXPECT().Validate().Return(nil)
-}
-
-func (s *charmsMockSuite) expectPrepareCharmUpload(curl *charm.URL) {
-	s.state.EXPECT().PrepareCharmUpload(curl).Return(s.charm, nil)
 }
 
 func (s *charmsMockSuite) expectCharmURL(curl *charm.URL) {

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -235,7 +235,8 @@ func NewClientWithFileSystem(config Config, fileSystem FileSystem) (*Client, err
 	config.Logger.Tracef("NewClient to %q", config.URL)
 
 	apiRequester := NewAPIRequester(config.Transport, config.Logger)
-	restClient := NewHTTPRESTClient(apiRequester, config.Headers)
+	apiRequestLogger := NewAPIRequesterLogger(apiRequester, config.Logger)
+	restClient := NewHTTPRESTClient(apiRequestLogger, config.Headers)
 
 	return &Client{
 		url:           base.String(),

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -263,23 +263,31 @@ func (s *MachineSuite) TestDyingMachine(c *gc.C) {
 func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
 	s.AgentSuite.PatchValue(&instancepoller.ShortPoll, 500*time.Millisecond)
 	s.AgentSuite.PatchValue(&instancepoller.ShortPollCap, 500*time.Millisecond)
+
+	stream := s.Environ.Config().AgentStream()
 	usefulVersion := version.Binary{
 		Number:  jujuversion.Current,
 		Arch:    arch.HostArch(),
 		Release: "ubuntu",
 	}
-	envtesting.AssertUploadFakeToolsVersions(
-		c, s.DefaultToolsStorage,
-		s.Environ.Config().AgentStream(),
-		s.Environ.Config().AgentStream(),
-		usefulVersion,
-	)
+	envtesting.AssertUploadFakeToolsVersions(c, s.DefaultToolsStorage, stream, stream, usefulVersion)
+
 	m, _, _ := s.primeAgent(c, state.JobManageModel)
 	a := s.newAgent(c, m)
-	defer a.Stop()
+	defer func() { _ = a.Stop() }()
 	go func() {
 		c.Check(a.Run(cmdtesting.Context(c)), jc.ErrorIsNil)
 	}()
+
+	// Wait for the workers to start. This ensures that the central
+	// hub referred to in startAddressPublisher has been assigned,
+	// and we will will not fail race tests with concurrent access.
+	select {
+	case <-a.WorkersStarted():
+	case <-time.After(testing.LongWait):
+		c.Fatalf("timed out waiting for agent workers to start")
+	}
+
 	startAddressPublisher(s, c, a)
 
 	// Add one unit to an application;

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
 	github.com/juju/gomaasapi/v2 v2.0.0-20210323144809-92beddd020fe
-	github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076
+	github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a
 	github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcM
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
-github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076 h1:Y9skx/w7NYVMj5N7t+rV66BYEMItpoSDG+Stb8beRuU=
-github.com/juju/http/v2 v2.0.0-20210527161802-e8d841c4e076/go.mod h1:y1PngvubGWeSpDBI4kxdaTc9f3HEThd2A5mv0MKBi74=
+github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a h1:Moqm99huPhL1lffDs8uNZ6VJ3kAPDxPPu/kbZlMAy98=
+github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a/go.mod h1:y1PngvubGWeSpDBI4kxdaTc9f3HEThd2A5mv0MKBi74=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v1.0.1/go.mod h1:K+CyYVHU/NcfbMpK7YIVobh4U4Fci3EUB2AqIRtl+xs=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -113,7 +113,7 @@ func SampleCloudSpec() environscloudspec.CloudSpec {
 	}
 }
 
-// SampleConfig() returns an environment configuration with all required
+// SampleConfig returns an environment configuration with all required
 // attributes set.
 func SampleConfig() testing.Attrs {
 	return testing.Attrs{
@@ -369,37 +369,37 @@ func Reset(c *gc.C) {
 	}
 }
 
-func (state *environState) destroy() {
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	state.destroyLocked()
+func (s *environState) destroy() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.destroyLocked()
 }
 
-func (state *environState) destroyLocked() {
-	if !state.bootstrapped {
+func (s *environState) destroyLocked() {
+	if !s.bootstrapped {
 		return
 	}
-	apiServer := state.apiServer
-	apiStatePool := state.apiStatePool
-	leaseManager := state.leaseManager
-	multiWatcherWorker := state.multiWatcherWorker
-	modelCacheWorker := state.modelCacheWorker
-	state.apiServer = nil
-	state.apiStatePool = nil
-	state.apiState = nil
-	state.controller = nil
-	state.leaseManager = nil
-	state.bootstrapped = false
-	state.hub = nil
-	state.multiWatcherWorker = nil
-	state.modelCacheWorker = nil
+	apiServer := s.apiServer
+	apiStatePool := s.apiStatePool
+	leaseManager := s.leaseManager
+	multiWatcherWorker := s.multiWatcherWorker
+	modelCacheWorker := s.modelCacheWorker
+	s.apiServer = nil
+	s.apiStatePool = nil
+	s.apiState = nil
+	s.controller = nil
+	s.leaseManager = nil
+	s.bootstrapped = false
+	s.hub = nil
+	s.multiWatcherWorker = nil
+	s.modelCacheWorker = nil
 
 	// Release the lock while we close resources. In particular,
 	// we must not hold the lock while the API server is being
 	// closed, as it may need to interact with the Environ while
 	// shutting down.
-	state.mu.Unlock()
-	defer state.mu.Lock()
+	s.mu.Unlock()
+	defer s.mu.Lock()
 
 	// The apiServer depends on the modelCache, so stop the apiserver first.
 	if apiServer != nil {


### PR DESCRIPTION
Merge from 2.9 to bring forward:
- #13093 from manadart/2.9-machine-agent-test-race
- #13092 from hpidcock/fix-1929364
- #13089 from SimonRichardson/request-recorder-collector
- #13088 from SimonRichardson/leadership-context
- #13075 from manadart/2.9-net-get-machine
- #13081 from jujubot/increment-to-2.9.6

Only conflicts were the usual trivial ones in the version files.