### PR TITLE
Delete clusterrolebindings before creating;

### DIFF
--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -23,10 +24,6 @@ import (
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
 )
-
-func strPtr(b string) *string {
-	return &b
-}
 
 func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8sspecs.K8sMutatingWebhook, assertCalls ...*gomock.Call) {
 
@@ -56,7 +53,7 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -156,7 +153,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateV1Beta1(c 
 			Service: &admissionregistrationv1beta1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -222,7 +219,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepNameV1
 			Service: &admissionregistrationv1beta1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -291,7 +288,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdateV1Beta1(c 
 			Service: &admissionregistrationv1beta1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -364,7 +361,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateV1(c *gc.C
 			Service: &admissionregistrationv1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -430,7 +427,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsCreateKeepNameV1
 			Service: &admissionregistrationv1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -499,7 +496,7 @@ func (s *K8sBrokerSuite) TestEnsureMutatingWebhookConfigurationsUpdateV1(c *gc.C
 			Service: &admissionregistrationv1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -574,7 +571,7 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -670,7 +667,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateV1Beta1(
 			Service: &admissionregistrationv1beta1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -736,7 +733,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 			Service: &admissionregistrationv1beta1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -805,7 +802,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdateV1Beta1(
 			Service: &admissionregistrationv1beta1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -878,7 +875,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateV1(c *gc
 			Service: &admissionregistrationv1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -944,7 +941,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsCreateKeepName
 			Service: &admissionregistrationv1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},
@@ -1013,7 +1010,7 @@ func (s *K8sBrokerSuite) TestEnsureValidatingWebhookConfigurationsUpdateV1(c *gc
 			Service: &admissionregistrationv1.ServiceReference{
 				Name:      "apple-service",
 				Namespace: "apples",
-				Path:      strPtr("/apple"),
+				Path:      pointer.StringPtr("/apple"),
 			},
 			CABundle: CABundle,
 		},

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
@@ -170,7 +171,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 				Annotations: a.annotations(config),
 			},
 			// Will be automounted by the pod.
-			AutomountServiceAccountToken: boolPtr(false),
+			AutomountServiceAccountToken: pointer.BoolPtr(false),
 		},
 	}
 	applier.Apply(&serviceAccount)
@@ -339,7 +340,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		}
 		var numPods *int32
 		if !exists {
-			numPods = int32Ptr(1)
+			numPods = pointer.Int32Ptr(1)
 		}
 		statefulset := resources.StatefulSet{
 			StatefulSet: appsv1.StatefulSet{
@@ -401,7 +402,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		}
 		var numPods *int32
 		if !exists {
-			numPods = int32Ptr(1)
+			numPods = pointer.Int32Ptr(1)
 		}
 		// Config storage to update the podspec with storage info.
 		if err = configureStorage(storageUniqueID, handlePVCForStatelessResource); err != nil {
@@ -1190,8 +1191,8 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:  int64Ptr(0),
-			RunAsGroup: int64Ptr(0),
+			RunAsUser:  pointer.Int64Ptr(0),
+			RunAsGroup: pointer.Int64Ptr(0),
 		},
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
@@ -1273,8 +1274,8 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			}},
 			// Run Pebble as root (because it's a service manager).
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  int64Ptr(0),
-				RunAsGroup: int64Ptr(0),
+				RunAsUser:  pointer.Int64Ptr(0),
+				RunAsGroup: pointer.Int64Ptr(0),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -1578,20 +1579,4 @@ func (a *app) filesystemToVolumeInfo(name string,
 		Spec: *pvcSpec,
 	}
 	return nil, pvc, newStorageClass, nil
-}
-
-func int32Ptr(v int32) *int32 {
-	return &v
-}
-
-func int64Ptr(v int64) *int64 {
-	return &v
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func strPtr(b string) *string {
-	return &b
 }

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/application"
@@ -210,7 +211,7 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
 		ServiceAccountName:           "gitlab",
-		AutomountServiceAccountToken: application.BoolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",
 			ImagePullPolicy: corev1.PullIfNotPresent,
@@ -438,7 +439,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 					},
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: application.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/name": "gitlab",
@@ -464,7 +465,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 									"storage.juju.is/name": "database",
 								}},
 							Spec: corev1.PersistentVolumeClaimSpec{
-								StorageClassName: application.StrPtr("test-workload-storage"),
+								StorageClassName: pointer.StringPtr("test-workload-storage"),
 								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
@@ -505,7 +506,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
-					StorageClassName: application.StrPtr("test-workload-storage"),
+					StorageClassName: pointer.StringPtr("test-workload-storage"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceStorage: k8sresource.MustParse("100Mi"),
@@ -537,7 +538,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: application.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"app.kubernetes.io/name": "gitlab"},
 					},
@@ -577,7 +578,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 					},
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
-					StorageClassName: application.StrPtr("test-workload-storage"),
+					StorageClassName: pointer.StringPtr("test-workload-storage"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceStorage: k8sresource.MustParse("100Mi"),
@@ -1009,7 +1010,7 @@ func (s *applicationSuite) TestStateStateful(c *gc.C) {
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"app.kubernetes.io/name": "gitlab"},
 				},
-				Replicas: application.Int32Ptr(int32(desiredReplicas)),
+				Replicas: pointer.Int32Ptr(int32(desiredReplicas)),
 			},
 		}
 		_, err := s.client.AppsV1().StatefulSets("test").Create(context.TODO(),
@@ -1037,7 +1038,7 @@ func (s *applicationSuite) TestStateStateless(c *gc.C) {
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"app.kubernetes.io/name": "gitlab"},
 				},
-				Replicas: application.Int32Ptr(int32(desiredReplicas)),
+				Replicas: pointer.Int32Ptr(int32(desiredReplicas)),
 			},
 		}
 		_, err := s.client.AppsV1().Deployments("test").Create(context.TODO(),
@@ -1866,7 +1867,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 					},
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: application.Int32Ptr(1),
+					Replicas: pointer.Int32Ptr(1),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/name": "gitlab",
@@ -1892,7 +1893,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 									"storage.juju.is/name": "database",
 								}},
 							Spec: corev1.PersistentVolumeClaimSpec{
-								StorageClassName: application.StrPtr("test-workload-storage"),
+								StorageClassName: pointer.StringPtr("test-workload-storage"),
 								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -20,13 +20,6 @@ func Test(t *testing.T) {
 	gc.TestingT(t)
 }
 
-var (
-	Int32Ptr = int32Ptr
-	Int64Ptr = int64Ptr
-	BoolPtr  = boolPtr
-	StrPtr   = strPtr
-)
-
 type (
 	AnnotationUpdater = annotationUpdater
 )

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -22,6 +22,7 @@ import (
 	k8sstorage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -922,8 +923,12 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), controllerServiceAccount, gomock.Any()).
 			Return(controllerServiceAccount, nil),
 		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), controllerServiceCRB.Name, gomock.Any()).
-			Return(controllerServiceCRB, nil),
-		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), controllerServiceCRB, gomock.Any()).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Patch(
+			gomock.Any(), controllerServiceCRB.Name, types.StrategicMergePatchType, gomock.Any(),
+			v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), controllerServiceCRB, gomock.Any()).
 			Return(controllerServiceCRB, nil),
 
 		// Check the operator storage exists.

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -514,7 +515,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 				Spec: core.PodSpec{
 					RestartPolicy:                core.RestartPolicyAlways,
 					ServiceAccountName:           "controller",
-					AutomountServiceAccountToken: boolPtr(true),
+					AutomountServiceAccountToken: pointer.BoolPtr(true),
 					Volumes: []core.Volume{
 						{
 							Name: "juju-controller-test-server-pem",
@@ -752,7 +753,7 @@ $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-
 			},
 			Annotations: map[string]string{"controller.juju.is/id": testing.ControllerTag.Id()},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 
 	controllerServiceCRB := &rbacv1.ClusterRoleBinding{

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -46,3 +46,9 @@ func DefaultPropagationPolicy() *metav1.DeletionPropagation {
 	v := metav1.DeletePropagationForeground
 	return &v
 }
+
+// DeletePropagationBackground returns the background propagation policy.
+func DeletePropagationBackground() *metav1.DeletionPropagation {
+	v := metav1.DeletePropagationBackground
+	return &v
+}

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -17,6 +17,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -55,7 +56,7 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -152,14 +153,14 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -167,8 +168,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -206,14 +207,14 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"replicas": {
 											Type:    "integer",
-											Minimum: float64Ptr(1),
+											Minimum: pointer.Float64Ptr(1),
 										},
 									},
 								},
 								"PS": {
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+											Type: "integer", Minimum: pointer.Float64Ptr(1),
 										},
 									},
 								},
@@ -221,8 +222,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"replicas": {
 											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+											Minimum: pointer.Float64Ptr(1),
+											Maximum: pointer.Float64Ptr(1),
 										},
 									},
 								},
@@ -267,14 +268,14 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1beta1
 											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -282,8 +283,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1beta1
 											Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -321,14 +322,14 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1beta1
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"replicas": {
 											Type:    "integer",
-											Minimum: float64Ptr(1),
+											Minimum: pointer.Float64Ptr(1),
 										},
 									},
 								},
 								"PS": {
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"replicas": {
-											Type: "integer", Minimum: float64Ptr(1),
+											Type: "integer", Minimum: pointer.Float64Ptr(1),
 										},
 									},
 								},
@@ -336,8 +337,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1beta1
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"replicas": {
 											Type:    "integer",
-											Minimum: float64Ptr(1),
-											Maximum: float64Ptr(1),
+											Minimum: pointer.Float64Ptr(1),
+											Maximum: pointer.Float64Ptr(1),
 										},
 									},
 								},
@@ -394,7 +395,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1(c *g
 							Schema: &apiextensionsv1.CustomResourceValidation{
 								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 									Type:                   "object",
-									XPreserveUnknownFields: boolPtr(true),
+									XPreserveUnknownFields: pointer.BoolPtr(true),
 								},
 							},
 							AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
@@ -448,7 +449,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1(c *g
 					Schema: &apiextensionsv1.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 							Type:                   "object",
-							XPreserveUnknownFields: boolPtr(true),
+							XPreserveUnknownFields: pointer.BoolPtr(true),
 						},
 					},
 					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
@@ -511,7 +512,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1(c *g
 							Schema: &apiextensionsv1.CustomResourceValidation{
 								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 									Type:                   "object",
-									XPreserveUnknownFields: boolPtr(true),
+									XPreserveUnknownFields: pointer.BoolPtr(true),
 								},
 							},
 							AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
@@ -565,7 +566,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1(c *g
 					Schema: &apiextensionsv1.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 							Type:                   "object",
-							XPreserveUnknownFields: boolPtr(true),
+							XPreserveUnknownFields: pointer.BoolPtr(true),
 						},
 					},
 					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
@@ -621,7 +622,7 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -837,7 +838,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 												"PS": {
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{
 														"replicas": {
-															Type: "integer", Minimum: float64Ptr(1),
+															Type: "integer", Minimum: pointer.Float64Ptr(1),
 														},
 													},
 												},
@@ -845,8 +846,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{
 														"replicas": {
 															Type:    "integer",
-															Minimum: float64Ptr(1),
-															Maximum: float64Ptr(1),
+															Minimum: pointer.Float64Ptr(1),
+															Maximum: pointer.Float64Ptr(1),
 														},
 													},
 												},
@@ -854,7 +855,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{
 														"replicas": {
 															Type:    "integer",
-															Minimum: float64Ptr(1),
+															Minimum: pointer.Float64Ptr(1),
 														},
 													},
 												},
@@ -968,7 +969,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 												"PS": {
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{
 														"replicas": {
-															Type: "integer", Minimum: float64Ptr(1),
+															Type: "integer", Minimum: pointer.Float64Ptr(1),
 														},
 													},
 												},
@@ -976,8 +977,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{
 														"replicas": {
 															Type:    "integer",
-															Minimum: float64Ptr(1),
-															Maximum: float64Ptr(1),
+															Minimum: pointer.Float64Ptr(1),
+															Maximum: pointer.Float64Ptr(1),
 														},
 													},
 												},
@@ -985,7 +986,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{
 														"replicas": {
 															Type:    "integer",
-															Minimum: float64Ptr(1),
+															Minimum: pointer.Float64Ptr(1),
 														},
 													},
 												},
@@ -1102,14 +1103,14 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1117,8 +1118,8 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1162,14 +1163,14 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1177,8 +1178,8 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1264,14 +1265,14 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1279,8 +1280,8 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -53,7 +54,7 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, IngressResources []k8ss
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -327,7 +328,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesCreateV1(c *gc.C) {
 						Path: "/testpath",
 						Backend: networkingv1.IngressBackend{
 							Resource: &core.TypedLocalObjectReference{
-								APIGroup: strPtr("k8s.example.com"),
+								APIGroup: pointer.StringPtr("k8s.example.com"),
 								Kind:     "StorageBucket",
 								Name:     "icon-assets",
 							},
@@ -391,7 +392,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateV1(c *gc.C) {
 						Path: "/testpath",
 						Backend: networkingv1.IngressBackend{
 							Resource: &core.TypedLocalObjectReference{
-								APIGroup: strPtr("k8s.example.com"),
+								APIGroup: pointer.StringPtr("k8s.example.com"),
 								Kind:     "StorageBucket",
 								Name:     "icon-assets",
 							},
@@ -461,7 +462,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceIngressResourcesUpdateConflictWithExis
 						Path: "/testpath",
 						Backend: networkingv1.IngressBackend{
 							Resource: &core.TypedLocalObjectReference{
-								APIGroup: strPtr("k8s.example.com"),
+								APIGroup: pointer.StringPtr("k8s.example.com"),
 								Kind:     "StorageBucket",
 								Name:     "icon-assets",
 							},

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
@@ -1666,7 +1667,7 @@ func (k *kubernetesClient) configureDaemonSet(
 			Selector: &v1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
-			RevisionHistoryLimit: utils.Int32Ptr(daemonsetRevisionHistoryLimit),
+			RevisionHistoryLimit: pointer.Int32Ptr(daemonsetRevisionHistoryLimit),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: deploymentName + "-",
@@ -1768,7 +1769,7 @@ func (k *kubernetesClient) configureDeployment(
 		Spec: apps.DeploymentSpec{
 			// TODO(caas): MinReadySeconds, ProgressDeadlineSeconds support.
 			Replicas:             replicas,
-			RevisionHistoryLimit: utils.Int32Ptr(deploymentRevisionHistoryLimit),
+			RevisionHistoryLimit: pointer.Int32Ptr(deploymentRevisionHistoryLimit),
 			Selector: &v1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -4008,10 +4008,16 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
 		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), svcAccount, v1.CreateOptions{}).Return(svcAccount, nil),
-		s.mockClusterRoles.EXPECT().Get(gomock.Any(), cr.Name, gomock.Any()).Return(cr, nil),
-		s.mockClusterRoles.EXPECT().Update(gomock.Any(), cr, gomock.Any()).Return(cr, nil),
-		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb.Name, gomock.Any()).Return(crb, nil),
-		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb, gomock.Any()).Return(crb, nil),
+		s.mockClusterRoles.EXPECT().Get(gomock.Any(), cr.Name, gomock.Any()).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoles.EXPECT().Patch(
+			gomock.Any(), cr.Name, types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoles.EXPECT().Create(gomock.Any(), cr, gomock.Any()).Return(cr, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb.Name, gomock.Any()).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Patch(
+			gomock.Any(), crb.Name, types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb, gomock.Any()).Return(crb, nil),
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
@@ -4189,8 +4195,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), svcAccount, v1.UpdateOptions{}).Return(svcAccount, nil),
 		s.mockClusterRoles.EXPECT().Get(gomock.Any(), cr.Name, gomock.Any()).Return(cr, nil),
 		s.mockClusterRoles.EXPECT().Update(gomock.Any(), cr, gomock.Any()).Return(cr, nil),
-		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), "app-name-test-app-name", gomock.Any()).Return(crb, nil),
-		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb, gomock.Any()).Return(crb, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb.Name, gomock.Any()).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Patch(
+			gomock.Any(), crb.Name, types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb, gomock.Any()).Return(crb, nil),
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
 			Return(nil, s.k8sNotFoundError()),
@@ -4717,8 +4726,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), svcAccount2, v1.CreateOptions{}).Return(svcAccount2, nil),
 		s.mockClusterRoles.EXPECT().Get(gomock.Any(), clusterrole2.Name, gomock.Any()).Return(clusterrole2, nil),
 		s.mockClusterRoles.EXPECT().Update(gomock.Any(), clusterrole2, gomock.Any()).Return(clusterrole2, nil),
-		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb2.Name, gomock.Any()).Return(crb2, nil),
-		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb2, gomock.Any()).Return(crb2, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb2.Name, gomock.Any()).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Patch(
+			gomock.Any(), crb2.Name, types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb2, gomock.Any()).Return(crb2, nil),
 
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
@@ -5039,8 +5051,11 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 		s.mockRoleBindings.EXPECT().Create(gomock.Any(), rb2, v1.CreateOptions{}).Return(rb2, nil),
 		s.mockClusterRoles.EXPECT().Get(gomock.Any(), clusterrole2.Name, gomock.Any()).Return(clusterrole2, nil),
 		s.mockClusterRoles.EXPECT().Update(gomock.Any(), clusterrole2, gomock.Any()).Return(clusterrole2, nil),
-		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb2.Name, gomock.Any()).Return(crb2, nil),
-		s.mockClusterRoleBindings.EXPECT().Update(gomock.Any(), crb2, gomock.Any()).Return(crb2, nil),
+		s.mockClusterRoleBindings.EXPECT().Get(gomock.Any(), crb2.Name, gomock.Any()).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Patch(
+			gomock.Any(), crb2.Name, types.StrategicMergePatchType, gomock.Any(), v1.PatchOptions{FieldManager: "juju"},
+		).Return(nil, s.k8sNotFoundError()),
+		s.mockClusterRoleBindings.EXPECT().Create(gomock.Any(), crb2, gomock.Any()).Return(crb2, nil),
 
 		s.mockSecrets.EXPECT().Create(gomock.Any(), secretArg, v1.CreateOptions{}).Return(secretArg, nil),
 		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -59,26 +60,6 @@ type K8sSuite struct {
 
 var _ = gc.Suite(&K8sSuite{})
 
-func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func intPtr(i int) *int {
-	return &i
-}
-
-func int32Ptr(i int32) *int32 {
-	return &i
-}
-
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 
 	podSpec := specs.PodSpec{
@@ -89,10 +70,10 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 		KubernetesResources: &k8sspecs.KubernetesResources{
 			Pod: &k8sspecs.PodSpec{
 				RestartPolicy:                 core.RestartPolicyOnFailure,
-				ActiveDeadlineSeconds:         int64Ptr(10),
-				TerminationGracePeriodSeconds: int64Ptr(20),
+				ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+				TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 				SecurityContext: &core.PodSecurityContext{
-					RunAsNonRoot:       boolPtr(true),
+					RunAsNonRoot:       pointer.BoolPtr(true),
 					SupplementalGroups: []int64{1, 2},
 				},
 				ReadinessGates: []core.PodReadinessGate{
@@ -102,7 +83,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 				HostNetwork:       true,
 				HostPID:           true,
 				PriorityClassName: "system-cluster-critical",
-				Priority:          int32Ptr(2000000000),
+				Priority:          pointer.Int32Ptr(2000000000),
 			},
 		},
 	}
@@ -122,8 +103,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 					Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
 				},
 				SecurityContext: &core.SecurityContext{
-					RunAsNonRoot: boolPtr(true),
-					Privileged:   boolPtr(true),
+					RunAsNonRoot: pointer.BoolPtr(true),
+					Privileged:   pointer.BoolPtr(true),
 				},
 			},
 		}, {
@@ -140,10 +121,10 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 		Annotations: annotations.Annotation{},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
-			ActiveDeadlineSeconds:         int64Ptr(10),
-			TerminationGracePeriodSeconds: int64Ptr(20),
+			ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+			TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 			SecurityContext: &core.PodSecurityContext{
-				RunAsNonRoot:       boolPtr(true),
+				RunAsNonRoot:       pointer.BoolPtr(true),
 				SupplementalGroups: []int64{1, 2},
 			},
 			ReadinessGates: []core.PodReadinessGate{
@@ -153,9 +134,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 			HostNetwork:                  true,
 			HostPID:                      true,
 			PriorityClassName:            "system-cluster-critical",
-			Priority:                     int32Ptr(2000000000),
+			Priority:                     pointer.Int32Ptr(2000000000),
 			ServiceAccountName:           "app-name",
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			InitContainers:               initContainers(),
 			Containers: []core.Container{
 				{
@@ -164,8 +145,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 					Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 					ImagePullPolicy: core.PullAlways,
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot: boolPtr(true),
-						Privileged:   boolPtr(true),
+						RunAsNonRoot: pointer.BoolPtr(true),
+						Privileged:   pointer.BoolPtr(true),
 					},
 					ReadinessProbe: &core.Probe{
 						InitialDelaySeconds: 10,
@@ -182,9 +163,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 					Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
 					// Defaults since not specified.
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				},
@@ -204,10 +185,10 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 		KubernetesResources: &k8sspecs.KubernetesResources{
 			Pod: &k8sspecs.PodSpec{
 				RestartPolicy:                 core.RestartPolicyOnFailure,
-				ActiveDeadlineSeconds:         int64Ptr(10),
-				TerminationGracePeriodSeconds: int64Ptr(20),
+				ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+				TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 				SecurityContext: &core.PodSecurityContext{
-					RunAsNonRoot:       boolPtr(true),
+					RunAsNonRoot:       pointer.BoolPtr(true),
 					SupplementalGroups: []int64{1, 2},
 				},
 				ReadinessGates: []core.PodReadinessGate{
@@ -235,7 +216,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 	envVarThing1.ValueFrom.ConfigMapKeyRef.Name = "foo"
 
 	envFromSourceSecret1 := core.EnvFromSource{
-		SecretRef: &core.SecretEnvSource{Optional: boolPtr(true)},
+		SecretRef: &core.SecretEnvSource{Optional: pointer.BoolPtr(true)},
 	}
 	envFromSourceSecret1.SecretRef.Name = "secret1"
 
@@ -245,7 +226,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 	envFromSourceSecret2.SecretRef.Name = "secret2"
 
 	envFromSourceConfigmap1 := core.EnvFromSource{
-		ConfigMapRef: &core.ConfigMapEnvSource{Optional: boolPtr(true)},
+		ConfigMapRef: &core.ConfigMapEnvSource{Optional: pointer.BoolPtr(true)},
 	}
 	envFromSourceConfigmap1.ConfigMapRef.Name = "configmap1"
 
@@ -326,8 +307,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 					Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
 				},
 				SecurityContext: &core.SecurityContext{
-					RunAsNonRoot: boolPtr(true),
-					Privileged:   boolPtr(true),
+					RunAsNonRoot: pointer.BoolPtr(true),
+					Privileged:   pointer.BoolPtr(true),
 				},
 			},
 		}, {
@@ -344,10 +325,10 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 		Annotations: annotations.Annotation{},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
-			ActiveDeadlineSeconds:         int64Ptr(10),
-			TerminationGracePeriodSeconds: int64Ptr(20),
+			ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+			TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 			SecurityContext: &core.PodSecurityContext{
-				RunAsNonRoot:       boolPtr(true),
+				RunAsNonRoot:       pointer.BoolPtr(true),
 				SupplementalGroups: []int64{1, 2},
 			},
 			ReadinessGates: []core.PodReadinessGate{
@@ -355,7 +336,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 			},
 			DNSPolicy:                    core.DNSClusterFirst,
 			ServiceAccountName:           "app-name",
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			InitContainers:               initContainers(),
 			Containers: []core.Container{
 				{
@@ -364,8 +345,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 					Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 					ImagePullPolicy: core.PullAlways,
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot: boolPtr(true),
-						Privileged:   boolPtr(true),
+						RunAsNonRoot: pointer.BoolPtr(true),
+						Privileged:   pointer.BoolPtr(true),
 					},
 					ReadinessProbe: &core.Probe{
 						InitialDelaySeconds: 10,
@@ -411,9 +392,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 					Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
 					// Defaults since not specified.
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				},
@@ -441,8 +422,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithInitContainers(c *gc.C) {
 					Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
 				},
 				SecurityContext: &core.SecurityContext{
-					RunAsNonRoot: boolPtr(true),
-					Privileged:   boolPtr(true),
+					RunAsNonRoot: pointer.BoolPtr(true),
+					Privileged:   pointer.BoolPtr(true),
 				},
 			},
 		}, {
@@ -480,8 +461,8 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithInitContainers(c *gc.C) {
 						Handler:          core.Handler{HTTPGet: &core.HTTPGetAction{Path: "/liveready"}},
 					},
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot: boolPtr(true),
-						Privileged:   boolPtr(true),
+						RunAsNonRoot: pointer.BoolPtr(true),
+						Privileged:   pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				}, {
@@ -490,9 +471,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithInitContainers(c *gc.C) {
 					Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
 					// Defaults since not specified.
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				},
@@ -507,9 +488,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithInitContainers(c *gc.C) {
 					ImagePullPolicy: core.PullAlways,
 					// Defaults since not specified.
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 				},
 			}, initContainers()...),
@@ -530,10 +511,10 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 				Labels:                        map[string]string{"foo": "bax"},
 				Annotations:                   map[string]string{"foo": "baz"},
 				RestartPolicy:                 core.RestartPolicyOnFailure,
-				ActiveDeadlineSeconds:         int64Ptr(10),
-				TerminationGracePeriodSeconds: int64Ptr(20),
+				ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+				TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 				SecurityContext: &core.PodSecurityContext{
-					RunAsNonRoot:       boolPtr(true),
+					RunAsNonRoot:       pointer.BoolPtr(true),
 					SupplementalGroups: []int64{1, 2},
 				},
 				ReadinessGates: []core.PodReadinessGate{
@@ -561,19 +542,19 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 		Annotations: map[string]string{"foo": "baz"},
 		PodSpec: core.PodSpec{
 			RestartPolicy:                 core.RestartPolicyOnFailure,
-			ActiveDeadlineSeconds:         int64Ptr(10),
-			TerminationGracePeriodSeconds: int64Ptr(20),
+			ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+			TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 			ReadinessGates: []core.PodReadinessGate{
 				{ConditionType: core.PodInitialized},
 			},
 			DNSPolicy:                    core.DNSClusterFirst,
 			ServiceAccountName:           "app-name",
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			HostNetwork:                  true,
 			HostPID:                      true,
 			InitContainers:               initContainers(),
 			SecurityContext: &core.PodSecurityContext{
-				RunAsNonRoot:       boolPtr(true),
+				RunAsNonRoot:       pointer.BoolPtr(true),
 				SupplementalGroups: []int64{1, 2},
 			},
 			Containers: []core.Container{
@@ -583,9 +564,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 					Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 					ImagePullPolicy: core.PullAlways,
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				},
@@ -611,7 +592,7 @@ func (s *K8sSuite) TestPrepareWorkloadSpecPrimarySA(c *gc.C) {
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		PodSpec: core.PodSpec{
 			ServiceAccountName:           "app-name",
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			InitContainers:               initContainers(),
 			Containers: []core.Container{
 				{
@@ -620,9 +601,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecPrimarySA(c *gc.C) {
 					Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 					ImagePullPolicy: core.PullAlways,
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				},
@@ -692,7 +673,7 @@ var basicHeadlessServiceArg = &core.Service{
 
 var primeServiceAccount = &specs.PrimeServiceAccountSpecV3{
 	ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 		Roles: []specs.Role{
 			{
 				Rules: []specs.PolicyRule{
@@ -751,9 +732,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecConfigPairs(c *gc.C) {
 					},
 					// Defaults since not specified.
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				}, {
@@ -762,9 +743,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecConfigPairs(c *gc.C) {
 					Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP, Name: "fred"}},
 					// Defaults since not specified.
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot:             boolPtr(false),
-						ReadOnlyRootFilesystem:   boolPtr(false),
-						AllowPrivilegeEscalation: boolPtr(true),
+						RunAsNonRoot:             pointer.BoolPtr(false),
+						ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: pointer.BoolPtr(true),
 					},
 					VolumeMounts: dataVolumeMounts(),
 				},
@@ -992,12 +973,12 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 				VolumeSource: specs.VolumeSource{
 					ConfigMap: &specs.ResourceRefVol{
 						Name:        "log-config",
-						DefaultMode: int32Ptr(511),
+						DefaultMode: pointer.Int32Ptr(511),
 						Files: []specs.FileRef{
 							{
 								Key:  "log_level",
 								Path: "log_level",
-								Mode: int32Ptr(511),
+								Mode: pointer.Int32Ptr(511),
 							},
 						},
 					},
@@ -1012,12 +993,12 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 							LocalObjectReference: core.LocalObjectReference{
 								Name: "log-config",
 							},
-							DefaultMode: int32Ptr(511),
+							DefaultMode: pointer.Int32Ptr(511),
 							Items: []core.KeyToPath{
 								{
 									Key:  "log_level",
 									Path: "log_level",
-									Mode: int32Ptr(511),
+									Mode: pointer.Int32Ptr(511),
 								},
 							},
 						},
@@ -1032,12 +1013,12 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 				VolumeSource: specs.VolumeSource{
 					ConfigMap: &specs.ResourceRefVol{
 						Name:        "non-existing-config-map",
-						DefaultMode: int32Ptr(511),
+						DefaultMode: pointer.Int32Ptr(511),
 						Files: []specs.FileRef{
 							{
 								Key:  "log_level",
 								Path: "log_level",
-								Mode: int32Ptr(511),
+								Mode: pointer.Int32Ptr(511),
 							},
 						},
 					},
@@ -1054,12 +1035,12 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 				VolumeSource: specs.VolumeSource{
 					Secret: &specs.ResourceRefVol{
 						Name:        "mysecret2",
-						DefaultMode: int32Ptr(511),
+						DefaultMode: pointer.Int32Ptr(511),
 						Files: []specs.FileRef{
 							{
 								Key:  "password",
 								Path: "my-group/my-password",
-								Mode: int32Ptr(511),
+								Mode: pointer.Int32Ptr(511),
 							},
 						},
 					},
@@ -1072,12 +1053,12 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 					VolumeSource: core.VolumeSource{
 						Secret: &core.SecretVolumeSource{
 							SecretName:  "mysecret2",
-							DefaultMode: int32Ptr(511),
+							DefaultMode: pointer.Int32Ptr(511),
 							Items: []core.KeyToPath{
 								{
 									Key:  "password",
 									Path: "my-group/my-password",
-									Mode: int32Ptr(511),
+									Mode: pointer.Int32Ptr(511),
 								},
 							},
 						},
@@ -1092,12 +1073,12 @@ func (s *K8sBrokerSuite) TestFileSetToVolumeNonFiles(c *gc.C) {
 				VolumeSource: specs.VolumeSource{
 					Secret: &specs.ResourceRefVol{
 						Name:        "non-existing-secret",
-						DefaultMode: int32Ptr(511),
+						DefaultMode: pointer.Int32Ptr(511),
 						Files: []specs.FileRef{
 							{
 								Key:  "password",
 								Path: "my-group/my-password",
-								Mode: int32Ptr(511),
+								Mode: pointer.Int32Ptr(511),
 							},
 						},
 					},
@@ -1206,8 +1187,8 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 			Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 			ImagePullPolicy: core.PullAlways,
 			SecurityContext: &core.SecurityContext{
-				RunAsNonRoot: boolPtr(true),
-				Privileged:   boolPtr(true),
+				RunAsNonRoot: pointer.BoolPtr(true),
+				Privileged:   pointer.BoolPtr(true),
 			},
 			ReadinessProbe: &core.Probe{
 				InitialDelaySeconds: 10,
@@ -1227,9 +1208,9 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 			Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
 			// Defaults since not specified.
 			SecurityContext: &core.SecurityContext{
-				RunAsNonRoot:             boolPtr(false),
-				ReadOnlyRootFilesystem:   boolPtr(false),
-				AllowPrivilegeEscalation: boolPtr(true),
+				RunAsNonRoot:             pointer.BoolPtr(false),
+				ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+				AllowPrivilegeEscalation: pointer.BoolPtr(true),
 			},
 			VolumeMounts: dataVolumeMounts(),
 		},
@@ -1271,8 +1252,8 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 			Ports:           []core.ContainerPort{{ContainerPort: int32(80), Protocol: core.ProtocolTCP}},
 			ImagePullPolicy: core.PullAlways,
 			SecurityContext: &core.SecurityContext{
-				RunAsNonRoot: boolPtr(true),
-				Privileged:   boolPtr(true),
+				RunAsNonRoot: pointer.BoolPtr(true),
+				Privileged:   pointer.BoolPtr(true),
 			},
 			ReadinessProbe: &core.Probe{
 				InitialDelaySeconds: 10,
@@ -1296,9 +1277,9 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 			Ports: []core.ContainerPort{{ContainerPort: int32(8080), Protocol: core.ProtocolTCP}},
 			// Defaults since not specified.
 			SecurityContext: &core.SecurityContext{
-				RunAsNonRoot:             boolPtr(false),
-				ReadOnlyRootFilesystem:   boolPtr(false),
-				AllowPrivilegeEscalation: boolPtr(true),
+				RunAsNonRoot:             pointer.BoolPtr(false),
+				ReadOnlyRootFilesystem:   pointer.BoolPtr(false),
+				AllowPrivilegeEscalation: pointer.BoolPtr(true),
 			},
 			VolumeMounts: append(dataVolumeMounts(), []core.VolumeMount{
 				{Name: "myhostpath", MountPath: "/host/etc/cni/net.d"},
@@ -1537,14 +1518,14 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1552,8 +1533,8 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1594,14 +1575,14 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1609,8 +1590,8 @@ func (s *K8sBrokerSuite) assertDestroy(c *gc.C, isController bool, destroyFunc f
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1872,7 +1853,7 @@ func unitStatefulSetArg(numUnits int32, scName string, podSpec core.PodSpec) *ap
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -1934,14 +1915,14 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -1949,8 +1930,8 @@ func (s *K8sBrokerSuite) TestDeleteServiceForApplication(c *gc.C) {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -2181,7 +2162,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -2295,7 +2276,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -2494,7 +2475,7 @@ password: shhhh`[1:],
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -2743,7 +2724,7 @@ password: shhhh`[1:],
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -3136,8 +3117,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
-			Scale:      intPtr(2),
-			Generation: int64Ptr(1),
+			Scale:      utils.IntPtr(2),
+			Generation: pointer.Int64Ptr(1),
 			Status: status.StatusInfo{
 				Status: status.Active,
 			},
@@ -3228,8 +3209,8 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
-			Scale:      intPtr(2),
-			Generation: int64Ptr(1),
+			Scale:      utils.IntPtr(2),
+			Generation: pointer.Int64Ptr(1),
 			Status: status.StatusInfo{
 				Status: status.Active,
 			},
@@ -3292,8 +3273,8 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 				network.NewProviderAddress("10.0.0.1", network.WithScope(network.ScopePublic)),
 				network.NewProviderAddress("host.com.au", network.WithScope(network.ScopePublic)),
 			},
-			Scale:      intPtr(2),
-			Generation: int64Ptr(1),
+			Scale:      utils.IntPtr(2),
+			Generation: pointer.Int64Ptr(1),
 			Status: status.StatusInfo{
 				Status: status.Active,
 			},
@@ -3338,7 +3319,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3422,7 +3403,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{"app.kubernetes.io/name": "app-name"},
@@ -3554,7 +3535,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -3602,7 +3583,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -3714,7 +3695,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -3762,7 +3743,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -3877,7 +3858,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	podSpec := getBasicPodspec()
 	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
 		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			Roles: []specs.Role{
 				{
 					Global: true,
@@ -3912,7 +3893,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -3960,7 +3941,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
@@ -4059,7 +4040,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	podSpec := getBasicPodspec()
 	podSpec.ServiceAccount = &specs.PrimeServiceAccountSpecV3{
 		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			Roles: []specs.Role{
 				{
 					Global: true,
@@ -4094,7 +4075,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -4142,7 +4123,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
@@ -4259,7 +4240,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 						Name: "sa2",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
 
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Name: "role2",
@@ -4298,7 +4279,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -4346,7 +4327,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role1 := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -4399,7 +4380,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role2 := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -4507,7 +4488,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					{
 						Name: "sa2",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Name:   "cluster-role2",
@@ -4558,7 +4539,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -4606,7 +4587,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role1 := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -4659,7 +4640,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	clusterrole2 := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
@@ -4780,7 +4761,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 					{
 						Name: "sa-foo",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Global: true,
@@ -4839,7 +4820,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -4887,7 +4868,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role1 := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -4940,7 +4921,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 				"controller.juju.is/id": testing.ControllerTag.Id(),
 			},
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	clusterrole2 := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
@@ -5197,7 +5178,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 		UpdateStrategy: &specs.UpdateStrategy{
 			Type: "RollingUpdate",
 			RollingUpdate: &specs.RollingUpdateSpec{
-				Partition: int32Ptr(10),
+				Partition: pointer.Int32Ptr(10),
 			},
 		},
 	}
@@ -5225,7 +5206,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 	statefulSetArg.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
 		Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-			Partition: int32Ptr(10),
+			Partition: pointer.Int32Ptr(10),
 		},
 	}
 
@@ -5325,7 +5306,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -5412,7 +5393,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 			},
 		},
 		Spec: core.PersistentVolumeClaimSpec{
-			StorageClassName: strPtr("workload-storage"),
+			StorageClassName: pointer.StringPtr("workload-storage"),
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
 					core.ResourceStorage: resource.MustParse("100Mi"),
@@ -5453,7 +5434,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -5560,7 +5541,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 			},
 		},
 		Spec: core.PersistentVolumeClaimSpec{
-			StorageClassName: strPtr("workload-storage"),
+			StorageClassName: pointer.StringPtr("workload-storage"),
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
 					core.ResourceStorage: resource.MustParse("100Mi"),
@@ -5601,7 +5582,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -5770,7 +5751,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			},
 		},
 		Spec: core.PersistentVolumeClaimSpec{
-			StorageClassName: strPtr("workload-storage"),
+			StorageClassName: pointer.StringPtr("workload-storage"),
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
 					core.ResourceStorage: resource.MustParse("100Mi"),
@@ -5810,7 +5791,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -5948,7 +5929,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 			},
 		},
 		Spec: core.PersistentVolumeClaimSpec{
-			StorageClassName: strPtr("workload-storage"),
+			StorageClassName: pointer.StringPtr("workload-storage"),
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
 					core.ResourceStorage: resource.MustParse("100Mi"),
@@ -5988,7 +5969,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -6121,7 +6102,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 			},
 		},
 		Spec: core.PersistentVolumeClaimSpec{
-			StorageClassName: strPtr("workload-storage"),
+			StorageClassName: pointer.StringPtr("workload-storage"),
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
 					core.ResourceStorage: resource.MustParse("100Mi"),
@@ -6161,7 +6142,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -6304,7 +6285,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -6421,7 +6402,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "app-name"},
 			},
-			RevisionHistoryLimit: int32Ptr(0),
+			RevisionHistoryLimit: pointer.Int32Ptr(0),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					GenerateName: "app-name-",
@@ -7490,7 +7471,7 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDaemonSet(c *gc.C) {
 	_, err = provider.UpdateStrategyForDaemonSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 		RollingUpdate: &specs.RollingUpdateSpec{
-			Partition: int32Ptr(10),
+			Partition: pointer.Int32Ptr(10),
 		},
 	})
 	c.Assert(err, gc.ErrorMatches, `rolling update spec for daemonset not valid`)
@@ -7558,7 +7539,7 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForDeployment(c *gc.C) {
 	_, err = provider.UpdateStrategyForDeployment(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 		RollingUpdate: &specs.RollingUpdateSpec{
-			Partition:      int32Ptr(10),
+			Partition:      pointer.Int32Ptr(10),
 			MaxUnavailable: &specs.IntOrString{IntVal: 10},
 		},
 	})
@@ -7622,7 +7603,7 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 		RollingUpdate: &specs.RollingUpdateSpec{
-			Partition: int32Ptr(10),
+			Partition: pointer.Int32Ptr(10),
 			MaxSurge:  &specs.IntOrString{IntVal: 10},
 		},
 	})
@@ -7631,7 +7612,7 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 		RollingUpdate: &specs.RollingUpdateSpec{
-			Partition:      int32Ptr(10),
+			Partition:      pointer.Int32Ptr(10),
 			MaxUnavailable: &specs.IntOrString{IntVal: 10},
 		},
 	})
@@ -7648,7 +7629,7 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 	_, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "OnDelete",
 		RollingUpdate: &specs.RollingUpdateSpec{
-			Partition: int32Ptr(10),
+			Partition: pointer.Int32Ptr(10),
 		},
 	})
 	c.Assert(err, gc.ErrorMatches, `rolling update spec is not supported for "OnDelete"`)
@@ -7656,14 +7637,14 @@ func (s *K8sBrokerSuite) TestUpdateStrategyForStatefulSet(c *gc.C) {
 	o, err = provider.UpdateStrategyForStatefulSet(specs.UpdateStrategy{
 		Type: "RollingUpdate",
 		RollingUpdate: &specs.RollingUpdateSpec{
-			Partition: int32Ptr(10),
+			Partition: pointer.Int32Ptr(10),
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(o, jc.DeepEquals, appsv1.StatefulSetUpdateStrategy{
 		Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-			Partition: int32Ptr(10),
+			Partition: pointer.Int32Ptr(10),
 		},
 	})
 }
@@ -7779,7 +7760,7 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClassFromResource(c *
 			},
 		},
 		Spec: networkingv1.IngressSpec{
-			IngressClassName: strPtr("foo"),
+			IngressClassName: pointer.StringPtr("foo"),
 			Rules: []networkingv1.IngressRule{{
 				Host: "172.0.0.1.xip.io",
 				IngressRuleValue: networkingv1.IngressRuleValue{

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/caas"
@@ -399,7 +400,7 @@ func modelOperatorDeployment(
 			),
 		},
 		Spec: apps.DeploymentSpec{
-			Replicas: utils.Int32Ptr(1),
+			Replicas: pointer.Int32Ptr(1),
 			Selector: &meta.LabelSelector{
 				MatchLabels: selectorLabels,
 			},

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
@@ -58,7 +59,7 @@ var operatorServiceArg = &core.Service{
 func operatorPodSpec(serviceAccountName string, withStorage bool) core.PodSpec {
 	spec := core.PodSpec{
 		ServiceAccountName:           serviceAccountName,
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 		Containers: []core.Container{{
 			Name:            "juju-operator",
 			ImagePullPolicy: core.PullIfNotPresent,
@@ -284,7 +285,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfig(c *gc.C) {
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 			Annotations: operatorAnnotations,
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -393,7 +394,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorCreate(c *gc.C) {
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 			Annotations: operatorAnnotations,
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -508,7 +509,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorUpdate(c *gc.C) {
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 			Annotations: operatorAnnotations,
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -647,7 +648,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoStorageExistingPVC(c *gc.C) {
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 			Annotations: operatorAnnotations,
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -779,7 +780,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoStorage(c *gc.C) {
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 			Annotations: operatorAnnotations,
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	role := &rbacv1.Role{
 		ObjectMeta: v1.ObjectMeta{
@@ -882,7 +883,7 @@ func (s *K8sBrokerSuite) TestEnsureOperatorNoAgentConfigMissingConfigMap(c *gc.C
 			Labels:      map[string]string{"app.kubernetes.io/managed-by": "juju", "operator.juju.is/name": "test", "operator.juju.is/target": "application"},
 			Annotations: operatorAnnotations,
 		},
-		AutomountServiceAccountToken: boolPtr(true),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 	}
 	svcAccountUID := svcAccount.GetUID()
 	role := &rbacv1.Role{

--- a/caas/kubernetes/provider/resources/applier.go
+++ b/caas/kubernetes/provider/resources/applier.go
@@ -90,7 +90,3 @@ func (a *applier) Run(ctx context.Context, client kubernetes.Interface, noRollba
 	}
 	return nil
 }
-
-func int64Ptr(v int64) *int64 {
-	return &v
-}

--- a/caas/kubernetes/provider/resources/applier.go
+++ b/caas/kubernetes/provider/resources/applier.go
@@ -90,3 +90,7 @@ func (a *applier) Run(ctx context.Context, client kubernetes.Interface, noRollba
 	}
 	return nil
 }
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}

--- a/caas/kubernetes/provider/resources/clusterrolebinding.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding.go
@@ -92,10 +92,12 @@ func (rb *ClusterRoleBinding) Delete(ctx context.Context, client kubernetes.Inte
 	return nil
 }
 
-func shouldDelete(crb1, crb2 rbacv1.ClusterRoleBinding) bool {
-	return crb1.RoleRef.APIGroup != crb2.RoleRef.APIGroup ||
-		crb1.RoleRef.Kind != crb2.RoleRef.Kind ||
-		crb1.RoleRef.Name != crb2.RoleRef.Name
+// shouldDelete checks if there are any changes in the immutable field to decide
+// if the existing cluster role binding should be deleted or not.
+func shouldDelete(existing, new rbacv1.ClusterRoleBinding) bool {
+	return existing.RoleRef.APIGroup != new.RoleRef.APIGroup ||
+		existing.RoleRef.Kind != new.RoleRef.Kind ||
+		existing.RoleRef.Name != new.RoleRef.Name
 }
 
 // Ensure ensures this cluster role exists in it's desired form inside the

--- a/caas/kubernetes/provider/resources/clusterrolebinding.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/core/status"
@@ -81,7 +82,7 @@ func (rb *ClusterRoleBinding) Delete(ctx context.Context, client kubernetes.Inte
 	api := client.RbacV1().ClusterRoleBindings()
 	err := api.Delete(ctx, rb.Name, metav1.DeleteOptions{
 		PropagationPolicy:  k8sconstants.DeletePropagationBackground(),
-		GracePeriodSeconds: int64Ptr(0),
+		GracePeriodSeconds: pointer.Int64Ptr(0),
 		Preconditions:      &metav1.Preconditions{UID: &rb.UID},
 	})
 	if k8serrors.IsNotFound(err) {
@@ -116,7 +117,7 @@ func (rb *ClusterRoleBinding) Ensure(
 	if err != nil && !errors.IsNotFound(err) {
 		return cleanups, errors.Annotatef(err, "getting existing cluster role binding %q", rb.Name)
 	}
-	doUpdate := !errors.IsNotFound(err)
+	doUpdate := err == nil
 	if err == nil {
 		hasClaim, err := RunClaims(claims...).Assert(&existing.ClusterRoleBinding)
 		if err != nil {

--- a/caas/kubernetes/provider/scale/scale_test.go
+++ b/caas/kubernetes/provider/scale/scale_test.go
@@ -13,9 +13,9 @@ import (
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas/kubernetes/provider/scale"
-	"github.com/juju/juju/caas/kubernetes/provider/utils"
 )
 
 type ScaleSuite struct {
@@ -45,7 +45,7 @@ func (s *ScaleSuite) TestDeploymentScale(c *gc.C) {
 				Name: "test",
 			},
 			Spec: apps.DeploymentSpec{
-				Replicas: utils.Int32Ptr(1),
+				Replicas: pointer.Int32Ptr(1),
 			},
 		},
 		meta.CreateOptions{})
@@ -112,7 +112,7 @@ func (s *ScaleSuite) TestStatefulSetScale(c *gc.C) {
 				Name: "test",
 			},
 			Spec: apps.StatefulSetSpec{
-				Replicas: utils.Int32Ptr(1),
+				Replicas: pointer.Int32Ptr(1),
 			},
 		},
 		meta.CreateOptions{})

--- a/caas/kubernetes/provider/specs/admissionregistration_test.go
+++ b/caas/kubernetes/provider/specs/admissionregistration_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/testing"
@@ -76,7 +77,7 @@ webhooks:
 						Service: &admissionregistrationv1beta1.ServiceReference{
 							Name:      "apple-service",
 							Namespace: "apples",
-							Path:      strPtr("/apple"),
+							Path:      pointer.StringPtr("/apple"),
 						},
 						CABundle: CABundle,
 					},
@@ -158,7 +159,7 @@ webhooks:
 						Service: &admissionregistrationv1beta1.ServiceReference{
 							Name:      "apple-service",
 							Namespace: "apples",
-							Path:      strPtr("/apple"),
+							Path:      pointer.StringPtr("/apple"),
 						},
 						CABundle: CABundle,
 					},
@@ -266,7 +267,7 @@ webhooks:
 					},
 					AdmissionReviewVersions: []string{"v1", "v1beta1"},
 					SideEffects:             &sideEffects,
-					TimeoutSeconds:          int32Ptr(5),
+					TimeoutSeconds:          pointer.Int32Ptr(5),
 				},
 			},
 		},
@@ -339,7 +340,7 @@ webhooks:
 					},
 					AdmissionReviewVersions: []string{"v1", "v1beta1"},
 					SideEffects:             &sideEffects,
-					TimeoutSeconds:          int32Ptr(5),
+					TimeoutSeconds:          pointer.Int32Ptr(5),
 				},
 			},
 		},

--- a/caas/kubernetes/provider/specs/container_env_test.go
+++ b/caas/kubernetes/provider/specs/container_env_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/testing"
@@ -86,7 +87,7 @@ containers:
 	envVarThing1.ValueFrom.ConfigMapKeyRef.Name = "foo"
 
 	envFromSourceSecret1 := core.EnvFromSource{
-		SecretRef: &core.SecretEnvSource{Optional: boolPtr(true)},
+		SecretRef: &core.SecretEnvSource{Optional: pointer.BoolPtr(true)},
 	}
 	envFromSourceSecret1.SecretRef.Name = "secret1"
 
@@ -96,7 +97,7 @@ containers:
 	envFromSourceSecret2.SecretRef.Name = "secret2"
 
 	envFromSourceConfigmap1 := core.EnvFromSource{
-		ConfigMapRef: &core.ConfigMapEnvSource{Optional: boolPtr(true)},
+		ConfigMapRef: &core.ConfigMapEnvSource{Optional: pointer.BoolPtr(true)},
 	}
 	envFromSourceConfigmap1.ConfigMapRef.Name = "configmap1"
 

--- a/caas/kubernetes/provider/specs/customresourcedefinition_test.go
+++ b/caas/kubernetes/provider/specs/customresourcedefinition_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/testing"
@@ -95,7 +96,7 @@ spec:
 					{Name: "v1beta2", Served: true, Storage: false},
 				},
 				Scope:                 "Cluster",
-				PreserveUnknownFields: boolPtr(false),
+				PreserveUnknownFields: pointer.BoolPtr(false),
 				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 					Kind:     "TFJob",
 					Plural:   "tfjobs",
@@ -122,7 +123,7 @@ spec:
 											"PS": {
 												Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 													"replicas": {
-														Type: "integer", Minimum: float64Ptr(1),
+														Type: "integer", Minimum: pointer.Float64Ptr(1),
 													},
 												},
 											},
@@ -130,8 +131,8 @@ spec:
 												Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 													"replicas": {
 														Type:    "integer",
-														Minimum: float64Ptr(1),
-														Maximum: float64Ptr(1),
+														Minimum: pointer.Float64Ptr(1),
+														Maximum: pointer.Float64Ptr(1),
 													},
 												},
 											},
@@ -139,7 +140,7 @@ spec:
 												Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 													"replicas": {
 														Type:    "integer",
-														Minimum: float64Ptr(1),
+														Minimum: pointer.Float64Ptr(1),
 													},
 												},
 											},
@@ -234,7 +235,7 @@ spec:
 						Schema: &apiextensionsv1.CustomResourceValidation{
 							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 								Type:                   "object",
-								XPreserveUnknownFields: boolPtr(true),
+								XPreserveUnknownFields: pointer.BoolPtr(true),
 							},
 						},
 						AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{

--- a/caas/kubernetes/provider/specs/ingress_test.go
+++ b/caas/kubernetes/provider/specs/ingress_test.go
@@ -12,6 +12,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/testing"
@@ -111,7 +112,7 @@ spec:
 			SpecV1: networkingv1.IngressSpec{
 				DefaultBackend: &networkingv1.IngressBackend{
 					Resource: &core.TypedLocalObjectReference{
-						APIGroup: strPtr("k8s.example.com"),
+						APIGroup: pointer.StringPtr("k8s.example.com"),
 						Kind:     "StorageBucket",
 						Name:     "static-assets",
 					},
@@ -126,7 +127,7 @@ spec:
 										PathType: &pathType,
 										Backend: networkingv1.IngressBackend{
 											Resource: &core.TypedLocalObjectReference{
-												APIGroup: strPtr("k8s.example.com"),
+												APIGroup: pointer.StringPtr("k8s.example.com"),
 												Kind:     "StorageBucket",
 												Name:     "icon-assets",
 											},

--- a/caas/kubernetes/provider/specs/legacy_test.go
+++ b/caas/kubernetes/provider/specs/legacy_test.go
@@ -9,6 +9,7 @@ import (
 	core "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/specs"
@@ -209,8 +210,8 @@ echo "do some stuff here for gitlab container"
 				},
 				ProviderContainer: &k8sspecs.K8sContainerSpec{
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot: boolPtr(true),
-						Privileged:   boolPtr(true),
+						RunAsNonRoot: pointer.BoolPtr(true),
+						Privileged:   pointer.BoolPtr(true),
 					},
 					LivenessProbe: &core.Probe{
 						InitialDelaySeconds: 10,
@@ -297,10 +298,10 @@ echo "do some stuff here for gitlab-init container"
 					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
 					RestartPolicy:                 core.RestartPolicyOnFailure,
-					ActiveDeadlineSeconds:         int64Ptr(10),
-					TerminationGracePeriodSeconds: int64Ptr(20),
+					ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
+					TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 					SecurityContext: &core.PodSecurityContext{
-						RunAsNonRoot:       boolPtr(true),
+						RunAsNonRoot:       pointer.BoolPtr(true),
 						SupplementalGroups: []int64{1, 2},
 					},
 					ReadinessGates: []core.PodReadinessGate{
@@ -330,7 +331,7 @@ echo "do some stuff here for gitlab-init container"
 													"PS": {
 														Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 															"replicas": {
-																Type: "integer", Minimum: float64Ptr(1),
+																Type: "integer", Minimum: pointer.Float64Ptr(1),
 															},
 														},
 													},
@@ -338,8 +339,8 @@ echo "do some stuff here for gitlab-init container"
 														Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 															"replicas": {
 																Type:    "integer",
-																Minimum: float64Ptr(1),
-																Maximum: float64Ptr(1),
+																Minimum: pointer.Float64Ptr(1),
+																Maximum: pointer.Float64Ptr(1),
 															},
 														},
 													},
@@ -347,7 +348,7 @@ echo "do some stuff here for gitlab-init container"
 														Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 															"replicas": {
 																Type:    "integer",
-																Minimum: float64Ptr(1),
+																Minimum: pointer.Float64Ptr(1),
 															},
 														},
 													},

--- a/caas/kubernetes/provider/specs/v2_test.go
+++ b/caas/kubernetes/provider/specs/v2_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/specs"
@@ -332,7 +333,7 @@ foo: bar
 
 	sa1 := &specs.PrimeServiceAccountSpecV3{
 		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			Roles: []specs.Role{
 				{
 					Global: true,
@@ -414,8 +415,8 @@ echo "do some stuff here for gitlab container"
 				},
 				ProviderContainer: &k8sspecs.K8sContainerSpec{
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot: boolPtr(true),
-						Privileged:   boolPtr(true),
+						RunAsNonRoot: pointer.BoolPtr(true),
+						Privileged:   pointer.BoolPtr(true),
 					},
 					LivenessProbe: &core.Probe{
 						InitialDelaySeconds: 10,
@@ -498,7 +499,7 @@ echo "do some stuff here for gitlab-init container"
 				{
 					Name: "k8sServiceAccount1",
 					ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-						AutomountServiceAccountToken: boolPtr(true),
+						AutomountServiceAccountToken: pointer.BoolPtr(true),
 						Roles: []specs.Role{
 							{
 								Global: true,
@@ -581,7 +582,7 @@ echo "do some stuff here for gitlab-init container"
 				Service: &admissionregistration.ServiceReference{
 					Name:      "apple-service",
 					Namespace: "apples",
-					Path:      strPtr("/apple"),
+					Path:      pointer.StringPtr("/apple"),
 				},
 				CABundle: CABundle1,
 			},
@@ -619,7 +620,7 @@ echo "do some stuff here for gitlab-init container"
 			},
 			AdmissionReviewVersions: []string{"v1", "v1beta1"},
 			SideEffects:             &sideEffects,
-			TimeoutSeconds:          int32Ptr(5),
+			TimeoutSeconds:          pointer.Int32Ptr(5),
 		}
 
 		pSpecs.ProviderPod = &k8sspecs.K8sPodSpec{
@@ -628,11 +629,11 @@ echo "do some stuff here for gitlab-init container"
 				Pod: &k8sspecs.PodSpec{
 					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
-					ActiveDeadlineSeconds:         int64Ptr(10),
+					ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,
-					TerminationGracePeriodSeconds: int64Ptr(20),
+					TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 					SecurityContext: &core.PodSecurityContext{
-						RunAsNonRoot:       boolPtr(true),
+						RunAsNonRoot:       pointer.BoolPtr(true),
 						SupplementalGroups: []int64{1, 2},
 					},
 					ReadinessGates: []core.PodReadinessGate{
@@ -642,7 +643,7 @@ echo "do some stuff here for gitlab-init container"
 					HostNetwork:       true,
 					HostPID:           true,
 					PriorityClassName: "system-cluster-critical",
-					Priority:          int32Ptr(2000000000),
+					Priority:          pointer.Int32Ptr(2000000000),
 				},
 				Secrets: []k8sspecs.K8sSecret{
 					{
@@ -677,7 +678,7 @@ password: shhhh`[1:],
 									{Name: "v1beta2", Served: true, Storage: false},
 								},
 								Scope:                 "Cluster",
-								PreserveUnknownFields: boolPtr(false),
+								PreserveUnknownFields: pointer.BoolPtr(false),
 								Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 									Kind:     "TFJob",
 									Plural:   "tfjobs",
@@ -704,7 +705,7 @@ password: shhhh`[1:],
 															"PS": {
 																Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 																	"replicas": {
-																		Type: "integer", Minimum: float64Ptr(1),
+																		Type: "integer", Minimum: pointer.Float64Ptr(1),
 																	},
 																},
 															},
@@ -712,8 +713,8 @@ password: shhhh`[1:],
 																Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 																	"replicas": {
 																		Type:    "integer",
-																		Minimum: float64Ptr(1),
-																		Maximum: float64Ptr(1),
+																		Minimum: pointer.Float64Ptr(1),
+																		Maximum: pointer.Float64Ptr(1),
 																	},
 																},
 															},
@@ -721,7 +722,7 @@ password: shhhh`[1:],
 																Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 																	"replicas": {
 																		Type:    "integer",
-																		Minimum: float64Ptr(1),
+																		Minimum: pointer.Float64Ptr(1),
 																	},
 																},
 															},

--- a/caas/kubernetes/provider/specs/v3_test.go
+++ b/caas/kubernetes/provider/specs/v3_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/specs"
@@ -467,7 +468,7 @@ foo: bar
 
 	sa1 := &specs.PrimeServiceAccountSpecV3{
 		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			Roles: []specs.Role{
 				{
 					Rules: []specs.PolicyRule{
@@ -545,7 +546,7 @@ echo "do some stuff here for gitlab container"
 								{
 									Path:    "file1",
 									Content: expectedFileContent,
-									Mode:    int32Ptr(644),
+									Mode:    pointer.Int32Ptr(644),
 								},
 							},
 						},
@@ -575,12 +576,12 @@ echo "do some stuff here for gitlab container"
 						VolumeSource: specs.VolumeSource{
 							ConfigMap: &specs.ResourceRefVol{
 								Name:        "log-config",
-								DefaultMode: int32Ptr(511),
+								DefaultMode: pointer.Int32Ptr(511),
 								Files: []specs.FileRef{
 									{
 										Key:  "log_level",
 										Path: "log_level",
-										Mode: int32Ptr(511),
+										Mode: pointer.Int32Ptr(511),
 									},
 								},
 							},
@@ -592,12 +593,12 @@ echo "do some stuff here for gitlab container"
 						VolumeSource: specs.VolumeSource{
 							Secret: &specs.ResourceRefVol{
 								Name:        "mysecret2",
-								DefaultMode: int32Ptr(511),
+								DefaultMode: pointer.Int32Ptr(511),
 								Files: []specs.FileRef{
 									{
 										Key:  "password",
 										Path: "my-group/my-password",
-										Mode: int32Ptr(511),
+										Mode: pointer.Int32Ptr(511),
 									},
 								},
 							},
@@ -606,8 +607,8 @@ echo "do some stuff here for gitlab container"
 				},
 				ProviderContainer: &k8sspecs.K8sContainerSpec{
 					SecurityContext: &core.SecurityContext{
-						RunAsNonRoot: boolPtr(true),
-						Privileged:   boolPtr(true),
+						RunAsNonRoot: pointer.BoolPtr(true),
+						Privileged:   pointer.BoolPtr(true),
 					},
 					LivenessProbe: &core.Probe{
 						InitialDelaySeconds: 10,
@@ -690,7 +691,7 @@ echo "do some stuff here for gitlab-init container"
 				{
 					Name: "k8sServiceAccount1",
 					ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-						AutomountServiceAccountToken: boolPtr(true),
+						AutomountServiceAccountToken: pointer.BoolPtr(true),
 						Roles: []specs.Role{
 							{
 								Name:   "k8sRole",
@@ -773,7 +774,7 @@ echo "do some stuff here for gitlab-init container"
 				SpecV1: networkingv1.IngressSpec{
 					DefaultBackend: &networkingv1.IngressBackend{
 						Resource: &core.TypedLocalObjectReference{
-							APIGroup: strPtr("k8s.example.com"),
+							APIGroup: pointer.StringPtr("k8s.example.com"),
 							Kind:     "StorageBucket",
 							Name:     "static-assets",
 						},
@@ -788,7 +789,7 @@ echo "do some stuff here for gitlab-init container"
 											PathType: &pathType1,
 											Backend: networkingv1.IngressBackend{
 												Resource: &core.TypedLocalObjectReference{
-													APIGroup: strPtr("k8s.example.com"),
+													APIGroup: pointer.StringPtr("k8s.example.com"),
 													Kind:     "StorageBucket",
 													Name:     "icon-assets",
 												},
@@ -825,7 +826,7 @@ echo "do some stuff here for gitlab-init container"
 				Service: &admissionregistrationv1beta1.ServiceReference{
 					Name:      "apple-service",
 					Namespace: "apples",
-					Path:      strPtr("/apple"),
+					Path:      pointer.StringPtr("/apple"),
 				},
 				CABundle: CABundle1,
 			},
@@ -863,7 +864,7 @@ echo "do some stuff here for gitlab-init container"
 			},
 			AdmissionReviewVersions: []string{"v1", "v1beta1"},
 			SideEffects:             &sideEffects,
-			TimeoutSeconds:          int32Ptr(5),
+			TimeoutSeconds:          pointer.Int32Ptr(5),
 		}
 
 		pSpecs.ProviderPod = &k8sspecs.K8sPodSpec{
@@ -908,11 +909,11 @@ echo "do some stuff here for gitlab-init container"
 				Pod: &k8sspecs.PodSpec{
 					Labels:                        map[string]string{"foo": "bax"},
 					Annotations:                   map[string]string{"foo": "baz"},
-					ActiveDeadlineSeconds:         int64Ptr(10),
+					ActiveDeadlineSeconds:         pointer.Int64Ptr(10),
 					RestartPolicy:                 core.RestartPolicyOnFailure,
-					TerminationGracePeriodSeconds: int64Ptr(20),
+					TerminationGracePeriodSeconds: pointer.Int64Ptr(20),
 					SecurityContext: &core.PodSecurityContext{
-						RunAsNonRoot:       boolPtr(true),
+						RunAsNonRoot:       pointer.BoolPtr(true),
 						SupplementalGroups: []int64{1, 2},
 					},
 					ReadinessGates: []core.PodReadinessGate{
@@ -922,7 +923,7 @@ echo "do some stuff here for gitlab-init container"
 					HostNetwork:       true,
 					HostPID:           true,
 					PriorityClassName: "system-cluster-critical",
-					Priority:          int32Ptr(2000000000),
+					Priority:          pointer.Int32Ptr(2000000000),
 				},
 				Secrets: []k8sspecs.K8sSecret{
 					{
@@ -963,7 +964,7 @@ password: shhhh`[1:],
 									{Name: "v1beta2", Served: true, Storage: false},
 								},
 								Scope:                 "Cluster",
-								PreserveUnknownFields: boolPtr(false),
+								PreserveUnknownFields: pointer.BoolPtr(false),
 								Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 									Kind:     "TFJob",
 									Plural:   "tfjobs",
@@ -990,7 +991,7 @@ password: shhhh`[1:],
 															"PS": {
 																Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 																	"replicas": {
-																		Type: "integer", Minimum: float64Ptr(1),
+																		Type: "integer", Minimum: pointer.Float64Ptr(1),
 																	},
 																},
 															},
@@ -998,8 +999,8 @@ password: shhhh`[1:],
 																Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 																	"replicas": {
 																		Type:    "integer",
-																		Minimum: float64Ptr(1),
-																		Maximum: float64Ptr(1),
+																		Minimum: pointer.Float64Ptr(1),
+																		Maximum: pointer.Float64Ptr(1),
 																	},
 																},
 															},
@@ -1007,7 +1008,7 @@ password: shhhh`[1:],
 																Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 																	"replicas": {
 																		Type:    "integer",
-																		Minimum: float64Ptr(1),
+																		Minimum: pointer.Float64Ptr(1),
 																	},
 																},
 															},
@@ -1057,7 +1058,7 @@ password: shhhh`[1:],
 										Schema: &apiextensionsv1.CustomResourceValidation{
 											OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 												Type:                   "object",
-												XPreserveUnknownFields: boolPtr(true),
+												XPreserveUnknownFields: pointer.BoolPtr(true),
 											},
 										},
 										AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
@@ -1468,7 +1469,7 @@ kubernetesResources:
 func (s *v3SpecsSuite) TestPrimeServiceAccountToK8sRBACResources(c *gc.C) {
 	primeSA := specs.PrimeServiceAccountSpecV3{
 		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			Roles: []specs.Role{
 				{
 					Global: true,
@@ -1497,7 +1498,7 @@ func (s *v3SpecsSuite) TestPrimeServiceAccountToK8sRBACResources(c *gc.C) {
 			{
 				Name: "test-app-rbac",
 				ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-					AutomountServiceAccountToken: boolPtr(true),
+					AutomountServiceAccountToken: pointer.BoolPtr(true),
 					Roles: []specs.Role{
 						{
 							Name:   "test-role",
@@ -1520,7 +1521,7 @@ func (s *v3SpecsSuite) TestPrimeServiceAccountToK8sRBACResources(c *gc.C) {
 func (s *v3SpecsSuite) TestPrimeServiceAccountValidate(c *gc.C) {
 	primeSA := specs.PrimeServiceAccountSpecV3{
 		ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 			Roles: []specs.Role{
 				{
 					Global: true,
@@ -1563,7 +1564,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesValidate(c *gc.C) {
 					{
 						Name: "sa2",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Name:   "cluster-role2",
@@ -1599,7 +1600,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesValidate(c *gc.C) {
 					{
 						Name: "sa2",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Name:   "cluster-role2",
@@ -1618,7 +1619,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesValidate(c *gc.C) {
 					{
 						Name: "sa2",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Name:   "cluster-role3",
@@ -1643,7 +1644,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesValidate(c *gc.C) {
 					{
 						Name: "sa2",
 						ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-							AutomountServiceAccountToken: boolPtr(true),
+							AutomountServiceAccountToken: pointer.BoolPtr(true),
 							Roles: []specs.Role{
 								{
 									Name:   "cluster-role2",
@@ -1749,7 +1750,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 			{
 				Name: "sa1",
 				ServiceAccountSpecV3: specs.ServiceAccountSpecV3{
-					AutomountServiceAccountToken: boolPtr(true),
+					AutomountServiceAccountToken: pointer.BoolPtr(true),
 					Roles: []specs.Role{
 						{
 							Name: "role1",
@@ -1849,7 +1850,7 @@ func (s *v3SpecsSuite) TestK8sRBACResourcesToK8s(c *gc.C) {
 				Labels:      map[string]string{"juju-app": "app-name"},
 				Annotations: annotations,
 			},
-			AutomountServiceAccountToken: boolPtr(true),
+			AutomountServiceAccountToken: pointer.BoolPtr(true),
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2121,24 +2122,4 @@ bar: a-bad-guy
 
 	_, err := k8sspecs.ParsePodSpec(specStr)
 	c.Assert(err, gc.ErrorMatches, `json: unknown field "bar"`)
-}
-
-func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func int32Ptr(i int32) *int32 {
-	return &i
-}
-
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func strPtr(b string) *string {
-	return &b
 }

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -12,6 +12,7 @@ import (
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sstorage "github.com/juju/juju/caas/kubernetes/provider/storage"
@@ -81,7 +82,7 @@ func (k *kubernetesClient) configureStatefulSet(
 			Selector: &v1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
-			RevisionHistoryLimit: utils.Int32Ptr(statefulSetRevisionHistoryLimit),
+			RevisionHistoryLimit: pointer.Int32Ptr(statefulSetRevisionHistoryLimit),
 			Template: core.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels:      utils.LabelsMerge(workloadSpec.Pod.Labels, selectorLabels),

--- a/caas/kubernetes/provider/teardown_test.go
+++ b/caas/kubernetes/provider/teardown_test.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	k8swatchertest "github.com/juju/juju/caas/kubernetes/provider/watcher/test"
 	"github.com/juju/juju/testing"
@@ -53,14 +54,14 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -68,8 +69,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -111,14 +112,14 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -126,8 +127,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownSuccess(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -321,14 +322,14 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -336,8 +337,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -377,14 +378,14 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
 										"PS": {
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
-													Type: "integer", Minimum: float64Ptr(1),
+													Type: "integer", Minimum: pointer.Float64Ptr(1),
 												},
 											},
 										},
@@ -392,8 +393,8 @@ func (s *K8sBrokerSuite) TestDeleteClusterScopeResourcesModelTeardownTimeout(c *
 											Properties: map[string]apiextensionsv1.JSONSchemaProps{
 												"replicas": {
 													Type:    "integer",
-													Minimum: float64Ptr(1),
-													Maximum: float64Ptr(1),
+													Minimum: pointer.Float64Ptr(1),
+													Maximum: pointer.Float64Ptr(1),
 												},
 											},
 										},

--- a/caas/kubernetes/provider/utils/types.go
+++ b/caas/kubernetes/provider/utils/types.go
@@ -3,7 +3,7 @@
 
 package utils
 
-// Returns a ptr for the supplied 32 bit integer
-func Int32Ptr(i int32) *int32 {
+// Returns a ptr for the supplied integer.
+func IntPtr(i int) *int {
 	return &i
 }

--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,7 @@ require (
 	k8s.io/apimachinery v0.19.6
 	k8s.io/client-go v0.19.6
 	k8s.io/klog/v2 v2.3.0
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 )
 
 replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e


### PR DESCRIPTION
*Delete cluster role bindings before creating and ensure the resource has been deleted completely before creating;*

Driveby: refactor all caas code to use client-go pointer helper functions;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju deploy /tmp/charm-builds/mariadb-k8s/ --debug  --resource mysql_image=mariadb

$ yml2json /tmp/charm-builds/mariadb-k8s/reactive/k8s_resources.yaml| jq '.kubernetesResources.serviceAccounts'
[
  {
    "name": "rbac-foo",
    "roles": [
      {
        "rules": [
          {
            "apiGroups": [
              ""
            ],
            "verbs": [
              "get",
              "watch",
              "list"
            ],
            "resources": [
              "pods"
            ]
          }
        ],
        "global": true,
        "name": "pod-cluster-role"
      }
    ],
    "automountServiceAccountToken": true
  }
]

$ mkubectl -nt1 get clusterrolebinding.rbac.authorization.k8s.io/rbac-foo-t1-pod-cluster-role -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    controller.juju.is/id: 1bb4c340-1536-4281-815b-ad893b5fcd73
    model.juju.is/id: b3bcd724-b4e0-4bb1-80e2-af346cbba787
  creationTimestamp: "2021-07-02T06:11:17Z"
  labels:
    app.juju.is/created-by: controller
    app.kubernetes.io/managed-by: juju
    app.kubernetes.io/name: mariadb-k8s
    model.juju.is/name: t1
  managedFields:
  - apiVersion: rbac.authorization.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:controller.juju.is/id: {}
          f:model.juju.is/id: {}
        f:labels:
          .: {}
          f:app.kubernetes.io/managed-by: {}
          f:app.kubernetes.io/name: {}
          f:model.juju.is/name: {}
      f:roleRef:
        f:apiGroup: {}
        f:kind: {}
        f:name: {}
      f:subjects: {}
    manager: juju
    operation: Update
    time: "2021-07-02T06:11:17Z"
  name: rbac-foo-t1-pod-cluster-role
  resourceVersion: "166248"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/rbac-foo-t1-pod-cluster-role
  uid: ace7f3f1-6d2f-4cd3-aca1-b9211126d1d0
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: t1-pod-cluster-role
subjects:
- kind: ServiceAccount
  name: rbac-foo
  namespace: t1

# change podspec a bit then build and upgrade charm
$ juju upgrade-charm mariadb-k8s --path /tmp/charm-builds/mariadb-k8s/ --debug --resource mysql_image=mariadb

$ mkubectl -nt1 get clusterrolebinding.rbac.authorization.k8s.io/rbac-foo-t1-pod-cluster-role -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    controller.juju.is/id: 1bb4c340-1536-4281-815b-ad893b5fcd73
    model.juju.is/id: b3bcd724-b4e0-4bb1-80e2-af346cbba787
  creationTimestamp: "2021-07-02T06:12:30Z"
  labels:
    app.juju.is/created-by: controller
    app.kubernetes.io/managed-by: juju
    app.kubernetes.io/name: mariadb-k8s
    model.juju.is/name: t1
  managedFields:
  - apiVersion: rbac.authorization.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:controller.juju.is/id: {}
          f:model.juju.is/id: {}
        f:labels:
          .: {}
          f:app.kubernetes.io/managed-by: {}
          f:app.kubernetes.io/name: {}
          f:model.juju.is/name: {}
      f:roleRef:
        f:apiGroup: {}
        f:kind: {}
        f:name: {}
      f:subjects: {}
    manager: juju
    operation: Update
    time: "2021-07-02T06:12:30Z"
  name: rbac-foo-t1-pod-cluster-role
  resourceVersion: "166401"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/rbac-foo-t1-pod-cluster-role
  uid: 6ccb09f0-f931-408a-a478-f2c7a5ad817c
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: t1-pod-cluster-role
subjects:
- kind: ServiceAccount
  name: rbac-foo
  namespace: t1

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1934180
