### PR TITLE
[2.9] Fix linter warnings for tests

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -533,7 +533,7 @@ func (*suite) TestPromotedMongoInfo(c *gc.C) {
 	conf, err := agent.NewAgentConfig(attrParams)
 	c.Assert(err, jc.ErrorIsNil)
 
-	mongoInfo, ok := conf.MongoInfo()
+	_, ok := conf.MongoInfo()
 	c.Assert(ok, jc.IsFalse)
 
 	// Promote the agent to a controller by
@@ -542,7 +542,7 @@ func (*suite) TestPromotedMongoInfo(c *gc.C) {
 	// to use MongoInfo.
 	conf.SetStateServingInfo(stateServingInfo())
 
-	mongoInfo, ok = conf.MongoInfo()
+	mongoInfo, ok := conf.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Check(mongoInfo.Info.Addrs, jc.DeepEquals, []string{"localhost:69", "3.4.2.1:69"})
 	c.Check(mongoInfo.Info.DisableTLS, jc.IsFalse)

--- a/api/provisioner/provisioner_test.go
+++ b/api/provisioner/provisioner_test.go
@@ -649,9 +649,9 @@ func (s *provisionerSuite) TestWatchModelMachines(c *gc.C) {
 	wc.AssertChange(s.machine.Id())
 
 	// Add another 2 machines make sure they are detected.
-	otherMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	_, err = s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
-	otherMachine, err = s.State.AddMachine("quantal", state.JobHostUnits)
+	otherMachine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange("1", "2")
 

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -521,10 +521,10 @@ func (s *clientSuite) TestEnableHA0Preserves5(c *gc.C) {
 }
 
 func (s *clientSuite) TestEnableHAErrors(c *gc.C) {
-	enableHAResult, err := s.enableHA(c, -1, emptyCons, defaultSeries, nil)
+	_, err := s.enableHA(c, -1, emptyCons, defaultSeries, nil)
 	c.Assert(err, gc.ErrorMatches, "number of controllers must be odd and non-negative")
 
-	enableHAResult, err = s.enableHA(c, 3, emptyCons, defaultSeries, nil)
+	enableHAResult, err := s.enableHA(c, 3, emptyCons, defaultSeries, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(enableHAResult.Maintained, gc.DeepEquals, []string{"machine-0"})
 	c.Assert(enableHAResult.Added, gc.DeepEquals, []string{"machine-1", "machine-2"})

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -301,6 +301,7 @@ func (s *RegisterSuite) TestControllerUUIDExists(c *gc.C) {
 		ControllerUUID: mockControllerUUID,
 		CACert:         testing.CACert,
 	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
 		return []base.UserModel{{

--- a/environs/manual/sshprovisioner/init_test.go
+++ b/environs/manual/sshprovisioner/init_test.go
@@ -44,11 +44,11 @@ func (s *initialisationSuite) TestDetectionError(c *gc.C) {
 	// if the script fails for whatever reason, then checkProvisioned
 	// will return an error. stderr will be included in the error message.
 	defer installFakeSSH(c, sshprovisioner.DetectionScript, []string{scriptResponse, "oh noes"}, 33)()
-	hc, _, err := sshprovisioner.DetectSeriesAndHardwareCharacteristics("hostname")
+	_, _, err := sshprovisioner.DetectSeriesAndHardwareCharacteristics("hostname")
 	c.Assert(err, gc.ErrorMatches, "subprocess encountered error code 33 \\(oh noes\\)")
 	// if the script doesn't fail, stderr is simply ignored.
 	defer installFakeSSH(c, sshprovisioner.DetectionScript, []string{scriptResponse, "non-empty-stderr"}, 0)()
-	hc, _, err = sshprovisioner.DetectSeriesAndHardwareCharacteristics("hostname")
+	hc, _, err := sshprovisioner.DetectSeriesAndHardwareCharacteristics("hostname")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hc.String(), gc.Equals, "arch=armhf cores=1 mem=4M")
 }

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -488,7 +488,7 @@ func (s *crossmodelSuite) TestFindOffersWithPermission(c *gc.C) {
 	s.addOtherModelApplication(c)
 	s.createTestUser(c)
 	s.loginTestUser(c)
-	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
+	_, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"otheruser/othermodel", "--format", "yaml")
 	c.Assert(err, gc.ErrorMatches, ".*no matching application offers found.*")
 
@@ -497,7 +497,7 @@ func (s *crossmodelSuite) TestFindOffersWithPermission(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.loginTestUser(c)
-	ctx, err = cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
+	ctx, err := cmdtesting.RunCommand(c, crossmodel.NewFindEndpointsCommand(),
 		"otheruser/othermodel", "--format", "yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), gc.Equals, `
@@ -562,7 +562,7 @@ func (s *crossmodelSuite) TestConsumeWithPermission(c *gc.C) {
 	s.addOtherModelApplication(c)
 	s.createTestUser(c)
 	s.loginTestUser(c)
-	ctx, err := cmdtesting.RunCommand(c, application.NewConsumeCommand(),
+	_, err := cmdtesting.RunCommand(c, application.NewConsumeCommand(),
 		"-m", "admin/controller", "otheruser/othermodel.hosted-mysql")
 	c.Assert(err, gc.ErrorMatches, `application offer "otheruser/othermodel.hosted-mysql" not found`)
 
@@ -573,7 +573,7 @@ func (s *crossmodelSuite) TestConsumeWithPermission(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.loginTestUser(c)
-	ctx, err = cmdtesting.RunCommand(c, application.NewConsumeCommand(),
+	ctx, err := cmdtesting.RunCommand(c, application.NewConsumeCommand(),
 		"-m", "admin/controller", "otheruser/othermodel.hosted-mysql", "othermysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, `

--- a/network/containerizer/bridgepolicy_integration_test.go
+++ b/network/containerizer/bridgepolicy_integration_test.go
@@ -669,6 +669,7 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerTwoSpacesOneM
 	err := s.containerMachine.SetConstraints(constraints.Value{
 		Spaces: &[]string{"somespace", "dmz"},
 	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	bridgePolicy, err := containerizer.NewBridgePolicy(cfg(c, 13, "provider"), s.State)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -796,7 +796,7 @@ func (s *assignCleanSuite) TestAssignToMachineNoneAvailable(c *gc.C) {
 	// Add a state management machine which can host units and check it is not chosen.
 	// Note that this must the first machine added, as AddMachine can only
 	// be used to add state-manager machines for the bootstrap machine.
-	m, err = s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
+	_, err = s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	m, err = s.assignUnit(unit)
 	c.Assert(m, gc.IsNil)

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -54,10 +54,9 @@ func (r *RestoreSuite) TestReplicasetIsReset(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer server.DestroyWithLog()
 	mgoAddr := server.Addr()
-	dialInfo := server.DialInfo()
 
 	var cfg *replicaset.Config
-	dialInfo = server.DialInfo()
+	dialInfo := server.DialInfo()
 	dialInfo.Addrs = []string{mgoAddr}
 	err = resetReplicaSet(dialInfo, mgoAddr)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/externalcontroller_test.go
+++ b/state/externalcontroller_test.go
@@ -64,9 +64,9 @@ func (s *externalControllerSuite) TestSave(c *gc.C) {
 func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
 	uuid1 := utils.MustNewUUID().String()
-	ec, err := s.externalControllers.Save(controllerInfo, uuid1)
+	_, err := s.externalControllers.Save(controllerInfo, uuid1)
 	c.Assert(err, jc.ErrorIsNil)
-	ec, err = s.externalControllers.Save(controllerInfo, uuid1)
+	ec, err := s.externalControllers.Save(controllerInfo, uuid1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
 	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -694,10 +694,10 @@ func (s *linkLayerDevicesStateSuite) TestAddDeviceOpsWithAddresses(c *gc.C) {
 
 	state.RunTransaction(c, s.State, ops)
 
-	dev, err := s.machine.LinkLayerDevice(devName)
+	_, err = s.machine.LinkLayerDevice(devName)
 	c.Assert(err, jc.ErrorIsNil)
 
-	dev, err = s.machine.LinkLayerDevice("eth0")
+	dev, err := s.machine.LinkLayerDevice("eth0")
 	c.Assert(err, jc.ErrorIsNil)
 
 	addrs, err := dev.Addresses()

--- a/state/relationnetworks_test.go
+++ b/state/relationnetworks_test.go
@@ -103,9 +103,9 @@ func (s *relationNetworksSuite) TestSaveAdminOverrides(c *gc.C) {
 }
 
 func (s *relationNetworksSuite) TestSaveIdempotent(c *gc.C) {
-	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
+	_, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
-	rin, err = s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
+	rin, err := s.relationNetworks.Save("wordpress:db mysql:server", false, []string{"192.168.1.0/16"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rin.RelationKey(), gc.Equals, "wordpress:db mysql:server")
 	c.Assert(rin.CIDRS(), jc.DeepEquals, []string{"192.168.1.0/16"})


### PR DESCRIPTION
This PR addresses ineffassignment linter warnings found in some of the tests.