### PR TITLE
Cache: Coherence

### DIFF
--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -342,7 +342,6 @@ func (w *MachineLXDProfileWatcher) removeUnit(_ string, value interface{}) {
 	if len(w.applications) > 0 && !profile.Empty() {
 		notify = true
 	}
-	return
 }
 
 // provisionedChanged notifies when called.  Topic subscribed to is specific to

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -156,6 +156,7 @@ func (w *ConfigWatcher) configChanged(topic string, value interface{}) {
 		return
 	}
 	w.notify()
+	w.hash = hash
 }
 
 // StringsWatcher will return what has changed.
@@ -270,15 +271,6 @@ type PredicateStringsWatcher struct {
 	*stringsWatcherBase
 
 	fn predicateFunc
-}
-
-// newChangeWatcher provides a PredicateStringsWatcher which notifies
-// with all strings passed to it.
-func newChangeWatcher(values ...string) *PredicateStringsWatcher {
-	return &PredicateStringsWatcher{
-		stringsWatcherBase: newStringsWatcherBase(values...),
-		fn:                 func(string) bool { return true },
-	}
 }
 
 func regexpPredicate(compiled *regexp.Regexp) func(string) bool {


### PR DESCRIPTION
The cache would fail to notify if you changed from a value and back to
the original value (flip flopping). This is because the underlying hash value 
was never written. 

This has two consequences:

 1. The cache could never emit a change of the original value
 2. Because we never cached the new value, if the new value was the same
 as the old one, we would still emit the event.

The fix is easy, just save the hash after the notify and we can have
better cache coherency.

## QA steps

If you change the model-config logging-config to a new value and back to the 
old value, it should now correctly go back to the old value. Flip-flopping of values 
in the logging-config exposes this relatively easily.

```sh
$ juju bootstrap lxd test
$ juju model-config logging-config="<root>=WARN"
$ juju model-config logging-config="<root>=DEBUG"
```

View `$ juju debug-log -m controller` to ensure that the flip-flop happens. 
