### PR TITLE
Set target series in pre-upgrade-series hook environment

### DIFF
--- a/acceptancetests/repository/charms/dummy-sink/hooks/pre-series-upgrade
+++ b/acceptancetests/repository/charms/dummy-sink/hooks/pre-series-upgrade
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Load modules from $JUJU_CHARM_DIR/lib
-import sys
+import sys, os
 sys.path.append('lib')
 
-print("test pre-series-upgrade hook")
+print(os.environ)

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -661,15 +661,8 @@ func (u *Unit) LogActionMessage(tag names.ActionTag, message string) error {
 }
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
-func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	res, err := u.st.UpgradeSeriesUnitStatus()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if len(res) != 1 {
-		return "", errors.Errorf("expected 1 result, got %d", len(res))
-	}
-	return res[0], nil
+func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+	return u.st.UpgradeSeriesUnitStatus()
 }
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -740,6 +740,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 		*(result.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
 			Results: []params.UpgradeSeriesStatusResult{{
 				Status: "completed",
+				Target: "focal",
 			}},
 		}
 		return nil
@@ -747,24 +748,10 @@ func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	seriesStatus, err := unit.UpgradeSeriesStatus()
+	seriesStatus, target, err := unit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(seriesStatus, gc.Equals, model.UpgradeSeriesCompleted)
-}
-
-func (s *unitSuite) TestUpgradeSeriesStatusMultipleReturnsError(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Assert(result, gc.FitsTypeOf, &params.UpgradeSeriesStatusResults{})
-		*(result.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
-			Results: []params.UpgradeSeriesStatusResult{{}, {}},
-		}
-		return nil
-	})
-	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-
-	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.UpgradeSeriesStatus()
-	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
+	c.Check(seriesStatus, gc.Equals, model.UpgradeSeriesCompleted)
+	c.Check(target, gc.Equals, "focal")
 }
 
 func (s *unitSuite) TestRelationStatus(c *gc.C) {

--- a/apiserver/common/mocks/upgradeseries.go
+++ b/apiserver/common/mocks/upgradeseries.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/juju/juju/apiserver/common"
 	model "github.com/juju/juju/core/model"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockUpgradeSeriesBackend is a mock of UpgradeSeriesBackend interface
+// MockUpgradeSeriesBackend is a mock of UpgradeSeriesBackend interface.
 type MockUpgradeSeriesBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeSeriesBackendMockRecorder
 }
 
-// MockUpgradeSeriesBackendMockRecorder is the mock recorder for MockUpgradeSeriesBackend
+// MockUpgradeSeriesBackendMockRecorder is the mock recorder for MockUpgradeSeriesBackend.
 type MockUpgradeSeriesBackendMockRecorder struct {
 	mock *MockUpgradeSeriesBackend
 }
 
-// NewMockUpgradeSeriesBackend creates a new mock instance
+// NewMockUpgradeSeriesBackend creates a new mock instance.
 func NewMockUpgradeSeriesBackend(ctrl *gomock.Controller) *MockUpgradeSeriesBackend {
 	mock := &MockUpgradeSeriesBackend{ctrl: ctrl}
 	mock.recorder = &MockUpgradeSeriesBackendMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeSeriesBackend) EXPECT() *MockUpgradeSeriesBackendMockRecorder {
 	return m.recorder
 }
 
-// Machine mocks base method
+// Machine mocks base method.
 func (m *MockUpgradeSeriesBackend) Machine(arg0 string) (common.UpgradeSeriesMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Machine", arg0)
@@ -46,13 +47,13 @@ func (m *MockUpgradeSeriesBackend) Machine(arg0 string) (common.UpgradeSeriesMac
 	return ret0, ret1
 }
 
-// Machine indicates an expected call of Machine
+// Machine indicates an expected call of Machine.
 func (mr *MockUpgradeSeriesBackendMockRecorder) Machine(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockUpgradeSeriesBackend)(nil).Machine), arg0)
 }
 
-// Unit mocks base method
+// Unit mocks base method.
 func (m *MockUpgradeSeriesBackend) Unit(arg0 string) (common.UpgradeSeriesUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unit", arg0)
@@ -61,36 +62,36 @@ func (m *MockUpgradeSeriesBackend) Unit(arg0 string) (common.UpgradeSeriesUnit, 
 	return ret0, ret1
 }
 
-// Unit indicates an expected call of Unit
+// Unit indicates an expected call of Unit.
 func (mr *MockUpgradeSeriesBackendMockRecorder) Unit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUpgradeSeriesBackend)(nil).Unit), arg0)
 }
 
-// MockUpgradeSeriesMachine is a mock of UpgradeSeriesMachine interface
+// MockUpgradeSeriesMachine is a mock of UpgradeSeriesMachine interface.
 type MockUpgradeSeriesMachine struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeSeriesMachineMockRecorder
 }
 
-// MockUpgradeSeriesMachineMockRecorder is the mock recorder for MockUpgradeSeriesMachine
+// MockUpgradeSeriesMachineMockRecorder is the mock recorder for MockUpgradeSeriesMachine.
 type MockUpgradeSeriesMachineMockRecorder struct {
 	mock *MockUpgradeSeriesMachine
 }
 
-// NewMockUpgradeSeriesMachine creates a new mock instance
+// NewMockUpgradeSeriesMachine creates a new mock instance.
 func NewMockUpgradeSeriesMachine(ctrl *gomock.Controller) *MockUpgradeSeriesMachine {
 	mock := &MockUpgradeSeriesMachine{ctrl: ctrl}
 	mock.recorder = &MockUpgradeSeriesMachineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeSeriesMachine) EXPECT() *MockUpgradeSeriesMachineMockRecorder {
 	return m.recorder
 }
 
-// RemoveUpgradeSeriesLock mocks base method
+// RemoveUpgradeSeriesLock mocks base method.
 func (m *MockUpgradeSeriesMachine) RemoveUpgradeSeriesLock() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveUpgradeSeriesLock")
@@ -98,13 +99,13 @@ func (m *MockUpgradeSeriesMachine) RemoveUpgradeSeriesLock() error {
 	return ret0
 }
 
-// RemoveUpgradeSeriesLock indicates an expected call of RemoveUpgradeSeriesLock
+// RemoveUpgradeSeriesLock indicates an expected call of RemoveUpgradeSeriesLock.
 func (mr *MockUpgradeSeriesMachineMockRecorder) RemoveUpgradeSeriesLock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeSeriesLock", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).RemoveUpgradeSeriesLock))
 }
 
-// Series mocks base method
+// Series mocks base method.
 func (m *MockUpgradeSeriesMachine) Series() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Series")
@@ -112,13 +113,13 @@ func (m *MockUpgradeSeriesMachine) Series() string {
 	return ret0
 }
 
-// Series indicates an expected call of Series
+// Series indicates an expected call of Series.
 func (mr *MockUpgradeSeriesMachineMockRecorder) Series() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Series))
 }
 
-// SetInstanceStatus mocks base method
+// SetInstanceStatus mocks base method.
 func (m *MockUpgradeSeriesMachine) SetInstanceStatus(arg0 status.StatusInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0)
@@ -126,13 +127,13 @@ func (m *MockUpgradeSeriesMachine) SetInstanceStatus(arg0 status.StatusInfo) err
 	return ret0
 }
 
-// SetInstanceStatus indicates an expected call of SetInstanceStatus
+// SetInstanceStatus indicates an expected call of SetInstanceStatus.
 func (mr *MockUpgradeSeriesMachineMockRecorder) SetInstanceStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetInstanceStatus), arg0)
 }
 
-// SetUpgradeSeriesStatus mocks base method
+// SetUpgradeSeriesStatus mocks base method.
 func (m *MockUpgradeSeriesMachine) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1)
@@ -140,13 +141,13 @@ func (m *MockUpgradeSeriesMachine) SetUpgradeSeriesStatus(arg0 model.UpgradeSeri
 	return ret0
 }
 
-// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus
+// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesMachineMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetUpgradeSeriesStatus), arg0, arg1)
 }
 
-// StartUpgradeSeriesUnitCompletion mocks base method
+// StartUpgradeSeriesUnitCompletion mocks base method.
 func (m *MockUpgradeSeriesMachine) StartUpgradeSeriesUnitCompletion(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartUpgradeSeriesUnitCompletion", arg0)
@@ -154,13 +155,13 @@ func (m *MockUpgradeSeriesMachine) StartUpgradeSeriesUnitCompletion(arg0 string)
 	return ret0
 }
 
-// StartUpgradeSeriesUnitCompletion indicates an expected call of StartUpgradeSeriesUnitCompletion
+// StartUpgradeSeriesUnitCompletion indicates an expected call of StartUpgradeSeriesUnitCompletion.
 func (mr *MockUpgradeSeriesMachineMockRecorder) StartUpgradeSeriesUnitCompletion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartUpgradeSeriesUnitCompletion", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).StartUpgradeSeriesUnitCompletion), arg0)
 }
 
-// Units mocks base method
+// Units mocks base method.
 func (m *MockUpgradeSeriesMachine) Units() ([]common.UpgradeSeriesUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units")
@@ -169,13 +170,13 @@ func (m *MockUpgradeSeriesMachine) Units() ([]common.UpgradeSeriesUnit, error) {
 	return ret0, ret1
 }
 
-// Units indicates an expected call of Units
+// Units indicates an expected call of Units.
 func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Units))
 }
 
-// UpdateMachineSeries mocks base method
+// UpdateMachineSeries mocks base method.
 func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMachineSeries", arg0)
@@ -183,13 +184,13 @@ func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string) error {
 	return ret0
 }
 
-// UpdateMachineSeries indicates an expected call of UpdateMachineSeries
+// UpdateMachineSeries indicates an expected call of UpdateMachineSeries.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpdateMachineSeries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMachineSeries", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpdateMachineSeries), arg0)
 }
 
-// UpgradeSeriesStatus mocks base method
+// UpgradeSeriesStatus mocks base method.
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")
@@ -198,13 +199,13 @@ func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesSta
 	return ret0, ret1
 }
 
-// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus
+// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesStatus))
 }
 
-// UpgradeSeriesTarget mocks base method
+// UpgradeSeriesTarget mocks base method.
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesTarget() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesTarget")
@@ -213,13 +214,13 @@ func (m *MockUpgradeSeriesMachine) UpgradeSeriesTarget() (string, error) {
 	return ret0, ret1
 }
 
-// UpgradeSeriesTarget indicates an expected call of UpgradeSeriesTarget
+// UpgradeSeriesTarget indicates an expected call of UpgradeSeriesTarget.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesTarget() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesTarget", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesTarget))
 }
 
-// UpgradeSeriesUnitStatuses mocks base method
+// UpgradeSeriesUnitStatuses mocks base method.
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesUnitStatuses() (map[string]state.UpgradeSeriesUnitStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesUnitStatuses")
@@ -228,13 +229,13 @@ func (m *MockUpgradeSeriesMachine) UpgradeSeriesUnitStatuses() (map[string]state
 	return ret0, ret1
 }
 
-// UpgradeSeriesUnitStatuses indicates an expected call of UpgradeSeriesUnitStatuses
+// UpgradeSeriesUnitStatuses indicates an expected call of UpgradeSeriesUnitStatuses.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesUnitStatuses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesUnitStatuses", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesUnitStatuses))
 }
 
-// WatchUpgradeSeriesNotifications mocks base method
+// WatchUpgradeSeriesNotifications mocks base method.
 func (m *MockUpgradeSeriesMachine) WatchUpgradeSeriesNotifications() (state.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchUpgradeSeriesNotifications")
@@ -243,36 +244,36 @@ func (m *MockUpgradeSeriesMachine) WatchUpgradeSeriesNotifications() (state.Noti
 	return ret0, ret1
 }
 
-// WatchUpgradeSeriesNotifications indicates an expected call of WatchUpgradeSeriesNotifications
+// WatchUpgradeSeriesNotifications indicates an expected call of WatchUpgradeSeriesNotifications.
 func (mr *MockUpgradeSeriesMachineMockRecorder) WatchUpgradeSeriesNotifications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpgradeSeriesNotifications", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).WatchUpgradeSeriesNotifications))
 }
 
-// MockUpgradeSeriesUnit is a mock of UpgradeSeriesUnit interface
+// MockUpgradeSeriesUnit is a mock of UpgradeSeriesUnit interface.
 type MockUpgradeSeriesUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeSeriesUnitMockRecorder
 }
 
-// MockUpgradeSeriesUnitMockRecorder is the mock recorder for MockUpgradeSeriesUnit
+// MockUpgradeSeriesUnitMockRecorder is the mock recorder for MockUpgradeSeriesUnit.
 type MockUpgradeSeriesUnitMockRecorder struct {
 	mock *MockUpgradeSeriesUnit
 }
 
-// NewMockUpgradeSeriesUnit creates a new mock instance
+// NewMockUpgradeSeriesUnit creates a new mock instance.
 func NewMockUpgradeSeriesUnit(ctrl *gomock.Controller) *MockUpgradeSeriesUnit {
 	mock := &MockUpgradeSeriesUnit{ctrl: ctrl}
 	mock.recorder = &MockUpgradeSeriesUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeSeriesUnit) EXPECT() *MockUpgradeSeriesUnitMockRecorder {
 	return m.recorder
 }
 
-// AssignedMachineId mocks base method
+// AssignedMachineId mocks base method.
 func (m *MockUpgradeSeriesUnit) AssignedMachineId() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignedMachineId")
@@ -281,13 +282,13 @@ func (m *MockUpgradeSeriesUnit) AssignedMachineId() (string, error) {
 	return ret0, ret1
 }
 
-// AssignedMachineId indicates an expected call of AssignedMachineId
+// AssignedMachineId indicates an expected call of AssignedMachineId.
 func (mr *MockUpgradeSeriesUnitMockRecorder) AssignedMachineId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachineId", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).AssignedMachineId))
 }
 
-// SetUpgradeSeriesStatus mocks base method
+// SetUpgradeSeriesStatus mocks base method.
 func (m *MockUpgradeSeriesUnit) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1)
@@ -295,13 +296,13 @@ func (m *MockUpgradeSeriesUnit) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesS
 	return ret0
 }
 
-// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus
+// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesUnitMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).SetUpgradeSeriesStatus), arg0, arg1)
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockUpgradeSeriesUnit) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -309,22 +310,23 @@ func (m *MockUpgradeSeriesUnit) Tag() names.Tag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockUpgradeSeriesUnitMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).Tag))
 }
 
-// UpgradeSeriesStatus mocks base method
-func (m *MockUpgradeSeriesUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
+// UpgradeSeriesStatus mocks base method.
+func (m *MockUpgradeSeriesUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")
 	ret0, _ := ret[0].(model.UpgradeSeriesStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus
+// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesUnitMockRecorder) UpgradeSeriesStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).UpgradeSeriesStatus))

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -35,7 +35,9 @@ func (s *upgradeSeriesSuite) SetUpTest(c *gc.C) {
 	s.unitTag2 = names.NewUnitTag("redis/1")
 }
 
-func (s *upgradeSeriesSuite) assertBackendApi(c *gc.C, tag names.Tag) (*common.UpgradeSeriesAPI, *gomock.Controller, *mocks.MockUpgradeSeriesBackend) {
+func (s *upgradeSeriesSuite) assertBackendApi(
+	c *gc.C, tag names.Tag,
+) (*common.UpgradeSeriesAPI, *gomock.Controller, *mocks.MockUpgradeSeriesBackend) {
 	resources := common.NewResources()
 	authorizer := apiservertesting.FakeAuthorizer{
 		Tag: tag,
@@ -130,7 +132,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTag(c *gc.C) {
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareRunning, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareRunning, "focal", nil)
 	mockUnit.EXPECT().SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted, gomock.Any()).Return(nil)
 
 	args := params.UpgradeSeriesStatusParams{
@@ -162,7 +164,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTagWithInvalidStatus(
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesNotStarted, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesNotStarted, "", nil)
 
 	args := params.UpgradeSeriesStatusParams{
 		Params: []params.UpgradeSeriesStatusParam{
@@ -188,7 +190,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, "focal", nil)
 
 	args := params.Entities{
 		Entities: []params.Entity{
@@ -201,7 +203,10 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{
-			{Status: model.UpgradeSeriesPrepareCompleted},
+			{
+				Status: model.UpgradeSeriesPrepareCompleted,
+				Target: "focal",
+			},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -45833,6 +45833,9 @@
                         },
                         "status": {
                             "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -46395,6 +46398,9 @@
                             "$ref": "#/definitions/Error"
                         },
                         "status": {
+                            "type": "string"
+                        },
+                        "target": {
                             "type": "string"
                         }
                     },

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1229,6 +1229,7 @@ type DumpModelRequest struct {
 type UpgradeSeriesStatusResult struct {
 	Error  *Error                    `json:"error,omitempty"`
 	Status model.UpgradeSeriesStatus `json:"status,omitempty"`
+	Target string                    `json:"target,omitempty"`
 }
 
 // UpgradeSeriesStatusResults contains the upgrade series status results for

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -378,28 +378,8 @@ func (m *Machine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	return lock.MachineStatus, errors.Trace(err)
 }
 
-// UnitStatus returns the series upgrade status for the input unit.
-func (m *Machine) UpgradeSeriesUnitStatus(unitName string) (model.UpgradeSeriesStatus, error) {
-	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
-	defer closer()
-
-	var lock upgradeSeriesLockDoc
-	err := coll.FindId(m.Id()).One(&lock)
-	if err == mgo.ErrNotFound {
-		return "", errors.NotFoundf("upgrade series lock for machine %q", m.Id())
-	}
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if _, ok := lock.UnitStatuses[unitName]; !ok {
-		return "", errors.NotFoundf("unit %q of machine %q", unitName, m.Id())
-	}
-
-	return lock.UnitStatuses[unitName].Status, nil
-}
-
-// UnitStatus returns the unit statuses from the upgrade-series lock
-// for this machine.
+// UpgradeSeriesUnitStatuses returns the unit statuses
+// from the upgrade-series lock for this machine.
 func (m *Machine) UpgradeSeriesUnitStatuses() (map[string]UpgradeSeriesUnitStatus, error) {
 	lock, err := m.getUpgradeSeriesLock()
 	if err != nil {

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -23,16 +23,16 @@ const (
 type Info struct {
 	Kind hooks.Kind `yaml:"kind"`
 
-	// RelationId identifies the relation associated with the hook. It is
-	// only set when Kind indicates a relation hook.
+	// RelationId identifies the relation associated with the hook.
+	// It is only set when Kind indicates a relation hook.
 	RelationId int `yaml:"relation-id,omitempty"`
 
 	// RemoteUnit is the name of the unit that triggered the hook. It is only
 	// set when Kind indicates a relation hook other than relation-broken.
 	RemoteUnit string `yaml:"remote-unit,omitempty"`
 
-	// RemoteApplication is always set if either an app or a unit triggers the hook.
-	// If the app triggers the hook, then RemoteUnit will be empty
+	// RemoteApplication is always set if either an app or a unit triggers
+	// the hook. If the app triggers the hook, then RemoteUnit will be empty.
 	RemoteApplication string `yaml:"remote-application,omitempty"`
 
 	// ChangeVersion identifies the most recent unit settings change
@@ -48,6 +48,11 @@ type Info struct {
 
 	// WorkloadName is the name of the sidecar container or workload relevant to the hook.
 	WorkloadName string `yaml:"workload-name,omitempty"`
+
+	// SeriesUpgradeTarget is the series that the unit's machine is to be
+	// updated to when Juju is issued the `upgrade-series` command.
+	// It is only set for the pre-series-upgrade hook.
+	SeriesUpgradeTarget string `yaml:"series-upgrade-target,omitempty"`
 }
 
 // Validate returns an error if the info is not valid.

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -80,8 +80,14 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook requires a workload name", hi.Kind)
 		}
 		return nil
-	case hooks.Install, hooks.Remove, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationCreated, hooks.RelationBroken,
-		hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus, hooks.PreSeriesUpgrade, hooks.PostSeriesUpgrade:
+	case hooks.PreSeriesUpgrade:
+		if hi.SeriesUpgradeTarget == "" {
+			return fmt.Errorf("%q hook requires a target series", hi.Kind)
+		}
+		return nil
+	case hooks.Install, hooks.Remove, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop,
+		hooks.RelationCreated, hooks.RelationBroken, hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus,
+		hooks.PostSeriesUpgrade:
 		return nil
 	case hooks.Action:
 		return fmt.Errorf("hooks.Kind Action is deprecated")

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -46,6 +46,9 @@ var validateTests = []struct {
 	}, {
 		hook.Info{Kind: hooks.PebbleReady},
 		`"pebble-ready" hook requires a workload name`,
+	}, {
+		hook.Info{Kind: hooks.PreSeriesUpgrade},
+		`"pre-series-upgrade" hook requires a target series`,
 	},
 	{hook.Info{Kind: hooks.Install}, ""},
 	{hook.Info{Kind: hooks.Start}, ""},
@@ -65,6 +68,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.StorageAttached, StorageId: "data/0"}, ""},
 	{hook.Info{Kind: hooks.StorageDetaching, StorageId: "data/0"}, ""},
 	{hook.Info{Kind: hooks.PebbleReady, WorkloadName: "gitlab"}, ""},
+	{hook.Info{Kind: hooks.PreSeriesUpgrade, SeriesUpgradeTarget: "focal"}, ""},
 }
 
 func (s *InfoSuite) TestValidate(c *gc.C) {

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -294,8 +294,8 @@ func (u *mockUnit) WatchInstanceData() (watcher.NotifyWatcher, error) {
 	return u.instanceDataWatcher, nil
 }
 
-func (u *mockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	return model.UpgradeSeriesPrepareStarted, nil
+func (u *mockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+	return model.UpgradeSeriesPrepareStarted, "focal", nil
 }
 
 func (u *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -90,11 +90,16 @@ type Snapshot struct {
 	// executed by this unit.
 	Commands []string
 
-	// UpgradeSeriesStatus is the preparation status of any currently running
-	// series upgrade
+	// UpgradeSeriesStatus is the preparation status of
+	// any currently running series upgrade.
 	UpgradeSeriesStatus model.UpgradeSeriesStatus
 
-	// ContainerRunningStatus is set on CAAS models for remote init/upgrade of charm.
+	// UpgradeSeriesTarget is the OS series that an in-flight
+	// series upgrade is transitioning to.
+	UpgradeSeriesTarget string
+
+	// ContainerRunningStatus is set on CAAS models
+	// for remote init/upgrade of charm.
 	ContainerRunningStatus *ContainerRunningStatus
 
 	// LXDProfileName is the name of the lxd profile applied to the unit's

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -50,10 +50,10 @@ type Unit interface {
 	WatchInstanceData() (watcher.NotifyWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)
 	WatchActionNotifications() (watcher.StringsWatcher, error)
-	// WatchRelation returns a watcher that fires when relations
+	// WatchRelations returns a watcher that fires when relations
 	// relevant for this unit change.
 	WatchRelations() (watcher.StringsWatcher, error)
-	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
+	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error)
 }
 
 type Application interface {

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -303,6 +303,7 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 		LeaderSettingsVersion: 1,
 		Leader:                true,
 		UpgradeSeriesStatus:   model.UpgradeSeriesPrepareStarted,
+		UpgradeSeriesTarget:   "focal",
 	})
 }
 

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -190,7 +190,10 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 			Started:   true,
 		},
 	}
+
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareStarted
+	s.remoteState.UpgradeSeriesTarget = "focal"
+
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run pre-series-upgrade hook")

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -748,6 +748,7 @@ func (s *rebootResolverSuite) TestStartHookDeferredWhenUpgradeIsInProgress(c *gc
 	for _, statusTest := range statusChecks {
 		c.Logf("triggering resolver with upgrade status: %s", statusTest.status)
 		s.remoteState.UpgradeSeriesStatus = statusTest.status
+		s.remoteState.UpgradeSeriesTarget = "focal"
 
 		op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 		if statusTest.expErr != nil {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -327,6 +327,10 @@ type HookContext struct {
 	// workloadName is the name of the container which the hook is in relation to.
 	workloadName string
 
+	// seriesUpgradeTarget is the series that the unit's machine is to be
+	// updated to when Juju is issued the `upgrade-series` command.
+	seriesUpgradeTarget string
+
 	mu sync.Mutex
 }
 
@@ -1049,6 +1053,11 @@ func (ctx *HookContext) HookVars(
 		vars = append(vars, "JUJU_WORKLOAD_NAME="+ctx.workloadName)
 	}
 
+	if ctx.seriesUpgradeTarget != "" {
+		vars = append(vars,
+			"JUJU_TARGET_SERIES="+ctx.seriesUpgradeTarget,
+		)
+	}
 	return append(vars, OSDependentEnvVars(paths, env)...), nil
 }
 

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -186,8 +186,9 @@ type HookContext struct {
 	// address.
 	publicAddress string
 
-	// availabilityzone is the cached value of the unit's availability zone name.
-	availabilityzone string
+	// availabilityZone is the cached value of the unit's
+	// availability zone name.
+	availabilityZone string
 
 	// configSettings holds the application configuration.
 	configSettings charm.Settings
@@ -246,10 +247,12 @@ type HookContext struct {
 	// apiAddrs contains the API server addresses.
 	apiAddrs []string
 
-	// legacyProxySettings are the current legacy proxy settings that the uniter knows about.
+	// legacyProxySettings are the current legacy proxy settings
+	// that the uniter knows about.
 	legacyProxySettings proxy.Settings
 
-	// jujuProxySettings are the current juju proxy settings that the uniter knows about.
+	// jujuProxySettings are the current juju proxy settings
+	// that the uniter knows about.
 	jujuProxySettings proxy.Settings
 
 	// meterStatus is the status of the unit's metering.
@@ -266,14 +269,16 @@ type HookContext struct {
 	// like a juju-run command or a hook
 	process HookProcess
 
-	// rebootPriority tells us when the hook wants to reboot. If rebootPriority is hooks.RebootNow
-	// the hook will be killed and requeued
+	// rebootPriority tells us when the hook wants to reboot. If rebootPriority
+	// is hooks.RebootNow the hook will be killed and requeued.
 	rebootPriority jujuc.RebootPriority
 
-	// storage provides access to the information about storage attached to the unit.
+	// storage provides access to the information about storage
+	// attached to the unit.
 	storage StorageContextAccessor
 
-	// storageId is the tag of the storage instance associated with the running hook.
+	// storageId is the tag of the storage instance associated
+	// with the running hook.
 	storageTag names.StorageTag
 
 	// hasRunSetStatus is true if a call to the status-set was made during the
@@ -667,10 +672,10 @@ func (ctx *HookContext) PrivateAddress() (string, error) {
 // if it was not found (or is not available).
 // Implements jujuc.HookContext.ContextInstance, part of runner.Context.
 func (ctx *HookContext) AvailabilityZone() (string, error) {
-	if ctx.availabilityzone == "" {
+	if ctx.availabilityZone == "" {
 		return "", errors.NotFoundf("availability zone")
 	}
-	return ctx.availabilityzone, nil
+	return ctx.availabilityZone, nil
 }
 
 // StorageTags returns a list of tags for storage instances
@@ -995,7 +1000,7 @@ func (ctx *HookContext) HookVars(
 		"JUJU_SLA="+ctx.slaLevel,
 		"JUJU_MACHINE_ID="+ctx.assignedMachineTag.Id(),
 		"JUJU_PRINCIPAL_UNIT="+ctx.principal,
-		"JUJU_AVAILABILITY_ZONE="+ctx.availabilityzone,
+		"JUJU_AVAILABILITY_ZONE="+ctx.availabilityZone,
 		"JUJU_VERSION="+version.Current.String(),
 		"CLOUD_API_VERSION="+ctx.cloudAPIVersion,
 		// Some of these will be empty, but that is fine, better

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -67,7 +67,7 @@ type Paths interface {
 	// the hook tool symlinks.
 	GetToolsDir() string
 
-	// GetCharmDir returns the filesystem path to the directory in which
+	// GetBaseDir returns the filesystem path to the directory in which
 	// the charm is installed.
 	GetBaseDir() string
 

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -182,7 +182,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 		logger:             f.logger,
 		componentDir:       f.paths.ComponentDir,
 		componentFuncs:     registeredComponentFuncs,
-		availabilityzone:   f.zone,
+		availabilityZone:   f.zone,
 		principal:          f.principal,
 	}
 	if err := f.updateContext(ctx); err != nil {

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -246,6 +246,9 @@ func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
 		ctx.workloadName = hookInfo.WorkloadName
 		hookName = fmt.Sprintf("%s-%s", hookInfo.WorkloadName, hookName)
 	}
+	if hookInfo.Kind == hooks.PreSeriesUpgrade {
+		ctx.seriesUpgradeTarget = hookInfo.SeriesUpgradeTarget
+	}
 	ctx.id = f.newId(hookName)
 	ctx.hookName = hookName
 	return ctx, nil

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -66,7 +66,7 @@ func NewHookContext(hcParams HookContextParams) (*HookContext, error) {
 	if err != nil && !params.IsCodeNoAddressSet(err) {
 		return nil, err
 	}
-	ctx.availabilityzone, err = hcParams.Unit.AvailabilityZone()
+	ctx.availabilityZone, err = hcParams.Unit.AvailabilityZone()
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func NewModelHookContext(p ModelHookContextParams) *HookContext {
 		},
 		relationId:         -1,
 		assignedMachineTag: p.MachineTag,
-		availabilityzone:   p.AvailZone,
+		availabilityZone:   p.AvailZone,
 		slaLevel:           p.SLALevel,
 		principal:          p.UnitName,
 		cloudAPIVersion:    "6.66",

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -131,7 +131,8 @@ type ContextUnit interface {
 	// UnitName returns the executing unit's name.
 	UnitName() string
 
-	// Config returns the current application configuration of the executing unit.
+	// ConfigSettings returns the current application
+	// configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)
 
 	// GoalState returns the goal state for the current unit.

--- a/worker/uniter/upgradeseries/resolver.go
+++ b/worker/uniter/upgradeseries/resolver.go
@@ -51,7 +51,10 @@ func (r *upgradeSeriesResolver) NextOp(
 	if localState.Kind == operation.Continue {
 		if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
 			remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareStarted {
-			return opFactory.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
+			return opFactory.NewRunHook(hook.Info{
+				Kind:                hooks.PreSeriesUpgrade,
+				SeriesUpgradeTarget: remoteState.UpgradeSeriesTarget,
+			})
 		}
 
 		// The uniter's local state will be in the "not started" state if the


### PR DESCRIPTION
Adds `JUJU_TARGET_SERIES` to environment when running a `pre-upgrade-series` hook.

## QA steps

- Bootstrap this patch, ensuring debug log-level.
- `juju deploy ./acceptancetests/repository/charms/dummy-sink --series xenial`
- `juju upgrade-series 0 prepare bionic -y`
- Check the `debug-log` output and see that the charm's pre-upgrade-series hook prints its environment with the target series:
```
unit-dummy-sink-0: 12:09:21 DEBUG unit.dummy-sink/0.pre-series-upgrade environ({'DEBIAN_FRONTEND': 'noninteractive', 'JUJU_AGENT_SOCKET_ADDRESS': '@/var/lib/juju/agents/unit-dummy-sink-0/agent.socket', 'JUJU_AVAILABILITY_ZONE': '', 'APT_LISTCHANGES_FRONTEND': 'none', 'JUJU_CHARM_FTP_PROXY': '', 'JUJU_CHARM_HTTPS_PROXY': '', 'JUJU_PRINCIPAL_UNIT': '', 'JUJU_HOOK_NAME': 'pre-series-upgrade', 'JUJU_CONTEXT_ID': 'dummy-sink/0-pre-series-upgrade-6644375957170369267', 'JUJU_MACHINE_ID': '0', 'JUJU_MODEL_NAME': 'default', 'CHARM_DIR': '/var/lib/juju/agents/unit-dummy-sink-0/charm', 'JUJU_METER_STATUS': 'AMBER', 'JUJU_API_ADDRESSES': '10.161.87.106:17070', 'JUJU_CHARM_HTTP_PROXY': '', 'CLOUD_API_VERSION': '', 'TERM': 'tmux-256color', 'JUJU_TARGET_SERIES': 'bionic', 'JUJU_UNIT_NAME': 'dummy-sink/0', 'JUJU_SLA': 'unsupported', 'JUJU_VERSION': '2.9.9.1', 'JUJU_CHARM_NO_PROXY': '127.0.0.1,localhost,::1', 'JUJU_CHARM_DIR': '/var/lib/juju/agents/unit-dummy-sink-0/charm', 'LANG': 'C.UTF-8', 'JUJU_AGENT_SOCKET_NETWORK': 'unix', 'JUJU_METER_INFO': 'not set', 'JUJU_DISPATCH_PATH': 'hooks/pre-series-upgrade', 'PATH': '/var/lib/juju/tools/unit-dummy-sink-0:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin', 'JUJU_MODEL_UUID': 'c6f6dcfb-e51f-4e56-8f79-c5c594844d97'})
```

## Documentation changes

TBC

## Bug reference

https://bugs.launchpad.net/juju/+bug/1908035
