### PR TITLE
Fixes label issue with model operator in 2.9 upgrade

### DIFF
--- a/caas/kubernetes/provider/exec/exec.go
+++ b/caas/kubernetes/provider/exec/exec.go
@@ -95,7 +95,7 @@ func NewForJujuCloudSpec(
 		return nil, errors.Trace(err)
 	}
 
-	legacyLabels, err := k8sutils.IsLegacyModelLabels(modelName, c.CoreV1().Namespaces())
+	legacyLabels, err := k8sutils.IsLegacyModelLabels(modelName, modelName, c.CoreV1().Namespaces())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -184,7 +184,7 @@ func newK8sBroker(
 	}
 
 	isLegacy, err := utils.IsLegacyModelLabels(
-		newCfg.Config.Name(), k8sClient.CoreV1().Namespaces())
+		namespace, newCfg.Config.Name(), k8sClient.CoreV1().Namespaces())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -44,10 +44,11 @@ const (
 func GetOperatorPodName(
 	podAPI typedcorev1.PodInterface,
 	nsAPI typedcorev1.NamespaceInterface,
-	appName string,
+	appName,
+	namespace,
 	model string,
 ) (string, error) {
-	legacyLabels, err := utils.IsLegacyModelLabels(model, nsAPI)
+	legacyLabels, err := utils.IsLegacyModelLabels(namespace, model, nsAPI)
 	if err != nil {
 		return "", errors.Annotatef(err, "determining legacy label status for model %s", model)
 	}

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -1214,7 +1214,7 @@ func (s *K8sBrokerSuite) TestGetOperatorPodName(c *gc.C) {
 			}}, nil),
 	)
 
-	name, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", "test")
+	name, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", s.getNamespace(), "test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(name, jc.DeepEquals, `mariadb-k8s-operator-0`)
 }
@@ -1230,6 +1230,6 @@ func (s *K8sBrokerSuite) TestGetOperatorPodNameNotFound(c *gc.C) {
 			Return(&core.PodList{Items: []core.Pod{}}, nil),
 	)
 
-	_, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", "test")
+	_, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", s.getNamespace(), "test")
 	c.Assert(err, gc.ErrorMatches, `operator pod for application "mariadb-k8s" not found`)
 }

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -40,13 +40,13 @@ func HasLabels(src, has labels.Set) bool {
 
 // IsLegacyModelLabels checks to see if the provided model is running on an older
 // labeling scheme or a newer one.
-func IsLegacyModelLabels(model string, namespaceI core.NamespaceInterface) (bool, error) {
-	ns, err := namespaceI.Get(context.TODO(), model, meta.GetOptions{})
+func IsLegacyModelLabels(namespace, model string, namespaceI core.NamespaceInterface) (bool, error) {
+	ns, err := namespaceI.Get(context.TODO(), namespace, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}
 	if err != nil {
-		return true, errors.Annotatef(err, "unable to determine legacy status for namespace %s", model)
+		return true, errors.Annotatef(err, "unable to determine legacy status for namespace %s", namespace)
 	}
 
 	return !HasLabels(ns.Labels, LabelsForModel(model, false)), nil

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -83,7 +83,7 @@ func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
 		_, err := l.client.CoreV1().Namespaces().Create(context.TODO(), test.Namespace, meta.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
-		legacy, err := utils.IsLegacyModelLabels(test.Model, l.client.CoreV1().Namespaces())
+		legacy, err := utils.IsLegacyModelLabels(test.Namespace.Name, test.Model, l.client.CoreV1().Namespaces())
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(legacy, gc.Equals, test.IsLegacy)
 	}

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -231,6 +231,7 @@ func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 			podAPI,
 			c.execClient.RawClient().CoreV1().Namespaces(),
 			appName,
+			c.execClient.NameSpace(),
 			modelName,
 		)
 

--- a/cmd/juju/commands/ssh_container_test.go
+++ b/cmd/juju/commands/ssh_container_test.go
@@ -263,7 +263,7 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPod(c *gc.C) {
 			}, nil),
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
 
-		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.modelName, metav1.GetOptions{}).
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), "test-ns", metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
 		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().
@@ -291,7 +291,7 @@ func (s *sshContainerSuite) TestResolveTargetForOperatorPodNoProviderID(c *gc.C)
 			}, nil),
 		s.execClient.EXPECT().NameSpace().AnyTimes().Return("test-ns"),
 
-		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.modelName, metav1.GetOptions{}).
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), "test-ns", metav1.GetOptions{}).
 			Return(nil, k8serrors.NewNotFound(schema.GroupResource{}, "test")),
 
 		s.mockPods.EXPECT().List(gomock.Any(), metav1.ListOptions{LabelSelector: "operator.juju.is/name=mariadb-k8s,operator.juju.is/target=application"}).AnyTimes().


### PR DESCRIPTION
When upgrading to 2.9 Juju was trying to re-implement the model operator
with new labels on controller models. This was because the model name
was being used to search for the namespace which is not always the same.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Perform an upgrade from 2.8 to 2.9 on microk8s. You want to check the final controller logs for any errors while ensure model operator resources.

## Bug reference

N/A
