### PR TITLE
Charmhub retries

### DIFF
--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -60,7 +60,7 @@ func NewFacade(ctx facade.Context) (*CharmHubAPI, error) {
 	}
 
 	return newCharmHubAPI(m, ctx.Auth(), charmHubClientFactory{
-		httpTransport: charmhub.RequestRecorderHTTPTransport(ctx.RequestRecorder()),
+		httpTransport: charmhub.RequestHTTPTransport(ctx.RequestRecorder(), charmhub.DefaultRetryPolicy()),
 	})
 }
 

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -125,7 +125,7 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 		return nil, errors.Trace(err)
 	}
 
-	httpTransport := charmhub.RequestRecorderHTTPTransport(ctx.RequestRecorder())
+	httpTransport := charmhub.RequestHTTPTransport(ctx.RequestRecorder(), charmhub.DefaultRetryPolicy())
 
 	return &API{
 		CharmsAPI:            commonCharmsAPI,

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -145,6 +145,7 @@ func (s *RESTSuite) TestGetWithFailureRetry(c *gc.C) {
 		called++
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
+	defer server.Close()
 
 	transport := RequestHTTPTransport(nil, jujuhttp.RetryPolicy{
 		Attempts: 3,
@@ -167,6 +168,7 @@ func (s *RESTSuite) TestGetWithFailureWithoutRetry(c *gc.C) {
 		called++
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
+	defer server.Close()
 
 	transport := RequestHTTPTransport(nil, jujuhttp.RetryPolicy{
 		Attempts: 3,
@@ -191,6 +193,7 @@ func (s *RESTSuite) TestGetWithNoRetry(c *gc.C) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "{}")
 	}))
+	defer server.Close()
 
 	transport := RequestHTTPTransport(nil, jujuhttp.RetryPolicy{
 		Attempts: 3,

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
 	github.com/juju/gomaasapi/v2 v2.0.0-20210323144809-92beddd020fe
-	github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a
+	github.com/juju/http/v2 v2.0.0-20210623153641-418e83b0dab4
 	github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcM
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s6VnK1wGFibaCrPXPYijFa4=
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
-github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a h1:Moqm99huPhL1lffDs8uNZ6VJ3kAPDxPPu/kbZlMAy98=
-github.com/juju/http/v2 v2.0.0-20210616081525-ede00d07798a/go.mod h1:y1PngvubGWeSpDBI4kxdaTc9f3HEThd2A5mv0MKBi74=
+github.com/juju/http/v2 v2.0.0-20210623153641-418e83b0dab4 h1:rG3LBPCjMbyJS49DmiTG3tn/taVkaDiN898aDf+6fdk=
+github.com/juju/http/v2 v2.0.0-20210623153641-418e83b0dab4/go.mod h1:1cSFAPYQcBMP3uzXzAkTrX756GmMM/Dw0WxcnhNNntc=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v1.0.1/go.mod h1:K+CyYVHU/NcfbMpK7YIVobh4U4Fci3EUB2AqIRtl+xs=


### PR DESCRIPTION
The PR attempts to retry charmhub requests when the server returns the
following status codes:

  - http.StatusBadGateway
  - http.StatusGatewayTimeout
  - http.StatusServiceUnavailable
  - http.StatusTooManyRequests


## QA steps

Unit tests pass.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1928182
