### PR TITLE
Integration: Run integration sub test

### DIFF
--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -87,6 +87,15 @@ run_linter() {
 
 skip() {
 	CMD="${1}"
+
+	if [[ -n ${RUN_LIST} ]]; then
+		# shellcheck disable=SC2143,SC2046
+		if [[ ! $(echo "${RUN_LIST}" | grep -w "${CMD}") ]]; then
+			echo "SKIP"
+			exit 1
+		fi
+	fi
+
 	# shellcheck disable=SC2143,SC2046
 	if [[ $(echo "${SKIP_LIST:-}" | grep -w "${CMD}") ]]; then
 		echo "SKIP"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -19,6 +19,7 @@ OPTIND=1
 VERBOSE=1
 RUN_ALL="false"
 SKIP_LIST=""
+RUN_LIST=""
 ARITFACT_FILE=""
 OUTPUT_FILE=""
 
@@ -330,6 +331,21 @@ if [[ $# -gt 0 ]]; then
 		export RUN_SUBTEST="${2}"
 		echo "==> Running subtest: ${2}"
 		run_test "test_${1}" "" "" "${TEST}"
+		TEST_RESULT=success
+		exit
+	fi
+	# shellcheck disable=SC2143
+	if [[ "$(echo "${2}" | grep -E "^test_")" ]]; then
+		TEST="$(grep -lr "${2}" "suites/${1}")"
+		if [[ -z ${TEST} ]]; then
+			echo "==> Unable to find test ${2} in ${1}."
+			echo "    Try and run the test suite directly."
+			exit 1
+		fi
+
+		export RUN_LIST="test_${1},${2}"
+		echo "==> Running subtest ${2} for ${1} suite"
+		run_test "test_${1}" "${1}" "" ""
 		TEST_RESULT=success
 		exit
 	fi

--- a/tests/suites/examples/task.sh
+++ b/tests/suites/examples/task.sh
@@ -1,5 +1,5 @@
 test_examples() {
-	if [ "$(skip 'test_example')" ]; then
+	if [ "$(skip 'test_examples')" ]; then
 		echo "==> TEST SKIPPED: example tests"
 		return
 	fi


### PR DESCRIPTION
This allows running integration sub-tests whilst inside the integration
tests. What this provides is a useful way to do the following:

    ./main.sh deploy test_deploy_charms

This only runs the deploy charms tests and skips any of the other tests.

We want to employ this from our CI setup, where we have so many tests now that
they're getting timed out because they're taking too long. If we can shard the tests
out based on the suites and individual tests, we can better positive results from our
CI.

## QA steps

Ensure that it only runs the bundles tests.

```sh
(cd tests && ./main.sh deploy test_deploy_bundles)
```
