### PR TITLE
add logger label of charmhub

### DIFF
--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -33,7 +33,7 @@ func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.
 	}
 	url, _ := modelConfig.CharmHubURL()
 
-	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"),
+	config, err := charmhub.CharmHubConfigFromURL(url, logger,
 		charmhub.WithMetadataHeaders(metadata),
 		charmhub.WithHTTPTransport(func(charmhub.Logger) charmhub.Transport {
 			return httpClient

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -277,7 +277,6 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		return nil, errors.Trace(err)
 	}
 
-	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
 		// TODO (stickupkid): Get the http transport from the facade context
 		charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
@@ -286,9 +285,9 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfig(logger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
-	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -136,7 +135,7 @@ type charmHubClientFactory struct {
 }
 
 func (f charmHubClientFactory) Client(url string) (Client, error) {
-	cfg, err := charmhub.CharmHubConfigFromURL(url, logger.ChildWithLabels("client", corelogger.HTTP),
+	cfg, err := charmhub.CharmHubConfigFromURL(url, logger,
 		charmhub.WithHTTPTransport(f.httpTransport),
 	)
 	if err != nil {

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -639,7 +639,6 @@ func (a *API) charmHubRepository() (corecharm.Repository, error) {
 		return nil, errors.Trace(err)
 	}
 
-	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
 		charmhub.WithHTTPTransport(func(charmhub.Logger) charmhub.Transport {
 			return a.httpClient
@@ -649,9 +648,9 @@ func (a *API) charmHubRepository() (corecharm.Repository, error) {
 	var chCfg charmhub.Config
 	chURL, ok := cfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfig(logger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -102,7 +102,6 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
 		// TODO (stickupkid): Get the http transport from the facade context
 		charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
@@ -111,9 +110,9 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfig(logger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -80,7 +80,6 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 		switch {
 		case charm.CharmHub.Matches(schema):
 
-			clientLogger := logger.Child("client")
 			options := []charmhub.Option{
 				// TODO (stickupkid): Get the httpClient from the facade context
 				charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
@@ -89,9 +88,9 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 			var chCfg charmhub.Config
 			chURL, ok := modelCfg.CharmHubURL()
 			if ok {
-				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 			} else {
-				chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+				chCfg, err = charmhub.CharmHubConfig(logger, options...)
 			}
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -161,13 +161,14 @@ func CharmHubConfig(logger Logger, options ...Option) (Config, error) {
 		headers.Add(MetadataHeader, k+"="+m[k])
 	}
 
+	chLogger := logger.ChildWithLabels("client", corelogger.CHARMHUB)
 	return Config{
 		URL:       *opts.url,
 		Version:   CharmHubServerVersion,
 		Entity:    CharmHubServerEntity,
 		Headers:   headers,
-		Transport: opts.transportFunc(logger.ChildWithLabels("transport", corelogger.HTTP)),
-		Logger:    logger,
+		Transport: opts.transportFunc(chLogger.ChildWithLabels("transport", corelogger.HTTP)),
+		Logger:    chLogger,
 	}, nil
 }
 

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -424,7 +424,7 @@ func (d downloadLogger) Debugf(msg string, args ...interface{}) {
 
 func (d downloadLogger) Tracef(msg string, args ...interface{}) {}
 
-func (d downloadLogger) ChildWithLabels(name string, labels ...string) loggo.Logger {
+func (d downloadLogger) ChildWithLabels(string, ...string) loggo.Logger {
 	return loggo.Logger{}
 }
 

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -59,10 +59,10 @@ The filtering options combine as follows:
 * All --exclude options are logically ORed together.
 * All --include-module options are logically ORed together.
 * All --exclude-module options are logically ORed together.
-* All --include-labels options are logically ORed together.
-* All --exclude-labels options are logically ORed together.
+* All --include-label options are logically ORed together.
+* All --exclude-label options are logically ORed together.
 * The combined --include, --exclude, --include-module, --exclude-module,
-  --include-labels and --exclude-labels selections are logically ANDed to form 
+  --include-label and --exclude-label selections are logically ANDed to form
   the complete filter.
 
 Examples:

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -13,4 +13,8 @@ const (
 	// METRICS defines a common label for dealing with metric output. This
 	// should be used as a fallback for when prometheus isn't available.
 	METRICS Label = "metrics"
+
+	// CHARMHUB defines a common label for dealing with the charmhub client
+	// and callers.
+	CHARMHUB Label = "charmhub"
 )

--- a/resource/resourceadapters/charmhub.go
+++ b/resource/resourceadapters/charmhub.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/charmstore"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/resource/repositories"
 )
 
@@ -50,13 +51,12 @@ func newCharmHubClient(st chClientState) (ResourceClient, error) {
 		return &CharmHubClient{}, errors.Trace(err)
 	}
 
-	chLogger := logger.Child("charmhub")
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, chLogger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(chLogger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfig(logger)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -65,7 +65,7 @@ func newCharmHubClient(st chClientState) (ResourceClient, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &CharmHubClient{client: chClient, logger: chLogger}, nil
+	return &CharmHubClient{client: chClient, logger: logger.ChildWithLabels("charmhub", corelogger.CHARMHUB)}, nil
 }
 
 type CharmHubClient struct {


### PR DESCRIPTION
Add CHARMHUB logger label.  Ensure its used by adding to the logger in the client creation, rather than the callers.

## QA steps

```
$ juju bootstrap localhost testme
$ juju model-config  "logging-config='#charmhub=TRACE'" -m controller

# while watching the output of `juju debug-log -m controller`, run the following and verify output.
$ juju deploy juju-qa-test
$ juju info juju-qa-test
$ juju find juju-qa-test
```
