### PR TITLE
fix lp:1931708 -  run unit state upgrade step from machine agent.

### DIFF
--- a/upgrades/steps_28_test.go
+++ b/upgrades/steps_28_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/upgrades"
 	"github.com/juju/juju/upgrades/mocks"
+	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	configsettermocks "github.com/juju/juju/worker/upgradedatabase/mocks"
 )
@@ -67,11 +68,15 @@ type mockSteps28Suite struct {
 
 	dataDir    string
 	tagOne     names.Tag
+	tagTwo     names.Tag
 	storTagOne names.Tag
 
 	opStateOne         operation.State
+	opStateTwo         operation.State
 	opStateOneYaml     string
+	opStateTwoYaml     string
 	opStateOneFileName string
+	opStateTwoFileName string
 
 	opStorOne         bool
 	opStorOneYaml     string
@@ -92,12 +97,19 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.tagOne = names.NewUnitTag("testing/0")
+	s.tagTwo = names.NewUnitTag("testing/1")
 	s.storTagOne = names.NewStorageTag("data/3")
 
 	s.opStateOne = operation.State{
 		Leader: true,
 		Kind:   operation.Continue,
 		Step:   operation.Pending,
+	}
+
+	s.opStateTwo = operation.State{
+		Kind: operation.RunHook,
+		Step: operation.Pending,
+		Hook: &hook.Info{Kind: hooks.ConfigChanged},
 	}
 
 	s.opStorOne = true
@@ -113,6 +125,11 @@ func (s *mockSteps28Suite) SetUpTest(c *gc.C) {
 	s.opStorOneYaml, s.opStorOneFileName = writeStorageState(c, unitOneStateDir, s.storTagOne, s.opStorOne)
 
 	s.opRelationYaml, s.opRelationFileName = setupRelationState(c, unitOneStateDir)
+
+	unitTwoStateDir := filepath.Join(agentDir, s.tagTwo.String(), "state")
+	err = os.MkdirAll(unitTwoStateDir, 0755)
+	c.Assert(err, jc.ErrorIsNil)
+	s.opStateTwoYaml, s.opStateTwoFileName = writeUnitStateFile(c, unitTwoStateDir, s.opStateTwo)
 }
 
 // writeUnitStateFile writes the operation.State in yaml format to the
@@ -214,10 +231,10 @@ type relDiskInfo struct {
 	ChangedPending bool   `yaml:"changed-pending,omitempty"`
 }
 
-func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerNotUnit(c *gc.C) {
+func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerNotMachine(c *gc.C) {
 	defer s.setup(c).Finish()
 	s.expectAPIState()
-	s.expectAgentConfigMachineTag()
+	s.expectAgentConfigUnitTag()
 	s.patchClient()
 	err := upgrades.MoveUnitAgentStateToController(s.mockCtx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -226,13 +243,15 @@ func (s *mockSteps28Suite) TestMoveUnitAgentStateToControllerNotUnit(c *gc.C) {
 func (s *mockSteps28Suite) TestMoveUnitAgentStateToController(c *gc.C) {
 	defer s.setup(c).Finish()
 	s.expectAPIState()
-	s.expectAgentConfigUnitTag()
-	s.expectWriteAgentState(c)
+	s.expectAgentConfigMachineTag()
+	s.expectWriteTwoAgentState(c)
 	s.patchClient()
 
 	err := upgrades.MoveUnitAgentStateToController(s.mockCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = os.Stat(s.opStateOneFileName)
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+	_, err = os.Stat(s.opStateTwoFileName)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 	_, err = os.Stat(s.opStorOneFileName)
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
@@ -271,11 +290,11 @@ func (s *mockSteps28Suite) expectDataDir() {
 }
 
 func (s *mockSteps28Suite) expectAgentConfigMachineTag() {
-	s.mockAgentConfig.EXPECT().Tag().Return(names.NewMachineTag("0"))
+	s.mockAgentConfig.EXPECT().Tag().Return(names.NewMachineTag("0")).AnyTimes()
 }
 
 func (s *mockSteps28Suite) expectAgentConfigUnitTag() {
-	s.mockAgentConfig.EXPECT().Tag().Return(s.tagOne).AnyTimes()
+	s.mockAgentConfig.EXPECT().Tag().Return(names.NewUnitTag("test/0"))
 }
 
 func (s *mockSteps28Suite) patchClient() {
@@ -284,12 +303,15 @@ func (s *mockSteps28Suite) patchClient() {
 	})
 }
 
-func (s *mockSteps28Suite) expectWriteAgentState(c *gc.C) {
+func (s *mockSteps28Suite) expectWriteTwoAgentState(c *gc.C) {
 	args := []params.SetUnitStateArg{{
 		Tag:           s.tagOne.String(),
 		UniterState:   &s.opStateOneYaml,
 		StorageState:  &s.opStorOneYaml,
 		RelationState: &s.opRelationYaml,
+	}, {
+		Tag:         s.tagTwo.String(),
+		UniterState: &s.opStateTwoYaml,
 	}}
 	cExp := s.mockClient.EXPECT()
 	cExp.WriteAgentState(unitStateMatcher{c, args}).Return(nil)

--- a/worker/deployer/nested.go
+++ b/worker/deployer/nested.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
-	"github.com/kr/pretty"
 
 	"github.com/juju/juju/agent"
 	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
@@ -156,7 +155,7 @@ func NewNestedContext(config ContextConfig) (Context, error) {
 	// Stat all the units that context should have deployed and started.
 	units := context.deployedUnits()
 	stopped := context.stoppedUnits()
-	config.Logger.Infof("new context: units %q, stopped %q", pretty.Sprint(units), pretty.Sprint(stopped))
+	config.Logger.Infof("new context: units %q, stopped %q", strings.Join(units.Values(), ", "), strings.Join(stopped.Values(), ", "))
 	for _, u := range units.SortedValues() {
 		if u == "" {
 			config.Logger.Warningf("empty unit")


### PR DESCRIPTION
Combining the machine and unit agents in 2.9 meant that prior upgrade steps requiring a unit agent would no longer be run, as the unit agent no longer has an upgrade-step worker.  

There is only one pre juju 2.9 upgrade step that requires the unit agent.  Revert a prior fix to run as unit agents, instead of the machine agent.  

Given that the unit agents are now stopped when the machine agent runs its upgrade steps.  There is little value in threading an upgrade-steps worker in the nested unit agent.

## QA steps

```console
# Setup a controller and model with 2.7
sudo snap refresh juju --channel 2.7/stable
/snap/bin/juju bootstrap localhost upgrade-me
/snap/bin/juju deploy wordpress
/snap/bin/juju deploy mysql
/snap/bin/juju add-relation wordpress mysql

# upgrade the controller and model, ensure you go directly from 2.7.x to the test code.
juju upgrade-controller --build-agent
juju upgrade-model --agent-version 2.9.7.1

# The wordpress agent should not go into an error state, nor should the install hook be run after upgrade.
juju show-status-log wordpress/0
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931708
