### PR TITLE
Update Pebble to include panic fixes in layer parsing code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.9.0
 	github.com/aws/smithy-go v1.4.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20210609205628-b152ff448bbe
+	github.com/canonical/pebble v0.0.0-20210629225259-602ad4b50023
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/dnaeon/go-vcr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20210609205628-b152ff448bbe h1:j5CKKpGzFRoqgEb0t5DstYvigs2NVOFNII2F5NX0MUw=
-github.com/canonical/pebble v0.0.0-20210609205628-b152ff448bbe/go.mod h1:Glkg6kOpPMNw1BDDzRHH0U9i3pnc6Y+zV+pHwdX4SU0=
+github.com/canonical/pebble v0.0.0-20210629225259-602ad4b50023 h1:a6t8Dr4o08Wx4TwFgRmknw4BP5u4IjmcgX06ymaNdGI=
+github.com/canonical/pebble v0.0.0-20210629225259-602ad4b50023/go.mod h1:Glkg6kOpPMNw1BDDzRHH0U9i3pnc6Y+zV+pHwdX4SU0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
This pulls in https://github.com/canonical/pebble/pull/51:

* Fix panic when command is not set in combined layer
* Fix panic when service object/dict is null
* Also disallow use of empty string as service name

## QA steps

Make a layer with any of the above issues in it and call `add_layer` from a charm (see steps at https://github.com/canonical/pebble/issues/50) and it will now fail with an error message instead of panicking.
