### PR TITLE
[2.8] Support ssh with proxy to fan subnets

### DIFF
--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -116,7 +116,19 @@ func (c *scpCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	options, err := c.getSSHOptions(false, targets...)
+	if c.proxy {
+		for _, target := range targets {
+			// If we are trying to connect to a container on a FAN address,
+			// we need to route the traffic via the machine that hosts it.
+			// This is required as the controller is unable to route fan
+			// traffic across subnets.
+			if err = c.maybePopulateTargetViaField(target, c.statusClient.Status); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+
+	options, err := c.getSSHOptions(false, targets)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The juju ssh --proxy command uses the controller as a jumpbox and
invokes 'nc' to forward ssh traffic to the target machine. While this
approach works fine for regular machines, it fails (for substrates as
ec2) for container machines (lxd/kvm) when they only have a FAN address.

This is generally acceptable as juju only requires for machines to be
able to connect to the controller and not vice-versa. In particular, ec2
does not allow FAN connectivity from the controller model to any other
Juju model (and vice versa).

To workaround this limitation, we now first check whether the machine we
are trying to connect to is a container. If that's the case, we identify
the address of the machine that hosts the container and modify the ssh
proxy command to use a 2-level proxying scheme: we ssh to the
controller, then ssh to the machine hosting the container and then run
'nc' to route the ssh traffic to the intended machine.

**Caveats**: this workaround cannot be applied in a scenario where we 
`juju scp` to copy files between two different **container remotes**
as each remote in this case would need a custom ssh proxy command.
The workaround for this case is to copy the file from remote A to local
and in a second step copy the file from local to remote B.

## QA steps

Bootstrap to ec2. Then:

```sh
$ juju deploy mysql --to lxd

# should fail
$ juju ssh mysql/0
ERROR cannot connect to any address: [252.40.132.122:22]

# should work with this patch
$ juju ssh --proxy mysql/0 hostname
juju-12d453-0-lxd-0
Connection to 252.40.132.122 closed.

# try scp
$ echo "BTC" > wallet
$ juju scp --proxy -- -3 wallet mysql/0:
$ juju scp --proxy -- -3 wallet 0:

# Verify the files have been uploaded
$ juju ssh --proxy 0 cat wallet
BTC
Connection to 172.31.40.132 closed.

$ juju ssh --proxy 0/lxd/0 cat wallet
BTC
Connection to 252.40.132.122 closed.
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1932547