### PR TITLE
Add support for bespoke service principals in Azure credentials

### DIFF
--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	fakeApplicationId     = "00000000-0000-0000-0000-000000000000"
+	fakeApplicationId     = "60a04dc9-1857-425f-8076-5ba81ca53d66"
 	fakeSubscriptionId    = "22222222-2222-2222-2222-222222222222"
 	fakeStorageAccountKey = "quay"
 )

--- a/provider/azure/credentials_test.go
+++ b/provider/azure/credentials_test.go
@@ -324,9 +324,10 @@ func (s *credentialsSuite) TestFinalizeCredentialInteractive(c *gc.C) {
 	c.Assert(out, gc.NotNil)
 	c.Assert(out.AuthType(), gc.Equals, cloud.AuthType("service-principal-secret"))
 	c.Assert(out.Attributes(), jc.DeepEquals, map[string]string{
-		"application-id":       "appid",
-		"application-password": "service-principal-password",
-		"subscription-id":      "subscription",
+		"application-id":        "appid",
+		"application-password":  "service-principal-password",
+		"application-object-id": "application-object-id",
+		"subscription-id":       "subscription",
 	})
 
 	s.servicePrincipalCreator.CheckCallNames(c, "InteractiveCreate")
@@ -390,6 +391,7 @@ func (s *credentialsSuite) TestFinalizeCredentialAzureCLI(c *gc.C) {
 	c.Assert(attrs["subscription-id"], gc.Equals, "test-account1-id")
 	c.Assert(attrs["application-id"], gc.Equals, "appid")
 	c.Assert(attrs["application-password"], gc.Equals, "service-principal-password")
+	c.Assert(attrs["application-object-id"], gc.Equals, "application-object-id")
 }
 
 func (s *credentialsSuite) TestFinalizeCredentialAzureCLIShowAccountError(c *gc.C) {
@@ -575,6 +577,7 @@ func (s *credentialsSuite) TestFinalizeCredentialAzureCLIDeviceFallback(c *gc.C)
 	c.Assert(attrs["subscription-id"], gc.Equals, "test-account1-id")
 	c.Assert(attrs["application-id"], gc.Equals, "appid")
 	c.Assert(attrs["application-password"], gc.Equals, "service-principal-password")
+	c.Assert(attrs["application-object-id"], gc.Equals, "application-object-id")
 	s.servicePrincipalCreator.CheckCallNames(c, "InteractiveCreate")
 }
 
@@ -582,14 +585,14 @@ type servicePrincipalCreator struct {
 	testing.Stub
 }
 
-func (c *servicePrincipalCreator) InteractiveCreate(sdkCtx context.Context, stderr io.Writer, params azureauth.ServicePrincipalParams) (appId, password string, _ error) {
+func (c *servicePrincipalCreator) InteractiveCreate(sdkCtx context.Context, stderr io.Writer, params azureauth.ServicePrincipalParams) (appId, spId, password string, _ error) {
 	c.MethodCall(c, "InteractiveCreate", sdkCtx, stderr, params)
-	return "appid", "service-principal-password", c.NextErr()
+	return "appid", "application-object-id", "service-principal-password", c.NextErr()
 }
 
-func (c *servicePrincipalCreator) Create(sdkCtx context.Context, params azureauth.ServicePrincipalParams) (appId, password string, _ error) {
+func (c *servicePrincipalCreator) Create(sdkCtx context.Context, params azureauth.ServicePrincipalParams) (appId, spId, password string, _ error) {
 	c.MethodCall(c, "Create", sdkCtx, params)
-	return "appid", "service-principal-password", c.NextErr()
+	return "appid", "application-object-id", "service-principal-password", c.NextErr()
 }
 
 type azureCLI struct {

--- a/provider/azure/internal/azureauth/serviceprincipal_test.go
+++ b/provider/azure/internal/azureauth/serviceprincipal_test.go
@@ -192,7 +192,7 @@ func (s *InteractiveSuite) TestInteractive(c *gc.C) {
 	subscriptionId := "22222222-2222-2222-2222-222222222222"
 	sdkCtx := context.Background()
 
-	appId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
+	appId, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, &stderr, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -202,6 +202,7 @@ func (s *InteractiveSuite) TestInteractive(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(appId, gc.Equals, "60a04dc9-1857-425f-8076-5ba81ca53d66")
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
+	c.Assert(spObjectId, gc.Equals, "sp-object-id")
 	c.Assert(stderr.String(), gc.Equals, `
 Initiating interactive authentication.
 
@@ -270,7 +271,7 @@ func (s *InteractiveSuite) TestInteractiveRoleAssignmentAlreadyExists(c *gc.C) {
 		NewUUID:          s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, _, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, _, _, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -302,7 +303,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalAlreadyExists(c *gc.C)
 		NewUUID:          s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -311,6 +312,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalAlreadyExists(c *gc.C)
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
+	c.Assert(spObjectId, gc.Equals, "sp-object-id")
 
 	c.Assert(requests, gc.HasLen, 12)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")
@@ -370,7 +372,7 @@ func (s *InteractiveSuite) testInteractiveRetriesCreateServicePrincipal(c *gc.C,
 		NewUUID: s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -379,6 +381,7 @@ func (s *InteractiveSuite) testInteractiveRetriesCreateServicePrincipal(c *gc.C,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
+	c.Assert(spObjectId, gc.Equals, "sp-object-id")
 
 	c.Assert(requests, gc.HasLen, 10)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")
@@ -416,7 +419,7 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 		NewUUID: s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -425,6 +428,7 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(password, gc.Equals, "33333333-3333-3333-3333-333333333333")
+	c.Assert(spObjectId, gc.Equals, "sp-object-id")
 
 	c.Assert(requests, gc.HasLen, 10)
 	c.Check(requests[0].URL.Path, gc.Equals, "/subscriptions/22222222-2222-2222-2222-222222222222")


### PR DESCRIPTION
Juju on Azure needs to support credentials built on custom service principals. Such credentials will have a different application id and application object id to the hard coded defaults. We add a new optional "application-object-id" attribute to Juju credentials. It is optional because older credentials don't have it. When Juju needs the application object id, and the default service principal is in use, it simply uses the official juju app hard coded default. If the default service principal is not used, the application object id is read from the credential attributes.

When juju add-credential is run, we now grab the application object id and store it in the credential. This will usually be just the same as the hard coded default. Older credentials won't have it so there is code to insert the correct value later.

As a small refactor, the initialisation of the environ was split up into SetCloudSpec() and SetConfig() to conform with current best practise.

NB older 2.8 clients will no longer be able to talk to Azure controllers since they do not know about the new credential attribute.

## QA steps

The steps to verify that the new way of looking up a non-default application object id are quite involved - see the bug.
For QA, we can test the usual behaviour, by bootstrapping with two different credentials:

```
    cred1:
      auth-type: service-principal-secret
      application-id: 60a04dc9-1857-425f-8076-5ba81ca53d66
      application-password: xxxxx
      application-object-id: 8b744cea-179d-4a73-9dff-20d52126030a
      subscription-id: 2eebf55a-1e02-45d8-a299-02aed8aea00b
```
```
    cred2:
      auth-type: service-principal-secret
      application-id: 60a04dc9-1857-425f-8076-5ba81ca53d66
      application-password: xxxxx
      subscription-id: 2eebf55a-1e02-45d8-a299-02aed8aea00b
```

One has the application-object-id, the other doesn't. In both cases, we can set up a machine with disk encryption.

```
juju create-storage-pool des azure encrypted=true vault-name-prefix=juju
juju add-machine --constraints="root-disk-source=des"
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929436
