### PR TITLE
Logging: Reset optional fields

### DIFF
--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -304,6 +304,9 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 		defer close(logCh)
 		var m params.LogRecord
 		for {
+			// ResetOptionalFields will remove any stale data for a log record
+			// that might have stale data when reading the JSON.
+			m.ResetOptionalFields()
 			// Receive() blocks until data arrives but will also be
 			// unblocked when the API handler calls socket.Close as it
 			// finishes.

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -302,14 +302,17 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 		// we leak goroutines on client disconnect, because the server
 		// isn't shutting down so h.abort is never closed.
 		defer close(logCh)
-		var m params.LogRecord
 		for {
-			// ResetOptionalFields will remove any stale data for a log record
-			// that might have stale data when reading the JSON.
-			m.ResetOptionalFields()
 			// Receive() blocks until data arrives but will also be
 			// unblocked when the API handler calls socket.Close as it
 			// finishes.
+
+			// Do not lift the LogRecord outside of the for-loop as any fields
+			// with omitempty will not get cleared between iterations. The
+			// logsink has to work with different versions of juju we need to
+			// ensure that we have consistent data, even at the cost of
+			// performance.
+			var m params.LogRecord
 			if err := socket.ReadJSON(&m); err != nil {
 				if gorillaws.IsCloseError(err, gorillaws.CloseNormalClosure, gorillaws.CloseGoingAway) {
 					logger.Tracef("logsink closed: %v", err)

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1053,6 +1053,9 @@ type RebootActionResult struct {
 // LogRecord is used to transmit log messages to the logsink API
 // endpoint.  Single character field names are used for serialisation
 // to keep the size down. These messages are going to be sent a lot.
+//
+// WARNING: Enure when you use this LogRecord to call ResetOptionalFields if
+// using the same log record instance for unmarshalling.
 type LogRecord struct {
 	Time     time.Time `json:"t"`
 	Module   string    `json:"m"`
@@ -1061,6 +1064,14 @@ type LogRecord struct {
 	Message  string    `json:"x"`
 	Entity   string    `json:"e,omitempty"`
 	Labels   []string  `json:"c,omitempty"`
+}
+
+// ResetOptionalFields will clear the fields of a LogRecord which are optional.
+// This will allow us to reuse the same record when unmarshalling the log record
+// and removes the stale data.
+func (m LogRecord) ResetOptionalFields() {
+	m.Entity = ""
+	m.Labels = nil
 }
 
 // PubSubMessage is used to propagate pubsub messages from one api server to the

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -1053,9 +1053,6 @@ type RebootActionResult struct {
 // LogRecord is used to transmit log messages to the logsink API
 // endpoint.  Single character field names are used for serialisation
 // to keep the size down. These messages are going to be sent a lot.
-//
-// WARNING: Enure when you use this LogRecord to call ResetOptionalFields if
-// using the same log record instance for unmarshalling.
 type LogRecord struct {
 	Time     time.Time `json:"t"`
 	Module   string    `json:"m"`
@@ -1064,14 +1061,6 @@ type LogRecord struct {
 	Message  string    `json:"x"`
 	Entity   string    `json:"e,omitempty"`
 	Labels   []string  `json:"c,omitempty"`
-}
-
-// ResetOptionalFields will clear the fields of a LogRecord which are optional.
-// This will allow us to reuse the same record when unmarshalling the log record
-// and removes the stale data.
-func (m LogRecord) ResetOptionalFields() {
-	m.Entity = ""
-	m.Labels = nil
 }
 
 // PubSubMessage is used to propagate pubsub messages from one api server to the

--- a/worker/logsender/bufferedlogwriter.go
+++ b/worker/logsender/bufferedlogwriter.go
@@ -143,10 +143,10 @@ func (w *BufferedLogWriter) loop() {
 			w.mu.Unlock()
 		}
 	}
-
 }
 
-// Write sends a new log message to the writer. This implements the loggo.Writer interface.
+// Write sends a new log message to the writer.
+// This implements the loggo.Writer interface.
 func (w *BufferedLogWriter) Write(entry loggo.Entry) {
 	w.in <- &LogRecord{
 		Time:     entry.Timestamp,


### PR DESCRIPTION
When the logsink reads the log records on the connection, it reuses one
log record for all reads. The problem occurs when there is a partial log
record that can have missing entities or labels. As entity and labels
are optional; if they happen to be set, but the next one doesn't have
them, then the ReadJSON (unmarshaller) doesn't clear ALL the fields, it
just updates what is required. This results in labels from the previous
read being in all future reads until a new record happens to have a new
entity or label.

Assuming a stream of log records from A->B->C->D was sent and only B had
an entity, all subsequent records (C->D) would have the same entity as
B.

The code is simple, just create a new instance of LogRecord.

## QA steps

Ideally, you need two terminals running (tmux is wise).

#### First terminal

```sh
$ juju debug-log -m controller
```

#### Second terminal

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller "logging-config='#http=TRACE'"
$ juju info bad
$ juju model-config -m controller "logging-config='<root>=DEBUG"
```

#### Expectations

There should be no labels on any logs that aren't `juju.apiserver.charmhub.client` or `juju.apiserver.charmhub.client.transport`.
