### PR TITLE
Packaging: Update packaging dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
 	github.com/juju/os/v2 v2.1.2
-	github.com/juju/packaging/v2 v2.0.0-20210622141625-c7a51bd50843
+	github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
 	github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/juju/os v0.0.0-20191022170002-da411304426c/go.mod h1:buR1fIbfLx3neIA/
 github.com/juju/os/v2 v2.0.0/go.mod h1:S/AadPYIeAZtep7zu519c+eWGWV7dVR+Hb8RTGBR1+I=
 github.com/juju/os/v2 v2.1.2 h1:RZ1mRJ/fx6O6KpLBLaNwMbb+EMI+iEfBPTdb3CWpi7w=
 github.com/juju/os/v2 v2.1.2/go.mod h1:S/AadPYIeAZtep7zu519c+eWGWV7dVR+Hb8RTGBR1+I=
-github.com/juju/packaging/v2 v2.0.0-20210622141625-c7a51bd50843 h1:jyAlb5SVhAeCoH3DkWFA6QvjNgh3ifVwlJkllp9khE0=
-github.com/juju/packaging/v2 v2.0.0-20210622141625-c7a51bd50843/go.mod h1:QkkuIt0as7ewiNyrDrr1MyyRm3TVrabyMsLQdr97Sx8=
+github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350 h1:WpkR19siuBHnaPfe8WochnyEtzVEYS7TlDoF/l83VUI=
+github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350/go.mod h1:QkkuIt0as7ewiNyrDrr1MyyRm3TVrabyMsLQdr97Sx8=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93/go.mod h1:zrbmo4nBKaiP/Ez3F67ewkMbzGYfXyMvRtbOfuAwG0w=
 github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSwAjh/uLXDM=


### PR DESCRIPTION
The following updates the packaging dependency to handle udev failures
from snap installs. The effective workaround is to retry a second time.
We can take advantage of #13099 changes, which allows retries on mount
failures for the same udev failures.

Note: this should only really manifest itself for nested privileged
containers... esp. our CI and integration testing.


## QA steps

Tests pass.

```sh
$ juju bootstrap lxd test
```
