### PR TITLE
update test-network

### DIFF
--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -6,8 +6,8 @@ run_network_health() {
 	ensure "network-health" "${file}"
 
 	# Deploy some applications for different series.
-	juju deploy mongodb --series focal
-	juju deploy juju-gui --series xenial
+	juju deploy ubuntu ubuntu-focal --series focal
+	juju deploy ubuntu ubuntu-xenial --series xenial
 	juju deploy ubuntu ubuntu-bionic --series bionic
 
 	# Now the testing charm for each series.
@@ -15,20 +15,20 @@ run_network_health() {
 	juju deploy 'cs:~juju-qa/network-health' network-health-bionic --series bionic
 	juju deploy 'cs:~juju-qa/network-health' network-health-focal --series focal
 
+	juju add-relation network-health-focal ubuntu-focal
+	juju add-relation network-health-xenial ubuntu-xenial
+	juju add-relation network-health-bionic ubuntu-bionic
+
 	juju expose network-health-xenial
 	juju expose network-health-bionic
 	juju expose network-health-focal
 
-	juju add-relation network-health-focal mongodb
-	juju add-relation network-health-xenial juju-gui
-	juju add-relation network-health-bionic ubuntu-bionic
-
-	wait_for "mongodb" "$(idle_condition "mongodb" 1)"
-	wait_for "juju-gui" "$(idle_condition "juju-gui" 0)"
-	wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 5)"
-	wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "mongodb")"
+	wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 3)"
+	wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 4)"
+	wait_for "ubuntu-xenial" "$(idle_condition "ubuntu-xenial" 5)"
+	wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "ubuntu-focal")"
 	wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu-bionic")"
-	wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "juju-gui")"
+	wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "ubuntu-xenial")"
 
 	check_default_routes
 	check_accessibility
@@ -57,7 +57,7 @@ check_accessibility() {
 		curl_cmd="curl 2>/dev/null ${ip}:8039"
 
 		# Check that each of the principles can access the subordinate.
-		for principle_unit in "mongodb/0" "juju-gui/0" "ubuntu-bionic/0"; do
+		for principle_unit in "ubuntu-focal/0" "ubuntu-xenial/0" "ubuntu-bionic/0"; do
 			check_contains "$(juju run --unit $principle_unit "$curl_cmd")" "pass"
 		done
 


### PR DESCRIPTION
Use only ubuntu as principal units in run_network_health.  Other charms fail install hook due to apt or snap issues on a random schedule.

## QA steps

```console
 (cd tests ; ./main.sh -v -p aws network)
```

