### PR TITLE
Fix/lp 1934614

### DIFF
--- a/api/caasapplicationprovisioner/client.go
+++ b/api/caasapplicationprovisioner/client.go
@@ -244,11 +244,11 @@ func (c *Client) SetOperatorStatus(appName string, status status.Status, message
 }
 
 // Units returns all the units for an Application.
-func (c *Client) Units(appName string) ([]names.Tag, error) {
+func (c *Client) Units(appName string) ([]params.CAASUnit, error) {
 	args := params.Entities{Entities: []params.Entity{{
 		Tag: names.NewApplicationTag(appName).String(),
 	}}}
-	var result params.EntitiesResults
+	var result params.CAASUnitsResults
 	if err := c.facade.FacadeCall("Units", args, &result); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -260,15 +260,18 @@ func (c *Client) Units(appName string) ([]names.Tag, error) {
 	if res.Error != nil {
 		return nil, errors.Annotatef(maybeNotFound(res.Error), "unable to fetch units for %s", appName)
 	}
-	tags := make([]names.Tag, 0, len(res.Entities))
-	for _, v := range res.Entities {
+	out := make([]params.CAASUnit, len(res.Units))
+	for i, v := range res.Units {
 		tag, err := names.ParseUnitTag(v.Tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		tags = append(tags, tag)
+		out[i] = params.CAASUnit{
+			Tag:        tag,
+			UnitStatus: v.UnitStatus,
+		}
 	}
-	return tags, nil
+	return out, nil
 }
 
 // GarbageCollect cleans up units that have gone away permanently.

--- a/api/caasapplicationprovisioner/client_test.go
+++ b/api/caasapplicationprovisioner/client_test.go
@@ -253,10 +253,12 @@ func (s *provisionerSuite) TestAllUnits(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "Units")
 		c.Assert(arg, jc.DeepEquals, params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.EntitiesResults{})
-		*(result.(*params.EntitiesResults)) = params.EntitiesResults{
-			Results: []params.EntitiesResult{{
-				Entities: []params.Entity{{"unit-gitlab-0"}},
+		c.Assert(result, gc.FitsTypeOf, &params.CAASUnitsResults{})
+		*(result.(*params.CAASUnitsResults)) = params.CAASUnitsResults{
+			Results: []params.CAASUnitsResult{{
+				Units: []params.CAASUnitInfo{
+					{Tag: "unit-gitlab-0"},
+				},
 			}},
 		}
 		return nil
@@ -264,7 +266,9 @@ func (s *provisionerSuite) TestAllUnits(c *gc.C) {
 
 	tags, err := client.Units("gitlab")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tags, jc.SameContents, []names.Tag{names.NewUnitTag("gitlab/0")})
+	c.Assert(tags, jc.SameContents, []params.CAASUnit{
+		{Tag: names.NewUnitTag("gitlab/0")},
+	})
 }
 
 func (s *provisionerSuite) TestGarbageCollect(c *gc.C) {

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -352,6 +352,7 @@ type mockUnit struct {
 	life                state.Life
 	destroyOp           *state.DestroyUnitOperation
 	containerInfo       *mockCloudContainer
+	status              status.StatusInfo
 	tag                 names.Tag
 	updateUnitOperation *state.UpdateUnitOperation
 }
@@ -363,6 +364,11 @@ func (u *mockUnit) Tag() names.Tag {
 func (u *mockUnit) DestroyOperation() *state.DestroyUnitOperation {
 	u.MethodCall(u, "DestroyOperation")
 	return u.destroyOp
+}
+
+func (u *mockUnit) Status() (status.StatusInfo, error) {
+	u.MethodCall(u, "Status")
+	return u.status, u.NextErr()
 }
 
 func (u *mockUnit) EnsureDead() error {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -153,9 +153,24 @@ func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 			},
 		},
 		units: []*mockUnit{
-			{tag: names.NewUnitTag("gitlab/0")},
-			{tag: names.NewUnitTag("gitlab/1")},
-			{tag: names.NewUnitTag("gitlab/2")},
+			{
+				tag: names.NewUnitTag("gitlab/0"),
+				status: status.StatusInfo{
+					Status: status.Active,
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/1"),
+				status: status.StatusInfo{
+					Status: status.Maintenance,
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/2"),
+				status: status.StatusInfo{
+					Status: status.Unknown,
+				},
+			},
 		},
 	}
 	result, err := s.api.Units(params.Entities{
@@ -165,10 +180,28 @@ func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Entities, gc.DeepEquals, []params.Entity{
-		{Tag: "unit-gitlab-0"},
-		{Tag: "unit-gitlab-1"},
-		{Tag: "unit-gitlab-2"},
+	c.Assert(result.Results[0].Units, gc.DeepEquals, []params.CAASUnitInfo{
+		{
+			Tag: "unit-gitlab-0",
+			UnitStatus: &params.UnitStatus{
+				AgentStatus:    params.DetailedStatus{Status: "active"},
+				WorkloadStatus: params.DetailedStatus{Status: "active"},
+			},
+		},
+		{
+			Tag: "unit-gitlab-1",
+			UnitStatus: &params.UnitStatus{
+				AgentStatus:    params.DetailedStatus{Status: "maintenance"},
+				WorkloadStatus: params.DetailedStatus{Status: "maintenance"},
+			},
+		},
+		{
+			Tag: "unit-gitlab-2",
+			UnitStatus: &params.UnitStatus{
+				AgentStatus:    params.DetailedStatus{Status: "unknown"},
+				WorkloadStatus: params.DetailedStatus{Status: "unknown"},
+			},
+		},
 	})
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -71,6 +71,7 @@ type Unit interface {
 	EnsureDead() error
 	ContainerInfo() (state.CloudContainer, error)
 	UpdateOperation(props state.UnitUpdateProperties) *state.UpdateUnitOperation
+	Status() (status.StatusInfo, error)
 }
 
 type Resources interface {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6772,7 +6772,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/EntitiesResults"
+                            "$ref": "#/definitions/CAASUnitsResults"
                         }
                     },
                     "description": "Units returns all the units for each application specified."
@@ -7050,6 +7050,51 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/CAASApplicationProvisioningInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "CAASUnitInfo": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        },
+                        "unit-status": {
+                            "$ref": "#/definitions/UnitStatus"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "CAASUnitsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CAASUnitInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CAASUnitsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CAASUnitsResult"
                             }
                         }
                     },
@@ -7611,6 +7656,52 @@
                         "url"
                     ]
                 },
+                "DetailedStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "err": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "data",
+                        "since",
+                        "kind",
+                        "version",
+                        "life"
+                    ]
+                },
                 "DockerImageInfo": {
                     "type": "object",
                     "properties": {
@@ -7642,39 +7733,6 @@
                     "additionalProperties": false,
                     "required": [
                         "entities"
-                    ]
-                },
-                "EntitiesResult": {
-                    "type": "object",
-                    "properties": {
-                        "entities": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Entity"
-                            }
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "entities"
-                    ]
-                },
-                "EntitiesResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/EntitiesResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "Entity": {
@@ -8210,6 +8268,63 @@
                     "additionalProperties": false,
                     "required": [
                         "watcher-id"
+                    ]
+                },
+                "UnitStatus": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "agent-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "leader": {
+                            "type": "boolean"
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "opened-ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public-address": {
+                            "type": "string"
+                        },
+                        "subordinates": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/UnitStatus"
+                                }
+                            }
+                        },
+                        "workload-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "agent-status",
+                        "workload-status",
+                        "workload-version",
+                        "machine",
+                        "opened-ports",
+                        "public-address",
+                        "charm",
+                        "subordinates"
                     ]
                 },
                 "UpdateApplicationUnitArgs": {

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -4,8 +4,10 @@
 package params
 
 import (
-	"github.com/juju/juju/core/constraints"
+	"github.com/juju/names/v4"
 	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/core/constraints"
 )
 
 // CAASUnitIntroductionArgs is used by sidecar units to introduce
@@ -99,4 +101,27 @@ type CAASApplicationOCIResourceResult struct {
 // CAASApplicationOCIResources holds a list of image OCI resources.
 type CAASApplicationOCIResources struct {
 	Images map[string]DockerImageInfo `json:"images"`
+}
+
+// CAASUnitInfo holds CAAS unit information.
+type CAASUnitInfo struct {
+	Tag        string      `json:"tag"`
+	UnitStatus *UnitStatus `json:"unit-status,omitempty"`
+}
+
+// CAASUnit holds CAAS unit information.
+type CAASUnit struct {
+	Tag        names.Tag   `json:"tag"`
+	UnitStatus *UnitStatus `json:"unit-status,omitempty"`
+}
+
+// CAASUnitsResult holds a slice of CAAS unit information or an error.
+type CAASUnitsResult struct {
+	Units []CAASUnitInfo `json:"units,omitempty"`
+	Error *Error         `json:"error,omitempty"`
+}
+
+// CAASUnitsResults contains multiple CAAS units result.
+type CAASUnitsResults struct {
+	Results []CAASUnitsResult `json:"results"`
 }

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -111,8 +111,8 @@ type CAASUnitInfo struct {
 
 // CAASUnit holds CAAS unit information.
 type CAASUnit struct {
-	Tag        names.Tag   `json:"tag"`
-	UnitStatus *UnitStatus `json:"unit-status,omitempty"`
+	Tag        names.Tag
+	UnitStatus *UnitStatus
 }
 
 // CAASUnitsResult holds a slice of CAAS unit information or an error.

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1001,8 +1001,6 @@ func (a *app) WatchReplicas() (watcher.NotifyWatcher, error) {
 }
 
 func (a *app) State() (caas.ApplicationState, error) {
-	// TODO: include workload pods status for application status.
-	// FYI: func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 	state := caas.ApplicationState{}
 	switch a.deploymentType {
 	case caas.DeploymentStateful:

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1001,6 +1001,8 @@ func (a *app) WatchReplicas() (watcher.NotifyWatcher, error) {
 }
 
 func (a *app) State() (caas.ApplicationState, error) {
+	// TODO: include workload pods status for application status.
+	// FYI: func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 	state := caas.ApplicationState{}
 	switch a.deploymentType {
 	case caas.DeploymentStateful:

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
+	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/mod v0.4.0 // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
@@ -119,7 +120,6 @@ require (
 	google.golang.org/api v0.29.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d // indirect
-	google.golang.org/grpc v1.33.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -1079,8 +1079,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
-google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -799,6 +800,8 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
+go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -1078,6 +1081,8 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
+google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -198,7 +198,7 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worke
 			s.brokerApp.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
 				return watchertest.NewMockNotifyWatcher(s.appReplicasChan), nil
 			}),
-			// refresh application status - test seperately.
+			// refresh application status - test separately.
 			s.brokerApp.EXPECT().State().
 				DoAndReturn(func() (caas.ApplicationState, error) {
 					s.notifyReady <- struct{}{}
@@ -316,7 +316,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 			return nil, nil
 		}),
 
-		// refresh application status - test seperately.
+		// refresh application status - test separately.
 		s.brokerApp.EXPECT().State().
 			DoAndReturn(func() (caas.ApplicationState, error) {
 				s.notifyReady <- struct{}{}
@@ -341,7 +341,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 			return s.ociResources, nil
 		}),
 
-		// refresh application status - test seperately.
+		// refresh application status - test separately.
 		s.brokerApp.EXPECT().State().
 			DoAndReturn(func() (caas.ApplicationState, error) {
 				s.notifyReady <- struct{}{}
@@ -385,7 +385,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 			Status:         params.EntityStatus{},
 		}).Return(nil, nil),
 
-		// refresh application status - test seperately.
+		// refresh application status - test separately.
 		s.brokerApp.EXPECT().State().
 			DoAndReturn(func() (caas.ApplicationState, error) {
 				s.notifyReady <- struct{}{}
@@ -470,7 +470,7 @@ func (s *ApplicationWorkerSuite) TestScaleChanges(c *gc.C) {
 		s.unitFacade.EXPECT().ApplicationScale("test").Return(3, nil),
 		s.brokerApp.EXPECT().Scale(3).Return(nil),
 
-		// refresh application status - test seperately.
+		// refresh application status - test separately.
 		s.brokerApp.EXPECT().State().
 			DoAndReturn(func() (caas.ApplicationState, error) {
 				close(done)
@@ -501,7 +501,7 @@ func (s *ApplicationWorkerSuite) TestTrustChanges(c *gc.C) {
 		s.unitFacade.EXPECT().ApplicationTrust("test").Return(true, nil),
 		s.brokerApp.EXPECT().Trust(true).Return(nil),
 
-		// refresh application status - test seperately.
+		// refresh application status - test separately.
 		s.brokerApp.EXPECT().State().
 			DoAndReturn(func() (caas.ApplicationState, error) {
 				close(done)

--- a/worker/caasapplicationprovisioner/manifold.go
+++ b/worker/caasapplicationprovisioner/manifold.go
@@ -22,6 +22,7 @@ type Logger interface {
 	Infof(string, ...interface{})
 	Errorf(string, ...interface{})
 	Warningf(string, ...interface{})
+	Tracef(string, ...interface{})
 
 	Child(string) loggo.Logger
 }

--- a/worker/caasapplicationprovisioner/mocks/broker_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/broker_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	caas "github.com/juju/juju/caas"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockCAASBroker is a mock of CAASBroker interface
+// MockCAASBroker is a mock of CAASBroker interface.
 type MockCAASBroker struct {
 	ctrl     *gomock.Controller
 	recorder *MockCAASBrokerMockRecorder
 }
 
-// MockCAASBrokerMockRecorder is the mock recorder for MockCAASBroker
+// MockCAASBrokerMockRecorder is the mock recorder for MockCAASBroker.
 type MockCAASBrokerMockRecorder struct {
 	mock *MockCAASBroker
 }
 
-// NewMockCAASBroker creates a new mock instance
+// NewMockCAASBroker creates a new mock instance.
 func NewMockCAASBroker(ctrl *gomock.Controller) *MockCAASBroker {
 	mock := &MockCAASBroker{ctrl: ctrl}
 	mock.recorder = &MockCAASBrokerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 	return m.recorder
 }
 
-// AnnotateUnit mocks base method
+// AnnotateUnit mocks base method.
 func (m *MockCAASBroker) AnnotateUnit(arg0 string, arg1 caas.DeploymentMode, arg2 string, arg3 names.UnitTag) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2, arg3)
@@ -42,13 +43,13 @@ func (m *MockCAASBroker) AnnotateUnit(arg0 string, arg1 caas.DeploymentMode, arg
 	return ret0
 }
 
-// AnnotateUnit indicates an expected call of AnnotateUnit
+// AnnotateUnit indicates an expected call of AnnotateUnit.
 func (mr *MockCAASBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockCAASBroker)(nil).AnnotateUnit), arg0, arg1, arg2, arg3)
 }
 
-// Application mocks base method
+// Application mocks base method.
 func (m *MockCAASBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
@@ -56,7 +57,7 @@ func (m *MockCAASBroker) Application(arg0 string, arg1 caas.DeploymentType) caas
 	return ret0
 }
 
-// Application indicates an expected call of Application
+// Application indicates an expected call of Application.
 func (mr *MockCAASBrokerMockRecorder) Application(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockCAASBroker)(nil).Application), arg0, arg1)

--- a/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	caasapplicationprovisioner "github.com/juju/juju/api/caasapplicationprovisioner"
@@ -15,33 +17,32 @@ import (
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockCAASProvisionerFacade is a mock of CAASProvisionerFacade interface
+// MockCAASProvisionerFacade is a mock of CAASProvisionerFacade interface.
 type MockCAASProvisionerFacade struct {
 	ctrl     *gomock.Controller
 	recorder *MockCAASProvisionerFacadeMockRecorder
 }
 
-// MockCAASProvisionerFacadeMockRecorder is the mock recorder for MockCAASProvisionerFacade
+// MockCAASProvisionerFacadeMockRecorder is the mock recorder for MockCAASProvisionerFacade.
 type MockCAASProvisionerFacadeMockRecorder struct {
 	mock *MockCAASProvisionerFacade
 }
 
-// NewMockCAASProvisionerFacade creates a new mock instance
+// NewMockCAASProvisionerFacade creates a new mock instance.
 func NewMockCAASProvisionerFacade(ctrl *gomock.Controller) *MockCAASProvisionerFacade {
 	mock := &MockCAASProvisionerFacade{ctrl: ctrl}
 	mock.recorder = &MockCAASProvisionerFacadeMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCAASProvisionerFacade) EXPECT() *MockCAASProvisionerFacadeMockRecorder {
 	return m.recorder
 }
 
-// ApplicationCharmURL mocks base method
+// ApplicationCharmURL mocks base method.
 func (m *MockCAASProvisionerFacade) ApplicationCharmURL(arg0 string) (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationCharmURL", arg0)
@@ -50,13 +51,13 @@ func (m *MockCAASProvisionerFacade) ApplicationCharmURL(arg0 string) (*charm.URL
 	return ret0, ret1
 }
 
-// ApplicationCharmURL indicates an expected call of ApplicationCharmURL
+// ApplicationCharmURL indicates an expected call of ApplicationCharmURL.
 func (mr *MockCAASProvisionerFacadeMockRecorder) ApplicationCharmURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmURL", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ApplicationCharmURL), arg0)
 }
 
-// ApplicationOCIResources mocks base method
+// ApplicationOCIResources mocks base method.
 func (m *MockCAASProvisionerFacade) ApplicationOCIResources(arg0 string) (map[string]resources.DockerImageDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationOCIResources", arg0)
@@ -65,13 +66,13 @@ func (m *MockCAASProvisionerFacade) ApplicationOCIResources(arg0 string) (map[st
 	return ret0, ret1
 }
 
-// ApplicationOCIResources indicates an expected call of ApplicationOCIResources
+// ApplicationOCIResources indicates an expected call of ApplicationOCIResources.
 func (mr *MockCAASProvisionerFacadeMockRecorder) ApplicationOCIResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationOCIResources", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ApplicationOCIResources), arg0)
 }
 
-// CharmInfo mocks base method
+// CharmInfo mocks base method.
 func (m *MockCAASProvisionerFacade) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmInfo", arg0)
@@ -80,13 +81,13 @@ func (m *MockCAASProvisionerFacade) CharmInfo(arg0 string) (*charms.CharmInfo, e
 	return ret0, ret1
 }
 
-// CharmInfo indicates an expected call of CharmInfo
+// CharmInfo indicates an expected call of CharmInfo.
 func (mr *MockCAASProvisionerFacadeMockRecorder) CharmInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).CharmInfo), arg0)
 }
 
-// GarbageCollect mocks base method
+// GarbageCollect mocks base method.
 func (m *MockCAASProvisionerFacade) GarbageCollect(arg0 string, arg1 []names.Tag, arg2 int, arg3 []string, arg4 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GarbageCollect", arg0, arg1, arg2, arg3, arg4)
@@ -94,13 +95,13 @@ func (m *MockCAASProvisionerFacade) GarbageCollect(arg0 string, arg1 []names.Tag
 	return ret0
 }
 
-// GarbageCollect indicates an expected call of GarbageCollect
+// GarbageCollect indicates an expected call of GarbageCollect.
 func (mr *MockCAASProvisionerFacadeMockRecorder) GarbageCollect(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).GarbageCollect), arg0, arg1, arg2, arg3, arg4)
 }
 
-// Life mocks base method
+// Life mocks base method.
 func (m *MockCAASProvisionerFacade) Life(arg0 string) (life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life", arg0)
@@ -109,13 +110,13 @@ func (m *MockCAASProvisionerFacade) Life(arg0 string) (life.Value, error) {
 	return ret0, ret1
 }
 
-// Life indicates an expected call of Life
+// Life indicates an expected call of Life.
 func (mr *MockCAASProvisionerFacadeMockRecorder) Life(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).Life), arg0)
 }
 
-// ProvisioningInfo mocks base method
+// ProvisioningInfo mocks base method.
 func (m *MockCAASProvisionerFacade) ProvisioningInfo(arg0 string) (caasapplicationprovisioner.ProvisioningInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo", arg0)
@@ -124,13 +125,13 @@ func (m *MockCAASProvisionerFacade) ProvisioningInfo(arg0 string) (caasapplicati
 	return ret0, ret1
 }
 
-// ProvisioningInfo indicates an expected call of ProvisioningInfo
+// ProvisioningInfo indicates an expected call of ProvisioningInfo.
 func (mr *MockCAASProvisionerFacadeMockRecorder) ProvisioningInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ProvisioningInfo), arg0)
 }
 
-// SetOperatorStatus mocks base method
+// SetOperatorStatus mocks base method.
 func (m *MockCAASProvisionerFacade) SetOperatorStatus(arg0 string, arg1 status.Status, arg2 string, arg3 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetOperatorStatus", arg0, arg1, arg2, arg3)
@@ -138,13 +139,13 @@ func (m *MockCAASProvisionerFacade) SetOperatorStatus(arg0 string, arg1 status.S
 	return ret0
 }
 
-// SetOperatorStatus indicates an expected call of SetOperatorStatus
+// SetOperatorStatus indicates an expected call of SetOperatorStatus.
 func (mr *MockCAASProvisionerFacadeMockRecorder) SetOperatorStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOperatorStatus", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).SetOperatorStatus), arg0, arg1, arg2, arg3)
 }
 
-// SetPassword mocks base method
+// SetPassword mocks base method.
 func (m *MockCAASProvisionerFacade) SetPassword(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPassword", arg0, arg1)
@@ -152,28 +153,28 @@ func (m *MockCAASProvisionerFacade) SetPassword(arg0, arg1 string) error {
 	return ret0
 }
 
-// SetPassword indicates an expected call of SetPassword
+// SetPassword indicates an expected call of SetPassword.
 func (mr *MockCAASProvisionerFacadeMockRecorder) SetPassword(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).SetPassword), arg0, arg1)
 }
 
-// Units mocks base method
-func (m *MockCAASProvisionerFacade) Units(arg0 string) ([]names.Tag, error) {
+// Units mocks base method.
+func (m *MockCAASProvisionerFacade) Units(arg0 string) ([]params.CAASUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units", arg0)
-	ret0, _ := ret[0].([]names.Tag)
+	ret0, _ := ret[0].([]params.CAASUnit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Units indicates an expected call of Units
+// Units indicates an expected call of Units.
 func (mr *MockCAASProvisionerFacadeMockRecorder) Units(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).Units), arg0)
 }
 
-// UpdateUnits mocks base method
+// UpdateUnits mocks base method.
 func (m *MockCAASProvisionerFacade) UpdateUnits(arg0 params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUnits", arg0)
@@ -182,13 +183,13 @@ func (m *MockCAASProvisionerFacade) UpdateUnits(arg0 params.UpdateApplicationUni
 	return ret0, ret1
 }
 
-// UpdateUnits indicates an expected call of UpdateUnits
+// UpdateUnits indicates an expected call of UpdateUnits.
 func (mr *MockCAASProvisionerFacadeMockRecorder) UpdateUnits(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnits", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).UpdateUnits), arg0)
 }
 
-// WatchApplication mocks base method
+// WatchApplication mocks base method.
 func (m *MockCAASProvisionerFacade) WatchApplication(arg0 string) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplication", arg0)
@@ -197,13 +198,13 @@ func (m *MockCAASProvisionerFacade) WatchApplication(arg0 string) (watcher.Notif
 	return ret0, ret1
 }
 
-// WatchApplication indicates an expected call of WatchApplication
+// WatchApplication indicates an expected call of WatchApplication.
 func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplication(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplication), arg0)
 }
 
-// WatchApplications mocks base method
+// WatchApplications mocks base method.
 func (m *MockCAASProvisionerFacade) WatchApplications() (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplications")
@@ -212,7 +213,7 @@ func (m *MockCAASProvisionerFacade) WatchApplications() (watcher.StringsWatcher,
 	return ret0, ret1
 }
 
-// WatchApplications indicates an expected call of WatchApplications
+// WatchApplications indicates an expected call of WatchApplications.
 func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplications", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplications))

--- a/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	watcher "github.com/juju/juju/core/watcher"
-	reflect "reflect"
 )
 
-// MockCAASUnitProvisionerFacade is a mock of CAASUnitProvisionerFacade interface
+// MockCAASUnitProvisionerFacade is a mock of CAASUnitProvisionerFacade interface.
 type MockCAASUnitProvisionerFacade struct {
 	ctrl     *gomock.Controller
 	recorder *MockCAASUnitProvisionerFacadeMockRecorder
 }
 
-// MockCAASUnitProvisionerFacadeMockRecorder is the mock recorder for MockCAASUnitProvisionerFacade
+// MockCAASUnitProvisionerFacadeMockRecorder is the mock recorder for MockCAASUnitProvisionerFacade.
 type MockCAASUnitProvisionerFacadeMockRecorder struct {
 	mock *MockCAASUnitProvisionerFacade
 }
 
-// NewMockCAASUnitProvisionerFacade creates a new mock instance
+// NewMockCAASUnitProvisionerFacade creates a new mock instance.
 func NewMockCAASUnitProvisionerFacade(ctrl *gomock.Controller) *MockCAASUnitProvisionerFacade {
 	mock := &MockCAASUnitProvisionerFacade{ctrl: ctrl}
 	mock.recorder = &MockCAASUnitProvisionerFacadeMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCAASUnitProvisionerFacade) EXPECT() *MockCAASUnitProvisionerFacadeMockRecorder {
 	return m.recorder
 }
 
-// ApplicationScale mocks base method
+// ApplicationScale mocks base method.
 func (m *MockCAASUnitProvisionerFacade) ApplicationScale(arg0 string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationScale", arg0)
@@ -43,13 +44,13 @@ func (m *MockCAASUnitProvisionerFacade) ApplicationScale(arg0 string) (int, erro
 	return ret0, ret1
 }
 
-// ApplicationScale indicates an expected call of ApplicationScale
+// ApplicationScale indicates an expected call of ApplicationScale.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationScale", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationScale), arg0)
 }
 
-// ApplicationTrust mocks base method
+// ApplicationTrust mocks base method.
 func (m *MockCAASUnitProvisionerFacade) ApplicationTrust(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationTrust", arg0)
@@ -58,13 +59,13 @@ func (m *MockCAASUnitProvisionerFacade) ApplicationTrust(arg0 string) (bool, err
 	return ret0, ret1
 }
 
-// ApplicationTrust indicates an expected call of ApplicationTrust
+// ApplicationTrust indicates an expected call of ApplicationTrust.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationTrust(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTrust", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationTrust), arg0)
 }
 
-// UpdateApplicationService mocks base method
+// UpdateApplicationService mocks base method.
 func (m *MockCAASUnitProvisionerFacade) UpdateApplicationService(arg0 params.UpdateApplicationServiceArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateApplicationService", arg0)
@@ -72,13 +73,13 @@ func (m *MockCAASUnitProvisionerFacade) UpdateApplicationService(arg0 params.Upd
 	return ret0
 }
 
-// UpdateApplicationService indicates an expected call of UpdateApplicationService
+// UpdateApplicationService indicates an expected call of UpdateApplicationService.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) UpdateApplicationService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplicationService", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).UpdateApplicationService), arg0)
 }
 
-// WatchApplicationScale mocks base method
+// WatchApplicationScale mocks base method.
 func (m *MockCAASUnitProvisionerFacade) WatchApplicationScale(arg0 string) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplicationScale", arg0)
@@ -87,13 +88,13 @@ func (m *MockCAASUnitProvisionerFacade) WatchApplicationScale(arg0 string) (watc
 	return ret0, ret1
 }
 
-// WatchApplicationScale indicates an expected call of WatchApplicationScale
+// WatchApplicationScale indicates an expected call of WatchApplicationScale.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) WatchApplicationScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationScale", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).WatchApplicationScale), arg0)
 }
 
-// WatchApplicationTrustHash mocks base method
+// WatchApplicationTrustHash mocks base method.
 func (m *MockCAASUnitProvisionerFacade) WatchApplicationTrustHash(arg0 string) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplicationTrustHash", arg0)
@@ -102,7 +103,7 @@ func (m *MockCAASUnitProvisionerFacade) WatchApplicationTrustHash(arg0 string) (
 	return ret0, ret1
 }
 
-// WatchApplicationTrustHash indicates an expected call of WatchApplicationTrustHash
+// WatchApplicationTrustHash indicates an expected call of WatchApplicationTrustHash.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) WatchApplicationTrustHash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationTrustHash", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).WatchApplicationTrustHash), arg0)

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -46,7 +46,7 @@ type CAASProvisionerFacade interface {
 	CharmInfo(string) (*charmscommon.CharmInfo, error)
 	ApplicationCharmURL(string) (*charm.URL, error)
 	SetOperatorStatus(appName string, status status.Status, message string, data map[string]interface{}) error
-	Units(appName string) ([]names.Tag, error)
+	Units(appName string) ([]params.CAASUnit, error)
 	GarbageCollect(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error
 	ApplicationOCIResources(appName string) (map[string]resources.DockerImageDetails, error)
 	UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error)


### PR DESCRIPTION
*Application status of sidecar charms now get updated more accurately based on units status;*

driveby:

- rewrite the caasapplicationprovisioner test suite for easier adding additional tests;
- add missed tests for `Scale` and `Trust` logic in caasapplicationprovisioner worker;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps
scale sidecar application to different scale and watch the application status in `juju status`;

```console
$ juju deploy snappass-test

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.9.9    unsupported  21:19:18+10:00

App            Version  Status  Scale  Charm          Store     Channel  Rev  OS          Address         Message
snappass-test           active      1  snappass-test  charmhub  stable     9  kubernetes  10.152.183.194

Unit              Workload  Agent  Address      Ports  Message
snappass-test/0*  active    idle   10.1.97.236         snappass started

$ juju scale-application snappass-test -m k1:t1 3

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.9.9    unsupported  21:19:48+10:00

App            Version  Status   Scale  Charm          Store     Channel  Rev  OS          Address         Message
snappass-test           waiting    1/3  snappass-test  charmhub  stable     9  kubernetes  10.152.183.194  installing agent

Unit              Workload  Agent       Address      Ports  Message
snappass-test/0*  active    idle        10.1.97.236         snappass started
snappass-test/1   waiting   allocating  10.1.97.238         installing agent
snappass-test/2   waiting   allocating                      installing agent

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.9.9    unsupported  21:20:31+10:00

App            Version  Status  Scale  Charm          Store     Channel  Rev  OS          Address         Message
snappass-test           active      3  snappass-test  charmhub  stable     9  kubernetes  10.152.183.194

Unit              Workload  Agent  Address      Ports  Message
snappass-test/0*  active    idle   10.1.97.236         snappass started
snappass-test/1   active    idle   10.1.97.238         snappass started
snappass-test/2   active    idle   10.1.97.237         snappass started

$ juju scale-application snappass-test -m k1:t1 0

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version  SLA          Timestamp
t1     k1          microk8s/localhost  2.9.9    unsupported  21:22:44+10:00

App            Version  Status  Scale  Charm          Store     Channel  Rev  OS          Address         Message
snappass-test           active      0  snappass-test  charmhub  stable     9  kubernetes  10.152.183.194

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1934614
