### PR TITLE
Fix parsing of custom k8s image repos with a port

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -226,7 +226,10 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	imagePath := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
+	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	apiHostPorts, err := a.ctrlSt.APIHostPortsForAgents()
 	if err != nil {

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -93,11 +93,15 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 		return result, errors.Annotate(err, "getting api addresses")
 	}
 
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf,
+		vers.ToPatch(), version.OfficialBuild)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
 	result = params.ModelOperatorInfo{
 		APIAddresses: apiAddresses.Result,
-		ImagePath: podcfg.GetJujuOCIImagePath(controllerConf,
-			vers.ToPatch(), version.OfficialBuild),
-		Version: vers,
+		ImagePath:    imagePath,
+		Version:      vers,
 	}
 	return result, nil
 }

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -47,7 +47,8 @@ func (m *ModelOperatorSuite) TestProvisioningInfo(c *gc.C) {
 	controllerConf, err := m.state.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
-	imagePath := podcfg.GetJujuOCIImagePath(controllerConf, info.Version, version.OfficialBuild)
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, info.Version, version.OfficialBuild)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(imagePath, gc.Equals, info.ImagePath)
 
 	model, err := m.state.Model()

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -138,7 +138,10 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 		modelConfig,
 	)
 
-	imagePath := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
+	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
 	apiAddresses, err := a.APIAddresses()
 	if err == nil && apiAddresses.Error != nil {
 		err = apiAddresses.Error

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -394,7 +394,10 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	operatorImagePath := podcfg.GetJujuOCIImagePath(controllerCfg, vers.ToPatch(), version.OfficialBuild)
+	operatorImagePath, err := podcfg.GetJujuOCIImagePath(controllerCfg, vers.ToPatch(), version.OfficialBuild)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)
 	if err != nil {

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -539,7 +539,11 @@ func (a *app) upgradeMainResource(applier resources.Applier, ver version.Number)
 			return errors.NotValidf("init container of %q", a.name)
 		}
 		initContainer := initContainers[0]
-		initContainer.Image = podcfg.RebuildOldOperatorImagePath(initContainer.Image, ver)
+		var err error
+		initContainer.Image, err = podcfg.RebuildOldOperatorImagePath(initContainer.Image, ver)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		ss.Spec.Template.Spec.InitContainers = []corev1.Container{initContainer}
 		ss.Spec.Template.SetAnnotations(a.upgradeAnnotations(annotations.New(ss.Spec.Template.GetAnnotations()), ver))
 		ss.SetAnnotations(a.upgradeAnnotations(annotations.New(ss.GetAnnotations()), ver))

--- a/caas/kubernetes/provider/operator_upgrade.go
+++ b/caas/kubernetes/provider/operator_upgrade.go
@@ -191,7 +191,10 @@ func operatorUpgrade(
 		return errors.Trace(err)
 	}
 
-	operatorImagePath := podcfg.RebuildOldOperatorImagePath(operator.Config.OperatorImagePath, vers)
+	operatorImagePath, err := podcfg.RebuildOldOperatorImagePath(operator.Config.OperatorImagePath, vers)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if len(operatorImagePath) == 0 {
 		// This should never happen.
 		return errors.NotValidf("no resource is upgradable for application %q", appName)

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -134,8 +134,12 @@ func upgradePodTemplateSpec(
 	}
 
 	if imagePath == "" {
-		imagePath = podcfg.RebuildOldOperatorImagePath(
+		var err error
+		imagePath, err = podcfg.RebuildOldOperatorImagePath(
 			podTemplate.Spec.Containers[jujudContainerIdx].Image, vers)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	upgradedTemp := podTemplate.DeepCopy()

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -25,12 +25,27 @@ func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
 
 	cfg[controller.CAASImageRepo] = "testing-repo"
 	ver := version.MustParse("2.6-beta3")
-	path := podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	path, err := podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.DeepEquals, "testing-repo/jujud-operator:2.6-beta3.666")
 
+	cfg[controller.CAASImageRepo] = "testing-repo:8080"
+	ver = version.MustParse("2.6-beta3")
+	path, err = podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(path, jc.DeepEquals, "testing-repo:8080/jujud-operator:2.6-beta3.666")
+
 	cfg[controller.CAASOperatorImagePath] = "testing-old-repo/jujud-old-operator:1.6"
-	path = podcfg.GetJujuOCIImagePath(cfg, ver, 0)
+	path, err = podcfg.GetJujuOCIImagePath(cfg, ver, 0)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.DeepEquals, "testing-old-repo/jujud-old-operator:2.6-beta3")
+}
+
+func (*imageSuite) TestRebuildOldOperatorImagePath(c *gc.C) {
+	ver := version.MustParse("2.6-beta3")
+	path, err := podcfg.RebuildOldOperatorImagePath("jujusolutions/jujud-operator:666", ver)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(path, jc.DeepEquals, "jujusolutions/jujud-operator:2.6-beta3")
 }
 
 func (*imageSuite) TestImageForBase(c *gc.C) {

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -66,7 +66,9 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	podConfig.OfficialBuild = 666
-	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "jujusolutions/jujud-operator:6.6.6.666")
+	path, err := podConfig.GetControllerImagePath()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(path, gc.Equals, "jujusolutions/jujud-operator:6.6.6.666")
 	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "jujusolutions/juju-db:4.0")
 }
 
@@ -82,7 +84,10 @@ func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	podConfig.OfficialBuild = 666
-	c.Assert(podConfig.GetControllerImagePath(), gc.Equals, "path/to/my/repo/jujud-operator:6.6.6.666")
+	c.Assert(err, jc.ErrorIsNil)
+	path, err := podConfig.GetControllerImagePath()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(path, gc.Equals, "path/to/my/repo/jujud-operator:6.6.6.666")
 	c.Assert(podConfig.GetJujuDbOCIImagePath(), gc.Equals, "path/to/my/repo/juju-db:4.0")
 }
 

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -276,7 +276,10 @@ func (c *baseUpgradeCommand) initCAASVersions(
 	controllerCfg controller.Config, majorVersion int, streamsAgents tools.List,
 ) (tools.Versions, error) {
 	logger.Debugf("searching for agent images with major: %d", majorVersion)
-	imagePath := podcfg.GetJujuOCIImagePath(controllerCfg, version.Zero, 0)
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerCfg, version.Zero, 0)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	availableTags, err := docker.ListOperatorImages(imagePath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A small fix for an issue found by QA folks when setting up a custom docker image repo. If the repo URL configured using `caas-image-repo` has a port, the parsing fails.

## QA steps

There's a unit test which ensures the expected behaviour. There's no 2.9.8 images but do this

` juju bootstrap microk8s test --config caas-image-repo=docker.io:5000/jujusolutions`

and it won't find the image but you can check the correct image URL:

```
microk8s.kubectl -n controller-test get pod/controller-0 -o json | jq .spec.containers[0].image
"docker.io:5000/jujusolutions/jujud-operator:2.9.8"
```

Also bootstrap a standard microk8s controller to regression test default behaviour.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1934707
