### PR TITLE
Fix azure instance queries to account for old completed deployments

### DIFF
--- a/provider/azure/deployments.go
+++ b/provider/azure/deployments.go
@@ -6,7 +6,7 @@ package azure
 import (
 	stdcontext "context"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs/context"

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -18,7 +18,7 @@ import (
 	keyvaultservices "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	legacystorage "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage" // Pin this legacy storage API to 2017-10-01 since it's only used for unmanaged storage in models was created in 2.2 or earlier.
 	azurestorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
@@ -136,7 +136,7 @@ type azureEnviron struct {
 var _ environs.Environ = (*azureEnviron)(nil)
 
 // SetCloudSpec is specified in the environs.Environ interface.
-func (env *azureEnviron) SetCloudSpec(ctx stdcontext.Context, cloud environscloudspec.CloudSpec) error {
+func (env *azureEnviron) SetCloudSpec(_ stdcontext.Context, cloud environscloudspec.CloudSpec) error {
 	if err := validateCloudSpec(cloud); err != nil {
 		return errors.Annotate(err, "validating cloud spec")
 	}
@@ -164,11 +164,9 @@ func (env *azureEnviron) SetCloudSpec(ctx stdcontext.Context, cloud environsclou
 	// If no user specified resource group, make one from the model UUID.
 	if env.resourceGroup == "" {
 		modelTag := names.NewModelTag(cfg.UUID())
-		resourceGroupName, err := env.resourceGroupName(modelTag, cfg.Name())
-		if err != nil {
+		if env.resourceGroup, err = env.resourceGroupName(modelTag, cfg.Name()); err != nil {
 			return errors.Trace(err)
 		}
-		env.resourceGroup = resourceGroupName
 	}
 	env.modelName = cfg.Name()
 
@@ -233,7 +231,7 @@ func (env *azureEnviron) initEnviron() error {
 }
 
 // PrepareForBootstrap is part of the Environ interface.
-func (env *azureEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, controllerName string) error {
+func (env *azureEnviron) PrepareForBootstrap(ctx environs.BootstrapContext, _ string) error {
 	if ctx.ShouldVerifyCredentials() {
 		if err := verifyCredentials(env, nil); err != nil {
 			return errors.Trace(err)
@@ -292,14 +290,14 @@ func (env *azureEnviron) Bootstrap(
 // initResourceGroup creates a resource group for this environment.
 func (env *azureEnviron) initResourceGroup(ctx context.ProviderCallContext, controllerUUID string, existingResourceGroup, controller bool) error {
 	env.mu.Lock()
-	tags := tags.ResourceTags(
+	resourceTags := tags.ResourceTags(
 		names.NewModelTag(env.config.Config.UUID()),
 		names.NewControllerTag(controllerUUID),
 		env.config,
 	)
 	env.mu.Unlock()
 
-	resourceGroupsClient := resources.GroupsClient{env.resources}
+	resourceGroupsClient := resources.GroupsClient{BaseClient: env.resources}
 	if existingResourceGroup {
 		logger.Debugf("using existing resource group %q for model %q", env.resourceGroup, env.modelName)
 		g, err := resourceGroupsClient.Get(ctx, env.resourceGroup)
@@ -313,7 +311,7 @@ func (env *azureEnviron) initResourceGroup(ctx context.ProviderCallContext, cont
 		logger.Debugf("creating resource group %q for model %q", env.resourceGroup, env.modelName)
 		if _, err := resourceGroupsClient.CreateOrUpdate(ctx, env.resourceGroup, resources.Group{
 			Location: to.StringPtr(env.location),
-			Tags:     *to.StringMapPtr(tags),
+			Tags:     *to.StringMapPtr(resourceTags),
 		}); err != nil {
 			return errorutils.HandleCredentialError(errors.Annotate(err, "creating resource group"), ctx)
 		}
@@ -326,7 +324,7 @@ func (env *azureEnviron) initResourceGroup(ctx context.ProviderCallContext, cont
 		// e.g. those made by the firewaller. For the controller model,
 		// we fold the creation of these resources into the bootstrap
 		// machine's deployment.
-		if err := env.createCommonResourceDeployment(ctx, tags, nil); err != nil {
+		if err := env.createCommonResourceDeployment(ctx, resourceTags, nil); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -360,7 +358,7 @@ func (env *azureEnviron) createCommonResourceDeployment(
 	// Eventually we should have Create called asynchronously, but
 	// until then we do this, and ensure that the deployment has
 	// completed before we schedule additional deployments.
-	deploymentsClient := resources.DeploymentsClient{env.resources}
+	deploymentsClient := resources.DeploymentsClient{BaseClient: env.resources}
 	deploymentsClient.ResponseInspector = asyncCreationRespondDecorator(
 		deploymentsClient.ResponseInspector,
 	)
@@ -379,15 +377,15 @@ func (env *azureEnviron) createCommonResourceDeployment(
 
 // ControllerInstances is specified in the Environ interface.
 func (env *azureEnviron) ControllerInstances(ctx context.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
-	instances, err := env.allInstances(ctx, env.resourceGroup, false, true)
+	inst, err := env.allInstances(ctx, env.resourceGroup, false, controllerUUID)
 	if err != nil {
 		return nil, err
 	}
-	if len(instances) == 0 {
+	if len(inst) == 0 {
 		return nil, environs.ErrNoInstances
 	}
-	ids := make([]instance.Id, len(instances))
-	for i, inst := range instances {
+	ids := make([]instance.Id, len(inst))
+	for i, inst := range inst {
 		ids[i] = inst.Id()
 	}
 	return ids, nil
@@ -514,7 +512,7 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 	// Identify the instance type and image to provision.
 	instanceSpec, err := findInstanceSpec(
 		ctx,
-		compute.VirtualMachineImagesClient{env.compute},
+		compute.VirtualMachineImagesClient{BaseClient: env.compute},
 		instanceTypes,
 		&instances.InstanceConstraint{
 			Region:      env.location,
@@ -596,7 +594,7 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 	// Note: the instance is initialised without addresses to keep the
 	// API chatter down. We will refresh the instance if we need to know
 	// the addresses.
-	inst := &azureInstance{vmName, "Creating", env, nil, nil}
+	inst := &azureInstance{vmName, compute.ProvisioningStateCreating, env, nil, nil}
 	amd64 := arch.AMD64
 	hc := &instance.HardwareCharacteristics{
 		Arch:     &amd64,
@@ -655,7 +653,7 @@ func (env *azureEnviron) createVirtualMachine(
 	}
 
 	var nicDependsOn, vmDependsOn []string
-	var resources []armtemplates.Resource
+	var res []armtemplates.Resource
 	bootstrapping := instanceConfig.Bootstrap != nil
 	// We only need to deal with creating network resources
 	// if the user has not specified their own to use.
@@ -663,7 +661,7 @@ func (env *azureEnviron) createVirtualMachine(
 		// We're starting the bootstrap machine, so we will create the
 		// networking resources in the same deployment.
 		networkResources, dependsOn := networkTemplateResources(env.location, envTags, apiPorts, nil)
-		resources = append(resources, networkResources...)
+		res = append(res, networkResources...)
 		nicDependsOn = append(nicDependsOn, dependsOn...)
 	}
 	if !bootstrapping {
@@ -744,7 +742,7 @@ func (env *azureEnviron) createVirtualMachine(
 			// Availability needs to be 'Aligned' to support managed disks.
 			availabilityStorageOptions = &armtemplates.Sku{Name: "Aligned"}
 		}
-		resources = append(resources, armtemplates.Resource{
+		res = append(res, armtemplates.Resource{
 			APIVersion: computeAPIVersion,
 			Type:       "Microsoft.Compute/availabilitySets",
 			Name:       availabilitySetName,
@@ -782,7 +780,7 @@ func (env *azureEnviron) createVirtualMachine(
 		if env.config.loadBalancerSkuName == string(network.LoadBalancerSkuNameBasic) {
 			publicIPAddressAllocationMethod = network.Dynamic // preserve the settings that were used in Juju 2.4 and earlier
 		}
-		resources = append(resources, armtemplates.Resource{
+		res = append(res, armtemplates.Resource{
 			APIVersion: networkAPIVersion,
 			Type:       "Microsoft.Network/publicIPAddresses",
 			Name:       publicIPAddressName,
@@ -822,7 +820,7 @@ func (env *azureEnviron) createVirtualMachine(
 			Name:                                     to.StringPtr(ipConfigName),
 			InterfaceIPConfigurationPropertiesFormat: ipConfig,
 		}}
-		resources = append(resources, armtemplates.Resource{
+		res = append(res, armtemplates.Resource{
 			APIVersion: networkAPIVersion,
 			Type:       "Microsoft.Network/networkInterfaces",
 			Name:       nicName,
@@ -843,7 +841,7 @@ func (env *azureEnviron) createVirtualMachine(
 		})
 	}
 
-	resources = append(resources, armtemplates.Resource{
+	res = append(res, armtemplates.Resource{
 		APIVersion: computeAPIVersion,
 		Type:       "Microsoft.Compute/virtualMachines",
 		Name:       vmName,
@@ -855,11 +853,9 @@ func (env *azureEnviron) createVirtualMachine(
 					instanceSpec.InstanceType.Name,
 				),
 			},
-			StorageProfile: storageProfile,
-			OsProfile:      osProfile,
-			NetworkProfile: &compute.NetworkProfile{
-				&nics,
-			},
+			StorageProfile:  storageProfile,
+			OsProfile:       osProfile,
+			NetworkProfile:  &compute.NetworkProfile{NetworkInterfaces: &nics},
 			AvailabilitySet: availabilitySetSubResource,
 		},
 		DependsOn: vmDependsOn,
@@ -875,7 +871,7 @@ func (env *azureEnviron) createVirtualMachine(
 				err, "creating virtual machine extension",
 			)
 		}
-		resources = append(resources, armtemplates.Resource{
+		res = append(res, armtemplates.Resource{
 			APIVersion: computeAPIVersion,
 			Type:       "Microsoft.Compute/virtualMachines/extensions",
 			Name:       vmName + "/" + extensionName,
@@ -887,7 +883,7 @@ func (env *azureEnviron) createVirtualMachine(
 	}
 
 	logger.Debugf("- creating virtual machine deployment in %q", env.resourceGroup)
-	template := armtemplates.Template{Resources: resources}
+	template := armtemplates.Template{Resources: res}
 	// NOTE(axw) VMs take a long time to go to "Succeeded", so we do not
 	// block waiting for them to be fully provisioned. This means we won't
 	// return an error from StartInstance if the VM fails provisioning;
@@ -1008,8 +1004,8 @@ func (env *azureEnviron) waitCommonResourcesCreatedLocked() (*resources.Deployme
 			return deploymentIncompleteError{errors.New("deployment incomplete")}
 		}
 
-		state := to.String(result.Properties.ProvisioningState)
-		if state == "Succeeded" {
+		state := result.Properties.ProvisioningState
+		if state == resources.ProvisioningStateSucceeded {
 			// The deployment has succeeded, so the resources are
 			// ready for use.
 			deployment = &result
@@ -1017,7 +1013,9 @@ func (env *azureEnviron) waitCommonResourcesCreatedLocked() (*resources.Deployme
 		}
 		err = errors.Errorf("common resource deployment status is %q", state)
 		switch state {
-		case "Canceled", "Failed", "Deleted":
+		case resources.ProvisioningStateCanceled,
+			resources.ProvisioningStateFailed,
+			resources.ProvisioningStateDeleted:
 		default:
 			err = deploymentIncompleteError{err}
 		}
@@ -1094,7 +1092,7 @@ func newStorageProfile(
 	publisher := urnParts[0]
 	offer := urnParts[1]
 	sku := urnParts[2]
-	version := urnParts[3]
+	vers := urnParts[3]
 
 	osDiskName := vmName
 	osDiskSizeGB := mibToGB(instanceSpec.InstanceType.RootDisk)
@@ -1122,7 +1120,7 @@ func newStorageProfile(
 			Publisher: to.StringPtr(publisher),
 			Offer:     to.StringPtr(offer),
 			Sku:       to.StringPtr(sku),
-			Version:   to.StringPtr(version),
+			Version:   to.StringPtr(vers),
 		},
 		OsDisk: osDisk,
 	}, nil
@@ -1253,7 +1251,7 @@ func (env *azureEnviron) StopInstances(ctx context.ProviderCallContext, ids ...i
 	instancePips, err := instancePublicIPAddresses(
 		ctx,
 		env.resourceGroup,
-		network.PublicIPAddressesClient{env.network},
+		network.PublicIPAddressesClient{BaseClient: env.network},
 	)
 	if err != nil {
 		return errors.Trace(err)
@@ -1464,49 +1462,9 @@ func (env *azureEnviron) deleteVirtualMachine(
 	return nil
 }
 
-// Instances is specified in the Environ interface.
-func (env *azureEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
-	return env.instances(ctx, env.resourceGroup, ids, true /* refresh addresses */)
-}
-
-func (env *azureEnviron) instances(
-	ctx context.ProviderCallContext,
-	resourceGroup string,
-	ids []instance.Id,
-	refreshAddresses bool,
-) ([]instances.Instance, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
-	all, err := env.allInstances(ctx, resourceGroup, refreshAddresses, false)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	byId := make(map[instance.Id]instances.Instance)
-	for _, inst := range all {
-		byId[inst.Id()] = inst
-	}
-	var found int
-	matching := make([]instances.Instance, len(ids))
-	for i, id := range ids {
-		inst, ok := byId[id]
-		if !ok {
-			continue
-		}
-		matching[i] = inst
-		found++
-	}
-	if found == 0 {
-		return nil, environs.ErrNoInstances
-	} else if found < len(ids) {
-		return matching, environs.ErrPartialInstances
-	}
-	return matching, nil
-}
-
 // AdoptResources is part of the Environ interface.
-func (env *azureEnviron) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
-	groupClient := resources.GroupsClient{env.resources}
+func (env *azureEnviron) AdoptResources(ctx context.ProviderCallContext, controllerUUID string, _ version.Number) error {
+	groupClient := resources.GroupsClient{BaseClient: env.resources}
 
 	err := env.updateGroupControllerTag(ctx, &groupClient, env.resourceGroup, controllerUUID)
 	if err != nil {
@@ -1516,12 +1474,12 @@ func (env *azureEnviron) AdoptResources(ctx context.ProviderCallContext, control
 		return errors.Trace(err)
 	}
 
-	apiVersions, err := collectAPIVersions(ctx, resources.ProvidersClient{env.resources})
+	apiVersions, err := collectAPIVersions(ctx, resources.ProvidersClient{BaseClient: env.resources})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	resourceClient := resources.Client{env.resources}
+	resourceClient := resources.Client{BaseClient: env.resources}
 	res, err := resourceClient.ListByResourceGroupComplete(ctx, env.resourceGroup, "", "", nil)
 	if err != nil {
 		return errorutils.HandleCredentialError(errors.Annotate(err, "listing resources"), ctx)
@@ -1604,25 +1562,170 @@ func (env *azureEnviron) updateResourceControllerTag(
 	return errorutils.HandleCredentialError(errors.Annotatef(err, "updating controller for %q", to.String(resource.Name)), ctx)
 }
 
+var (
+	runningInstStates = []compute.ProvisioningState{
+		compute.ProvisioningStateCreating,
+		compute.ProvisioningStateUpdating,
+		compute.ProvisioningStateMigrating,
+		compute.ProvisioningStateSucceeded,
+	}
+)
+
+// Instances is specified in the Environ interface.
+func (env *azureEnviron) Instances(ctx context.ProviderCallContext, ids []instance.Id) ([]instances.Instance, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	insts := make([]instances.Instance, len(ids))
+	// Make a series of requests to cope with eventual consistency.
+	// Each request will attempt to add more instances to the requested set.
+	err := retry.Call(retry.CallArgs{
+		Func: func() error {
+			var need []instance.Id
+			for i, inst := range insts {
+				if inst == nil {
+					need = append(need, ids[i])
+				}
+			}
+			return env.gatherInstances(ctx, need, insts, env.resourceGroup, true)
+		},
+		IsFatalError: func(err error) bool {
+			return err != environs.ErrPartialInstances
+		},
+		Attempts:    -1,
+		Delay:       200 * time.Millisecond,
+		MaxDuration: 5 * time.Second,
+		Clock:       env.provider.config.RetryClock,
+	})
+
+	if err == environs.ErrPartialInstances {
+		for _, inst := range insts {
+			if inst != nil {
+				return insts, environs.ErrPartialInstances
+			}
+		}
+		return nil, environs.ErrNoInstances
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return insts, nil
+}
+
 // AllInstances is specified in the InstanceBroker interface.
 func (env *azureEnviron) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-	return env.allInstances(ctx, env.resourceGroup, true /* refresh addresses */, false /* all instances */)
+	return env.allInstances(ctx, env.resourceGroup, true, "")
 }
 
 // AllRunningInstances is specified in the InstanceBroker interface.
 func (env *azureEnviron) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-	return env.AllInstances(ctx)
+	return env.allInstances(ctx, env.resourceGroup, true, "", runningInstStates...)
 }
 
-// allInstances returns all of the instances in the given resource group,
-// and optionally ensures that each instance's addresses are up-to-date.
+// gatherInstances tries to get information on each instance id
+// whose corresponding insts slot is nil.
+// This function returns environs.ErrPartialInstances if the
+// insts slice has not been completely filled.
+func (env *azureEnviron) gatherInstances(
+	ctx context.ProviderCallContext,
+	ids []instance.Id,
+	insts []instances.Instance,
+	resourceGroup string,
+	refreshAddresses bool,
+	instStates ...compute.ProvisioningState,
+) error {
+	allInst, err := env.allInstances(ctx, resourceGroup, refreshAddresses, "", instStates...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	numFound := 0
+	// For each requested id, add it to the returned instances
+	// if we find it in the latest queried cloud instances.
+	for i, id := range ids {
+		if insts[i] != nil {
+			numFound++
+			continue
+		}
+		for _, inst := range allInst {
+			if inst.Id() != id {
+				continue
+			}
+			insts[i] = inst
+			numFound++
+		}
+	}
+	if numFound < len(ids) {
+		return environs.ErrPartialInstances
+	}
+	return nil
+}
+
+// allInstances returns all instances in the environment
+// with one of the specified instance states.
+// If no instance states are specified, then return all instances.
 func (env *azureEnviron) allInstances(
 	ctx context.ProviderCallContext,
 	resourceGroup string,
 	refreshAddresses bool,
-	controllerOnly bool,
+	controllerUUID string,
+	instStates ...compute.ProvisioningState,
 ) ([]instances.Instance, error) {
-	deploymentsClient := resources.DeploymentsClient{env.resources}
+	// Instances may be queued for deployment but provisioning has not yet started.
+	queued, err := env.allQueuedInstances(ctx, resourceGroup, controllerUUID != "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	provisioned, err := env.allProvisionedInstances(ctx, resourceGroup, controllerUUID, instStates...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Any provisioned or provisioning instances take precedence
+	// over any entries in the queued slice.
+	seenInst := set.NewStrings()
+	azureInstances := provisioned
+	for _, p := range provisioned {
+		seenInst.Add(string(p.Id()))
+	}
+	for _, q := range queued {
+		if seenInst.Contains(string(q.Id())) {
+			continue
+		}
+		azureInstances = append(azureInstances, q)
+	}
+
+	// Get the instance addresses if needed.
+	if len(azureInstances) > 0 && refreshAddresses {
+		if err := setInstanceAddresses(
+			ctx,
+			resourceGroup,
+			network.InterfacesClient{env.network},
+			network.PublicIPAddressesClient{env.network},
+			azureInstances,
+		); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	var result []instances.Instance
+	for _, inst := range azureInstances {
+		result = append(result, inst)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Id() < result[j].Id()
+	})
+	return result, nil
+}
+
+// allQueuedInstances returns any pending or failed machine deployments
+// in the given resource group.
+func (env *azureEnviron) allQueuedInstances(
+	ctx context.ProviderCallContext,
+	resourceGroup string,
+	controllerOnly bool,
+) ([]*azureInstance, error) {
+	deploymentsClient := resources.DeploymentsClient{BaseClient: env.resources}
 	deploymentsResult, err := deploymentsClient.ListByResourceGroupComplete(ctx, resourceGroup, "", nil)
 	if err != nil {
 		if isNotFoundResult(deploymentsResult.Response().Response) {
@@ -1642,6 +1745,20 @@ func (env *azureEnviron) allInstances(
 			return nil, errors.Annotate(err, "listing resources")
 		}
 		deployment := deploymentsResult.Value()
+		deployProvisioningState := resources.ProvisioningStateNotSpecified
+		if deployment.Properties != nil {
+			deployProvisioningState = deployment.Properties.ProvisioningState
+		}
+		switch deployProvisioningState {
+		case resources.ProvisioningStateAccepted,
+			resources.ProvisioningStateCreating,
+			resources.ProvisioningStateRunning,
+			resources.ProvisioningStateFailed,
+			resources.ProvisioningStateCanceled,
+			resources.ProvisioningStateNotSpecified:
+		default:
+			continue
+		}
 		name := to.String(deployment.Name)
 		if _, err := names.ParseMachineTag(name); err != nil {
 			// Deployments we create for Juju machines are named
@@ -1656,28 +1773,16 @@ func (env *azureEnviron) allInstances(
 		if controllerOnly && !isControllerDeployment(deployment) {
 			continue
 		}
-		provisioningState := to.String(deployment.Properties.ProvisioningState)
+		provisioningState := compute.ProvisioningStateCreating
+		switch deployProvisioningState {
+		case resources.ProvisioningStateFailed,
+			resources.ProvisioningStateCanceled:
+			provisioningState = compute.ProvisioningStateFailed
+		}
 		inst := &azureInstance{name, provisioningState, env, nil, nil}
 		azureInstances = append(azureInstances, inst)
 	}
-
-	if len(azureInstances) > 0 && refreshAddresses {
-		if err := setInstanceAddresses(
-			ctx,
-			resourceGroup,
-			network.InterfacesClient{env.network},
-			network.PublicIPAddressesClient{env.network},
-			azureInstances,
-		); err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-
-	instances := make([]instances.Instance, len(azureInstances))
-	for i, inst := range azureInstances {
-		instances[i] = inst
-	}
-	return instances, nil
+	return azureInstances, nil
 }
 
 func isControllerDeployment(deployment resources.DeploymentExtended) bool {
@@ -1698,6 +1803,71 @@ func isControllerDeployment(deployment resources.DeploymentExtended) bool {
 		}
 	}
 	return false
+}
+
+// allProvisionedInstances returns all of the instances
+// in the given resource group.
+func (env *azureEnviron) allProvisionedInstances(
+	ctx context.ProviderCallContext,
+	resourceGroup string,
+	controllerUUID string,
+	instStates ...compute.ProvisioningState,
+) ([]*azureInstance, error) {
+	vmClient := compute.VirtualMachinesClient{BaseClient: env.compute}
+	vmResult, err := vmClient.ListComplete(ctx, resourceGroup)
+	if err != nil {
+		if isNotFoundResult(vmResult.Response().Response) {
+			// This will occur if the resource group does not
+			// exist, e.g. in a fresh hosted environment.
+			return nil, nil
+		}
+		return nil, errorutils.HandleCredentialError(errors.Trace(err), ctx)
+	}
+	if vmResult.Response().IsEmpty() {
+		return nil, nil
+	}
+
+	var azureInstances []*azureInstance
+	for ; vmResult.NotDone(); err = vmResult.NextWithContext(ctx) {
+		if err != nil {
+			return nil, errors.Annotate(err, "listing instances")
+		}
+		vm := vmResult.Value()
+		name := to.String(vm.Name)
+		provisioningState := compute.ProvisioningState(to.String(vm.ProvisioningState))
+		if len(instStates) > 0 {
+			haveState := false
+			for _, wantState := range instStates {
+				if provisioningState == wantState {
+					haveState = true
+					break
+				}
+			}
+			if !haveState {
+				continue
+			}
+		}
+		if !isControllerInstance(vm, controllerUUID) {
+			continue
+		}
+		inst := &azureInstance{name, provisioningState, env, nil, nil}
+		azureInstances = append(azureInstances, inst)
+	}
+	return azureInstances, nil
+}
+
+func isControllerInstance(vm compute.VirtualMachine, controllerUUID string) bool {
+	if controllerUUID == "" {
+		return true
+	}
+	vmTags := vm.Tags
+	if v, ok := vmTags[tags.JujuIsController]; !ok || to.String(v) != "true" {
+		return false
+	}
+	if v, ok := vmTags[tags.JujuController]; !ok || to.String(v) != controllerUUID {
+		return false
+	}
+	return true
 }
 
 // Destroy is specified in the Environ interface.
@@ -2221,9 +2391,9 @@ func (env *azureEnviron) getStorageAccountKeyLocked(accountName string, refresh 
 }
 
 // Region is specified in the HasRegion interface.
-func (e *azureEnviron) Region() (simplestreams.CloudSpec, error) {
+func (env *azureEnviron) Region() (simplestreams.CloudSpec, error) {
 	return simplestreams.CloudSpec{
-		Region:   e.cloud.Region,
-		Endpoint: e.cloud.Endpoint,
+		Region:   env.cloud.Region,
+		Endpoint: env.cloud.Endpoint,
 	}, nil
 }

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/Azure/go-autorest/autorest/mocks"
 	"github.com/Azure/go-autorest/autorest/to"
 	jc "github.com/juju/testing/checkers"

--- a/provider/azure/utils.go
+++ b/provider/azure/utils.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/juju/errors"

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1603,7 +1603,7 @@ func (e *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Ins
 
 // AllRunningInstances is part of the environs.InstanceBroker interface.
 func (e *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
-	return e.allInstancesByState(ctx, "pending", "running")
+	return e.allInstancesByState(ctx, aliveInstanceStates...)
 }
 
 // allInstancesByState returns all instances in the environment


### PR DESCRIPTION
Using a custom Azure resource group, you can bootstrap and then destroy the controller and re-use the group for the next bootstrap. However, Juju had a buggy method of counting machines in a resource group - it would query the completed Deployment records. Because these records are retained on the group, the next bootstrap would think there are too many machines and exit.

This PR changes how machines are queried - it still has to look for deployments because there's a window where the deployment is created but the machine has not shown up yet. So Juju will now query any _incomplete_  deployments, and augment that list with any machines as well. Any machines found take precedence over deployments. The method to gather instances uses the same logic as for EC2 - a short retry loop to allow the requested instances time to get created.

Also fix some lint issues and the resources API version needed to be bumped.

## QA steps

bootstrap to a previously created resource group, add a machine to get 2 azure deployments recorded, destroy the controller, manually delete the resource group contents, and bootstrap again
```plain
juju bootstrap --config resource-group-name=test --no-default-model azure/eastus aztest
juju add-machine
juju destroy controller aztest
```
use the azure portal to see there's 2 Deployments recorded; manually delete resource group content
bootstrap again
`juju bootstrap --config resource-group-name=test --no-default-model azure/eastus`

Previously this would fail as per the bug.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1935979
