### PR TITLE
Select a random AZ instead of the first one when starting a machine

### DIFF
--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -50,10 +50,19 @@ func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachin
 	task.machinesMutex.RLock()
 	defer task.machinesMutex.RUnlock()
 	// sort to make comparisons in the tests easier.
-	sort.Sort(azMachineSort(task.availabilityZoneMachines))
-	retvalues := make([]AvailabilityZoneMachine, len(task.availabilityZoneMachines))
-	for i := range task.availabilityZoneMachines {
-		retvalues[i] = *task.availabilityZoneMachines[i]
+	zoneMachines := task.availabilityZoneMachines
+	sort.Slice(task.availabilityZoneMachines, func(i, j int) bool {
+		switch {
+		case zoneMachines[i].MachineIds.Size() < zoneMachines[j].MachineIds.Size():
+			return true
+		case zoneMachines[i].MachineIds.Size() == zoneMachines[j].MachineIds.Size():
+			return zoneMachines[i].ZoneName < zoneMachines[j].ZoneName
+		}
+		return false
+	})
+	retvalues := make([]AvailabilityZoneMachine, len(zoneMachines))
+	for i := range zoneMachines {
+		retvalues[i] = *zoneMachines[i]
 	}
 	return retvalues
 }

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1754,7 +1754,8 @@ func (s *ProvisionerSuite) TestProvisioningMachinesClearAZFailures(c *gc.C) {
 	c.Assert(count, gc.Equals, 3)
 	machineAZ, err := machine.AvailabilityZone()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineAZ, gc.Equals, "zone1")
+	// Zones 3 and 4 have the same machine count, one is picked at random.
+	c.Assert(set.NewStrings("zone3", "zone4").Contains(machineAZ), jc.IsTrue)
 }
 
 func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {


### PR DESCRIPTION
Juju selects the AZ to used when starting a machine based on the AZ with the lowest machine count. If more than one AZ is suitable, Juju would always select the first one (based on alphabetical order). This has the effect of loading up the first AZ if there are multiple models/controllers in use. This PR instead selects a random AZ out of those which have the smallest machine count.

The selection of AZ is based on the premise that the AZ distribution is loaded in when the provisioner worker starts. However, the logic was flawed because the set up of the AZ distribution required that the running instances be loaded first. And this was only done later when a watcher event is received. So the initial AZ map was always empty after an agent restart, messing up the distribution. So that is fixed as well.

Some unit tests have also been tweaked to use the new worker behaviour to run the test - previously they were triggering logic based on a retry signal, but they should be using the machine watcher notification.

## QA steps

The issue is easily seen - bootstrap to AWS and add a machine; the machine would always start in AZ "a". And the next in "b" etc. And after an agent restart, "a" would be used for the next machine.
Now, `juju add-machine` always selects a random AZ out of those that are eligible (as seen in juju status).

## Bug reference

https://bugs.launchpad.net/bugs/1933690
