### PR TITLE
Loggo wire up labels.

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -631,8 +631,10 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 	params := common.DebugLogParams{
 		IncludeEntity: []string{"a", "b"},
 		IncludeModule: []string{"c", "d"},
-		ExcludeEntity: []string{"e", "f"},
-		ExcludeModule: []string{"g", "h"},
+		IncludeLabel:  []string{"e", "f"},
+		ExcludeEntity: []string{"g", "h"},
+		ExcludeModule: []string{"i", "j"},
+		ExcludeLabel:  []string{"k", "l"},
 		Limit:         100,
 		Backlog:       200,
 		Level:         loggo.ERROR,
@@ -652,8 +654,10 @@ func (s *clientSuite) TestWatchDebugLogParamsEncoded(c *gc.C) {
 	c.Assert(values, jc.DeepEquals, url.Values{
 		"includeEntity": params.IncludeEntity,
 		"includeModule": params.IncludeModule,
+		"includeLabel":  params.IncludeLabel,
 		"excludeEntity": params.ExcludeEntity,
 		"excludeModule": params.ExcludeModule,
+		"excludeLabel":  params.ExcludeLabel,
 		"maxLines":      {"100"},
 		"backlog":       {"200"},
 		"level":         {"ERROR"},

--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -28,12 +28,18 @@ type DebugLogParams struct {
 	// are set all modules are considered included.  If a module is specified,
 	// all the submodules also match.
 	IncludeModule []string
+	// IncludeLabel lists logging labels to include in the response. If none
+	// are set all labels are considered included.
+	IncludeLabel []string
 	// ExcludeEntity lists entity tags to exclude from the response. As with
 	// IncludeEntity the values may finish with a '*'.
 	ExcludeEntity []string
-	// ExcludeModule lists logging modules to exclude from the resposne. If a
+	// ExcludeModule lists logging modules to exclude from the response. If a
 	// module is specified, all the submodules are also excluded.
 	ExcludeModule []string
+	// ExcludeLabel lists logging labels to exclude from the response.
+	ExcludeLabel []string
+
 	// Limit defines the maximum number of lines to return. Once this many
 	// have been sent, the socket is closed.  If zero, all filtered lines are
 	// sent down the connection until the client closes the connection.
@@ -59,8 +65,10 @@ func (args DebugLogParams) URLQuery() url.Values {
 	attrs := url.Values{
 		"includeEntity": args.IncludeEntity,
 		"includeModule": args.IncludeModule,
+		"includeLabel":  args.IncludeLabel,
 		"excludeEntity": args.ExcludeEntity,
 		"excludeModule": args.ExcludeModule,
+		"excludeLabel":  args.ExcludeLabel,
 	}
 	if args.Replay {
 		attrs.Set("replay", fmt.Sprint(args.Replay))
@@ -91,6 +99,7 @@ type LogMessage struct {
 	Module    string
 	Location  string
 	Message   string
+	Labels    []string
 }
 
 // StreamDebugLog requests the specified debug log records from the
@@ -128,6 +137,7 @@ func StreamDebugLog(source base.StreamConnector, args DebugLogParams) (<-chan Lo
 				Module:    msg.Module,
 				Location:  msg.Location,
 				Message:   msg.Message,
+				Labels:    msg.Labels,
 			}
 		}
 	}()

--- a/api/migrationmaster/client_test.go
+++ b/api/migrationmaster/client_test.go
@@ -583,8 +583,10 @@ func (s *ClientSuite) TestStreamModelLogs(c *gc.C) {
 		"startTime":     {"2016-12-02T10:24:01.001Z"},
 		"includeEntity": nil,
 		"includeModule": nil,
+		"includeLabel":  nil,
 		"excludeEntity": nil,
 		"excludeModule": nil,
+		"excludeLabel":  nil,
 	})
 }
 

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -190,6 +190,8 @@ type debugLogParams struct {
 	excludeEntity []string
 	includeModule []string
 	excludeModule []string
+	includeLabel  []string
+	excludeLabel  []string
 }
 
 func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -252,5 +252,12 @@ func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {
 	params.includeModule = queryMap["includeModule"]
 	params.excludeModule = queryMap["excludeModule"]
 
+	if label, ok := queryMap["includeLabel"]; ok {
+		params.includeLabel = label
+	}
+	if label, ok := queryMap["excludeLabel"]; ok {
+		params.excludeLabel = label
+	}
+
 	return params, nil
 }

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -77,6 +77,8 @@ func makeLogTailerParams(reqParams debugLogParams) state.LogTailerParams {
 		ExcludeEntity: reqParams.excludeEntity,
 		IncludeModule: reqParams.includeModule,
 		ExcludeModule: reqParams.excludeModule,
+		IncludeLabel:  reqParams.includeLabel,
+		ExcludeLabel:  reqParams.excludeLabel,
 	}
 	if reqParams.fromTheStart {
 		params.InitialLines = 0
@@ -92,6 +94,7 @@ func formatLogRecord(r *state.LogRecord) *params.LogMessage {
 		Module:    r.Module,
 		Location:  r.Location,
 		Message:   r.Message,
+		Labels:    r.Labels,
 	}
 }
 

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -44,8 +44,10 @@ func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
 		filterLevel:   loggo.INFO,
 		includeEntity: []string{"foo"},
 		includeModule: []string{"bar"},
+		includeLabel:  []string{"xxx"},
 		excludeEntity: []string{"baz"},
 		excludeModule: []string{"qux"},
+		excludeLabel:  []string{"yyy"},
 	}
 
 	called := false
@@ -60,8 +62,10 @@ func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
 		c.Assert(params.InitialLines, gc.Equals, 11)
 		c.Assert(params.IncludeEntity, jc.DeepEquals, []string{"foo"})
 		c.Assert(params.IncludeModule, jc.DeepEquals, []string{"bar"})
+		c.Assert(params.IncludeLabel, jc.DeepEquals, []string{"xxx"})
 		c.Assert(params.ExcludeEntity, jc.DeepEquals, []string{"baz"})
 		c.Assert(params.ExcludeModule, jc.DeepEquals, []string{"qux"})
+		c.Assert(params.ExcludeLabel, jc.DeepEquals, []string{"yyy"})
 
 		return newFakeLogTailer(), nil
 	})

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -135,7 +136,7 @@ type charmHubClientFactory struct {
 }
 
 func (f charmHubClientFactory) Client(url string) (Client, error) {
-	cfg, err := charmhub.CharmHubConfigFromURL(url, logger.Child("client"),
+	cfg, err := charmhub.CharmHubConfigFromURL(url, logger.ChildWithLabels("client", corelogger.HTTP),
 		charmhub.WithHTTPTransport(f.httpTransport),
 	)
 	if err != nil {

--- a/apiserver/facades/client/charmhub/convert.go
+++ b/apiserver/facades/client/charmhub/convert.go
@@ -293,8 +293,5 @@ func (c charmMeta) Manifest() *charm.Manifest {
 // is available.
 func isKubernetes(series []string) bool {
 	seriesSet := set.NewStrings(series...)
-	if seriesSet.Contains("kubernetes") {
-		return true
-	}
-	return false
+	return seriesSet.Contains("kubernetes")
 }

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -16,8 +16,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-var logger = loggo.GetLogger("apiserver.modelconfig")
-
 // NewFacade is used for API registration.
 func NewFacadeV2(ctx facade.Context) (*ModelConfigAPIV2, error) {
 	auth := ctx.Auth()

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -16,6 +16,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
+var logger = loggo.GetLogger("apiserver.modelconfig")
+
 // NewFacade is used for API registration.
 func NewFacadeV2(ctx facade.Context) (*ModelConfigAPIV2, error) {
 	auth := ctx.Auth()
@@ -167,7 +169,12 @@ func (c *ModelConfigAPI) checkLogTrace() state.ValidateConfigFunc {
 		if !ok {
 			return nil
 		}
-		logCfg, err := loggo.ParseConfigString(spec.(string))
+		// This prevents a panic when trying to convert a spec which can be nil.
+		logSpec, ok := spec.(string)
+		if !ok {
+			return nil
+		}
+		logCfg, err := loggo.ParseConfigString(logSpec)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/apiserver/logsink.go
+++ b/apiserver/logsink.go
@@ -174,6 +174,7 @@ func (s *agentLoggingStrategy) WriteLog(m params.LogRecord) error {
 		Location: m.Location,
 		Level:    level,
 		Message:  m.Message,
+		Labels:   m.Labels,
 	}}), "logging to DB failed")
 
 	// If the log entries cannot be inserted to the DB log out an error
@@ -213,6 +214,7 @@ func logToFile(writer io.Writer, prefix string, m params.LogRecord) error {
 		m.Module,
 		m.Location,
 		m.Message,
+		strings.Join(m.Labels, ","),
 	}, " ") + "\n"))
 	return err
 }

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -160,8 +160,8 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 	logPath := filepath.Join(s.config.LogDir, "logsink.log")
 	logContents, err := ioutil.ReadFile(logPath)
 	c.Assert(err, jc.ErrorIsNil)
-	line0 := modelUUID + ": machine-0 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well\n"
-	line1 := modelUUID + ": machine-0 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes\n"
+	line0 := modelUUID + ": machine-0 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well \n"
+	line1 := modelUUID + ": machine-0 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes \n"
 	c.Assert(string(logContents), gc.Equals, line0+line1)
 
 	// Check the file mode is as expected. This doesn't work on

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -237,6 +237,7 @@ func (h *logStreamRequestHandler) apiFromRecords(records []*state.LogRecord) par
 			Location:  rec.Location,
 			Level:     rec.Level.String(),
 			Message:   rec.Message,
+			Labels:    rec.Labels,
 		}
 		result.Records[i] = apiRec
 	}

--- a/apiserver/logtransfer.go
+++ b/apiserver/logtransfer.go
@@ -87,6 +87,7 @@ func (s *migrationLoggingStrategy) WriteLog(m params.LogRecord) error {
 		Location: m.Location,
 		Level:    level,
 		Message:  m.Message,
+		Labels:   m.Labels,
 	}})
 	if err == nil {
 		err = s.tracker.Track(m.Time)

--- a/apiserver/params/internal.go
+++ b/apiserver/params/internal.go
@@ -950,6 +950,7 @@ type LogMessage struct {
 	Module    string    `json:"mod"`
 	Location  string    `json:"loc"`
 	Message   string    `json:"msg"`
+	Labels    []string  `json:"lab"`
 }
 
 // ResourceUploadResult is used to return some details about an

--- a/apiserver/params/logstream.go
+++ b/apiserver/params/logstream.go
@@ -24,6 +24,7 @@ type LogStreamRecord struct {
 	Location  string    `json:"lo"`
 	Level     string    `json:"lv"`
 	Message   string    `json:"msg"`
+	Labels    []string  `json:"lab"`
 }
 
 // LogStreamConfig holds all the information necessary to open a

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1060,6 +1060,7 @@ type LogRecord struct {
 	Level    string    `json:"v"`
 	Message  string    `json:"x"`
 	Entity   string    `json:"e,omitempty"`
+	Labels   []string  `json:"c,omitempty"`
 }
 
 // PubSubMessage is used to propagate pubsub messages from one api server to the

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -32,6 +32,7 @@ import (
 
 	charmhubpath "github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/version"
 )
 
@@ -61,7 +62,7 @@ type Logger interface {
 	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
 
-	Child(string) loggo.Logger
+	ChildWithLabels(string, ...string) loggo.Logger
 }
 
 // Config holds configuration for creating a new charm hub client.
@@ -165,7 +166,7 @@ func CharmHubConfig(logger Logger, options ...Option) (Config, error) {
 		Version:   CharmHubServerVersion,
 		Entity:    CharmHubServerEntity,
 		Headers:   headers,
-		Transport: opts.transportFunc(logger.Child("transport")),
+		Transport: opts.transportFunc(logger.ChildWithLabels("transport", corelogger.HTTP)),
 		Logger:    logger,
 	}, nil
 }

--- a/charmhub/fake_test.go
+++ b/charmhub/fake_test.go
@@ -18,6 +18,6 @@ func (l *FakeLogger) Debugf(format string, args ...interface{}) {}
 
 func (l *FakeLogger) Tracef(format string, args ...interface{}) {}
 
-func (l *FakeLogger) Child(string) loggo.Logger {
+func (l *FakeLogger) ChildWithLabels(string, ...string) loggo.Logger {
 	return loggo.Logger{}
 }

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/httprequest.v1"
 
 	"github.com/juju/juju/charmhub/path"
+	corelogger "github.com/juju/juju/core/logger"
 )
 
 // MIME represents a MIME type for identifying requests and response bodies.
@@ -64,7 +65,7 @@ type Transport interface {
 // DefaultHTTPTransport creates a new HTTPTransport.
 func DefaultHTTPTransport(logger Logger) Transport {
 	return RequestHTTPTransport(loggingRequestRecorder{
-		logger: logger.Child("request-recorder"),
+		logger: logger.ChildWithLabels("request-recorder", corelogger.METRICS),
 	}, DefaultRetryPolicy())(logger)
 }
 

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -66,6 +66,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/leadership",
 		"core/lease",
 		"core/life",
+		"core/logger",
 		"core/lxdprofile",
 		"core/machinelock",
 		"core/migration",

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -424,7 +424,7 @@ func (d downloadLogger) Debugf(msg string, args ...interface{}) {
 
 func (d downloadLogger) Tracef(msg string, args ...interface{}) {}
 
-func (d downloadLogger) Child(name string) loggo.Logger {
+func (d downloadLogger) ChildWithLabels(name string, labels ...string) loggo.Logger {
 	return loggo.Logger{}
 }
 

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -52,13 +52,18 @@ The '--include-module' and '--exclude-module' options filter by (dotted)
 logging module name. The module name can be truncated such that all loggers
 with the prefix will match.
 
+The '--include-label' and '--exclude-label' options filter by logging label. 
+
 The filtering options combine as follows:
 * All --include options are logically ORed together.
 * All --exclude options are logically ORed together.
 * All --include-module options are logically ORed together.
 * All --exclude-module options are logically ORed together.
-* The combined --include, --exclude, --include-module and --exclude-module
-  selections are logically ANDed to form the complete filter.
+* All --include-labels options are logically ORed together.
+* All --exclude-labels options are logically ORed together.
+* The combined --include, --exclude, --include-module, --exclude-module,
+  --include-labels and --exclude-labels selections are logically ANDed to form 
+  the complete filter.
 
 Examples:
 
@@ -150,6 +155,8 @@ func (c *debugLogCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(cmd.NewAppendStringsValue(&c.params.ExcludeEntity), "exclude", "Do not show log messages for these entities")
 	f.Var(cmd.NewAppendStringsValue(&c.params.IncludeModule), "include-module", "Only show log messages for these logging modules")
 	f.Var(cmd.NewAppendStringsValue(&c.params.ExcludeModule), "exclude-module", "Do not show log messages for these logging modules")
+	f.Var(cmd.NewAppendStringsValue(&c.params.IncludeLabel), "include-label", "Only show log messages for these logging labels")
+	f.Var(cmd.NewAppendStringsValue(&c.params.ExcludeLabel), "exclude-label", "Do not show log messages for these logging labels")
 
 	f.StringVar(&c.level, "l", "", "Log level to show, one of [TRACE, DEBUG, INFO, WARNING, ERROR]")
 	f.StringVar(&c.level, "level", "", "")
@@ -310,6 +317,9 @@ func (c *debugLogCommand) writeLogRecord(w *ansiterm.Writer, r common.LogMessage
 	fmt.Fprintf(w, " %s ", r.Module)
 	if c.location {
 		loggocolor.LocationColor.Fprintf(w, "%s ", r.Location)
+	}
+	if len(r.Labels) > 0 {
+		fmt.Fprintf(w, "%v", r.Labels)
 	}
 	fmt.Fprintln(w, r.Message)
 }

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -90,6 +90,18 @@ func (s *DebugLogSuite) TestArgParsing(c *gc.C) {
 				Backlog:       10,
 			},
 		}, {
+			args: []string{"--include-label", "http", "--include-label", "apiserver"},
+			expected: common.DebugLogParams{
+				IncludeLabel: []string{"http", "apiserver"},
+				Backlog:      10,
+			},
+		}, {
+			args: []string{"--exclude-label", "http", "--exclude-label", "apiserver"},
+			expected: common.DebugLogParams{
+				ExcludeLabel: []string{"http", "apiserver"},
+				Backlog:      10,
+			},
+		}, {
 			args: []string{"--replay"},
 			expected: common.DebugLogParams{
 				Backlog: 10,

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/juju/clock"
@@ -203,13 +204,14 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.Stat
 			rec.Entity,
 			rec.Module,
 			rec.Message,
+			rec.Labels,
 		) + "\n")
 	}
 
 	return nil
 }
 
-func (c *dumpLogsCommand) format(timestamp time.Time, level loggo.Level, entity, module, message string) string {
+func (c *dumpLogsCommand) format(timestamp time.Time, level loggo.Level, entity, module, message string, labels []string) string {
 	ts := timestamp.In(time.UTC).Format("2006-01-02 15:04:05")
-	return fmt.Sprintf("%s: %s %s %s %s", entity, ts, level, module, message)
+	return fmt.Sprintf("%s: %s %s %s %s %s", entity, ts, level, module, message, strings.Join(labels, ","))
 }

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -1,0 +1,16 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logger
+
+// Label represents a common logger label type.
+type Label = string
+
+const (
+	// HTTP defines a common HTTP request label.
+	HTTP Label = "http"
+
+	// METRICS defines a common label for dealing with metric output. This
+	// should be used as a fallback for when prometheus isn't available.
+	METRICS Label = "metrics"
+)

--- a/featuretests/cmd_juju_dumplogs_test.go
+++ b/featuretests/cmd_juju_dumplogs_test.go
@@ -61,6 +61,7 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 				Location: "location",
 				Level:    loggo.INFO,
 				Message:  fmt.Sprintf("%d", i),
+				Labels:   []string{"http"},
 			}})
 			c.Assert(err, jc.ErrorIsNil)
 		}
@@ -72,7 +73,7 @@ func (s *dumpLogsCommandSuite) TestRun(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the log file for each environment
-	expectedLog := "machine-42: 2015-11-04 03:02:01 INFO module %d"
+	expectedLog := "machine-42: 2015-11-04 03:02:01 INFO module %d http"
 	for _, st := range states {
 		logName := context.AbsPath(fmt.Sprintf("%s.log", st.ModelUUID()))
 		logFile, err := os.Open(logName)

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2
-	github.com/juju/loggo v0.0.0-20210702145002-48aac3f452bc
+	github.com/juju/loggo v0.0.0-20210708153607-abb62bf570b2
 	github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2
-	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
+	github.com/juju/loggo v0.0.0-20210702145002-48aac3f452bc
 	github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVE
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e h1:FdDd7bdI6cjq5vaoYlK1mfQYfF9sF2VZw8VEZMsl5t8=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
-github.com/juju/loggo v0.0.0-20210702145002-48aac3f452bc h1:WGxk8Q48AZw9zX3kUAhxPCIWDdPzQRCpFAuNDldvRQc=
-github.com/juju/loggo v0.0.0-20210702145002-48aac3f452bc/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
+github.com/juju/loggo v0.0.0-20210708153607-abb62bf570b2 h1:x9vxpnvnq49KqzgfTmh3FUkA93qXZX5h4LZBDZOdOb0=
+github.com/juju/loggo v0.0.0-20210708153607-abb62bf570b2/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
 github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41 h1:/ucixsNZ+l94agL5LZioJ4ECyOz7kOYY+DKb/0NN6ME=
 github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41/go.mod h1:RI/7Oj7RFK3hzCrjmJVrEeMryn8PEzl6kiIz4QFb48Y=
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7LYjAfMZm+i6+VzOUBGhku+iOYeh0ohjIy7N9zd7JR4=

--- a/go.sum
+++ b/go.sum
@@ -446,6 +446,8 @@ github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVE
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e h1:FdDd7bdI6cjq5vaoYlK1mfQYfF9sF2VZw8VEZMsl5t8=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
+github.com/juju/loggo v0.0.0-20210702145002-48aac3f452bc h1:WGxk8Q48AZw9zX3kUAhxPCIWDdPzQRCpFAuNDldvRQc=
+github.com/juju/loggo v0.0.0-20210702145002-48aac3f452bc/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41 h1:/ucixsNZ+l94agL5LZioJ4ECyOz7kOYY+DKb/0NN6ME=
 github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41/go.mod h1:RI/7Oj7RFK3hzCrjmJVrEeMryn8PEzl6kiIz4QFb48Y=
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7LYjAfMZm+i6+VzOUBGhku+iOYeh0ohjIy7N9zd7JR4=

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -576,6 +576,7 @@ func MakeLogDoc(
 	location string,
 	level loggo.Level,
 	msg string,
+	labels []string,
 ) *logDoc {
 	return &logDoc{
 		Id:       bson.NewObjectId(),
@@ -586,6 +587,7 @@ func MakeLogDoc(
 		Location: location,
 		Level:    int(level),
 		Message:  msg,
+		Labels:   labels,
 	}
 }
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -321,6 +321,7 @@ type logDoc struct {
 	Location string        `bson:"l"` // "filename:lineno"
 	Level    int           `bson:"v"`
 	Message  string        `bson:"x"`
+	Labels   []string      `bson:"c,omitempty"` // e.g. http
 }
 
 type DbLogger struct {
@@ -368,6 +369,7 @@ func (logger *DbLogger) Log(records []LogRecord) error {
 			Location: r.Location,
 			Level:    int(r.Level),
 			Message:  r.Message,
+			Labels:   r.Labels,
 		})
 	}
 	_, err := bulk.Run()
@@ -427,6 +429,7 @@ type LogRecord struct {
 	Module   string
 	Location string
 	Message  string
+	Labels   []string
 }
 
 // LogTailerParams specifies the filtering a LogTailer should apply to
@@ -441,6 +444,8 @@ type LogTailerParams struct {
 	ExcludeEntity []string
 	IncludeModule []string
 	ExcludeModule []string
+	IncludeLabel  []string
+	ExcludeLabel  []string
 	Oplog         *mgo.Collection // For testing only
 }
 
@@ -760,6 +765,14 @@ func (t *logTailer) paramsToSelector(params LogTailerParams, prefix string) bson
 		sel = append(sel,
 			bson.DocElem{"m", bson.M{"$not": bson.RegEx{Pattern: makeModulePattern(params.ExcludeModule)}}})
 	}
+	if len(params.IncludeLabel) > 0 {
+		sel = append(sel,
+			bson.DocElem{"m", bson.RegEx{Pattern: makeLabelPattern(params.IncludeLabel)}})
+	}
+	if len(params.ExcludeLabel) > 0 {
+		sel = append(sel,
+			bson.DocElem{"m", bson.M{"$not": bson.RegEx{Pattern: makeLabelPattern(params.ExcludeLabel)}}})
+	}
 	if prefix != "" {
 		for i, elem := range sel {
 			sel[i].Name = prefix + elem.Name
@@ -784,6 +797,14 @@ func makeModulePattern(modules []string) string {
 		patterns = append(patterns, regexp.QuoteMeta(module))
 	}
 	return `^(` + strings.Join(patterns, "|") + `)(\..+)?$`
+}
+
+func makeLabelPattern(labels []string) string {
+	var patterns []string
+	for _, label := range labels {
+		patterns = append(patterns, regexp.QuoteMeta(label))
+	}
+	return `^(` + strings.Join(patterns, "|") + `)$`
 }
 
 func newRecentIdTracker(maxLen int) *recentIdTracker {
@@ -861,6 +882,7 @@ func logDocToRecord(modelUUID string, doc *logDoc) (*LogRecord, error) {
 		Module:   doc.Module,
 		Location: doc.Location,
 		Message:  doc.Message,
+		Labels:   doc.Labels,
 	}
 	return rec, nil
 }

--- a/state/logs.go
+++ b/state/logs.go
@@ -767,11 +767,11 @@ func (t *logTailer) paramsToSelector(params LogTailerParams, prefix string) bson
 	}
 	if len(params.IncludeLabel) > 0 {
 		sel = append(sel,
-			bson.DocElem{"m", bson.RegEx{Pattern: makeLabelPattern(params.IncludeLabel)}})
+			bson.DocElem{"c", bson.M{"$in": params.IncludeLabel}})
 	}
 	if len(params.ExcludeLabel) > 0 {
 		sel = append(sel,
-			bson.DocElem{"m", bson.M{"$not": bson.RegEx{Pattern: makeLabelPattern(params.ExcludeLabel)}}})
+			bson.DocElem{"c", bson.M{"$nin": params.ExcludeLabel}})
 	}
 	if prefix != "" {
 		for i, elem := range sel {
@@ -797,14 +797,6 @@ func makeModulePattern(modules []string) string {
 		patterns = append(patterns, regexp.QuoteMeta(module))
 	}
 	return `^(` + strings.Join(patterns, "|") + `)(\..+)?$`
-}
-
-func makeLabelPattern(labels []string) string {
-	var patterns []string
-	for _, label := range labels {
-		patterns = append(patterns, regexp.QuoteMeta(label))
-	}
-	return `^(` + strings.Join(patterns, "|") + `)$`
 }
 
 func newRecentIdTracker(maxLen int) *recentIdTracker {

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -556,6 +556,7 @@ func (s *LogTailerSuite) TestExcludeEntityWildcard(c *gc.C) {
 	}
 	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
 }
+
 func (s *LogTailerSuite) TestIncludeModule(c *gc.C) {
 	mod0 := logTemplate{Module: "foo.bar"}
 	mod1 := logTemplate{Module: "juju.thing"}
@@ -627,6 +628,77 @@ func (s *LogTailerSuite) TestIncludeExcludeModule(c *gc.C) {
 	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
 }
 
+func (s *LogTailerSuite) TestIncludeLabels(c *gc.C) {
+	mod0 := logTemplate{Labels: []string{"foo_bar"}}
+	mod1 := logTemplate{Labels: []string{"juju_thing"}}
+	subMod1 := logTemplate{Labels: []string{"juju_thing_hai"}}
+	mod2 := logTemplate{Labels: []string{"elsewhere"}}
+	writeLogs := func() {
+		s.writeLogs(c, s.otherUUID, 1, mod0)
+		s.writeLogs(c, s.otherUUID, 1, mod1)
+		s.writeLogs(c, s.otherUUID, 1, mod0)
+		s.writeLogs(c, s.otherUUID, 1, subMod1)
+		s.writeLogs(c, s.otherUUID, 1, mod0)
+		s.writeLogs(c, s.otherUUID, 1, mod2)
+	}
+	params := state.LogTailerParams{
+		IncludeLabel: []string{"juju_thing", "elsewhere"},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 1, mod1)
+		s.assertTailer(c, tailer, 1, subMod1)
+		s.assertTailer(c, tailer, 1, mod2)
+	}
+	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestExcludeLabels(c *gc.C) {
+	mod0 := logTemplate{Labels: []string{"foo_bar"}}
+	mod1 := logTemplate{Labels: []string{"juju_thing"}}
+	subMod1 := logTemplate{Labels: []string{"juju_thing_hai"}}
+	mod2 := logTemplate{Labels: []string{"elsewhere"}}
+	writeLogs := func() {
+		s.writeLogs(c, s.otherUUID, 1, mod0)
+		s.writeLogs(c, s.otherUUID, 1, mod1)
+		s.writeLogs(c, s.otherUUID, 1, mod0)
+		s.writeLogs(c, s.otherUUID, 1, subMod1)
+		s.writeLogs(c, s.otherUUID, 1, mod0)
+		s.writeLogs(c, s.otherUUID, 1, mod2)
+	}
+	params := state.LogTailerParams{
+		ExcludeLabel: []string{"juju.thing", "elsewhere"},
+	}
+	assert := func(tailer state.LogTailer) {
+		s.assertTailer(c, tailer, 2, mod0)
+	}
+	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
+}
+
+func (s *LogTailerSuite) TestIncludeExcludeLabels(c *gc.C) {
+	foo := logTemplate{Labels: []string{"foo"}}
+	bar := logTemplate{Labels: []string{"bar"}}
+	barSub := logTemplate{Labels: []string{"bar_thing"}}
+	baz := logTemplate{Labels: []string{"baz"}}
+	qux := logTemplate{Labels: []string{"qux"}}
+	writeLogs := func() {
+		s.writeLogs(c, s.otherUUID, 1, foo)
+		s.writeLogs(c, s.otherUUID, 1, bar)
+		s.writeLogs(c, s.otherUUID, 1, barSub)
+		s.writeLogs(c, s.otherUUID, 1, baz)
+		s.writeLogs(c, s.otherUUID, 1, qux)
+	}
+	params := state.LogTailerParams{
+		IncludeLabel: []string{"foo", "bar", "qux"},
+		ExcludeLabel: []string{"foo", "bar"},
+	}
+	assert := func(tailer state.LogTailer) {
+		// Except just "qux" because "foo" and "bar" were included and
+		// then excluded.
+		s.assertTailer(c, tailer, 1, qux)
+	}
+	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
+}
+
 func (s *LogTailerSuite) checkLogTailerFiltering(
 	c *gc.C,
 	st *state.State,
@@ -656,6 +728,7 @@ type logTemplate struct {
 	Location string
 	Level    loggo.Level
 	Message  string
+	Labels   []string
 }
 
 // emptyTag gives us an explicit way to specify an empty tag for the
@@ -744,6 +817,7 @@ func (s *LogTailerSuite) logTemplateToDoc(lt logTemplate, t time.Time) interface
 		lt.Location,
 		lt.Level,
 		lt.Message,
+		lt.Labels,
 	)
 }
 

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -365,7 +365,6 @@ func (m *Model) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttr
 	// applied as a delta to what's on disk; if there has
 	// been a concurrent update, the change may not be what
 	// the user asked for.
-
 	modelSettings, err := readSettings(st.db(), settingsC, modelGlobalKey)
 	if err != nil {
 		return errors.Annotatef(err, "model %q", m.UUID())

--- a/worker/logsender/bufferedlogwriter.go
+++ b/worker/logsender/bufferedlogwriter.go
@@ -22,6 +22,7 @@ type LogRecord struct {
 	Location string // e.g. "foo.go:42"
 	Level    loggo.Level
 	Message  string
+	Labels   []string
 
 	// Number of messages dropped after this one due to buffer limit.
 	DroppedAfter int
@@ -153,6 +154,7 @@ func (w *BufferedLogWriter) Write(entry loggo.Entry) {
 		Location: fmt.Sprintf("%s:%d", filepath.Base(entry.Filename), entry.Line),
 		Level:    entry.Level,
 		Message:  entry.Message,
+		Labels:   entry.Labels,
 	}
 }
 

--- a/worker/logsender/worker.go
+++ b/worker/logsender/worker.go
@@ -43,7 +43,6 @@ func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 			case <-stop:
 				logWriter.Close()
 			}
-			return
 		}()
 		var logWriter logsender.LogWriter
 		var err error
@@ -64,6 +63,7 @@ func New(logs LogRecordCh, logSenderAPI *logsender.API) worker.Worker {
 					Location: rec.Location,
 					Level:    rec.Level.String(),
 					Message:  rec.Message,
+					Labels:   rec.Labels,
 				})
 				if err != nil {
 					return errors.Trace(err)

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -613,6 +613,7 @@ func (w *Worker) transferLogs(targetInfo coremigration.TargetInfo, modelUUID str
 				Location: msg.Location,
 				Level:    msg.Severity,
 				Message:  msg.Message,
+				Labels:   msg.Labels,
 			})
 			if err != nil {
 				return errors.Trace(err)

--- a/worker/modelworkermanager/dblogger.go
+++ b/worker/modelworkermanager/dblogger.go
@@ -58,6 +58,7 @@ func (l *dbLogger) Write(entry loggo.Entry) {
 		Location: fmt.Sprintf("%s:%d", filepath.Base(entry.Filename), entry.Line),
 		Level:    entry.Level,
 		Message:  entry.Message,
+		Labels:   entry.Labels,
 	}})
 
 	if err != nil {


### PR DESCRIPTION
The following wires up the labels for the loggo library. Ensuring that we also
handle labels correctly in the debug-log command.

The change is simple yet powerful for helping tag various logs together as a
singular cohort, rather than individual models (tagging loggers). By tagging
a logger to a given tag you can get all the logs for a given tag. Although simple
in the premise, it is useful for debugging things like HTTP requests to
charmhub as an example.

The move away from global loggers (loggers created at the package level, see
below) and to dependency injected loggers has one downside; discoverability.

```go
package apiserver

var logger = loggo.GetLogger("juju.apiserver")
```

The discoverability of loggers now becomes almost impossible without deep diving 
into the code and tracing all the forked branches. With tagging, this should become
a lot simpler, we just need to ensure that logs are correctly tagged.

## QA steps

It's best to use a multi-terminal session for this (tmux)

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller "logging-config='#http=TRACE'"
$ juju debug-log -m controller
$ juju find windows
```

To see that the trace doesn't come through when using `exclude-label`

```sh
$ juju debug-log -m controller --exclude-label=http
```
