### PR TITLE
Facades: Allow empty charm config values

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -895,17 +895,18 @@ func parseCharmSettings(modelType state.ModelType, ch Charm, appName string, con
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
-	charmSettings := make(charm.Settings)
 
 	// If there isn't a charm YAML, then we can just return the charmConfig as
 	// the settings and no need to attempt to parse an empty yaml.
 	if len(charmYamlConfig) == 0 {
-		for k, v := range charmConfig {
-			charmSettings[k] = v
+		settings, err := ch.Config().ParseSettingsStrings(charmConfig)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
 		}
-		return appConfig, appCfgSchema, charmSettings, nil
+		return appConfig, appCfgSchema, settings, nil
 	}
 
+	var charmSettings charm.Settings
 	// Parse the charm YAML and check the yaml against the charm config.
 	if charmSettings, err = ch.Config().ParseSettingsYAML([]byte(charmYamlConfig), appName); err != nil {
 		// Check if this is 'juju get' output and parse it as such


### PR DESCRIPTION
The following changes allow the charm config as a map and the charm
config as a YAML to work as intended. The code previously assumed that
there was always a YAML and that the charm config map would always
overwrite it.

The problem occurs when there isn't a charm YAML and it would blindly
overwrite values. This caused empty strings to be converted
to `nil`, causing the --reset flow to be triggered. The --reset
flow sets the config defaults when it sees nil.

There is a much deeper problem and one that we will need to understand.
API versioning should essentially not touch old code _or_ at the very
least have enough testing to ensure that any new changes keeps the old
behaviour. 100% code coverage in these scenarios would be beneficial to
ensure that we didn't trip up here. The problem with attempting to get
to that level, is the amount of levels you have to test to just get that
far. From API server all the way down to state, it's a large task and
maybe not worth it?

## QA steps

Save bundle.yaml

```sh
cat >bundle.yaml<<EOF
  applications:
    haproxy:
      charm: cs:haproxy
      channel: stable
      options:
        services: ""
EOF
```

```sh
$ juju bootstrap lxd test
$ juju deploy ./bundle.yaml
$ juju config haproxy services

$  juju config haproxy services=""
WARNING the configuration setting "services" already has the value ""
$ juju config haproxy services


```

Notice that the default config shouldn't be shown.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1934151
