### PR TITLE
Bug #1934707: Correct tagging behaviour for jujud image

### DIFF
--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -61,12 +61,25 @@ func RebuildOldOperatorImagePath(imagePath string, ver version.Number) string {
 	return tagImagePath(imagePath, ver)
 }
 
+func splitLast(path string, sep string) (string, string) {
+	splits := strings.Split(path, sep)
+	if len(splits) > 1 {
+		newPath := strings.Join(splits[:len(splits)-1], sep)
+		last := splits[len(splits)-1]
+		return newPath, last
+	} else {
+		return path, ""
+	}
+}
+
 func tagImagePath(path string, ver version.Number) string {
 	var verString string
-	splittedPath := strings.Split(path, ":")
-	path = splittedPath[0]
-	if len(splittedPath) > 1 {
-		verString = splittedPath[1]
+	basePath, name := splitLast(path, "/")
+	if len(name) > 0 {
+		name, verString = splitLast(name, ":")
+		path = basePath + "/" + name
+	} else {
+		path, verString = splitLast(basePath, ":")
 	}
 	if ver != version.Zero {
 		verString = ver.String()

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -33,6 +33,31 @@ func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
 	c.Assert(path, jc.DeepEquals, "testing-old-repo/jujud-old-operator:2.6-beta3")
 }
 
+func (*imageSuite) TestGetJujuOCIImagePathWithLocalRepo(c *gc.C) {
+	cfg := testing.FakeControllerConfig()
+	ver := version.MustParse("2.6-beta3")
+
+	cfg[controller.CAASImageRepo] = "192.168.1.1/testing-repo"
+	path := podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	c.Assert(path, jc.DeepEquals, "192.168.1.1/testing-repo/jujud-operator:2.6-beta3.666")
+
+	cfg[controller.CAASImageRepo] = "192.168.1.1:8890/testing-repo"
+	path = podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	c.Assert(path, jc.DeepEquals, "192.168.1.1:8890/testing-repo/jujud-operator:2.6-beta3.666")
+
+	cfg[controller.CAASOperatorImagePath] = "192.168.1.1/testing-old-repo/jujud-old-operator:1.6"
+	path = podcfg.GetJujuOCIImagePath(cfg, ver, 0)
+	c.Assert(path, jc.DeepEquals, "192.168.1.1/testing-old-repo/jujud-old-operator:2.6-beta3")
+
+	cfg[controller.CAASOperatorImagePath] = "192.168.1.1:8890/testing-old-repo/jujud-old-operator:1.6"
+	path = podcfg.GetJujuOCIImagePath(cfg, ver, 0)
+	c.Assert(path, jc.DeepEquals, "192.168.1.1:8890/testing-old-repo/jujud-old-operator:2.6-beta3")
+
+	cfg[controller.CAASOperatorImagePath] = "jujud-old-operator:1.6"
+	path = podcfg.GetJujuOCIImagePath(cfg, ver, 0)
+	c.Assert(path, jc.DeepEquals, "jujud-old-operator:2.6-beta3")
+}
+
 func (*imageSuite) TestImageForBase(c *gc.C) {
 	_, err := podcfg.ImageForBase("", charm.Base{})
 	c.Assert(err, gc.ErrorMatches, `empty base name not valid`)


### PR DESCRIPTION
When user specify juju image repo containing port number, juju interpret and tag the image incorrectly, result in broken image name.

For example:
- Repo input: 192.168.1.1:8890/jujusolutions
- Version: 2.8.10

=> Image result: 192.168.1.1:2.8.10

This PR aims to fix this behaviour.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Run `juju bootstrap` with `caas-image-repo` configured to a local repo containing port number, juju should fetch the jujud image correctly.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1934707
