### PR TITLE
Do the annotation validation only for non legacy models;

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -227,12 +227,14 @@ func (k *kubernetesClient) ensureNamespaceAnnotationForControllerUUID(controller
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-	if ns != nil && !k8sannotations.New(ns.Annotations).HasAll(k.annotations) {
-		// This should never happen unless we changed annotations for a new juju version.
-		// But in this case, we should have already managed to fix it in upgrade steps.
-		return errors.NewNotValid(nil,
-			fmt.Sprintf("annotations %v for namespace %q must include %v", ns.Annotations, k.namespace, k.annotations),
-		)
+	if !isLegacy {
+		if ns != nil && !k8sannotations.New(ns.Annotations).HasAll(k.annotations) {
+			// This should never happen unless we changed annotations for a new juju version.
+			// But in this case, we should have already managed to fix it in upgrade steps.
+			return errors.NewNotValid(nil,
+				fmt.Sprintf("annotations %v for namespace %q must include %v", ns.Annotations, k.namespace, k.annotations),
+			)
+		}
 	}
 	annotationControllerUUIDKey := utils.AnnotationControllerUUIDKey(isLegacy)
 	k.annotations.Add(annotationControllerUUIDKey, controllerUUID)


### PR DESCRIPTION
*Do the annotation validation only for non legacy models;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# bootstrap to 2.8

$ juju add-model t1

$ juju deploy cs:~juju/mariadb-k8s-3
Located charm "cs:~juju/mariadb-k8s-3".
Deploying charm "cs:~juju/mariadb-k8s-3".

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.8.12   unsupported  17:20:34-07:00

App          Version                         Status  Scale  Charm        Store       Rev  OS          Address        Notes
mariadb-k8s  registry.jujucharms.com/juj...  active      1  mariadb-k8s  jujucharms    3  kubernetes  10.152.183.60

Unit            Workload  Agent  Address       Ports     Message
mariadb-k8s/0*  active    idle   10.1.243.245  3306/TCP

Storage Unit   Storage id  Type        Pool        Mountpoint      Size   Status    Message
mariadb-k8s/0  database/0  filesystem  kubernetes  /var/lib/mysql  35MiB  attached  Successfully provisioned volume pvc-aafdadc7-9896-455a-bbed-cb698563a747

$ juju upgrade-model -m controller --agent-stream=develop
best version:
    2.9.7
started upgrade to 2.9.7

$ juju upgrade-model -m t1 --agent-stream=develop
best version:
    2.9.7
started upgrade to 2.9.7

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.9.7    unsupported  17:22:10-07:00

App          Version                         Status  Scale  Charm        Store       Rev  OS          Address        Notes
mariadb-k8s  registry.jujucharms.com/juj...  active      1  mariadb-k8s  jujucharms    3  kubernetes  10.152.183.60

Unit            Workload  Agent  Address       Ports     Message
mariadb-k8s/0*  active    idle   10.1.243.253  3306/TCP

Storage Unit   Storage id  Type        Pool        Mountpoint      Size   Status    Message
mariadb-k8s/0  database/0  filesystem  kubernetes  /var/lib/mysql  35MiB  attached  Successfully provisioned volume pvc-aafdadc7-9896-455a-bbed-cb698563a747

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1933959
