### PR TITLE
Do not use --ipv6 to start mongo on k8s if ipv6 not supported

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1130,7 +1130,6 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 			fmt.Sprintf("--replSet=%s", mongo.ReplicaSetName),
 			"--quiet",
 			"--oplogSize=1024",
-			"--ipv6",
 			"--auth",
 			fmt.Sprintf("--keyFile=%s", c.pathJoin(c.pcfg.DataDir, c.fileNameSharedSecret)),
 			"--storageEngine=wiredTiger",
@@ -1139,14 +1138,26 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 		if wiredTigerCacheSize > 0 {
 			args = append(args, fmt.Sprintf("--wiredTigerCacheSizeGB=%v", wiredTigerCacheSize))
 		}
+		// Create the script used to start mongo.
+		const mongoSh = "/root/mongo.sh"
+		mongoStartup := fmt.Sprintf(caas.MongoStartupShTemplate, strings.Join(args, " "))
+		// Write it to a file so it can be executed.
+		mongoStartup = strings.ReplaceAll(mongoStartup, "\n", "\\n")
+		makeMongoCmd := fmt.Sprintf("printf '%s'>%s", mongoStartup, mongoSh)
+		mongoArgs := fmt.Sprintf("%[1]s && chmod a+x %[2]s && %[2]s", makeMongoCmd, mongoSh)
+		logger.Debugf("mongodb container args:\n%s", mongoArgs)
+
 		containerSpec = append(containerSpec, core.Container{
 			Name:            mongoDBContainerName,
 			ImagePullPolicy: core.PullIfNotPresent,
 			Image:           c.pcfg.GetJujuDbOCIImagePath(),
 			Command: []string{
-				"mongod",
+				"/bin/sh",
 			},
-			Args: args,
+			Args: []string{
+				"-c",
+				mongoArgs,
+			},
 			Ports: []core.ContainerPort{
 				{
 					Name:          "mongodb",

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -14,15 +14,13 @@ cp /opt/jujud $JUJU_TOOLS_DIR/jujud
 %[3]s
 `[1:]
 
-	// ContainerAgentStartUpSh is the start script for in-pod style k8s agents.
-	ContainerAgentStartUpSh = `
-export JUJU_DATA_DIR=%[1]s
-export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/%[2]s
-
-mkdir -p $JUJU_TOOLS_DIR
-cp /opt/containeragent $JUJU_TOOLS_DIR/containeragent
-# The in-pod style agent uses for hooks - hook tools are symlinks of jujuc.
-cp /opt/jujuc $JUJU_TOOLS_DIR/jujuc
-%[3]s
+	// MongoStartupShTemplate is used to generate the start script for mongodb.
+	MongoStartupShTemplate = `
+args="%s"
+ipv6Disabled=$(sysctl net.ipv6.conf.all.disable_ipv6 -n)
+if [ $ipv6Disabled -eq 0 ]; then
+  args="${args} --ipv6"
+fi
+$(mongod ${args})
 `[1:]
 )


### PR DESCRIPTION
When bootstrapping on microk8s, only use `--ipv6` as an arg to mongodb if ipv6 is supported.
To test for ipv6 support, we can do:
`sysctl net.ipv6.conf.all.disable_ipv6`

and use that value in configuring the mongo startup args.

## QA steps

I can't easily set up a microk8s without ipv6 support locally, I just did a bootstrap test

bootstrap to microk8s
check the mongo process to see that `--ipv6` is used for the ipv6 case
```
microk8s.kubectl -n controller-test exec -ti controller-0 -c mongodb -- bash -c "ps -aef | grep mongod"`
...
root           9       7  1 06:06 ?        00:00:03 mongod --dbpath=/var/lib/juju/db --sslPEMKeyFile=/var/lib/juju/server.pem --sslPEMKeyPassword=xxxxxxx --sslMode=requireSSL --port=37017 --journal --replSet=juju --quiet --oplogSize=1024 --auth --keyFile=/var/lib/juju/shared-secret --storageEngine=wiredTiger --bind_ip_all --ipv6
...
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1935075
