### PR TITLE
Do not pass bootstrap-series to k8s integration suites

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -206,16 +206,18 @@ juju_bootstrap() {
 	shift
 
 	series=
-	case "${BOOTSTRAP_SERIES}" in
-	"${CURRENT_LTS}")
-		series="--bootstrap-series=${BOOTSTRAP_SERIES} --config image-stream=daily --force"
-		;;
-	"") ;;
+	if [[ ${BOOTSTRAP_PROVIDER} != "k8s" ]]; then
+		case "${BOOTSTRAP_SERIES}" in
+		"${CURRENT_LTS}")
+			series="--bootstrap-series=${BOOTSTRAP_SERIES} --config image-stream=daily --force"
+			;;
+		"") ;;
 
-	*)
-		series="--bootstrap-series=${BOOTSTRAP_SERIES}"
-		;;
-	esac
+		*)
+			series="--bootstrap-series=${BOOTSTRAP_SERIES}"
+			;;
+		esac
+	fi
 
 	pre_bootstrap
 

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -299,7 +299,7 @@ archive_logs() {
 		echo "${TAR_OUTPUT}"
 		TEST_RESULT=failure
 	fi
-	
+
 }
 
 TEST_CURRENT=setup


### PR DESCRIPTION
The CAAS admission suite started failing after we threaded `bootstrap-series` through all the tests with JJB.

Here we ignore the `BOOTSTRAP_SERIES` environment variable if running on k8s.

## QA steps

`BOOTSTRAP_SERIES=focal BOOTSTRAP_PROVIDER=k8s BOOTSTRAP_CLOUD=microk8s ./main.sh -v caasadmission`
