### PR TITLE
Lower excessive test concurrency factor

### DIFF
--- a/state/action_test.go
+++ b/state/action_test.go
@@ -392,7 +392,7 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperationMany(c *gc.C) {
 	operationID, err := s.Model.EnqueueOperation("a test")
 	c.Assert(err, jc.ErrorIsNil)
 
-	numActions := 500
+	numActions := 100
 
 	wg := sync.WaitGroup{}
 	var actions []state.Action


### PR DESCRIPTION
Under https://github.com/juju/juju/pull/12857, the concurrency factor in `TestLastActionFinishCompletesOperationMany` was raised from 50 to 500.

This makes the test take too long to be valuable as a unit test.

Here we bring it back to a more reasonable 100.

## QA steps

Test still passes.

## Documentation changes

None

## Bug reference

N/A
