### PR TITLE
Add another whitelisted network error to bootstrap check

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -130,6 +130,7 @@ func WaitForAgentInitialisation(
 			strings.HasSuffix(errorMessage, "target machine actively refused it."), // Winsock message for connection refused
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
+			strings.HasSuffix(errorMessage, "network is unreachable"),
 			strings.HasSuffix(errorMessage, "deadline exceeded"),
 			strings.HasSuffix(errorMessage, "no api connection available"),
 			strings.Contains(errorMessage, "spaces are still being discovered"):


### PR DESCRIPTION
When bootstrapping, we connect to the controller api to check that things have come up correctly. There's an allowable set of errors that cause a retry (eg i/o timeout). Anything else is fatal. A new case has emerged of an error that needs to be allowed for: "network is unreachable".

## QA steps

bootstrap to aws

## Bug reference

https://bugs.launchpad.net/juju/+bug/1938019
