### PR TITLE
Log discovered spaces

### DIFF
--- a/environs/context/context_mock_test.go
+++ b/environs/context/context_mock_test.go
@@ -5,34 +5,35 @@
 package context
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockModelCredentialInvalidator is a mock of ModelCredentialInvalidator interface
+// MockModelCredentialInvalidator is a mock of ModelCredentialInvalidator interface.
 type MockModelCredentialInvalidator struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelCredentialInvalidatorMockRecorder
 }
 
-// MockModelCredentialInvalidatorMockRecorder is the mock recorder for MockModelCredentialInvalidator
+// MockModelCredentialInvalidatorMockRecorder is the mock recorder for MockModelCredentialInvalidator.
 type MockModelCredentialInvalidatorMockRecorder struct {
 	mock *MockModelCredentialInvalidator
 }
 
-// NewMockModelCredentialInvalidator creates a new mock instance
+// NewMockModelCredentialInvalidator creates a new mock instance.
 func NewMockModelCredentialInvalidator(ctrl *gomock.Controller) *MockModelCredentialInvalidator {
 	mock := &MockModelCredentialInvalidator{ctrl: ctrl}
 	mock.recorder = &MockModelCredentialInvalidatorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelCredentialInvalidator) EXPECT() *MockModelCredentialInvalidatorMockRecorder {
 	return m.recorder
 }
 
-// InvalidateModelCredential mocks base method
+// InvalidateModelCredential mocks base method.
 func (m *MockModelCredentialInvalidator) InvalidateModelCredential(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InvalidateModelCredential", arg0)
@@ -40,7 +41,7 @@ func (m *MockModelCredentialInvalidator) InvalidateModelCredential(arg0 string) 
 	return ret0
 }
 
-// InvalidateModelCredential indicates an expected call of InvalidateModelCredential
+// InvalidateModelCredential indicates an expected call of InvalidateModelCredential.
 func (mr *MockModelCredentialInvalidatorMockRecorder) InvalidateModelCredential(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateModelCredential", reflect.TypeOf((*MockModelCredentialInvalidator)(nil).InvalidateModelCredential), arg0)

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -367,10 +367,10 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method.
-func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
-	ret0, _ := ret[0].([]network.SpaceInfo)
+	ret0, _ := ret[0].(network.SpaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -55,7 +55,7 @@ type Networking interface {
 	// Spaces returns a slice of network.SpaceInfo with info, including
 	// details of all associated subnets, about all spaces known to the
 	// provider that have subnets available.
-	Spaces(ctx context.ProviderCallContext) ([]network.SpaceInfo, error)
+	Spaces(ctx context.ProviderCallContext) (network.SpaceInfos, error)
 
 	// ProviderSpaceInfo returns the details of the space requested as
 	// a ProviderSpaceInfo. This will contain everything needed to
@@ -116,6 +116,32 @@ type NetworkingEnviron interface {
 
 	// Networking defines the methods of networking capable environments.
 	Networking
+}
+
+// NoSpaceDiscoveryEnviron implements methods from Networking that represent an
+// environ without native space support (all but MAAS at the time of writing).
+// None of the method receiver references are used, so it can be embedded
+// as nil without fear of panics.
+type NoSpaceDiscoveryEnviron struct{}
+
+// SupportsSpaceDiscovery (Networking) indicates that
+// this environ does not support space discovery.
+func (*NoSpaceDiscoveryEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
+	return false, nil
+}
+
+// Spaces (Networking) indicates that this provider
+// does not support returning spaces.
+func (*NoSpaceDiscoveryEnviron) Spaces(context.ProviderCallContext) (network.SpaceInfos, error) {
+	return nil, errors.NotSupportedf("Spaces")
+}
+
+// ProviderSpaceInfo (Networking) indicates that this provider
+// does not support returning provider info for the input space.
+func (*NoSpaceDiscoveryEnviron) ProviderSpaceInfo(
+	context.ProviderCallContext, *network.SpaceInfo,
+) (*ProviderSpaceInfo, error) {
+	return nil, errors.NotSupportedf("ProviderSpaceInfo")
 }
 
 func supportsNetworking(environ BootstrapEnviron) (NetworkingEnviron, bool) {

--- a/environs/space/context_mock_test.go
+++ b/environs/space/context_mock_test.go
@@ -5,35 +5,36 @@
 package space
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockProviderCallContext is a mock of ProviderCallContext interface
+// MockProviderCallContext is a mock of ProviderCallContext interface.
 type MockProviderCallContext struct {
 	ctrl     *gomock.Controller
 	recorder *MockProviderCallContextMockRecorder
 }
 
-// MockProviderCallContextMockRecorder is the mock recorder for MockProviderCallContext
+// MockProviderCallContextMockRecorder is the mock recorder for MockProviderCallContext.
 type MockProviderCallContextMockRecorder struct {
 	mock *MockProviderCallContext
 }
 
-// NewMockProviderCallContext creates a new mock instance
+// NewMockProviderCallContext creates a new mock instance.
 func NewMockProviderCallContext(ctrl *gomock.Controller) *MockProviderCallContext {
 	mock := &MockProviderCallContext{ctrl: ctrl}
 	mock.recorder = &MockProviderCallContextMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProviderCallContext) EXPECT() *MockProviderCallContextMockRecorder {
 	return m.recorder
 }
 
-// Deadline mocks base method
+// Deadline mocks base method.
 func (m *MockProviderCallContext) Deadline() (time.Time, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Deadline")
@@ -42,13 +43,13 @@ func (m *MockProviderCallContext) Deadline() (time.Time, bool) {
 	return ret0, ret1
 }
 
-// Deadline indicates an expected call of Deadline
+// Deadline indicates an expected call of Deadline.
 func (mr *MockProviderCallContextMockRecorder) Deadline() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deadline", reflect.TypeOf((*MockProviderCallContext)(nil).Deadline))
 }
 
-// Done mocks base method
+// Done mocks base method.
 func (m *MockProviderCallContext) Done() <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Done")
@@ -56,13 +57,13 @@ func (m *MockProviderCallContext) Done() <-chan struct{} {
 	return ret0
 }
 
-// Done indicates an expected call of Done
+// Done indicates an expected call of Done.
 func (mr *MockProviderCallContextMockRecorder) Done() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockProviderCallContext)(nil).Done))
 }
 
-// Err mocks base method
+// Err mocks base method.
 func (m *MockProviderCallContext) Err() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
@@ -70,13 +71,13 @@ func (m *MockProviderCallContext) Err() error {
 	return ret0
 }
 
-// Err indicates an expected call of Err
+// Err indicates an expected call of Err.
 func (mr *MockProviderCallContextMockRecorder) Err() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockProviderCallContext)(nil).Err))
 }
 
-// InvalidateCredential mocks base method
+// InvalidateCredential mocks base method.
 func (m *MockProviderCallContext) InvalidateCredential(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InvalidateCredential", arg0)
@@ -84,13 +85,13 @@ func (m *MockProviderCallContext) InvalidateCredential(arg0 string) error {
 	return ret0
 }
 
-// InvalidateCredential indicates an expected call of InvalidateCredential
+// InvalidateCredential indicates an expected call of InvalidateCredential.
 func (mr *MockProviderCallContextMockRecorder) InvalidateCredential(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCredential", reflect.TypeOf((*MockProviderCallContext)(nil).InvalidateCredential), arg0)
 }
 
-// Value mocks base method
+// Value mocks base method.
 func (m *MockProviderCallContext) Value(arg0 interface{}) interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value", arg0)
@@ -98,7 +99,7 @@ func (m *MockProviderCallContext) Value(arg0 interface{}) interface{} {
 	return ret0
 }
 
-// Value indicates an expected call of Value
+// Value indicates an expected call of Value.
 func (mr *MockProviderCallContextMockRecorder) Value(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockProviderCallContext)(nil).Value), arg0)

--- a/environs/space/environs_mock_test.go
+++ b/environs/space/environs_mock_test.go
@@ -5,6 +5,8 @@
 package space
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
@@ -16,33 +18,32 @@ import (
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version/v2"
-	reflect "reflect"
 )
 
-// MockBootstrapEnviron is a mock of BootstrapEnviron interface
+// MockBootstrapEnviron is a mock of BootstrapEnviron interface.
 type MockBootstrapEnviron struct {
 	ctrl     *gomock.Controller
 	recorder *MockBootstrapEnvironMockRecorder
 }
 
-// MockBootstrapEnvironMockRecorder is the mock recorder for MockBootstrapEnviron
+// MockBootstrapEnvironMockRecorder is the mock recorder for MockBootstrapEnviron.
 type MockBootstrapEnvironMockRecorder struct {
 	mock *MockBootstrapEnviron
 }
 
-// NewMockBootstrapEnviron creates a new mock instance
+// NewMockBootstrapEnviron creates a new mock instance.
 func NewMockBootstrapEnviron(ctrl *gomock.Controller) *MockBootstrapEnviron {
 	mock := &MockBootstrapEnviron{ctrl: ctrl}
 	mock.recorder = &MockBootstrapEnvironMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBootstrapEnviron) EXPECT() *MockBootstrapEnvironMockRecorder {
 	return m.recorder
 }
 
-// Bootstrap mocks base method
+// Bootstrap mocks base method.
 func (m *MockBootstrapEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
@@ -51,13 +52,13 @@ func (m *MockBootstrapEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 co
 	return ret0, ret1
 }
 
-// Bootstrap indicates an expected call of Bootstrap
+// Bootstrap indicates an expected call of Bootstrap.
 func (mr *MockBootstrapEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapEnviron)(nil).Bootstrap), arg0, arg1, arg2)
 }
 
-// Config mocks base method
+// Config mocks base method.
 func (m *MockBootstrapEnviron) Config() *config.Config {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -65,13 +66,13 @@ func (m *MockBootstrapEnviron) Config() *config.Config {
 	return ret0
 }
 
-// Config indicates an expected call of Config
+// Config indicates an expected call of Config.
 func (mr *MockBootstrapEnvironMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockBootstrapEnviron)(nil).Config))
 }
 
-// ConstraintsValidator mocks base method
+// ConstraintsValidator mocks base method.
 func (m *MockBootstrapEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
@@ -80,13 +81,13 @@ func (m *MockBootstrapEnviron) ConstraintsValidator(arg0 context.ProviderCallCon
 	return ret0, ret1
 }
 
-// ConstraintsValidator indicates an expected call of ConstraintsValidator
+// ConstraintsValidator indicates an expected call of ConstraintsValidator.
 func (mr *MockBootstrapEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsValidator", reflect.TypeOf((*MockBootstrapEnviron)(nil).ConstraintsValidator), arg0)
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockBootstrapEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
@@ -94,13 +95,13 @@ func (m *MockBootstrapEnviron) Create(arg0 context.ProviderCallContext, arg1 env
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockBootstrapEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockBootstrapEnviron)(nil).Create), arg0, arg1)
 }
 
-// Destroy mocks base method
+// Destroy mocks base method.
 func (m *MockBootstrapEnviron) Destroy(arg0 context.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
@@ -108,13 +109,13 @@ func (m *MockBootstrapEnviron) Destroy(arg0 context.ProviderCallContext) error {
 	return ret0
 }
 
-// Destroy indicates an expected call of Destroy
+// Destroy indicates an expected call of Destroy.
 func (mr *MockBootstrapEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockBootstrapEnviron)(nil).Destroy), arg0)
 }
 
-// DestroyController mocks base method
+// DestroyController mocks base method.
 func (m *MockBootstrapEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
@@ -122,13 +123,13 @@ func (m *MockBootstrapEnviron) DestroyController(arg0 context.ProviderCallContex
 	return ret0
 }
 
-// DestroyController indicates an expected call of DestroyController
+// DestroyController indicates an expected call of DestroyController.
 func (mr *MockBootstrapEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyController", reflect.TypeOf((*MockBootstrapEnviron)(nil).DestroyController), arg0, arg1)
 }
 
-// PrepareForBootstrap mocks base method
+// PrepareForBootstrap mocks base method.
 func (m *MockBootstrapEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareForBootstrap", arg0, arg1)
@@ -136,13 +137,13 @@ func (m *MockBootstrapEnviron) PrepareForBootstrap(arg0 environs.BootstrapContex
 	return ret0
 }
 
-// PrepareForBootstrap indicates an expected call of PrepareForBootstrap
+// PrepareForBootstrap indicates an expected call of PrepareForBootstrap.
 func (mr *MockBootstrapEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForBootstrap", reflect.TypeOf((*MockBootstrapEnviron)(nil).PrepareForBootstrap), arg0, arg1)
 }
 
-// SetConfig mocks base method
+// SetConfig mocks base method.
 func (m *MockBootstrapEnviron) SetConfig(arg0 *config.Config) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConfig", arg0)
@@ -150,13 +151,13 @@ func (m *MockBootstrapEnviron) SetConfig(arg0 *config.Config) error {
 	return ret0
 }
 
-// SetConfig indicates an expected call of SetConfig
+// SetConfig indicates an expected call of SetConfig.
 func (mr *MockBootstrapEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBootstrapEnviron)(nil).SetConfig), arg0)
 }
 
-// StorageProvider mocks base method
+// StorageProvider mocks base method.
 func (m *MockBootstrapEnviron) StorageProvider(arg0 storage.ProviderType) (storage.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProvider", arg0)
@@ -165,13 +166,13 @@ func (m *MockBootstrapEnviron) StorageProvider(arg0 storage.ProviderType) (stora
 	return ret0, ret1
 }
 
-// StorageProvider indicates an expected call of StorageProvider
+// StorageProvider indicates an expected call of StorageProvider.
 func (mr *MockBootstrapEnvironMockRecorder) StorageProvider(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProvider", reflect.TypeOf((*MockBootstrapEnviron)(nil).StorageProvider), arg0)
 }
 
-// StorageProviderTypes mocks base method
+// StorageProviderTypes mocks base method.
 func (m *MockBootstrapEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProviderTypes")
@@ -180,36 +181,36 @@ func (m *MockBootstrapEnviron) StorageProviderTypes() ([]storage.ProviderType, e
 	return ret0, ret1
 }
 
-// StorageProviderTypes indicates an expected call of StorageProviderTypes
+// StorageProviderTypes indicates an expected call of StorageProviderTypes.
 func (mr *MockBootstrapEnvironMockRecorder) StorageProviderTypes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProviderTypes", reflect.TypeOf((*MockBootstrapEnviron)(nil).StorageProviderTypes))
 }
 
-// MockNetworkingEnviron is a mock of NetworkingEnviron interface
+// MockNetworkingEnviron is a mock of NetworkingEnviron interface.
 type MockNetworkingEnviron struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetworkingEnvironMockRecorder
 }
 
-// MockNetworkingEnvironMockRecorder is the mock recorder for MockNetworkingEnviron
+// MockNetworkingEnvironMockRecorder is the mock recorder for MockNetworkingEnviron.
 type MockNetworkingEnvironMockRecorder struct {
 	mock *MockNetworkingEnviron
 }
 
-// NewMockNetworkingEnviron creates a new mock instance
+// NewMockNetworkingEnviron creates a new mock instance.
 func NewMockNetworkingEnviron(ctrl *gomock.Controller) *MockNetworkingEnviron {
 	mock := &MockNetworkingEnviron{ctrl: ctrl}
 	mock.recorder = &MockNetworkingEnvironMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkingEnviron) EXPECT() *MockNetworkingEnvironMockRecorder {
 	return m.recorder
 }
 
-// AdoptResources mocks base method
+// AdoptResources mocks base method.
 func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext, arg1 string, arg2 version.Number) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdoptResources", arg0, arg1, arg2)
@@ -217,13 +218,13 @@ func (m *MockNetworkingEnviron) AdoptResources(arg0 context.ProviderCallContext,
 	return ret0
 }
 
-// AdoptResources indicates an expected call of AdoptResources
+// AdoptResources indicates an expected call of AdoptResources.
 func (mr *MockNetworkingEnvironMockRecorder) AdoptResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdoptResources", reflect.TypeOf((*MockNetworkingEnviron)(nil).AdoptResources), arg0, arg1, arg2)
 }
 
-// AllInstances mocks base method
+// AllInstances mocks base method.
 func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
@@ -232,13 +233,13 @@ func (m *MockNetworkingEnviron) AllInstances(arg0 context.ProviderCallContext) (
 	return ret0, ret1
 }
 
-// AllInstances indicates an expected call of AllInstances
+// AllInstances indicates an expected call of AllInstances.
 func (mr *MockNetworkingEnvironMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllInstances), arg0)
 }
 
-// AllRunningInstances mocks base method
+// AllRunningInstances mocks base method.
 func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
@@ -247,13 +248,13 @@ func (m *MockNetworkingEnviron) AllRunningInstances(arg0 context.ProviderCallCon
 	return ret0, ret1
 }
 
-// AllRunningInstances indicates an expected call of AllRunningInstances
+// AllRunningInstances indicates an expected call of AllRunningInstances.
 func (mr *MockNetworkingEnvironMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllRunningInstances), arg0)
 }
 
-// AllocateContainerAddresses mocks base method
+// AllocateContainerAddresses mocks base method.
 func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 names.MachineTag, arg3 network.InterfaceInfos) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateContainerAddresses", arg0, arg1, arg2, arg3)
@@ -262,13 +263,13 @@ func (m *MockNetworkingEnviron) AllocateContainerAddresses(arg0 context.Provider
 	return ret0, ret1
 }
 
-// AllocateContainerAddresses indicates an expected call of AllocateContainerAddresses
+// AllocateContainerAddresses indicates an expected call of AllocateContainerAddresses.
 func (mr *MockNetworkingEnvironMockRecorder) AllocateContainerAddresses(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).AllocateContainerAddresses), arg0, arg1, arg2, arg3)
 }
 
-// AreSpacesRoutable mocks base method
+// AreSpacesRoutable mocks base method.
 func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallContext, arg1, arg2 *environs.ProviderSpaceInfo) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AreSpacesRoutable", arg0, arg1, arg2)
@@ -277,13 +278,13 @@ func (m *MockNetworkingEnviron) AreSpacesRoutable(arg0 context.ProviderCallConte
 	return ret0, ret1
 }
 
-// AreSpacesRoutable indicates an expected call of AreSpacesRoutable
+// AreSpacesRoutable indicates an expected call of AreSpacesRoutable.
 func (mr *MockNetworkingEnvironMockRecorder) AreSpacesRoutable(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreSpacesRoutable", reflect.TypeOf((*MockNetworkingEnviron)(nil).AreSpacesRoutable), arg0, arg1, arg2)
 }
 
-// Bootstrap mocks base method
+// Bootstrap mocks base method.
 func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 context.ProviderCallContext, arg2 environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1, arg2)
@@ -292,13 +293,13 @@ func (m *MockNetworkingEnviron) Bootstrap(arg0 environs.BootstrapContext, arg1 c
 	return ret0, ret1
 }
 
-// Bootstrap indicates an expected call of Bootstrap
+// Bootstrap indicates an expected call of Bootstrap.
 func (mr *MockNetworkingEnvironMockRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).Bootstrap), arg0, arg1, arg2)
 }
 
-// Config mocks base method
+// Config mocks base method.
 func (m *MockNetworkingEnviron) Config() *config.Config {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -306,13 +307,13 @@ func (m *MockNetworkingEnviron) Config() *config.Config {
 	return ret0
 }
 
-// Config indicates an expected call of Config
+// Config indicates an expected call of Config.
 func (mr *MockNetworkingEnvironMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockNetworkingEnviron)(nil).Config))
 }
 
-// ConstraintsValidator mocks base method
+// ConstraintsValidator mocks base method.
 func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallContext) (constraints.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsValidator", arg0)
@@ -321,13 +322,13 @@ func (m *MockNetworkingEnviron) ConstraintsValidator(arg0 context.ProviderCallCo
 	return ret0, ret1
 }
 
-// ConstraintsValidator indicates an expected call of ConstraintsValidator
+// ConstraintsValidator indicates an expected call of ConstraintsValidator.
 func (mr *MockNetworkingEnvironMockRecorder) ConstraintsValidator(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsValidator", reflect.TypeOf((*MockNetworkingEnviron)(nil).ConstraintsValidator), arg0)
 }
 
-// ControllerInstances mocks base method
+// ControllerInstances mocks base method.
 func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallContext, arg1 string) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerInstances", arg0, arg1)
@@ -336,13 +337,13 @@ func (m *MockNetworkingEnviron) ControllerInstances(arg0 context.ProviderCallCon
 	return ret0, ret1
 }
 
-// ControllerInstances indicates an expected call of ControllerInstances
+// ControllerInstances indicates an expected call of ControllerInstances.
 func (mr *MockNetworkingEnvironMockRecorder) ControllerInstances(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerInstances", reflect.TypeOf((*MockNetworkingEnviron)(nil).ControllerInstances), arg0, arg1)
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 environs.CreateParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
@@ -350,13 +351,13 @@ func (m *MockNetworkingEnviron) Create(arg0 context.ProviderCallContext, arg1 en
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockNetworkingEnvironMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockNetworkingEnviron)(nil).Create), arg0, arg1)
 }
 
-// Destroy mocks base method
+// Destroy mocks base method.
 func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0)
@@ -364,13 +365,13 @@ func (m *MockNetworkingEnviron) Destroy(arg0 context.ProviderCallContext) error 
 	return ret0
 }
 
-// Destroy indicates an expected call of Destroy
+// Destroy indicates an expected call of Destroy.
 func (mr *MockNetworkingEnvironMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockNetworkingEnviron)(nil).Destroy), arg0)
 }
 
-// DestroyController mocks base method
+// DestroyController mocks base method.
 func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DestroyController", arg0, arg1)
@@ -378,13 +379,13 @@ func (m *MockNetworkingEnviron) DestroyController(arg0 context.ProviderCallConte
 	return ret0
 }
 
-// DestroyController indicates an expected call of DestroyController
+// DestroyController indicates an expected call of DestroyController.
 func (mr *MockNetworkingEnvironMockRecorder) DestroyController(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyController", reflect.TypeOf((*MockNetworkingEnviron)(nil).DestroyController), arg0, arg1)
 }
 
-// InstanceTypes mocks base method
+// InstanceTypes mocks base method.
 func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, arg1 constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceTypes", arg0, arg1)
@@ -393,13 +394,13 @@ func (m *MockNetworkingEnviron) InstanceTypes(arg0 context.ProviderCallContext, 
 	return ret0, ret1
 }
 
-// InstanceTypes indicates an expected call of InstanceTypes
+// InstanceTypes indicates an expected call of InstanceTypes.
 func (mr *MockNetworkingEnvironMockRecorder) InstanceTypes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceTypes", reflect.TypeOf((*MockNetworkingEnviron)(nil).InstanceTypes), arg0, arg1)
 }
 
-// Instances mocks base method
+// Instances mocks base method.
 func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instances", arg0, arg1)
@@ -408,13 +409,13 @@ func (m *MockNetworkingEnviron) Instances(arg0 context.ProviderCallContext, arg1
 	return ret0, ret1
 }
 
-// Instances indicates an expected call of Instances
+// Instances indicates an expected call of Instances.
 func (mr *MockNetworkingEnvironMockRecorder) Instances(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instances", reflect.TypeOf((*MockNetworkingEnviron)(nil).Instances), arg0, arg1)
 }
 
-// NetworkInterfaces mocks base method
+// NetworkInterfaces mocks base method.
 func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallContext, arg1 []instance.Id) ([]network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInterfaces", arg0, arg1)
@@ -423,13 +424,13 @@ func (m *MockNetworkingEnviron) NetworkInterfaces(arg0 context.ProviderCallConte
 	return ret0, ret1
 }
 
-// NetworkInterfaces indicates an expected call of NetworkInterfaces
+// NetworkInterfaces indicates an expected call of NetworkInterfaces.
 func (mr *MockNetworkingEnvironMockRecorder) NetworkInterfaces(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInterfaces", reflect.TypeOf((*MockNetworkingEnviron)(nil).NetworkInterfaces), arg0, arg1)
 }
 
-// PrecheckInstance mocks base method
+// PrecheckInstance mocks base method.
 func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContext, arg1 environs.PrecheckInstanceParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrecheckInstance", arg0, arg1)
@@ -437,13 +438,13 @@ func (m *MockNetworkingEnviron) PrecheckInstance(arg0 context.ProviderCallContex
 	return ret0
 }
 
-// PrecheckInstance indicates an expected call of PrecheckInstance
+// PrecheckInstance indicates an expected call of PrecheckInstance.
 func (mr *MockNetworkingEnvironMockRecorder) PrecheckInstance(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrecheckInstance", reflect.TypeOf((*MockNetworkingEnviron)(nil).PrecheckInstance), arg0, arg1)
 }
 
-// PrepareForBootstrap mocks base method
+// PrepareForBootstrap mocks base method.
 func (m *MockNetworkingEnviron) PrepareForBootstrap(arg0 environs.BootstrapContext, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareForBootstrap", arg0, arg1)
@@ -451,13 +452,13 @@ func (m *MockNetworkingEnviron) PrepareForBootstrap(arg0 environs.BootstrapConte
 	return ret0
 }
 
-// PrepareForBootstrap indicates an expected call of PrepareForBootstrap
+// PrepareForBootstrap indicates an expected call of PrepareForBootstrap.
 func (mr *MockNetworkingEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForBootstrap", reflect.TypeOf((*MockNetworkingEnviron)(nil).PrepareForBootstrap), arg0, arg1)
 }
 
-// Provider mocks base method
+// Provider mocks base method.
 func (m *MockNetworkingEnviron) Provider() environs.EnvironProvider {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Provider")
@@ -465,13 +466,13 @@ func (m *MockNetworkingEnviron) Provider() environs.EnvironProvider {
 	return ret0
 }
 
-// Provider indicates an expected call of Provider
+// Provider indicates an expected call of Provider.
 func (mr *MockNetworkingEnvironMockRecorder) Provider() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockNetworkingEnviron)(nil).Provider))
 }
 
-// ProviderSpaceInfo mocks base method
+// ProviderSpaceInfo mocks base method.
 func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallContext, arg1 *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderSpaceInfo", arg0, arg1)
@@ -480,13 +481,13 @@ func (m *MockNetworkingEnviron) ProviderSpaceInfo(arg0 context.ProviderCallConte
 	return ret0, ret1
 }
 
-// ProviderSpaceInfo indicates an expected call of ProviderSpaceInfo
+// ProviderSpaceInfo indicates an expected call of ProviderSpaceInfo.
 func (mr *MockNetworkingEnvironMockRecorder) ProviderSpaceInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderSpaceInfo", reflect.TypeOf((*MockNetworkingEnviron)(nil).ProviderSpaceInfo), arg0, arg1)
 }
 
-// ReleaseContainerAddresses mocks base method
+// ReleaseContainerAddresses mocks base method.
 func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderCallContext, arg1 []network.ProviderInterfaceInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
@@ -494,13 +495,13 @@ func (m *MockNetworkingEnviron) ReleaseContainerAddresses(arg0 context.ProviderC
 	return ret0
 }
 
-// ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses
+// ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses.
 func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).ReleaseContainerAddresses), arg0, arg1)
 }
 
-// SSHAddresses mocks base method
+// SSHAddresses mocks base method.
 func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
@@ -509,13 +510,13 @@ func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, a
 	return ret0, ret1
 }
 
-// SSHAddresses indicates an expected call of SSHAddresses
+// SSHAddresses indicates an expected call of SSHAddresses.
 func (mr *MockNetworkingEnvironMockRecorder) SSHAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).SSHAddresses), arg0, arg1)
 }
 
-// SetConfig mocks base method
+// SetConfig mocks base method.
 func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConfig", arg0)
@@ -523,28 +524,28 @@ func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
 	return ret0
 }
 
-// SetConfig indicates an expected call of SetConfig
+// SetConfig indicates an expected call of SetConfig.
 func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockNetworkingEnviron)(nil).SetConfig), arg0)
 }
 
-// Spaces mocks base method
-func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) ([]network.SpaceInfo, error) {
+// Spaces mocks base method.
+func (m *MockNetworkingEnviron) Spaces(arg0 context.ProviderCallContext) (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
-	ret0, _ := ret[0].([]network.SpaceInfo)
+	ret0, _ := ret[0].(network.SpaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Spaces indicates an expected call of Spaces
+// Spaces indicates an expected call of Spaces.
 func (mr *MockNetworkingEnvironMockRecorder) Spaces(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Spaces", reflect.TypeOf((*MockNetworkingEnviron)(nil).Spaces), arg0)
 }
 
-// StartInstance mocks base method
+// StartInstance mocks base method.
 func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
@@ -553,13 +554,13 @@ func (m *MockNetworkingEnviron) StartInstance(arg0 context.ProviderCallContext, 
 	return ret0, ret1
 }
 
-// StartInstance indicates an expected call of StartInstance
+// StartInstance indicates an expected call of StartInstance.
 func (mr *MockNetworkingEnvironMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockNetworkingEnviron)(nil).StartInstance), arg0, arg1)
 }
 
-// StopInstances mocks base method
+// StopInstances mocks base method.
 func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -571,14 +572,14 @@ func (m *MockNetworkingEnviron) StopInstances(arg0 context.ProviderCallContext, 
 	return ret0
 }
 
-// StopInstances indicates an expected call of StopInstances
+// StopInstances indicates an expected call of StopInstances.
 func (mr *MockNetworkingEnvironMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockNetworkingEnviron)(nil).StopInstances), varargs...)
 }
 
-// StorageProvider mocks base method
+// StorageProvider mocks base method.
 func (m *MockNetworkingEnviron) StorageProvider(arg0 storage.ProviderType) (storage.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProvider", arg0)
@@ -587,13 +588,13 @@ func (m *MockNetworkingEnviron) StorageProvider(arg0 storage.ProviderType) (stor
 	return ret0, ret1
 }
 
-// StorageProvider indicates an expected call of StorageProvider
+// StorageProvider indicates an expected call of StorageProvider.
 func (mr *MockNetworkingEnvironMockRecorder) StorageProvider(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProvider", reflect.TypeOf((*MockNetworkingEnviron)(nil).StorageProvider), arg0)
 }
 
-// StorageProviderTypes mocks base method
+// StorageProviderTypes mocks base method.
 func (m *MockNetworkingEnviron) StorageProviderTypes() ([]storage.ProviderType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageProviderTypes")
@@ -602,13 +603,13 @@ func (m *MockNetworkingEnviron) StorageProviderTypes() ([]storage.ProviderType, 
 	return ret0, ret1
 }
 
-// StorageProviderTypes indicates an expected call of StorageProviderTypes
+// StorageProviderTypes indicates an expected call of StorageProviderTypes.
 func (mr *MockNetworkingEnvironMockRecorder) StorageProviderTypes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageProviderTypes", reflect.TypeOf((*MockNetworkingEnviron)(nil).StorageProviderTypes))
 }
 
-// Subnets mocks base method
+// Subnets mocks base method.
 func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
@@ -617,13 +618,13 @@ func (m *MockNetworkingEnviron) Subnets(arg0 context.ProviderCallContext, arg1 i
 	return ret0, ret1
 }
 
-// Subnets indicates an expected call of Subnets
+// Subnets indicates an expected call of Subnets.
 func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).Subnets), arg0, arg1, arg2)
 }
 
-// SuperSubnets mocks base method
+// SuperSubnets mocks base method.
 func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
@@ -632,13 +633,13 @@ func (m *MockNetworkingEnviron) SuperSubnets(arg0 context.ProviderCallContext) (
 	return ret0, ret1
 }
 
-// SuperSubnets indicates an expected call of SuperSubnets
+// SuperSubnets indicates an expected call of SuperSubnets.
 func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuperSubnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).SuperSubnets), arg0)
 }
 
-// SupportsContainerAddresses mocks base method
+// SupportsContainerAddresses mocks base method.
 func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsContainerAddresses", arg0)
@@ -647,13 +648,13 @@ func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 context.Provider
 	return ret0, ret1
 }
 
-// SupportsContainerAddresses indicates an expected call of SupportsContainerAddresses
+// SupportsContainerAddresses indicates an expected call of SupportsContainerAddresses.
 func (mr *MockNetworkingEnvironMockRecorder) SupportsContainerAddresses(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).SupportsContainerAddresses), arg0)
 }
 
-// SupportsSpaceDiscovery mocks base method
+// SupportsSpaceDiscovery mocks base method.
 func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaceDiscovery", arg0)
@@ -662,13 +663,13 @@ func (m *MockNetworkingEnviron) SupportsSpaceDiscovery(arg0 context.ProviderCall
 	return ret0, ret1
 }
 
-// SupportsSpaceDiscovery indicates an expected call of SupportsSpaceDiscovery
+// SupportsSpaceDiscovery indicates an expected call of SupportsSpaceDiscovery.
 func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaceDiscovery(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsSpaceDiscovery", reflect.TypeOf((*MockNetworkingEnviron)(nil).SupportsSpaceDiscovery), arg0)
 }
 
-// SupportsSpaces mocks base method
+// SupportsSpaces mocks base method.
 func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportsSpaces", arg0)
@@ -677,7 +678,7 @@ func (m *MockNetworkingEnviron) SupportsSpaces(arg0 context.ProviderCallContext)
 	return ret0, ret1
 }
 
-// SupportsSpaces indicates an expected call of SupportsSpaces
+// SupportsSpaces indicates an expected call of SupportsSpaces.
 func (mr *MockNetworkingEnvironMockRecorder) SupportsSpaces(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsSpaces", reflect.TypeOf((*MockNetworkingEnviron)(nil).SupportsSpaces), arg0)

--- a/environs/space/spaces.go
+++ b/environs/space/spaces.go
@@ -63,11 +63,14 @@ func ReloadSpaces(ctx context.ProviderCallContext, state ReloadSpacesState, envi
 	if err != nil {
 		return errors.Trace(err)
 	}
+
 	if canDiscoverSpaces {
 		spaces, err := netEnviron.Spaces(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		logger.Infof("discovered spaces: %s", spaces.String())
 
 		providerSpaces := NewProviderSpaces(state)
 		if err := providerSpaces.SaveSpaces(spaces); err != nil {
@@ -145,7 +148,7 @@ func (s *ProviderSpaces) SaveSpaces(providerSpaces []network.SpaceInfo) error {
 			spaceNames.Add(spaceName)
 			spaceID = space.Id()
 
-			// To ensure that we can remove spaces, we backfill the new spaces
+			// To ensure that we can remove spaces, we back-fill the new spaces
 			// onto the modelSpaceMap.
 			s.modelSpaceMap[space.ProviderId()] = space
 		}

--- a/environs/space/spaces_mock_test.go
+++ b/environs/space/spaces_mock_test.go
@@ -5,37 +5,38 @@
 package space
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
-	reflect "reflect"
 )
 
-// MockReloadSpacesState is a mock of ReloadSpacesState interface
+// MockReloadSpacesState is a mock of ReloadSpacesState interface.
 type MockReloadSpacesState struct {
 	ctrl     *gomock.Controller
 	recorder *MockReloadSpacesStateMockRecorder
 }
 
-// MockReloadSpacesStateMockRecorder is the mock recorder for MockReloadSpacesState
+// MockReloadSpacesStateMockRecorder is the mock recorder for MockReloadSpacesState.
 type MockReloadSpacesStateMockRecorder struct {
 	mock *MockReloadSpacesState
 }
 
-// NewMockReloadSpacesState creates a new mock instance
+// NewMockReloadSpacesState creates a new mock instance.
 func NewMockReloadSpacesState(ctrl *gomock.Controller) *MockReloadSpacesState {
 	mock := &MockReloadSpacesState{ctrl: ctrl}
 	mock.recorder = &MockReloadSpacesStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReloadSpacesState) EXPECT() *MockReloadSpacesStateMockRecorder {
 	return m.recorder
 }
 
-// AddSpace mocks base method
+// AddSpace mocks base method.
 func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []string, arg3 bool) (Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSpace", arg0, arg1, arg2, arg3)
@@ -44,13 +45,13 @@ func (m *MockReloadSpacesState) AddSpace(arg0 string, arg1 network.Id, arg2 []st
 	return ret0, ret1
 }
 
-// AddSpace indicates an expected call of AddSpace
+// AddSpace indicates an expected call of AddSpace.
 func (mr *MockReloadSpacesStateMockRecorder) AddSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).AddSpace), arg0, arg1, arg2, arg3)
 }
 
-// AllEndpointBindingsSpaceNames mocks base method
+// AllEndpointBindingsSpaceNames mocks base method.
 func (m *MockReloadSpacesState) AllEndpointBindingsSpaceNames() (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllEndpointBindingsSpaceNames")
@@ -59,13 +60,13 @@ func (m *MockReloadSpacesState) AllEndpointBindingsSpaceNames() (set.Strings, er
 	return ret0, ret1
 }
 
-// AllEndpointBindingsSpaceNames indicates an expected call of AllEndpointBindingsSpaceNames
+// AllEndpointBindingsSpaceNames indicates an expected call of AllEndpointBindingsSpaceNames.
 func (mr *MockReloadSpacesStateMockRecorder) AllEndpointBindingsSpaceNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllEndpointBindingsSpaceNames", reflect.TypeOf((*MockReloadSpacesState)(nil).AllEndpointBindingsSpaceNames))
 }
 
-// AllSpaces mocks base method
+// AllSpaces mocks base method.
 func (m *MockReloadSpacesState) AllSpaces() ([]Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaces")
@@ -74,13 +75,13 @@ func (m *MockReloadSpacesState) AllSpaces() ([]Space, error) {
 	return ret0, ret1
 }
 
-// AllSpaces indicates an expected call of AllSpaces
+// AllSpaces indicates an expected call of AllSpaces.
 func (mr *MockReloadSpacesStateMockRecorder) AllSpaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaces", reflect.TypeOf((*MockReloadSpacesState)(nil).AllSpaces))
 }
 
-// ConstraintsBySpaceName mocks base method
+// ConstraintsBySpaceName mocks base method.
 func (m *MockReloadSpacesState) ConstraintsBySpaceName(arg0 string) ([]Constraints, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConstraintsBySpaceName", arg0)
@@ -89,13 +90,13 @@ func (m *MockReloadSpacesState) ConstraintsBySpaceName(arg0 string) ([]Constrain
 	return ret0, ret1
 }
 
-// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName
+// ConstraintsBySpaceName indicates an expected call of ConstraintsBySpaceName.
 func (mr *MockReloadSpacesStateMockRecorder) ConstraintsBySpaceName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConstraintsBySpaceName", reflect.TypeOf((*MockReloadSpacesState)(nil).ConstraintsBySpaceName), arg0)
 }
 
-// DefaultEndpointBindingSpace mocks base method
+// DefaultEndpointBindingSpace mocks base method.
 func (m *MockReloadSpacesState) DefaultEndpointBindingSpace() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
@@ -104,13 +105,13 @@ func (m *MockReloadSpacesState) DefaultEndpointBindingSpace() (string, error) {
 	return ret0, ret1
 }
 
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace
+// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
 func (mr *MockReloadSpacesStateMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockReloadSpacesState)(nil).DefaultEndpointBindingSpace))
 }
 
-// SaveProviderSubnets mocks base method
+// SaveProviderSubnets mocks base method.
 func (m *MockReloadSpacesState) SaveProviderSubnets(arg0 []network.SubnetInfo, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveProviderSubnets", arg0, arg1)
@@ -118,36 +119,36 @@ func (m *MockReloadSpacesState) SaveProviderSubnets(arg0 []network.SubnetInfo, a
 	return ret0
 }
 
-// SaveProviderSubnets indicates an expected call of SaveProviderSubnets
+// SaveProviderSubnets indicates an expected call of SaveProviderSubnets.
 func (mr *MockReloadSpacesStateMockRecorder) SaveProviderSubnets(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveProviderSubnets", reflect.TypeOf((*MockReloadSpacesState)(nil).SaveProviderSubnets), arg0, arg1)
 }
 
-// MockSpace is a mock of Space interface
+// MockSpace is a mock of Space interface.
 type MockSpace struct {
 	ctrl     *gomock.Controller
 	recorder *MockSpaceMockRecorder
 }
 
-// MockSpaceMockRecorder is the mock recorder for MockSpace
+// MockSpaceMockRecorder is the mock recorder for MockSpace.
 type MockSpaceMockRecorder struct {
 	mock *MockSpace
 }
 
-// NewMockSpace creates a new mock instance
+// NewMockSpace creates a new mock instance.
 func NewMockSpace(ctrl *gomock.Controller) *MockSpace {
 	mock := &MockSpace{ctrl: ctrl}
 	mock.recorder = &MockSpaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSpace) EXPECT() *MockSpaceMockRecorder {
 	return m.recorder
 }
 
-// EnsureDead mocks base method
+// EnsureDead mocks base method.
 func (m *MockSpace) EnsureDead() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDead")
@@ -155,13 +156,13 @@ func (m *MockSpace) EnsureDead() error {
 	return ret0
 }
 
-// EnsureDead indicates an expected call of EnsureDead
+// EnsureDead indicates an expected call of EnsureDead.
 func (mr *MockSpaceMockRecorder) EnsureDead() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockSpace)(nil).EnsureDead))
 }
 
-// Id mocks base method
+// Id mocks base method.
 func (m *MockSpace) Id() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
@@ -169,13 +170,13 @@ func (m *MockSpace) Id() string {
 	return ret0
 }
 
-// Id indicates an expected call of Id
+// Id indicates an expected call of Id.
 func (mr *MockSpaceMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockSpace)(nil).Id))
 }
 
-// Life mocks base method
+// Life mocks base method.
 func (m *MockSpace) Life() state.Life {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
@@ -183,13 +184,13 @@ func (m *MockSpace) Life() state.Life {
 	return ret0
 }
 
-// Life indicates an expected call of Life
+// Life indicates an expected call of Life.
 func (mr *MockSpaceMockRecorder) Life() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockSpace)(nil).Life))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockSpace) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -197,13 +198,13 @@ func (m *MockSpace) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockSpaceMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockSpace)(nil).Name))
 }
 
-// ProviderId mocks base method
+// ProviderId mocks base method.
 func (m *MockSpace) ProviderId() network.Id {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderId")
@@ -211,13 +212,13 @@ func (m *MockSpace) ProviderId() network.Id {
 	return ret0
 }
 
-// ProviderId indicates an expected call of ProviderId
+// ProviderId indicates an expected call of ProviderId.
 func (mr *MockSpaceMockRecorder) ProviderId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderId", reflect.TypeOf((*MockSpace)(nil).ProviderId))
 }
 
-// Remove mocks base method
+// Remove mocks base method.
 func (m *MockSpace) Remove() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove")
@@ -225,31 +226,31 @@ func (m *MockSpace) Remove() error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove
+// Remove indicates an expected call of Remove.
 func (mr *MockSpaceMockRecorder) Remove() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockSpace)(nil).Remove))
 }
 
-// MockConstraints is a mock of Constraints interface
+// MockConstraints is a mock of Constraints interface.
 type MockConstraints struct {
 	ctrl     *gomock.Controller
 	recorder *MockConstraintsMockRecorder
 }
 
-// MockConstraintsMockRecorder is the mock recorder for MockConstraints
+// MockConstraintsMockRecorder is the mock recorder for MockConstraints.
 type MockConstraintsMockRecorder struct {
 	mock *MockConstraints
 }
 
-// NewMockConstraints creates a new mock instance
+// NewMockConstraints creates a new mock instance.
 func NewMockConstraints(ctrl *gomock.Controller) *MockConstraints {
 	mock := &MockConstraints{ctrl: ctrl}
 	mock.recorder = &MockConstraintsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConstraints) EXPECT() *MockConstraintsMockRecorder {
 	return m.recorder
 }

--- a/environs/sync/simplestreams_mock_test.go
+++ b/environs/sync/simplestreams_mock_test.go
@@ -5,35 +5,36 @@
 package sync_test
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	simplestreams "github.com/juju/juju/environs/simplestreams"
-	reflect "reflect"
 )
 
-// MockSimplestreamsFetcher is a mock of SimplestreamsFetcher interface
+// MockSimplestreamsFetcher is a mock of SimplestreamsFetcher interface.
 type MockSimplestreamsFetcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockSimplestreamsFetcherMockRecorder
 }
 
-// MockSimplestreamsFetcherMockRecorder is the mock recorder for MockSimplestreamsFetcher
+// MockSimplestreamsFetcherMockRecorder is the mock recorder for MockSimplestreamsFetcher.
 type MockSimplestreamsFetcherMockRecorder struct {
 	mock *MockSimplestreamsFetcher
 }
 
-// NewMockSimplestreamsFetcher creates a new mock instance
+// NewMockSimplestreamsFetcher creates a new mock instance.
 func NewMockSimplestreamsFetcher(ctrl *gomock.Controller) *MockSimplestreamsFetcher {
 	mock := &MockSimplestreamsFetcher{ctrl: ctrl}
 	mock.recorder = &MockSimplestreamsFetcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSimplestreamsFetcher) EXPECT() *MockSimplestreamsFetcherMockRecorder {
 	return m.recorder
 }
 
-// GetMetadata mocks base method
+// GetMetadata mocks base method.
 func (m *MockSimplestreamsFetcher) GetMetadata(arg0 []simplestreams.DataSource, arg1 simplestreams.GetMetadataParams) ([]interface{}, *simplestreams.ResolveInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetadata", arg0, arg1)
@@ -43,13 +44,13 @@ func (m *MockSimplestreamsFetcher) GetMetadata(arg0 []simplestreams.DataSource, 
 	return ret0, ret1, ret2
 }
 
-// GetMetadata indicates an expected call of GetMetadata
+// GetMetadata indicates an expected call of GetMetadata.
 func (mr *MockSimplestreamsFetcherMockRecorder) GetMetadata(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockSimplestreamsFetcher)(nil).GetMetadata), arg0, arg1)
 }
 
-// NewDataSource mocks base method
+// NewDataSource mocks base method.
 func (m *MockSimplestreamsFetcher) NewDataSource(arg0 simplestreams.Config) simplestreams.DataSource {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewDataSource", arg0)
@@ -57,7 +58,7 @@ func (m *MockSimplestreamsFetcher) NewDataSource(arg0 simplestreams.Config) simp
 	return ret0
 }
 
-// NewDataSource indicates an expected call of NewDataSource
+// NewDataSource indicates an expected call of NewDataSource.
 func (mr *MockSimplestreamsFetcherMockRecorder) NewDataSource(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDataSource", reflect.TypeOf((*MockSimplestreamsFetcher)(nil).NewDataSource), arg0)

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -1781,10 +1781,10 @@ func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 interface{}) *gomock
 }
 
 // Spaces mocks base method.
-func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (m *MockNetworkingEnviron) Spaces(arg0 context0.ProviderCallContext) (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces", arg0)
-	ret0, _ := ret[0].([]network.SpaceInfo)
+	ret0, _ := ret[0].(network.SpaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -85,13 +85,15 @@ const (
 )
 
 type azureEnviron struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	// provider is the azureEnvironProvider used to open this environment.
 	provider *azureEnvironProvider
 
 	// cloud defines the cloud configuration for this environment.
 	cloud environscloudspec.CloudSpec
 
-	// location is the canonicalized location name. Use this instead
+	// location is the canonical location name. Use this instead
 	// of cloud.Region in API calls.
 	location string
 

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -105,16 +105,6 @@ func (env *azureEnviron) SuperSubnets(context.ProviderCallContext) ([]string, er
 	return nil, errors.NotSupportedf("super subnets")
 }
 
-// SupportsSpaceDiscovery implements environs.NetworkingEnviron.
-func (env *azureEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
-	return false, nil
-}
-
-// Spaces implements environs.NetworkingEnviron.
-func (env *azureEnviron) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
 // SupportsContainerAddresses implements environs.NetworkingEnviron.
 func (env *azureEnviron) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
 	return false, nil
@@ -130,13 +120,6 @@ func (env *azureEnviron) AllocateContainerAddresses(
 // ReleaseContainerAddresses implements environs.NetworkingEnviron.
 func (env *azureEnviron) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container addresses")
-}
-
-// ProviderSpaceInfo implements environs.NetworkingEnviron.
-func (*azureEnviron) ProviderSpaceInfo(
-	context.ProviderCallContext, *network.SpaceInfo,
-) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("provider space info")
 }
 
 // AreSpacesRoutable implements environs.NetworkingEnviron.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// The dummy provider implements an environment provider for testing
+// Package dummy implements an environment provider for testing
 // purposes, registered with environs under the name "dummy".
 //
 // The configuration YAML for the testing environment
@@ -1407,7 +1407,7 @@ func (env *environ) SupportsContainerAddresses(ctx context.ProviderCallContext) 
 }
 
 // Spaces is specified on environs.Networking.
-func (env *environ) Spaces(ctx context.ProviderCallContext) ([]network.SpaceInfo, error) {
+func (env *environ) Spaces(ctx context.ProviderCallContext) (network.SpaceInfos, error) {
 	if err := env.checkBroken("Spaces"); err != nil {
 		return []network.SpaceInfo{}, err
 	}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -83,6 +83,8 @@ var (
 var _ Client = (*ec2.Client)(nil)
 
 type environ struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	name  string
 	cloud environscloudspec.CloudSpec
 
@@ -187,11 +189,6 @@ func (e *environ) SupportsSpaces(ctx context.ProviderCallContext) (bool, error) 
 // SupportsContainerAddresses is specified on environs.Networking.
 func (e *environ) SupportsContainerAddresses(ctx context.ProviderCallContext) (bool, error) {
 	return false, errors.NotSupportedf("container address allocation")
-}
-
-// SupportsSpaceDiscovery is specified on environs.Networking.
-func (e *environ) SupportsSpaceDiscovery(ctx context.ProviderCallContext) (bool, error) {
-	return false, nil
 }
 
 var unsupportedConstraints = []string{
@@ -1463,12 +1460,6 @@ func makeSubnetInfo(
 
 }
 
-// Spaces is not implemented by the ec2 provider as we don't currently have
-// provider level spaces.
-func (e *environ) Spaces(ctx context.ProviderCallContext) ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("Spaces")
-}
-
 // Subnets returns basic information about the specified subnets known
 // by the provider for the specified instance or list of ids. subnetIds can be
 // empty, in which case all known are returned. Implements
@@ -2532,13 +2523,6 @@ func (e *environ) hasDefaultVPC(ctx context.ProviderCallContext) (bool, error) {
 		e.defaultVPCChecked = true
 	}
 	return e.defaultVPC != nil, nil
-}
-
-// ProviderSpaceInfo implements NetworkingEnviron.
-func (*environ) ProviderSpaceInfo(
-	ctx context.ProviderCallContext, space *network.SpaceInfo,
-) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("provider space info")
 }
 
 // AreSpacesRoutable implements NetworkingEnviron.

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -264,8 +264,7 @@ func (*Suite) TestSupportsSpaces(c *gc.C) {
 }
 
 func (*Suite) TestSupportsSpaceDiscovery(c *gc.C) {
-	var env *environ
-	supported, err := env.SupportsSpaceDiscovery(context.NewEmptyCloudCallContext())
+	supported, err := (&environ{}).SupportsSpaceDiscovery(context.NewEmptyCloudCallContext())
 	// TODO(jam): 2016-02-01 the comment on the interface says the error should
 	// conform to IsNotSupported, but all of the implementations just return
 	// nil for error and 'false' for supported.

--- a/provider/gce/environ.go
+++ b/provider/gce/environ.go
@@ -78,6 +78,8 @@ type gceConnection interface {
 }
 
 type environ struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	name  string
 	uuid  string
 	cloud environscloudspec.CloudSpec

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -325,16 +325,6 @@ func (e *environ) SupportsSpaces(ctx context.ProviderCallContext) (bool, error) 
 	return false, nil
 }
 
-// SupportsSpaceDiscovery implements environs.NetworkingEnviron.
-func (e *environ) SupportsSpaceDiscovery(ctx context.ProviderCallContext) (bool, error) {
-	return false, nil
-}
-
-// Spaces implements environs.NetworkingEnviron.
-func (e *environ) Spaces(ctx context.ProviderCallContext) ([]corenetwork.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
 // SupportsContainerAddresses implements environs.NetworkingEnviron.
 func (e *environ) SupportsContainerAddresses(ctx context.ProviderCallContext) (bool, error) {
 	return false, nil
@@ -348,13 +338,6 @@ func (e *environ) AllocateContainerAddresses(context.ProviderCallContext, instan
 // ReleaseContainerAddresses implements environs.NetworkingEnviron.
 func (e *environ) ReleaseContainerAddresses(context.ProviderCallContext, []corenetwork.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container addresses")
-}
-
-// ProviderSpaceInfo implements environs.NetworkingEnviron.
-func (*environ) ProviderSpaceInfo(
-	ctx context.ProviderCallContext, space *corenetwork.SpaceInfo,
-) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("provider space info")
 }
 
 // AreSpacesRoutable implements environs.NetworkingEnviron.

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -33,6 +33,8 @@ type baseProvider interface {
 }
 
 type environ struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	cloud    environscloudspec.CloudSpec
 	provider *environProvider
 

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -416,57 +416,37 @@ func (*environ) SuperSubnets(context.ProviderCallContext) ([]string, error) {
 // unless a general API failure occurs.
 func (e *environ) SupportsSpaces(context.ProviderCallContext) (bool, error) {
 	// Really old lxd versions (e.g. xenial/ppc64) do not even support the
-	// network API extension so the subnet discovery codepath will not
+	// network API extension so the subnet discovery code path will not
 	// work there.
 	return e.hasLXDNetworkAPISupport()
 }
 
-// SupportsSpaceDiscovery returns whether the current environment
-// supports discovering spaces from the provider. The returned error
-// satisfies errors.IsNotSupported(), unless a general API failure occurs.
-func (*environ) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
-	return false, nil
-}
-
-// Spaces returns a slice of network.SpaceInfo with info, including
-// details of all associated subnets, about all spaces known to the
-// provider that have subnets available.
-func (*environ) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
-// ProviderSpaceInfo returns the details of the space requested as
-// a ProviderSpaceInfo.
-func (*environ) ProviderSpaceInfo(context.ProviderCallContext, *network.SpaceInfo) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
 // AreSpacesRoutable returns whether the communication between the
-// two spaces can use cloud-local addaddresses.
+// two spaces can use cloud-local addresses.
 func (*environ) AreSpacesRoutable(context.ProviderCallContext, *environs.ProviderSpaceInfo, *environs.ProviderSpaceInfo) (bool, error) {
 	return false, errors.NotSupportedf("spaces")
 }
 
 // SupportsContainerAddresses returns true if the current environment is
-// able to allocate addaddresses for containers.
+// able to allocate addresses for containers.
 func (*environ) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
 	return false, nil
 }
 
-// AllocateContainerAddresses allocates a static addsubnetss for each of the
+// AllocateContainerAddresses allocates a static subnets for each of the
 // container NICs in preparedInfo, hosted by the hostInstanceID. Returns the
-// network config including all allocated addaddresses on success.
+// network config including all allocated addresses on success.
 func (*environ) AllocateContainerAddresses(context.ProviderCallContext, instance.Id, names.MachineTag, network.InterfaceInfos) (network.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("container address allocation")
 }
 
 // ReleaseContainerAddresses releases the previously allocated
-// addaddresses matching the interface details passed in.
+// addresses matching the interface details passed in.
 func (*environ) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }
 
-// SSHAddresses filters the input addaddresses to those suitable for SSH use.
+// SSHAddresses filters the input addresses to those suitable for SSH use.
 func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
 	return addresses, nil
 }

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -1875,7 +1875,7 @@ func (env *maasEnviron) subnetToSpaceIds(ctx context.ProviderCallContext) (map[s
 // Spaces returns all the spaces, that have subnets, known to the provider.
 // Space name is not filled in as the provider doesn't know the juju name for
 // the space.
-func (env *maasEnviron) Spaces(ctx context.ProviderCallContext) ([]corenetwork.SpaceInfo, error) {
+func (env *maasEnviron) Spaces(ctx context.ProviderCallContext) (corenetwork.SpaceInfos, error) {
 	if !env.usingMAAS2() {
 		return env.spaces1(ctx)
 	}

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -617,7 +617,7 @@ func (suite *environSuite) TestSpaces(c *gc.C) {
 
 	spaces, err := suite.makeEnviron().Spaces(suite.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedSpaces := []corenetwork.SpaceInfo{{
+	expectedSpaces := corenetwork.SpaceInfos{{
 		Name:       "space-1",
 		ProviderId: "2",
 		Subnets: []corenetwork.SubnetInfo{

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -49,6 +49,8 @@ var (
 )
 
 type manualEnviron struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	host string
 	user string
 	mu   sync.Mutex

--- a/provider/manual/environ_network.go
+++ b/provider/manual/environ_network.go
@@ -30,16 +30,6 @@ func (e *manualEnviron) SuperSubnets(context.ProviderCallContext) ([]string, err
 	return nil, errors.NotSupportedf("super subnets")
 }
 
-// SupportsSpaceDiscovery implements environs.NetworkingEnviron.
-func (e *manualEnviron) SupportsSpaceDiscovery(context.ProviderCallContext) (bool, error) {
-	return false, nil
-}
-
-// Spaces implements environs.NetworkingEnviron.
-func (e *manualEnviron) Spaces(context.ProviderCallContext) ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
 // SupportsContainerAddresses implements environs.NetworkingEnviron.
 func (e *manualEnviron) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
 	return false, nil
@@ -55,13 +45,6 @@ func (e *manualEnviron) AllocateContainerAddresses(
 // ReleaseContainerAddresses implements environs.NetworkingEnviron.
 func (e *manualEnviron) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container addresses")
-}
-
-// ProviderSpaceInfo implements environs.NetworkingEnviron.
-func (*manualEnviron) ProviderSpaceInfo(
-	context.ProviderCallContext, *network.SpaceInfo,
-) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("provider space info")
 }
 
 // AreSpacesRoutable implements environs.NetworkingEnviron.

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -40,6 +40,8 @@ import (
 )
 
 type Environ struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	Compute    providerCommon.OCIComputeClient
 	Networking providerCommon.OCINetworkingClient
 	Storage    providerCommon.OCIStorageClient

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1112,22 +1112,8 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 	return info, nil
 }
 
-func (e *Environ) SupportsSpaces(ctx envcontext.ProviderCallContext) (bool, error) {
+func (e *Environ) SupportsSpaces(envcontext.ProviderCallContext) (bool, error) {
 	return false, nil
-}
-
-func (e *Environ) SupportsSpaceDiscovery(ctx envcontext.ProviderCallContext) (bool, error) {
-	return false, nil
-}
-
-func (e *Environ) Spaces(ctx envcontext.ProviderCallContext) ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("Spaces")
-}
-
-func (e *Environ) ProviderSpaceInfo(
-	ctx envcontext.ProviderCallContext, space *network.SpaceInfo,
-) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("ProviderSpaceInfo")
 }
 
 func (e *Environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -323,6 +323,8 @@ func (p EnvironProvider) newConfig(cfg *config.Config) (*environConfig, error) {
 }
 
 type Environ struct {
+	environs.NoSpaceDiscoveryEnviron
+
 	name      string
 	uuid      string
 	namespace instance.Namespace
@@ -2322,22 +2324,12 @@ func (e *Environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 }
 
 // SupportsSpaces is specified on environs.Networking.
-func (e *Environ) SupportsSpaces(ctx context.ProviderCallContext) (bool, error) {
+func (e *Environ) SupportsSpaces(context.ProviderCallContext) (bool, error) {
 	return true, nil
 }
 
-// SupportsSpaceDiscovery is specified on environs.Networking.
-func (e *Environ) SupportsSpaceDiscovery(ctx context.ProviderCallContext) (bool, error) {
-	return false, nil
-}
-
-// Spaces is specified on environs.Networking.
-func (e *Environ) Spaces(ctx context.ProviderCallContext) ([]network.SpaceInfo, error) {
-	return nil, errors.NotSupportedf("spaces")
-}
-
 // SupportsContainerAddresses is specified on environs.Networking.
-func (e *Environ) SupportsContainerAddresses(ctx context.ProviderCallContext) (bool, error) {
+func (e *Environ) SupportsContainerAddresses(context.ProviderCallContext) (bool, error) {
 	return false, errors.NotSupportedf("container address")
 }
 
@@ -2363,13 +2355,6 @@ func (e *Environ) AllocateContainerAddresses(ctx context.ProviderCallContext, ho
 // ReleaseContainerAddresses is specified on environs.Networking.
 func (e *Environ) ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("release container address")
-}
-
-// ProviderSpaceInfo is specified on environs.NetworkingEnviron.
-func (*Environ) ProviderSpaceInfo(
-	ctx context.ProviderCallContext, space *network.SpaceInfo,
-) (*environs.ProviderSpaceInfo, error) {
-	return nil, errors.NotSupportedf("provider space info")
 }
 
 // AreSpacesRoutable is specified on environs.NetworkingEnviron.


### PR DESCRIPTION
This patch adds info-level logging to indicate the discovery of provider spaces. It is otherwise hard to see in logs, the effect of invoking 'reload-spaces'

In addition, we reduce boilerplate for the majority of environs, which do not support space discovery. Instead we embed a reference that implements a subset of `Networking` methods that affect this.

## QA steps

Bootstrap to MAAS. There should be an info-level line with `discovered spaces: ...`.

## Documentation changes

N/A

## Bug reference

None.
