### PR TITLE
Add test by cloud to bash integration tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -61,8 +61,8 @@ bootstrap() {
 	"localhost" | "lxd")
 		cloud="lxd"
 		;;
-	"lxd-remote" | "vsphere" | "openstack"  | "k8s" )
-    cloud="${BOOTSTRAP_CLOUD}"
+	"lxd-remote" | "vsphere" | "openstack" | "k8s")
+		cloud="${BOOTSTRAP_CLOUD}"
 		;;
 	"manual")
 		manual_name=${1}
@@ -101,7 +101,7 @@ bootstrap() {
 		fi
 	fi
 	if [[ ${BOOTSTRAP_REUSE} == "true" && ${BOOTSTRAP_PROVIDER} != "k8s" ]]; then
-	  # juju show-machine not supported with k8s controllers
+		# juju show-machine not supported with k8s controllers
 		OUT=$(juju show-machine -m "${bootstrapped_name}":controller --format=json | jq -r ".machines | .[] | .series")
 		if [[ -n ${OUT} ]]; then
 			OUT=$(echo "${OUT}" | grep -oh "${BOOTSTRAP_SERIES}" || true)
@@ -158,7 +158,7 @@ add_model() {
 	fi
 
 	if [[ ${BOOTSTRAP_PROVIDER} == "vsphere" ]]; then
-	  add_image_for_vsphere
+		add_image_for_vsphere
 	fi
 
 	echo "${model}" >>"${TEST_DIR}/models"
@@ -167,26 +167,26 @@ add_model() {
 # add_images_for_vsphere is used to add-image with known vSphere template paths for LTS series
 # and shouldn't be used by any of the tests directly.
 add_images_for_vsphere() {
-  juju metadata add-image juju-ci-root/templates/focal-test-template --series focal
-  juju metadata add-image juju-ci-root/templates/bionic-test-template --series bionic
-  juju metadata add-image juju-ci-root/templates/xenial-test-template --series xenial
+	juju metadata add-image juju-ci-root/templates/focal-test-template --series focal
+	juju metadata add-image juju-ci-root/templates/bionic-test-template --series bionic
+	juju metadata add-image juju-ci-root/templates/xenial-test-template --series xenial
 }
 
 # setup_vsphere_simplestreams generates image metadata for use during vSphere bootstrap.  There is
 # an assumption made with regards to the template name in the Boston vSphere.  This is for internal
 # use only and shouldn't be used by any of the tests directly.
 setup_vsphere_simplestreams() {
-  local dir series
+	local dir series
 
-  dir=${1}
-  series=${2:-"focal"}
+	dir=${1}
+	series=${2:-"focal"}
 
-  if [[ ! -f ${dir} ]]; then
-    mkdir "${dir}" || true
-  fi
+	if [[ ! -f ${dir} ]]; then
+		mkdir "${dir}" || true
+	fi
 
-  cloud_endpoint=$(juju clouds --client --format=json | jq -r ".[\"$BOOTSTRAP_CLOUD\"] | .endpoint")
-  juju metadata generate-image -i juju-ci-root/templates/"${series}"-test-template -r "${BOOTSTRAP_REGION}" -d "${dir}" -u "${cloud_endpoint}" -s "${series}"
+	cloud_endpoint=$(juju clouds --client --format=json | jq -r ".[\"$BOOTSTRAP_CLOUD\"] | .endpoint")
+	juju metadata generate-image -i juju-ci-root/templates/"${series}"-test-template -r "${BOOTSTRAP_REGION}" -d "${dir}" -u "${cloud_endpoint}" -s "${series}"
 }
 
 # juju_bootstrap is used to bootstrap a model for tracking. This is for internal
@@ -223,11 +223,10 @@ juju_bootstrap() {
 	if [[ ${BOOTSTRAP_PROVIDER} == "vsphere" ]]; then
 		echo "====> Creating image simplestream metadata for juju ($(green "${version}:${cloud}"))"
 
-	  image_streams_dir=/tmp/image-streams
-	  setup_vsphere_simplestreams ${image_streams_dir} "${BOOTSTRAP_SERIES}"
-	  image_metadata="--metadata-source ${image_streams_dir}"
+		image_streams_dir=${TEST_DIR}/image-streams
+		setup_vsphere_simplestreams "${image_streams_dir}" "${BOOTSTRAP_SERIES}"
+		image_metadata="--metadata-source ${image_streams_dir}"
 	fi
-
 
 	# When double quotes are added to ${series}, the juju bootstrap
 	# command looks correct, and works outside of the harness, but
@@ -240,8 +239,8 @@ juju_bootstrap() {
 	echo "${name}" >>"${TEST_DIR}/jujus"
 
 	if [[ ${BOOTSTRAP_PROVIDER} == "vsphere" ]]; then
-	  rm -r "${image_streams_dir}"
-	  add_images_for_vsphere
+		rm -r "${image_streams_dir}"
+		add_images_for_vsphere
 	fi
 }
 
@@ -360,15 +359,15 @@ introspect_controller() {
 
 	name=${1}
 
-  if [[ ${BOOTSTRAP_PROVIDER} == "k8s" ]]; then
-    echo "====> TODO: Implement introspection for k8s"
-    return
-  fi
+	if [[ ${BOOTSTRAP_PROVIDER} == "k8s" ]]; then
+		echo "====> TODO: Implement introspection for k8s"
+		return
+	fi
 
 	idents=$(juju machines -m "${name}:controller" --format=json | jq ".machines | keys | .[]")
-  if [[ -z ${idents} ]]; then
+	if [[ -z ${idents} ]]; then
 		return
-  fi
+	fi
 
 	echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" >"${TEST_DIR}/${name}-juju_engine_reports.log" 2>/dev/null
 	echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" >"${TEST_DIR}/${name}-juju_goroutines.log" 2>/dev/null

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -182,7 +182,7 @@ setup_vsphere_simplestreams() {
   series=${2:-"focal"}
 
   if [[ ! -f ${dir} ]]; then
-    mkdir ${dir} || true
+    mkdir "${dir}" || true
   fi
 
   cloud_endpoint=$(juju clouds --client --format=json | jq -r ".[\"$BOOTSTRAP_CLOUD\"] | .endpoint")
@@ -224,7 +224,7 @@ juju_bootstrap() {
 		echo "====> Creating image simplestream metadata for juju ($(green "${version}:${cloud}"))"
 
 	  image_streams_dir=/tmp/image-streams
-	  setup_vsphere_simplestreams ${image_streams_dir} ${BOOTSTRAP_SERIES}
+	  setup_vsphere_simplestreams ${image_streams_dir} "${BOOTSTRAP_SERIES}"
 	  image_metadata="--metadata-source ${image_streams_dir}"
 	fi
 

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -1,15 +1,12 @@
-run_deploy_microk8s() {
+run_controller_model_admission() {
+  # Echo out to ensure nice output to the test suite.
 	echo
 
-	name=${1}
-	export BOOTSTRAP_PROVIDER=microk8s
-	bootstrap microk8s "${name}"
+  # The following ensures that a bootstrap juju exists.
+  model_name="controller-model-admission"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
 
-	microk8s.config >"${TEST_DIR}"/kube.conf
-	export KUBE_CONFIG="${TEST_DIR}"/kube.conf
-}
-
-test_controller_model_admission() {
 	name=test-$(petname)
 
 	namespace=controller-"${BOOTSTRAPPED_JUJU_CTRL_NAME}"
@@ -81,15 +78,21 @@ EOF
 	check_contains "${juju_app}" "test-app"
 
 	echo "$juju_app" | check test-app
+
+	destroy_model "${model_name}"
 }
 
-test_new_model_admission() {
+run_new_model_admission() {
+  # Echo out to ensure nice output to the test suite.
+	echo
+
+  # The following ensures that a bootstrap juju exists.
+  model_name="new-model-admission"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
 	name=test-$(petname)
-
-	model_name=$(petname)
 	namespace=${model_name}
-
-	juju add-model "${model_name}"
 
 	kubectl --kubeconfig "${KUBE_CONFIG}" apply -f - <<EOF
 apiVersion: v1
@@ -158,12 +161,20 @@ EOF
 	check_contains "${juju_app}" "test-app"
 
 	echo "$juju_app" | check test-app
+
+	destroy_model "${model_name}"
 }
 
 # Tests that after the model operator pod restarts it can come back up without
 # having to be validated by itself.
-test_model_chicken_and_egg() {
-	name=test-$(petname)
+run_model_chicken_and_egg() {
+  # Echo out to ensure nice output to the test suite.
+	echo
+
+  # The following ensures that a bootstrap juju exists.
+  model_name="model-chicken-and-egg"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
 
 	namespace=controller-"${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 
@@ -175,4 +186,6 @@ test_model_chicken_and_egg() {
 	test_value=$(kubectl --kubeconfig "${KUBE_CONFIG}" get deployment -n "${namespace}" modeloperator -o=jsonpath='{.metadata.labels.test}')
 
 	check_contains "${test_value}" "foo"
+
+	destroy_model "${model_name}"
 }

--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -6,12 +6,20 @@ test_caasadmission() {
 
 	set_verbosity
 
-	echo "==> Checking for dependencies"
-	check_dependencies juju jq petname microk8s
+  case "${BOOTSTRAP_PROVIDER:-}" in
+    "k8s")
+      echo "==> Checking for dependencies"
+      check_dependencies petname
 
-	run_deploy_microk8s "$(petname)"
+      microk8s.config >"${TEST_DIR}"/kube.conf
+      export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 
-	test_controller_model_admission
-	test_new_model_admission
-	test_model_chicken_and_egg
+      run_controller_model_admission
+      run_new_model_admission
+      run_model_chicken_and_egg
+      ;;
+    *)
+      echo "==> TEST SKIPPED: caas admission tests, not a k8s provider"
+      ;;
+    esac
 }

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -247,7 +247,7 @@ bootstrap_alt_controller() {
 	echo "====> Bootstrapping ${name}"
 
 	file="${TEST_DIR}/${name}.log"
-	juju_bootstrap "${BOOTSTRAP_PROVIDER}" "${name}" "misc" "${file}"
+	juju_bootstrap "${BOOTSTRAP_CLOUD}" "${name}" "misc" "${file}"
 
 	END_TIME=$(date +%s)
 	echo "====> Bootstrapped ${name} ($((END_TIME - START_TIME))s)"


### PR DESCRIPTION

Add test by cloud to bash integration tests.  Allows for testing using clouds which have to be added, such as vSphere and OpenStack.  Renamed the "microk8s" provider to "k8s", as it's a cloud name.  Only specifying a provider will work if the provider and cloud name are the same.  Otherwise, use the cloud name to run the tests.

Caveats

- vSphere is setup to configure the controller to use pre-made vm templates as seen in the Boston vSphere only.
- OpenStack clouds must have images configured such that it is not necessary to provide image data at bootstrap time on the cli.

## QA steps

```console
# setup to bootstrap the Boston vsphere using the juju-ci folder and credentials.
(cd tests; ./main.sh -c <vsphere>  deploy deploy-charms)

# setup to bootstrap an openstack.
(cd tests; ./main.sh -c <openstack>  deploy deploy-charms)

# the k8s only test should still run by specifying a cloud to use:
(cd tests; ./main.sh -c microk8s  caasadmission)

# should not run, not a k8s provider
(cd tests; ./main.sh -p aws  caasadmission)
```
