### PR TITLE
State logs: index label fields

### DIFF
--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -137,6 +137,7 @@ func (s *LogsSuite) TestIndexesCreated(c *gc.C) {
 		"_id",   // default index
 		"t-_id", // timestamp and ID
 		"n",     // entity
+		"c",     // optional labels
 	})
 }
 


### PR DESCRIPTION
This follows on from https://github.com/juju/juju/pull/13149.

When using debug-logs it helps if we index the log fields correctly. The
following change ensures that we index the labels field (in this
instance it's the "c" field). As the field is optional, we now need to
create a sparse index for mongo.

See: https://docs.mongodb.com/manual/core/index-sparse/

## QA steps


It's best to use a multi-terminal session for this (tmux)

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller "logging-config='#http=TRACE'"
$ juju debug-log -m controller
$ juju find windows
```

To see that the trace doesn't come through when using `exclude-label`

```sh
$ juju debug-log -m controller --exclude-label=http
```