### PR TITLE
Rename AllAddresses AllDeviceAddresses

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -83,9 +83,9 @@ type LinkLayerAccessor interface {
 	// layer-2 devices for the machine.
 	AllLinkLayerDevices() ([]LinkLayerDevice, error)
 
-	// AllAddresses returns all IP addresses assigned to the machine's
-	// link-layer devices
-	AllAddresses() ([]LinkLayerAddress, error)
+	// AllDeviceAddresses returns all IP addresses assigned to
+	// the machine's link-layer devices
+	AllDeviceAddresses() ([]LinkLayerAddress, error)
 }
 
 // LinkLayerWriter describes an entity that can have link-layer
@@ -210,7 +210,7 @@ func (o *MachineLinkLayerOp) PopulateExistingDevices() error {
 // link-layer device addresses for the machine.
 func (o *MachineLinkLayerOp) PopulateExistingAddresses() error {
 	var err error
-	o.existingAddrs, err = o.machine.AllAddresses()
+	o.existingAddrs, err = o.machine.AllDeviceAddresses()
 	return errors.Trace(err)
 }
 

--- a/apiserver/common/networkingcommon/mocks/package_mock.go
+++ b/apiserver/common/networkingcommon/mocks/package_mock.go
@@ -5,13 +5,14 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	networkingcommon "github.com/juju/juju/apiserver/common/networkingcommon"
 	life "github.com/juju/juju/core/life"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
 	txn "github.com/juju/mgo/v2/txn"
-	reflect "reflect"
 )
 
 // MockBackingSpace is a mock of BackingSpace interface
@@ -575,9 +576,9 @@ func (mr *MockLinkLayerMachineMockRecorder) AddLinkLayerDeviceOps(arg0 interface
 }
 
 // AllAddresses mocks base method
-func (m *MockLinkLayerMachine) AllAddresses() ([]networkingcommon.LinkLayerAddress, error) {
+func (m *MockLinkLayerMachine) AllDeviceAddresses() ([]networkingcommon.LinkLayerAddress, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllAddresses")
+	ret := m.ctrl.Call(m, "AllDeviceAddresses")
 	ret0, _ := ret[0].([]networkingcommon.LinkLayerAddress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -586,7 +587,7 @@ func (m *MockLinkLayerMachine) AllAddresses() ([]networkingcommon.LinkLayerAddre
 // AllAddresses indicates an expected call of AllAddresses
 func (mr *MockLinkLayerMachineMockRecorder) AllAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockLinkLayerMachine)(nil).AllAddresses))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllDeviceAddresses", reflect.TypeOf((*MockLinkLayerMachine)(nil).AllDeviceAddresses))
 }
 
 // AllLinkLayerDevices mocks base method

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -31,10 +31,10 @@ func (m *linkLayerMachine) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
 	return out, nil
 }
 
-// AllLinkLayerDevices returns all layer-3 addresses for the machine
+// AllDeviceAddresses returns all layer-3 addresses for the machine
 // as a slice of the LinkLayerAddress indirection.
-func (m *linkLayerMachine) AllAddresses() ([]LinkLayerAddress, error) {
-	addrList, err := m.Machine.AllAddresses()
+func (m *linkLayerMachine) AllDeviceAddresses() ([]LinkLayerAddress, error) {
+	addrList, err := m.Machine.AllDeviceAddresses()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/provisioner/mocks/containerizer_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/containerizer_mock.go
@@ -5,37 +5,38 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
 	containerizer "github.com/juju/juju/network/containerizer"
 	state "github.com/juju/juju/state"
-	reflect "reflect"
 )
 
-// MockLinkLayerDevice is a mock of LinkLayerDevice interface
+// MockLinkLayerDevice is a mock of LinkLayerDevice interface.
 type MockLinkLayerDevice struct {
 	ctrl     *gomock.Controller
 	recorder *MockLinkLayerDeviceMockRecorder
 }
 
-// MockLinkLayerDeviceMockRecorder is the mock recorder for MockLinkLayerDevice
+// MockLinkLayerDeviceMockRecorder is the mock recorder for MockLinkLayerDevice.
 type MockLinkLayerDeviceMockRecorder struct {
 	mock *MockLinkLayerDevice
 }
 
-// NewMockLinkLayerDevice creates a new mock instance
+// NewMockLinkLayerDevice creates a new mock instance.
 func NewMockLinkLayerDevice(ctrl *gomock.Controller) *MockLinkLayerDevice {
 	mock := &MockLinkLayerDevice{ctrl: ctrl}
 	mock.recorder = &MockLinkLayerDeviceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 	return m.recorder
 }
 
-// Addresses mocks base method
+// Addresses mocks base method.
 func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addresses")
@@ -44,13 +45,13 @@ func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 	return ret0, ret1
 }
 
-// Addresses indicates an expected call of Addresses
+// Addresses indicates an expected call of Addresses.
 func (mr *MockLinkLayerDeviceMockRecorder) Addresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockLinkLayerDevice)(nil).Addresses))
 }
 
-// EthernetDeviceForBridge mocks base method
+// EthernetDeviceForBridge mocks base method.
 func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string, arg1 bool) (network.InterfaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0, arg1)
@@ -59,13 +60,13 @@ func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string, arg1 bool) (n
 	return ret0, ret1
 }
 
-// EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge
+// EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge.
 func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0, arg1)
 }
 
-// IsAutoStart mocks base method
+// IsAutoStart mocks base method.
 func (m *MockLinkLayerDevice) IsAutoStart() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAutoStart")
@@ -73,13 +74,13 @@ func (m *MockLinkLayerDevice) IsAutoStart() bool {
 	return ret0
 }
 
-// IsAutoStart indicates an expected call of IsAutoStart
+// IsAutoStart indicates an expected call of IsAutoStart.
 func (mr *MockLinkLayerDeviceMockRecorder) IsAutoStart() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAutoStart", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsAutoStart))
 }
 
-// IsUp mocks base method
+// IsUp mocks base method.
 func (m *MockLinkLayerDevice) IsUp() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUp")
@@ -87,13 +88,13 @@ func (m *MockLinkLayerDevice) IsUp() bool {
 	return ret0
 }
 
-// IsUp indicates an expected call of IsUp
+// IsUp indicates an expected call of IsUp.
 func (mr *MockLinkLayerDeviceMockRecorder) IsUp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUp", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsUp))
 }
 
-// MACAddress mocks base method
+// MACAddress mocks base method.
 func (m *MockLinkLayerDevice) MACAddress() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MACAddress")
@@ -101,13 +102,13 @@ func (m *MockLinkLayerDevice) MACAddress() string {
 	return ret0
 }
 
-// MACAddress indicates an expected call of MACAddress
+// MACAddress indicates an expected call of MACAddress.
 func (mr *MockLinkLayerDeviceMockRecorder) MACAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MACAddress", reflect.TypeOf((*MockLinkLayerDevice)(nil).MACAddress))
 }
 
-// MTU mocks base method
+// MTU mocks base method.
 func (m *MockLinkLayerDevice) MTU() uint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MTU")
@@ -115,13 +116,13 @@ func (m *MockLinkLayerDevice) MTU() uint {
 	return ret0
 }
 
-// MTU indicates an expected call of MTU
+// MTU indicates an expected call of MTU.
 func (mr *MockLinkLayerDeviceMockRecorder) MTU() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockLinkLayerDevice)(nil).MTU))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockLinkLayerDevice) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -129,13 +130,13 @@ func (m *MockLinkLayerDevice) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
-// ParentDevice mocks base method
+// ParentDevice mocks base method.
 func (m *MockLinkLayerDevice) ParentDevice() (containerizer.LinkLayerDevice, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentDevice")
@@ -144,13 +145,13 @@ func (m *MockLinkLayerDevice) ParentDevice() (containerizer.LinkLayerDevice, err
 	return ret0, ret1
 }
 
-// ParentDevice indicates an expected call of ParentDevice
+// ParentDevice indicates an expected call of ParentDevice.
 func (mr *MockLinkLayerDeviceMockRecorder) ParentDevice() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentDevice", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentDevice))
 }
 
-// ParentName mocks base method
+// ParentName mocks base method.
 func (m *MockLinkLayerDevice) ParentName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentName")
@@ -158,13 +159,13 @@ func (m *MockLinkLayerDevice) ParentName() string {
 	return ret0
 }
 
-// ParentName indicates an expected call of ParentName
+// ParentName indicates an expected call of ParentName.
 func (mr *MockLinkLayerDeviceMockRecorder) ParentName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentName", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentName))
 }
 
-// Type mocks base method
+// Type mocks base method.
 func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -172,13 +173,13 @@ func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 	return ret0
 }
 
-// Type indicates an expected call of Type
+// Type indicates an expected call of Type.
 func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
 }
 
-// VirtualPortType mocks base method
+// VirtualPortType mocks base method.
 func (m *MockLinkLayerDevice) VirtualPortType() network.VirtualPortType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VirtualPortType")
@@ -186,7 +187,7 @@ func (m *MockLinkLayerDevice) VirtualPortType() network.VirtualPortType {
 	return ret0
 }
 
-// VirtualPortType indicates an expected call of VirtualPortType
+// VirtualPortType indicates an expected call of VirtualPortType.
 func (mr *MockLinkLayerDeviceMockRecorder) VirtualPortType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualPortType", reflect.TypeOf((*MockLinkLayerDevice)(nil).VirtualPortType))

--- a/apiserver/facades/agent/provisioner/mocks/package_mock.go
+++ b/apiserver/facades/agent/provisioner/mocks/package_mock.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	set "github.com/juju/collections/set"
@@ -16,48 +18,47 @@ import (
 	containerizer "github.com/juju/juju/network/containerizer"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockMachine is a mock of Machine interface
+// MockMachine is a mock of Machine interface.
 type MockMachine struct {
 	ctrl     *gomock.Controller
 	recorder *MockMachineMockRecorder
 }
 
-// MockMachineMockRecorder is the mock recorder for MockMachine
+// MockMachineMockRecorder is the mock recorder for MockMachine.
 type MockMachineMockRecorder struct {
 	mock *MockMachine
 }
 
-// NewMockMachine creates a new mock instance
+// NewMockMachine creates a new mock instance.
 func NewMockMachine(ctrl *gomock.Controller) *MockMachine {
 	mock := &MockMachine{ctrl: ctrl}
 	mock.recorder = &MockMachineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 	return m.recorder
 }
 
-// AllAddresses mocks base method
-func (m *MockMachine) AllAddresses() ([]containerizer.Address, error) {
+// AllDeviceAddresses mocks base method.
+func (m *MockMachine) AllDeviceAddresses() ([]containerizer.Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllAddresses")
+	ret := m.ctrl.Call(m, "AllDeviceAddresses")
 	ret0, _ := ret[0].([]containerizer.Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AllAddresses indicates an expected call of AllAddresses
-func (mr *MockMachineMockRecorder) AllAddresses() *gomock.Call {
+// AllDeviceAddresses indicates an expected call of AllDeviceAddresses.
+func (mr *MockMachineMockRecorder) AllDeviceAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockMachine)(nil).AllAddresses))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllDeviceAddresses", reflect.TypeOf((*MockMachine)(nil).AllDeviceAddresses))
 }
 
-// AllLinkLayerDevices mocks base method
+// AllLinkLayerDevices mocks base method.
 func (m *MockMachine) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllLinkLayerDevices")
@@ -66,13 +67,13 @@ func (m *MockMachine) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, er
 	return ret0, ret1
 }
 
-// AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices
+// AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices.
 func (mr *MockMachineMockRecorder) AllLinkLayerDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllLinkLayerDevices", reflect.TypeOf((*MockMachine)(nil).AllLinkLayerDevices))
 }
 
-// AllSpaces mocks base method
+// AllSpaces mocks base method.
 func (m *MockMachine) AllSpaces() (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
@@ -81,13 +82,13 @@ func (m *MockMachine) AllSpaces() (set.Strings, error) {
 	return ret0, ret1
 }
 
-// AllSpaces indicates an expected call of AllSpaces
+// AllSpaces indicates an expected call of AllSpaces.
 func (mr *MockMachineMockRecorder) AllSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockMachine)(nil).AllSpaces))
 }
 
-// Constraints mocks base method
+// Constraints mocks base method.
 func (m *MockMachine) Constraints() (constraints.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
@@ -96,13 +97,13 @@ func (m *MockMachine) Constraints() (constraints.Value, error) {
 	return ret0, ret1
 }
 
-// Constraints indicates an expected call of Constraints
+// Constraints indicates an expected call of Constraints.
 func (mr *MockMachineMockRecorder) Constraints() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockMachine)(nil).Constraints))
 }
 
-// ContainerType mocks base method
+// ContainerType mocks base method.
 func (m *MockMachine) ContainerType() instance.ContainerType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
@@ -110,13 +111,13 @@ func (m *MockMachine) ContainerType() instance.ContainerType {
 	return ret0
 }
 
-// ContainerType indicates an expected call of ContainerType
+// ContainerType indicates an expected call of ContainerType.
 func (mr *MockMachineMockRecorder) ContainerType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMachine)(nil).ContainerType))
 }
 
-// Id mocks base method
+// Id mocks base method.
 func (m *MockMachine) Id() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
@@ -124,13 +125,13 @@ func (m *MockMachine) Id() string {
 	return ret0
 }
 
-// Id indicates an expected call of Id
+// Id indicates an expected call of Id.
 func (mr *MockMachineMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
 }
 
-// InstanceId mocks base method
+// InstanceId mocks base method.
 func (m *MockMachine) InstanceId() (instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId")
@@ -139,13 +140,13 @@ func (m *MockMachine) InstanceId() (instance.Id, error) {
 	return ret0, ret1
 }
 
-// InstanceId indicates an expected call of InstanceId
+// InstanceId indicates an expected call of InstanceId.
 func (mr *MockMachineMockRecorder) InstanceId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachine)(nil).InstanceId))
 }
 
-// IsManual mocks base method
+// IsManual mocks base method.
 func (m *MockMachine) IsManual() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsManual")
@@ -154,13 +155,13 @@ func (m *MockMachine) IsManual() (bool, error) {
 	return ret0, ret1
 }
 
-// IsManual indicates an expected call of IsManual
+// IsManual indicates an expected call of IsManual.
 func (mr *MockMachineMockRecorder) IsManual() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManual", reflect.TypeOf((*MockMachine)(nil).IsManual))
 }
 
-// MachineTag mocks base method
+// MachineTag mocks base method.
 func (m *MockMachine) MachineTag() names.MachineTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineTag")
@@ -168,13 +169,13 @@ func (m *MockMachine) MachineTag() names.MachineTag {
 	return ret0
 }
 
-// MachineTag indicates an expected call of MachineTag
+// MachineTag indicates an expected call of MachineTag.
 func (mr *MockMachineMockRecorder) MachineTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineTag", reflect.TypeOf((*MockMachine)(nil).MachineTag))
 }
 
-// Raw mocks base method
+// Raw mocks base method.
 func (m *MockMachine) Raw() *state.Machine {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Raw")
@@ -182,13 +183,13 @@ func (m *MockMachine) Raw() *state.Machine {
 	return ret0
 }
 
-// Raw indicates an expected call of Raw
+// Raw indicates an expected call of Raw.
 func (mr *MockMachineMockRecorder) Raw() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Raw", reflect.TypeOf((*MockMachine)(nil).Raw))
 }
 
-// RemoveAllAddresses mocks base method
+// RemoveAllAddresses mocks base method.
 func (m *MockMachine) RemoveAllAddresses() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllAddresses")
@@ -196,13 +197,13 @@ func (m *MockMachine) RemoveAllAddresses() error {
 	return ret0
 }
 
-// RemoveAllAddresses indicates an expected call of RemoveAllAddresses
+// RemoveAllAddresses indicates an expected call of RemoveAllAddresses.
 func (mr *MockMachineMockRecorder) RemoveAllAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllAddresses", reflect.TypeOf((*MockMachine)(nil).RemoveAllAddresses))
 }
 
-// SetConstraints mocks base method
+// SetConstraints mocks base method.
 func (m *MockMachine) SetConstraints(arg0 constraints.Value) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConstraints", arg0)
@@ -210,13 +211,13 @@ func (m *MockMachine) SetConstraints(arg0 constraints.Value) error {
 	return ret0
 }
 
-// SetConstraints indicates an expected call of SetConstraints
+// SetConstraints indicates an expected call of SetConstraints.
 func (mr *MockMachineMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockMachine)(nil).SetConstraints), arg0)
 }
 
-// SetDevicesAddresses mocks base method
+// SetDevicesAddresses mocks base method.
 func (m *MockMachine) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -228,13 +229,13 @@ func (m *MockMachine) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) 
 	return ret0
 }
 
-// SetDevicesAddresses indicates an expected call of SetDevicesAddresses
+// SetDevicesAddresses indicates an expected call of SetDevicesAddresses.
 func (mr *MockMachineMockRecorder) SetDevicesAddresses(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicesAddresses", reflect.TypeOf((*MockMachine)(nil).SetDevicesAddresses), arg0...)
 }
 
-// SetLinkLayerDevices mocks base method
+// SetLinkLayerDevices mocks base method.
 func (m *MockMachine) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -246,27 +247,13 @@ func (m *MockMachine) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) err
 	return ret0
 }
 
-// SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices
+// SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices.
 func (mr *MockMachineMockRecorder) SetLinkLayerDevices(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkLayerDevices", reflect.TypeOf((*MockMachine)(nil).SetLinkLayerDevices), arg0...)
 }
 
-// SetParentLinkLayerDevicesBeforeTheirChildren mocks base method
-func (m *MockMachine) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.LinkLayerDeviceArgs) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetParentLinkLayerDevicesBeforeTheirChildren", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetParentLinkLayerDevicesBeforeTheirChildren indicates an expected call of SetParentLinkLayerDevicesBeforeTheirChildren
-func (mr *MockMachineMockRecorder) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParentLinkLayerDevicesBeforeTheirChildren", reflect.TypeOf((*MockMachine)(nil).SetParentLinkLayerDevicesBeforeTheirChildren), arg0)
-}
-
-// Units mocks base method
+// Units mocks base method.
 func (m *MockMachine) Units() ([]provisioner.Unit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units")
@@ -275,36 +262,36 @@ func (m *MockMachine) Units() ([]provisioner.Unit, error) {
 	return ret0, ret1
 }
 
-// Units indicates an expected call of Units
+// Units indicates an expected call of Units.
 func (mr *MockMachineMockRecorder) Units() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockMachine)(nil).Units))
 }
 
-// MockBridgePolicy is a mock of BridgePolicy interface
+// MockBridgePolicy is a mock of BridgePolicy interface.
 type MockBridgePolicy struct {
 	ctrl     *gomock.Controller
 	recorder *MockBridgePolicyMockRecorder
 }
 
-// MockBridgePolicyMockRecorder is the mock recorder for MockBridgePolicy
+// MockBridgePolicyMockRecorder is the mock recorder for MockBridgePolicy.
 type MockBridgePolicyMockRecorder struct {
 	mock *MockBridgePolicy
 }
 
-// NewMockBridgePolicy creates a new mock instance
+// NewMockBridgePolicy creates a new mock instance.
 func NewMockBridgePolicy(ctrl *gomock.Controller) *MockBridgePolicy {
 	mock := &MockBridgePolicy{ctrl: ctrl}
 	mock.recorder = &MockBridgePolicyMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBridgePolicy) EXPECT() *MockBridgePolicyMockRecorder {
 	return m.recorder
 }
 
-// FindMissingBridgesForContainer mocks base method
+// FindMissingBridgesForContainer mocks base method.
 func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Machine, arg1 containerizer.Container) ([]network0.DeviceToBridge, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindMissingBridgesForContainer", arg0, arg1)
@@ -314,13 +301,13 @@ func (m *MockBridgePolicy) FindMissingBridgesForContainer(arg0 containerizer.Mac
 	return ret0, ret1, ret2
 }
 
-// FindMissingBridgesForContainer indicates an expected call of FindMissingBridgesForContainer
+// FindMissingBridgesForContainer indicates an expected call of FindMissingBridgesForContainer.
 func (mr *MockBridgePolicyMockRecorder) FindMissingBridgesForContainer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMissingBridgesForContainer", reflect.TypeOf((*MockBridgePolicy)(nil).FindMissingBridgesForContainer), arg0, arg1)
 }
 
-// PopulateContainerLinkLayerDevices mocks base method
+// PopulateContainerLinkLayerDevices mocks base method.
 func (m *MockBridgePolicy) PopulateContainerLinkLayerDevices(arg0 containerizer.Machine, arg1 containerizer.Container, arg2 bool) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PopulateContainerLinkLayerDevices", arg0, arg1, arg2)
@@ -329,36 +316,36 @@ func (m *MockBridgePolicy) PopulateContainerLinkLayerDevices(arg0 containerizer.
 	return ret0, ret1
 }
 
-// PopulateContainerLinkLayerDevices indicates an expected call of PopulateContainerLinkLayerDevices
+// PopulateContainerLinkLayerDevices indicates an expected call of PopulateContainerLinkLayerDevices.
 func (mr *MockBridgePolicyMockRecorder) PopulateContainerLinkLayerDevices(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopulateContainerLinkLayerDevices", reflect.TypeOf((*MockBridgePolicy)(nil).PopulateContainerLinkLayerDevices), arg0, arg1, arg2)
 }
 
-// MockUnit is a mock of Unit interface
+// MockUnit is a mock of Unit interface.
 type MockUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockUnitMockRecorder
 }
 
-// MockUnitMockRecorder is the mock recorder for MockUnit
+// MockUnitMockRecorder is the mock recorder for MockUnit.
 type MockUnitMockRecorder struct {
 	mock *MockUnit
 }
 
-// NewMockUnit creates a new mock instance
+// NewMockUnit creates a new mock instance.
 func NewMockUnit(ctrl *gomock.Controller) *MockUnit {
 	mock := &MockUnit{ctrl: ctrl}
 	mock.recorder = &MockUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUnit) EXPECT() *MockUnitMockRecorder {
 	return m.recorder
 }
 
-// Application mocks base method
+// Application mocks base method.
 func (m *MockUnit) Application() (provisioner.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application")
@@ -367,13 +354,13 @@ func (m *MockUnit) Application() (provisioner.Application, error) {
 	return ret0, ret1
 }
 
-// Application indicates an expected call of Application
+// Application indicates an expected call of Application.
 func (mr *MockUnitMockRecorder) Application() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockUnit)(nil).Application))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockUnit) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -381,36 +368,36 @@ func (m *MockUnit) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockUnitMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockUnit)(nil).Name))
 }
 
-// MockApplication is a mock of Application interface
+// MockApplication is a mock of Application interface.
 type MockApplication struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationMockRecorder
 }
 
-// MockApplicationMockRecorder is the mock recorder for MockApplication
+// MockApplicationMockRecorder is the mock recorder for MockApplication.
 type MockApplicationMockRecorder struct {
 	mock *MockApplication
 }
 
-// NewMockApplication creates a new mock instance
+// NewMockApplication creates a new mock instance.
 func NewMockApplication(ctrl *gomock.Controller) *MockApplication {
 	mock := &MockApplication{ctrl: ctrl}
 	mock.recorder = &MockApplicationMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 	return m.recorder
 }
 
-// Charm mocks base method
+// Charm mocks base method.
 func (m *MockApplication) Charm() (provisioner.Charm, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm")
@@ -420,13 +407,13 @@ func (m *MockApplication) Charm() (provisioner.Charm, bool, error) {
 	return ret0, ret1, ret2
 }
 
-// Charm indicates an expected call of Charm
+// Charm indicates an expected call of Charm.
 func (mr *MockApplicationMockRecorder) Charm() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockApplication)(nil).Charm))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockApplication) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -434,36 +421,36 @@ func (m *MockApplication) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockApplicationMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockApplication)(nil).Name))
 }
 
-// MockCharm is a mock of Charm interface
+// MockCharm is a mock of Charm interface.
 type MockCharm struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmMockRecorder
 }
 
-// MockCharmMockRecorder is the mock recorder for MockCharm
+// MockCharmMockRecorder is the mock recorder for MockCharm.
 type MockCharmMockRecorder struct {
 	mock *MockCharm
 }
 
-// NewMockCharm creates a new mock instance
+// NewMockCharm creates a new mock instance.
 func NewMockCharm(ctrl *gomock.Controller) *MockCharm {
 	mock := &MockCharm{ctrl: ctrl}
 	mock.recorder = &MockCharmMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 	return m.recorder
 }
 
-// LXDProfile mocks base method
+// LXDProfile mocks base method.
 func (m *MockCharm) LXDProfile() *charm.LXDProfile {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfile")
@@ -471,13 +458,13 @@ func (m *MockCharm) LXDProfile() *charm.LXDProfile {
 	return ret0
 }
 
-// LXDProfile indicates an expected call of LXDProfile
+// LXDProfile indicates an expected call of LXDProfile.
 func (mr *MockCharmMockRecorder) LXDProfile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfile", reflect.TypeOf((*MockCharm)(nil).LXDProfile))
 }
 
-// Revision mocks base method
+// Revision mocks base method.
 func (m *MockCharm) Revision() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revision")
@@ -485,7 +472,7 @@ func (m *MockCharm) Revision() int {
 	return ret0
 }
 
-// Revision indicates an expected call of Revision
+// Revision indicates an expected call of Revision.
 func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))

--- a/apiserver/facades/agent/provisioner/shim.go
+++ b/apiserver/facades/agent/provisioner/shim.go
@@ -39,11 +39,11 @@ func (m *MachineShim) AllLinkLayerDevices() ([]containerizer.LinkLayerDevice, er
 	return wrapped, nil
 }
 
-// AllAddresses implements Machine by wrapping each
+// AllDeviceAddresses implements Machine by wrapping each
 // state.Address reference in returned collection with
 // the containerizer Address implementation.
-func (m *MachineShim) AllAddresses() ([]containerizer.Address, error) {
-	addrs, err := m.Machine.AllAddresses()
+func (m *MachineShim) AllDeviceAddresses() ([]containerizer.Address, error) {
+	addrs, err := m.Machine.AllDeviceAddresses()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -510,8 +510,8 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 	gitLab := f.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: gitLabCh})
 
 	// Add a local-machine address.
-	// Adding it the the service instead of the container is OK here, a
-	// s we are interested in the return from unit.AllAddresses().
+	// Adding it the the service instead of the container is OK here,
+	// as we are interested in the return from unit.AllAddresses().
 	// It simulates the same thing.
 	// This should never be returned as an ingress address.
 	err := gitLab.UpdateCloudService("", network.SpaceAddresses{

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -29,9 +29,10 @@ type Machine interface {
 	// PrivateAddress returns the machine's preferred private address.
 	PrivateAddress() (network.SpaceAddress, error)
 
-	// AllAddresses returns the state representation of a machine's addresses.
+	// AllDeviceAddresses returns the state representation of a machine's
+	// addresses.
 	// TODO (manadart 2021-06-15): Indirect this too.
-	AllAddresses() ([]*state.Address, error)
+	AllDeviceAddresses() ([]*state.Address, error)
 
 	// AllDeviceSpaceAddresses returns all known addresses
 	// from the machine's link-layer devices.
@@ -254,7 +255,7 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 	// can be sorted for scope and primary/secondary status.
 	// We create a map for the information we need to return, and a separate
 	// sorted slice for iteration in the correct order.
-	addrs, err := n.machine.AllAddresses()
+	addrs, err := n.machine.AllDeviceAddresses()
 	if err != nil {
 		n.populateMachineNetworkInfoErrors(spaceSet, err)
 		return nil

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2776,7 +2776,7 @@ func (u *UniterAPIV4) getOneNetworkConfig(canAccess common.AuthFunc, unitTagArg,
 	// primary address.
 	//
 	// LKK Card: https://canonical.leankit.com/Boards/View/101652562/119258804
-	addresses, err := machine.AllAddresses()
+	addresses, err := machine.AllDeviceAddresses()
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get devices addresses")
 	}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4262,7 +4262,7 @@ func (s *uniterNetworkConfigSuite) addProvisionedMachineWithDevicesAndAddresses(
 	c.Assert(machine.SetLinkLayerDevices(devicesArgs...), jc.ErrorIsNil)
 	c.Assert(machine.SetDevicesAddresses(devicesAddrs...), jc.ErrorIsNil)
 
-	machineAddrs, err := machine.AllAddresses()
+	machineAddrs, err := machine.AllDeviceAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 
 	netAddrs := make([]network.SpaceAddress, len(machineAddrs))
@@ -4518,7 +4518,7 @@ func (s *uniterNetworkInfoSuite) addProvisionedMachineWithDevicesAndAddresses(c 
 	c.Assert(machine.SetLinkLayerDevices(devicesArgs...), jc.ErrorIsNil)
 	c.Assert(machine.SetDevicesAddresses(devicesAddrs...), jc.ErrorIsNil)
 
-	machineAddrs, err := machine.AllAddresses()
+	machineAddrs, err := machine.AllDeviceAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 
 	netAddrs := make([]network.SpaceAddress, len(machineAddrs))

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -361,7 +361,7 @@ func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 // AllAddresses mocks base method.
 func (m *MockMachine) AllAddresses() ([]Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllAddresses")
+	ret := m.ctrl.Call(m, "AllDeviceAddresses")
 	ret0, _ := ret[0].([]Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -370,7 +370,7 @@ func (m *MockMachine) AllAddresses() ([]Address, error) {
 // AllAddresses indicates an expected call of AllAddresses.
 func (mr *MockMachineMockRecorder) AllAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockMachine)(nil).AllAddresses))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllDeviceAddresses", reflect.TypeOf((*MockMachine)(nil).AllAddresses))
 }
 
 // AllSpaces mocks base method.

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -20,7 +20,7 @@ type machineShim struct {
 // AllAddresses implements Machine by wrapping each state.Address
 // reference in the Address indirection.
 func (m *machineShim) AllAddresses() ([]Address, error) {
-	addresses, err := m.Machine.AllAddresses()
+	addresses, err := m.Machine.AllDeviceAddresses()
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/controller/instancepoller/mock_test.go
+++ b/apiserver/facades/controller/instancepoller/mock_test.go
@@ -347,12 +347,12 @@ func (m *mockMachine) AllLinkLayerDevices() ([]networkingcommon.LinkLayerDevice,
 	return m.linkLayerDevices, nil
 }
 
-// AllAddresses implements StateMachine.
-func (m *mockMachine) AllAddresses() ([]networkingcommon.LinkLayerAddress, error) {
+// AllDeviceAddresses implements StateMachine.
+func (m *mockMachine) AllDeviceAddresses() ([]networkingcommon.LinkLayerAddress, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.MethodCall(m, "AllAddresses")
+	m.MethodCall(m, "AllDeviceAddresses")
 	if err := m.NextErr(); err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/controller/instancepoller/state.go
+++ b/apiserver/facades/controller/instancepoller/state.go
@@ -59,8 +59,8 @@ func (s machineShim) AllLinkLayerDevices() ([]networkingcommon.LinkLayerDevice, 
 	return out, nil
 }
 
-func (s machineShim) AllAddresses() ([]networkingcommon.LinkLayerAddress, error) {
-	addrList, err := s.Machine.AllAddresses()
+func (s machineShim) AllDeviceAddresses() ([]networkingcommon.LinkLayerAddress, error) {
+	addrList, err := s.Machine.AllDeviceAddresses()
 	if err != nil {
 		return nil, err
 	}

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -247,7 +247,7 @@ func linkLayerDevicesForSpaces(host Machine, spaces corenetwork.SpaceInfos) (map
 
 	// First pass, iterate the addresses, lookup the associated spaces, and
 	// gather the devices.
-	addresses, err := host.AllAddresses()
+	addresses, err := host.AllDeviceAddresses()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/network/containerizer/bridgepolicy_mock_test.go
+++ b/network/containerizer/bridgepolicy_mock_test.go
@@ -15,45 +15,45 @@ import (
 	state "github.com/juju/juju/state"
 )
 
-// MockContainer is a mock of Container interface
+// MockContainer is a mock of Container interface.
 type MockContainer struct {
 	ctrl     *gomock.Controller
 	recorder *MockContainerMockRecorder
 }
 
-// MockContainerMockRecorder is the mock recorder for MockContainer
+// MockContainerMockRecorder is the mock recorder for MockContainer.
 type MockContainerMockRecorder struct {
 	mock *MockContainer
 }
 
-// NewMockContainer creates a new mock instance
+// NewMockContainer creates a new mock instance.
 func NewMockContainer(ctrl *gomock.Controller) *MockContainer {
 	mock := &MockContainer{ctrl: ctrl}
 	mock.recorder = &MockContainerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockContainer) EXPECT() *MockContainerMockRecorder {
 	return m.recorder
 }
 
-// AllAddresses mocks base method
-func (m *MockContainer) AllAddresses() ([]Address, error) {
+// AllDeviceAddresses mocks base method.
+func (m *MockContainer) AllDeviceAddresses() ([]Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllAddresses")
+	ret := m.ctrl.Call(m, "AllDeviceAddresses")
 	ret0, _ := ret[0].([]Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AllAddresses indicates an expected call of AllAddresses
-func (mr *MockContainerMockRecorder) AllAddresses() *gomock.Call {
+// AllDeviceAddresses indicates an expected call of AllDeviceAddresses.
+func (mr *MockContainerMockRecorder) AllDeviceAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAddresses", reflect.TypeOf((*MockContainer)(nil).AllAddresses))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllDeviceAddresses", reflect.TypeOf((*MockContainer)(nil).AllDeviceAddresses))
 }
 
-// AllLinkLayerDevices mocks base method
+// AllLinkLayerDevices mocks base method.
 func (m *MockContainer) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllLinkLayerDevices")
@@ -62,13 +62,13 @@ func (m *MockContainer) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
 	return ret0, ret1
 }
 
-// AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices
+// AllLinkLayerDevices indicates an expected call of AllLinkLayerDevices.
 func (mr *MockContainerMockRecorder) AllLinkLayerDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllLinkLayerDevices", reflect.TypeOf((*MockContainer)(nil).AllLinkLayerDevices))
 }
 
-// AllSpaces mocks base method
+// AllSpaces mocks base method.
 func (m *MockContainer) AllSpaces() (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
@@ -77,13 +77,13 @@ func (m *MockContainer) AllSpaces() (set.Strings, error) {
 	return ret0, ret1
 }
 
-// AllSpaces indicates an expected call of AllSpaces
+// AllSpaces indicates an expected call of AllSpaces.
 func (mr *MockContainerMockRecorder) AllSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockContainer)(nil).AllSpaces))
 }
 
-// Constraints mocks base method
+// Constraints mocks base method.
 func (m *MockContainer) Constraints() (constraints.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
@@ -92,13 +92,13 @@ func (m *MockContainer) Constraints() (constraints.Value, error) {
 	return ret0, ret1
 }
 
-// Constraints indicates an expected call of Constraints
+// Constraints indicates an expected call of Constraints.
 func (mr *MockContainerMockRecorder) Constraints() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockContainer)(nil).Constraints))
 }
 
-// ContainerType mocks base method
+// ContainerType mocks base method.
 func (m *MockContainer) ContainerType() instance.ContainerType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
@@ -106,13 +106,13 @@ func (m *MockContainer) ContainerType() instance.ContainerType {
 	return ret0
 }
 
-// ContainerType indicates an expected call of ContainerType
+// ContainerType indicates an expected call of ContainerType.
 func (mr *MockContainerMockRecorder) ContainerType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockContainer)(nil).ContainerType))
 }
 
-// Id mocks base method
+// Id mocks base method.
 func (m *MockContainer) Id() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
@@ -120,13 +120,13 @@ func (m *MockContainer) Id() string {
 	return ret0
 }
 
-// Id indicates an expected call of Id
+// Id indicates an expected call of Id.
 func (mr *MockContainerMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockContainer)(nil).Id))
 }
 
-// Raw mocks base method
+// Raw mocks base method.
 func (m *MockContainer) Raw() *state.Machine {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Raw")
@@ -134,13 +134,13 @@ func (m *MockContainer) Raw() *state.Machine {
 	return ret0
 }
 
-// Raw indicates an expected call of Raw
+// Raw indicates an expected call of Raw.
 func (mr *MockContainerMockRecorder) Raw() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Raw", reflect.TypeOf((*MockContainer)(nil).Raw))
 }
 
-// RemoveAllAddresses mocks base method
+// RemoveAllAddresses mocks base method.
 func (m *MockContainer) RemoveAllAddresses() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllAddresses")
@@ -148,13 +148,13 @@ func (m *MockContainer) RemoveAllAddresses() error {
 	return ret0
 }
 
-// RemoveAllAddresses indicates an expected call of RemoveAllAddresses
+// RemoveAllAddresses indicates an expected call of RemoveAllAddresses.
 func (mr *MockContainerMockRecorder) RemoveAllAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllAddresses", reflect.TypeOf((*MockContainer)(nil).RemoveAllAddresses))
 }
 
-// SetConstraints mocks base method
+// SetConstraints mocks base method.
 func (m *MockContainer) SetConstraints(arg0 constraints.Value) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConstraints", arg0)
@@ -162,13 +162,13 @@ func (m *MockContainer) SetConstraints(arg0 constraints.Value) error {
 	return ret0
 }
 
-// SetConstraints indicates an expected call of SetConstraints
+// SetConstraints indicates an expected call of SetConstraints.
 func (mr *MockContainerMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockContainer)(nil).SetConstraints), arg0)
 }
 
-// SetDevicesAddresses mocks base method
+// SetDevicesAddresses mocks base method.
 func (m *MockContainer) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -180,13 +180,13 @@ func (m *MockContainer) SetDevicesAddresses(arg0 ...state.LinkLayerDeviceAddress
 	return ret0
 }
 
-// SetDevicesAddresses indicates an expected call of SetDevicesAddresses
+// SetDevicesAddresses indicates an expected call of SetDevicesAddresses.
 func (mr *MockContainerMockRecorder) SetDevicesAddresses(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicesAddresses", reflect.TypeOf((*MockContainer)(nil).SetDevicesAddresses), arg0...)
 }
 
-// SetLinkLayerDevices mocks base method
+// SetLinkLayerDevices mocks base method.
 func (m *MockContainer) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -198,50 +198,36 @@ func (m *MockContainer) SetLinkLayerDevices(arg0 ...state.LinkLayerDeviceArgs) e
 	return ret0
 }
 
-// SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices
+// SetLinkLayerDevices indicates an expected call of SetLinkLayerDevices.
 func (mr *MockContainerMockRecorder) SetLinkLayerDevices(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkLayerDevices", reflect.TypeOf((*MockContainer)(nil).SetLinkLayerDevices), arg0...)
 }
 
-// SetParentLinkLayerDevicesBeforeTheirChildren mocks base method
-func (m *MockContainer) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 []state.LinkLayerDeviceArgs) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetParentLinkLayerDevicesBeforeTheirChildren", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetParentLinkLayerDevicesBeforeTheirChildren indicates an expected call of SetParentLinkLayerDevicesBeforeTheirChildren
-func (mr *MockContainerMockRecorder) SetParentLinkLayerDevicesBeforeTheirChildren(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParentLinkLayerDevicesBeforeTheirChildren", reflect.TypeOf((*MockContainer)(nil).SetParentLinkLayerDevicesBeforeTheirChildren), arg0)
-}
-
-// MockAddress is a mock of Address interface
+// MockAddress is a mock of Address interface.
 type MockAddress struct {
 	ctrl     *gomock.Controller
 	recorder *MockAddressMockRecorder
 }
 
-// MockAddressMockRecorder is the mock recorder for MockAddress
+// MockAddressMockRecorder is the mock recorder for MockAddress.
 type MockAddressMockRecorder struct {
 	mock *MockAddress
 }
 
-// NewMockAddress creates a new mock instance
+// NewMockAddress creates a new mock instance.
 func NewMockAddress(ctrl *gomock.Controller) *MockAddress {
 	mock := &MockAddress{ctrl: ctrl}
 	mock.recorder = &MockAddressMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAddress) EXPECT() *MockAddressMockRecorder {
 	return m.recorder
 }
 
-// DeviceName mocks base method
+// DeviceName mocks base method.
 func (m *MockAddress) DeviceName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeviceName")
@@ -249,13 +235,13 @@ func (m *MockAddress) DeviceName() string {
 	return ret0
 }
 
-// DeviceName indicates an expected call of DeviceName
+// DeviceName indicates an expected call of DeviceName.
 func (mr *MockAddressMockRecorder) DeviceName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeviceName", reflect.TypeOf((*MockAddress)(nil).DeviceName))
 }
 
-// Subnet mocks base method
+// Subnet mocks base method.
 func (m *MockAddress) Subnet() (Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnet")
@@ -264,36 +250,36 @@ func (m *MockAddress) Subnet() (Subnet, error) {
 	return ret0, ret1
 }
 
-// Subnet indicates an expected call of Subnet
+// Subnet indicates an expected call of Subnet.
 func (mr *MockAddressMockRecorder) Subnet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockAddress)(nil).Subnet))
 }
 
-// MockSubnet is a mock of Subnet interface
+// MockSubnet is a mock of Subnet interface.
 type MockSubnet struct {
 	ctrl     *gomock.Controller
 	recorder *MockSubnetMockRecorder
 }
 
-// MockSubnetMockRecorder is the mock recorder for MockSubnet
+// MockSubnetMockRecorder is the mock recorder for MockSubnet.
 type MockSubnetMockRecorder struct {
 	mock *MockSubnet
 }
 
-// NewMockSubnet creates a new mock instance
+// NewMockSubnet creates a new mock instance.
 func NewMockSubnet(ctrl *gomock.Controller) *MockSubnet {
 	mock := &MockSubnet{ctrl: ctrl}
 	mock.recorder = &MockSubnetMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSubnet) EXPECT() *MockSubnetMockRecorder {
 	return m.recorder
 }
 
-// SpaceID mocks base method
+// SpaceID mocks base method.
 func (m *MockSubnet) SpaceID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpaceID")
@@ -301,36 +287,36 @@ func (m *MockSubnet) SpaceID() string {
 	return ret0
 }
 
-// SpaceID indicates an expected call of SpaceID
+// SpaceID indicates an expected call of SpaceID.
 func (mr *MockSubnetMockRecorder) SpaceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceID", reflect.TypeOf((*MockSubnet)(nil).SpaceID))
 }
 
-// MockLinkLayerDevice is a mock of LinkLayerDevice interface
+// MockLinkLayerDevice is a mock of LinkLayerDevice interface.
 type MockLinkLayerDevice struct {
 	ctrl     *gomock.Controller
 	recorder *MockLinkLayerDeviceMockRecorder
 }
 
-// MockLinkLayerDeviceMockRecorder is the mock recorder for MockLinkLayerDevice
+// MockLinkLayerDeviceMockRecorder is the mock recorder for MockLinkLayerDevice.
 type MockLinkLayerDeviceMockRecorder struct {
 	mock *MockLinkLayerDevice
 }
 
-// NewMockLinkLayerDevice creates a new mock instance
+// NewMockLinkLayerDevice creates a new mock instance.
 func NewMockLinkLayerDevice(ctrl *gomock.Controller) *MockLinkLayerDevice {
 	mock := &MockLinkLayerDevice{ctrl: ctrl}
 	mock.recorder = &MockLinkLayerDeviceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLinkLayerDevice) EXPECT() *MockLinkLayerDeviceMockRecorder {
 	return m.recorder
 }
 
-// Addresses mocks base method
+// Addresses mocks base method.
 func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addresses")
@@ -339,13 +325,13 @@ func (m *MockLinkLayerDevice) Addresses() ([]*state.Address, error) {
 	return ret0, ret1
 }
 
-// Addresses indicates an expected call of Addresses
+// Addresses indicates an expected call of Addresses.
 func (mr *MockLinkLayerDeviceMockRecorder) Addresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockLinkLayerDevice)(nil).Addresses))
 }
 
-// EthernetDeviceForBridge mocks base method
+// EthernetDeviceForBridge mocks base method.
 func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string, arg1 bool) (network.InterfaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EthernetDeviceForBridge", arg0, arg1)
@@ -354,13 +340,13 @@ func (m *MockLinkLayerDevice) EthernetDeviceForBridge(arg0 string, arg1 bool) (n
 	return ret0, ret1
 }
 
-// EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge
+// EthernetDeviceForBridge indicates an expected call of EthernetDeviceForBridge.
 func (mr *MockLinkLayerDeviceMockRecorder) EthernetDeviceForBridge(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthernetDeviceForBridge", reflect.TypeOf((*MockLinkLayerDevice)(nil).EthernetDeviceForBridge), arg0, arg1)
 }
 
-// IsAutoStart mocks base method
+// IsAutoStart mocks base method.
 func (m *MockLinkLayerDevice) IsAutoStart() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAutoStart")
@@ -368,13 +354,13 @@ func (m *MockLinkLayerDevice) IsAutoStart() bool {
 	return ret0
 }
 
-// IsAutoStart indicates an expected call of IsAutoStart
+// IsAutoStart indicates an expected call of IsAutoStart.
 func (mr *MockLinkLayerDeviceMockRecorder) IsAutoStart() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAutoStart", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsAutoStart))
 }
 
-// IsUp mocks base method
+// IsUp mocks base method.
 func (m *MockLinkLayerDevice) IsUp() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUp")
@@ -382,13 +368,13 @@ func (m *MockLinkLayerDevice) IsUp() bool {
 	return ret0
 }
 
-// IsUp indicates an expected call of IsUp
+// IsUp indicates an expected call of IsUp.
 func (mr *MockLinkLayerDeviceMockRecorder) IsUp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUp", reflect.TypeOf((*MockLinkLayerDevice)(nil).IsUp))
 }
 
-// MACAddress mocks base method
+// MACAddress mocks base method.
 func (m *MockLinkLayerDevice) MACAddress() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MACAddress")
@@ -396,13 +382,13 @@ func (m *MockLinkLayerDevice) MACAddress() string {
 	return ret0
 }
 
-// MACAddress indicates an expected call of MACAddress
+// MACAddress indicates an expected call of MACAddress.
 func (mr *MockLinkLayerDeviceMockRecorder) MACAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MACAddress", reflect.TypeOf((*MockLinkLayerDevice)(nil).MACAddress))
 }
 
-// MTU mocks base method
+// MTU mocks base method.
 func (m *MockLinkLayerDevice) MTU() uint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MTU")
@@ -410,13 +396,13 @@ func (m *MockLinkLayerDevice) MTU() uint {
 	return ret0
 }
 
-// MTU indicates an expected call of MTU
+// MTU indicates an expected call of MTU.
 func (mr *MockLinkLayerDeviceMockRecorder) MTU() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockLinkLayerDevice)(nil).MTU))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockLinkLayerDevice) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -424,13 +410,13 @@ func (m *MockLinkLayerDevice) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockLinkLayerDeviceMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLinkLayerDevice)(nil).Name))
 }
 
-// ParentDevice mocks base method
+// ParentDevice mocks base method.
 func (m *MockLinkLayerDevice) ParentDevice() (LinkLayerDevice, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentDevice")
@@ -439,13 +425,13 @@ func (m *MockLinkLayerDevice) ParentDevice() (LinkLayerDevice, error) {
 	return ret0, ret1
 }
 
-// ParentDevice indicates an expected call of ParentDevice
+// ParentDevice indicates an expected call of ParentDevice.
 func (mr *MockLinkLayerDeviceMockRecorder) ParentDevice() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentDevice", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentDevice))
 }
 
-// ParentName mocks base method
+// ParentName mocks base method.
 func (m *MockLinkLayerDevice) ParentName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParentName")
@@ -453,13 +439,13 @@ func (m *MockLinkLayerDevice) ParentName() string {
 	return ret0
 }
 
-// ParentName indicates an expected call of ParentName
+// ParentName indicates an expected call of ParentName.
 func (mr *MockLinkLayerDeviceMockRecorder) ParentName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParentName", reflect.TypeOf((*MockLinkLayerDevice)(nil).ParentName))
 }
 
-// Type mocks base method
+// Type mocks base method.
 func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -467,13 +453,13 @@ func (m *MockLinkLayerDevice) Type() network.LinkLayerDeviceType {
 	return ret0
 }
 
-// Type indicates an expected call of Type
+// Type indicates an expected call of Type.
 func (mr *MockLinkLayerDeviceMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLinkLayerDevice)(nil).Type))
 }
 
-// VirtualPortType mocks base method
+// VirtualPortType mocks base method.
 func (m *MockLinkLayerDevice) VirtualPortType() network.VirtualPortType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VirtualPortType")
@@ -481,7 +467,7 @@ func (m *MockLinkLayerDevice) VirtualPortType() network.VirtualPortType {
 	return ret0
 }
 
-// VirtualPortType indicates an expected call of VirtualPortType
+// VirtualPortType indicates an expected call of VirtualPortType.
 func (mr *MockLinkLayerDeviceMockRecorder) VirtualPortType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VirtualPortType", reflect.TypeOf((*MockLinkLayerDevice)(nil).VirtualPortType))

--- a/network/containerizer/linklayerdevicesforspaces_test.go
+++ b/network/containerizer/linklayerdevicesforspaces_test.go
@@ -306,7 +306,7 @@ func (s *linkLayerDevForSpacesSuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *linkLayerDevForSpacesSuite) expectMachineAddressesDevices() {
 	mExp := s.machine.EXPECT()
 	mExp.AllLinkLayerDevices().Return(s.devices, nil).AnyTimes()
-	mExp.AllAddresses().Return(s.addresses, nil).AnyTimes()
+	mExp.AllDeviceAddresses().Return(s.addresses, nil).AnyTimes()
 }
 
 func (s *linkLayerDevForSpacesSuite) expectNICAndBridgeWithIP(ctrl *gomock.Controller, dev, parent, spaceID string) {

--- a/network/containerizer/shim.go
+++ b/network/containerizer/shim.go
@@ -68,7 +68,7 @@ var _ LinkLayerDevice = (*linkLayerDevice)(nil)
 // describing a machine that is to host containers.
 type Machine interface {
 	Id() string
-	AllAddresses() ([]Address, error)
+	AllDeviceAddresses() ([]Address, error)
 	AllSpaces() (set.Strings, error)
 	SetLinkLayerDevices(devicesArgs ...state.LinkLayerDeviceArgs) (err error)
 	AllLinkLayerDevices() ([]LinkLayerDevice, error)
@@ -112,10 +112,10 @@ func (m *MachineShim) AllLinkLayerDevices() ([]LinkLayerDevice, error) {
 	return wrapped, nil
 }
 
-// AllAddresses implements Machine by wrapping each state.Address reference
-// in returned collection with the local Address implementation.
-func (m *MachineShim) AllAddresses() ([]Address, error) {
-	addrs, err := m.Machine.AllAddresses()
+// AllDeviceAddresses implements Machine by wrapping each state.Address
+// reference in returned collection with the local Address implementation.
+func (m *MachineShim) AllDeviceAddresses() ([]Address, error) {
+	addrs, err := m.Machine.AllDeviceAddresses()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -219,7 +219,7 @@ func (s *ipAddressesStateSuite) assertNoAddressesOnMachine(c *gc.C, machine *sta
 func (s *ipAddressesStateSuite) assertAllAddressesOnMachineMatchCount(
 	c *gc.C, machine *state.Machine, expectedCount int,
 ) {
-	results, err := machine.AllAddresses()
+	results, err := machine.AllDeviceAddresses()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, expectedCount, gc.Commentf(
 		"expected %d, got %d: %+v", expectedCount, len(results), results))
@@ -311,7 +311,7 @@ func (s *ipAddressesStateSuite) TestMachineRemoveAllAddressesTwiceStillSucceeds(
 func (s *ipAddressesStateSuite) TestMachineAllAddressesSuccess(c *gc.C) {
 	addedAddresses := s.addTwoDevicesWithTwoAddressesEach(c)
 
-	allAddresses, err := s.machine.AllAddresses()
+	allAddresses, err := s.machine.AllDeviceAddresses()
 	sort.Sort(AddressSorter(allAddresses))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(allAddresses, jc.DeepEquals, addedAddresses)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -1114,7 +1114,7 @@ func (s *linkLayerDevicesStateSuite) TestSetDeviceAddressesWithSubnetID(c *gc.C)
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	allAddr, err := s.machine.AllAddresses()
+	allAddr, err := s.machine.AllDeviceAddresses()
 	c.Assert(err, gc.IsNil)
 
 	expSubnetID := map[string]corenetwork.Id{

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -847,9 +847,7 @@ func (m *Machine) removeAllAddressesOps() ([]txn.Op, error) {
 
 // AllAddresses returns all known addresses assigned to
 // link-layer devices on the machine.
-// TODO (manadart 2021-05-12): Rename this to AllDeviceAddresses for
-// congruence with the method below.
-func (m *Machine) AllAddresses() ([]*Address, error) {
+func (m *Machine) AllDeviceAddresses() ([]*Address, error) {
 	var allAddresses []*Address
 	callbackFunc := func(doc *ipAddressDoc) {
 		allAddresses = append(allAddresses, newIPAddress(m.st, *doc))


### PR DESCRIPTION
Simple renaming of the method `AllAddresses` to `AllDeviceAddresses` on `state.Machine` to better indicate the addresses' source, and differentiate from the `Addresses` method.

## QA steps

Non-functional change, verified by unit tests.

## Documentation changes

None.

## Bug reference

N/A
