### PR TITLE
SpaceAddress conversion from single candidates instead of a slice

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -268,15 +268,12 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 		addrByIP[addr.Value()] = addr
 	}
 
-	candidates := make([]network.SpaceAddressCandidate, len(addrs))
+	spaceAddrs := make([]network.SpaceAddress, len(addrs))
 	for i, addr := range addrs {
-		candidates[i] = addr
-	}
-
-	spaceAddrs, err := network.ConvertToSpaceAddresses(candidates, n.subs)
-	if err != nil {
-		n.populateMachineNetworkInfoErrors(spaceSet, err)
-		return nil
+		if spaceAddrs[i], err = network.ConvertToSpaceAddress(addr, n.subs); err != nil {
+			n.populateMachineNetworkInfoErrors(spaceSet, err)
+			return nil
+		}
 	}
 	network.SortAddresses(spaceAddrs)
 

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -47,12 +47,18 @@ func (m *sshMachine) AllDeviceSpaceAddresses() (network.SpaceAddresses, error) {
 		return nil, errors.Trace(err)
 	}
 
-	candidates := make([]network.SpaceAddressCandidate, len(addrs))
-	for i, addr := range addrs {
-		candidates[i] = addr
+	subs, err := m.st.AllSubnetInfos()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
-	return network.ConvertToSpaceAddresses(candidates, m.st)
+	spaceAddrs := make(network.SpaceAddresses, len(addrs))
+	for i, addr := range addrs {
+		if spaceAddrs[i], err = network.ConvertToSpaceAddress(addr, subs); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return spaceAddrs, nil
 }
 
 type backend struct {

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -1017,20 +1017,24 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 
 	candidates := []network.SpaceAddressCandidate{
 		spaceAddressCandidate{
-			value:        "192.168.0.66",
-			configMethod: network.ConfigDHCP,
-			subnetCIDR:   "192.168.0.0/24",
-		},
-		spaceAddressCandidate{
 			value:        "252.80.0.100",
 			configMethod: network.ConfigStatic,
 			subnetCIDR:   "252.80.0.0/12",
 			isSecondary:  true,
 		},
+		spaceAddressCandidate{
+			value:        "192.168.0.66",
+			configMethod: network.ConfigDHCP,
+			subnetCIDR:   "192.168.0.0/24",
+		},
 	}
 
-	addrs, err := network.ConvertToSpaceAddresses(candidates, subs)
-	c.Assert(err, jc.ErrorIsNil)
+	addrs := make(network.SpaceAddresses, len(candidates))
+	for i, ca := range candidates {
+		var err error
+		addrs[i], err = network.ConvertToSpaceAddress(ca, subs)
+		c.Assert(err, jc.ErrorIsNil)
+	}
 
 	network.SortAddresses(addrs)
 	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{


### PR DESCRIPTION
We previously added `ConvertToSpaceAddresses` for converting a slice of indirections to `SpaceAddresses`. 

This is not ergonomic in Go, because any slice of concrete types needs to be copied into a slice of the suitable indirection before calling the conversion.

Here we opt instead to convert a single address per call, allowing us to generate `SpaceAddresses` directly by iteration.

## QA steps

Mechanical changes verified by green unit tests.

## Documentation changes

None.

## Bug reference

N/A
