### PR TITLE
Add RootDiskSource as unsupportedConstraints, match the docs.

### DIFF
--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -15,6 +15,7 @@ var unsupportedConstraints = []string{
 	constraints.InstanceType,
 	constraints.Spaces,
 	constraints.AllocatePublicIP,
+	constraints.RootDiskSource,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -435,6 +435,7 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 		constraints.CpuPower,
 		constraints.Tags,
 		constraints.VirtType,
+		constraints.RootDiskSource,
 	})
 	validator.RegisterVocabulary(
 		constraints.Arch,

--- a/provider/cloudsigma/environcaps.go
+++ b/provider/cloudsigma/environcaps.go
@@ -14,6 +14,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.RootDiskSource,
 }
 
 // ConstraintsValidator returns a Validator instance which

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -200,6 +200,7 @@ var unsupportedConstraints = []string{
 	// use virt-type in StartInstances
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.RootDiskSource,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -34,6 +34,7 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.RootDiskSource,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the

--- a/provider/maas/constraints.go
+++ b/provider/maas/constraints.go
@@ -20,6 +20,7 @@ var unsupportedConstraints = []string{
 	constraints.InstanceType,
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.RootDiskSource,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -328,6 +328,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.RootDiskSource,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -335,6 +335,7 @@ func (e *Environ) ConstraintsValidator(ctx envcontext.ProviderCallContext) (cons
 		constraints.Container,
 		constraints.VirtType,
 		constraints.Tags,
+		constraints.RootDiskSource,
 	}
 
 	validator := constraints.NewValidator()


### PR DESCRIPTION
Juju constraints documentation indicates that root disk sources is unsupported for many of the providers, ensure that the juju constraint validator for each agrees.  Added root-disk-source to unsupported list where missing.

https://discourse.charmhub.io/t/juju-constraints/1160