### PR TITLE
Github actions: Update homebrew formulae

### DIFF
--- a/.github/workflows/update-brew-formulae.yml
+++ b/.github/workflows/update-brew-formulae.yml
@@ -1,0 +1,16 @@
+name: "Update homebrew tap"
+on:
+  release:
+    types: [published]
+  schedule:
+    - cron:  '0 */12 * * *'
+jobs:
+  update-brew-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formulae
+        uses: dawidd6/action-homebrew-bump-formula@master
+        with:
+          token: "${{ secrets.TOKEN }}"
+          formula: juju
+          livecheck: true


### PR DESCRIPTION
The following adds a new github action to update the homebrew formulae
based on a newly published tag or on a 12-hour schedule (cron).

This should ensure we always have the latest tag in homebrew.

@hpidcock might be worth a look?

## QA steps

Unsure on this one, try it and see?
