### PR TITLE
enhance test-network-health

### DIFF
--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -6,23 +6,29 @@ run_network_health() {
 	ensure "network-health" "${file}"
 
 	# Deploy some applications for different series.
-	juju deploy mongodb --series xenial
+	juju deploy mongodb --series focal
+	juju deploy juju-gui --series xenial
 	juju deploy ubuntu ubuntu-bionic --series bionic
 
 	# Now the testing charm for each series.
 	juju deploy 'cs:~juju-qa/network-health' network-health-xenial --series xenial
 	juju deploy 'cs:~juju-qa/network-health' network-health-bionic --series bionic
+	juju deploy 'cs:~juju-qa/network-health' network-health-focal --series focal
 
 	juju expose network-health-xenial
 	juju expose network-health-bionic
+	juju expose network-health-focal
 
-	juju add-relation network-health-xenial mongodb
+	juju add-relation network-health-focal mongodb
+	juju add-relation network-health-xenial juju-gui
 	juju add-relation network-health-bionic ubuntu-bionic
 
-	wait_for "mongodb" "$(idle_condition "mongodb" 0)"
-	wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 3)"
-	wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "mongodb")"
+	wait_for "mongodb" "$(idle_condition "mongodb" 1)"
+	wait_for "juju-gui" "$(idle_condition "juju-gui" 0)"
+	wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 5)"
+	wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "mongodb")"
 	wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu-bionic")"
+	wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "juju-gui")"
 
 	check_default_routes
 	check_accessibility
@@ -45,13 +51,13 @@ check_default_routes() {
 check_accessibility() {
 	echo "[+] checking neighbour connectivity and external access"
 
-	for net_health_unit in "network-health-xenial/0" "network-health-bionic/0"; do
+	for net_health_unit in "network-health-xenial/0" "network-health-bionic/0" "network-health-focal/0"; do
 		ip="$(juju show-unit $net_health_unit --format json | jq -r ".[\"$net_health_unit\"] | .[\"public-address\"]")"
 
 		curl_cmd="curl 2>/dev/null ${ip}:8039"
 
 		# Check that each of the principles can access the subordinate.
-		for principle_unit in "mongodb/0" "ubuntu-bionic/0"; do
+		for principle_unit in "mongodb/0" "juju-gui/0" "ubuntu-bionic/0"; do
 			check_contains "$(juju run --unit $principle_unit "$curl_cmd")" "pass"
 		done
 


### PR DESCRIPTION
Add focal unit to network-health.

Swap around what charm uses what series.  There have been some recent charm install issues around apt update and apt install charmhelpers which causes unrelated failures in different substraights.

## QA steps

```console
vpn
(cd tests ; ./main.sh -v -c boston-vsphere network)
```
