### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/acceptancetests/repository/charms/dummy-sink/hooks/pre-series-upgrade
+++ b/acceptancetests/repository/charms/dummy-sink/hooks/pre-series-upgrade
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Load modules from $JUJU_CHARM_DIR/lib
-import sys
+import sys, os
 sys.path.append('lib')
 
-print("test pre-series-upgrade hook")
+print(os.environ)

--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -661,15 +661,8 @@ func (u *Unit) LogActionMessage(tag names.ActionTag, message string) error {
 }
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
-func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	res, err := u.st.UpgradeSeriesUnitStatus()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if len(res) != 1 {
-		return "", errors.Errorf("expected 1 result, got %d", len(res))
-	}
-	return res[0], nil
+func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+	return u.st.UpgradeSeriesUnitStatus()
 }
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state

--- a/api/uniter/unit_test.go
+++ b/api/uniter/unit_test.go
@@ -740,6 +740,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 		*(result.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
 			Results: []params.UpgradeSeriesStatusResult{{
 				Status: "completed",
+				Target: "focal",
 			}},
 		}
 		return nil
@@ -747,24 +748,10 @@ func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	seriesStatus, err := unit.UpgradeSeriesStatus()
+	seriesStatus, target, err := unit.UpgradeSeriesStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(seriesStatus, gc.Equals, model.UpgradeSeriesCompleted)
-}
-
-func (s *unitSuite) TestUpgradeSeriesStatusMultipleReturnsError(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Assert(result, gc.FitsTypeOf, &params.UpgradeSeriesStatusResults{})
-		*(result.(*params.UpgradeSeriesStatusResults)) = params.UpgradeSeriesStatusResults{
-			Results: []params.UpgradeSeriesStatusResult{{}, {}},
-		}
-		return nil
-	})
-	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
-
-	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.UpgradeSeriesStatus()
-	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
+	c.Check(seriesStatus, gc.Equals, model.UpgradeSeriesCompleted)
+	c.Check(target, gc.Equals, "focal")
 }
 
 func (s *unitSuite) TestRelationStatus(c *gc.C) {

--- a/apiserver/common/mocks/upgradeseries.go
+++ b/apiserver/common/mocks/upgradeseries.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/juju/juju/apiserver/common"
 	model "github.com/juju/juju/core/model"
 	status "github.com/juju/juju/core/status"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockUpgradeSeriesBackend is a mock of UpgradeSeriesBackend interface
+// MockUpgradeSeriesBackend is a mock of UpgradeSeriesBackend interface.
 type MockUpgradeSeriesBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeSeriesBackendMockRecorder
 }
 
-// MockUpgradeSeriesBackendMockRecorder is the mock recorder for MockUpgradeSeriesBackend
+// MockUpgradeSeriesBackendMockRecorder is the mock recorder for MockUpgradeSeriesBackend.
 type MockUpgradeSeriesBackendMockRecorder struct {
 	mock *MockUpgradeSeriesBackend
 }
 
-// NewMockUpgradeSeriesBackend creates a new mock instance
+// NewMockUpgradeSeriesBackend creates a new mock instance.
 func NewMockUpgradeSeriesBackend(ctrl *gomock.Controller) *MockUpgradeSeriesBackend {
 	mock := &MockUpgradeSeriesBackend{ctrl: ctrl}
 	mock.recorder = &MockUpgradeSeriesBackendMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeSeriesBackend) EXPECT() *MockUpgradeSeriesBackendMockRecorder {
 	return m.recorder
 }
 
-// Machine mocks base method
+// Machine mocks base method.
 func (m *MockUpgradeSeriesBackend) Machine(arg0 string) (common.UpgradeSeriesMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Machine", arg0)
@@ -46,13 +47,13 @@ func (m *MockUpgradeSeriesBackend) Machine(arg0 string) (common.UpgradeSeriesMac
 	return ret0, ret1
 }
 
-// Machine indicates an expected call of Machine
+// Machine indicates an expected call of Machine.
 func (mr *MockUpgradeSeriesBackendMockRecorder) Machine(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockUpgradeSeriesBackend)(nil).Machine), arg0)
 }
 
-// Unit mocks base method
+// Unit mocks base method.
 func (m *MockUpgradeSeriesBackend) Unit(arg0 string) (common.UpgradeSeriesUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unit", arg0)
@@ -61,36 +62,36 @@ func (m *MockUpgradeSeriesBackend) Unit(arg0 string) (common.UpgradeSeriesUnit, 
 	return ret0, ret1
 }
 
-// Unit indicates an expected call of Unit
+// Unit indicates an expected call of Unit.
 func (mr *MockUpgradeSeriesBackendMockRecorder) Unit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockUpgradeSeriesBackend)(nil).Unit), arg0)
 }
 
-// MockUpgradeSeriesMachine is a mock of UpgradeSeriesMachine interface
+// MockUpgradeSeriesMachine is a mock of UpgradeSeriesMachine interface.
 type MockUpgradeSeriesMachine struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeSeriesMachineMockRecorder
 }
 
-// MockUpgradeSeriesMachineMockRecorder is the mock recorder for MockUpgradeSeriesMachine
+// MockUpgradeSeriesMachineMockRecorder is the mock recorder for MockUpgradeSeriesMachine.
 type MockUpgradeSeriesMachineMockRecorder struct {
 	mock *MockUpgradeSeriesMachine
 }
 
-// NewMockUpgradeSeriesMachine creates a new mock instance
+// NewMockUpgradeSeriesMachine creates a new mock instance.
 func NewMockUpgradeSeriesMachine(ctrl *gomock.Controller) *MockUpgradeSeriesMachine {
 	mock := &MockUpgradeSeriesMachine{ctrl: ctrl}
 	mock.recorder = &MockUpgradeSeriesMachineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeSeriesMachine) EXPECT() *MockUpgradeSeriesMachineMockRecorder {
 	return m.recorder
 }
 
-// RemoveUpgradeSeriesLock mocks base method
+// RemoveUpgradeSeriesLock mocks base method.
 func (m *MockUpgradeSeriesMachine) RemoveUpgradeSeriesLock() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveUpgradeSeriesLock")
@@ -98,13 +99,13 @@ func (m *MockUpgradeSeriesMachine) RemoveUpgradeSeriesLock() error {
 	return ret0
 }
 
-// RemoveUpgradeSeriesLock indicates an expected call of RemoveUpgradeSeriesLock
+// RemoveUpgradeSeriesLock indicates an expected call of RemoveUpgradeSeriesLock.
 func (mr *MockUpgradeSeriesMachineMockRecorder) RemoveUpgradeSeriesLock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUpgradeSeriesLock", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).RemoveUpgradeSeriesLock))
 }
 
-// Series mocks base method
+// Series mocks base method.
 func (m *MockUpgradeSeriesMachine) Series() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Series")
@@ -112,13 +113,13 @@ func (m *MockUpgradeSeriesMachine) Series() string {
 	return ret0
 }
 
-// Series indicates an expected call of Series
+// Series indicates an expected call of Series.
 func (mr *MockUpgradeSeriesMachineMockRecorder) Series() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Series))
 }
 
-// SetInstanceStatus mocks base method
+// SetInstanceStatus mocks base method.
 func (m *MockUpgradeSeriesMachine) SetInstanceStatus(arg0 status.StatusInfo) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0)
@@ -126,13 +127,13 @@ func (m *MockUpgradeSeriesMachine) SetInstanceStatus(arg0 status.StatusInfo) err
 	return ret0
 }
 
-// SetInstanceStatus indicates an expected call of SetInstanceStatus
+// SetInstanceStatus indicates an expected call of SetInstanceStatus.
 func (mr *MockUpgradeSeriesMachineMockRecorder) SetInstanceStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetInstanceStatus), arg0)
 }
 
-// SetUpgradeSeriesStatus mocks base method
+// SetUpgradeSeriesStatus mocks base method.
 func (m *MockUpgradeSeriesMachine) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1)
@@ -140,13 +141,13 @@ func (m *MockUpgradeSeriesMachine) SetUpgradeSeriesStatus(arg0 model.UpgradeSeri
 	return ret0
 }
 
-// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus
+// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesMachineMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).SetUpgradeSeriesStatus), arg0, arg1)
 }
 
-// StartUpgradeSeriesUnitCompletion mocks base method
+// StartUpgradeSeriesUnitCompletion mocks base method.
 func (m *MockUpgradeSeriesMachine) StartUpgradeSeriesUnitCompletion(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartUpgradeSeriesUnitCompletion", arg0)
@@ -154,13 +155,13 @@ func (m *MockUpgradeSeriesMachine) StartUpgradeSeriesUnitCompletion(arg0 string)
 	return ret0
 }
 
-// StartUpgradeSeriesUnitCompletion indicates an expected call of StartUpgradeSeriesUnitCompletion
+// StartUpgradeSeriesUnitCompletion indicates an expected call of StartUpgradeSeriesUnitCompletion.
 func (mr *MockUpgradeSeriesMachineMockRecorder) StartUpgradeSeriesUnitCompletion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartUpgradeSeriesUnitCompletion", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).StartUpgradeSeriesUnitCompletion), arg0)
 }
 
-// Units mocks base method
+// Units mocks base method.
 func (m *MockUpgradeSeriesMachine) Units() ([]common.UpgradeSeriesUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units")
@@ -169,13 +170,13 @@ func (m *MockUpgradeSeriesMachine) Units() ([]common.UpgradeSeriesUnit, error) {
 	return ret0, ret1
 }
 
-// Units indicates an expected call of Units
+// Units indicates an expected call of Units.
 func (mr *MockUpgradeSeriesMachineMockRecorder) Units() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).Units))
 }
 
-// UpdateMachineSeries mocks base method
+// UpdateMachineSeries mocks base method.
 func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMachineSeries", arg0)
@@ -183,13 +184,13 @@ func (m *MockUpgradeSeriesMachine) UpdateMachineSeries(arg0 string) error {
 	return ret0
 }
 
-// UpdateMachineSeries indicates an expected call of UpdateMachineSeries
+// UpdateMachineSeries indicates an expected call of UpdateMachineSeries.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpdateMachineSeries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMachineSeries", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpdateMachineSeries), arg0)
 }
 
-// UpgradeSeriesStatus mocks base method
+// UpgradeSeriesStatus mocks base method.
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")
@@ -198,13 +199,13 @@ func (m *MockUpgradeSeriesMachine) UpgradeSeriesStatus() (model.UpgradeSeriesSta
 	return ret0, ret1
 }
 
-// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus
+// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesStatus))
 }
 
-// UpgradeSeriesTarget mocks base method
+// UpgradeSeriesTarget mocks base method.
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesTarget() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesTarget")
@@ -213,13 +214,13 @@ func (m *MockUpgradeSeriesMachine) UpgradeSeriesTarget() (string, error) {
 	return ret0, ret1
 }
 
-// UpgradeSeriesTarget indicates an expected call of UpgradeSeriesTarget
+// UpgradeSeriesTarget indicates an expected call of UpgradeSeriesTarget.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesTarget() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesTarget", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesTarget))
 }
 
-// UpgradeSeriesUnitStatuses mocks base method
+// UpgradeSeriesUnitStatuses mocks base method.
 func (m *MockUpgradeSeriesMachine) UpgradeSeriesUnitStatuses() (map[string]state.UpgradeSeriesUnitStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesUnitStatuses")
@@ -228,13 +229,13 @@ func (m *MockUpgradeSeriesMachine) UpgradeSeriesUnitStatuses() (map[string]state
 	return ret0, ret1
 }
 
-// UpgradeSeriesUnitStatuses indicates an expected call of UpgradeSeriesUnitStatuses
+// UpgradeSeriesUnitStatuses indicates an expected call of UpgradeSeriesUnitStatuses.
 func (mr *MockUpgradeSeriesMachineMockRecorder) UpgradeSeriesUnitStatuses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesUnitStatuses", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).UpgradeSeriesUnitStatuses))
 }
 
-// WatchUpgradeSeriesNotifications mocks base method
+// WatchUpgradeSeriesNotifications mocks base method.
 func (m *MockUpgradeSeriesMachine) WatchUpgradeSeriesNotifications() (state.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchUpgradeSeriesNotifications")
@@ -243,36 +244,36 @@ func (m *MockUpgradeSeriesMachine) WatchUpgradeSeriesNotifications() (state.Noti
 	return ret0, ret1
 }
 
-// WatchUpgradeSeriesNotifications indicates an expected call of WatchUpgradeSeriesNotifications
+// WatchUpgradeSeriesNotifications indicates an expected call of WatchUpgradeSeriesNotifications.
 func (mr *MockUpgradeSeriesMachineMockRecorder) WatchUpgradeSeriesNotifications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpgradeSeriesNotifications", reflect.TypeOf((*MockUpgradeSeriesMachine)(nil).WatchUpgradeSeriesNotifications))
 }
 
-// MockUpgradeSeriesUnit is a mock of UpgradeSeriesUnit interface
+// MockUpgradeSeriesUnit is a mock of UpgradeSeriesUnit interface.
 type MockUpgradeSeriesUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockUpgradeSeriesUnitMockRecorder
 }
 
-// MockUpgradeSeriesUnitMockRecorder is the mock recorder for MockUpgradeSeriesUnit
+// MockUpgradeSeriesUnitMockRecorder is the mock recorder for MockUpgradeSeriesUnit.
 type MockUpgradeSeriesUnitMockRecorder struct {
 	mock *MockUpgradeSeriesUnit
 }
 
-// NewMockUpgradeSeriesUnit creates a new mock instance
+// NewMockUpgradeSeriesUnit creates a new mock instance.
 func NewMockUpgradeSeriesUnit(ctrl *gomock.Controller) *MockUpgradeSeriesUnit {
 	mock := &MockUpgradeSeriesUnit{ctrl: ctrl}
 	mock.recorder = &MockUpgradeSeriesUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUpgradeSeriesUnit) EXPECT() *MockUpgradeSeriesUnitMockRecorder {
 	return m.recorder
 }
 
-// AssignedMachineId mocks base method
+// AssignedMachineId mocks base method.
 func (m *MockUpgradeSeriesUnit) AssignedMachineId() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignedMachineId")
@@ -281,13 +282,13 @@ func (m *MockUpgradeSeriesUnit) AssignedMachineId() (string, error) {
 	return ret0, ret1
 }
 
-// AssignedMachineId indicates an expected call of AssignedMachineId
+// AssignedMachineId indicates an expected call of AssignedMachineId.
 func (mr *MockUpgradeSeriesUnitMockRecorder) AssignedMachineId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachineId", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).AssignedMachineId))
 }
 
-// SetUpgradeSeriesStatus mocks base method
+// SetUpgradeSeriesStatus mocks base method.
 func (m *MockUpgradeSeriesUnit) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1)
@@ -295,13 +296,13 @@ func (m *MockUpgradeSeriesUnit) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesS
 	return ret0
 }
 
-// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus
+// SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesUnitMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).SetUpgradeSeriesStatus), arg0, arg1)
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockUpgradeSeriesUnit) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -309,22 +310,23 @@ func (m *MockUpgradeSeriesUnit) Tag() names.Tag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockUpgradeSeriesUnitMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).Tag))
 }
 
-// UpgradeSeriesStatus mocks base method
-func (m *MockUpgradeSeriesUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
+// UpgradeSeriesStatus mocks base method.
+func (m *MockUpgradeSeriesUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")
 	ret0, _ := ret[0].(model.UpgradeSeriesStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus
+// UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus.
 func (mr *MockUpgradeSeriesUnitMockRecorder) UpgradeSeriesStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUpgradeSeriesUnit)(nil).UpgradeSeriesStatus))

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -35,7 +35,9 @@ func (s *upgradeSeriesSuite) SetUpTest(c *gc.C) {
 	s.unitTag2 = names.NewUnitTag("redis/1")
 }
 
-func (s *upgradeSeriesSuite) assertBackendApi(c *gc.C, tag names.Tag) (*common.UpgradeSeriesAPI, *gomock.Controller, *mocks.MockUpgradeSeriesBackend) {
+func (s *upgradeSeriesSuite) assertBackendApi(
+	c *gc.C, tag names.Tag,
+) (*common.UpgradeSeriesAPI, *gomock.Controller, *mocks.MockUpgradeSeriesBackend) {
 	resources := common.NewResources()
 	authorizer := apiservertesting.FakeAuthorizer{
 		Tag: tag,
@@ -130,7 +132,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTag(c *gc.C) {
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareRunning, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareRunning, "focal", nil)
 	mockUnit.EXPECT().SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted, gomock.Any()).Return(nil)
 
 	args := params.UpgradeSeriesStatusParams{
@@ -162,7 +164,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTagWithInvalidStatus(
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesNotStarted, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesNotStarted, "", nil)
 
 	args := params.UpgradeSeriesStatusParams{
 		Params: []params.UpgradeSeriesStatusParam{
@@ -188,7 +190,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
 
 	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
-	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesPrepareCompleted, "focal", nil)
 
 	args := params.Entities{
 		Entities: []params.Entity{
@@ -201,7 +203,10 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.UpgradeSeriesStatusResults{
 		Results: []params.UpgradeSeriesStatusResult{
-			{Status: model.UpgradeSeriesPrepareCompleted},
+			{
+				Status: model.UpgradeSeriesPrepareCompleted,
+				Target: "focal",
+			},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
 	})

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -32,7 +32,8 @@ func NewFacade(ctx facade.Context) (*Facade, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return internalFacade(&backend{m.ModelTag(), st, stateenvirons.EnvironConfigGetter{Model: m}}, ctx.Auth(), context.CallContext(st))
+	return internalFacade(
+		&backend{st, stateenvirons.EnvironConfigGetter{Model: m}, m.ModelTag()}, ctx.Auth(), context.CallContext(st))
 }
 
 func internalFacade(backend Backend, auth facade.Authorizer, callCtx context.ProviderCallContext) (*Facade, error) {
@@ -55,7 +56,7 @@ func (facade *Facade) checkIsModelAdmin() error {
 }
 
 // PublicAddress reports the preferred public network address for one
-// or more entities. Machines and units are suppored.
+// or more entities. Machines and units are supported.
 func (facade *Facade) PublicAddress(args params.Entities) (params.SSHAddressResults, error) {
 	if err := facade.checkIsModelAdmin(); err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -37324,7 +37324,7 @@
                             "$ref": "#/definitions/SSHAddressResults"
                         }
                     },
-                    "description": "PublicAddress reports the preferred public network address for one\nor more entities. Machines and units are suppored."
+                    "description": "PublicAddress reports the preferred public network address for one\nor more entities. Machines and units are supported."
                 },
                 "PublicKeys": {
                     "type": "object",
@@ -45366,6 +45366,9 @@
                         },
                         "status": {
                             "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -45928,6 +45931,9 @@
                             "$ref": "#/definitions/Error"
                         },
                         "status": {
+                            "type": "string"
+                        },
+                        "target": {
                             "type": "string"
                         }
                     },

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1203,6 +1203,7 @@ type DumpModelRequest struct {
 type UpgradeSeriesStatusResult struct {
 	Error  *Error                    `json:"error,omitempty"`
 	Status model.UpgradeSeriesStatus `json:"status,omitempty"`
+	Target string                    `json:"target,omitempty"`
 }
 
 // UpgradeSeriesStatusResults contains the upgrade series status results for

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -13,21 +13,20 @@ import (
 	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
-	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 )
 
-func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, error) {
+func attemptMicroK8sCloud(cmdRunner CommandRunner) (jujucloud.Cloud, error) {
 	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner)
 	if err != nil {
-		return cloud.Cloud{}, err
+		return jujucloud.Cloud{}, err
 	}
 
 	k8sCloud, err := k8scloud.CloudFromKubeConfigClusterReader(
 		k8s.MicroK8sClusterName,
 		bytes.NewReader(microk8sConfig),
 		k8scloud.CloudParamaters{
-			Description: cloud.DefaultCloudDescription(cloud.CloudTypeKubernetes),
+			Description: jujucloud.DefaultCloudDescription(jujucloud.CloudTypeKubernetes),
 			Name:        k8s.K8sCloudMicrok8s,
 			Regions: []jujucloud.Region{{
 				Name: k8s.Microk8sRegion,
@@ -38,43 +37,41 @@ func attemptMicroK8sCloud(cmdRunner CommandRunner) (cloud.Cloud, error) {
 	return k8sCloud, err
 }
 
-func attemptMicroK8sCredential(cmdRunner CommandRunner) (cloud.Credential, error) {
+func attemptMicroK8sCredential(cmdRunner CommandRunner) (jujucloud.Credential, error) {
 	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner)
 	if err != nil {
-		return cloud.Credential{}, err
+		return jujucloud.Credential{}, err
 	}
 
 	k8sConfig, err := k8scloud.ConfigFromReader(bytes.NewReader(microk8sConfig))
 	if err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "processing microk8s config to make juju credentials")
+		return jujucloud.Credential{}, errors.Annotate(err, "processing microk8s config to make juju credentials")
 	}
 
 	contextName, err := k8scloud.PickContextByClusterName(k8sConfig, k8s.MicroK8sClusterName)
 	if err != nil {
-		return cloud.Credential{}, errors.Trace(err)
+		return jujucloud.Credential{}, errors.Trace(err)
 	}
 
 	context := k8sConfig.Contexts[contextName]
 	resolver := clientconfig.GetJujuAdminServiceAccountResolver(jujuclock.WallClock)
 	conf, err := resolver(k8s.K8sCloudMicrok8s, k8sConfig, contextName)
 	if err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "resolving microk8s credentials")
+		return jujucloud.Credential{}, errors.Annotate(err, "resolving microk8s credentials")
 	}
 
 	return k8scloud.CredentialFromKubeConfig(context.AuthInfo, conf)
 }
 
 func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
-	result, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: "which microk8s.config",
-	})
-	if err != nil || result.Code != 0 {
+	_, err := cmdRunner.LookPath("microk8s")
+	if err != nil {
 		return []byte{}, errors.NotFoundf("microk8s")
 	}
 	execParams := exec.RunParams{
-		Commands: "microk8s.config",
+		Commands: "microk8s config",
 	}
-	result, err = cmdRunner.RunCommands(execParams)
+	result, err := cmdRunner.RunCommands(execParams)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
@@ -28,10 +27,9 @@ var (
 type detectCloudSuite struct{}
 
 type builtinCloudRet struct {
-	cloud          cloud.Cloud
-	credential     jujucloud.Credential
-	credentialName string
-	err            error
+	cloud      jujucloud.Cloud
+	credential jujucloud.Credential
+	err        error
 }
 
 type dummyRunner struct {
@@ -43,13 +41,18 @@ func (d dummyRunner) RunCommands(run exec.RunParams) (*exec.ExecResponse, error)
 	return results[0].(*exec.ExecResponse), testing.TypeAssertError(results[1])
 }
 
-func cloudGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (cloud.Cloud, error) {
-	return func(provider.CommandRunner) (cloud.Cloud, error) {
+func (d dummyRunner) LookPath(file string) (string, error) {
+	results := d.MethodCall(d, "LookPath", file)
+	return results[0].(string), testing.TypeAssertError(results[1])
+}
+
+func cloudGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (jujucloud.Cloud, error) {
+	return func(provider.CommandRunner) (jujucloud.Cloud, error) {
 		return args.cloud, args.err
 	}
 }
 
-func credentialGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (cloud.Credential, error) {
+func credentialGetterFunc(args builtinCloudRet) func(provider.CommandRunner) (jujucloud.Credential, error) {
 	return func(provider.CommandRunner) (jujucloud.Credential, error) {
 		return args.credential, args.err
 	}

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	stdcontext "context"
 	"net/url"
+	osexec "os/exec"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
@@ -67,12 +68,17 @@ func (kubernetesEnvironProvider) Version() int {
 // CommandRunner allows to run commands on the underlying system
 type CommandRunner interface {
 	RunCommands(run exec.RunParams) (*exec.ExecResponse, error)
+	LookPath(string) (string, error)
 }
 
 type defaultRunner struct{}
 
 func (defaultRunner) RunCommands(run exec.RunParams) (*exec.ExecResponse, error) {
 	return exec.RunCommands(run)
+}
+
+func (defaultRunner) LookPath(file string) (string, error) {
+	return osexec.LookPath(file)
 }
 
 // NewK8sClients returns the k8s clients to access a cluster.

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -221,15 +221,21 @@ func (s SubnetInfos) GetByAddress(addr string) (SubnetInfos, error) {
 // GetBySpaceID returns all subnets with the input space ID,
 // including those inferred by being overlays of subnets in the space.
 func (s SubnetInfos) GetBySpaceID(spaceID string) (SubnetInfos, error) {
-	var spaceUnderlays SubnetInfos
+	var subsInSpace SubnetInfos
 	for _, sub := range s {
 		if sub.SpaceID == spaceID {
-			spaceUnderlays = append(spaceUnderlays, sub)
+			subsInSpace = append(subsInSpace, sub)
 		}
 	}
 
 	var spaceOverlays SubnetInfos
-	for _, sub := range spaceUnderlays {
+	for _, sub := range subsInSpace {
+		// If we picked up an overlay because the space was already set,
+		// don't try to find subnets for which it is an underlay.
+		if sub.FanInfo != nil {
+			continue
+		}
+
 		// TODO (manadart 2020-05-13): See comment for GetByUnderlayCIDR.
 		// This will only be correct for unique CIDRs.
 		overlays, err := s.GetByUnderlayCIDR(sub.CIDR)
@@ -237,8 +243,8 @@ func (s SubnetInfos) GetBySpaceID(spaceID string) (SubnetInfos, error) {
 			return nil, errors.Trace(err)
 		}
 
-		// Only include overlays that don't have a space ID.
-		// This makes the method idempotent and avoids duplication.
+		// Don't include overlays that already have a space ID.
+		// They will have been retrieved as subsInSpace.
 		for _, overlay := range overlays {
 			if overlay.SpaceID == "" {
 				overlay.SpaceID = spaceID
@@ -247,7 +253,13 @@ func (s SubnetInfos) GetBySpaceID(spaceID string) (SubnetInfos, error) {
 		}
 	}
 
-	return append(spaceUnderlays, spaceOverlays...), nil
+	return append(subsInSpace, spaceOverlays...), nil
+}
+
+// AllSubnetInfos implements SubnetLookup
+// by returning all of the subnets.
+func (s SubnetInfos) AllSubnetInfos() (SubnetInfos, error) {
+	return s, nil
 }
 
 // EqualTo returns true if this slice of SubnetInfo is equal to the input.

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -321,3 +321,15 @@ func (*subnetSuite) TestSubnetInfosGetBySpaceID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subs, gc.DeepEquals, s[2:])
 }
+
+func (*subnetSuite) TestSubnetInfosAllSubnetInfos(c *gc.C) {
+	s := network.SubnetInfos{
+		{ID: "1", CIDR: "10.10.10.0/24", ProviderId: "1"},
+		{ID: "2", CIDR: "10.10.10.0/24", ProviderId: "2"},
+		{ID: "3", CIDR: "20.20.20.0/24"},
+	}
+
+	allSubs, err := s.AllSubnetInfos()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(allSubs, gc.DeepEquals, s)
+}

--- a/state/ipaddresses_test.go
+++ b/state/ipaddresses_test.go
@@ -317,45 +317,6 @@ func (s *ipAddressesStateSuite) TestMachineAllAddressesSuccess(c *gc.C) {
 	c.Assert(allAddresses, jc.DeepEquals, addedAddresses)
 }
 
-func (s *ipAddressesStateSuite) TestMachineAllDeviceSpaceAddresses(c *gc.C) {
-	addrs := s.addTwoDevicesWithTwoAddressesEach(c)
-	expected := make(network.SpaceAddresses, len(addrs))
-	for i, addr := range addrs {
-		expected[i] = network.SpaceAddress{
-			MachineAddress: network.NewMachineAddress(
-				addr.Value(),
-				network.WithCIDR(addr.SubnetCIDR()),
-				network.WithConfigType(addr.ConfigMethod()),
-			),
-			SpaceID: network.AlphaSpaceId,
-		}
-	}
-
-	networkAddresses, err := s.machine.AllDeviceSpaceAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-
-	network.SortAddresses(expected)
-	network.SortAddresses(networkAddresses)
-
-	c.Assert(networkAddresses, jc.DeepEquals, expected)
-}
-
-func (s *ipAddressesStateSuite) TestMachineAllDeviceSpaceAddressesFanScope(c *gc.C) {
-	_, _ = s.addNamedDeviceWithAddresses(c, "eth0", "252.80.0.100/12")
-
-	networkAddresses, err := s.machine.AllDeviceSpaceAddresses()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(networkAddresses, jc.DeepEquals, network.SpaceAddresses{{
-		MachineAddress: network.NewMachineAddress(
-			"252.80.0.100",
-			network.WithCIDR("252.80.0.0/12"),
-			network.WithConfigType(network.ConfigStatic),
-			network.WithScope(network.ScopeFanLocal),
-		),
-		SpaceID: network.AlphaSpaceId,
-	}})
-}
-
 func (s *ipAddressesStateSuite) TestLinkLayerDeviceRemoveAlsoRemovesDeviceAddresses(c *gc.C) {
 	device, _ := s.addNamedDeviceWithAddresses(c, "eth0", "10.20.30.40/16", "fc00::/64")
 	s.assertAllAddressesOnMachineMatchCount(c, s.machine, 2)
@@ -365,10 +326,9 @@ func (s *ipAddressesStateSuite) TestLinkLayerDeviceRemoveAlsoRemovesDeviceAddres
 	s.assertNoAddressesOnMachine(c, s.machine)
 }
 
-func (s *ipAddressesStateSuite) TestMachineRemoveAlsoRemoveAllAddresses(c *gc.C) {
+func (s *ipAddressesStateSuite) TestMachineRemoveAlsoRemovesAllAddresses(c *gc.C) {
 	s.addTwoDevicesWithTwoAddressesEach(c)
 	s.ensureMachineDeadAndRemove(c, s.machine)
-
 	s.assertNoAddressesOnMachine(c, s.machine)
 }
 

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -378,28 +378,8 @@ func (m *Machine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
 	return lock.MachineStatus, errors.Trace(err)
 }
 
-// UnitStatus returns the series upgrade status for the input unit.
-func (m *Machine) UpgradeSeriesUnitStatus(unitName string) (model.UpgradeSeriesStatus, error) {
-	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
-	defer closer()
-
-	var lock upgradeSeriesLockDoc
-	err := coll.FindId(m.Id()).One(&lock)
-	if err == mgo.ErrNotFound {
-		return "", errors.NotFoundf("upgrade series lock for machine %q", m.Id())
-	}
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if _, ok := lock.UnitStatuses[unitName]; !ok {
-		return "", errors.NotFoundf("unit %q of machine %q", unitName, m.Id())
-	}
-
-	return lock.UnitStatuses[unitName].Status, nil
-}
-
-// UnitStatus returns the unit statuses from the upgrade-series lock
-// for this machine.
+// UpgradeSeriesUnitStatuses returns the unit statuses
+// from the upgrade-series lock for this machine.
 func (m *Machine) UpgradeSeriesUnitStatuses() (map[string]UpgradeSeriesUnitStatus, error) {
 	lock, err := m.getUpgradeSeriesLock()
 	if err != nil {

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -322,8 +322,27 @@ func (s *Subnet) updateSpaceName(spaceName string) (bool, error) {
 	return spaceNameChange && spaceName != "" && s.doc.FanLocalUnderlay == "", nil
 }
 
-// NetworkSubnet maps the subnet fields into a network.SubnetInfo.
-func (s *Subnet) NetworkSubnet() network.SubnetInfo {
+// AllSubnetInfos returns SubnetInfos for all subnets in the model.
+func (st *State) AllSubnetInfos() (network.SubnetInfos, error) {
+	subs, err := st.AllSubnets()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	result := make(network.SubnetInfos, len(subs))
+	for i, sub := range subs {
+		result[i] = sub.networkSubnet()
+	}
+	return result, nil
+}
+
+// networkSubnet maps the subnet fields into a network.SubnetInfo.
+// Note that this method should not be exported.
+// It is only called on subnets that are guaranteed, if Fan overlays,
+// to have had their space IDs correctly set based on their underlays.
+// Calling it on an overlay not processed in this way will yield a
+// space ID of "0", which may be incorrect.
+func (s *Subnet) networkSubnet() network.SubnetInfo {
 	var fanInfo *network.FanCIDRs
 	if s.doc.FanLocalUnderlay != "" || s.doc.FanOverlay != "" {
 		fanInfo = &network.FanCIDRs{
@@ -341,37 +360,12 @@ func (s *Subnet) NetworkSubnet() network.SubnetInfo {
 		AvailabilityZones: s.doc.AvailabilityZones,
 		FanInfo:           fanInfo,
 		IsPublic:          s.doc.IsPublic,
-		SpaceID:           s.doc.SpaceID,
+		SpaceID:           s.spaceID,
 		// SpaceName and ProviderSpaceID are populated by Space.NetworkSpace().
 		// For now, we do not look them up here.
 	}
 
-	// If this is a fan overlay, it will have a (numeric) space ID of 0.
-	// This is because it inherits the space of its underlay.
-	// In this case we replace it with an empty string so as not to cause
-	// confusion.
-	// Space.NetworkSpace() sets this correctly as expected.
-	// TODO (manadart 2020-04-09): We will probably need to populate this at
-	// some point.
-	if sInfo.FanLocalUnderlay() != "" {
-		sInfo.SpaceID = ""
-	}
-
 	return sInfo
-}
-
-// AllSubnetInfos returns SubnetInfos for all subnets in the model.
-func (st *State) AllSubnetInfos() (network.SubnetInfos, error) {
-	subs, err := st.AllSubnets()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	result := make(network.SubnetInfos, len(subs))
-	for i, sub := range subs {
-		result[i] = sub.NetworkSubnet()
-	}
-	return result, nil
 }
 
 // SubnetUpdate adds new info to the subnet based on provided info.

--- a/state/unit.go
+++ b/state/unit.go
@@ -2957,12 +2957,30 @@ func (g *HistoryGetter) StatusHistory(filter status.StatusHistoryFilter) ([]stat
 }
 
 // UpgradeSeriesStatus returns the upgrade status of the units assigned machine.
-func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	machine, err := u.machine()
+func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+	mID, err := u.AssignedMachineId()
 	if err != nil {
-		return "", err
+		return "", "", errors.Trace(err)
 	}
-	return machine.UpgradeSeriesUnitStatus(u.Name())
+
+	coll, closer := u.st.db().GetCollection(machineUpgradeSeriesLocksC)
+	defer closer()
+
+	var lock upgradeSeriesLockDoc
+	err = coll.FindId(mID).One(&lock)
+	if err == mgo.ErrNotFound {
+		return "", "", errors.NotFoundf("upgrade series lock for machine %q", mID)
+	}
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+
+	sts, ok := lock.UnitStatuses[u.Name()]
+	if !ok {
+		return "", "", errors.NotFoundf("unit %q of machine %q", u.Name(), mID)
+	}
+
+	return sts.Status, lock.ToSeries, nil
 }
 
 // SetUpgradeSeriesStatus sets the upgrade status of the units assigned machine.

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -50,10 +50,19 @@ func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachin
 	task.machinesMutex.RLock()
 	defer task.machinesMutex.RUnlock()
 	// sort to make comparisons in the tests easier.
-	sort.Sort(azMachineSort(task.availabilityZoneMachines))
-	retvalues := make([]AvailabilityZoneMachine, len(task.availabilityZoneMachines))
-	for i := range task.availabilityZoneMachines {
-		retvalues[i] = *task.availabilityZoneMachines[i]
+	zoneMachines := task.availabilityZoneMachines
+	sort.Slice(task.availabilityZoneMachines, func(i, j int) bool {
+		switch {
+		case zoneMachines[i].MachineIds.Size() < zoneMachines[j].MachineIds.Size():
+			return true
+		case zoneMachines[i].MachineIds.Size() == zoneMachines[j].MachineIds.Size():
+			return zoneMachines[i].ZoneName < zoneMachines[j].ZoneName
+		}
+		return false
+	})
+	retvalues := make([]AvailabilityZoneMachine, len(zoneMachines))
+	for i := range zoneMachines {
+		retvalues[i] = *zoneMachines[i]
 	}
 	return retvalues
 }

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -11,13 +11,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/names/v4"
-
 	"github.com/golang/mock/gomock"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v2"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v2/workertest"
 	gc "gopkg.in/check.v1"
@@ -47,6 +48,7 @@ import (
 type ProvisionerTaskSuite struct {
 	testing.IsolationSuite
 
+	setupDone            chan bool
 	modelMachinesChanges chan []string
 	modelMachinesWatcher watcher.StringsWatcher
 
@@ -71,6 +73,7 @@ var _ = gc.Suite(&ProvisionerTaskSuite{})
 func (s *ProvisionerTaskSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 
+	s.setupDone = make(chan bool)
 	s.modelMachinesChanges = make(chan []string)
 	s.modelMachinesWatcher = watchertest.NewMockStringsWatcher(s.modelMachinesChanges)
 
@@ -94,7 +97,7 @@ func (s *ProvisionerTaskSuite) SetUpTest(c *gc.C) {
 		Stub:      &testing.Stub{},
 		callsChan: make(chan string, 2),
 		allInstancesFunc: func(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-			return s.instances, nil
+			return s.instances, s.instanceBroker.NextErr()
 		},
 	}
 
@@ -206,11 +209,88 @@ func (s *ProvisionerTaskSuite) TestProvisionerRetries(c *gc.C) {
 	s.instanceBroker.CheckCallNames(c, "StartInstance", "StartInstance")
 }
 
+func (s *ProvisionerTaskSuite) TestEvenZonePlacement(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// There are 3 available usedZones, so test with 4 machines
+	// to ensure even spread across usedZones.
+	machines := []*testMachine{{
+		id: "0",
+	}, {
+		id: "1",
+	}, {
+		id: "2",
+	}, {
+		id: "3",
+	}}
+	broker := s.setUpZonedEnviron(ctrl, machines...)
+	azConstraints := newAZConstraintStartInstanceParamsMatcher()
+	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).Times(len(machines))
+
+	var usedZones []string
+	expectedIds := set.NewStrings()
+	for _, m := range machines {
+		expectedIds.Add(m.id)
+		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
+			Instance: &testInstance{id: "instance-" + m.id},
+		}, nil).Do(func(ctx, params interface{}) {
+			usedZones = append(usedZones, params.(environs.StartInstanceParams).AvailabilityZone)
+		})
+	}
+	broker.EXPECT().StopInstances(s.callCtx, gomock.Any()).Do(func(ctx interface{}, ids ...interface{}) {
+		for _, id := range ids {
+			expectedIds.Remove(fmt.Sprintf("%s", id))
+		}
+		c.Assert(expectedIds.Size(), gc.Equals, 0)
+	})
+
+	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	s.sendModelMachinesChange(c, expectedIds.Values()...)
+
+	shortAttempt := &utils.AttemptStrategy{
+		Total: coretesting.LongWait,
+		Delay: 10 * time.Millisecond,
+	}
+	for a := shortAttempt.Start(); a.Next(); {
+		if len(usedZones) == 4 {
+			break
+		}
+	}
+	zoneCounts := make(map[string]int)
+	for _, z := range usedZones {
+		count := zoneCounts[z] + 1
+		zoneCounts[z] = count
+	}
+	for z, count := range zoneCounts {
+		if count == 0 || count > 2 {
+			c.Fatalf("expected either 1 or 2 machines for %v, got %d", z, count)
+		}
+	}
+	c.Assert(set.NewStrings(usedZones...).SortedValues(), jc.DeepEquals, []string{"az1", "az2", "az3"})
+
+	workertest.CleanKill(c, task)
+}
+
 func (s *ProvisionerTaskSuite) TestMultipleSpaceConstraints(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	broker := s.setUpZonedEnviron(ctrl)
+	m0 := &testMachine{
+		id:          "0",
+		constraints: "spaces=alpha,beta",
+		topology: params.ProvisioningNetworkTopology{
+			SubnetAZs: map[string][]string{
+				"subnet-1": {"az-1"},
+				"subnet-2": {"az-2"},
+			},
+			SpaceSubnets: map[string][]string{
+				"alpha": {"subnet-1"},
+				"beta":  {"subnet-2"},
+			},
+		},
+	}
+	broker := s.setUpZonedEnviron(ctrl, m0)
 	spaceConstraints := newSpaceConstraintStartInstanceParamsMatcher("alpha", "beta")
 
 	spaceConstraints.addMatch("subnets-to-zones", func(p environs.StartInstanceParams) bool {
@@ -246,28 +326,14 @@ func (s *ProvisionerTaskSuite) TestMultipleSpaceConstraints(c *gc.C) {
 	// Use satisfaction of this call as the synchronisation point.
 	started := make(chan struct{})
 	broker.EXPECT().StartInstance(s.callCtx, spaceConstraints).Return(&environs.StartInstanceResult{
-		Instance: &testInstance{id: "instance-1"},
+		Instance: &testInstance{id: "instance-0"},
 	}, nil).Do(func(_ ...interface{}) {
 		go func() { started <- struct{}{} }()
 	})
 	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
-	m0 := &testMachine{
-		id:          "0",
-		constraints: "spaces=alpha,beta",
-		topology: params.ProvisioningNetworkTopology{
-			SubnetAZs: map[string][]string{
-				"subnet-1": {"az-1"},
-				"subnet-2": {"az-2"},
-			},
-			SpaceSubnets: map[string][]string{
-				"alpha": {"subnet-1"},
-				"beta":  {"subnet-2"},
-			},
-		},
-	}
-	s.machineStatusResults = []apiprovisioner.MachineStatusResult{{Machine: m0, Status: params.StatusResult{}}}
-	s.sendMachineErrorRetryChange(c)
+	s.sendModelMachinesChange(c, "0")
 
 	select {
 	case <-started:
@@ -282,21 +348,21 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoZoneAvailable(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	broker := s.setUpZonedEnviron(ctrl)
+	m0 := &testMachine{
+		id:          "0",
+		constraints: "zones=az9",
+	}
+	broker := s.setUpZonedEnviron(ctrl, m0)
 
 	// Constraint for availability zone az9 can not be satisfied;
 	// this broker only knows of az1, az2, az3.
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az9")
 	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil)
 
+	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 	task := s.newProvisionerTaskWithBroker(c, broker, nil)
-
-	m0 := &testMachine{
-		id:          "0",
-		constraints: "zones=az9",
-	}
-	s.machineStatusResults = []apiprovisioner.MachineStatusResult{{Machine: m0, Status: params.StatusResult{}}}
-	s.sendMachineErrorRetryChange(c)
+	s.sendModelMachinesChange(c, "0")
+	s.waitForWorkerSetup(c, "worker not set up")
 
 	// Wait for instance status to be set.
 	timeout := time.After(coretesting.LongWait)
@@ -320,7 +386,11 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroup(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	broker := s.setUpZonedEnviron(ctrl)
+	m0 := &testMachine{
+		id:          "0",
+		constraints: "zones=az1",
+	}
+	broker := s.setUpZonedEnviron(ctrl, m0)
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az1")
 	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil)
 
@@ -335,19 +405,15 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroup(c *gc.C) {
 	// Use satisfaction of this call as the synchronisation point.
 	started := make(chan struct{})
 	broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
-		Instance: &testInstance{id: "instance-1"},
+		Instance: &testInstance{id: "instance-0"},
 	}, nil).Do(func(_ ...interface{}) {
 		go func() { started <- struct{}{} }()
 	})
+	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
 	task := s.newProvisionerTaskWithBroker(c, broker, nil)
 
-	m0 := &testMachine{
-		id:          "0",
-		constraints: "zones=az1",
-	}
-	s.machineStatusResults = []apiprovisioner.MachineStatusResult{{Machine: m0, Status: params.StatusResult{}}}
-	s.sendMachineErrorRetryChange(c)
+	s.sendModelMachinesChange(c, "0")
 
 	select {
 	case <-started:
@@ -364,14 +430,6 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroupRetry(c *gc
 
 	broker := s.setUpZonedEnviron(ctrl)
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az1")
-
-	// For the call to start instance, we expect the same zone constraint to
-	// be present, but we also expect that the zone in start instance params
-	// matches the constraint, based on being available in this environ.
-	azConstraintsAndDerivedZone := newAZConstraintStartInstanceParamsMatcher("az1")
-	azConstraintsAndDerivedZone.addMatch("availability zone: az1", func(p environs.StartInstanceParams) bool {
-		return p.AvailabilityZone == "az1"
-	})
 
 	failedErr := errors.Errorf("oh no")
 	// Use satisfaction of this call as the synchronisation point.
@@ -410,7 +468,12 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroup(c *gc.C)
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	broker := s.setUpZonedEnviron(ctrl)
+	m0 := &testMachine{
+		id:          "0",
+		constraints: "zones=az1,az2",
+	}
+	broker := s.setUpZonedEnviron(ctrl, m0)
+
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az1", "az2")
 	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil)
 
@@ -426,10 +489,11 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroup(c *gc.C)
 	// Use satisfaction of this call as the synchronisation point.
 	started := make(chan struct{})
 	broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
-		Instance: &testInstance{id: "instance-1"},
+		Instance: &testInstance{id: "instance-0"},
 	}, nil).Do(func(_ ...interface{}) {
 		go func() { started <- struct{}{} }()
 	})
+	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
 	// Another machine from the same distribution group is already in az1,
 	// so we expect the machine to be created in az2.
@@ -437,13 +501,7 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroup(c *gc.C)
 		names.NewMachineTag("0"): {"az1"},
 	})
 
-	m0 := &testMachine{
-		id:          "0",
-		constraints: "zones=az1,az2",
-	}
-	s.machineStatusResults = []apiprovisioner.MachineStatusResult{{Machine: m0, Status: params.StatusResult{}}}
-	s.sendMachineErrorRetryChange(c)
-
+	s.sendModelMachinesChange(c, "0")
 	select {
 	case <-started:
 	case <-time.After(coretesting.LongWait):
@@ -459,15 +517,6 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroupRetry(c *
 
 	broker := s.setUpZonedEnviron(ctrl)
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az1", "az2")
-
-	// For the call to start instance, we expect the same zone constraints to
-	// be present, but we also expect that the zone in start instance params
-	// was selected from the constraints, based on a machine from the same
-	// distribution group already being in one of the zones.
-	azConstraintsAndDerivedZone := newAZConstraintStartInstanceParamsMatcher("az1", "az2")
-	azConstraintsAndDerivedZone.addMatch("availability zone: az1", func(p environs.StartInstanceParams) bool {
-		return p.AvailabilityZone == "az2"
-	})
 
 	// Use satisfaction of this call as the synchronisation point.
 	failedErr := errors.Errorf("oh no")
@@ -513,15 +562,6 @@ func (s *ProvisionerTaskSuite) TestZoneRestrictiveConstraintsWithDistributionGro
 	broker := s.setUpZonedEnviron(ctrl)
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az2")
 
-	// For the call to start instance, we expect the same zone constraints to
-	// be present, but we also expect that the zone in start instance params
-	// was selected from the constraints, based on a machine from the same
-	// distribution group already being in one of the zones.
-	azConstraintsAndDerivedZone := newAZConstraintStartInstanceParamsMatcher("az2")
-	azConstraintsAndDerivedZone.addMatch("availability zone: az2", func(p environs.StartInstanceParams) bool {
-		return p.AvailabilityZone == "az2"
-	})
-
 	// Use satisfaction of this call as the synchronisation point.
 	failedErr := errors.Errorf("oh no")
 	started := make(chan struct{})
@@ -566,21 +606,37 @@ func (s *ProvisionerTaskSuite) TestPopulateAZMachinesErrorWorkerStopped(c *gc.C)
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	// `ProvisionerTask.populateAvailabilityZoneMachines` calls through to this method.
 	broker := mocks.NewMockZonedEnviron(ctrl)
-	broker.EXPECT().AllRunningInstances(s.callCtx).Return(nil, errors.New("boom"))
+	broker.EXPECT().AllRunningInstances(s.callCtx).Return(nil, errors.New("boom")).Do(func(_ ...interface{}) {
+		go func() { close(s.setupDone) }()
+	})
 
 	task := s.newProvisionerTaskWithBroker(c, broker, map[names.MachineTag][]string{
 		names.NewMachineTag("0"): {"az1"},
 	})
+	s.sendModelMachinesChange(c, "0")
+	s.waitForWorkerSetup(c, "worker not set up")
 
 	err := workertest.CheckKill(c, task)
-	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(err, gc.ErrorMatches, "failed to process updated machines: .* boom")
 }
 
 // setUpZonedEnviron creates a mock environ with instances based on those set
 // on the test suite, and 3 availability zones.
-func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller) *mocks.MockZonedEnviron {
+func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machines ...*testMachine) *mocks.MockZonedEnviron {
+	broker := mocks.NewMockZonedEnviron(ctrl)
+	if len(machines) == 0 {
+		return broker
+	}
+	for _, m := range machines {
+		inst := &testInstance{id: m.id}
+		s.instances = append(s.instances, inst)
+		s.machinesResults = append(s.machinesResults, apiprovisioner.MachineResult{Machine: m})
+		s.machineStatusResults = append(s.machineStatusResults, apiprovisioner.MachineStatusResult{Machine: m, Status: params.StatusResult{
+			Status: "pending",
+		}})
+	}
+
 	instanceIds := make([]instance.Id, len(s.instances))
 	for i, inst := range s.instances {
 		instanceIds[i] = inst.Id()
@@ -595,12 +651,21 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller) *mocks
 		zones[i] = az
 	}
 
-	broker := mocks.NewMockZonedEnviron(ctrl)
 	exp := broker.EXPECT()
-	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil)
-	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return(map[instance.Id]string{}, nil)
+	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).Times(2)
+	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return(map[instance.Id]string{}, nil).Do(func(_ ...interface{}) {
+		go func() { close(s.setupDone) }()
+	})
 	exp.AvailabilityZones(s.callCtx).Return(zones, nil)
 	return broker
+}
+
+func (s *ProvisionerTaskSuite) waitForWorkerSetup(c *gc.C, msg string) {
+	select {
+	case <-s.setupDone:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf(msg)
+	}
 }
 
 func (s *ProvisionerTaskSuite) waitForTask(c *gc.C, expectedCalls []string) {
@@ -786,6 +851,9 @@ func (m *testMachine) Life() life.Value {
 }
 
 func (m *testMachine) InstanceId() (instance.Id, error) {
+	if m.instance == nil {
+		return "", params.Error{Code: "not provisioned"}
+	}
 	return m.instance.Id(), nil
 }
 
@@ -842,7 +910,7 @@ func (m *testMachine) SetStatus(_ status.Status, _ string, _ map[string]interfac
 }
 
 func (m *testMachine) Status() (status.Status, string, error) {
-	return "", "", nil
+	return "pending", "", nil
 }
 
 func (m *testMachine) ModelAgentVersion() (*version.Number, error) {
@@ -909,7 +977,7 @@ func (m *startInstanceParamsMatcher) addMatch(msg string, match func(environs.St
 func newAZConstraintStartInstanceParamsMatcher(zones ...string) *startInstanceParamsMatcher {
 	match := func(p environs.StartInstanceParams) bool {
 		if !p.Constraints.HasZones() {
-			return false
+			return len(zones) == 0
 		}
 		cZones := *p.Constraints.Zones
 		if len(cZones) != len(zones) {

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1754,7 +1754,8 @@ func (s *ProvisionerSuite) TestProvisioningMachinesClearAZFailures(c *gc.C) {
 	c.Assert(count, gc.Equals, 3)
 	machineAZ, err := machine.AvailabilityZone()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machineAZ, gc.Equals, "zone1")
+	// Zones 3 and 4 have the same machine count, one is picked at random.
+	c.Assert(set.NewStrings("zone3", "zone4").Contains(machineAZ), jc.IsTrue)
 }
 
 func (s *ProvisionerSuite) TestProvisioningMachinesDerivedAZ(c *gc.C) {

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -23,16 +23,16 @@ const (
 type Info struct {
 	Kind hooks.Kind `yaml:"kind"`
 
-	// RelationId identifies the relation associated with the hook. It is
-	// only set when Kind indicates a relation hook.
+	// RelationId identifies the relation associated with the hook.
+	// It is only set when Kind indicates a relation hook.
 	RelationId int `yaml:"relation-id,omitempty"`
 
 	// RemoteUnit is the name of the unit that triggered the hook. It is only
 	// set when Kind indicates a relation hook other than relation-broken.
 	RemoteUnit string `yaml:"remote-unit,omitempty"`
 
-	// RemoteApplication is always set if either an app or a unit triggers the hook.
-	// If the app triggers the hook, then RemoteUnit will be empty
+	// RemoteApplication is always set if either an app or a unit triggers
+	// the hook. If the app triggers the hook, then RemoteUnit will be empty.
 	RemoteApplication string `yaml:"remote-application,omitempty"`
 
 	// ChangeVersion identifies the most recent unit settings change
@@ -48,6 +48,11 @@ type Info struct {
 
 	// WorkloadName is the name of the sidecar container or workload relevant to the hook.
 	WorkloadName string `yaml:"workload-name,omitempty"`
+
+	// SeriesUpgradeTarget is the series that the unit's machine is to be
+	// updated to when Juju is issued the `upgrade-series` command.
+	// It is only set for the pre-series-upgrade hook.
+	SeriesUpgradeTarget string `yaml:"series-upgrade-target,omitempty"`
 }
 
 // Validate returns an error if the info is not valid.
@@ -75,8 +80,14 @@ func (hi Info) Validate() error {
 			return fmt.Errorf("%q hook requires a workload name", hi.Kind)
 		}
 		return nil
-	case hooks.Install, hooks.Remove, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop, hooks.RelationCreated, hooks.RelationBroken,
-		hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus, hooks.PreSeriesUpgrade, hooks.PostSeriesUpgrade:
+	case hooks.PreSeriesUpgrade:
+		if hi.SeriesUpgradeTarget == "" {
+			return fmt.Errorf("%q hook requires a target series", hi.Kind)
+		}
+		return nil
+	case hooks.Install, hooks.Remove, hooks.Start, hooks.ConfigChanged, hooks.UpgradeCharm, hooks.Stop,
+		hooks.RelationCreated, hooks.RelationBroken, hooks.CollectMetrics, hooks.MeterStatusChanged, hooks.UpdateStatus,
+		hooks.PostSeriesUpgrade:
 		return nil
 	case hooks.Action:
 		return fmt.Errorf("hooks.Kind Action is deprecated")

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -46,6 +46,9 @@ var validateTests = []struct {
 	}, {
 		hook.Info{Kind: hooks.PebbleReady},
 		`"pebble-ready" hook requires a workload name`,
+	}, {
+		hook.Info{Kind: hooks.PreSeriesUpgrade},
+		`"pre-series-upgrade" hook requires a target series`,
 	},
 	{hook.Info{Kind: hooks.Install}, ""},
 	{hook.Info{Kind: hooks.Start}, ""},
@@ -65,6 +68,7 @@ var validateTests = []struct {
 	{hook.Info{Kind: hooks.StorageAttached, StorageId: "data/0"}, ""},
 	{hook.Info{Kind: hooks.StorageDetaching, StorageId: "data/0"}, ""},
 	{hook.Info{Kind: hooks.PebbleReady, WorkloadName: "gitlab"}, ""},
+	{hook.Info{Kind: hooks.PreSeriesUpgrade, SeriesUpgradeTarget: "focal"}, ""},
 }
 
 func (s *InfoSuite) TestValidate(c *gc.C) {

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -294,8 +294,8 @@ func (u *mockUnit) WatchInstanceData() (watcher.NotifyWatcher, error) {
 	return u.instanceDataWatcher, nil
 }
 
-func (u *mockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	return model.UpgradeSeriesPrepareStarted, nil
+func (u *mockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+	return model.UpgradeSeriesPrepareStarted, "focal", nil
 }
 
 func (u *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) error {

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -89,11 +89,16 @@ type Snapshot struct {
 	// executed by this unit.
 	Commands []string
 
-	// UpgradeSeriesStatus is the preparation status of any currently running
-	// series upgrade
+	// UpgradeSeriesStatus is the preparation status of
+	// any currently running series upgrade.
 	UpgradeSeriesStatus model.UpgradeSeriesStatus
 
-	// ContainerRunningStatus is set on CAAS models for remote init/upgrade of charm.
+	// UpgradeSeriesTarget is the OS series that an in-flight
+	// series upgrade is transitioning to.
+	UpgradeSeriesTarget string
+
+	// ContainerRunningStatus is set on CAAS models
+	// for remote init/upgrade of charm.
 	ContainerRunningStatus *ContainerRunningStatus
 
 	// LXDProfileName is the name of the lxd profile applied to the unit's

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -50,10 +50,10 @@ type Unit interface {
 	WatchInstanceData() (watcher.NotifyWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)
 	WatchActionNotifications() (watcher.StringsWatcher, error)
-	// WatchRelation returns a watcher that fires when relations
+	// WatchRelations returns a watcher that fires when relations
 	// relevant for this unit change.
 	WatchRelations() (watcher.StringsWatcher, error)
-	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
+	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error)
 }
 
 type Application interface {

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -303,6 +303,7 @@ func (s *WatcherSuiteIAAS) TestSnapshot(c *gc.C) {
 		LeaderSettingsVersion: 1,
 		Leader:                true,
 		UpgradeSeriesStatus:   model.UpgradeSeriesPrepareStarted,
+		UpgradeSeriesTarget:   "focal",
 	})
 }
 

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -190,7 +190,10 @@ func (s *iaasResolverSuite) TestUpgradeSeriesPrepareStatusChanged(c *gc.C) {
 			Started:   true,
 		},
 	}
+
 	s.remoteState.UpgradeSeriesStatus = model.UpgradeSeriesPrepareStarted
+	s.remoteState.UpgradeSeriesTarget = "focal"
+
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.String(), gc.Equals, "run pre-series-upgrade hook")
@@ -745,6 +748,7 @@ func (s *rebootResolverSuite) TestStartHookDeferredWhenUpgradeIsInProgress(c *gc
 	for _, statusTest := range statusChecks {
 		c.Logf("triggering resolver with upgrade status: %s", statusTest.status)
 		s.remoteState.UpgradeSeriesStatus = statusTest.status
+		s.remoteState.UpgradeSeriesTarget = "focal"
 
 		op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 		if statusTest.expErr != nil {

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -182,7 +182,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 		logger:             f.logger,
 		componentDir:       f.paths.ComponentDir,
 		componentFuncs:     registeredComponentFuncs,
-		availabilityzone:   f.zone,
+		availabilityZone:   f.zone,
 		principal:          f.principal,
 	}
 	if err := f.updateContext(ctx); err != nil {
@@ -245,6 +245,9 @@ func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
 	if hookInfo.Kind.IsWorkload() {
 		ctx.workloadName = hookInfo.WorkloadName
 		hookName = fmt.Sprintf("%s-%s", hookInfo.WorkloadName, hookName)
+	}
+	if hookInfo.Kind == hooks.PreSeriesUpgrade {
+		ctx.seriesUpgradeTarget = hookInfo.SeriesUpgradeTarget
 	}
 	ctx.id = f.newId(hookName)
 	ctx.hookName = hookName

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -66,7 +66,7 @@ func NewHookContext(hcParams HookContextParams) (*HookContext, error) {
 	if err != nil && !params.IsCodeNoAddressSet(err) {
 		return nil, err
 	}
-	ctx.availabilityzone, err = hcParams.Unit.AvailabilityZone()
+	ctx.availabilityZone, err = hcParams.Unit.AvailabilityZone()
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func NewModelHookContext(p ModelHookContextParams) *HookContext {
 		},
 		relationId:         -1,
 		assignedMachineTag: p.MachineTag,
-		availabilityzone:   p.AvailZone,
+		availabilityZone:   p.AvailZone,
 		slaLevel:           p.SLALevel,
 		principal:          p.UnitName,
 		cloudAPIVersion:    "6.66",

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -131,7 +131,8 @@ type ContextUnit interface {
 	// UnitName returns the executing unit's name.
 	UnitName() string
 
-	// Config returns the current application configuration of the executing unit.
+	// ConfigSettings returns the current application
+	// configuration of the executing unit.
 	ConfigSettings() (charm.Settings, error)
 
 	// GoalState returns the goal state for the current unit.

--- a/worker/uniter/upgradeseries/resolver.go
+++ b/worker/uniter/upgradeseries/resolver.go
@@ -51,7 +51,10 @@ func (r *upgradeSeriesResolver) NextOp(
 	if localState.Kind == operation.Continue {
 		if localState.UpgradeSeriesStatus == model.UpgradeSeriesNotStarted &&
 			remoteState.UpgradeSeriesStatus == model.UpgradeSeriesPrepareStarted {
-			return opFactory.NewRunHook(hook.Info{Kind: hooks.PreSeriesUpgrade})
+			return opFactory.NewRunHook(hook.Info{
+				Kind:                hooks.PreSeriesUpgrade,
+				SeriesUpgradeTarget: remoteState.UpgradeSeriesTarget,
+			})
 		}
 
 		// The uniter's local state will be in the "not started" state if the


### PR DESCRIPTION
Merge from 2.9 to bring forward:
- #13147 from manadart/2.9-pre-upgrade-series-target
- #13141 from ycliuhw/fix/windows-bootstrap2microk8s
- #13148 from wallyworld/fix-zone-placement
- #13144 from jujubot/increment-to-2.9.9
- #13138 from manadart/2.9-rework-all-device-addrs

Conflicts:
- caas/kubernetes/provider/bootstrap.go
- caas/kubernetes/provider/builtin.go
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go
- worker/provisioner/provisioner_task_test.go