### PR TITLE
Fix agent binary downloading to only download once.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -645,9 +645,7 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 		stateAuthFunc: httpCtxt.stateForRequestAuthenticatedUser,
 	}
 	modelToolsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
-	modelToolsDownloadHandler := &toolsDownloadHandler{
-		ctxt: httpCtxt,
-	}
+	modelToolsDownloadHandler := newToolsDownloadHandler(httpCtxt)
 	resourcesHandler := &ResourcesHandler{
 		StateAuthFunc: func(req *http.Request, tagKinds ...string) (ResourcesBackend, state.PoolHelper, names.Tag, error) {
 			st, entity, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)

--- a/apiserver/httpcontext.go
+++ b/apiserver/httpcontext.go
@@ -37,6 +37,11 @@ func (ctxt *httpContext) stateForRequestUnauthenticated(r *http.Request) (*state
 	return st, nil
 }
 
+// statePool returns the StatePool for this controller.
+func (ctxt *httpContext) statePool() *state.StatePool {
+	return ctxt.srv.shared.statePool
+}
+
 // stateForRequestAuthenticated returns a state instance appropriate for
 // using for the model implicit in the given request.
 // It also returns the authenticated entity.


### PR DESCRIPTION
- Fixes stampeding herd of agents upgrading where those agent binaries are not cached by requests for the same agent version wait for the first request to finish caching it.
- Fixes caching of large tar's in a bytes.Buffer by storing on disk in tmp.
- Fixes cache sharing by storing tars in controller model tool storage when pulled from simplestreams.
- Always pull from simplestreams using controller model environ

Before:
```
machine-0: 16:03:47 INFO juju.worker.upgrader fetching agent binaries from "https://10.157.66.56:17070/model/cc6afd2f-2f0b-4f50-8b00-74e3ade9ceb8/tools/2.9.12-ubuntu-amd64"
machine-0: 16:03:47 INFO juju.apiserver 2.9.12-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:03:48 INFO juju.apiserver fetching 2.9.12-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.12-linux-amd64.tgz
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:05 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 16:05:06 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:06 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
machine-0: 16:05:07 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
```

Now:
```
machine-0: 15:34:08 INFO juju.worker.upgrader fetching agent binaries from "https://10.157.66.105:17070/model/e28b5fc7-52ea-4ffd-8850-0d8407e592dc/tools/2.9.12-ubuntu-amd64"
machine-0: 15:34:08 INFO juju.apiserver 2.9.12-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:34:10 INFO juju.apiserver fetching 2.9.12-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.12-linux-amd64.tgz
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:34 INFO juju.apiserver 2.9.11-ubuntu-amd64 agent binaries not found locally, fetching
machine-0: 15:36:36 INFO juju.apiserver fetching 2.9.11-ubuntu-amd64 agent binaries from http://192.168.1.65:9999/released-agents/juju-2.9.11-linux-amd64.tgz
```

## QA steps

```
$ juju version
2.9.10-ubuntu-amd64
$ juju bootstrap ...
$ juju deploy hello-juju -n 10
# upgrade the controller to 2.9.12 (+2 versions above current, skipping 2.9.11)
$ juju upgrade-controller
# wait for upgrade
# put a rate limit on the simplestream server to slow downloads (say 1Mbyte/s)
$ juju upgrade-model --agent-version 2.9.11
# all the agents should get a cache miss, but only one should start a download
$ juju debug-log | grep "agent binaries"
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1936684
https://bugs.launchpad.net/juju/+bug/1900021
