### PR TITLE
Implement AllDeviceSpaceAddresses as domain concern and remove from state package

### DIFF
--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -32,7 +32,8 @@ func NewFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return internalFacade(&backend{m.ModelTag(), st, stateenvirons.EnvironConfigGetter{Model: m}}, ctx.Auth(), context.CallContext(st))
+	return internalFacade(
+		&backend{st, stateenvirons.EnvironConfigGetter{Model: m}, m.ModelTag()}, ctx.Auth(), context.CallContext(st))
 }
 
 func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {
@@ -55,7 +56,7 @@ func (facade *Facade) checkIsModelAdmin() error {
 }
 
 // PublicAddress reports the preferred public network address for one
-// or more entities. Machines and units are suppored.
+// or more entities. Machines and units are supported.
 func (facade *Facade) PublicAddress(args params.Entities) (params.SSHAddressResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -37732,7 +37732,7 @@
                             "$ref": "#/definitions/SSHAddressResults"
                         }
                     },
-                    "description": "PublicAddress reports the preferred public network address for one\nor more entities. Machines and units are suppored."
+                    "description": "PublicAddress reports the preferred public network address for one\nor more entities. Machines and units are supported."
                 },
                 "PublicKeys": {
                     "type": "object",

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -983,3 +983,77 @@ func (s *AddressSuite) TestIsValidAddressConfigTypeWithInvalidValues(c *gc.C) {
 	result = network.IsValidAddressConfigType(" ")
 	c.Check(result, jc.IsFalse)
 }
+
+// spaceAddressCandidate implements the SpaceAddressCandidate
+// interface from the core/network package.
+type spaceAddressCandidate struct {
+	value        string
+	configMethod network.AddressConfigType
+	subnetCIDR   string
+	isSecondary  bool
+}
+
+func (s spaceAddressCandidate) Value() string {
+	return s.value
+}
+
+func (s spaceAddressCandidate) ConfigMethod() network.AddressConfigType {
+	return s.configMethod
+}
+
+func (s spaceAddressCandidate) SubnetCIDR() string {
+	return s.subnetCIDR
+}
+
+func (s spaceAddressCandidate) IsSecondary() bool {
+	return s.isSecondary
+}
+
+func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
+	subs := network.SubnetInfos{
+		{ID: "1", CIDR: "192.168.0.0/24", SpaceID: "666"},
+		{ID: "2", CIDR: "10.10.10.0/24", SpaceID: "999"},
+	}
+
+	candidates := []network.SpaceAddressCandidate{
+		spaceAddressCandidate{
+			value:        "192.168.0.66",
+			configMethod: network.ConfigDHCP,
+			subnetCIDR:   "192.168.0.0/24",
+		},
+		spaceAddressCandidate{
+			value:        "10.10.10.66",
+			configMethod: network.ConfigStatic,
+			subnetCIDR:   "10.10.10.0/24",
+			isSecondary:  true,
+		},
+	}
+
+	addrs, err := network.ConvertToSpaceAddresses(candidates, subs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	network.SortAddresses(addrs)
+	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value:      "192.168.0.66",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+				ConfigType: network.ConfigDHCP,
+				CIDR:       "192.168.0.0/24",
+			},
+			SpaceID: "666",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value:       "10.10.10.66",
+				Type:        network.IPv4Address,
+				Scope:       network.ScopeCloudLocal,
+				ConfigType:  network.ConfigStatic,
+				CIDR:        "10.10.10.0/24",
+				IsSecondary: true,
+			},
+			SpaceID: "999",
+		},
+	})
+}

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -1012,7 +1012,7 @@ func (s spaceAddressCandidate) IsSecondary() bool {
 func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 	subs := network.SubnetInfos{
 		{ID: "1", CIDR: "192.168.0.0/24", SpaceID: "666"},
-		{ID: "2", CIDR: "10.10.10.0/24", SpaceID: "999"},
+		{ID: "2", CIDR: "252.80.0.0/12", SpaceID: "999"},
 	}
 
 	candidates := []network.SpaceAddressCandidate{
@@ -1022,9 +1022,9 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 			subnetCIDR:   "192.168.0.0/24",
 		},
 		spaceAddressCandidate{
-			value:        "10.10.10.66",
+			value:        "252.80.0.100",
 			configMethod: network.ConfigStatic,
-			subnetCIDR:   "10.10.10.0/24",
+			subnetCIDR:   "252.80.0.0/12",
 			isSecondary:  true,
 		},
 	}
@@ -1046,11 +1046,11 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 		},
 		{
 			MachineAddress: network.MachineAddress{
-				Value:       "10.10.10.66",
+				Value:       "252.80.0.100",
 				Type:        network.IPv4Address,
-				Scope:       network.ScopeCloudLocal,
+				Scope:       network.ScopeFanLocal,
 				ConfigType:  network.ConfigStatic,
-				CIDR:        "10.10.10.0/24",
+				CIDR:        "252.80.0.0/12",
 				IsSecondary: true,
 			},
 			SpaceID: "999",

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -256,6 +256,12 @@ func (s SubnetInfos) GetBySpaceID(spaceID string) (SubnetInfos, error) {
 	return append(subsInSpace, spaceOverlays...), nil
 }
 
+// AllSubnetInfos implements SubnetLookup
+// by returning all of the subnets.
+func (s SubnetInfos) AllSubnetInfos() (SubnetInfos, error) {
+	return s, nil
+}
+
 // EqualTo returns true if this slice of SubnetInfo is equal to the input.
 func (s SubnetInfos) EqualTo(other SubnetInfos) bool {
 	if len(s) != len(other) {

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -321,3 +321,15 @@ func (*subnetSuite) TestSubnetInfosGetBySpaceID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subs, gc.DeepEquals, s[2:])
 }
+
+func (*subnetSuite) TestSubnetInfosAllSubnetInfos(c *gc.C) {
+	s := network.SubnetInfos{
+		{ID: "1", CIDR: "10.10.10.0/24", ProviderId: "1"},
+		{ID: "2", CIDR: "10.10.10.0/24", ProviderId: "2"},
+		{ID: "3", CIDR: "20.20.20.0/24"},
+	}
+
+	allSubs, err := s.AllSubnetInfos()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(allSubs, gc.DeepEquals, s)
+}

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -317,45 +317,6 @@ func (s *ipAddressesStateSuite) TestMachineAllAddressesSuccess(c *gc.C) {
 	c.Assert(allAddresses, jc.DeepEquals, addedAddresses)
 }
 
-func (s *ipAddressesStateSuite) TestMachineAllDeviceSpaceAddresses(c *gc.C) {
-	addrs := s.addTwoDevicesWithTwoAddressesEach(c)
-	expected := make(network.SpaceAddresses, len(addrs))
-	for i, addr := range addrs {
-		expected[i] = network.SpaceAddress{
-			MachineAddress: network.NewMachineAddress(
-				addr.Value(),
-				network.WithCIDR(addr.SubnetCIDR()),
-				network.WithConfigType(addr.ConfigMethod()),
-			),
-			SpaceID: network.AlphaSpaceId,
-		}
-	}
-
-	networkAddresses, err := s.machine.AllDeviceSpaceAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-
-	network.SortAddresses(expected)
-	network.SortAddresses(networkAddresses)
-
-	c.Assert(networkAddresses, jc.DeepEquals, expected)
-}
-
-func (s *ipAddressesStateSuite) TestMachineAllDeviceSpaceAddressesFanScope(c *gc.C) {
-	_, _ = s.addNamedDeviceWithAddresses(c, "eth0", "252.80.0.100/12")
-
-	networkAddresses, err := s.machine.AllDeviceSpaceAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(networkAddresses, jc.DeepEquals, network.SpaceAddresses{{
-		MachineAddress: network.NewMachineAddress(
-			"252.80.0.100",
-			network.WithCIDR("252.80.0.0/12"),
-			network.WithConfigType(network.ConfigStatic),
-			network.WithScope(network.ScopeFanLocal),
-		),
-		SpaceID: network.AlphaSpaceId,
-	}})
-}
-
 func (s *ipAddressesStateSuite) TestLinkLayerDeviceRemoveAlsoRemovesDeviceAddresses(c *gc.C) {
 	device, _ := s.addNamedDeviceWithAddresses(c, "eth0", "10.20.30.40/16", "fc00::/64")
 	s.assertAllAddressesOnMachineMatchCount(c, s.machine, 2)
@@ -365,10 +326,9 @@ func (s *ipAddressesStateSuite) TestLinkLayerDeviceRemoveAlsoRemovesDeviceAddres
 	s.assertNoAddressesOnMachine(c, s.machine)
 }
 
-func (s *ipAddressesStateSuite) TestMachineRemoveAlsoRemoveAllAddresses(c *gc.C) {
+func (s *ipAddressesStateSuite) TestMachineRemoveAlsoRemovesAllAddresses(c *gc.C) {
 	s.addTwoDevicesWithTwoAddressesEach(c)
 	s.ensureMachineDeadAndRemove(c, s.machine)
-
 	s.assertNoAddressesOnMachine(c, s.machine)
 }
 

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -860,48 +860,6 @@ func (m *Machine) AllDeviceAddresses() ([]*Address, error) {
 	return allAddresses, nil
 }
 
-// AllDeviceSpaceAddresses returns the SpaceAddress representation of
-// all known addresses assigned to link-layer devices on the machine.
-// These addresses are populated with sufficient detail to be accurately
-// sortable by network.SortAddresses.
-func (m *Machine) AllDeviceSpaceAddresses() (corenetwork.SpaceAddresses, error) {
-	subnets, err := m.st.AllSubnets()
-	if err != nil {
-		return nil, errors.Annotate(err, "retrieving subnets")
-	}
-
-	var allAddresses corenetwork.SpaceAddresses
-	callbackFunc := func(doc *ipAddressDoc) {
-		addr := corenetwork.SpaceAddress{
-			MachineAddress: corenetwork.NewMachineAddress(
-				doc.Value,
-				corenetwork.WithConfigType(doc.ConfigMethod),
-				corenetwork.WithCIDR(doc.SubnetCIDR),
-				corenetwork.WithSecondary(doc.IsSecondary),
-			),
-		}
-
-		// If this is not a loopback device, attempt to
-		// set the space ID based on the subnet.
-		if doc.ConfigMethod != corenetwork.ConfigLoopback && doc.SubnetCIDR != "" {
-			for _, sub := range subnets {
-				if sub.CIDR() == doc.SubnetCIDR {
-					addr.SpaceID = sub.spaceID
-					break
-				}
-			}
-		}
-
-		allAddresses = append(allAddresses, addr)
-	}
-
-	findQuery := findAddressesQuery(m.doc.Id, "")
-	if err := m.st.forEachIPAddressDoc(findQuery, callbackFunc); err != nil {
-		return nil, errors.Trace(err)
-	}
-	return allAddresses, nil
-}
-
 // AllSpaces returns the set of spaceIDs that this machine is
 // actively connected to.
 // TODO(jam): 2016-12-18 This should evolve to look at the

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -845,7 +845,7 @@ func (m *Machine) removeAllAddressesOps() ([]txn.Op, error) {
 	return m.st.removeMatchingIPAddressesDocOps(findQuery)
 }
 
-// AllAddresses returns all known addresses assigned to
+// AllDeviceAddresses returns all known addresses assigned to
 // link-layer devices on the machine.
 func (m *Machine) AllDeviceAddresses() ([]*Address, error) {
 	var allAddresses []*Address

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -338,7 +338,7 @@ func (st *State) AllSubnetInfos() (network.SubnetInfos, error) {
 
 // networkSubnet maps the subnet fields into a network.SubnetInfo.
 // Note that this method should not be exported.
-// It is only called for on subnets are guaranteed, if Fan overlays,
+// It is only called on subnets that are guaranteed, if Fan overlays,
 // to have had their space IDs correctly set based on their underlays.
 // Calling it on an overlay not processed in this way will yield a
 // space ID of "0", which may be incorrect.


### PR DESCRIPTION
This is preamble to changes coming for `NetworkInfoIAAS` in the uniter facade.

We remove the `AllDeviceSpaceAddresses` from `state.Machine` and instead represent the conversion from suitable address candidates in the `core/network` domain modelling.

Changes are made accordingly at the 2 usage sites - the `uniter` and `sshclient` facades.

Some efficiency accommodations for retrieving and manipulating `SubnetInfos` are included. See individual commit descriptions.

## QA steps

- Bootstrap this patch.
- `juju deploy ubuntu`.
- `juju run --unit ubuntu/0 "network-get juju-info --format yaml"` returns without error.
- `juju ssh 0` establishes a SSH session.

## Documentation changes

None.

## Bug reference

Advances https://bugs.launchpad.net/juju/+bug/1897261
