### PR TITLE
Logs: Ensure we close goroutine on cancel

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -680,7 +681,7 @@ func (s *DeadlineStream) WriteJSON(v interface{}) error {
 // WatchDebugLog returns a channel of structured Log Messages. Only log entries
 // that match the filtering specified in the DebugLogParams are returned.
 func (c *Client) WatchDebugLog(args common.DebugLogParams) (<-chan common.LogMessage, error) {
-	return common.StreamDebugLog(c.st, args)
+	return common.StreamDebugLog(context.TODO(), c.st, args)
 }
 
 // lxdCharmProfiler massages a charm.Charm into a LXDProfiler inside of the

--- a/api/migrationmaster/client.go
+++ b/api/migrationmaster/client.go
@@ -4,6 +4,7 @@
 package migrationmaster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -302,8 +303,8 @@ func (c *Client) MinionReportTimeout() (time.Duration, error) {
 // will yield the logs on or after that time - these are the logs that
 // need to be transferred to the target after the migration is
 // successful.
-func (c *Client) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
-	return common.StreamDebugLog(c.caller.RawAPICaller(), common.DebugLogParams{
+func (c *Client) StreamModelLog(ctx context.Context, start time.Time) (<-chan common.LogMessage, error) {
+	return common.StreamDebugLog(ctx, c.caller.RawAPICaller(), common.DebugLogParams{
 		Replay:    true,
 		NoTail:    true,
 		StartTime: start,

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -572,7 +572,7 @@ func (s *ClientSuite) TestMinionReportTimeout(c *gc.C) {
 func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
 	caller := fakeConnector{path: new(string), attrs: &url.Values{}}
 	client := migrationmaster.NewClient(caller, nil)
-	stream, err := client.StreamModelLog(time.Date(2016, 12, 2, 10, 24, 1, 1000000, time.UTC))
+	stream, err := client.StreamModelLog(context.TODO(), time.Date(2016, 12, 2, 10, 24, 1, 1000000, time.UTC))
 	c.Assert(stream, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "colonel abrams")
 

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -4,6 +4,7 @@
 package migrationmaster_test
 
 import (
+	"context"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -1275,7 +1276,7 @@ func (f *stubMasterFacade) Reap() error {
 	return nil
 }
 
-func (f *stubMasterFacade) StreamModelLog(start time.Time) (<-chan common.LogMessage, error) {
+func (f *stubMasterFacade) StreamModelLog(_ context.Context, start time.Time) (<-chan common.LogMessage, error) {
 	f.stub.AddCall("StreamModelLog", start)
 	if f.streamErr != nil {
 		return nil, f.streamErr


### PR DESCRIPTION
The following cleans up the StreamDebugLogs goroutine if
the callee wants to cancel the streaming of the logs.

I noticed the TODO whilst threading through a new debug-log parameter.


## QA steps

Test pass.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1644084