### PR TITLE
Download and deploy the controller charm from charmhub at bootstrap

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -980,7 +980,7 @@ func (api *APIBase) setCharmWithAgentValidation(
 		if unsupportedReason != "" {
 			return errors.NotSupportedf(unsupportedReason)
 		}
-		return api.applicationSetCharm(params, newCharm, stateCharmOrigin(newOrigin))
+		return api.applicationSetCharm(params, newCharm, newOrigin)
 	}
 
 	// Check if the controller agent tools version is greater than the
@@ -1007,14 +1007,14 @@ func (api *APIBase) setCharmWithAgentValidation(
 		}
 	}
 
-	return api.applicationSetCharm(params, newCharm, stateCharmOrigin(newOrigin))
+	return api.applicationSetCharm(params, newCharm, newOrigin)
 }
 
 // applicationSetCharm sets the charm for the given for the application.
 func (api *APIBase) applicationSetCharm(
 	params setCharmParams,
 	stateCharm Charm,
-	stateOrigin *state.CharmOrigin,
+	origin corecharm.Origin,
 ) error {
 	var err error
 	var settings charm.Settings
@@ -1043,7 +1043,7 @@ func (api *APIBase) applicationSetCharm(
 	force := params.Force
 	cfg := state.SetCharmConfig{
 		Charm:              api.stateCharm(stateCharm),
-		CharmOrigin:        stateOrigin,
+		CharmOrigin:        StateCharmOrigin(origin),
 		Channel:            params.Channel,
 		ConfigSettings:     settings,
 		ForceSeries:        force.ForceSeries,

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -76,7 +76,7 @@ func DeployApplication(st ApplicationDeployer, args DeployApplicationParams) (Ap
 		Name:              args.ApplicationName,
 		Series:            args.Series,
 		Charm:             args.Charm,
-		CharmOrigin:       stateCharmOrigin(args.CharmOrigin),
+		CharmOrigin:       StateCharmOrigin(args.CharmOrigin),
 		Channel:           args.Channel,
 		Storage:           stateStorageConstraints(args.Storage),
 		Devices:           stateDeviceConstraints(args.Devices),
@@ -159,7 +159,8 @@ func stateDeviceConstraints(cons map[string]devices.Constraints) map[string]stat
 	return result
 }
 
-func stateCharmOrigin(origin corecharm.Origin) *state.CharmOrigin {
+// StateCharmOrigin returns a state layer CharmOrigin given a core Origin.
+func StateCharmOrigin(origin corecharm.Origin) *state.CharmOrigin {
 	var ch *state.Channel
 	if c := origin.Channel; c != nil {
 		normalizedC := c.Normalize()

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -306,6 +306,9 @@ type StateInitializationParams struct {
 	// to a controller.
 	ControllerConfig controller.Config
 
+	// ControllerCharmRisk is used when deploying the controller charm.
+	ControllerCharmRisk string
+
 	// ControllerInheritedConfig is a set of config attributes to be shared by all
 	// models managed by this controller.
 	ControllerInheritedConfig map[string]interface{}
@@ -362,6 +365,7 @@ type stateInitializationParamsInternal struct {
 	ControllerCloudRegion                   string                            `yaml:"controller-cloud-region"`
 	ControllerCloudCredentialName           string                            `yaml:"controller-cloud-credential-name,omitempty"`
 	ControllerCloudCredential               *cloud.Credential                 `yaml:"controller-cloud-credential,omitempty"`
+	ControllerCharmRisk                     string                            `yaml:"controller-charm-risk,omitempty"`
 }
 
 // Marshal marshals StateInitializationParams to an opaque byte array.
@@ -375,22 +379,23 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		return nil, errors.Annotate(err, "marshalling cloud definition")
 	}
 	internal := stateInitializationParamsInternal{
-		p.ControllerConfig,
-		p.ControllerModelConfig.AllAttrs(),
-		p.ControllerModelEnvironVersion,
-		p.ControllerInheritedConfig,
-		p.RegionInheritedConfig,
-		p.HostedModelConfig,
-		p.StoragePools,
-		p.BootstrapMachineInstanceId,
-		p.BootstrapMachineConstraints,
-		p.BootstrapMachineHardwareCharacteristics,
-		p.ModelConstraints,
-		string(customImageMetadataJSON),
-		string(controllerCloud),
-		p.ControllerCloudRegion,
-		p.ControllerCloudCredentialName,
-		p.ControllerCloudCredential,
+		ControllerConfig:                        p.ControllerConfig,
+		ControllerModelConfig:                   p.ControllerModelConfig.AllAttrs(),
+		ControllerModelEnvironVersion:           p.ControllerModelEnvironVersion,
+		ControllerInheritedConfig:               p.ControllerInheritedConfig,
+		RegionInheritedConfig:                   p.RegionInheritedConfig,
+		HostedModelConfig:                       p.HostedModelConfig,
+		StoragePools:                            p.StoragePools,
+		BootstrapMachineInstanceId:              p.BootstrapMachineInstanceId,
+		BootstrapMachineConstraints:             p.BootstrapMachineConstraints,
+		BootstrapMachineHardwareCharacteristics: p.BootstrapMachineHardwareCharacteristics,
+		ModelConstraints:                        p.ModelConstraints,
+		CustomImageMetadataJSON:                 string(customImageMetadataJSON),
+		ControllerCloud:                         string(controllerCloud),
+		ControllerCloudRegion:                   p.ControllerCloudRegion,
+		ControllerCloudCredentialName:           p.ControllerCloudCredentialName,
+		ControllerCloudCredential:               p.ControllerCloudCredential,
+		ControllerCharmRisk:                     p.ControllerCharmRisk,
 	}
 	return yaml.Marshal(&internal)
 }
@@ -431,6 +436,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerCloudRegion:                   internal.ControllerCloudRegion,
 		ControllerCloudCredentialName:           internal.ControllerCloudCredentialName,
 		ControllerCloudCredential:               internal.ControllerCloudCredential,
+		ControllerCharmRisk:                     internal.ControllerCharmRisk,
 	}
 	return nil
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2141,7 +2141,7 @@ func (s *BootstrapSuite) TestBootstrapTestingOptions(c *gc.C) {
 	c.Assert(gotArgs.ExtraAgentValuesForTesting, jc.DeepEquals, map[string]string{"foo": "bar", "hello": "world"})
 }
 
-func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
+func (s *BootstrapSuite) TestBootstrapWithLocalControllerCharm(c *gc.C) {
 	for _, test := range []struct {
 		charmPath string
 		err       string
@@ -2150,13 +2150,13 @@ func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
 			charmPath: testcharms.Repo.CharmDir("juju-controller").Path,
 		}, {
 			charmPath: testcharms.Repo.CharmDir("mysql").Path,
-			err:       `--controller-charm ".*mysql" is not a "juju-controller" charm`,
+			err:       `--controller-charm-path ".*mysql" is not a "juju-controller" charm`,
 		}, {
 			charmPath: c.MkDir(),
-			err:       `--controller-charm ".*" is not a valid charm`,
+			err:       `--controller-charm-path ".*" is not a valid charm`,
 		}, {
 			charmPath: "/invalid/path",
-			err:       `problem with --controller-charm: .* /invalid/path: .*`,
+			err:       `problem with --controller-charm-path: .* /invalid/path: .*`,
 		},
 	} {
 		var gotArgs bootstrap.BootstrapParams
@@ -2170,7 +2170,7 @@ func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
 			return bootstrapFuncs
 		})
 		_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
-			"dummy", "devcontroller", "--controller-charm", test.charmPath,
+			"dummy", "devcontroller", "--controller-charm-path", test.charmPath,
 		)
 		if test.err == "" {
 			c.Assert(err, gc.Equals, cmd.ErrSilent)
@@ -2179,6 +2179,11 @@ func (s *BootstrapSuite) TestBootstrapWithControllerCharm(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, test.err)
 		}
 	}
+}
+
+func (s *BootstrapSuite) TestBootstrapInvalidControllerCharmRisk(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--controller-charm-risk", "foo")
+	c.Assert(err, gc.ErrorMatches, `controller charm risk "foo" not valid`)
 }
 
 func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -27,8 +26,6 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agentbootstrap"
 	agenttools "github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/api"
-	"github.com/juju/juju/apiserver"
 	"github.com/juju/juju/caas"
 	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
@@ -41,7 +38,6 @@ import (
 	"github.com/juju/juju/core/network"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/bootstrap"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
@@ -379,9 +375,9 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		logger.Debugf("Juju Dashboard successfully set up")
 	}
 
-	// Add a controller charm.
-	if err := c.populateControllerCharm(st); err != nil {
-		return errors.Annotate(err, "deploying the controller charm")
+	// Deploy and set up the controller charm and application.
+	if err := c.deployControllerCharm(st, args.ControllerCharmRisk); err != nil {
+		return errors.Annotate(err, "cannot deploy controller application")
 	}
 
 	// bootstrap nodes always get the vote
@@ -390,123 +386,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	return node.SetHasVote(true)
-}
-
-func (c *BootstrapCommand) populateControllerCharm(st *state.State) error {
-	controllerCharmPath := filepath.Join(c.DataDir(), "charms", bootstrap.ControllerCharmArchive)
-	_, err := os.Stat(controllerCharmPath)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	m, err := st.Machine(agent.BootstrapControllerId)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	curl, err := addControllerCharm(st, m.Series(), controllerCharmPath)
-	if err != nil {
-		return errors.Annotatef(err, "cannot store controller charm at %q", controllerCharmPath)
-	}
-	if err = addControllerApplication(st, curl, m); err != nil {
-		return errors.Annotate(err, "cannot add controller application")
-	}
-	logger.Debugf("Successfully deployed local Juju controller charm")
-	return nil
-}
-
-func addControllerCharm(st *state.State, series, charmFileName string) (*charm.URL, error) {
-	archive, err := charm.ReadCharmArchive(charmFileName)
-	if err != nil {
-		return nil, errors.Errorf("invalid charm archive: %v", err)
-	}
-
-	name := archive.Meta().Name
-	if name != bootstrap.ControllerCharmName {
-		return nil, errors.Errorf("unexpected controller charm name %q", name)
-	}
-
-	// Only local for now.
-	schema := charm.Local
-
-	// Reserve a charm URL for it in state.
-	curl := &charm.URL{
-		Schema:   schema.String(),
-		Name:     name,
-		Revision: archive.Revision(),
-		Series:   series,
-	}
-	switch schema {
-	case charm.Local:
-		curl, err = st.PrepareLocalCharmUpload(curl)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-	case charm.CharmHub:
-		if _, err := st.PrepareCharmUpload(curl); err != nil {
-			return nil, errors.Trace(err)
-		}
-
-	default:
-		return nil, errors.Errorf("unsupported schema %q", schema)
-	}
-
-	// Now we need to repackage it with the reserved URL, upload it to
-	// provider storage and update the state.
-	err = apiserver.RepackageAndUploadCharm(st, archive, curl)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return curl, nil
-}
-
-func addControllerApplication(st *state.State, curl *charm.URL, m *state.Machine) error {
-	ch, err := st.Charm(curl)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	cfg := charm.Settings{
-		"is-juju": true,
-	}
-	controllerCfg, err := st.ControllerConfig()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	cfg["identity-provider-url"] = controllerCfg.IdentityURL()
-	addr := controllerCfg.PublicDNSAddress()
-	if addr == "" {
-		pa, err := m.PublicAddress()
-		if err != nil && !network.IsNoAddressError(err) {
-			return errors.Trace(err)
-		}
-		if err == nil {
-			addr = pa.Value
-		}
-	}
-	cfg["controller-url"] = api.ControllerAPIURL(addr)
-	cfg["model-url-template"] = api.ModelAPITemplateURL(addr)
-	app, err := st.AddApplication(state.AddApplicationArgs{
-		Name:   bootstrap.ControllerApplicationName,
-		Series: curl.Series,
-		Charm:  ch,
-		CharmOrigin: &state.CharmOrigin{
-			Source: curl.Schema,
-			Type:   "charm",
-		},
-		CharmConfig: cfg,
-	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	u, err := app.AddUnit(state.AddUnitParams{})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return u.AssignToMachine(m)
 }
 
 func getAddressesForMongo(

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -1,0 +1,265 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/charm/v9"
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+	coreos "github.com/juju/juju/core/os"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/facades/client/application"
+	"github.com/juju/juju/apiserver/facades/client/charms/interfaces"
+	"github.com/juju/juju/apiserver/facades/client/charms/services"
+	"github.com/juju/juju/charmhub"
+	corearch "github.com/juju/juju/core/arch"
+	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/network"
+	coreseries "github.com/juju/juju/core/series"
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/state"
+	statestorage "github.com/juju/juju/state/storage"
+)
+
+const controllerCharmURL = "ch:juju-controller"
+
+func (c *BootstrapCommand) deployControllerCharm(st *state.State, charmRisk string) error {
+	// Get details of the controller machine for later.
+	m, err := st.Machine(agent.BootstrapControllerId)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	hw, err := m.HardwareCharacteristics()
+	if err != nil {
+		return err
+	}
+	arch := corearch.DefaultArchitecture
+	if hw.Arch != nil {
+		arch = *hw.Arch
+	}
+
+	// First try using a local charm specified at bootstrap time.
+	source := "local"
+	curl, origin, err := populateLocalControllerCharm(st, c.DataDir(), m.Series(), arch)
+	if err != nil && !errors.IsNotFound(err) {
+		return errors.Annotate(err, "deploying local controller charm")
+	}
+	// If no local charm, use the one from charmhub.
+	if err != nil {
+		source = "store"
+		if curl, origin, err = populateStoreControllerCharm(st, charmRisk, m.Series(), arch); err != nil {
+			return errors.Annotate(err, "deploying charmhub controller charm")
+		}
+	}
+
+	// Once the charm is added, set up the controller application.
+	if err = addControllerApplication(st, curl, *origin, m); err != nil {
+		return errors.Annotate(err, "cannot add controller application")
+	}
+	logger.Debugf("Successfully deployed %s Juju controller charm", source)
+	return nil
+}
+
+// These are patched for testing.
+var (
+	newCharmRepo = func(cfg services.CharmRepoFactoryConfig) (corecharm.Repository, error) {
+		charmRepoFactory := services.NewCharmRepoFactory(cfg)
+		return charmRepoFactory.GetCharmRepository(corecharm.CharmHub)
+	}
+	newCharmDownloader = func(cfg services.CharmDownloaderConfig) (interfaces.Downloader, error) {
+		return services.NewCharmDownloader(cfg)
+	}
+)
+
+// populateStoreControllerCharm downloads and stores the controller charm from charmhub.
+func populateStoreControllerCharm(st *state.State, charmRisk, series, arch string) (*charm.URL, *corecharm.Origin, error) {
+	model, err := st.Model()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stateBackend := &stateShim{st}
+	charmRepo, err := newCharmRepo(services.CharmRepoFactoryConfig{
+		Logger:       logger,
+		Transport:    charmhub.DefaultHTTPTransport(logger),
+		StateBackend: stateBackend,
+		ModelBackend: model,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	curl := charm.MustParseURL(controllerCharmURL)
+	channel := corecharm.MakeRiskOnlyChannel(charmRisk)
+	origin := corecharm.Origin{
+		Source:  corecharm.CharmHub,
+		Type:    "charm",
+		Channel: &channel,
+		Platform: corecharm.Platform{
+			Architecture: arch,
+			OS:           strings.ToLower(coreos.Ubuntu.String()),
+			Series:       charmhub.NotAvailable,
+		},
+	}
+
+	var supportedSeries []string
+	curl, origin, supportedSeries, err = charmRepo.ResolveWithPreferredChannel(curl, origin, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	// We prefer the latest LTS series but if the controller charm supported series
+	// matches that of the machine, use that one. The controller charm doesn't have
+	// any series specific code.
+	if charmSeries := set.NewStrings(supportedSeries...); charmSeries.Contains(series) {
+		curl = curl.WithSeries(series)
+	} else if charmSeries.Contains(coreseries.LatestLts()) {
+		curl = curl.WithSeries(coreseries.LatestLts())
+	} else {
+		// Fallback in case controller charm is out of date.
+		curl = curl.WithSeries("focal")
+	}
+
+	storageFactory := func(modelUUID string) services.Storage {
+		return statestorage.NewStorage(model.UUID(), st.MongoSession())
+	}
+	charmDownloader, err := newCharmDownloader(services.CharmDownloaderConfig{
+		Logger:         logger,
+		Transport:      charmhub.DefaultHTTPTransport(logger),
+		StorageFactory: storageFactory,
+		StateBackend:   stateBackend,
+		ModelBackend:   model,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resOrigin, err := charmDownloader.DownloadAndStore(curl.String(), origin, nil, false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return curl, &resOrigin, nil
+}
+
+// stateShim allows us to use a real state instance with the charm services logic.
+type stateShim struct {
+	*state.State
+}
+
+func (st *stateShim) PrepareCharmUpload(curl *charm.URL) (services.UploadedCharm, error) {
+	return st.State.PrepareCharmUpload(curl)
+}
+
+func (st *stateShim) UpdateUploadedCharm(info state.CharmInfo) (services.UploadedCharm, error) {
+	return st.State.UpdateUploadedCharm(info)
+}
+
+// populateLocalControllerCharm downloads and stores a local controller charm archive.
+func populateLocalControllerCharm(st *state.State, dataDir, series, arch string) (*charm.URL, *corecharm.Origin, error) {
+	controllerCharmPath := filepath.Join(dataDir, "charms", bootstrap.ControllerCharmArchive)
+	_, err := os.Stat(controllerCharmPath)
+	if os.IsNotExist(err) {
+		return nil, nil, errors.NotFoundf(controllerCharmPath)
+	}
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	curl, err := addLocalControllerCharm(st, series, controllerCharmPath)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "cannot store controller charm at %q", controllerCharmPath)
+	}
+	logger.Debugf("Successfully deployed local Juju controller charm")
+	origin := corecharm.Origin{
+		Source: corecharm.Local,
+		Type:   "charm",
+		Platform: corecharm.Platform{
+			Architecture: arch,
+			OS:           "ubuntu",
+			Series:       series,
+		},
+	}
+	return curl, &origin, nil
+}
+
+// addLocalControllerCharm adds the specified local charm to the controller.
+func addLocalControllerCharm(st *state.State, series, charmFileName string) (*charm.URL, error) {
+	archive, err := charm.ReadCharmArchive(charmFileName)
+	if err != nil {
+		return nil, errors.Errorf("invalid charm archive: %v", err)
+	}
+
+	name := archive.Meta().Name
+	if name != bootstrap.ControllerCharmName {
+		return nil, errors.Errorf("unexpected controller charm name %q", name)
+	}
+
+	// Reserve a charm URL for it in state.
+	curl := &charm.URL{
+		Schema:   charm.Local.String(),
+		Name:     name,
+		Revision: archive.Revision(),
+		Series:   series,
+	}
+	curl, err = st.PrepareLocalCharmUpload(curl)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Now we need to repackage it with the reserved URL, upload it to
+	// provider storage and update the state.
+	err = apiserver.RepackageAndUploadCharm(st, archive, curl)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return curl, nil
+}
+
+// addControllerApplication deploys and configures the controller application.
+func addControllerApplication(st *state.State, curl *charm.URL, origin corecharm.Origin, m *state.Machine) error {
+	ch, err := st.Charm(curl)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg := charm.Settings{
+		"is-juju": true,
+	}
+	controllerCfg, err := st.ControllerConfig()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg["identity-provider-url"] = controllerCfg.IdentityURL()
+	addr := controllerCfg.PublicDNSAddress()
+	if addr == "" {
+		pa, err := m.PublicAddress()
+		if err != nil && !network.IsNoAddressError(err) {
+			return errors.Trace(err)
+		}
+		if err == nil {
+			addr = pa.Value
+		}
+	}
+	cfg["controller-url"] = api.ControllerAPIURL(addr)
+	cfg["model-url-template"] = api.ModelAPITemplateURL(addr)
+	app, err := st.AddApplication(state.AddApplicationArgs{
+		Name:        bootstrap.ControllerApplicationName,
+		Series:      m.Series(),
+		Charm:       ch,
+		CharmOrigin: application.StateCharmOrigin(origin),
+		CharmConfig: cfg,
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	u, err := app.AddUnit(state.AddUnitParams{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return u.AssignToMachine(m)
+}

--- a/core/charm/downloader/downloader.go
+++ b/core/charm/downloader/downloader.go
@@ -49,7 +49,7 @@ type Storage interface {
 	Store(*charm.URL, DownloadedCharm) error
 }
 
-// DownloadResult encapsulates the details of a downloaded charm.
+// DownloadedCharm encapsulates the details of a downloaded charm.
 type DownloadedCharm struct {
 	// Charm provides information about the charm contents.
 	Charm charm.Charm

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -183,6 +183,8 @@ type BootstrapParams struct {
 	// ControllerCharmPath is a local controller charm archive.
 	ControllerCharmPath string
 
+	ControllerCharmRisk string
+
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
 }
@@ -623,6 +625,7 @@ func bootstrapIAAS(
 	if err := instanceConfig.SetControllerCharm(args.ControllerCharmPath); err != nil {
 		return errors.Trace(err)
 	}
+	instanceConfig.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
 
 	var environVersion int
 	if e, ok := environ.(environs.Environ); ok {
@@ -749,6 +752,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
 	icfg.Bootstrap.JujuDbSnapAssertionsPath = args.JujuDbSnapAssertionsPath
 	icfg.Bootstrap.ControllerCharm = args.ControllerCharmPath
+	icfg.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
 	return nil
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1118,6 +1118,21 @@ func (s *bootstrapSuite) TestBootstrapControllerCharmLocal(c *gc.C) {
 	c.Assert(env.instanceConfig.Bootstrap.ControllerCharm, gc.Equals, path)
 }
 
+func (s *bootstrapSuite) TestBootstrapControllerCharmRisk(c *gc.C) {
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
+		s.callContext, bootstrap.BootstrapParams{
+			ControllerConfig:         coretesting.FakeControllerConfig(),
+			AdminSecret:              "admin-secret",
+			CAPrivateKey:             coretesting.CAKey,
+			SupportedBootstrapSeries: supportedJujuSeries,
+			ControllerCharmRisk:      "beta",
+		})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(env.instanceConfig.Bootstrap.ControllerCharmRisk, gc.Equals, "beta")
+}
+
 // createImageMetadata creates some image metadata in a local directory.
 func createImageMetadata(c *gc.C) (dir string, _ []*imagemetadata.ImageMetadata) {
 	return createImageMetadataForArch(c, "amd64")


### PR DESCRIPTION
There's a new "juju-controller" charm published to charmhub as beta.

When bootstrapping, we now deploy that charm. Previously there was only the option to deploy a local controller charm.

## QA steps

juju bootstrap aws --no-default-model
juju status

You will see a controller application and unit for the bootstrap machine.

Or you can do

juju bootstrap aws --no-default-model --controller-charm-risk=edge

or

juju bootstrap aws --no-default-model --controller-charm-path=/path/to/local/charm