### PR TITLE
[2.9] Fix error in equinix credential detection

### DIFF
--- a/provider/equinix/credentials.go
+++ b/provider/equinix/credentials.go
@@ -47,13 +47,15 @@ func (e environProviderCredentials) DetectCredentials(cloudName string) (*cloud.
 	if val, present := os.LookupEnv("METAL_AUTH_TOKEN"); present {
 		creds.AuthToken = val
 	} else {
-		return nil, errors.Errorf("equinix metal auth token not present")
+		logger.Debugf("METAL_AUTH_TOKEN environment variable not set")
+		return nil, errors.NotFoundf("equinix metal auth token")
 	}
 
 	if val, present := os.LookupEnv("METAL_PROJECT_ID"); present {
 		creds.ProjectID = val
 	} else {
-		return nil, errors.Errorf("equinix metal project ID not present")
+		logger.Debugf("METAL_PROJECT_ID environment variable not set")
+		return nil, errors.NotFoundf("equinix metal project ID")
 	}
 
 	result.AuthCredentials["default"] = cloud.NewCredential(

--- a/provider/equinix/credentials_test.go
+++ b/provider/equinix/credentials_test.go
@@ -28,12 +28,12 @@ func (e credentialsSuite) TestDetectCredentials_NoMetalToken(c *gc.C) {
 	cred := environProviderCredentials{}
 	os.Setenv("METAL_PROJECT_ID", "project-id")
 	_, err := cred.DetectCredentials("equinix_test")
-	c.Assert(err.Error(), jc.Contains, "equinix metal auth token not present")
+	c.Assert(err.Error(), jc.Contains, "equinix metal auth token not found")
 }
 
 func (e credentialsSuite) TestDetectCredentials_NoProject(c *gc.C) {
 	cred := environProviderCredentials{}
 	os.Setenv("METAL_AUTH_TOKEN", "metal")
 	_, err := cred.DetectCredentials("equinix_test")
-	c.Assert(err.Error(), jc.Contains, "equinix metal project ID not present")
+	c.Assert(err.Error(), jc.Contains, "equinix metal project ID not found")
 }


### PR DESCRIPTION
This PR updates the equinix provider to return NotFound errors when it cannot detect the appropriate token/project envvars. Prior to this change, the provider returned generic errors which the `juju autoload-credentials` command spits out instead of ignoring.

## QA steps

```sh
$ juju autoload-credentials --debug
...
17:28:38 DEBUG juju.provider.equinix credentials.go:50 METAL_AUTH_TOKEN environment variable not set
...
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1936954