### PR TITLE
Export-bundle: Handle local charms

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -541,6 +541,11 @@ func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults
 		charmURL := application.CharmURL()
 		if charm.CharmHub.Matches(curl.Schema) {
 			charmURL = curl.Name
+		} else if charm.Local.Matches(curl.Schema) {
+			charmURL = fmt.Sprintf("local:%s", curl.Name)
+			if curl.Revision >= 0 {
+				charmURL = fmt.Sprintf("%s-%d", charmURL, curl.Revision)
+			}
 		}
 
 		var channel string


### PR DESCRIPTION
The following ensures that we don't export anything but the charm name
and revision for local charms. It's required that we export the local:
prefix to ensure that they're not confused with charmhub charm names
(they require no prefix).

## QA steps

```sh
$ juju bootstrap lxd test
$ cd testcharms/charm-hub/charms/juju-qa-test
$ charmcraft build
$ cd -
$ juju deploy ./testcharms/charm-hub/charms/juju-qa-test/juju-qa-test.charm
$ juju export-bundle
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1936276