### PR TITLE
Charm: Allow series and manifest.yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
-	github.com/juju/charm/v8 v8.0.0-20210720094626-3015879331f3
+	github.com/juju/charm/v8 v8.0.0-20210722102001-7d7bf2b0acef
 	github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx
 github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7 h1:zEIYPqGRtR6R2SNza8f74Wr+7/pkubE8mKAlnXIXdnI=
 github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7/go.mod h1:GFZ3KcDmWTesil7L3nuSsN5aeGZuL2pNdUoGWswDTgM=
 github.com/juju/charm/v8 v8.0.0-20210304015923-e7ca8ffa7716/go.mod h1:fAs/8HQjkAuVkhEyE//h1O3qxB/4Nv3w5zFK6tNZNEY=
-github.com/juju/charm/v8 v8.0.0-20210720094626-3015879331f3 h1:6/lwk+9p2F9cepHajjzxqI+jQg/7uGZx93fJlSbo/hI=
-github.com/juju/charm/v8 v8.0.0-20210720094626-3015879331f3/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
+github.com/juju/charm/v8 v8.0.0-20210722102001-7d7bf2b0acef h1:mx8PwS1m3ETp0NAjjcxMeQoVFnLkEtkv4jIjjNb8ItU=
+github.com/juju/charm/v8 v8.0.0-20210722102001-7d7bf2b0acef/go.mod h1:W5J2j7v5aAbOVqep8NFysd+p/sShXFqLraG4A6iOzDM=
 github.com/juju/charm/v9 v9.0.0-20210421060150-6a300db18162/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c h1:+p8LWnIJCzmptGw1Tz7mb0EtOjMEZUHARbnW5vI1oSI=
 github.com/juju/charmrepo/v6 v6.0.0-20210422125831-407c8ef9471c/go.mod h1:okPBT5bIwu7M231F/eThmf7uT+ct8OATcAhU7tTOpqs=


### PR DESCRIPTION
The following adds the ability to have a series and a manifest, only to
treat this style of charm as a V1.

This is a regression introduced when moving the format detection from
v1 to v2.

## QA steps

```sh
$ juju bootstrap microk8s m8s
$ juju deploy cs:dex-auth
```
