### PR TITLE
Fix/windows bootstrap2microk8s

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -309,9 +309,9 @@ func (c *controllerStack) getResourceName(name string) string {
 
 func (c *controllerStack) pathJoin(elem ...string) string {
 	// Setting series for bootstrapping to kubernetes is currently not supported.
-	// Always use forward-slash for now.
+	// We always use forward-slash because Linux is the only OS we support now.
 	pathSeparator := "/"
-	return strings.Join(elem, string(pathSeparator))
+	return strings.Join(elem, pathSeparator)
 }
 
 func (c *controllerStack) getControllerSecret() (secret *core.Secret, err error) {

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"bytes"
-	osexec "os/exec"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
@@ -65,7 +64,7 @@ func attemptMicroK8sCredential(cmdRunner CommandRunner) (jujucloud.Credential, e
 }
 
 func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
-	_, err := osexec.LookPath("microk8s")
+	_, err := cmdRunner.LookPath("microk8s")
 	if err != nil {
 		return []byte{}, errors.NotFoundf("microk8s")
 	}

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -73,7 +73,7 @@ func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
 		Commands: cmd,
 	})
 	if err != nil || result.Code != 0 {
-		return []byte{}, errors.NotFoundf("command microk8s")
+		return []byte{}, errors.NotFoundf("microk8s")
 	}
 	execParams := exec.RunParams{
 		Commands: "microk8s config",

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -5,10 +5,10 @@ package provider
 
 import (
 	"bytes"
+	osexec "os/exec"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
-	jujuos "github.com/juju/os/v2"
 	"github.com/juju/utils/v2/exec"
 
 	"github.com/juju/juju/caas"
@@ -65,20 +65,14 @@ func attemptMicroK8sCredential(cmdRunner CommandRunner) (jujucloud.Credential, e
 }
 
 func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
-	cmd := "which microk8s"
-	if jujuos.HostOS() == jujuos.Windows {
-		cmd = "where.exe microk8s"
-	}
-	result, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: cmd,
-	})
-	if err != nil || result.Code != 0 {
+	_, err := osexec.LookPath("microk8s")
+	if err != nil {
 		return []byte{}, errors.NotFoundf("microk8s")
 	}
 	execParams := exec.RunParams{
 		Commands: "microk8s config",
 	}
-	result, err = cmdRunner.RunCommands(execParams)
+	result, err := cmdRunner.RunCommands(execParams)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -8,26 +8,26 @@ import (
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
+	jujuos "github.com/juju/os/v2"
 	"github.com/juju/utils/v2/exec"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
-	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 )
 
-func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, error) {
+func attemptMicroK8sCloud(cmdRunner CommandRunner) (jujucloud.Cloud, error) {
 	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner)
 	if err != nil {
-		return cloud.Cloud{}, err
+		return jujucloud.Cloud{}, err
 	}
 
 	k8sCloud, err := k8scloud.CloudFromKubeConfigClusterReader(
 		caas.MicroK8sClusterName,
 		bytes.NewReader(microk8sConfig),
 		k8scloud.CloudParamaters{
-			Description: cloud.DefaultCloudDescription(cloud.CloudTypeCAAS),
+			Description: jujucloud.DefaultCloudDescription(jujucloud.CloudTypeCAAS),
 			Name:        caas.K8sCloudMicrok8s,
 			Regions: []jujucloud.Region{{
 				Name: caas.Microk8sRegion,
@@ -38,41 +38,45 @@ func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, error) {
 	return k8sCloud, err
 }
 
-func attemptMicroK8sCredential(cmdRunner CommandRunner) (cloud.Credential, error) {
+func attemptMicroK8sCredential(cmdRunner CommandRunner) (jujucloud.Credential, error) {
 	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner)
 	if err != nil {
-		return cloud.Credential{}, err
+		return jujucloud.Credential{}, err
 	}
 
 	k8sConfig, err := k8scloud.ConfigFromReader(bytes.NewReader(microk8sConfig))
 	if err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "processing microk8s config to make juju credentials")
+		return jujucloud.Credential{}, errors.Annotate(err, "processing microk8s config to make juju credentials")
 	}
 
 	contextName, err := k8scloud.PickContextByClusterName(k8sConfig, caas.MicroK8sClusterName)
 	if err != nil {
-		return cloud.Credential{}, errors.Trace(err)
+		return jujucloud.Credential{}, errors.Trace(err)
 	}
 
 	context := k8sConfig.Contexts[contextName]
 	resolver := clientconfig.GetJujuAdminServiceAccountResolver(jujuclock.WallClock)
 	conf, err := resolver(caas.K8sCloudMicrok8s, k8sConfig, contextName)
 	if err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "resolving microk8s credentials")
+		return jujucloud.Credential{}, errors.Annotate(err, "resolving microk8s credentials")
 	}
 
 	return k8scloud.CredentialFromKubeConfig(context.AuthInfo, conf)
 }
 
 func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
+	cmd := "which microk8s"
+	if jujuos.HostOS() == jujuos.Windows {
+		cmd = "where.exe microk8s"
+	}
 	result, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: "which microk8s.config",
+		Commands: cmd,
 	})
 	if err != nil || result.Code != 0 {
-		return []byte{}, errors.NotFoundf("microk8s")
+		return []byte{}, errors.NotFoundf("command microk8s")
 	}
 	execParams := exec.RunParams{
-		Commands: "microk8s.config",
+		Commands: "microk8s config",
 	}
 	result, err = cmdRunner.RunCommands(execParams)
 	if err != nil {

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -9,6 +9,7 @@ import (
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
+	jujuos "github.com/juju/os/v2"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/exec"
 	"gopkg.in/yaml.v2"
@@ -61,7 +62,7 @@ func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *caas.ClusterMetadata
 		} else {
 			storageMsg += "\nand "
 		}
-		storageMsg += fmt.Sprintf("operator storage provisioned by the workload storage class")
+		storageMsg += "operator storage provisioned by the workload storage class"
 	}
 
 	if clusterMetadata.NominatedStorageClass != nil {
@@ -300,7 +301,14 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	return cld, nil
 }
 
-func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
+func checkMicrok8sUserGroupSetup(cmdRunner CommandRunner) error {
+	if jujuos.HostOS() == jujuos.Windows {
+		// The microk8s on windows is running on a vm managed by multipass.
+		// Even the vm does not have the user group properly configured but it is not
+		// a problem because microk8s CLI uses `multipass exec` with sudo to run the commands.
+		// https://github.com/ubuntu/microk8s/blob/master/installer/vm_providers/_multipass/_multipass.py#L50
+		return nil
+	}
 	resp, err := cmdRunner.RunCommands(exec.RunParams{
 		Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`,
 	})
@@ -318,8 +326,15 @@ Users in that group are granted access to microk8s commands and this
 is needed for Juju to be able to interact with microk8s.
 
 Add yourself to that group before trying again:
-  sudo usermod -a -G microk8s %s
+	sudo usermod -a -G microk8s %s
 `[1:], user)
+	}
+	return nil
+}
+
+func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
+	if err := checkMicrok8sUserGroupSetup(cmdRunner); err != nil {
+		return errors.Trace(err)
 	}
 
 	status, err := microK8sStatus(cmdRunner)
@@ -346,7 +361,7 @@ Add yourself to that group before trying again:
 func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 	var status microk8sStatus
 	result, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: "microk8s.status --wait-ready --timeout 15 --yaml",
+		Commands: "microk8s status --wait-ready --timeout 15 --yaml",
 	})
 	if err != nil {
 		return status, errors.Trace(err)
@@ -357,7 +372,7 @@ func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 			msg = string(result.Stdout)
 		}
 		if msg == "" {
-			msg = "unknown error running microk8s.status"
+			msg = "unknown error running microk8s status"
 		}
 		return status, errors.New(msg)
 	}

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -5,6 +5,7 @@ package provider_test
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -111,14 +112,15 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
-
+	if runtime.GOOS != "windows" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 0}, nil)
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
 	var ctx mockContext
@@ -152,13 +154,15 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
 
+	if runtime.GOOS != "windows" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 0}, nil)
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
 	var ctx mockContext
@@ -189,42 +193,51 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
+	if runtime.GOOS != "windows" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 0}, nil)
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
+	if runtime.GOOS != "windows" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 0}, nil)
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable storage'`)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
+	if runtime.GOOS != "windows" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 0}, nil)
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s.status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable dns'`)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableNotInGroup(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("no need to check user group setup for windows")
+	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
@@ -27,7 +26,7 @@ var (
 type detectCloudSuite struct{}
 
 type builtinCloudRet struct {
-	cloud      cloud.Cloud
+	cloud      jujucloud.Cloud
 	credential jujucloud.Credential
 	err        error
 }
@@ -41,13 +40,18 @@ func (d dummyRunner) RunCommands(run exec.RunParams) (*exec.ExecResponse, error)
 	return results[0].(*exec.ExecResponse), testing.TypeAssertError(results[1])
 }
 
-func cloudGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (cloud.Cloud, error) {
-	return func(provider.CommandRunner) (cloud.Cloud, error) {
+func (d dummyRunner) LookPath(file string) (string, error) {
+	results := d.MethodCall(d, "LookPath", file)
+	return results[0].(string), testing.TypeAssertError(results[1])
+}
+
+func cloudGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (jujucloud.Cloud, error) {
+	return func(provider.CommandRunner) (jujucloud.Cloud, error) {
 		return args.cloud, args.err
 	}
 }
 
-func credentialGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (cloud.Credential, error) {
+func credentialGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (jujucloud.Credential, error) {
 	return func(provider.CommandRunner) (jujucloud.Credential, error) {
 		return args.credential, args.err
 	}

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -27,10 +27,9 @@ var (
 type detectCloudSuite struct{}
 
 type builtinCloudRet struct {
-	cloud          cloud.Cloud
-	credential     jujucloud.Credential
-	credentialName string
-	err            error
+	cloud      cloud.Cloud
+	credential jujucloud.Credential
+	err        error
 }
 
 type dummyRunner struct {

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	stdcontext "context"
 	"net/url"
+	osexec "os/exec"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
@@ -57,12 +58,17 @@ func (kubernetesEnvironProvider) Version() int {
 // CommandRunner allows to run commands on the underlying system
 type CommandRunner interface {
 	RunCommands(run exec.RunParams) (*exec.ExecResponse, error)
+	LookPath(string) (string, error)
 }
 
 type defaultRunner struct{}
 
 func (defaultRunner) RunCommands(run exec.RunParams) (*exec.ExecResponse, error) {
 	return exec.RunCommands(run)
+}
+
+func (defaultRunner) LookPath(file string) (string, error) {
+	return osexec.LookPath(file)
 }
 
 // NewK8sClients returns the k8s clients to access a cluster.


### PR DESCRIPTION
*Fixed a few issues for bootstrapping to microk8s from a windows host;*

- cloud validation checks failed;
- wrong path separator for mount paths on configmaps and secrets etc;

Note:
Microk8s won't work with multipass using VirtualBox due to:
- VirtualBox uses NAT default which causes the VM is not accessible from the windows host;
- Since version 1.6, Multipass supports launching VM with network options. However, the `microk8s install` command does not provide a way for us to use the --network option;

Therefore, Hyper-V is required for bootstrapping to microk8s from a windows machine.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# install microk8s a windows machine having Hyper-V enabled;
$ microk8s.exe install
# add kubeconfig to $HOME\.kube\ if you want to use kubectl directly
$ microk8s.exe config | Add-Content -Path $HOME\.kube\config
$ PS C:\Users\xxx\Code\Go\src\github.com\juju\juju> juju bootstrap microk8s
Creating Juju controller "microk8s-localhost" on microk8s/localhost
Bootstrap to Kubernetes cluster identified as microk8s/localhost
Fetching Juju Dashboard 0.7.1
Creating k8s resources for controller "controller-microk8s-localhost"
Starting controller pod
Bootstrap agent now started
Contacting Juju controller at 10.152.183.211 to verify accessibility...

Bootstrap complete, controller "microk8s-localhost" is now available in namespace "controller-microk8s-localhost"

Now you can run
        juju add-model <model-name>
to create a new model to deploy k8s workloads.

$ juju add-model t1
Added 't1' model on microk8s/localhost with credential 'microk8s' for user 'admin'

$ juju deploy ch:kelvin-snappass-test
Located charm "kelvin-snappass-test" in charm-hub, revision 5
Deploying "kelvin-snappass-test" from charm-hub charm "kelvin-snappass-test", revision 5 in channel stable

$ juju deploy cs:~juju/mariadb-k8s-3
Located charm "mariadb-k8s" in charm-store, revision 3
Deploying "mariadb-k8s" from charm-store charm "mariadb-k8s", revision 3 in channel stable

$ juju status --color --storage --relations
Model  Controller          Cloud/Region        Version  SLA          Timestamp
t1     microk8s-localhost  microk8s/localhost  2.9.8    unsupported  16:29:57+10:00

App                   Version                  Status  Scale  Charm                 Store       Channel  Rev  OS          Address         Message
kelvin-snappass-test                           active      1  kelvin-snappass-test  charmhub    stable     5  kubernetes  10.152.183.197
mariadb-k8s           res:mysql_image@e6ea77e  active      1  mariadb-k8s           charmstore  stable     3  kubernetes  10.152.183.143

Unit                     Workload  Agent  Address      Ports     Message
kelvin-snappass-test/0*  active    idle   10.1.254.81            snappass started
mariadb-k8s/0*           active    idle   10.1.254.83  3306/TCP

Storage Unit   Storage id  Type        Pool        Mountpoint      Size   Status    Message
mariadb-k8s/0  database/0  filesystem  kubernetes  /var/lib/mysql  35MiB  attached  Successfully provisioned volume pvc-20a186ea-0869-42d9-a672-cb4ff28caf30

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931590
https://bugs.launchpad.net/juju/+bug/1931591
