### PR TITLE
Deploy: Deloyment of private charms

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -22,6 +22,7 @@ import (
 	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/charmrepo/v6"
 	csclientparams "github.com/juju/charmrepo/v6/csclient/params"
+	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/collections/set"
@@ -2848,6 +2849,11 @@ func (f *fakeDeployAPI) GrantOffer(user, access string, offerURLs ...string) err
 	return jujutesting.TypeAssertError(res[0])
 }
 
+func (f *fakeDeployAPI) ResolveWithPreferredChannel(url *charm.URL, risk csparams.Channel) (*charm.URL, csparams.Channel, []string, error) {
+	results := f.MethodCall(f, "ResolveWithPreferredChannel", url)
+	return results[0].(*charm.URL), results[1].(csparams.Channel), results[2].([]string), results[3].(error)
+}
+
 type fakeCharmStoreAPI struct {
 	*fakeDeployAPI
 }
@@ -2872,7 +2878,9 @@ func vanillaFakeModelAPI(cfgAttrs map[string]interface{}) *fakeDeployAPI {
 	var logger loggo.Logger
 	fakeAPI := &fakeDeployAPI{CallMocker: jujutesting.NewCallMocker(logger)}
 	fakeAPI.charmRepoFunc = func() (*store.CharmStoreAdaptor, error) {
-		return &store.CharmStoreAdaptor{MacaroonGetter: &noopMacaroonGetter{}}, nil
+		return &store.CharmStoreAdaptor{
+			MacaroonGetter: &noopMacaroonGetter{},
+		}, nil
 	}
 
 	fakeAPI.Call("Close").Returns(error(nil))

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 	"github.com/juju/version/v2"
-	"github.com/juju/worker/v2/catacomb"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
@@ -177,9 +176,6 @@ type refreshCommand struct {
 	// Storage is a map of storage constraints, keyed on the storage name
 	// defined in charm storage metadata, to add or update during upgrade.
 	Storage map[string]storage.Constraints
-
-	catacomb catacomb.Catacomb
-	plan     catacomb.Plan
 }
 
 const refreshDoc = `

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
 	csclientparams "github.com/juju/charmrepo/v6/csclient/params"
+	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
@@ -450,8 +451,12 @@ func (s *RefreshErrorsStateSuite) deployApplication(c *gc.C) {
 
 func (s *RefreshErrorsStateSuite) TestInvalidSwitchURL(c *gc.C) {
 	s.deployApplication(c)
+
+	url := charm.MustParseURL("cs:missing")
+	s.fakeAPI.Call("ResolveWithPreferredChannel", url).Returns(url, csparams.Channel("stable"), []string{}, errors.Errorf(`bad`))
+
 	_, err := s.runRefresh(c, s.cmd, "riak", "--switch=cs:missing")
-	c.Assert(err, gc.ErrorMatches, `cannot resolve URL "cs:missing":.*`)
+	c.Assert(err, gc.ErrorMatches, `bad`)
 }
 
 func (s *RefreshErrorsStateSuite) TestNoPathFails(c *gc.C) {


### PR DESCRIPTION
When resolving a private charm we need to correctly discharge a
macaroon, so that we can get a token. When we moved the resolving of
charms to the server-side, this was taken into account. In the end, we
believed that it would be better to fall back to the previous method of
charm resolution. This is until server-side deployments will be a thing.

The code path for this was wrong in the client. The new strategy for 
charm resolution now states; if there is no error, then just return. Else if it's
a charmhub charm and it's not supported show a nice error. Otherwise,
just fail. If it's any other charm, fallback to the prior workflow. 

As we have no way to know if a charm is a private charm upfront without
an API call (causing a discharge), the scenario is the best we can achieve
when dealing with multiple stores.

## QA steps

### Setup private charm

Note: you'll have to fix the dummy charm by adding some series to the
metadata.yaml

```sh
$ charm login
$ charm push ./testcharms/charm-repo/quantal/dummy
$ charm release cs:~<user-name>/dummy-1
```

Note: don't grant permissions!

### Deploy private charm

```sh
$ juju bootstrap lxd test
$ juju deploy cs:~<user-name>/dummy-1
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1932072
