### PR TITLE
DebugLog: Space labels correctly.

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -319,7 +319,7 @@ func (c *debugLogCommand) writeLogRecord(w *ansiterm.Writer, r common.LogMessage
 		loggocolor.LocationColor.Fprintf(w, "%s ", r.Location)
 	}
 	if len(r.Labels) > 0 {
-		fmt.Fprintf(w, "%v", r.Labels)
+		fmt.Fprintf(w, "%v ", strings.Join(r.Labels, ","))
 	}
 	fmt.Fprintln(w, r.Message)
 }

--- a/cmd/juju/commands/debuglog_test.go
+++ b/cmd/juju/commands/debuglog_test.go
@@ -196,6 +196,49 @@ func (s *DebugLogSuite) TestLogOutput(c *gc.C) {
 		"machine-0: 14:15:23 INFO test.module somefile.go:123 this is the log output\n")
 }
 
+func (s *DebugLogSuite) TestLogOutputWithLogs(c *gc.C) {
+	// test timezone is 6 hours east of UTC
+	tz := time.FixedZone("test", 6*60*60)
+	s.PatchValue(&getDebugLogAPI, func(_ *debugLogCommand) (DebugLogAPI, error) {
+		return &fakeDebugLogAPI{log: []common.LogMessage{
+			{
+				Entity:    "machine-0",
+				Timestamp: time.Date(2016, 10, 9, 8, 15, 23, 345000000, time.UTC),
+				Severity:  "INFO",
+				Module:    "test.module",
+				Location:  "somefile.go:123",
+				Message:   "this is the log output",
+				Labels:    []string{"http,foo"},
+			},
+		}}, nil
+	})
+	checkOutput := func(args ...string) {
+		count := len(args)
+		args, expected := args[:count-1], args[count-1]
+		ctx, err := cmdtesting.RunCommand(c, newDebugLogCommandTZ(jujuclienttesting.MinimalStore(), tz), args...)
+		c.Check(err, jc.ErrorIsNil)
+		c.Check(cmdtesting.Stdout(ctx), gc.Equals, expected)
+
+	}
+	checkOutput(
+		"machine-0: 14:15:23 INFO test.module http,foo this is the log output\n")
+	checkOutput(
+		"--ms",
+		"machine-0: 14:15:23.345 INFO test.module http,foo this is the log output\n")
+	checkOutput(
+		"--utc",
+		"machine-0: 08:15:23 INFO test.module http,foo this is the log output\n")
+	checkOutput(
+		"--date",
+		"machine-0: 2016-10-09 14:15:23 INFO test.module http,foo this is the log output\n")
+	checkOutput(
+		"--utc", "--date",
+		"machine-0: 2016-10-09 08:15:23 INFO test.module http,foo this is the log output\n")
+	checkOutput(
+		"--location",
+		"machine-0: 14:15:23 INFO test.module somefile.go:123 http,foo this is the log output\n")
+}
+
 type fakeDebugLogAPI struct {
 	log    []common.LogMessage
 	params common.DebugLogParams


### PR DESCRIPTION
The labels aren't correctly spaced in the debug-log output and can be a
bit of an eyesore. The PR just fixes that and renders it in a much nicer
way.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller "logging-config='#http=TRACE'"
$ juju find --type=bundle
$ juju debug-log -m controller
...
machine-0: 17:04:36 TRACE juju.apiserver.charmhub.client http GET response HTTP/1.1 200 OK
...
```
