### PR TITLE
minor changes related to lp:1871224

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -904,6 +904,9 @@ func (c *configInternal) APIInfo() (*api.Info, bool) {
 
 // MongoInfo is defined on Config interface.
 func (c *configInternal) MongoInfo() (info *mongo.MongoInfo, ok bool) {
+	if c.apiDetails == nil || c.apiDetails.addresses == nil {
+		return nil, false
+	}
 	ssi, ok := c.StateServingInfo()
 	if !ok {
 		return nil, false

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -72,8 +72,7 @@ type APIHostPortsSetter struct {
 // SetAPIHostPorts is the APIAddressSetter interface.
 func (s APIHostPortsSetter) SetAPIHostPorts(servers []network.HostPorts) error {
 	return s.ChangeConfig(func(c ConfigSetter) error {
-		c.SetAPIHostPorts(servers)
-		return nil
+		return c.SetAPIHostPorts(servers)
 	})
 }
 
@@ -314,7 +313,7 @@ type configSetterOnly interface {
 	SetUpgradedToVersion(newVersion version.Number)
 
 	// SetAPIHostPorts sets the API host/port addresses to connect to.
-	SetAPIHostPorts(servers []network.HostPorts)
+	SetAPIHostPorts(servers []network.HostPorts) error
 
 	// SetCACert sets the CA cert used for validating API connections.
 	SetCACert(string)
@@ -616,9 +615,13 @@ func (c *configInternal) SetUpgradedToVersion(newVersion version.Number) {
 	c.upgradedToVersion = newVersion
 }
 
-func (c *configInternal) SetAPIHostPorts(servers []network.HostPorts) {
+func (c *configInternal) SetAPIHostPorts(servers []network.HostPorts) error {
+	if len(servers) == 0 {
+		return errors.BadRequestf("servers not provided")
+	}
 	if c.apiDetails == nil {
-		return
+		// This shouldn't happen, NewAgentConfig checks valid addresses.
+		c.apiDetails = &apiDetails{}
 	}
 	var addrs []string
 	for _, serverHostPorts := range servers {
@@ -627,6 +630,7 @@ func (c *configInternal) SetAPIHostPorts(servers []network.HostPorts) {
 	}
 	c.apiDetails.addresses = addrs
 	logger.Debugf("API server address details %q written to agent config as %q", servers, addrs)
+	return nil
 }
 
 func (c *configInternal) SetCACert(cert string) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -667,6 +668,14 @@ func (*suite) TestSetAPIHostPorts(c *gc.C) {
 		"0.4.0.1:4444",
 		"elsewhere.net:4444",
 	})
+}
+
+func (*suite) TestSetAPIHostPortsErrorOnEmpty(c *gc.C) {
+	conf, err := agent.NewAgentConfig(attributeParams)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = conf.SetAPIHostPorts([]network.HostPorts{})
+	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (*suite) TestSetCACert(c *gc.C) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"

--- a/state/backups/backups_linux.go
+++ b/state/backups/backups_linux.go
@@ -138,7 +138,9 @@ func (b *backups) Restore(backupId string, args RestoreArgs) (names.Tag, error) 
 	// information and broken functionality between backup and restore.
 
 	APIHostPorts := network.NewSpaceHostPorts(ssi.APIPort, args.PrivateAddress, args.PublicAddress)
-	agentConfig.SetAPIHostPorts([]network.HostPorts{APIHostPorts.HostPorts()})
+	if err := agentConfig.SetAPIHostPorts([]network.HostPorts{APIHostPorts.HostPorts()}); err != nil {
+		return nil, errors.Annotate(err, "cannot set api host ports")
+	}
 	if err := agentConfig.Write(); err != nil {
 		return nil, errors.Annotate(err, "cannot write new agent configuration")
 	}

--- a/upgrades/mocks/context_mock.go
+++ b/upgrades/mocks/context_mock.go
@@ -5,92 +5,103 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	agent "github.com/juju/juju/agent"
 	base "github.com/juju/juju/api/base"
 	upgrades "github.com/juju/juju/upgrades"
-	reflect "reflect"
 )
 
-// MockContext is a mock of Context interface
+// MockContext is a mock of Context interface.
 type MockContext struct {
 	ctrl     *gomock.Controller
 	recorder *MockContextMockRecorder
 }
 
-// MockContextMockRecorder is the mock recorder for MockContext
+// MockContextMockRecorder is the mock recorder for MockContext.
 type MockContextMockRecorder struct {
 	mock *MockContext
 }
 
-// NewMockContext creates a new mock instance
+// NewMockContext creates a new mock instance.
 func NewMockContext(ctrl *gomock.Controller) *MockContext {
 	mock := &MockContext{ctrl: ctrl}
 	mock.recorder = &MockContextMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockContext) EXPECT() *MockContextMockRecorder {
 	return m.recorder
 }
 
-// APIContext mocks base method
+// APIContext mocks base method.
 func (m *MockContext) APIContext() upgrades.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIContext")
 	ret0, _ := ret[0].(upgrades.Context)
 	return ret0
 }
 
-// APIContext indicates an expected call of APIContext
+// APIContext indicates an expected call of APIContext.
 func (mr *MockContextMockRecorder) APIContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIContext", reflect.TypeOf((*MockContext)(nil).APIContext))
 }
 
-// APIState mocks base method
+// APIState mocks base method.
 func (m *MockContext) APIState() base.APICaller {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIState")
 	ret0, _ := ret[0].(base.APICaller)
 	return ret0
 }
 
-// APIState indicates an expected call of APIState
+// APIState indicates an expected call of APIState.
 func (mr *MockContextMockRecorder) APIState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIState", reflect.TypeOf((*MockContext)(nil).APIState))
 }
 
-// AgentConfig mocks base method
+// AgentConfig mocks base method.
 func (m *MockContext) AgentConfig() agent.ConfigSetter {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AgentConfig")
 	ret0, _ := ret[0].(agent.ConfigSetter)
 	return ret0
 }
 
-// AgentConfig indicates an expected call of AgentConfig
+// AgentConfig indicates an expected call of AgentConfig.
 func (mr *MockContextMockRecorder) AgentConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentConfig", reflect.TypeOf((*MockContext)(nil).AgentConfig))
 }
 
-// State mocks base method
+// State mocks base method.
 func (m *MockContext) State() upgrades.StateBackend {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State")
 	ret0, _ := ret[0].(upgrades.StateBackend)
 	return ret0
 }
 
-// State indicates an expected call of State
+// State indicates an expected call of State.
 func (mr *MockContextMockRecorder) State() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockContext)(nil).State))
 }
 
-// StateContext mocks base method
+// StateContext mocks base method.
 func (m *MockContext) StateContext() upgrades.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateContext")
 	ret0, _ := ret[0].(upgrades.Context)
 	return ret0
 }
 
-// StateContext indicates an expected call of StateContext
+// StateContext indicates an expected call of StateContext.
 func (mr *MockContextMockRecorder) StateContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateContext", reflect.TypeOf((*MockContext)(nil).StateContext))
 }

--- a/upgrades/mocks/upgradestepsclient_mock.go
+++ b/upgrades/mocks/upgradestepsclient_mock.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
-	reflect "reflect"
 )
 
-// MockUpgradeStepsClient is a mock of UpgradeStepsClient interface
+// MockUpgradeStepsClient is a mock of UpgradeStepsClient interface.
 type MockUpgradeStepsClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeStepsClientMockRecorder
 }
 
-// MockUpgradeStepsClientMockRecorder is the mock recorder for MockUpgradeStepsClient
+// MockUpgradeStepsClientMockRecorder is the mock recorder for MockUpgradeStepsClient.
 type MockUpgradeStepsClientMockRecorder struct {
 	mock *MockUpgradeStepsClient
 }
 
-// NewMockUpgradeStepsClient creates a new mock instance
+// NewMockUpgradeStepsClient creates a new mock instance.
 func NewMockUpgradeStepsClient(ctrl *gomock.Controller) *MockUpgradeStepsClient {
 	mock := &MockUpgradeStepsClient{ctrl: ctrl}
 	mock.recorder = &MockUpgradeStepsClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeStepsClient) EXPECT() *MockUpgradeStepsClientMockRecorder {
 	return m.recorder
 }
 
-// WriteAgentState mocks base method
+// WriteAgentState mocks base method.
 func (m *MockUpgradeStepsClient) WriteAgentState(arg0 []params.SetUnitStateArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAgentState", arg0)
@@ -41,7 +42,7 @@ func (m *MockUpgradeStepsClient) WriteAgentState(arg0 []params.SetUnitStateArg) 
 	return ret0
 }
 
-// WriteAgentState indicates an expected call of WriteAgentState
+// WriteAgentState indicates an expected call of WriteAgentState.
 func (mr *MockUpgradeStepsClientMockRecorder) WriteAgentState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAgentState", reflect.TypeOf((*MockUpgradeStepsClient)(nil).WriteAgentState), arg0)

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -243,7 +243,10 @@ func (w *Worker) doSUCCESS(status watcher.MigrationStatus) error {
 	}
 
 	err = w.config.Agent.ChangeConfig(func(conf agent.ConfigSetter) error {
-		conf.SetAPIHostPorts([]network.HostPorts{hps.HostPorts()})
+		err := conf.SetAPIHostPorts([]network.HostPorts{hps.HostPorts()})
+		if err != nil {
+			return errors.Trace(err)
+		}
 		conf.SetCACert(status.TargetCACert)
 		return nil
 	})

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -443,7 +443,7 @@ type stubAgentConfig struct {
 	caCert string
 }
 
-func (mc *stubAgentConfig) SetAPIHostPorts(servers []network.HostPorts) {
+func (mc *stubAgentConfig) SetAPIHostPorts(servers []network.HostPorts) error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.addrs = nil
@@ -452,6 +452,7 @@ func (mc *stubAgentConfig) SetAPIHostPorts(servers []network.HostPorts) {
 			mc.addrs = append(mc.addrs, network.DialAddress(hp))
 		}
 	}
+	return nil
 }
 
 func (mc *stubAgentConfig) SetCACert(cert string) {

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -19,30 +19,30 @@ import (
 	version "github.com/juju/version/v2"
 )
 
-// MockAgent is a mock of Agent interface
+// MockAgent is a mock of Agent interface.
 type MockAgent struct {
 	ctrl     *gomock.Controller
 	recorder *MockAgentMockRecorder
 }
 
-// MockAgentMockRecorder is the mock recorder for MockAgent
+// MockAgentMockRecorder is the mock recorder for MockAgent.
 type MockAgentMockRecorder struct {
 	mock *MockAgent
 }
 
-// NewMockAgent creates a new mock instance
+// NewMockAgent creates a new mock instance.
 func NewMockAgent(ctrl *gomock.Controller) *MockAgent {
 	mock := &MockAgent{ctrl: ctrl}
 	mock.recorder = &MockAgentMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 	return m.recorder
 }
 
-// ChangeConfig mocks base method
+// ChangeConfig mocks base method.
 func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeConfig", arg0)
@@ -50,13 +50,13 @@ func (m *MockAgent) ChangeConfig(arg0 agent.ConfigMutator) error {
 	return ret0
 }
 
-// ChangeConfig indicates an expected call of ChangeConfig
+// ChangeConfig indicates an expected call of ChangeConfig.
 func (mr *MockAgentMockRecorder) ChangeConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeConfig", reflect.TypeOf((*MockAgent)(nil).ChangeConfig), arg0)
 }
 
-// CurrentConfig mocks base method
+// CurrentConfig mocks base method.
 func (m *MockAgent) CurrentConfig() agent.Config {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentConfig")
@@ -64,36 +64,36 @@ func (m *MockAgent) CurrentConfig() agent.Config {
 	return ret0
 }
 
-// CurrentConfig indicates an expected call of CurrentConfig
+// CurrentConfig indicates an expected call of CurrentConfig.
 func (mr *MockAgentMockRecorder) CurrentConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentConfig", reflect.TypeOf((*MockAgent)(nil).CurrentConfig))
 }
 
-// MockConfig is a mock of Config interface
+// MockConfig is a mock of Config interface.
 type MockConfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockConfigMockRecorder
 }
 
-// MockConfigMockRecorder is the mock recorder for MockConfig
+// MockConfigMockRecorder is the mock recorder for MockConfig.
 type MockConfigMockRecorder struct {
 	mock *MockConfig
 }
 
-// NewMockConfig creates a new mock instance
+// NewMockConfig creates a new mock instance.
 func NewMockConfig(ctrl *gomock.Controller) *MockConfig {
 	mock := &MockConfig{ctrl: ctrl}
 	mock.recorder = &MockConfigMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConfig) EXPECT() *MockConfigMockRecorder {
 	return m.recorder
 }
 
-// APIAddresses mocks base method
+// APIAddresses mocks base method.
 func (m *MockConfig) APIAddresses() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
@@ -102,13 +102,13 @@ func (m *MockConfig) APIAddresses() ([]string, error) {
 	return ret0, ret1
 }
 
-// APIAddresses indicates an expected call of APIAddresses
+// APIAddresses indicates an expected call of APIAddresses.
 func (mr *MockConfigMockRecorder) APIAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfig)(nil).APIAddresses))
 }
 
-// APIInfo mocks base method
+// APIInfo mocks base method.
 func (m *MockConfig) APIInfo() (*api.Info, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
@@ -117,13 +117,13 @@ func (m *MockConfig) APIInfo() (*api.Info, bool) {
 	return ret0, ret1
 }
 
-// APIInfo indicates an expected call of APIInfo
+// APIInfo indicates an expected call of APIInfo.
 func (mr *MockConfigMockRecorder) APIInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfig)(nil).APIInfo))
 }
 
-// CACert mocks base method
+// CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
@@ -131,13 +131,13 @@ func (m *MockConfig) CACert() string {
 	return ret0
 }
 
-// CACert indicates an expected call of CACert
+// CACert indicates an expected call of CACert.
 func (mr *MockConfigMockRecorder) CACert() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfig)(nil).CACert))
 }
 
-// Controller mocks base method
+// Controller mocks base method.
 func (m *MockConfig) Controller() names.ControllerTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
@@ -145,13 +145,13 @@ func (m *MockConfig) Controller() names.ControllerTag {
 	return ret0
 }
 
-// Controller indicates an expected call of Controller
+// Controller indicates an expected call of Controller.
 func (mr *MockConfigMockRecorder) Controller() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfig)(nil).Controller))
 }
 
-// DataDir mocks base method
+// DataDir mocks base method.
 func (m *MockConfig) DataDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
@@ -159,13 +159,13 @@ func (m *MockConfig) DataDir() string {
 	return ret0
 }
 
-// DataDir indicates an expected call of DataDir
+// DataDir indicates an expected call of DataDir.
 func (mr *MockConfigMockRecorder) DataDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfig)(nil).DataDir))
 }
 
-// Dir mocks base method
+// Dir mocks base method.
 func (m *MockConfig) Dir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
@@ -173,13 +173,13 @@ func (m *MockConfig) Dir() string {
 	return ret0
 }
 
-// Dir indicates an expected call of Dir
+// Dir indicates an expected call of Dir.
 func (mr *MockConfigMockRecorder) Dir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfig)(nil).Dir))
 }
 
-// Jobs mocks base method
+// Jobs mocks base method.
 func (m *MockConfig) Jobs() []model.MachineJob {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
@@ -187,13 +187,13 @@ func (m *MockConfig) Jobs() []model.MachineJob {
 	return ret0
 }
 
-// Jobs indicates an expected call of Jobs
+// Jobs indicates an expected call of Jobs.
 func (mr *MockConfigMockRecorder) Jobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfig)(nil).Jobs))
 }
 
-// JujuDBSnapChannel mocks base method
+// JujuDBSnapChannel mocks base method.
 func (m *MockConfig) JujuDBSnapChannel() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
@@ -201,13 +201,13 @@ func (m *MockConfig) JujuDBSnapChannel() string {
 	return ret0
 }
 
-// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
+// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel.
 func (mr *MockConfigMockRecorder) JujuDBSnapChannel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfig)(nil).JujuDBSnapChannel))
 }
 
-// LogDir mocks base method
+// LogDir mocks base method.
 func (m *MockConfig) LogDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
@@ -215,13 +215,13 @@ func (m *MockConfig) LogDir() string {
 	return ret0
 }
 
-// LogDir indicates an expected call of LogDir
+// LogDir indicates an expected call of LogDir.
 func (mr *MockConfigMockRecorder) LogDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfig)(nil).LogDir))
 }
 
-// LoggingConfig mocks base method
+// LoggingConfig mocks base method.
 func (m *MockConfig) LoggingConfig() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
@@ -229,13 +229,13 @@ func (m *MockConfig) LoggingConfig() string {
 	return ret0
 }
 
-// LoggingConfig indicates an expected call of LoggingConfig
+// LoggingConfig indicates an expected call of LoggingConfig.
 func (mr *MockConfigMockRecorder) LoggingConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfig)(nil).LoggingConfig))
 }
 
-// MetricsSpoolDir mocks base method
+// MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
@@ -243,13 +243,13 @@ func (m *MockConfig) MetricsSpoolDir() string {
 	return ret0
 }
 
-// MetricsSpoolDir indicates an expected call of MetricsSpoolDir
+// MetricsSpoolDir indicates an expected call of MetricsSpoolDir.
 func (mr *MockConfigMockRecorder) MetricsSpoolDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfig)(nil).MetricsSpoolDir))
 }
 
-// Model mocks base method
+// Model mocks base method.
 func (m *MockConfig) Model() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
@@ -257,13 +257,13 @@ func (m *MockConfig) Model() names.ModelTag {
 	return ret0
 }
 
-// Model indicates an expected call of Model
+// Model indicates an expected call of Model.
 func (mr *MockConfigMockRecorder) Model() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfig)(nil).Model))
 }
 
-// MongoInfo mocks base method
+// MongoInfo mocks base method.
 func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
@@ -272,13 +272,13 @@ func (m *MockConfig) MongoInfo() (*mongo.MongoInfo, bool) {
 	return ret0, ret1
 }
 
-// MongoInfo indicates an expected call of MongoInfo
+// MongoInfo indicates an expected call of MongoInfo.
 func (mr *MockConfigMockRecorder) MongoInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfig)(nil).MongoInfo))
 }
 
-// MongoMemoryProfile mocks base method
+// MongoMemoryProfile mocks base method.
 func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
@@ -286,13 +286,13 @@ func (m *MockConfig) MongoMemoryProfile() mongo.MemoryProfile {
 	return ret0
 }
 
-// MongoMemoryProfile indicates an expected call of MongoMemoryProfile
+// MongoMemoryProfile indicates an expected call of MongoMemoryProfile.
 func (mr *MockConfigMockRecorder) MongoMemoryProfile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfig)(nil).MongoMemoryProfile))
 }
 
-// MongoVersion mocks base method
+// MongoVersion mocks base method.
 func (m *MockConfig) MongoVersion() mongo.Version {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
@@ -300,13 +300,13 @@ func (m *MockConfig) MongoVersion() mongo.Version {
 	return ret0
 }
 
-// MongoVersion indicates an expected call of MongoVersion
+// MongoVersion indicates an expected call of MongoVersion.
 func (mr *MockConfigMockRecorder) MongoVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfig)(nil).MongoVersion))
 }
 
-// NonSyncedWritesToRaftLog mocks base method
+// NonSyncedWritesToRaftLog mocks base method.
 func (m *MockConfig) NonSyncedWritesToRaftLog() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NonSyncedWritesToRaftLog")
@@ -314,13 +314,13 @@ func (m *MockConfig) NonSyncedWritesToRaftLog() bool {
 	return ret0
 }
 
-// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog
+// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog.
 func (mr *MockConfigMockRecorder) NonSyncedWritesToRaftLog() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfig)(nil).NonSyncedWritesToRaftLog))
 }
 
-// Nonce mocks base method
+// Nonce mocks base method.
 func (m *MockConfig) Nonce() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
@@ -328,13 +328,13 @@ func (m *MockConfig) Nonce() string {
 	return ret0
 }
 
-// Nonce indicates an expected call of Nonce
+// Nonce indicates an expected call of Nonce.
 func (mr *MockConfigMockRecorder) Nonce() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfig)(nil).Nonce))
 }
 
-// OldPassword mocks base method
+// OldPassword mocks base method.
 func (m *MockConfig) OldPassword() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
@@ -342,13 +342,13 @@ func (m *MockConfig) OldPassword() string {
 	return ret0
 }
 
-// OldPassword indicates an expected call of OldPassword
+// OldPassword indicates an expected call of OldPassword.
 func (mr *MockConfigMockRecorder) OldPassword() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfig)(nil).OldPassword))
 }
 
-// StateServingInfo mocks base method
+// StateServingInfo mocks base method.
 func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
@@ -357,13 +357,13 @@ func (m *MockConfig) StateServingInfo() (controller.StateServingInfo, bool) {
 	return ret0, ret1
 }
 
-// StateServingInfo indicates an expected call of StateServingInfo
+// StateServingInfo indicates an expected call of StateServingInfo.
 func (mr *MockConfigMockRecorder) StateServingInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfig)(nil).StateServingInfo))
 }
 
-// SystemIdentityPath mocks base method
+// SystemIdentityPath mocks base method.
 func (m *MockConfig) SystemIdentityPath() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
@@ -371,13 +371,13 @@ func (m *MockConfig) SystemIdentityPath() string {
 	return ret0
 }
 
-// SystemIdentityPath indicates an expected call of SystemIdentityPath
+// SystemIdentityPath indicates an expected call of SystemIdentityPath.
 func (mr *MockConfigMockRecorder) SystemIdentityPath() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfig)(nil).SystemIdentityPath))
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockConfig) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -385,13 +385,13 @@ func (m *MockConfig) Tag() names.Tag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockConfigMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfig)(nil).Tag))
 }
 
-// TransientDataDir mocks base method
+// TransientDataDir mocks base method.
 func (m *MockConfig) TransientDataDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
@@ -399,13 +399,13 @@ func (m *MockConfig) TransientDataDir() string {
 	return ret0
 }
 
-// TransientDataDir indicates an expected call of TransientDataDir
+// TransientDataDir indicates an expected call of TransientDataDir.
 func (mr *MockConfigMockRecorder) TransientDataDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfig)(nil).TransientDataDir))
 }
 
-// UpgradedToVersion mocks base method
+// UpgradedToVersion mocks base method.
 func (m *MockConfig) UpgradedToVersion() version.Number {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
@@ -413,13 +413,13 @@ func (m *MockConfig) UpgradedToVersion() version.Number {
 	return ret0
 }
 
-// UpgradedToVersion indicates an expected call of UpgradedToVersion
+// UpgradedToVersion indicates an expected call of UpgradedToVersion.
 func (mr *MockConfigMockRecorder) UpgradedToVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfig)(nil).UpgradedToVersion))
 }
 
-// Value mocks base method
+// Value mocks base method.
 func (m *MockConfig) Value(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
@@ -427,13 +427,13 @@ func (m *MockConfig) Value(arg0 string) string {
 	return ret0
 }
 
-// Value indicates an expected call of Value
+// Value indicates an expected call of Value.
 func (mr *MockConfigMockRecorder) Value(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfig)(nil).Value), arg0)
 }
 
-// WriteCommands mocks base method
+// WriteCommands mocks base method.
 func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
@@ -442,36 +442,36 @@ func (m *MockConfig) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 	return ret0, ret1
 }
 
-// WriteCommands indicates an expected call of WriteCommands
+// WriteCommands indicates an expected call of WriteCommands.
 func (mr *MockConfigMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfig)(nil).WriteCommands), arg0)
 }
 
-// MockConfigSetter is a mock of ConfigSetter interface
+// MockConfigSetter is a mock of ConfigSetter interface.
 type MockConfigSetter struct {
 	ctrl     *gomock.Controller
 	recorder *MockConfigSetterMockRecorder
 }
 
-// MockConfigSetterMockRecorder is the mock recorder for MockConfigSetter
+// MockConfigSetterMockRecorder is the mock recorder for MockConfigSetter.
 type MockConfigSetterMockRecorder struct {
 	mock *MockConfigSetter
 }
 
-// NewMockConfigSetter creates a new mock instance
+// NewMockConfigSetter creates a new mock instance.
 func NewMockConfigSetter(ctrl *gomock.Controller) *MockConfigSetter {
 	mock := &MockConfigSetter{ctrl: ctrl}
 	mock.recorder = &MockConfigSetterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConfigSetter) EXPECT() *MockConfigSetterMockRecorder {
 	return m.recorder
 }
 
-// APIAddresses mocks base method
+// APIAddresses mocks base method.
 func (m *MockConfigSetter) APIAddresses() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIAddresses")
@@ -480,13 +480,13 @@ func (m *MockConfigSetter) APIAddresses() ([]string, error) {
 	return ret0, ret1
 }
 
-// APIAddresses indicates an expected call of APIAddresses
+// APIAddresses indicates an expected call of APIAddresses.
 func (mr *MockConfigSetterMockRecorder) APIAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockConfigSetter)(nil).APIAddresses))
 }
 
-// APIInfo mocks base method
+// APIInfo mocks base method.
 func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "APIInfo")
@@ -495,13 +495,13 @@ func (m *MockConfigSetter) APIInfo() (*api.Info, bool) {
 	return ret0, ret1
 }
 
-// APIInfo indicates an expected call of APIInfo
+// APIInfo indicates an expected call of APIInfo.
 func (mr *MockConfigSetterMockRecorder) APIInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIInfo", reflect.TypeOf((*MockConfigSetter)(nil).APIInfo))
 }
 
-// CACert mocks base method
+// CACert mocks base method.
 func (m *MockConfigSetter) CACert() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
@@ -509,13 +509,13 @@ func (m *MockConfigSetter) CACert() string {
 	return ret0
 }
 
-// CACert indicates an expected call of CACert
+// CACert indicates an expected call of CACert.
 func (mr *MockConfigSetterMockRecorder) CACert() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockConfigSetter)(nil).CACert))
 }
 
-// Clone mocks base method
+// Clone mocks base method.
 func (m *MockConfigSetter) Clone() agent.Config {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone")
@@ -523,13 +523,13 @@ func (m *MockConfigSetter) Clone() agent.Config {
 	return ret0
 }
 
-// Clone indicates an expected call of Clone
+// Clone indicates an expected call of Clone.
 func (mr *MockConfigSetterMockRecorder) Clone() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockConfigSetter)(nil).Clone))
 }
 
-// Controller mocks base method
+// Controller mocks base method.
 func (m *MockConfigSetter) Controller() names.ControllerTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Controller")
@@ -537,13 +537,13 @@ func (m *MockConfigSetter) Controller() names.ControllerTag {
 	return ret0
 }
 
-// Controller indicates an expected call of Controller
+// Controller indicates an expected call of Controller.
 func (mr *MockConfigSetterMockRecorder) Controller() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockConfigSetter)(nil).Controller))
 }
 
-// DataDir mocks base method
+// DataDir mocks base method.
 func (m *MockConfigSetter) DataDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DataDir")
@@ -551,13 +551,13 @@ func (m *MockConfigSetter) DataDir() string {
 	return ret0
 }
 
-// DataDir indicates an expected call of DataDir
+// DataDir indicates an expected call of DataDir.
 func (mr *MockConfigSetterMockRecorder) DataDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataDir", reflect.TypeOf((*MockConfigSetter)(nil).DataDir))
 }
 
-// Dir mocks base method
+// Dir mocks base method.
 func (m *MockConfigSetter) Dir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dir")
@@ -565,13 +565,13 @@ func (m *MockConfigSetter) Dir() string {
 	return ret0
 }
 
-// Dir indicates an expected call of Dir
+// Dir indicates an expected call of Dir.
 func (mr *MockConfigSetterMockRecorder) Dir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dir", reflect.TypeOf((*MockConfigSetter)(nil).Dir))
 }
 
-// Jobs mocks base method
+// Jobs mocks base method.
 func (m *MockConfigSetter) Jobs() []model.MachineJob {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
@@ -579,13 +579,13 @@ func (m *MockConfigSetter) Jobs() []model.MachineJob {
 	return ret0
 }
 
-// Jobs indicates an expected call of Jobs
+// Jobs indicates an expected call of Jobs.
 func (mr *MockConfigSetterMockRecorder) Jobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockConfigSetter)(nil).Jobs))
 }
 
-// JujuDBSnapChannel mocks base method
+// JujuDBSnapChannel mocks base method.
 func (m *MockConfigSetter) JujuDBSnapChannel() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JujuDBSnapChannel")
@@ -593,13 +593,13 @@ func (m *MockConfigSetter) JujuDBSnapChannel() string {
 	return ret0
 }
 
-// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel
+// JujuDBSnapChannel indicates an expected call of JujuDBSnapChannel.
 func (mr *MockConfigSetterMockRecorder) JujuDBSnapChannel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JujuDBSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).JujuDBSnapChannel))
 }
 
-// LogDir mocks base method
+// LogDir mocks base method.
 func (m *MockConfigSetter) LogDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogDir")
@@ -607,13 +607,13 @@ func (m *MockConfigSetter) LogDir() string {
 	return ret0
 }
 
-// LogDir indicates an expected call of LogDir
+// LogDir indicates an expected call of LogDir.
 func (mr *MockConfigSetterMockRecorder) LogDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDir", reflect.TypeOf((*MockConfigSetter)(nil).LogDir))
 }
 
-// LoggingConfig mocks base method
+// LoggingConfig mocks base method.
 func (m *MockConfigSetter) LoggingConfig() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoggingConfig")
@@ -621,13 +621,13 @@ func (m *MockConfigSetter) LoggingConfig() string {
 	return ret0
 }
 
-// LoggingConfig indicates an expected call of LoggingConfig
+// LoggingConfig indicates an expected call of LoggingConfig.
 func (mr *MockConfigSetterMockRecorder) LoggingConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).LoggingConfig))
 }
 
-// MetricsSpoolDir mocks base method
+// MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MetricsSpoolDir")
@@ -635,13 +635,13 @@ func (m *MockConfigSetter) MetricsSpoolDir() string {
 	return ret0
 }
 
-// MetricsSpoolDir indicates an expected call of MetricsSpoolDir
+// MetricsSpoolDir indicates an expected call of MetricsSpoolDir.
 func (mr *MockConfigSetterMockRecorder) MetricsSpoolDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsSpoolDir", reflect.TypeOf((*MockConfigSetter)(nil).MetricsSpoolDir))
 }
 
-// Model mocks base method
+// Model mocks base method.
 func (m *MockConfigSetter) Model() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
@@ -649,13 +649,13 @@ func (m *MockConfigSetter) Model() names.ModelTag {
 	return ret0
 }
 
-// Model indicates an expected call of Model
+// Model indicates an expected call of Model.
 func (mr *MockConfigSetterMockRecorder) Model() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockConfigSetter)(nil).Model))
 }
 
-// MongoInfo mocks base method
+// MongoInfo mocks base method.
 func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoInfo")
@@ -664,13 +664,13 @@ func (m *MockConfigSetter) MongoInfo() (*mongo.MongoInfo, bool) {
 	return ret0, ret1
 }
 
-// MongoInfo indicates an expected call of MongoInfo
+// MongoInfo indicates an expected call of MongoInfo.
 func (mr *MockConfigSetterMockRecorder) MongoInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoInfo", reflect.TypeOf((*MockConfigSetter)(nil).MongoInfo))
 }
 
-// MongoMemoryProfile mocks base method
+// MongoMemoryProfile mocks base method.
 func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoMemoryProfile")
@@ -678,13 +678,13 @@ func (m *MockConfigSetter) MongoMemoryProfile() mongo.MemoryProfile {
 	return ret0
 }
 
-// MongoMemoryProfile indicates an expected call of MongoMemoryProfile
+// MongoMemoryProfile indicates an expected call of MongoMemoryProfile.
 func (mr *MockConfigSetterMockRecorder) MongoMemoryProfile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).MongoMemoryProfile))
 }
 
-// MongoVersion mocks base method
+// MongoVersion mocks base method.
 func (m *MockConfigSetter) MongoVersion() mongo.Version {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MongoVersion")
@@ -692,13 +692,13 @@ func (m *MockConfigSetter) MongoVersion() mongo.Version {
 	return ret0
 }
 
-// MongoVersion indicates an expected call of MongoVersion
+// MongoVersion indicates an expected call of MongoVersion.
 func (mr *MockConfigSetterMockRecorder) MongoVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).MongoVersion))
 }
 
-// NonSyncedWritesToRaftLog mocks base method
+// NonSyncedWritesToRaftLog mocks base method.
 func (m *MockConfigSetter) NonSyncedWritesToRaftLog() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NonSyncedWritesToRaftLog")
@@ -706,13 +706,13 @@ func (m *MockConfigSetter) NonSyncedWritesToRaftLog() bool {
 	return ret0
 }
 
-// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog
+// NonSyncedWritesToRaftLog indicates an expected call of NonSyncedWritesToRaftLog.
 func (mr *MockConfigSetterMockRecorder) NonSyncedWritesToRaftLog() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfigSetter)(nil).NonSyncedWritesToRaftLog))
 }
 
-// Nonce mocks base method
+// Nonce mocks base method.
 func (m *MockConfigSetter) Nonce() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
@@ -720,13 +720,13 @@ func (m *MockConfigSetter) Nonce() string {
 	return ret0
 }
 
-// Nonce indicates an expected call of Nonce
+// Nonce indicates an expected call of Nonce.
 func (mr *MockConfigSetterMockRecorder) Nonce() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockConfigSetter)(nil).Nonce))
 }
 
-// OldPassword mocks base method
+// OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OldPassword")
@@ -734,169 +734,171 @@ func (m *MockConfigSetter) OldPassword() string {
 	return ret0
 }
 
-// OldPassword indicates an expected call of OldPassword
+// OldPassword indicates an expected call of OldPassword.
 func (mr *MockConfigSetterMockRecorder) OldPassword() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OldPassword", reflect.TypeOf((*MockConfigSetter)(nil).OldPassword))
 }
 
-// SetAPIHostPorts mocks base method
-func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) {
+// SetAPIHostPorts mocks base method.
+func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetAPIHostPorts", arg0)
+	ret := m.ctrl.Call(m, "SetAPIHostPorts", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// SetAPIHostPorts indicates an expected call of SetAPIHostPorts
+// SetAPIHostPorts indicates an expected call of SetAPIHostPorts.
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
 }
 
-// SetCACert mocks base method
+// SetCACert mocks base method.
 func (m *MockConfigSetter) SetCACert(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCACert", arg0)
 }
 
-// SetCACert indicates an expected call of SetCACert
+// SetCACert indicates an expected call of SetCACert.
 func (mr *MockConfigSetterMockRecorder) SetCACert(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCACert", reflect.TypeOf((*MockConfigSetter)(nil).SetCACert), arg0)
 }
 
-// SetControllerAPIPort mocks base method
+// SetControllerAPIPort mocks base method.
 func (m *MockConfigSetter) SetControllerAPIPort(arg0 int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetControllerAPIPort", arg0)
 }
 
-// SetControllerAPIPort indicates an expected call of SetControllerAPIPort
+// SetControllerAPIPort indicates an expected call of SetControllerAPIPort.
 func (mr *MockConfigSetterMockRecorder) SetControllerAPIPort(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetControllerAPIPort", reflect.TypeOf((*MockConfigSetter)(nil).SetControllerAPIPort), arg0)
 }
 
-// SetJujuDBSnapChannel mocks base method
+// SetJujuDBSnapChannel mocks base method.
 func (m *MockConfigSetter) SetJujuDBSnapChannel(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetJujuDBSnapChannel", arg0)
 }
 
-// SetJujuDBSnapChannel indicates an expected call of SetJujuDBSnapChannel
+// SetJujuDBSnapChannel indicates an expected call of SetJujuDBSnapChannel.
 func (mr *MockConfigSetterMockRecorder) SetJujuDBSnapChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetJujuDBSnapChannel", reflect.TypeOf((*MockConfigSetter)(nil).SetJujuDBSnapChannel), arg0)
 }
 
-// SetLoggingConfig mocks base method
+// SetLoggingConfig mocks base method.
 func (m *MockConfigSetter) SetLoggingConfig(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetLoggingConfig", arg0)
 }
 
-// SetLoggingConfig indicates an expected call of SetLoggingConfig
+// SetLoggingConfig indicates an expected call of SetLoggingConfig.
 func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoggingConfig", reflect.TypeOf((*MockConfigSetter)(nil).SetLoggingConfig), arg0)
 }
 
-// SetMongoMemoryProfile mocks base method
+// SetMongoMemoryProfile mocks base method.
 func (m *MockConfigSetter) SetMongoMemoryProfile(arg0 mongo.MemoryProfile) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoMemoryProfile", arg0)
 }
 
-// SetMongoMemoryProfile indicates an expected call of SetMongoMemoryProfile
+// SetMongoMemoryProfile indicates an expected call of SetMongoMemoryProfile.
 func (mr *MockConfigSetterMockRecorder) SetMongoMemoryProfile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoMemoryProfile", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoMemoryProfile), arg0)
 }
 
-// SetMongoVersion mocks base method
+// SetMongoVersion mocks base method.
 func (m *MockConfigSetter) SetMongoVersion(arg0 mongo.Version) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMongoVersion", arg0)
 }
 
-// SetMongoVersion indicates an expected call of SetMongoVersion
+// SetMongoVersion indicates an expected call of SetMongoVersion.
 func (mr *MockConfigSetterMockRecorder) SetMongoVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMongoVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetMongoVersion), arg0)
 }
 
-// SetNonSyncedWritesToRaftLog mocks base method
+// SetNonSyncedWritesToRaftLog mocks base method.
 func (m *MockConfigSetter) SetNonSyncedWritesToRaftLog(arg0 bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetNonSyncedWritesToRaftLog", arg0)
 }
 
-// SetNonSyncedWritesToRaftLog indicates an expected call of SetNonSyncedWritesToRaftLog
+// SetNonSyncedWritesToRaftLog indicates an expected call of SetNonSyncedWritesToRaftLog.
 func (mr *MockConfigSetterMockRecorder) SetNonSyncedWritesToRaftLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonSyncedWritesToRaftLog", reflect.TypeOf((*MockConfigSetter)(nil).SetNonSyncedWritesToRaftLog), arg0)
 }
 
-// SetOldPassword mocks base method
+// SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetOldPassword", arg0)
 }
 
-// SetOldPassword indicates an expected call of SetOldPassword
+// SetOldPassword indicates an expected call of SetOldPassword.
 func (mr *MockConfigSetterMockRecorder) SetOldPassword(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOldPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetOldPassword), arg0)
 }
 
-// SetPassword mocks base method
+// SetPassword mocks base method.
 func (m *MockConfigSetter) SetPassword(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPassword", arg0)
 }
 
-// SetPassword indicates an expected call of SetPassword
+// SetPassword indicates an expected call of SetPassword.
 func (mr *MockConfigSetterMockRecorder) SetPassword(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockConfigSetter)(nil).SetPassword), arg0)
 }
 
-// SetStateServingInfo mocks base method
+// SetStateServingInfo mocks base method.
 func (m *MockConfigSetter) SetStateServingInfo(arg0 controller.StateServingInfo) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetStateServingInfo", arg0)
 }
 
-// SetStateServingInfo indicates an expected call of SetStateServingInfo
+// SetStateServingInfo indicates an expected call of SetStateServingInfo.
 func (mr *MockConfigSetterMockRecorder) SetStateServingInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).SetStateServingInfo), arg0)
 }
 
-// SetUpgradedToVersion mocks base method
+// SetUpgradedToVersion mocks base method.
 func (m *MockConfigSetter) SetUpgradedToVersion(arg0 version.Number) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetUpgradedToVersion", arg0)
 }
 
-// SetUpgradedToVersion indicates an expected call of SetUpgradedToVersion
+// SetUpgradedToVersion indicates an expected call of SetUpgradedToVersion.
 func (mr *MockConfigSetterMockRecorder) SetUpgradedToVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).SetUpgradedToVersion), arg0)
 }
 
-// SetValue mocks base method
+// SetValue mocks base method.
 func (m *MockConfigSetter) SetValue(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetValue", arg0, arg1)
 }
 
-// SetValue indicates an expected call of SetValue
+// SetValue indicates an expected call of SetValue.
 func (mr *MockConfigSetterMockRecorder) SetValue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValue", reflect.TypeOf((*MockConfigSetter)(nil).SetValue), arg0, arg1)
 }
 
-// StateServingInfo mocks base method
+// StateServingInfo mocks base method.
 func (m *MockConfigSetter) StateServingInfo() (controller.StateServingInfo, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateServingInfo")
@@ -905,13 +907,13 @@ func (m *MockConfigSetter) StateServingInfo() (controller.StateServingInfo, bool
 	return ret0, ret1
 }
 
-// StateServingInfo indicates an expected call of StateServingInfo
+// StateServingInfo indicates an expected call of StateServingInfo.
 func (mr *MockConfigSetterMockRecorder) StateServingInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateServingInfo", reflect.TypeOf((*MockConfigSetter)(nil).StateServingInfo))
 }
 
-// SystemIdentityPath mocks base method
+// SystemIdentityPath mocks base method.
 func (m *MockConfigSetter) SystemIdentityPath() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SystemIdentityPath")
@@ -919,13 +921,13 @@ func (m *MockConfigSetter) SystemIdentityPath() string {
 	return ret0
 }
 
-// SystemIdentityPath indicates an expected call of SystemIdentityPath
+// SystemIdentityPath indicates an expected call of SystemIdentityPath.
 func (mr *MockConfigSetterMockRecorder) SystemIdentityPath() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SystemIdentityPath", reflect.TypeOf((*MockConfigSetter)(nil).SystemIdentityPath))
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockConfigSetter) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -933,13 +935,13 @@ func (m *MockConfigSetter) Tag() names.Tag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockConfigSetterMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockConfigSetter)(nil).Tag))
 }
 
-// TransientDataDir mocks base method
+// TransientDataDir mocks base method.
 func (m *MockConfigSetter) TransientDataDir() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransientDataDir")
@@ -947,13 +949,13 @@ func (m *MockConfigSetter) TransientDataDir() string {
 	return ret0
 }
 
-// TransientDataDir indicates an expected call of TransientDataDir
+// TransientDataDir indicates an expected call of TransientDataDir.
 func (mr *MockConfigSetterMockRecorder) TransientDataDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransientDataDir", reflect.TypeOf((*MockConfigSetter)(nil).TransientDataDir))
 }
 
-// UpgradedToVersion mocks base method
+// UpgradedToVersion mocks base method.
 func (m *MockConfigSetter) UpgradedToVersion() version.Number {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradedToVersion")
@@ -961,13 +963,13 @@ func (m *MockConfigSetter) UpgradedToVersion() version.Number {
 	return ret0
 }
 
-// UpgradedToVersion indicates an expected call of UpgradedToVersion
+// UpgradedToVersion indicates an expected call of UpgradedToVersion.
 func (mr *MockConfigSetterMockRecorder) UpgradedToVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradedToVersion", reflect.TypeOf((*MockConfigSetter)(nil).UpgradedToVersion))
 }
 
-// Value mocks base method
+// Value mocks base method.
 func (m *MockConfigSetter) Value(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
@@ -975,13 +977,13 @@ func (m *MockConfigSetter) Value(arg0 string) string {
 	return ret0
 }
 
-// Value indicates an expected call of Value
+// Value indicates an expected call of Value.
 func (mr *MockConfigSetterMockRecorder) Value(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockConfigSetter)(nil).Value), arg0)
 }
 
-// WriteCommands mocks base method
+// WriteCommands mocks base method.
 func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteCommands", arg0)
@@ -990,7 +992,7 @@ func (m *MockConfigSetter) WriteCommands(arg0 shell.Renderer) ([]string, error) 
 	return ret0, ret1
 }
 
-// WriteCommands indicates an expected call of WriteCommands
+// WriteCommands indicates an expected call of WriteCommands.
 func (mr *MockConfigSetterMockRecorder) WriteCommands(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteCommands", reflect.TypeOf((*MockConfigSetter)(nil).WriteCommands), arg0)

--- a/worker/upgradedatabase/mocks/lock.go
+++ b/worker/upgradedatabase/mocks/lock.go
@@ -5,63 +5,70 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockLock is a mock of Lock interface
+// MockLock is a mock of Lock interface.
 type MockLock struct {
 	ctrl     *gomock.Controller
 	recorder *MockLockMockRecorder
 }
 
-// MockLockMockRecorder is the mock recorder for MockLock
+// MockLockMockRecorder is the mock recorder for MockLock.
 type MockLockMockRecorder struct {
 	mock *MockLock
 }
 
-// NewMockLock creates a new mock instance
+// NewMockLock creates a new mock instance.
 func NewMockLock(ctrl *gomock.Controller) *MockLock {
 	mock := &MockLock{ctrl: ctrl}
 	mock.recorder = &MockLockMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLock) EXPECT() *MockLockMockRecorder {
 	return m.recorder
 }
 
-// IsUnlocked mocks base method
+// IsUnlocked mocks base method.
 func (m *MockLock) IsUnlocked() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUnlocked")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsUnlocked indicates an expected call of IsUnlocked
+// IsUnlocked indicates an expected call of IsUnlocked.
 func (mr *MockLockMockRecorder) IsUnlocked() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnlocked", reflect.TypeOf((*MockLock)(nil).IsUnlocked))
 }
 
-// Unlock mocks base method
+// Unlock mocks base method.
 func (m *MockLock) Unlock() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Unlock")
 }
 
-// Unlock indicates an expected call of Unlock
+// Unlock indicates an expected call of Unlock.
 func (mr *MockLockMockRecorder) Unlock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockLock)(nil).Unlock))
 }
 
-// Unlocked mocks base method
+// Unlocked mocks base method.
 func (m *MockLock) Unlocked() <-chan struct{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unlocked")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
-// Unlocked indicates an expected call of Unlocked
+// Unlocked indicates an expected call of Unlocked.
 func (mr *MockLockMockRecorder) Unlocked() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlocked", reflect.TypeOf((*MockLock)(nil).Unlocked))
 }

--- a/worker/upgradedatabase/mocks/package.go
+++ b/worker/upgradedatabase/mocks/package.go
@@ -5,39 +5,41 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	upgradedatabase "github.com/juju/juju/worker/upgradedatabase"
 	version "github.com/juju/version/v2"
-	reflect "reflect"
 )
 
-// MockLogger is a mock of Logger interface
+// MockLogger is a mock of Logger interface.
 type MockLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerMockRecorder
 }
 
-// MockLoggerMockRecorder is the mock recorder for MockLogger
+// MockLoggerMockRecorder is the mock recorder for MockLogger.
 type MockLoggerMockRecorder struct {
 	mock *MockLogger
 }
 
-// NewMockLogger creates a new mock instance
+// NewMockLogger creates a new mock instance.
 func NewMockLogger(ctrl *gomock.Controller) *MockLogger {
 	mock := &MockLogger{ctrl: ctrl}
 	mock.recorder = &MockLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
-// Debugf mocks base method
+// Debugf mocks base method.
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -45,14 +47,16 @@ func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Debugf", varargs...)
 }
 
-// Debugf indicates an expected call of Debugf
+// Debugf indicates an expected call of Debugf.
 func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
-// Errorf mocks base method
+// Errorf mocks base method.
 func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -60,14 +64,16 @@ func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Errorf", varargs...)
 }
 
-// Errorf indicates an expected call of Errorf
+// Errorf indicates an expected call of Errorf.
 func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
 }
 
-// Infof mocks base method
+// Infof mocks base method.
 func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
@@ -75,152 +81,169 @@ func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Infof", varargs...)
 }
 
-// Infof indicates an expected call of Infof
+// Infof indicates an expected call of Infof.
 func (mr *MockLoggerMockRecorder) Infof(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
 }
 
-// MockPool is a mock of Pool interface
+// MockPool is a mock of Pool interface.
 type MockPool struct {
 	ctrl     *gomock.Controller
 	recorder *MockPoolMockRecorder
 }
 
-// MockPoolMockRecorder is the mock recorder for MockPool
+// MockPoolMockRecorder is the mock recorder for MockPool.
 type MockPoolMockRecorder struct {
 	mock *MockPool
 }
 
-// NewMockPool creates a new mock instance
+// NewMockPool creates a new mock instance.
 func NewMockPool(ctrl *gomock.Controller) *MockPool {
 	mock := &MockPool{ctrl: ctrl}
 	mock.recorder = &MockPoolMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPool) EXPECT() *MockPoolMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockPool) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockPoolMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPool)(nil).Close))
 }
 
-// EnsureUpgradeInfo mocks base method
+// EnsureUpgradeInfo mocks base method.
 func (m *MockPool) EnsureUpgradeInfo(arg0 string, arg1, arg2 version.Number) (upgradedatabase.UpgradeInfo, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureUpgradeInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(upgradedatabase.UpgradeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EnsureUpgradeInfo indicates an expected call of EnsureUpgradeInfo
+// EnsureUpgradeInfo indicates an expected call of EnsureUpgradeInfo.
 func (mr *MockPoolMockRecorder) EnsureUpgradeInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUpgradeInfo", reflect.TypeOf((*MockPool)(nil).EnsureUpgradeInfo), arg0, arg1, arg2)
 }
 
-// IsPrimary mocks base method
+// IsPrimary mocks base method.
 func (m *MockPool) IsPrimary(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPrimary", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsPrimary indicates an expected call of IsPrimary
+// IsPrimary indicates an expected call of IsPrimary.
 func (mr *MockPoolMockRecorder) IsPrimary(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPrimary", reflect.TypeOf((*MockPool)(nil).IsPrimary), arg0)
 }
 
-// SetStatus mocks base method
+// SetStatus mocks base method.
 func (m *MockPool) SetStatus(arg0 string, arg1 status.Status, arg2 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetStatus indicates an expected call of SetStatus
+// SetStatus indicates an expected call of SetStatus.
 func (mr *MockPoolMockRecorder) SetStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockPool)(nil).SetStatus), arg0, arg1, arg2)
 }
 
-// MockUpgradeInfo is a mock of UpgradeInfo interface
+// MockUpgradeInfo is a mock of UpgradeInfo interface.
 type MockUpgradeInfo struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeInfoMockRecorder
 }
 
-// MockUpgradeInfoMockRecorder is the mock recorder for MockUpgradeInfo
+// MockUpgradeInfoMockRecorder is the mock recorder for MockUpgradeInfo.
 type MockUpgradeInfoMockRecorder struct {
 	mock *MockUpgradeInfo
 }
 
-// NewMockUpgradeInfo creates a new mock instance
+// NewMockUpgradeInfo creates a new mock instance.
 func NewMockUpgradeInfo(ctrl *gomock.Controller) *MockUpgradeInfo {
 	mock := &MockUpgradeInfo{ctrl: ctrl}
 	mock.recorder = &MockUpgradeInfoMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeInfo) EXPECT() *MockUpgradeInfoMockRecorder {
 	return m.recorder
 }
 
-// Refresh mocks base method
+// Refresh mocks base method.
 func (m *MockUpgradeInfo) Refresh() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Refresh")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Refresh indicates an expected call of Refresh
+// Refresh indicates an expected call of Refresh.
 func (mr *MockUpgradeInfoMockRecorder) Refresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockUpgradeInfo)(nil).Refresh))
 }
 
-// SetStatus mocks base method
+// SetStatus mocks base method.
 func (m *MockUpgradeInfo) SetStatus(arg0 state.UpgradeStatus) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStatus", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetStatus indicates an expected call of SetStatus
+// SetStatus indicates an expected call of SetStatus.
 func (mr *MockUpgradeInfoMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockUpgradeInfo)(nil).SetStatus), arg0)
 }
 
-// Status mocks base method
+// Status mocks base method.
 func (m *MockUpgradeInfo) Status() state.UpgradeStatus {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
 	ret0, _ := ret[0].(state.UpgradeStatus)
 	return ret0
 }
 
-// Status indicates an expected call of Status
+// Status indicates an expected call of Status.
 func (mr *MockUpgradeInfoMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockUpgradeInfo)(nil).Status))
 }
 
-// Watch mocks base method
+// Watch mocks base method.
 func (m *MockUpgradeInfo) Watch() state.NotifyWatcher {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch")
 	ret0, _ := ret[0].(state.NotifyWatcher)
 	return ret0
 }
 
-// Watch indicates an expected call of Watch
+// Watch indicates an expected call of Watch.
 func (mr *MockUpgradeInfoMockRecorder) Watch() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockUpgradeInfo)(nil).Watch))
 }

--- a/worker/upgradedatabase/mocks/watcher.go
+++ b/worker/upgradedatabase/mocks/watcher.go
@@ -5,87 +5,98 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockNotifyWatcher is a mock of NotifyWatcher interface
+// MockNotifyWatcher is a mock of NotifyWatcher interface.
 type MockNotifyWatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockNotifyWatcherMockRecorder
 }
 
-// MockNotifyWatcherMockRecorder is the mock recorder for MockNotifyWatcher
+// MockNotifyWatcherMockRecorder is the mock recorder for MockNotifyWatcher.
 type MockNotifyWatcherMockRecorder struct {
 	mock *MockNotifyWatcher
 }
 
-// NewMockNotifyWatcher creates a new mock instance
+// NewMockNotifyWatcher creates a new mock instance.
 func NewMockNotifyWatcher(ctrl *gomock.Controller) *MockNotifyWatcher {
 	mock := &MockNotifyWatcher{ctrl: ctrl}
 	mock.recorder = &MockNotifyWatcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNotifyWatcher) EXPECT() *MockNotifyWatcherMockRecorder {
 	return m.recorder
 }
 
-// Changes mocks base method
+// Changes mocks base method.
 func (m *MockNotifyWatcher) Changes() <-chan struct{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Changes")
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
-// Changes indicates an expected call of Changes
+// Changes indicates an expected call of Changes.
 func (mr *MockNotifyWatcherMockRecorder) Changes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Changes", reflect.TypeOf((*MockNotifyWatcher)(nil).Changes))
 }
 
-// Err mocks base method
+// Err mocks base method.
 func (m *MockNotifyWatcher) Err() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Err indicates an expected call of Err
+// Err indicates an expected call of Err.
 func (mr *MockNotifyWatcherMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockNotifyWatcher)(nil).Err))
 }
 
-// Kill mocks base method
+// Kill mocks base method.
 func (m *MockNotifyWatcher) Kill() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
-// Kill indicates an expected call of Kill
+// Kill indicates an expected call of Kill.
 func (mr *MockNotifyWatcherMockRecorder) Kill() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockNotifyWatcher)(nil).Kill))
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockNotifyWatcher) Stop() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockNotifyWatcherMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockNotifyWatcher)(nil).Stop))
 }
 
-// Wait mocks base method
+// Wait mocks base method.
 func (m *MockNotifyWatcher) Wait() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Wait indicates an expected call of Wait
+// Wait indicates an expected call of Wait.
 func (mr *MockNotifyWatcherMockRecorder) Wait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockNotifyWatcher)(nil).Wait))
 }


### PR DESCRIPTION
Fix nil pointer panic potential in MongoInfo.

SetAPIHostPorts should not be able to set the api details addresses to an empty slice, nor should it ignore addresses if api details is nil.  The later should not happen, there are checks to prevent it, but just in case.

## QA steps

No change to existing bootstrap nor deploy behavior.

## Bug reference

Related to https://bugs.launchpad.net/juju/+bug/1871224, though not a complete fix.
