### PR TITLE
Add support to ec2 provider for encrypted root disks, kms, gp3, io2, throughput.

### DIFF
--- a/provider/ec2/internal/testing/volumes.go
+++ b/provider/ec2/internal/testing/volumes.go
@@ -34,6 +34,8 @@ func (srv *Server) CreateVolume(ctx context.Context, in *ec2.CreateVolumeInput, 
 	}
 	volume.Encrypted = in.Encrypted
 	volume.Iops = in.Iops
+	volume.KmsKeyId = in.KmsKeyId
+	volume.Throughput = in.Throughput
 	return &ec2.CreateVolumeOutput{
 		Attachments:      nil,
 		AvailabilityZone: volume.AvailabilityZone,
@@ -44,6 +46,8 @@ func (srv *Server) CreateVolume(ctx context.Context, in *ec2.CreateVolumeInput, 
 		Tags:             volume.Tags,
 		VolumeId:         volume.VolumeId,
 		VolumeType:       volume.VolumeType,
+		KmsKeyId:         volume.KmsKeyId,
+		Throughput:       volume.Throughput,
 	}, nil
 }
 


### PR DESCRIPTION
Adds support to EC2 provider for:
- Encrypted root disks
- KMS key selection for encrypted disks via "kms-key-id" key
- Add support for GP3 and IO2 volume types
- Add support for "throughput" key on GP3 volumes

## QA steps

```
juju bootstrap aws \
  --storage-pool name=ebs-encrypted \
  --storage-pool type=ebs \
  --storage-pool encrypted=true \
  --storage-pool kms-key-id="arn:aws:kms:us-east-1:<snip>" \
  --storage-pool volume-type=gp3 \
  --storage-pool throughput=500M \
  --bootstrap-constraints="root-disk-source=ebs-encrypted"
```

## Documentation changes

Updates required for AWS documentation in storage docs.
https://discourse.charmhub.io/t/use-juju-storage/1079

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931139
