### PR TITLE
Ensure we correctly set proxy for LXD

### DIFF
--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -199,11 +199,9 @@ func (s *serverFactory) RemoteServer(spec environscloudspec.CloudSpec) (Server, 
 	if !ok {
 		return nil, errors.NotValidf("credentials")
 	}
-	serverSpec := lxd.NewServerSpec(spec.Endpoint,
-		serverCert,
-		clientCert,
-	)
-	serverSpec.WithProxy(proxy.DefaultConfig.GetProxy)
+
+	serverSpec := lxd.NewServerSpec(spec.Endpoint, serverCert, clientCert).WithProxy(proxy.DefaultConfig.GetProxy)
+
 	svr, err := s.newRemoteServerFunc(serverSpec)
 	if err == nil {
 		err = s.bootstrapRemoteServer(svr)


### PR DESCRIPTION
We were never setting a proxy correctly for LXD remote connections, because we do not assign the result of `ServerSpec.WithProxy`.

We fix this here.

## QA steps

- Ensure you have a LXD server exposed to the network.
- Add it as a juju cloud (I actually copied my local LXD cloud/cred into a new one named "lxd-as-remote" with my machine's network IP as the endoint).
- Check that a bootstrap succeeds.
- Now add some bogus proxy config to the clouds.yaml entry, for example:
```
    config:
      http-proxy: http://10.9.9.9:4000
      https-proxy: http://10.9.9.9:4000
```
- Bootstrap should now fail, because we attempt to use the bogus proxy.

## Documentation changes

None.

## Bug reference

N/A
