### PR TITLE
NetworkInfoIAAS - sort ingress addresses with same rules as bind addresses

### DIFF
--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -48,6 +48,6 @@ func PatchGetStorageStateError(patcher patcher, err error) {
 }
 
 func (n *NetworkInfoIAAS) MachineNetworkInfos() (map[string]params.NetworkInfoResult, error) {
-	err := n.populateMachineNetworkInfos()
-	return n.machineNetworkInfos, err
+	err := n.populateMachineAddresses()
+	return n.machineAddresses, err
 }

--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/agent/meterstatus"
-	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/state"
 )
@@ -47,7 +46,7 @@ func PatchGetStorageStateError(patcher patcher, err error) {
 	patcher.PatchValue(&getStorageState, func(st *state.State) (storageAccess, error) { return nil, err })
 }
 
-func (n *NetworkInfoIAAS) MachineNetworkInfos() (map[string]params.NetworkInfoResult, error) {
+func (n *NetworkInfoIAAS) MachineNetworkInfos() (map[string][]NetInfoAddress, error) {
 	err := n.populateMachineAddresses()
 	return n.machineAddresses, err
 }


### PR DESCRIPTION
In a series of patches leading up to #12982, we ensured that bind addresses returned to the `network-get` call for IAAS models were sorted according to new rules that ensured primary addresses are preferred over secondary ones.

Here we rework `NetworkInfoIAAS` so that we longer prematurely materialise the initially retrieved machine addresses as `params.NetworkInfoResult`. This allows us to preserve sorting according to `SpaceAddress` rules, meaning that ingress addresses, now materilised later, conform to the same sorting rules as bind addresses, with primary addresses preferred over secondary.

The code is significantly simplified because we no longer synthetically create sortable space addresses from too-early crafted `NetworkInfoResult` objects in order to create ingress addresses.

## QA steps

Same as for #12961 (_Testing resolution of the bug_ is longer optional), but *also* ensure that ingress addresses are sorted.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1897261
