### PR TITLE
Tidier Address Sorting

### DIFF
--- a/apiserver/facades/agent/uniter/networkinfocaas.go
+++ b/apiserver/facades/agent/uniter/networkinfocaas.go
@@ -4,6 +4,8 @@
 package uniter
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/params"
@@ -28,7 +30,7 @@ func newNetworkInfoCAAS(base *NetworkInfoBase) (*NetworkInfoCAAS, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	network.SortAddresses(addrs)
+	sort.Sort(addrs)
 
 	return &NetworkInfoCAAS{
 		NetworkInfoBase: base,
@@ -153,7 +155,7 @@ func (n *NetworkInfoCAAS) NetworksForRelation(
 		}
 	}
 
-	network.SortAddresses(ingress)
+	sort.Sort(ingress)
 
 	egress, err := n.getEgressForRelation(rel, ingress)
 	if err != nil {

--- a/apiserver/facades/agent/uniter/networkinfoiaas.go
+++ b/apiserver/facades/agent/uniter/networkinfoiaas.go
@@ -5,6 +5,7 @@ package uniter
 
 import (
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -122,7 +123,7 @@ func (n *NetworkInfoIAAS) ProcessAPIRequest(args params.NetworkInfoParams) (para
 
 		if len(info.IngressAddresses) == 0 {
 			ingress := spaceAddressesFromNetworkInfo(n.machineNetworkInfos[space].Info)
-			network.SortAddresses(ingress)
+			sort.Sort(ingress)
 			info.IngressAddresses = ingress.Values()
 		}
 
@@ -183,7 +184,7 @@ func (n *NetworkInfoIAAS) NetworksForRelation(
 		ingress = spaceAddressesFromNetworkInfo(n.machineNetworkInfos[boundSpace].Info)
 	}
 
-	network.SortAddresses(ingress)
+	sort.Sort(ingress)
 
 	egress, err := n.getEgressForRelation(rel, ingress)
 	if err != nil {
@@ -268,14 +269,14 @@ func (n *NetworkInfoIAAS) populateMachineNetworkInfos() error {
 		addrByIP[addr.Value()] = addr
 	}
 
-	spaceAddrs := make([]network.SpaceAddress, len(addrs))
+	spaceAddrs := make(network.SpaceAddresses, len(addrs))
 	for i, addr := range addrs {
 		if spaceAddrs[i], err = network.ConvertToSpaceAddress(addr, n.subs); err != nil {
 			n.populateMachineNetworkInfoErrors(spaceSet, err)
 			return nil
 		}
 	}
-	network.SortAddresses(spaceAddrs)
+	sort.Sort(spaceAddrs)
 
 	logger.Debugf("Looking for address from %v in spaces %v", spaceAddrs, spaceSet.Values())
 

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -6,6 +6,7 @@ package network_test
 import (
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -705,7 +706,7 @@ func (*AddressSuite) TestSortAddresses(c *gc.C) {
 	addrs = append(addrs, network.NewSpaceAddress("6.8.8.8", network.WithSecondary(true)))
 	addrs = append(addrs, network.NewSpaceAddress("172.16.0.1", network.WithSecondary(true)))
 
-	network.SortAddresses(addrs)
+	sort.Sort(addrs)
 	c.Assert(addrs.Values(), jc.DeepEquals, []string{
 		// Public IPv4 addresses on top.
 		"7.8.8.8",
@@ -1036,7 +1037,7 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	network.SortAddresses(addrs)
+	sort.Sort(addrs)
 	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
 		{
 			MachineAddress: network.MachineAddress{

--- a/core/network/hostport_test.go
+++ b/core/network/hostport_test.go
@@ -5,6 +5,7 @@ package network_test
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -187,7 +188,7 @@ func (s *HostPortSuite) assertHostPorts(c *gc.C, actual network.HostPorts, expec
 
 func (s *HostPortSuite) TestSortHostPorts(c *gc.C) {
 	hps := s.makeHostPorts()
-	network.SortHostPorts(hps)
+	sort.Sort(hps)
 	s.assertHostPorts(c, hps.HostPorts(),
 		// Public IPv4 addresses on top.
 		"0.1.2.0:1234",

--- a/state/address.go
+++ b/state/address.go
@@ -492,7 +492,7 @@ func dupeAndSort(a []network.SpaceHostPorts) []network.SpaceHostPorts {
 		for _, hp := range val {
 			inner = append(inner, hp)
 		}
-		network.SortHostPorts(inner)
+		sort.Sort(inner)
 		result = append(result, inner)
 	}
 	sort.Sort(hostsPortsSlice(result))

--- a/state/machine.go
+++ b/state/machine.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -1755,7 +1756,7 @@ func (m *Machine) setAddressesOps(
 	fromNetwork := func(in network.SpaceAddresses, origin network.Origin) []address {
 		sorted := make(network.SpaceAddresses, len(in))
 		copy(sorted, in)
-		network.SortAddresses(sorted)
+		sort.Sort(sorted)
 		return fromNetworkAddresses(sorted, origin)
 	}
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -1747,7 +1747,7 @@ func (s *MachineSuite) TestSetProviderAddresses(c *gc.C) {
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	network.SortAddresses(addresses)
+	sort.Sort(addresses)
 	c.Assert(machine.Addresses(), jc.DeepEquals, addresses)
 }
 

--- a/worker/peergrouper/publish.go
+++ b/worker/peergrouper/publish.go
@@ -5,6 +5,7 @@ package peergrouper
 
 import (
 	"reflect"
+	"sort"
 	"sync"
 
 	"github.com/juju/errors"
@@ -30,7 +31,7 @@ func (s *CachingAPIHostPortsSetter) SetAPIHostPorts(apiServers []network.SpaceHo
 	sorted := make([]network.SpaceHostPorts, len(apiServers))
 	for i, hostPorts := range apiServers {
 		sorted[i] = append(network.SpaceHostPorts{}, hostPorts...)
-		network.SortHostPorts(sorted[i])
+		sort.Sort(sorted[i])
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
Depends on #13169 

Simplifies address sorting and makes it more flexible, so that we can recruit sort order outside of `core/network`.

`sortOrder` becomes `SortOrderMostPublic` accepting the Address indirection instead of a concrete `MachineAddress`.

For both `SpaceAddresses` and `HostPorts` there are no longer intermediate sorting types (nor was there eny good reason for their existence). And the `Sort[Addresses|HostPorts]` methods are removed due to being too shallow - `sort.Sort` is used directly instead.

## QA steps

Mechanical changes verified by unit tests.

## Documentation changes

None.

## Bug reference

N/A
