### PR TITLE
Move to Pubsub v2

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/ratelimit"
 	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v2/dependency"

--- a/apiserver/basesuite_test.go
+++ b/apiserver/basesuite_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -210,5 +210,5 @@ type ModelPresence interface {
 
 // Hub represents the central hub that the API server has.
 type Hub interface {
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 }

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v2/workertest"

--- a/apiserver/observer/request_notifier_test.go
+++ b/apiserver/observer/request_notifier_test.go
@@ -144,9 +144,9 @@ type connectionHub struct {
 	details apiserver.APIConnection
 }
 
-func (hub *connectionHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
+func (hub *connectionHub) Publish(topic string, data interface{}) (func(), error) {
 	hub.called++
 	hub.topic = topic
 	hub.details = data.(apiserver.APIConnection)
-	return nil, nil
+	return func() {}, nil
 }

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -20,7 +20,7 @@ import (
 // Hub defines the publish method that the handler uses to publish
 // messages on the centralhub of the apiserver.
 type Hub interface {
-	Publish(string, interface{}) (<-chan struct{}, error)
+	Publish(string, interface{}) (func(), error)
 }
 
 func newPubSubHandler(h httpContext, hub Hub) http.Handler {

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	gc "gopkg.in/check.v1"

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -24,7 +24,7 @@ import (
 // that are used. The context uses an interface to allow mocking
 // of the hub.
 type SharedHub interface {
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 	Subscribe(topic string, handler interface{}) (func(), error)
 }
 

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
 	"github.com/prometheus/client_golang/prometheus"
@@ -160,9 +160,9 @@ type stubHub struct {
 	published []string
 }
 
-func (s *stubHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
+func (s *stubHub) Publish(topic string, data interface{}) (func(), error) {
 	s.published = append(s.published, topic)
-	return nil, nil
+	return func() {}, nil
 }
 
 func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
@@ -180,7 +180,7 @@ func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("handler didn't")
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -20,7 +20,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/replicaset"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/symlink"

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/proxy"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/utils/v2/voyeur"
 	"github.com/juju/version"
 	"github.com/juju/worker/v2"

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/status"
 )
@@ -145,7 +145,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 	})
 
 	if a.details.CharmURL != details.CharmURL {
-		a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})
+		_ = a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})
 	}
 
 	a.details = details
@@ -156,7 +156,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 		a.configHash = configHash
 		a.hashCache = hashCache
 		a.hashCache.incMisses()
-		a.hub.Publish(a.topic(applicationConfigChange), hashCache)
+		_ = a.hub.Publish(a.topic(applicationConfigChange), hashCache)
 	}
 }
 

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -4,7 +4,7 @@
 package cache
 
 import (
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/settings"
 )
@@ -87,7 +87,7 @@ func (b *Branch) setDetails(details BranchChange) {
 	})
 
 	b.details = details
-	b.hub.Publish(branchChange, b.copy())
+	_ = b.hub.Publish(branchChange, b.copy())
 }
 
 // copy returns a copy of the branch, ensuring appropriate deep copying.

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -4,7 +4,7 @@
 package cache
 
 import (
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/lxdprofile"
 )

--- a/core/cache/charmconfigwatcher.go
+++ b/core/cache/charmconfigwatcher.go
@@ -6,7 +6,7 @@ package cache
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/settings"
 )

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"gopkg.in/tomb.v2"
 )
 
@@ -326,7 +326,7 @@ func (c *Controller) modelWatcher(uuid string) ModelWatcher {
 func (c *Controller) updateModel(ch ModelChange) {
 	model := c.ensureModel(ch.ModelUUID)
 	model.setDetails(ch)
-	c.hub.Publish(modelUpdatedTopic, model)
+	_ = c.hub.Publish(modelUpdatedTopic, model)
 }
 
 // removeModel removes the model from the cache.
@@ -340,7 +340,7 @@ func (c *Controller) removeModel(ch RemoveModel) error {
 			return errors.Trace(err)
 		}
 		delete(c.models, ch.ModelUUID)
-		c.hub.Publish(modelRemovedTopic, ch.ModelUUID)
+		_ = c.hub.Publish(modelRemovedTopic, ch.ModelUUID)
 	}
 	return nil
 }

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/lxdprofile"
 )

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -169,7 +169,7 @@ func (m *Machine) setDetails(details MachineChange) {
 	m.details = details
 
 	if provisioned {
-		m.model.hub.Publish(m.topic(machineProvisioned), nil)
+		_ = m.model.hub.Publish(m.topic(machineProvisioned), nil)
 	}
 
 	configHash, err := hashSettings(details.Config)

--- a/core/cache/modelwatcher.go
+++ b/core/cache/modelwatcher.go
@@ -6,7 +6,7 @@ package cache
 import (
 	"sync"
 
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"gopkg.in/tomb.v2"
 )
 

--- a/core/cache/modelwatcher_test.go
+++ b/core/cache/modelwatcher_test.go
@@ -6,6 +6,7 @@ package cache
 import (
 	"time"
 
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2/workertest"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
@@ -111,7 +112,7 @@ func (s *modelWatcherSuite) TestMultipleUpdates(c *gc.C) {
 	// We know the events are handled in order, so we only need to wait for the
 	// last of the three events to have been processed.
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Errorf("publish event not handled")
 	}

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -199,11 +199,11 @@ func (u *Unit) setDetails(details UnitChange) {
 	// Publish a unit addition event if a unit gets a machine ID for the first
 	// time, or if this is a subordinate that was not previously in the cache.
 	if landingOnMachine || newSubordinate {
-		u.model.hub.Publish(modelUnitAdd, toPublish)
+		_ = u.model.hub.Publish(modelUnitAdd, toPublish)
 	}
 
 	// Publish change event for those that may be waiting.
-	u.model.hub.Publish(unitChangeTopic(details.Name), &toPublish)
+	_ = u.model.hub.Publish(unitChangeTopic(details.Name), &toPublish)
 }
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"
 )

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/globalclock"
@@ -247,7 +247,7 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 
 	start := time.Now()
 	defer func() {
-		elapsed := time.Now().Sub(start)
+		elapsed := time.Since(start)
 		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
 
@@ -265,7 +265,7 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 	// This is an explicit step so that we can more accurately diagnose issues
 	// in-theatre.
 	select {
-	case <-delivered:
+	case <-pubsub.Wait(delivered):
 	case <-s.config.Clock.After(s.config.ForwardTimeout):
 		logger.Warningf("delivery timeout waiting for %s to be processed", command)
 		s.record(command.Operation, "delivery timeout", start)

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
 	github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6
+	github.com/juju/pubsub/v2 v2.0.0-00010101000000-000000000000
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216
@@ -121,3 +122,5 @@ replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0
 replace github.com/hashicorp/raft-boltdb => github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5
 
 replace gopkg.in/juju/names.v3 => github.com/juju/names v0.0.0-20200331100531-2c9a102df211
+
+replace github.com/juju/pubsub/v2 => github.com/SimonRichardson/pubsub/v2 v2.0.0-20210723115204-8d13ba3eb76d

--- a/go.mod
+++ b/go.mod
@@ -59,8 +59,7 @@ require (
 	github.com/juju/packaging v0.0.0-20210322161715-32d1b6c12454
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
-	github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6
-	github.com/juju/pubsub/v2 v2.0.0-00010101000000-000000000000
+	github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216
@@ -122,5 +121,3 @@ replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0
 replace github.com/hashicorp/raft-boltdb => github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5
 
 replace gopkg.in/juju/names.v3 => github.com/juju/names v0.0.0-20200331100531-2c9a102df211
-
-replace github.com/juju/pubsub/v2 => github.com/SimonRichardson/pubsub/v2 v2.0.0-20210723115204-8d13ba3eb76d

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/SimonRichardson/pubsub/v2 v2.0.0-20210723115204-8d13ba3eb76d h1:knXZK1sZf2e1UhEJ7pHDZmmDyLsUH9Xyznu+b8fahuw=
-github.com/SimonRichardson/pubsub/v2 v2.0.0-20210723115204-8d13ba3eb76d/go.mod h1:muz5gqZ/u1pTC84e9scTKhEtmvE02wbuK1kvyLzIwQc=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd h1:JdtityihAc6A+gVfYh6vGXfZQg+XOLyBvla/7NbXFCg=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -413,6 +411,8 @@ github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4 h1:y2eoq0Uof/dWLAXRyKKG
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6 h1:2aARJxmMC2IF9GqVtt5PYcIy4jyuAcR44byqwXKTK0o=
 github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6/go.mod h1:umz/NzotkJCFQHT3hqeLRISzYNCZzyV1sogjeAILCWw=
+github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289 h1:JPKuGuO4eDWUstv4puLCAdikIiI4235jYUCiYILjgjI=
+github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289/go.mod h1:muz5gqZ/u1pTC84e9scTKhEtmvE02wbuK1kvyLzIwQc=
 github.com/juju/qthttptest v0.0.1/go.mod h1://LCf/Ls22/rPw2u1yWukUJvYtfPY4nYpWUl2uZhryo=
 github.com/juju/qthttptest v0.1.1 h1:JPju5P5CDMCy8jmBJV2wGLjDItUsx2KKL514EfOYueM=
 github.com/juju/qthttptest v0.1.1/go.mod h1:aTlAv8TYaflIiTDIQYzxnl1QdPjAg8Q8qJMErpKy6A4=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/SimonRichardson/pubsub/v2 v2.0.0-20210723115204-8d13ba3eb76d h1:knXZK1sZf2e1UhEJ7pHDZmmDyLsUH9Xyznu+b8fahuw=
+github.com/SimonRichardson/pubsub/v2 v2.0.0-20210723115204-8d13ba3eb76d/go.mod h1:muz5gqZ/u1pTC84e9scTKhEtmvE02wbuK1kvyLzIwQc=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd h1:JdtityihAc6A+gVfYh6vGXfZQg+XOLyBvla/7NbXFCg=
 github.com/ajstarks/svgo v0.0.0-20181006003313-6ce6a3bcf6cd/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -451,6 +453,7 @@ github.com/juju/testing v0.0.0-20170608054451-2fe0e88cf232/go.mod h1:63prj8cnj0t
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180807043854-177f846b8501/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
+github.com/juju/testing v0.0.0-20180807044555-c84dd6ba038a/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180820040200-b0b89ba330f2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/series"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -37,7 +37,7 @@ import (
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/retry"
 	"github.com/juju/schema"
 	gitjujutesting "github.com/juju/testing"

--- a/pubsub/centralhub/centralhub.go
+++ b/pubsub/centralhub/centralhub.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/utils/v2"
 	"gopkg.in/yaml.v2"
 )

--- a/pubsub/centralhub/centralhub_test.go
+++ b/pubsub/centralhub/centralhub_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -46,7 +46,7 @@ func (s *CentralHubSuite) TestSetsOrigin(c *gc.C) {
 
 	done, err := hub.Publish(topic, map[string]interface{}{"key": "value"})
 	c.Assert(err, jc.ErrorIsNil)
-	s.waitForSubscribers(c, done)
+	s.waitForSubscribers(c, pubsub.Wait(done))
 	c.Assert(called, jc.IsTrue)
 }
 
@@ -74,7 +74,7 @@ func (s *CentralHubSuite) TestYAMLMarshalling(c *gc.C) {
 	// With the default JSON marshalling, integers are marshalled to floats into the map.
 	done, err := hub.Publish(topic, IntStruct{1234})
 	c.Assert(err, jc.ErrorIsNil)
-	s.waitForSubscribers(c, done)
+	s.waitForSubscribers(c, pubsub.Wait(done))
 	c.Assert(called, jc.IsTrue)
 }
 
@@ -111,6 +111,6 @@ func (s *CentralHubSuite) TestPostProcessingMaps(c *gc.C) {
 		Key:    "value",
 		Nested: IntStruct{1234}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.waitForSubscribers(c, done)
+	s.waitForSubscribers(c, pubsub.Wait(done))
 	c.Assert(called, jc.IsTrue)
 }

--- a/state/pool.go
+++ b/state/pool.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/mongo"

--- a/state/state.go
+++ b/state/state.go
@@ -25,7 +25,7 @@ import (
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/v2"
 	"github.com/juju/version"

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
 	gc "gopkg.in/check.v1"
@@ -56,7 +56,7 @@ func (s *HubWatcherSuite) SetUpTest(c *gc.C) {
 func (s *HubWatcherSuite) publish(c *gc.C, changes ...watcher.Change) {
 	var processed <-chan struct{}
 	for _, change := range changes {
-		processed = s.hub.Publish(watcher.TxnWatcherCollection, change)
+		processed = pubsub.Wait(s.hub.Publish(watcher.TxnWatcherCollection, change))
 	}
 	select {
 	case <-processed:

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -315,7 +315,7 @@ func newFakeHub(c *gc.C, expected int) *fakeHub {
 	}
 }
 
-func (hub *fakeHub) Publish(topic string, data interface{}) <-chan struct{} {
+func (hub *fakeHub) Publish(topic string, data interface{}) func() {
 	switch topic {
 	case watcher.TxnWatcherStarting:
 		close(hub.started)

--- a/state/workers.go
+++ b/state/workers.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/state/watcher"

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -5,7 +5,7 @@ package agentconfigupdater
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -6,7 +6,7 @@ package agentconfigupdater_test
 import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"

--- a/worker/agentconfigupdater/worker.go
+++ b/worker/agentconfigupdater/worker.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"
 

--- a/worker/agentconfigupdater/worker_test.go
+++ b/worker/agentconfigupdater/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -133,7 +133,7 @@ func (s *WorkerSuite) TestUpdateMongoProfile(c *gc.C) {
 	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -145,7 +145,7 @@ func (s *WorkerSuite) TestUpdateMongoProfile(c *gc.C) {
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -164,7 +164,7 @@ func (s *WorkerSuite) TestUpdateJujuDBSnapChannel(c *gc.C) {
 	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -176,7 +176,7 @@ func (s *WorkerSuite) TestUpdateJujuDBSnapChannel(c *gc.C) {
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -195,7 +195,7 @@ func (s *WorkerSuite) TestUpdateSyncWritesToRaftLog(c *gc.C) {
 	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -207,7 +207,7 @@ func (s *WorkerSuite) TestUpdateSyncWritesToRaftLog(c *gc.C) {
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}

--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/apiserver/observers.go
+++ b/worker/apiserver/observers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver"

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/agent"

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/centralhub/manifold.go
+++ b/worker/centralhub/manifold.go
@@ -5,7 +5,7 @@ package centralhub
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"gopkg.in/tomb.v2"

--- a/worker/centralhub/manifold_test.go
+++ b/worker/centralhub/manifold_test.go
@@ -5,7 +5,7 @@ package centralhub_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/dependency"

--- a/worker/controllerport/manifold.go
+++ b/worker/controllerport/manifold.go
@@ -5,7 +5,7 @@ package controllerport
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/controllerport/manifold_test.go
+++ b/worker/controllerport/manifold_test.go
@@ -6,7 +6,7 @@ package controllerport_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/controllerport/worker.go
+++ b/worker/controllerport/worker.go
@@ -5,7 +5,7 @@ package controllerport
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"gopkg.in/tomb.v2"

--- a/worker/controllerport/worker_test.go
+++ b/worker/controllerport/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -82,7 +82,7 @@ func (s *WorkerSuite) TestNoChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-processed:
+	case <-pubsub.Wait(processed):
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for processed")
 	}
@@ -97,7 +97,7 @@ func (s *WorkerSuite) TestChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-processed:
+	case <-pubsub.Wait(processed):
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for processed")
 	}

--- a/worker/httpserver/manifold.go
+++ b/worker/httpserver/manifold.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2/catacomb"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -407,7 +407,7 @@ func (s *WorkerControllerPortSuite) TestDualPortListenerWithDelay(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("the handler should have exited early and not be waiting")
 	}

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/lease/manifold/manifold_test.go
+++ b/worker/lease/manifold/manifold_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -5,7 +5,7 @@ package modelcache
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/modelcache/manifold_test.go
+++ b/worker/modelcache/manifold_test.go
@@ -6,7 +6,7 @@ package modelcache_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jt "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -275,7 +275,7 @@ func (s *WorkerSuite) TestControllerConfigPubsubChange(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("config changed not handled")
 	}

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -107,7 +107,7 @@ var (
 // grouper uses.
 type Hub interface {
 	Subscribe(topic string, handler interface{}) (func(), error)
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 }
 
 // pgWorker is a worker which watches the controller nodes in state

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/replicaset"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/voyeur"
@@ -1132,8 +1132,8 @@ func (nopAPIHostPortsSetter) SetAPIHostPorts(apiServers []network.SpaceHostPorts
 
 type nopHub struct{}
 
-func (nopHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
-	return nil, nil
+func (nopHub) Publish(topic string, data interface{}) (func(), error) {
+	return func() {}, nil
 }
 
 func (nopHub) Subscribe(topic string, handler interface{}) (func(), error) {

--- a/worker/presence/manifold.go
+++ b/worker/presence/manifold.go
@@ -5,7 +5,7 @@ package presence
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/presence/manifold_test.go
+++ b/worker/presence/manifold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/presence/presence.go
+++ b/worker/presence/presence.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"
 
@@ -141,7 +141,7 @@ func (w *wrapper) forwarderConnect(topic string, data forwarder.OriginTarget, er
 	}
 	w.logger.Tracef("request presence info from %s", request)
 	msg := apiserver.OriginTarget{Target: request}
-	w.hub.Publish(apiserver.PresenceRequestTopic, msg)
+	_, _ = w.hub.Publish(apiserver.PresenceRequestTopic, msg)
 	w.logger.Tracef("request sent")
 }
 

--- a/worker/presence/presence_test.go
+++ b/worker/presence/presence_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -195,7 +195,7 @@ func (s *PresenceSuite) TestForwarderDisconnectConnectFromOther(c *gc.C) {
 		forwarder.DisconnectedTopic,
 		apiserver.OriginTarget{Origin: ourServer, Target: otherServer})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, alive(agent1), missing(agent2))
 }
 
@@ -209,7 +209,7 @@ func (s *PresenceSuite) TestForwarderDisconnectOthersIgnored(c *gc.C) {
 		forwarder.DisconnectedTopic,
 		apiserver.OriginTarget{Origin: "machine-7", Target: otherServer})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, alive(agent1), alive(agent2))
 }
 
@@ -228,7 +228,7 @@ func (s *PresenceSuite) TestConnectTopic(c *gc.C) {
 			UserData:        "test",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, corepresence.Value{
 		Model:           "model-uuid",
 		Server:          "machine-5",
@@ -253,7 +253,7 @@ func (s *PresenceSuite) TestDisconnectTopic(c *gc.C) {
 			ConnectionID: agent2.ConnectionID,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, alive(agent1))
 }
 
@@ -323,7 +323,7 @@ func (s *PresenceSuite) TestPresenceResponse(c *gc.C) {
 			},
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 
 	s.AssertConnections(c, alive(agent1), alive(agent2), alive(agent3), alive(agent4))
 }

--- a/worker/pubsub/manifold.go
+++ b/worker/pubsub/manifold.go
@@ -6,7 +6,7 @@ package pubsub
 import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/pubsub/manifold_test.go
+++ b/worker/pubsub/manifold_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/pubsub/remoteserver.go
+++ b/worker/pubsub/remoteserver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/collections/deque"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/retry"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"

--- a/worker/pubsub/remoteserver_test.go
+++ b/worker/pubsub/remoteserver_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -182,7 +182,7 @@ func (s *RemoteServerSuite) TestConnectRetryInterruptedOnTargetConnection(c *gc.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("worker didn't consume the event")
 	}

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -201,7 +201,7 @@ func (s *SubscriberSuite) enableHA(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("message handling not completed")
 	}
@@ -252,7 +252,7 @@ func (s *SubscriberSuite) TestEnableHAInternalAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("message handling not completed")
 	}
@@ -276,7 +276,7 @@ func (s *SubscriberSuite) TestSameMessagesForwardedForMachine(c *gc.C) {
 		expected = append(expected, message)
 		done, err := s.hub.Publish(message.Topic, nil)
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:
@@ -313,7 +313,7 @@ func (s *SubscriberSuite) TestSameMessagesForwardedForController(c *gc.C) {
 		expected = append(expected, message)
 		done, err := s.hub.Publish(message.Topic, nil)
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:
@@ -340,7 +340,7 @@ func (s *SubscriberSuite) TestLocalMessagesNotForwarded(c *gc.C) {
 			"local-only": true,
 		})
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:
@@ -367,7 +367,7 @@ func (s *SubscriberSuite) TestOtherOriginMessagesNotForwarded(c *gc.C) {
 			"origin": "other",
 		})
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:

--- a/worker/raft/raftbackstop/manifold.go
+++ b/worker/raft/raftbackstop/manifold.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/raft/raftbackstop/manifold_test.go
+++ b/worker/raft/raftbackstop/manifold_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/raftbackstop/worker.go
+++ b/worker/raft/raftbackstop/worker.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 

--- a/worker/raft/raftbackstop/worker_test.go
+++ b/worker/raft/raftbackstop/worker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -348,7 +348,7 @@ func (s *WorkerSuite) publishDetails(c *gc.C, serverAddrs map[string]string) {
 	received, err := s.hub.Publish(apiserver.DetailsTopic, details)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-received:
+	case <-pubsub.Wait(received):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for details to be received")
 	}

--- a/worker/raft/raftclusterer/manifold.go
+++ b/worker/raft/raftclusterer/manifold.go
@@ -6,7 +6,7 @@ package raftclusterer
 import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 )

--- a/worker/raft/raftclusterer/manifold_test.go
+++ b/worker/raft/raftclusterer/manifold_test.go
@@ -6,7 +6,7 @@ package raftclusterer_test
 import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/workertest"
@@ -550,7 +550,7 @@ func (s *WorkerSuite) publishDetails(c *gc.C, serverAddrs map[string]string) {
 	received, err := s.hub.Publish(apiserver.DetailsTopic, details)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-received:
+	case <-pubsub.Wait(received):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for details to be received")
 	}

--- a/worker/raft/raftforwarder/manifold.go
+++ b/worker/raft/raftforwarder/manifold.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/raft/raftforwarder/manifold_test.go
+++ b/worker/raft/raftforwarder/manifold_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/raft/raftforwarder/worker_test.go
+++ b/worker/raft/raftforwarder/worker_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/rafttransport/manifold.go
+++ b/worker/raft/rafttransport/manifold.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/rafttransport/streamlayer.go
+++ b/worker/raft/rafttransport/streamlayer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/pubsub/apiserver"

--- a/worker/raft/rafttransport/worker.go
+++ b/worker/raft/rafttransport/worker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/replicaset"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"


### PR DESCRIPTION
The following moves to pubsub v2, which doesn't require everyone to wait
for every subscriber to be done. Instead, if you want the old
functionality you can call the high-level function in the package.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy cs:~jameinel/ubuntu-lite-9 ubuntu
$ juju deploy cs:~jameinel/ubuntu-lite-9 ubuntux
$ juju deploy cs:~jameinel/ubuntu-lite-9 ubuntuz
$ juju remove-machine 1 -m controller
$ juju enable-ha
```

Check the raft logs to see if there are any errors.

```sh
juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE"
```
## Bug reference

TBA
