### PR TITLE
Scripts: Juju inspect

### DIFF
--- a/scripts/juju-inspect/Makefile
+++ b/scripts/juju-inspect/Makefile
@@ -1,0 +1,13 @@
+PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env GOARCH)
+
+BUILD_DIR ?= $(PROJECT_DIR)/_build
+BIN_DIR = ${BUILD_DIR}/${GOOS}_${GOARCH}/bin
+
+build:
+	@go build -o ${BIN_DIR}/juju-inspect
+
+install:
+	@go install 

--- a/scripts/juju-inspect/Makefile
+++ b/scripts/juju-inspect/Makefile
@@ -3,10 +3,11 @@ PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 
-BUILD_DIR ?= $(PROJECT_DIR)/_build
+BUILD_DIR ?= $(abspath $(PROJECT_DIR)/../../_build)
 BIN_DIR = ${BUILD_DIR}/${GOOS}_${GOARCH}/bin
 
 build:
+	echo ${BUILD_DIR}
 	@go build -o ${BIN_DIR}/juju-inspect
 
 install:

--- a/scripts/juju-inspect/README.md
+++ b/scripts/juju-inspect/README.md
@@ -1,0 +1,30 @@
+# juju-inspect
+
+Juju inspect is intended to analyse engine reports from a Juju controller. You
+can feed it multiple engine reports and it will tell you various information
+about the state of the controllers.
+
+### Run
+
+Running it is extremely simple:
+
+```sh
+go run main.go report_1 report_2 report_3
+```
+
+The output should look like:
+
+```sh
+Analysis of Engine Report:
+
+Raft Leader:
+        machine-2 is the leader.
+
+Mongo Primary:
+        There are no primaries found.
+
+Pubsub Forwarder:
+        machine-0 is connected to the following: [machine-1]
+        machine-1 is connected to the following: [machine-0]
+        machine-2 is connected to the following: [machine-0 machine-1]
+```

--- a/scripts/juju-inspect/README.md
+++ b/scripts/juju-inspect/README.md
@@ -1,7 +1,7 @@
 # juju-inspect
 
 Juju inspect is intended to analyse engine reports from a Juju controller. You
-can feed it multiple engine reports and it will tell you various information
+can feed it multiple engine reports, and it will tell you various information
 about the state of the controllers.
 
 ### Run
@@ -9,7 +9,8 @@ about the state of the controllers.
 Running it is extremely simple:
 
 ```sh
-go run main.go report_1 report_2 report_3
+make install
+juju-inspect report_1 report_2 report_3
 ```
 
 The output should look like:
@@ -18,13 +19,26 @@ The output should look like:
 Analysis of Engine Report:
 
 Raft Leader:
-        machine-2 is the leader.
+        machine-1 is the leader.
 
 Mongo Primary:
-        There are no primaries found.
+        machine-2 is the primary.
 
 Pubsub Forwarder:
-        machine-0 is connected to the following: [machine-1]
-        machine-1 is connected to the following: [machine-0]
         machine-2 is connected to the following: [machine-0 machine-1]
+        machine-0 is connected to the following: [machine-1 machine-2]
+        machine-1 is connected to the following: [machine-0 machine-2]
+
+Manifolds:
+        machine-0 has 69 manifolds
+        machine-1 has 69 manifolds
+        machine-2 has 69 manifolds
+
+Start Counts:
+        machine-0 start-count: 516
+          - max: "is-primary-controller-flag" with: 189
+        machine-1 start-count: 421
+          - max: "is-primary-controller-flag" with: 178
+        machine-2 start-count: 498
+          - max: "machine-action-runner" with: 274
 ```

--- a/scripts/juju-inspect/main.go
+++ b/scripts/juju-inspect/main.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/juju/scripts/juju-inspect/rules"
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	files := os.Args[1:]
+	if len(files) == 0 {
+		log.Fatal("expected at least on file")
+	}
+	allRules := []Rule{
+		rules.NewRaftRule(),
+		rules.NewMongoRule(),
+		rules.NewPubsubRule(),
+		rules.NewManifoldsRule(),
+		rules.NewStartCountRule(),
+	}
+
+	if len(files) == 1 {
+		matches, err := filepath.Glob(files[0])
+		if err == nil && len(matches) > 0 {
+			files = matches
+		}
+	}
+
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		row1, _, err := bufio.NewReader(f).ReadLine()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = f.Seek(int64(len(row1)), io.SeekStart)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var report rules.Report
+		if err := yaml.NewDecoder(f).Decode(&report); err != nil {
+			log.Fatal(err)
+		}
+
+		// TODO (pick a better name somehow - agent.name?)
+		name := report.Manifolds["agent"].Report.Agent
+		for _, rule := range allRules {
+			rule.Run(name, report)
+		}
+	}
+
+	fmt.Println("")
+	fmt.Println("Analysis of Engine Report:")
+	fmt.Println("")
+	for _, rule := range allRules {
+		fmt.Println(rule.Summary())
+
+		analysis := rule.Analyse()
+
+		buf := new(bytes.Buffer)
+		scanner := bufio.NewScanner(strings.NewReader(analysis))
+		for scanner.Scan() {
+			fmt.Fprintf(buf, "\t%s\n", scanner.Text())
+		}
+
+		fmt.Printf("%s\n", buf.String())
+	}
+}
+
+type Rule interface {
+	Run(string, rules.Report)
+	Summary() string
+	Analyse() string
+}

--- a/scripts/juju-inspect/main.go
+++ b/scripts/juju-inspect/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/juju/scripts/juju-inspect/rules"
+	"github.com/juju/version/v2"
 	"gopkg.in/yaml.v2"
 )
 
@@ -96,5 +97,6 @@ type Rule interface {
 }
 
 type AgentReport struct {
-	Agent string `yaml:"agent"`
+	Agent   string         `yaml:"agent"`
+	Version version.Number `yaml:"version"`
 }

--- a/scripts/juju-inspect/main.go
+++ b/scripts/juju-inspect/main.go
@@ -18,7 +18,9 @@ import (
 )
 
 func main() {
+	var includeNested bool
 	var startCountAmount int
+	flag.BoolVar(&includeNested, "include-nested", false, "inlcude nested agents")
 	flag.IntVar(&startCountAmount, "start-count-amount", 3, "number of start counts to show")
 	flag.Parse()
 
@@ -30,8 +32,8 @@ func main() {
 		rules.NewRaftRule(),
 		rules.NewMongoRule(),
 		rules.NewPubsubRule(),
-		rules.NewManifoldsRule(),
-		rules.NewStartCountRule(startCountAmount),
+		rules.NewManifoldsRule(includeNested),
+		rules.NewStartCountRule(includeNested, startCountAmount),
 	}
 
 	if len(files) == 1 {

--- a/scripts/juju-inspect/main.go
+++ b/scripts/juju-inspect/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -17,7 +18,11 @@ import (
 )
 
 func main() {
-	files := os.Args[1:]
+	var startCountAmount int
+	flag.IntVar(&startCountAmount, "start-count-amount", 3, "number of start counts to show")
+	flag.Parse()
+
+	files := flag.Args()
 	if len(files) == 0 {
 		log.Fatal("expected at least on file")
 	}
@@ -26,7 +31,7 @@ func main() {
 		rules.NewMongoRule(),
 		rules.NewPubsubRule(),
 		rules.NewManifoldsRule(),
-		rules.NewStartCountRule(),
+		rules.NewStartCountRule(startCountAmount),
 	}
 
 	if len(files) == 1 {

--- a/scripts/juju-inspect/main.go
+++ b/scripts/juju-inspect/main.go
@@ -42,6 +42,8 @@ func main() {
 			log.Fatal(err)
 		}
 
+		// Engine reports aren't actually valid yaml files. Instead they have a
+		// header that isn't a comment! This code exists to skip that line.
 		row1, _, err := bufio.NewReader(f).ReadLine()
 		if err != nil {
 			log.Fatal(err)

--- a/scripts/juju-inspect/rules/entities.go
+++ b/scripts/juju-inspect/rules/entities.go
@@ -3,24 +3,24 @@
 
 package rules
 
+import "gopkg.in/yaml.v3"
+
 type Report struct {
 	Manifolds map[string]Worker `yaml:"manifolds"`
 }
 
 type Worker struct {
-	Inputs     []string     `yaml:"inputs"`
-	Report     WorkerReport `yaml:"report"`
-	StartCount int          `yaml:"start-count"`
-	Started    string       `yaml:"started"`
-	State      string       `yaml:"state"`
+	Inputs     []string    `yaml:"inputs"`
+	Report     interface{} `yaml:"report"`
+	StartCount int         `yaml:"start-count"`
+	Started    string      `yaml:"started"`
+	State      string      `yaml:"state"`
 }
 
-type WorkerReport struct {
-	Agent   string                  `yaml:"agent"`
-	State   string                  `yaml:"state"`
-	Targets map[string]WorkerTarget `yaml:"targets"`
-}
-
-type WorkerTarget struct {
-	Status string
+func (w Worker) UnmarshalReport(out interface{}) error {
+	b, err := yaml.Marshal(w.Report)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(b, out)
 }

--- a/scripts/juju-inspect/rules/entities.go
+++ b/scripts/juju-inspect/rules/entities.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rules
+
+type Report struct {
+	Manifolds map[string]Worker `yaml:"manifolds"`
+}
+
+type Worker struct {
+	Inputs     []string     `yaml:"inputs"`
+	Report     WorkerReport `yaml:"report"`
+	StartCount int          `yaml:"start-count"`
+	Started    string       `yaml:"started"`
+	State      string       `yaml:"state"`
+}
+
+type WorkerReport struct {
+	Agent   string                  `yaml:"agent"`
+	State   string                  `yaml:"state"`
+	Targets map[string]WorkerTarget `yaml:"targets"`
+}
+
+type WorkerTarget struct {
+	Status string
+}

--- a/scripts/juju-inspect/rules/manifolds.go
+++ b/scripts/juju-inspect/rules/manifolds.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rules
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type ManifoldsRule struct {
+	counts map[string]int
+}
+
+func NewManifoldsRule() *ManifoldsRule {
+	return &ManifoldsRule{
+		counts: make(map[string]int),
+	}
+}
+
+func (r *ManifoldsRule) Run(name string, report Report) {
+	r.counts[name] = len(report.Manifolds)
+}
+
+func (r *ManifoldsRule) Summary() string {
+	return "Manifolds:"
+}
+
+func (r *ManifoldsRule) Analyse() string {
+	buf := new(bytes.Buffer)
+	for ctrl, t := range r.counts {
+		fmt.Fprintf(buf, "%s has %d manifolds\n", ctrl, t)
+	}
+	return buf.String()
+}

--- a/scripts/juju-inspect/rules/manifolds.go
+++ b/scripts/juju-inspect/rules/manifolds.go
@@ -4,8 +4,8 @@
 package rules
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 )
 
 type ManifoldsRule struct {
@@ -18,18 +18,16 @@ func NewManifoldsRule() *ManifoldsRule {
 	}
 }
 
-func (r *ManifoldsRule) Run(name string, report Report) {
+func (r *ManifoldsRule) Run(name string, report Report) error {
 	r.counts[name] = len(report.Manifolds)
+	return nil
 }
 
-func (r *ManifoldsRule) Summary() string {
-	return "Manifolds:"
-}
-
-func (r *ManifoldsRule) Analyse() string {
-	buf := new(bytes.Buffer)
+func (r *ManifoldsRule) Write(w io.Writer) {
+	fmt.Fprintln(w, "Manifolds:")
+	fmt.Fprintln(w, "")
 	for ctrl, t := range r.counts {
-		fmt.Fprintf(buf, "%s has %d manifolds\n", ctrl, t)
+		fmt.Fprintf(w, "\t%s has %d manifolds\n", ctrl, t)
 	}
-	return buf.String()
+	fmt.Fprintln(w, "")
 }

--- a/scripts/juju-inspect/rules/manifolds.go
+++ b/scripts/juju-inspect/rules/manifolds.go
@@ -6,28 +6,81 @@ package rules
 import (
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 )
 
 type ManifoldsRule struct {
-	counts map[string]int
+	includeNested bool
+	counts        map[string]map[string]int
 }
 
-func NewManifoldsRule() *ManifoldsRule {
+func NewManifoldsRule(includeNested bool) *ManifoldsRule {
 	return &ManifoldsRule{
-		counts: make(map[string]int),
+		includeNested: includeNested,
+		counts:        make(map[string]map[string]int),
 	}
 }
 
 func (r *ManifoldsRule) Run(name string, report Report) error {
-	r.counts[name] = len(report.Manifolds)
+	if _, ok := r.counts[name]; !ok {
+		r.counts[name] = make(map[string]int)
+	}
+	var suffix string
+	if strings.Contains(name, ":") {
+		index := strings.Index(name, ":")
+		suffix = name[index:]
+	}
+	r.counts[name][suffix] += len(report.Manifolds)
+
+	if !r.includeNested {
+		return nil
+	}
+
+	manager, ok := report.Manifolds["model-worker-manager"]
+	if !ok {
+		return nil
+	}
+
+	var nested NestedReport
+	if err := manager.UnmarshalReport(&nested); err != nil {
+		return err
+	}
+
+	for subName, worker := range nested.Workers {
+
+		var nestedReport Report
+		if err := worker.UnmarshalReport(&nestedReport); err != nil {
+			return err
+		}
+
+		if err := r.Run(fmt.Sprintf("%s:%s", name, subName), nestedReport); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func (r *ManifoldsRule) Write(w io.Writer) {
 	fmt.Fprintln(w, "Manifolds:")
 	fmt.Fprintln(w, "")
-	for ctrl, t := range r.counts {
-		fmt.Fprintf(w, "\t%s has %d manifolds\n", ctrl, t)
+
+	counts := make([]string, 0, len(r.counts))
+	for k := range r.counts {
+		counts = append(counts, k)
+	}
+	sort.Strings(counts)
+
+	for _, ctrl := range counts {
+		agents := r.counts[ctrl]
+		for nested, t := range agents {
+			fmt.Fprintf(w, "\t%s:%s has %d manifolds\n", ctrl, nested, t)
+		}
 	}
 	fmt.Fprintln(w, "")
+}
+
+type NestedReport struct {
+	Workers map[string]Worker `yaml:"workers"`
 }

--- a/scripts/juju-inspect/rules/mongo.go
+++ b/scripts/juju-inspect/rules/mongo.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rules
+
+import "fmt"
+
+type MongoRule struct {
+	found     map[string]bool
+	primaries map[string]bool
+}
+
+func NewMongoRule() *MongoRule {
+	return &MongoRule{
+		found:     make(map[string]bool),
+		primaries: make(map[string]bool),
+	}
+}
+
+func (r *MongoRule) Run(name string, report Report) {
+	mgo, ok := report.Manifolds["transaction-pruner"]
+	if !ok {
+		r.found[name] = false
+		return
+	}
+
+	r.found[name] = true
+	r.primaries[name] = mgo.State == "started"
+}
+
+func (r *MongoRule) Summary() string {
+	return "Mongo Primary:"
+}
+
+func (r *MongoRule) Analyse() string {
+	var primary bool
+	var ctrl string
+	for name, ldr := range r.primaries {
+		if primary && ldr {
+			// Two or more primaries
+			return "Two or more primaries have been found in the files!"
+		}
+		if ldr {
+			primary = true
+			ctrl = name
+		}
+	}
+	if !primary {
+		return "There are no primaries found."
+	}
+	return fmt.Sprintf("%s is the primary.", ctrl)
+}

--- a/scripts/juju-inspect/rules/mongo.go
+++ b/scripts/juju-inspect/rules/mongo.go
@@ -43,6 +43,7 @@ func (r *MongoRule) Write(w io.Writer) {
 		if primary && ldr {
 			// Two or more primaries
 			fmt.Fprintln(w, "\tTwo or more primaries have been found in the files!")
+			fmt.Fprintln(w, "")
 			return
 		}
 		if ldr {
@@ -52,6 +53,7 @@ func (r *MongoRule) Write(w io.Writer) {
 	}
 	if !primary {
 		fmt.Fprintln(w, "\tThere are no primaries found.")
+		fmt.Fprintln(w, "")
 		return
 	}
 	fmt.Fprintf(w, "\t%s is the primary.\n", ctrl)

--- a/scripts/juju-inspect/rules/pubsub.go
+++ b/scripts/juju-inspect/rules/pubsub.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rules
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+type PubsubRule struct {
+	found   map[string]bool
+	targets map[string][]string
+}
+
+func NewPubsubRule() *PubsubRule {
+	return &PubsubRule{
+		found:   make(map[string]bool),
+		targets: make(map[string][]string),
+	}
+}
+
+func (r *PubsubRule) Run(name string, report Report) {
+	pubsub, ok := report.Manifolds["pubsub-forwarder"]
+	if !ok {
+		r.found[name] = false
+		return
+	}
+
+	r.found[name] = true
+
+	var targets []string
+	for name, target := range pubsub.Report.Targets {
+		if target.Status == "connected" {
+			targets = append(targets, name)
+		}
+	}
+	r.targets[name] = targets
+}
+
+func (r *PubsubRule) Summary() string {
+	return "Pubsub Forwarder:"
+}
+
+func (r *PubsubRule) Analyse() string {
+	buf := new(bytes.Buffer)
+	for name, targets := range r.targets {
+		if !r.found[name] {
+			fmt.Fprintf(buf, "%s pubsub-forwarder not found!\n", name)
+			continue
+		}
+		sort.Strings(targets)
+		fmt.Fprintf(buf, "%s is connected to the following: %v\n", name, targets)
+	}
+	return buf.String()
+}

--- a/scripts/juju-inspect/rules/pubsub.go
+++ b/scripts/juju-inspect/rules/pubsub.go
@@ -4,8 +4,8 @@
 package rules
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"sort"
 )
 
@@ -21,37 +21,48 @@ func NewPubsubRule() *PubsubRule {
 	}
 }
 
-func (r *PubsubRule) Run(name string, report Report) {
+func (r *PubsubRule) Run(name string, report Report) error {
 	pubsub, ok := report.Manifolds["pubsub-forwarder"]
 	if !ok {
 		r.found[name] = false
-		return
+		return nil
 	}
 
 	r.found[name] = true
 
+	var out PubsubReport
+	if err := pubsub.UnmarshalReport(&out); err != nil {
+		return err
+	}
+
 	var targets []string
-	for name, target := range pubsub.Report.Targets {
+	for name, target := range out.Targets {
 		if target.Status == "connected" {
 			targets = append(targets, name)
 		}
 	}
 	r.targets[name] = targets
+	return nil
 }
 
-func (r *PubsubRule) Summary() string {
-	return "Pubsub Forwarder:"
-}
-
-func (r *PubsubRule) Analyse() string {
-	buf := new(bytes.Buffer)
+func (r *PubsubRule) Write(w io.Writer) {
+	fmt.Fprintln(w, "Pubsub Forwarder:")
+	fmt.Fprintln(w, "")
 	for name, targets := range r.targets {
 		if !r.found[name] {
-			fmt.Fprintf(buf, "%s pubsub-forwarder not found!\n", name)
+			fmt.Fprintf(w, "\t%s pubsub-forwarder not found!\n", name)
 			continue
 		}
 		sort.Strings(targets)
-		fmt.Fprintf(buf, "%s is connected to the following: %v\n", name, targets)
+		fmt.Fprintf(w, "\t%s is connected to the following: %v\n", name, targets)
 	}
-	return buf.String()
+	fmt.Fprintln(w, "")
+}
+
+type PubsubReport struct {
+	Targets map[string]PubsubTarget `yaml:"targets"`
+}
+
+type PubsubTarget struct {
+	Status string
 }

--- a/scripts/juju-inspect/rules/raft.go
+++ b/scripts/juju-inspect/rules/raft.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rules
+
+import "fmt"
+
+type RaftRule struct {
+	found   map[string]bool
+	leaders map[string]bool
+}
+
+func NewRaftRule() *RaftRule {
+	return &RaftRule{
+		found:   make(map[string]bool),
+		leaders: make(map[string]bool),
+	}
+}
+
+func (r *RaftRule) Run(name string, report Report) {
+	raft, ok := report.Manifolds["raft"]
+	if !ok {
+		r.found[name] = false
+		return
+	}
+
+	r.found[name] = true
+	r.leaders[name] = raft.Report.State == "Leader"
+}
+
+func (r *RaftRule) Summary() string {
+	return "Raft Leader:"
+}
+
+func (r *RaftRule) Analyse() string {
+	var leader bool
+	var ctrl string
+	for name, ldr := range r.leaders {
+		if leader && ldr {
+			// Two or more leaders
+			return "Two or more leaders have been found in the files!"
+		}
+		if ldr {
+			leader = true
+			ctrl = name
+		}
+	}
+	if !leader {
+		return "There are no leaders found."
+	}
+	return fmt.Sprintf("%s is the leader.", ctrl)
+}

--- a/scripts/juju-inspect/rules/raft.go
+++ b/scripts/juju-inspect/rules/raft.go
@@ -49,6 +49,7 @@ func (r *RaftRule) Write(w io.Writer) {
 		if leader && ldr {
 			// Two or more leaders
 			fmt.Fprintln(w, "\tTwo or more leaders have been found in the files!")
+			fmt.Fprintln(w, "")
 			return
 		}
 		if ldr {
@@ -58,6 +59,7 @@ func (r *RaftRule) Write(w io.Writer) {
 	}
 	if !leader {
 		fmt.Fprintln(w, "\tThere are no leaders found.")
+		fmt.Fprintln(w, "")
 		return
 	}
 	fmt.Fprintf(w, "\t%s is the leader.\n", ctrl)

--- a/scripts/juju-inspect/rules/startcount.go
+++ b/scripts/juju-inspect/rules/startcount.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package rules
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+type StartCountRule struct {
+	counts map[string]map[string]int
+}
+
+func NewStartCountRule() *StartCountRule {
+	return &StartCountRule{
+		counts: make(map[string]map[string]int),
+	}
+}
+
+func (r *StartCountRule) Run(name string, report Report) {
+	for manifoldName, manifold := range report.Manifolds {
+		if _, ok := r.counts[name]; !ok {
+			r.counts[name] = make(map[string]int)
+		}
+		r.counts[name][manifoldName] = manifold.StartCount
+	}
+}
+
+func (r *StartCountRule) Summary() string {
+	return "Start Counts:"
+}
+
+type namedCount struct {
+	name  string
+	count int
+}
+
+func (r *StartCountRule) Analyse() string {
+	// Gather
+	total := make(map[string]int, len(r.counts))
+	highest := make(map[string]namedCount, len(r.counts))
+	for ctrl, manifolds := range r.counts {
+		for name, v := range manifolds {
+			total[ctrl] += v
+
+			nc := highest[ctrl]
+			if v > nc.count {
+				highest[ctrl] = namedCount{
+					name:  name,
+					count: v,
+				}
+			}
+		}
+	}
+
+	order := make([]string, 0, len(total))
+	for k := range total {
+		order = append(order, k)
+	}
+	sort.Strings(order)
+
+	// Report
+	buf := new(bytes.Buffer)
+	for _, ctrl := range order {
+		t := total[ctrl]
+		fmt.Fprintf(buf, "%s start-count: %d\n", ctrl, t)
+		fmt.Fprintf(buf, "  - max: %q with: %d\n", highest[ctrl].name, highest[ctrl].count)
+	}
+	return buf.String()
+}

--- a/scripts/juju-inspect/rules/startcount.go
+++ b/scripts/juju-inspect/rules/startcount.go
@@ -10,12 +10,14 @@ import (
 )
 
 type StartCountRule struct {
-	counts map[string]map[string]int
+	highestListNum int
+	counts         map[string]map[string]int
 }
 
-func NewStartCountRule() *StartCountRule {
+func NewStartCountRule(highestListNum int) *StartCountRule {
 	return &StartCountRule{
-		counts: make(map[string]map[string]int),
+		highestListNum: highestListNum,
+		counts:         make(map[string]map[string]int),
 	}
 }
 
@@ -66,7 +68,7 @@ func (r *StartCountRule) Write(w io.Writer) {
 		t := total[ctrl]
 		fmt.Fprintf(w, "\t%s start-count: %d\n", ctrl, t)
 
-		n := 3
+		n := r.highestListNum
 		h := highest[ctrl]
 		if num := len(h); num < n {
 			n = num


### PR DESCRIPTION
Juju inspect attempts to improve the live debugging of a live juju
controller (HA). This is just in it's infancy and is missing a lot of
knowledge. The was originally formulated whilst trawling through 100s of
engine reports and loosing track of what was what.

This was originally trying to workout what was the mongo primary, but
found uses in lots of other ways. Restart counts, raft issues et al.

## QA steps

Grab some engine reports from a HA controller and run it.

```sh
Analysis of Engine Report:

Raft Leader:
        machine-1 is the leader.

Mongo Primary:
        machine-2 is the primary.

Pubsub Forwarder:
        machine-2 is connected to the following: [machine-0 machine-1]
        machine-0 is connected to the following: [machine-1 machine-2]
        machine-1 is connected to the following: [machine-0 machine-2]

Manifolds:
        machine-0 has 69 manifolds
        machine-1 has 69 manifolds
        machine-2 has 69 manifolds

Start Counts:
        machine-0 start-count: 516
          - max: "is-primary-controller-flag" with: 189
        machine-1 start-count: 421
          - max: "is-primary-controller-flag" with: 178
        machine-2 start-count: 498
          - max: "machine-action-runner" with: 274
```

