### PR TITLE
Actions: Sort exec failure order

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -161,6 +162,7 @@ func (c *runCommandBase) processOperationResults(ctx *cmd.Context, results *acti
 		for k, v := range failed {
 			list = append(list, fmt.Sprintf(" - id %q with return code %d", k, v))
 		}
+		sort.Strings(list)
 
 		return errors.Errorf(`
 the following task%s failed:


### PR DESCRIPTION
This was spotted trying to land a fix in develop, where the ordering of
the task failures is a map and we depend on that order to verify test
results.

## QA steps

Tests pass.

```
$ go test -v ./cmd/juju/action -check.v -check.f=ExecSuite
```