### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/api/caasapplicationprovisioner/client.go
+++ b/api/caasapplicationprovisioner/client.go
@@ -244,11 +244,11 @@ func (c *Client) SetOperatorStatus(appName string, status status.Status, message
 }
 
 // Units returns all the units for an Application.
-func (c *Client) Units(appName string) ([]names.Tag, error) {
+func (c *Client) Units(appName string) ([]params.CAASUnit, error) {
 	args := params.Entities{Entities: []params.Entity{{
 		Tag: names.NewApplicationTag(appName).String(),
 	}}}
-	var result params.EntitiesResults
+	var result params.CAASUnitsResults
 	if err := c.facade.FacadeCall("Units", args, &result); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -260,15 +260,18 @@ func (c *Client) Units(appName string) ([]names.Tag, error) {
 	if res.Error != nil {
 		return nil, errors.Annotatef(maybeNotFound(res.Error), "unable to fetch units for %s", appName)
 	}
-	tags := make([]names.Tag, 0, len(res.Entities))
-	for _, v := range res.Entities {
+	out := make([]params.CAASUnit, len(res.Units))
+	for i, v := range res.Units {
 		tag, err := names.ParseUnitTag(v.Tag)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		tags = append(tags, tag)
+		out[i] = params.CAASUnit{
+			Tag:        tag,
+			UnitStatus: v.UnitStatus,
+		}
 	}
-	return tags, nil
+	return out, nil
 }
 
 // GarbageCollect cleans up units that have gone away permanently.

--- a/api/caasapplicationprovisioner/client_test.go
+++ b/api/caasapplicationprovisioner/client_test.go
@@ -253,10 +253,12 @@ func (s *provisionerSuite) TestAllUnits(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "Units")
 		c.Assert(arg, jc.DeepEquals, params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
-		c.Assert(result, gc.FitsTypeOf, &params.EntitiesResults{})
-		*(result.(*params.EntitiesResults)) = params.EntitiesResults{
-			Results: []params.EntitiesResult{{
-				Entities: []params.Entity{{"unit-gitlab-0"}},
+		c.Assert(result, gc.FitsTypeOf, &params.CAASUnitsResults{})
+		*(result.(*params.CAASUnitsResults)) = params.CAASUnitsResults{
+			Results: []params.CAASUnitsResult{{
+				Units: []params.CAASUnitInfo{
+					{Tag: "unit-gitlab-0"},
+				},
 			}},
 		}
 		return nil
@@ -264,7 +266,9 @@ func (s *provisionerSuite) TestAllUnits(c *gc.C) {
 
 	tags, err := client.Units("gitlab")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(tags, jc.SameContents, []names.Tag{names.NewUnitTag("gitlab/0")})
+	c.Assert(tags, jc.SameContents, []params.CAASUnit{
+		{Tag: names.NewUnitTag("gitlab/0")},
+	})
 }
 
 func (s *provisionerSuite) TestGarbageCollect(c *gc.C) {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/ratelimit"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/apiserver/basesuite_test.go
+++ b/apiserver/basesuite_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"

--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -33,7 +33,7 @@ func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.
 	}
 	url, _ := modelConfig.CharmHubURL()
 
-	config, err := charmhub.CharmHubConfigFromURL(url, logger.Child("charmhub"),
+	config, err := charmhub.CharmHubConfigFromURL(url, logger,
 		charmhub.WithMetadataHeaders(metadata),
 		charmhub.WithHTTPTransport(func(charmhub.Logger) charmhub.Transport {
 			return httpClient

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -238,5 +238,5 @@ type ModelPresence interface {
 
 // Hub represents the central hub that the API server has.
 type Hub interface {
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -147,7 +147,6 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 		return nil, errors.Trace(err)
 	}
 
-	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
 		// TODO (stickupkid): Get the http transport from the facade context
 		charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
@@ -156,9 +155,9 @@ func newFacadeBase(ctx facade.Context) (*APIBase, error) {
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfig(logger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/charmhub/charmhub.go
+++ b/apiserver/facades/client/charmhub/charmhub.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
-	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -136,7 +135,7 @@ type charmHubClientFactory struct {
 }
 
 func (f charmHubClientFactory) Client(url string) (Client, error) {
-	cfg, err := charmhub.CharmHubConfigFromURL(url, logger.ChildWithLabels("client", corelogger.HTTP),
+	cfg, err := charmhub.CharmHubConfigFromURL(url, logger,
 		charmhub.WithHTTPTransport(f.httpTransport),
 	)
 	if err != nil {

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v2/workertest"

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -102,7 +102,6 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 		return nil, errors.Trace(err)
 	}
 
-	clientLogger := logger.Child("client")
 	options := []charmhub.Option{
 		// TODO (stickupkid): Get the http transport from the facade context
 		charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
@@ -111,9 +110,9 @@ func NewFacade(ctx facade.Context) (*MachineManagerAPI, error) {
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+		chCfg, err = charmhub.CharmHubConfig(logger, options...)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -80,7 +80,6 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 		switch {
 		case charm.CharmHub.Matches(schema):
 
-			clientLogger := logger.Child("client")
 			options := []charmhub.Option{
 				// TODO (stickupkid): Get the httpClient from the facade context
 				charmhub.WithHTTPTransport(charmhub.DefaultHTTPTransport),
@@ -89,9 +88,9 @@ func NewFacadeV2(ctx facade.Context) (*API, error) {
 			var chCfg charmhub.Config
 			chURL, ok := modelCfg.CharmHubURL()
 			if ok {
-				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, clientLogger, options...)
+				chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger, options...)
 			} else {
-				chCfg, err = charmhub.CharmHubConfig(clientLogger, options...)
+				chCfg, err = charmhub.CharmHubConfig(logger, options...)
 			}
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -352,6 +352,7 @@ type mockUnit struct {
 	life                state.Life
 	destroyOp           *state.DestroyUnitOperation
 	containerInfo       *mockCloudContainer
+	status              status.StatusInfo
 	tag                 names.Tag
 	updateUnitOperation *state.UpdateUnitOperation
 }
@@ -363,6 +364,11 @@ func (u *mockUnit) Tag() names.Tag {
 func (u *mockUnit) DestroyOperation() *state.DestroyUnitOperation {
 	u.MethodCall(u, "DestroyOperation")
 	return u.destroyOp
+}
+
+func (u *mockUnit) Status() (status.StatusInfo, error) {
+	u.MethodCall(u, "Status")
+	return u.status, u.NextErr()
 }
 
 func (u *mockUnit) EnsureDead() error {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -153,9 +153,24 @@ func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 			},
 		},
 		units: []*mockUnit{
-			{tag: names.NewUnitTag("gitlab/0")},
-			{tag: names.NewUnitTag("gitlab/1")},
-			{tag: names.NewUnitTag("gitlab/2")},
+			{
+				tag: names.NewUnitTag("gitlab/0"),
+				status: status.StatusInfo{
+					Status: status.Active,
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/1"),
+				status: status.StatusInfo{
+					Status: status.Maintenance,
+				},
+			},
+			{
+				tag: names.NewUnitTag("gitlab/2"),
+				status: status.StatusInfo{
+					Status: status.Unknown,
+				},
+			},
 		},
 	}
 	result, err := s.api.Units(params.Entities{
@@ -165,10 +180,28 @@ func (s *CAASApplicationProvisionerSuite) TestUnits(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].Entities, gc.DeepEquals, []params.Entity{
-		{Tag: "unit-gitlab-0"},
-		{Tag: "unit-gitlab-1"},
-		{Tag: "unit-gitlab-2"},
+	c.Assert(result.Results[0].Units, gc.DeepEquals, []params.CAASUnitInfo{
+		{
+			Tag: "unit-gitlab-0",
+			UnitStatus: &params.UnitStatus{
+				AgentStatus:    params.DetailedStatus{Status: "active"},
+				WorkloadStatus: params.DetailedStatus{Status: "active"},
+			},
+		},
+		{
+			Tag: "unit-gitlab-1",
+			UnitStatus: &params.UnitStatus{
+				AgentStatus:    params.DetailedStatus{Status: "maintenance"},
+				WorkloadStatus: params.DetailedStatus{Status: "maintenance"},
+			},
+		},
+		{
+			Tag: "unit-gitlab-2",
+			UnitStatus: &params.UnitStatus{
+				AgentStatus:    params.DetailedStatus{Status: "unknown"},
+				WorkloadStatus: params.DetailedStatus{Status: "unknown"},
+			},
+		},
 	})
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -71,6 +71,7 @@ type Unit interface {
 	EnsureDead() error
 	ContainerInfo() (state.CloudContainer, error)
 	UpdateOperation(props state.UnitUpdateProperties) *state.UpdateUnitOperation
+	Status() (status.StatusInfo, error)
 }
 
 type Resources interface {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6474,7 +6474,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/EntitiesResults"
+                            "$ref": "#/definitions/CAASUnitsResults"
                         }
                     },
                     "description": "Units returns all the units for each application specified."
@@ -6752,6 +6752,51 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/CAASApplicationProvisioningInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "CAASUnitInfo": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        },
+                        "unit-status": {
+                            "$ref": "#/definitions/UnitStatus"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "CAASUnitsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CAASUnitInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CAASUnitsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CAASUnitsResult"
                             }
                         }
                     },
@@ -7313,6 +7358,52 @@
                         "url"
                     ]
                 },
+                "DetailedStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "err": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "data",
+                        "since",
+                        "kind",
+                        "version",
+                        "life"
+                    ]
+                },
                 "DockerImageInfo": {
                     "type": "object",
                     "properties": {
@@ -7344,39 +7435,6 @@
                     "additionalProperties": false,
                     "required": [
                         "entities"
-                    ]
-                },
-                "EntitiesResult": {
-                    "type": "object",
-                    "properties": {
-                        "entities": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Entity"
-                            }
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "entities"
-                    ]
-                },
-                "EntitiesResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/EntitiesResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "Entity": {
@@ -7912,6 +7970,63 @@
                     "additionalProperties": false,
                     "required": [
                         "watcher-id"
+                    ]
+                },
+                "UnitStatus": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "agent-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "leader": {
+                            "type": "boolean"
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "opened-ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public-address": {
+                            "type": "string"
+                        },
+                        "subordinates": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/UnitStatus"
+                                }
+                            }
+                        },
+                        "workload-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "agent-status",
+                        "workload-status",
+                        "workload-version",
+                        "machine",
+                        "opened-ports",
+                        "public-address",
+                        "charm",
+                        "subordinates"
                     ]
                 },
                 "UpdateApplicationUnitArgs": {

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -18,18 +18,17 @@ import (
 // Hub defines the only method of the apiserver centralhub that
 // the observer uses.
 type Hub interface {
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 }
 
 // RequestObserver serves as a sink for API server requests and
 // responses.
 type RequestObserver struct {
-	clock              clock.Clock
-	hub                Hub
-	logger             loggo.Logger
-	connLogger         loggo.Logger
-	pingLogger         loggo.Logger
-	apiConnectionCount func() int64
+	clock      clock.Clock
+	hub        Hub
+	logger     loggo.Logger
+	connLogger loggo.Logger
+	pingLogger loggo.Logger
 
 	// state represents information that's built up as methods on this
 	// type are called. We segregate this to ensure it's clear what
@@ -46,8 +45,8 @@ type RequestObserver struct {
 	}
 }
 
-// RequestObservercontext provides information needed for a
-// RequestObserverContext to operate correctly.
+// RequestObserverContext provides information needed for a
+// RequestObserver to operate correctly.
 type RequestObserverContext struct {
 
 	// Clock is the clock to use for all time operations on this type.

--- a/apiserver/observer/request_notifier_test.go
+++ b/apiserver/observer/request_notifier_test.go
@@ -144,9 +144,9 @@ type connectionHub struct {
 	details apiserver.APIConnection
 }
 
-func (hub *connectionHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
+func (hub *connectionHub) Publish(topic string, data interface{}) (func(), error) {
 	hub.called++
 	hub.topic = topic
 	hub.details = data.(apiserver.APIConnection)
-	return nil, nil
+	return func() {}, nil
 }

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -4,8 +4,10 @@
 package params
 
 import (
-	"github.com/juju/juju/core/constraints"
+	"github.com/juju/names/v4"
 	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/core/constraints"
 )
 
 // CAASUnitIntroductionArgs is used by sidecar units to introduce
@@ -99,4 +101,27 @@ type CAASApplicationOCIResourceResult struct {
 // CAASApplicationOCIResources holds a list of image OCI resources.
 type CAASApplicationOCIResources struct {
 	Images map[string]DockerImageInfo `json:"images"`
+}
+
+// CAASUnitInfo holds CAAS unit information.
+type CAASUnitInfo struct {
+	Tag        string      `json:"tag"`
+	UnitStatus *UnitStatus `json:"unit-status,omitempty"`
+}
+
+// CAASUnit holds CAAS unit information.
+type CAASUnit struct {
+	Tag        names.Tag
+	UnitStatus *UnitStatus
+}
+
+// CAASUnitsResult holds a slice of CAAS unit information or an error.
+type CAASUnitsResult struct {
+	Units []CAASUnitInfo `json:"units,omitempty"`
+	Error *Error         `json:"error,omitempty"`
+}
+
+// CAASUnitsResults contains multiple CAAS units result.
+type CAASUnitsResults struct {
+	Results []CAASUnitsResult `json:"results"`
 }

--- a/apiserver/pubsub.go
+++ b/apiserver/pubsub.go
@@ -20,7 +20,7 @@ import (
 // Hub defines the publish method that the handler uses to publish
 // messages on the centralhub of the apiserver.
 type Hub interface {
-	Publish(string, interface{}) (<-chan struct{}, error)
+	Publish(string, interface{}) (func(), error)
 }
 
 func newPubSubHandler(h httpContext, hub Hub) http.Handler {

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -14,7 +14,7 @@ import (
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -24,7 +24,7 @@ import (
 // that are used. The context uses an interface to allow mocking
 // of the hub.
 type SharedHub interface {
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 	Subscribe(topic string, handler interface{}) (func(), error)
 }
 

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
 	"github.com/prometheus/client_golang/prometheus"
@@ -160,9 +160,9 @@ type stubHub struct {
 	published []string
 }
 
-func (s *stubHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
+func (s *stubHub) Publish(topic string, data interface{}) (func(), error) {
 	s.published = append(s.published, topic)
-	return nil, nil
+	return func() {}, nil
 }
 
 func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
@@ -180,7 +180,7 @@ func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("handler didn't")
 	}

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -161,13 +161,14 @@ func CharmHubConfig(logger Logger, options ...Option) (Config, error) {
 		headers.Add(MetadataHeader, k+"="+m[k])
 	}
 
+	chLogger := logger.ChildWithLabels("client", corelogger.CHARMHUB)
 	return Config{
 		URL:       *opts.url,
 		Version:   CharmHubServerVersion,
 		Entity:    CharmHubServerEntity,
 		Headers:   headers,
-		Transport: opts.transportFunc(logger.ChildWithLabels("transport", corelogger.HTTP)),
-		Logger:    logger,
+		Transport: opts.transportFunc(chLogger.ChildWithLabels("transport", corelogger.HTTP)),
+		Logger:    chLogger,
 	}, nil
 }
 

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -424,7 +424,7 @@ func (d downloadLogger) Debugf(msg string, args ...interface{}) {
 
 func (d downloadLogger) Tracef(msg string, args ...interface{}) {}
 
-func (d downloadLogger) ChildWithLabels(name string, labels ...string) loggo.Logger {
+func (d downloadLogger) ChildWithLabels(string, ...string) loggo.Logger {
 	return loggo.Logger{}
 }
 

--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -59,10 +59,10 @@ The filtering options combine as follows:
 * All --exclude options are logically ORed together.
 * All --include-module options are logically ORed together.
 * All --exclude-module options are logically ORed together.
-* All --include-labels options are logically ORed together.
-* All --exclude-labels options are logically ORed together.
+* All --include-label options are logically ORed together.
+* All --exclude-label options are logically ORed together.
 * The combined --include, --exclude, --include-module, --exclude-module,
-  --include-labels and --exclude-labels selections are logically ANDed to form 
+  --include-label and --exclude-label selections are logically ANDed to form
   the complete filter.
 
 Examples:

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -130,6 +130,7 @@ func WaitForAgentInitialisation(
 			strings.HasSuffix(errorMessage, "target machine actively refused it."), // Winsock message for connection refused
 			strings.HasSuffix(errorMessage, "connection is shut down"),
 			strings.HasSuffix(errorMessage, "i/o timeout"),
+			strings.HasSuffix(errorMessage, "network is unreachable"),
 			strings.HasSuffix(errorMessage, "deadline exceeded"),
 			strings.HasSuffix(errorMessage, "no api connection available"):
 			ctx.Verbosef("Still waiting for API to become available: %v", err)

--- a/cmd/jujud/agent/addons/addons.go
+++ b/cmd/jujud/agent/addons/addons.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/replicaset/v2"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/symlink"

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/proxy"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/utils/v2/voyeur"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v2"

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
@@ -1410,7 +1411,7 @@ func startAddressPublisher(suite cleanupSuite, c *gc.C, agent *MachineAgent) {
 
 				// Ensure that it has been sent, before moving on.
 				select {
-				case <-sent:
+				case <-pubsub.Wait(sent):
 				case <-time.After(testing.ShortWait):
 				}
 			}

--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/status"
 )
@@ -145,7 +145,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 	})
 
 	if a.details.CharmURL != details.CharmURL {
-		a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})
+		_ = a.hub.Publish(applicationCharmURLChange, appCharmUrlChange{appName: a.details.Name, chURL: details.CharmURL})
 	}
 
 	a.details = details
@@ -156,7 +156,7 @@ func (a *Application) setDetails(details ApplicationChange) {
 		a.configHash = configHash
 		a.hashCache = hashCache
 		a.hashCache.incMisses()
-		a.hub.Publish(a.topic(applicationConfigChange), hashCache)
+		_ = a.hub.Publish(a.topic(applicationConfigChange), hashCache)
 	}
 }
 

--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -4,7 +4,7 @@
 package cache
 
 import (
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/settings"
 )
@@ -87,7 +87,7 @@ func (b *Branch) setDetails(details BranchChange) {
 	})
 
 	b.details = details
-	b.hub.Publish(branchChange, b.copy())
+	_ = b.hub.Publish(branchChange, b.copy())
 }
 
 // copy returns a copy of the branch, ensuring appropriate deep copying.

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -4,7 +4,7 @@
 package cache
 
 import (
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/lxdprofile"
 )

--- a/core/cache/charmconfigwatcher.go
+++ b/core/cache/charmconfigwatcher.go
@@ -6,7 +6,7 @@ package cache
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/settings"
 )

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"gopkg.in/tomb.v2"
 )
 
@@ -327,7 +327,7 @@ func (c *Controller) modelWatcher(uuid string) ModelWatcher {
 func (c *Controller) updateModel(ch ModelChange) {
 	model := c.ensureModel(ch.ModelUUID)
 	model.setDetails(ch)
-	c.hub.Publish(modelUpdatedTopic, model)
+	_ = c.hub.Publish(modelUpdatedTopic, model)
 }
 
 // removeModel removes the model from the cache.
@@ -341,7 +341,7 @@ func (c *Controller) removeModel(ch RemoveModel) error {
 			return errors.Trace(err)
 		}
 		delete(c.models, ch.ModelUUID)
-		c.hub.Publish(modelRemovedTopic, ch.ModelUUID)
+		_ = c.hub.Publish(modelRemovedTopic, ch.ModelUUID)
 	}
 	return nil
 }

--- a/core/cache/lxdprofilewatcher.go
+++ b/core/cache/lxdprofilewatcher.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/core/lxdprofile"
 )

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -169,7 +169,7 @@ func (m *Machine) setDetails(details MachineChange) {
 	m.details = details
 
 	if provisioned {
-		m.model.hub.Publish(m.topic(machineProvisioned), nil)
+		_ = m.model.hub.Publish(m.topic(machineProvisioned), nil)
 	}
 
 	configHash, err := hashSettings(details.Config)

--- a/core/cache/modelwatcher.go
+++ b/core/cache/modelwatcher.go
@@ -6,7 +6,7 @@ package cache
 import (
 	"sync"
 
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"gopkg.in/tomb.v2"
 )
 

--- a/core/cache/modelwatcher_test.go
+++ b/core/cache/modelwatcher_test.go
@@ -6,6 +6,7 @@ package cache
 import (
 	"time"
 
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2/workertest"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
@@ -111,7 +112,7 @@ func (s *modelWatcherSuite) TestMultipleUpdates(c *gc.C) {
 	// We know the events are handled in order, so we only need to wait for the
 	// last of the three events to have been processed.
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Errorf("publish event not handled")
 	}

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -200,11 +200,11 @@ func (u *Unit) setDetails(details UnitChange) {
 	// Publish a unit addition event if a unit gets a machine ID for the first
 	// time, or if this is a subordinate that was not previously in the cache.
 	if landingOnMachine || newSubordinate {
-		u.model.hub.Publish(modelUnitAdd, toPublish)
+		_ = u.model.hub.Publish(modelUnitAdd, toPublish)
 	}
 
 	// Publish change event for those that may be waiting.
-	u.model.hub.Publish(unitChangeTopic(details.Name), &toPublish)
+	_ = u.model.hub.Publish(unitChangeTopic(details.Name), &toPublish)
 }
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"
 )

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -13,4 +13,8 @@ const (
 	// METRICS defines a common label for dealing with metric output. This
 	// should be used as a fallback for when prometheus isn't available.
 	METRICS Label = "metrics"
+
+	// CHARMHUB defines a common label for dealing with the charmhub client
+	// and callers.
+	CHARMHUB Label = "charmhub"
 )

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/globalclock"
@@ -247,7 +247,7 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 
 	start := time.Now()
 	defer func() {
-		elapsed := time.Now().Sub(start)
+		elapsed := time.Since(start)
 		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
 
@@ -265,7 +265,7 @@ func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
 	// This is an explicit step so that we can more accurately diagnose issues
 	// in-theatre.
 	select {
-	case <-delivered:
+	case <-pubsub.Wait(delivered):
 	case <-s.config.Clock.After(s.config.ForwardTimeout):
 		logger.Warningf("delivery timeout waiting for %s to be processed", command)
 		s.record(command.Operation, "delivery timeout", start)

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
-	github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6
+	github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset/v2 v2.0.0-20210310024806-bbbdc5f31eb3
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216
@@ -109,6 +109,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
+	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/mod v0.4.0 // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
@@ -120,7 +121,6 @@ require (
 	google.golang.org/api v0.29.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d // indirect
-	google.golang.org/grpc v1.33.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -483,8 +484,8 @@ github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSw
 github.com/juju/proxy v0.0.0-20180516023828-df38202e4713/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4 h1:y2eoq0Uof/dWLAXRyKKGOJuF0TEkauPscQI7Q1XQqvM=
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
-github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6 h1:2aARJxmMC2IF9GqVtt5PYcIy4jyuAcR44byqwXKTK0o=
-github.com/juju/pubsub v0.0.0-20190419131051-c1f7536b9cc6/go.mod h1:umz/NzotkJCFQHT3hqeLRISzYNCZzyV1sogjeAILCWw=
+github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289 h1:JPKuGuO4eDWUstv4puLCAdikIiI4235jYUCiYILjgjI=
+github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289/go.mod h1:muz5gqZ/u1pTC84e9scTKhEtmvE02wbuK1kvyLzIwQc=
 github.com/juju/qthttptest v0.0.1/go.mod h1://LCf/Ls22/rPw2u1yWukUJvYtfPY4nYpWUl2uZhryo=
 github.com/juju/qthttptest v0.1.1 h1:JPju5P5CDMCy8jmBJV2wGLjDItUsx2KKL514EfOYueM=
 github.com/juju/qthttptest v0.1.1/go.mod h1:aTlAv8TYaflIiTDIQYzxnl1QdPjAg8Q8qJMErpKy6A4=
@@ -520,6 +521,7 @@ github.com/juju/testing v0.0.0-20170608054451-2fe0e88cf232/go.mod h1:63prj8cnj0t
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180807043854-177f846b8501/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
+github.com/juju/testing v0.0.0-20180807044555-c84dd6ba038a/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180820040200-b0b89ba330f2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
@@ -798,8 +800,9 @@ go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
+go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -1077,8 +1080,8 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
-google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
+google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -37,7 +37,7 @@ import (
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/retry"
 	"github.com/juju/schema"
 	gitjujutesting "github.com/juju/testing"

--- a/pubsub/centralhub/centralhub.go
+++ b/pubsub/centralhub/centralhub.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/utils/v2"
 	"gopkg.in/yaml.v2"
 )

--- a/pubsub/centralhub/centralhub_test.go
+++ b/pubsub/centralhub/centralhub_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -46,7 +46,7 @@ func (s *CentralHubSuite) TestSetsOrigin(c *gc.C) {
 
 	done, err := hub.Publish(topic, map[string]interface{}{"key": "value"})
 	c.Assert(err, jc.ErrorIsNil)
-	s.waitForSubscribers(c, done)
+	s.waitForSubscribers(c, pubsub.Wait(done))
 	c.Assert(called, jc.IsTrue)
 }
 
@@ -74,7 +74,7 @@ func (s *CentralHubSuite) TestYAMLMarshalling(c *gc.C) {
 	// With the default JSON marshalling, integers are marshalled to floats into the map.
 	done, err := hub.Publish(topic, IntStruct{1234})
 	c.Assert(err, jc.ErrorIsNil)
-	s.waitForSubscribers(c, done)
+	s.waitForSubscribers(c, pubsub.Wait(done))
 	c.Assert(called, jc.IsTrue)
 }
 
@@ -111,6 +111,6 @@ func (s *CentralHubSuite) TestPostProcessingMaps(c *gc.C) {
 		Key:    "value",
 		Nested: IntStruct{1234}})
 	c.Assert(err, jc.ErrorIsNil)
-	s.waitForSubscribers(c, done)
+	s.waitForSubscribers(c, pubsub.Wait(done))
 	c.Assert(called, jc.IsTrue)
 }

--- a/resource/resourceadapters/charmhub.go
+++ b/resource/resourceadapters/charmhub.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/charmstore"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/resource/repositories"
 )
 
@@ -50,13 +51,12 @@ func newCharmHubClient(st chClientState) (ResourceClient, error) {
 		return &CharmHubClient{}, errors.Trace(err)
 	}
 
-	chLogger := logger.Child("charmhub")
 	var chCfg charmhub.Config
 	chURL, ok := modelCfg.CharmHubURL()
 	if ok {
-		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, chLogger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfigFromURL(chURL, logger)
 	} else {
-		chCfg, err = charmhub.CharmHubConfig(chLogger.Child("client"))
+		chCfg, err = charmhub.CharmHubConfig(logger)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -65,7 +65,7 @@ func newCharmHubClient(st chClientState) (ResourceClient, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &CharmHubClient{client: chClient, logger: chLogger}, nil
+	return &CharmHubClient{client: chClient, logger: logger.ChildWithLabels("charmhub", corelogger.CHARMHUB)}, nil
 }
 
 type CharmHubClient struct {

--- a/state/pool.go
+++ b/state/pool.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/mongo"

--- a/state/state.go
+++ b/state/state.go
@@ -25,7 +25,7 @@ import (
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jujutxn "github.com/juju/txn/v2"
 	"github.com/juju/utils/v2"
 	"github.com/juju/version/v2"

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
 	gc "gopkg.in/check.v1"
@@ -57,7 +57,7 @@ func (s *HubWatcherSuite) SetUpTest(c *gc.C) {
 func (s *HubWatcherSuite) publish(c *gc.C, changes ...watcher.Change) {
 	var processed <-chan struct{}
 	for _, change := range changes {
-		processed = s.hub.Publish(watcher.TxnWatcherCollection, change)
+		processed = pubsub.Wait(s.hub.Publish(watcher.TxnWatcherCollection, change))
 	}
 	select {
 	case <-processed:

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -21,7 +21,7 @@ import (
 // Hub represents a pubsub hub. The TxnWatcher only ever publishes
 // events to the hub.
 type Hub interface {
-	Publish(topic string, data interface{}) <-chan struct{}
+	Publish(topic string, data interface{}) func()
 }
 
 // Clock represents the time methods used.
@@ -287,7 +287,7 @@ func (w *TxnWatcher) loop() error {
 	backoff := backoffStrategy.NewTimer(now)
 	d, _ := backoff.NextSleep(now)
 	next := w.clock.After(d)
-	w.hub.Publish(TxnWatcherStarting, nil)
+	_ = w.hub.Publish(TxnWatcherStarting, nil)
 	for {
 		select {
 		case <-w.tomb.Dying():
@@ -354,7 +354,7 @@ func (w *TxnWatcher) loop() error {
 			w.logger.Warningf("txn watcher sync error: %v\ncurrent retry count %d", err, syncRetryCount)
 			_, isSyncError := errors.Cause(err).(outOfSyncError)
 			if isSyncError || syncRetryCount > maxSyncRetries {
-				w.hub.Publish(TxnWatcherSyncErr, err)
+				_ = w.hub.Publish(TxnWatcherSyncErr, err)
 				return errors.Trace(err)
 			}
 			logCollection = nil
@@ -376,7 +376,7 @@ func (w *TxnWatcher) flush() {
 	// refreshEvents are stored newest first.
 	for i := len(w.syncEvents) - 1; i >= 0; i-- {
 		e := w.syncEvents[i]
-		w.hub.Publish(TxnWatcherCollection, e)
+		_ = w.hub.Publish(TxnWatcherCollection, e)
 	}
 	w.averageSyncLen = (filterFactor * float64(len(w.syncEvents))) + ((1.0 - filterFactor) * w.averageSyncLen)
 	w.syncEventsLastLen = len(w.syncEvents)

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -393,7 +393,7 @@ func newFakeHub(c *gc.C, expected int) *fakeHub {
 	}
 }
 
-func (hub *fakeHub) Publish(topic string, data interface{}) <-chan struct{} {
+func (hub *fakeHub) Publish(topic string, data interface{}) func() {
 	switch topic {
 	case watcher.TxnWatcherStarting:
 		close(hub.started)

--- a/state/workers.go
+++ b/state/workers.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/state/watcher"

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -6,8 +6,8 @@ run_network_health() {
 	ensure "network-health" "${file}"
 
 	# Deploy some applications for different series.
-	juju deploy mongodb --series focal
-	juju deploy juju-gui --series xenial
+	juju deploy ubuntu ubuntu-focal --series focal
+	juju deploy ubuntu ubuntu-xenial --series xenial
 	juju deploy ubuntu ubuntu-bionic --series bionic
 
 	# Now the testing charm for each series.
@@ -15,20 +15,20 @@ run_network_health() {
 	juju deploy 'cs:~juju-qa/network-health' network-health-bionic --series bionic
 	juju deploy 'cs:~juju-qa/network-health' network-health-focal --series focal
 
+	juju add-relation network-health-focal ubuntu-focal
+	juju add-relation network-health-xenial ubuntu-xenial
+	juju add-relation network-health-bionic ubuntu-bionic
+
 	juju expose network-health-xenial
 	juju expose network-health-bionic
 	juju expose network-health-focal
 
-	juju add-relation network-health-focal mongodb
-	juju add-relation network-health-xenial juju-gui
-	juju add-relation network-health-bionic ubuntu-bionic
-
-	wait_for "mongodb" "$(idle_condition "mongodb" 1)"
-	wait_for "juju-gui" "$(idle_condition "juju-gui" 0)"
-	wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 5)"
-	wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "mongodb")"
+	wait_for "ubuntu-bionic" "$(idle_condition "ubuntu-bionic" 3)"
+	wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 4)"
+	wait_for "ubuntu-xenial" "$(idle_condition "ubuntu-xenial" 5)"
+	wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "ubuntu-focal")"
 	wait_for "network-health-bionic" "$(idle_subordinate_condition "network-health-bionic" "ubuntu-bionic")"
-	wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "juju-gui")"
+	wait_for "network-health-xenial" "$(idle_subordinate_condition "network-health-xenial" "ubuntu-xenial")"
 
 	check_default_routes
 	check_accessibility
@@ -57,7 +57,7 @@ check_accessibility() {
 		curl_cmd="curl 2>/dev/null ${ip}:8039"
 
 		# Check that each of the principles can access the subordinate.
-		for principle_unit in "mongodb/0" "juju-gui/0" "ubuntu-bionic/0"; do
+		for principle_unit in "ubuntu-focal/0" "ubuntu-xenial/0" "ubuntu-bionic/0"; do
 			check_contains "$(juju exec --unit $principle_unit "$curl_cmd")" "pass"
 		done
 

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -5,7 +5,7 @@ package agentconfigupdater
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -6,7 +6,7 @@ package agentconfigupdater_test
 import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"

--- a/worker/agentconfigupdater/worker.go
+++ b/worker/agentconfigupdater/worker.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"
 

--- a/worker/agentconfigupdater/worker_test.go
+++ b/worker/agentconfigupdater/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -133,7 +133,7 @@ func (s *WorkerSuite) TestUpdateMongoProfile(c *gc.C) {
 	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -145,7 +145,7 @@ func (s *WorkerSuite) TestUpdateMongoProfile(c *gc.C) {
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -164,7 +164,7 @@ func (s *WorkerSuite) TestUpdateJujuDBSnapChannel(c *gc.C) {
 	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -176,7 +176,7 @@ func (s *WorkerSuite) TestUpdateJujuDBSnapChannel(c *gc.C) {
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -195,7 +195,7 @@ func (s *WorkerSuite) TestUpdateSyncWritesToRaftLog(c *gc.C) {
 	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}
@@ -207,7 +207,7 @@ func (s *WorkerSuite) TestUpdateSyncWritesToRaftLog(c *gc.C) {
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("event not handled")
 	}

--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/cmd"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/apiserver/manifold_test.go
+++ b/worker/apiserver/manifold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/apiserver/observers.go
+++ b/worker/apiserver/observers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver"

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 
 	"github.com/juju/juju/agent"

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -252,11 +252,24 @@ func (a *appWorker) loop() error {
 			if err != nil {
 				return errors.Trace(err)
 			}
+		case <-a.clock.After(10 * time.Second):
+			// for refresh application status.
 		}
 		if done {
 			return nil
 		}
+		if err = a.refreshApplicationStatus(app, appLife); err != nil {
+			return errors.Annotatef(err, "refreshing application status for %q", a.name)
+		}
 	}
+}
+
+func getTagsFromUnits(in []params.CAASUnit) []names.Tag {
+	var out []names.Tag
+	for _, v := range in {
+		out = append(out, v.Tag)
+	}
+	return out
 }
 
 func (a *appWorker) updateState(app caas.Application, force bool, lastReportedStatus map[string]status.StatusInfo) (map[string]status.StatusInfo, error) {
@@ -299,7 +312,7 @@ func (a *appWorker) updateState(app caas.Application, force bool, lastReportedSt
 		}
 	}
 
-	err = a.facade.GarbageCollect(a.name, observedUnits, st.DesiredReplicas, st.Replicas, force)
+	err = a.facade.GarbageCollect(a.name, getTagsFromUnits(observedUnits), st.DesiredReplicas, st.Replicas, force)
 	if errors.IsNotFound(err) {
 		return nil, nil
 	} else if err != nil {
@@ -400,6 +413,40 @@ func (a *appWorker) updateState(app caas.Application, force bool, lastReportedSt
 		}
 	}
 	return reportedStatus, nil
+}
+
+func (a *appWorker) refreshApplicationStatus(app caas.Application, appLife life.Value) error {
+	if appLife != life.Alive {
+		return nil
+	}
+	st, err := app.State()
+	if errors.IsNotFound(err) {
+		// Do nothing.
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+
+	// refresh the units information.
+	units, err := a.facade.Units(a.name)
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	readyUnitsCount := 0
+	for _, unit := range units {
+		if unit.UnitStatus.AgentStatus.Status == string(status.Active) {
+			readyUnitsCount++
+		}
+	}
+	if st.DesiredReplicas > 0 && st.DesiredReplicas > readyUnitsCount {
+		// Only set status to waiting for scale up.
+		// When the application gets scaled down, the desired units will be kept running and
+		// the application should be active always.
+		return a.setApplicationStatus(status.Waiting, "waiting for units settled down", nil)
+	}
+	return a.setApplicationStatus(status.Active, "", nil)
 }
 
 func (a *appWorker) ensureScale(app caas.Application) error {
@@ -541,9 +588,9 @@ func (a *appWorker) alive(app caas.Application) error {
 	reason := "unchanged"
 	// TODO(sidecar): implement Equals method for caas.ApplicationConfig
 	if !reflect.DeepEqual(config, a.lastApplied) {
-		err = app.Ensure(config)
-		if err != nil {
-			return errors.Annotate(err, "ensuring application")
+		if err = app.Ensure(config); err != nil {
+			_ = a.setApplicationStatus(status.Error, err.Error(), nil)
+			return errors.Annotatef(err, "ensuring application %q", a.name)
 		}
 		a.lastApplied = config
 		reason = "deployed"
@@ -551,13 +598,13 @@ func (a *appWorker) alive(app caas.Application) error {
 			reason = "updated"
 		}
 	}
-
-	err = a.facade.SetOperatorStatus(a.name, status.Active, reason, nil)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
+	a.logger.Debugf("application %q was %q", a.name, reason)
 	return nil
+}
+
+func (a *appWorker) setApplicationStatus(s status.Status, reason string, data map[string]interface{}) error {
+	a.logger.Tracef("updating application %q status to %q, %q, %v", a.name, s, reason, data)
+	return a.facade.SetOperatorStatus(a.name, s, reason, data)
 }
 
 func (a *appWorker) dying(app caas.Application) error {

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -39,28 +39,54 @@ var _ = gc.Suite(&ApplicationWorkerSuite{})
 type ApplicationWorkerSuite struct {
 	coretesting.BaseSuite
 
-	clock    *testclock.Clock
 	modelTag names.ModelTag
 	logger   loggo.Logger
+
+	appCharmInfo        *charmscommon.CharmInfo
+	appCharmURL         *charm.URL
+	appProvisioningInfo api.ProvisioningInfo
+	ociResources        map[string]resources.DockerImageDetails
 }
 
 func (s *ApplicationWorkerSuite) SetUpTest(c *gc.C) {
-	s.clock = testclock.NewClock(time.Now())
+	s.BaseSuite.SetUpTest(c)
+
 	s.modelTag = names.NewModelTag("ffffffff-ffff-ffff-ffff-ffffffffffff")
 	s.logger = loggo.GetLogger("test")
 }
 
-func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
-	var err error
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
+type testCase struct {
+	clock      *testclock.Clock
+	facade     *mocks.MockCAASProvisionerFacade
+	broker     *mocks.MockCAASBroker
+	brokerApp  *caasmocks.MockApplication
+	unitFacade *mocks.MockCAASUnitProvisionerFacade
 
-	appCharmURL := &charm.URL{
+	appScaleChan     chan struct{}
+	notifyReady      chan struct{}
+	appStateChan     chan struct{}
+	appChan          chan struct{}
+	appReplicasChan  chan struct{}
+	appTrustHashChan chan []string
+}
+
+func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worker.Worker, testCase, *gomock.Controller) {
+	ctrl := gomock.NewController(c)
+
+	tc := testCase{}
+
+	tc.clock = testclock.NewClock(time.Time{})
+	tc.facade = mocks.NewMockCAASProvisionerFacade(ctrl)
+	tc.broker = mocks.NewMockCAASBroker(ctrl)
+	tc.unitFacade = mocks.NewMockCAASUnitProvisionerFacade(ctrl)
+	tc.brokerApp = caasmocks.NewMockApplication(ctrl)
+
+	s.appCharmURL = &charm.URL{
 		Schema:   "cs",
 		Name:     "test",
 		Revision: -1,
 	}
-	appCharmInfo := &charmscommon.CharmInfo{
+	s.appCharmInfo = &charmscommon.CharmInfo{
 		Meta: &charm.Meta{
 			Name: "test",
 
@@ -85,127 +111,173 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 			}},
 		},
 	}
-	appProvisioningInfo := api.ProvisioningInfo{
+	s.appProvisioningInfo = api.ProvisioningInfo{
 		Series:   "focal",
-		CharmURL: appCharmURL,
+		CharmURL: s.appCharmURL,
 	}
-	ociResources := map[string]resources.DockerImageDetails{
+	s.ociResources = map[string]resources.DockerImageDetails{
 		"test-oci": {
 			RegistryPath: "some/test:img",
 		},
 	}
 
-	notifyReady := make(chan struct{}, 1)
+	tc.appScaleChan = make(chan struct{}, 1)
+	tc.notifyReady = make(chan struct{}, 1)
+	tc.appStateChan = make(chan struct{}, 1)
+	tc.appChan = make(chan struct{}, 1)
+	tc.appReplicasChan = make(chan struct{}, 1)
+	tc.appTrustHashChan = make(chan []string, 1)
 
-	appStateChan := make(chan struct{}, 1)
-	appStateWatcher := watchertest.NewMockNotifyWatcher(appStateChan)
-
-	appChan := make(chan struct{}, 1)
-	appWatcher := watchertest.NewMockNotifyWatcher(appChan)
-
-	appReplicasChan := make(chan struct{}, 1)
-	appReplicasWatcher := watchertest.NewMockNotifyWatcher(appReplicasChan)
-
-	appScaleChan := make(chan struct{}, 1)
-	appScaleWatcher := watchertest.NewMockNotifyWatcher(appScaleChan)
-
-	appTrustHashChan := make(chan []string, 1)
-	appTrushHashWatcher := watchertest.NewMockStringsWatcher(appTrustHashChan)
-
-	brokerApp := caasmocks.NewMockApplication(ctrl)
-	broker := mocks.NewMockCAASBroker(ctrl)
-	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
-	unitFacade := mocks.NewMockCAASUnitProvisionerFacade(ctrl)
-
-	done := make(chan struct{})
-	gomock.InOrder(
-		// Initialize in loop.
-		facade.EXPECT().ApplicationCharmURL("test").DoAndReturn(func(string) (*charm.URL, error) {
-			return appCharmURL, nil
-		}),
-		facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
-			return appCharmInfo, nil
-		}),
-		facade.EXPECT().SetPassword("test", gomock.Any()).Return(nil),
-		broker.EXPECT().Application("test", caas.DeploymentStateful).DoAndReturn(
-			func(string, caas.DeploymentType) caas.Application {
-				return brokerApp
-			},
-		),
-
-		unitFacade.EXPECT().WatchApplicationScale("test").Return(appScaleWatcher, nil),
-		unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(appTrushHashWatcher, nil),
-
-		// Initial run - Ensure() for the application.
-		facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
-			return life.Alive, nil
-		}),
-		facade.EXPECT().WatchApplication("test").Return(appStateWatcher, nil),
-		facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
-			return appProvisioningInfo, nil
-		}),
-		facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
-			return appCharmInfo, nil
-		}),
-		brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
-			return caas.DeploymentState{}, nil
-		}),
-		facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
-			return ociResources, nil
-		}),
-		brokerApp.EXPECT().Ensure(gomock.Any()).DoAndReturn(func(config caas.ApplicationConfig) error {
-			mc := jc.NewMultiChecker()
-			mc.AddExpr(`_.IntroductionSecret`, gc.HasLen, 24)
-			mc.AddExpr(`_.Charm`, gc.NotNil)
-			c.Check(config, mc, caas.ApplicationConfig{
-				CharmBaseImage: resources.DockerImageDetails{
-					RegistryPath: "jujusolutions/charm-base:ubuntu-20.04",
-				},
-				Containers: map[string]caas.ContainerConfig{
-					"test": {
-						Name: "test",
-						Image: resources.DockerImageDetails{
-							RegistryPath: "some/test:img",
+	startFunc := func(additionalAssertCalls ...*gomock.Call) worker.Worker {
+		config := caasapplicationprovisioner.AppWorkerConfig{
+			Name:       "test",
+			Facade:     tc.facade,
+			Broker:     tc.broker,
+			ModelTag:   s.modelTag,
+			Clock:      tc.clock,
+			Logger:     s.logger,
+			UnitFacade: tc.unitFacade,
+		}
+		expectedCalls := append([]*gomock.Call{
+			// Initialize in loop.
+			tc.facade.EXPECT().ApplicationCharmURL("test").DoAndReturn(func(string) (*charm.URL, error) {
+				return s.appCharmURL, nil
+			}),
+			tc.facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
+				return s.appCharmInfo, nil
+			}),
+			tc.facade.EXPECT().SetPassword("test", gomock.Any()).Return(nil),
+			tc.broker.EXPECT().Application("test", caas.DeploymentStateful).AnyTimes().Return(tc.brokerApp),
+			tc.unitFacade.EXPECT().WatchApplicationScale("test").Return(watchertest.NewMockNotifyWatcher(tc.appScaleChan), nil),
+			tc.unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(watchertest.NewMockStringsWatcher(tc.appTrustHashChan), nil),
+		},
+			// ROUND 0 - Ensure() for the application.
+			tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+				return life.Alive, nil
+			}),
+			tc.facade.EXPECT().WatchApplication("test").Return(watchertest.NewMockNotifyWatcher(tc.appStateChan), nil),
+			tc.facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
+				return s.appProvisioningInfo, nil
+			}),
+			tc.facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
+				return s.appCharmInfo, nil
+			}),
+			tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+				return caas.DeploymentState{}, nil
+			}),
+			tc.facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
+				return s.ociResources, nil
+			}),
+			tc.brokerApp.EXPECT().Ensure(gomock.Any()).DoAndReturn(func(config caas.ApplicationConfig) error {
+				mc := jc.NewMultiChecker()
+				mc.AddExpr(`_.IntroductionSecret`, gc.HasLen, 24)
+				mc.AddExpr(`_.Charm`, gc.NotNil)
+				c.Check(config, mc, caas.ApplicationConfig{
+					CharmBaseImage: resources.DockerImageDetails{
+						RegistryPath: "jujusolutions/charm-base:ubuntu-20.04",
+					},
+					Containers: map[string]caas.ContainerConfig{
+						"test": {
+							Name: "test",
+							Image: resources.DockerImageDetails{
+								RegistryPath: "some/test:img",
+							},
 						},
 					},
-				},
-			})
-			return nil
-		}),
-		facade.EXPECT().SetOperatorStatus("test", status.Active, "deployed", nil).Return(nil),
-		brokerApp.EXPECT().Watch().Return(appWatcher, nil),
-		brokerApp.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
-			appReplicasChan <- struct{}{}
-			return appReplicasWatcher, nil
-		}),
+				})
+				return nil
+			}),
+			tc.brokerApp.EXPECT().Watch().Return(watchertest.NewMockNotifyWatcher(tc.appChan), nil),
+			tc.brokerApp.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
+				return watchertest.NewMockNotifyWatcher(tc.appReplicasChan), nil
+			}),
+			// refresh application status - test separately.
+			tc.brokerApp.EXPECT().State().
+				DoAndReturn(func() (caas.ApplicationState, error) {
+					tc.notifyReady <- struct{}{}
+					return caas.ApplicationState{}, errors.NotFoundf("")
+				}),
+		)
 
+		gomock.InOrder(append(expectedCalls, additionalAssertCalls...)...)
+
+		f := caasapplicationprovisioner.NewAppWorker(config)
+		c.Assert(f, gc.NotNil)
+		appWorker, err := f()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(appWorker, gc.NotNil)
+		s.AddCleanup(func(c *gc.C) {
+			close(tc.notifyReady)
+			workertest.CleanKill(c, appWorker)
+		})
+		return appWorker
+	}
+	return startFunc, tc, ctrl
+}
+
+var unitsAPIResultSingleActive = []params.CAASUnit{
+	{
+		Tag: names.NewUnitTag("test/0"),
+		UnitStatus: &params.UnitStatus{
+			AgentStatus: params.DetailedStatus{Status: "active"},
+		},
+	},
+}
+
+var unitsAPIResultPartialActive = []params.CAASUnit{
+	{
+		Tag: names.NewUnitTag("test/0"),
+		UnitStatus: &params.UnitStatus{
+			AgentStatus: params.DetailedStatus{Status: "active"},
+		},
+	},
+	{
+		Tag: names.NewUnitTag("test/1"),
+		UnitStatus: &params.UnitStatus{
+			AgentStatus: params.DetailedStatus{Status: "waiting"},
+		},
+	},
+	{
+		Tag: names.NewUnitTag("test/2"),
+		UnitStatus: &params.UnitStatus{
+			AgentStatus: params.DetailedStatus{Status: "waiting"},
+		},
+	},
+}
+
+func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	assertionCalls := []*gomock.Call{
 		// Got replicaChanges -> updateState().
-		facade.EXPECT().Units("test").DoAndReturn(func(string) ([]names.Tag, error) {
-			return []names.Tag{
-				names.NewUnitTag("test/0"),
-			}, nil
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			return unitsAPIResultSingleActive, nil
 		}),
-		brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
+		tc.brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
 			return caas.ApplicationState{
 				DesiredReplicas: 1,
 				Replicas:        []string{"test-0"},
 			}, nil
 		}),
-		brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+		tc.brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
 			return &caas.Service{
 				Id:        "deadbeef",
 				Addresses: network.NewProviderAddresses("10.6.6.6"),
 			}, nil
 		}),
-		unitFacade.EXPECT().UpdateApplicationService(params.UpdateApplicationServiceArg{
+		tc.unitFacade.EXPECT().UpdateApplicationService(params.UpdateApplicationServiceArg{
 			ApplicationTag: "application-test",
 			ProviderId:     "deadbeef",
 			Addresses:      params.FromProviderAddresses(network.NewProviderAddress("10.6.6.6")),
 		}).Return(nil),
-		facade.EXPECT().GarbageCollect("test", []names.Tag{names.NewUnitTag("test/0")}, 1, []string{"test-0"}, false).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
-			return nil
-		}),
-		brokerApp.EXPECT().Units().Return([]caas.Unit{{
+		tc.facade.EXPECT().GarbageCollect("test", []names.Tag{names.NewUnitTag("test/0")}, 1, []string{"test-0"}, false).
+			DoAndReturn(
+				func(_ string, _ []names.Tag, _ int, _ []string, _ bool) error { return nil },
+			),
+		tc.brokerApp.EXPECT().Units().Return([]caas.Unit{{
 			Id:      "test-0",
 			Address: "10.10.10.1",
 			Dying:   false,
@@ -233,7 +305,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 				},
 			}},
 		}}, nil),
-		facade.EXPECT().UpdateUnits(params.UpdateApplicationUnits{
+		tc.facade.EXPECT().UpdateUnits(params.UpdateApplicationUnits{
 			ApplicationTag: "application-test",
 			Status:         params.EntityStatus{},
 			Units: []params.ApplicationUnitParams{{
@@ -258,135 +330,143 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 				}},
 			}},
 		}).DoAndReturn(func(_ params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error) {
-			appStateChan <- struct{}{}
 			return nil, nil
 		}),
 
+		// refresh application status - test separately.
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				tc.notifyReady <- struct{}{}
+				return caas.ApplicationState{}, errors.NotFoundf("")
+			}),
+
 		// Second run - Ensure() for the application.
-		facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+		// Should not Ensure since unchanged.
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
 			return life.Alive, nil
 		}),
-		facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
-			return appProvisioningInfo, nil
+		tc.facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
+			return s.appProvisioningInfo, nil
 		}),
-		facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
-			return appCharmInfo, nil
+		tc.facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
+			return s.appCharmInfo, nil
 		}),
-		brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+		tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
 			return caas.DeploymentState{}, nil
 		}),
-		facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
-			appChan <- struct{}{}
-			return ociResources, nil
+		tc.facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
+			return s.ociResources, nil
 		}),
-		// Second run should not Ensure since unchanged.
-		facade.EXPECT().SetOperatorStatus("test", status.Active, "unchanged", nil).Return(nil),
+
+		// refresh application status - test separately.
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				tc.notifyReady <- struct{}{}
+				return caas.ApplicationState{}, errors.NotFoundf("")
+			}),
 
 		// Got appChanges -> updateState().
-		facade.EXPECT().Units("test").DoAndReturn(func(string) ([]names.Tag, error) {
-			return []names.Tag{
-				names.NewUnitTag("test/0"),
-			}, nil
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			return unitsAPIResultSingleActive, nil
 		}),
-		brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
+		tc.brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
 			return caas.ApplicationState{
 				DesiredReplicas: 0,
 				Replicas:        []string(nil),
 			}, nil
 		}),
-		brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+		tc.brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
 			return &caas.Service{
 				Id:        "deadbeef",
 				Addresses: network.NewProviderAddresses("10.6.6.6"),
 			}, nil
 		}),
-		unitFacade.EXPECT().UpdateApplicationService(params.UpdateApplicationServiceArg{
+		tc.unitFacade.EXPECT().UpdateApplicationService(params.UpdateApplicationServiceArg{
 			ApplicationTag: "application-test",
 			ProviderId:     "deadbeef",
 			Addresses:      params.FromProviderAddresses(network.NewProviderAddress("10.6.6.6")),
 		}).Return(nil),
-		facade.EXPECT().GarbageCollect("test", []names.Tag{names.NewUnitTag("test/0")}, 0, []string(nil), false).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
-			notifyReady <- struct{}{}
+		tc.facade.EXPECT().GarbageCollect("test", []names.Tag{names.NewUnitTag("test/0")}, 0, []string(nil), false).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
 			return nil
 		}),
 
-		brokerApp.EXPECT().Units().Return([]caas.Unit{{
+		tc.brokerApp.EXPECT().Units().Return([]caas.Unit{{
 			Id:    "test-0",
 			Dying: true,
 			Status: status.StatusInfo{
 				Status: status.Terminated,
 			},
 		}}, nil),
-		facade.EXPECT().UpdateUnits(params.UpdateApplicationUnits{
+		tc.facade.EXPECT().UpdateUnits(params.UpdateApplicationUnits{
 			ApplicationTag: "application-test",
 			Status:         params.EntityStatus{},
 		}).Return(nil, nil),
 
+		// refresh application status - test separately.
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				tc.notifyReady <- struct{}{}
+				return caas.ApplicationState{}, errors.NotFoundf("")
+			}),
+
 		// 1st Notify() - dying.
-		facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
 			return life.Dying, nil
 		}),
-		brokerApp.EXPECT().Delete().DoAndReturn(func() error {
-			notifyReady <- struct{}{}
+		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
+			tc.notifyReady <- struct{}{}
 			return nil
 		}),
 
 		// 2nd Notify() - dead.
-		facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
 			return life.Dead, nil
 		}),
-		brokerApp.EXPECT().Delete().DoAndReturn(func() error {
+		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
 			return nil
 		}),
-		brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+		tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
 			return caas.DeploymentState{
 				Exists:      false,
 				Terminating: false,
 			}, nil
 		}),
-		facade.EXPECT().Units("test").DoAndReturn(func(string) ([]names.Tag, error) {
-			return []names.Tag(nil), nil
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			return []params.CAASUnit(nil), nil
 		}),
-		brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
+		tc.brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
 			return caas.ApplicationState{
 				DesiredReplicas: 0,
 				Replicas:        []string(nil),
 			}, nil
 		}),
-		brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+		tc.brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
 			return nil, errors.NotFoundf("test")
 		}),
-		facade.EXPECT().GarbageCollect("test", []names.Tag(nil), 0, []string(nil), true).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
+		tc.facade.EXPECT().GarbageCollect("test", []names.Tag(nil), 0, []string(nil), true).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
 			close(done)
-			close(notifyReady)
 			return nil
 		}),
-	)
-
-	config := caasapplicationprovisioner.AppWorkerConfig{
-		Name:       "test",
-		Facade:     facade,
-		Broker:     broker,
-		ModelTag:   s.modelTag,
-		Clock:      s.clock,
-		Logger:     s.logger,
-		UnitFacade: unitFacade,
 	}
-	startFunc := caasapplicationprovisioner.NewAppWorker(config)
-	c.Assert(startFunc, gc.NotNil)
-	appWorker, err := startFunc()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(appWorker, gc.NotNil)
+
+	appWorker := newAppWorker(assertionCalls...)
 
 	go func(w appNotifyWorker) {
-		for {
-			select {
-			case _, ok := <-notifyReady:
-				if !ok {
-					return
-				}
-				w.Notify()
-			}
+		steps := []func(){
+			// Test replica changes.
+			func() { tc.appReplicasChan <- struct{}{} },
+			// Test app state changes.
+			func() { tc.appStateChan <- struct{}{} },
+			// Test app changes from cloud.
+			func() { tc.appChan <- struct{}{} },
+			// Test Notify - dying.
+			w.Notify,
+			// Test Notify - dead.
+			w.Notify,
+		}
+		for _, step := range steps {
+			<-tc.notifyReady
+			step()
 		}
 	}(appWorker.(appNotifyWorker))
 
@@ -395,8 +475,287 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 	case <-time.After(coretesting.ShortWait):
 		c.Errorf("timed out waiting for worker")
 	}
+}
 
-	workertest.CleanKill(c, appWorker)
+func (s *ApplicationWorkerSuite) TestScaleChanges(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	assertionCalls := []*gomock.Call{
+		tc.unitFacade.EXPECT().ApplicationScale("test").Return(3, nil),
+		tc.brokerApp.EXPECT().Scale(3).Return(nil),
+
+		// refresh application status - test separately.
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				close(done)
+				return caas.ApplicationState{}, errors.NotFoundf("")
+			}),
+	}
+
+	appWorker := newAppWorker(assertionCalls...)
+
+	go func(w appNotifyWorker) {
+		<-tc.notifyReady
+		tc.appScaleChan <- struct{}{}
+	}(appWorker.(appNotifyWorker))
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
+}
+
+func (s *ApplicationWorkerSuite) TestTrustChanges(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+	assertionCalls := []*gomock.Call{
+		tc.unitFacade.EXPECT().ApplicationTrust("test").Return(true, nil),
+		tc.brokerApp.EXPECT().Trust(true).Return(nil),
+
+		// refresh application status - test separately.
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				close(done)
+				return caas.ApplicationState{}, errors.NotFoundf("")
+			}),
+	}
+
+	appWorker := newAppWorker(assertionCalls...)
+
+	go func(w appNotifyWorker) {
+		<-tc.notifyReady
+		tc.appTrustHashChan <- []string{"test"}
+	}(appWorker.(appNotifyWorker))
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
+}
+
+func (s *ApplicationWorkerSuite) assertRefreshApplicationStatus(
+	c *gc.C, tc testCase, workerGetter func(additionalAssertCalls ...*gomock.Call) worker.Worker,
+	assertionCalls ...*gomock.Call,
+) {
+	appWorker := workerGetter(assertionCalls...)
+	go func(w appNotifyWorker) {
+		<-tc.notifyReady
+		w.Notify()
+	}(appWorker.(appNotifyWorker))
+}
+
+func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusNewUnitsAllocating(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	s.assertRefreshApplicationStatus(c, tc, newAppWorker,
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+			return life.Alive, nil
+		}),
+		tc.facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
+			return s.appProvisioningInfo, nil
+		}),
+		tc.facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
+			return s.appCharmInfo, nil
+		}),
+		tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+			return caas.DeploymentState{}, nil
+		}),
+		tc.facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
+			return s.ociResources, nil
+		}),
+
+		// Desired: 3;
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				return caas.ApplicationState{DesiredReplicas: 3}, nil
+			}),
+		// Active unit: 1;
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			c.Assert(len(unitsAPIResultSingleActive), gc.DeepEquals, 1)
+			return unitsAPIResultSingleActive, nil
+		}),
+		tc.facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units settled down", nil).
+			DoAndReturn(func(string, status.Status, string, map[string]interface{}) error {
+				close(done)
+				return nil
+			}),
+	)
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
+}
+
+func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusAllUnitsAreSettled(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	s.assertRefreshApplicationStatus(c, tc, newAppWorker,
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+			return life.Alive, nil
+		}),
+		tc.facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
+			return s.appProvisioningInfo, nil
+		}),
+		tc.facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
+			return s.appCharmInfo, nil
+		}),
+		tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+			return caas.DeploymentState{}, nil
+		}),
+		tc.facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
+			return s.ociResources, nil
+		}),
+
+		// Desired: 1;
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				return caas.ApplicationState{DesiredReplicas: 1}, nil
+			}),
+		// Active unit: 1;
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			c.Assert(len(unitsAPIResultSingleActive), gc.DeepEquals, 1)
+			return unitsAPIResultSingleActive, nil
+		}),
+		tc.facade.EXPECT().SetOperatorStatus("test", status.Active, "", nil).
+			DoAndReturn(func(string, status.Status, string, map[string]interface{}) error {
+				close(done)
+				return nil
+			}),
+	)
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
+}
+
+func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusTransitionFromWaitingToActive(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	s.assertRefreshApplicationStatus(c, tc, newAppWorker,
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+			return life.Alive, nil
+		}),
+		tc.facade.EXPECT().ProvisioningInfo("test").DoAndReturn(func(string) (api.ProvisioningInfo, error) {
+			return s.appProvisioningInfo, nil
+		}),
+		tc.facade.EXPECT().CharmInfo("cs:test").DoAndReturn(func(string) (*charmscommon.CharmInfo, error) {
+			return s.appCharmInfo, nil
+		}),
+		tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+			return caas.DeploymentState{}, nil
+		}),
+		tc.facade.EXPECT().ApplicationOCIResources("test").DoAndReturn(func(string) (map[string]resources.DockerImageDetails, error) {
+			return s.ociResources, nil
+		}),
+		// No change, so no Ensure().
+
+		// Scaled up to 3;
+		tc.brokerApp.EXPECT().State().
+			DoAndReturn(func() (caas.ApplicationState, error) {
+				return caas.ApplicationState{DesiredReplicas: 3}, nil
+			}),
+		// Total 3, active 1, waiting 2;
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			c.Assert(len(unitsAPIResultPartialActive), gc.DeepEquals, 3)
+			return unitsAPIResultPartialActive, nil
+		}),
+		tc.facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units settled down", nil).
+			DoAndReturn(func(string, status.Status, string, map[string]interface{}) error {
+				err := tc.clock.WaitAdvance(10*time.Second, coretesting.ShortWait, 2)
+				c.Assert(err, jc.ErrorIsNil)
+				close(done)
+				return nil
+			}),
+	)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		c.Errorf("timed out waiting for worker")
+	}
+}
+
+func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusNoOpsForDyingApplication(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	s.assertRefreshApplicationStatus(c, tc, newAppWorker,
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+			return life.Dying, nil
+		}),
+		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
+			close(done)
+			return nil
+		}),
+	)
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
+}
+
+func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusNoOpsForDeadApplication(c *gc.C) {
+	newAppWorker, tc, ctrl := s.getWorker(c)
+	defer ctrl.Finish()
+
+	done := make(chan struct{})
+
+	s.assertRefreshApplicationStatus(c, tc, newAppWorker,
+		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
+			return life.Dead, nil
+		}),
+		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
+			return nil
+		}),
+		tc.brokerApp.EXPECT().Exists().DoAndReturn(func() (caas.DeploymentState, error) {
+			return caas.DeploymentState{
+				Exists:      false,
+				Terminating: false,
+			}, nil
+		}),
+		tc.facade.EXPECT().Units("test").DoAndReturn(func(string) ([]params.CAASUnit, error) {
+			return []params.CAASUnit(nil), nil
+		}),
+		tc.brokerApp.EXPECT().State().DoAndReturn(func() (caas.ApplicationState, error) {
+			return caas.ApplicationState{
+				DesiredReplicas: 0,
+				Replicas:        []string(nil),
+			}, nil
+		}),
+		tc.brokerApp.EXPECT().Service().DoAndReturn(func() (*caas.Service, error) {
+			return nil, errors.NotFoundf("test")
+		}),
+		tc.facade.EXPECT().GarbageCollect("test", []names.Tag(nil), 0, []string(nil), true).DoAndReturn(func(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error {
+			close(done)
+			return nil
+		}),
+	)
+	select {
+	case <-done:
+	case <-time.After(coretesting.ShortWait):
+		c.Errorf("timed out waiting for worker")
+	}
 }
 
 type appNotifyWorker interface {

--- a/worker/caasapplicationprovisioner/manifold.go
+++ b/worker/caasapplicationprovisioner/manifold.go
@@ -22,6 +22,7 @@ type Logger interface {
 	Infof(string, ...interface{})
 	Errorf(string, ...interface{})
 	Warningf(string, ...interface{})
+	Tracef(string, ...interface{})
 
 	Child(string) loggo.Logger
 }

--- a/worker/caasapplicationprovisioner/mocks/broker_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/broker_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	caas "github.com/juju/juju/caas"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockCAASBroker is a mock of CAASBroker interface
+// MockCAASBroker is a mock of CAASBroker interface.
 type MockCAASBroker struct {
 	ctrl     *gomock.Controller
 	recorder *MockCAASBrokerMockRecorder
 }
 
-// MockCAASBrokerMockRecorder is the mock recorder for MockCAASBroker
+// MockCAASBrokerMockRecorder is the mock recorder for MockCAASBroker.
 type MockCAASBrokerMockRecorder struct {
 	mock *MockCAASBroker
 }
 
-// NewMockCAASBroker creates a new mock instance
+// NewMockCAASBroker creates a new mock instance.
 func NewMockCAASBroker(ctrl *gomock.Controller) *MockCAASBroker {
 	mock := &MockCAASBroker{ctrl: ctrl}
 	mock.recorder = &MockCAASBrokerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 	return m.recorder
 }
 
-// AnnotateUnit mocks base method
+// AnnotateUnit mocks base method.
 func (m *MockCAASBroker) AnnotateUnit(arg0 string, arg1 caas.DeploymentMode, arg2 string, arg3 names.UnitTag) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AnnotateUnit", arg0, arg1, arg2, arg3)
@@ -42,13 +43,13 @@ func (m *MockCAASBroker) AnnotateUnit(arg0 string, arg1 caas.DeploymentMode, arg
 	return ret0
 }
 
-// AnnotateUnit indicates an expected call of AnnotateUnit
+// AnnotateUnit indicates an expected call of AnnotateUnit.
 func (mr *MockCAASBrokerMockRecorder) AnnotateUnit(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnotateUnit", reflect.TypeOf((*MockCAASBroker)(nil).AnnotateUnit), arg0, arg1, arg2, arg3)
 }
 
-// Application mocks base method
+// Application mocks base method.
 func (m *MockCAASBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
@@ -56,7 +57,7 @@ func (m *MockCAASBroker) Application(arg0 string, arg1 caas.DeploymentType) caas
 	return ret0
 }
 
-// Application indicates an expected call of Application
+// Application indicates an expected call of Application.
 func (mr *MockCAASBrokerMockRecorder) Application(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockCAASBroker)(nil).Application), arg0, arg1)

--- a/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v9"
 	caasapplicationprovisioner "github.com/juju/juju/api/caasapplicationprovisioner"
@@ -15,33 +17,32 @@ import (
 	status "github.com/juju/juju/core/status"
 	watcher "github.com/juju/juju/core/watcher"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockCAASProvisionerFacade is a mock of CAASProvisionerFacade interface
+// MockCAASProvisionerFacade is a mock of CAASProvisionerFacade interface.
 type MockCAASProvisionerFacade struct {
 	ctrl     *gomock.Controller
 	recorder *MockCAASProvisionerFacadeMockRecorder
 }
 
-// MockCAASProvisionerFacadeMockRecorder is the mock recorder for MockCAASProvisionerFacade
+// MockCAASProvisionerFacadeMockRecorder is the mock recorder for MockCAASProvisionerFacade.
 type MockCAASProvisionerFacadeMockRecorder struct {
 	mock *MockCAASProvisionerFacade
 }
 
-// NewMockCAASProvisionerFacade creates a new mock instance
+// NewMockCAASProvisionerFacade creates a new mock instance.
 func NewMockCAASProvisionerFacade(ctrl *gomock.Controller) *MockCAASProvisionerFacade {
 	mock := &MockCAASProvisionerFacade{ctrl: ctrl}
 	mock.recorder = &MockCAASProvisionerFacadeMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCAASProvisionerFacade) EXPECT() *MockCAASProvisionerFacadeMockRecorder {
 	return m.recorder
 }
 
-// ApplicationCharmURL mocks base method
+// ApplicationCharmURL mocks base method.
 func (m *MockCAASProvisionerFacade) ApplicationCharmURL(arg0 string) (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationCharmURL", arg0)
@@ -50,13 +51,13 @@ func (m *MockCAASProvisionerFacade) ApplicationCharmURL(arg0 string) (*charm.URL
 	return ret0, ret1
 }
 
-// ApplicationCharmURL indicates an expected call of ApplicationCharmURL
+// ApplicationCharmURL indicates an expected call of ApplicationCharmURL.
 func (mr *MockCAASProvisionerFacadeMockRecorder) ApplicationCharmURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmURL", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ApplicationCharmURL), arg0)
 }
 
-// ApplicationOCIResources mocks base method
+// ApplicationOCIResources mocks base method.
 func (m *MockCAASProvisionerFacade) ApplicationOCIResources(arg0 string) (map[string]resources.DockerImageDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationOCIResources", arg0)
@@ -65,13 +66,13 @@ func (m *MockCAASProvisionerFacade) ApplicationOCIResources(arg0 string) (map[st
 	return ret0, ret1
 }
 
-// ApplicationOCIResources indicates an expected call of ApplicationOCIResources
+// ApplicationOCIResources indicates an expected call of ApplicationOCIResources.
 func (mr *MockCAASProvisionerFacadeMockRecorder) ApplicationOCIResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationOCIResources", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ApplicationOCIResources), arg0)
 }
 
-// CharmInfo mocks base method
+// CharmInfo mocks base method.
 func (m *MockCAASProvisionerFacade) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmInfo", arg0)
@@ -80,13 +81,13 @@ func (m *MockCAASProvisionerFacade) CharmInfo(arg0 string) (*charms.CharmInfo, e
 	return ret0, ret1
 }
 
-// CharmInfo indicates an expected call of CharmInfo
+// CharmInfo indicates an expected call of CharmInfo.
 func (mr *MockCAASProvisionerFacadeMockRecorder) CharmInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).CharmInfo), arg0)
 }
 
-// GarbageCollect mocks base method
+// GarbageCollect mocks base method.
 func (m *MockCAASProvisionerFacade) GarbageCollect(arg0 string, arg1 []names.Tag, arg2 int, arg3 []string, arg4 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GarbageCollect", arg0, arg1, arg2, arg3, arg4)
@@ -94,13 +95,13 @@ func (m *MockCAASProvisionerFacade) GarbageCollect(arg0 string, arg1 []names.Tag
 	return ret0
 }
 
-// GarbageCollect indicates an expected call of GarbageCollect
+// GarbageCollect indicates an expected call of GarbageCollect.
 func (mr *MockCAASProvisionerFacadeMockRecorder) GarbageCollect(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).GarbageCollect), arg0, arg1, arg2, arg3, arg4)
 }
 
-// Life mocks base method
+// Life mocks base method.
 func (m *MockCAASProvisionerFacade) Life(arg0 string) (life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life", arg0)
@@ -109,13 +110,13 @@ func (m *MockCAASProvisionerFacade) Life(arg0 string) (life.Value, error) {
 	return ret0, ret1
 }
 
-// Life indicates an expected call of Life
+// Life indicates an expected call of Life.
 func (mr *MockCAASProvisionerFacadeMockRecorder) Life(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).Life), arg0)
 }
 
-// ProvisioningInfo mocks base method
+// ProvisioningInfo mocks base method.
 func (m *MockCAASProvisionerFacade) ProvisioningInfo(arg0 string) (caasapplicationprovisioner.ProvisioningInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisioningInfo", arg0)
@@ -124,13 +125,13 @@ func (m *MockCAASProvisionerFacade) ProvisioningInfo(arg0 string) (caasapplicati
 	return ret0, ret1
 }
 
-// ProvisioningInfo indicates an expected call of ProvisioningInfo
+// ProvisioningInfo indicates an expected call of ProvisioningInfo.
 func (mr *MockCAASProvisionerFacadeMockRecorder) ProvisioningInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ProvisioningInfo), arg0)
 }
 
-// SetOperatorStatus mocks base method
+// SetOperatorStatus mocks base method.
 func (m *MockCAASProvisionerFacade) SetOperatorStatus(arg0 string, arg1 status.Status, arg2 string, arg3 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetOperatorStatus", arg0, arg1, arg2, arg3)
@@ -138,13 +139,13 @@ func (m *MockCAASProvisionerFacade) SetOperatorStatus(arg0 string, arg1 status.S
 	return ret0
 }
 
-// SetOperatorStatus indicates an expected call of SetOperatorStatus
+// SetOperatorStatus indicates an expected call of SetOperatorStatus.
 func (mr *MockCAASProvisionerFacadeMockRecorder) SetOperatorStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOperatorStatus", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).SetOperatorStatus), arg0, arg1, arg2, arg3)
 }
 
-// SetPassword mocks base method
+// SetPassword mocks base method.
 func (m *MockCAASProvisionerFacade) SetPassword(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetPassword", arg0, arg1)
@@ -152,28 +153,28 @@ func (m *MockCAASProvisionerFacade) SetPassword(arg0, arg1 string) error {
 	return ret0
 }
 
-// SetPassword indicates an expected call of SetPassword
+// SetPassword indicates an expected call of SetPassword.
 func (mr *MockCAASProvisionerFacadeMockRecorder) SetPassword(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).SetPassword), arg0, arg1)
 }
 
-// Units mocks base method
-func (m *MockCAASProvisionerFacade) Units(arg0 string) ([]names.Tag, error) {
+// Units mocks base method.
+func (m *MockCAASProvisionerFacade) Units(arg0 string) ([]params.CAASUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Units", arg0)
-	ret0, _ := ret[0].([]names.Tag)
+	ret0, _ := ret[0].([]params.CAASUnit)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Units indicates an expected call of Units
+// Units indicates an expected call of Units.
 func (mr *MockCAASProvisionerFacadeMockRecorder) Units(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Units", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).Units), arg0)
 }
 
-// UpdateUnits mocks base method
+// UpdateUnits mocks base method.
 func (m *MockCAASProvisionerFacade) UpdateUnits(arg0 params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUnits", arg0)
@@ -182,13 +183,13 @@ func (m *MockCAASProvisionerFacade) UpdateUnits(arg0 params.UpdateApplicationUni
 	return ret0, ret1
 }
 
-// UpdateUnits indicates an expected call of UpdateUnits
+// UpdateUnits indicates an expected call of UpdateUnits.
 func (mr *MockCAASProvisionerFacadeMockRecorder) UpdateUnits(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnits", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).UpdateUnits), arg0)
 }
 
-// WatchApplication mocks base method
+// WatchApplication mocks base method.
 func (m *MockCAASProvisionerFacade) WatchApplication(arg0 string) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplication", arg0)
@@ -197,13 +198,13 @@ func (m *MockCAASProvisionerFacade) WatchApplication(arg0 string) (watcher.Notif
 	return ret0, ret1
 }
 
-// WatchApplication indicates an expected call of WatchApplication
+// WatchApplication indicates an expected call of WatchApplication.
 func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplication(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplication), arg0)
 }
 
-// WatchApplications mocks base method
+// WatchApplications mocks base method.
 func (m *MockCAASProvisionerFacade) WatchApplications() (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplications")
@@ -212,7 +213,7 @@ func (m *MockCAASProvisionerFacade) WatchApplications() (watcher.StringsWatcher,
 	return ret0, ret1
 }
 
-// WatchApplications indicates an expected call of WatchApplications
+// WatchApplications indicates an expected call of WatchApplications.
 func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplications", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplications))

--- a/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/unitfacade_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	watcher "github.com/juju/juju/core/watcher"
-	reflect "reflect"
 )
 
-// MockCAASUnitProvisionerFacade is a mock of CAASUnitProvisionerFacade interface
+// MockCAASUnitProvisionerFacade is a mock of CAASUnitProvisionerFacade interface.
 type MockCAASUnitProvisionerFacade struct {
 	ctrl     *gomock.Controller
 	recorder *MockCAASUnitProvisionerFacadeMockRecorder
 }
 
-// MockCAASUnitProvisionerFacadeMockRecorder is the mock recorder for MockCAASUnitProvisionerFacade
+// MockCAASUnitProvisionerFacadeMockRecorder is the mock recorder for MockCAASUnitProvisionerFacade.
 type MockCAASUnitProvisionerFacadeMockRecorder struct {
 	mock *MockCAASUnitProvisionerFacade
 }
 
-// NewMockCAASUnitProvisionerFacade creates a new mock instance
+// NewMockCAASUnitProvisionerFacade creates a new mock instance.
 func NewMockCAASUnitProvisionerFacade(ctrl *gomock.Controller) *MockCAASUnitProvisionerFacade {
 	mock := &MockCAASUnitProvisionerFacade{ctrl: ctrl}
 	mock.recorder = &MockCAASUnitProvisionerFacadeMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCAASUnitProvisionerFacade) EXPECT() *MockCAASUnitProvisionerFacadeMockRecorder {
 	return m.recorder
 }
 
-// ApplicationScale mocks base method
+// ApplicationScale mocks base method.
 func (m *MockCAASUnitProvisionerFacade) ApplicationScale(arg0 string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationScale", arg0)
@@ -43,13 +44,13 @@ func (m *MockCAASUnitProvisionerFacade) ApplicationScale(arg0 string) (int, erro
 	return ret0, ret1
 }
 
-// ApplicationScale indicates an expected call of ApplicationScale
+// ApplicationScale indicates an expected call of ApplicationScale.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationScale", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationScale), arg0)
 }
 
-// ApplicationTrust mocks base method
+// ApplicationTrust mocks base method.
 func (m *MockCAASUnitProvisionerFacade) ApplicationTrust(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationTrust", arg0)
@@ -58,13 +59,13 @@ func (m *MockCAASUnitProvisionerFacade) ApplicationTrust(arg0 string) (bool, err
 	return ret0, ret1
 }
 
-// ApplicationTrust indicates an expected call of ApplicationTrust
+// ApplicationTrust indicates an expected call of ApplicationTrust.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) ApplicationTrust(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTrust", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).ApplicationTrust), arg0)
 }
 
-// UpdateApplicationService mocks base method
+// UpdateApplicationService mocks base method.
 func (m *MockCAASUnitProvisionerFacade) UpdateApplicationService(arg0 params.UpdateApplicationServiceArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateApplicationService", arg0)
@@ -72,13 +73,13 @@ func (m *MockCAASUnitProvisionerFacade) UpdateApplicationService(arg0 params.Upd
 	return ret0
 }
 
-// UpdateApplicationService indicates an expected call of UpdateApplicationService
+// UpdateApplicationService indicates an expected call of UpdateApplicationService.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) UpdateApplicationService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplicationService", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).UpdateApplicationService), arg0)
 }
 
-// WatchApplicationScale mocks base method
+// WatchApplicationScale mocks base method.
 func (m *MockCAASUnitProvisionerFacade) WatchApplicationScale(arg0 string) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplicationScale", arg0)
@@ -87,13 +88,13 @@ func (m *MockCAASUnitProvisionerFacade) WatchApplicationScale(arg0 string) (watc
 	return ret0, ret1
 }
 
-// WatchApplicationScale indicates an expected call of WatchApplicationScale
+// WatchApplicationScale indicates an expected call of WatchApplicationScale.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) WatchApplicationScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationScale", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).WatchApplicationScale), arg0)
 }
 
-// WatchApplicationTrustHash mocks base method
+// WatchApplicationTrustHash mocks base method.
 func (m *MockCAASUnitProvisionerFacade) WatchApplicationTrustHash(arg0 string) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchApplicationTrustHash", arg0)
@@ -102,7 +103,7 @@ func (m *MockCAASUnitProvisionerFacade) WatchApplicationTrustHash(arg0 string) (
 	return ret0, ret1
 }
 
-// WatchApplicationTrustHash indicates an expected call of WatchApplicationTrustHash
+// WatchApplicationTrustHash indicates an expected call of WatchApplicationTrustHash.
 func (mr *MockCAASUnitProvisionerFacadeMockRecorder) WatchApplicationTrustHash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplicationTrustHash", reflect.TypeOf((*MockCAASUnitProvisionerFacade)(nil).WatchApplicationTrustHash), arg0)

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -46,7 +46,7 @@ type CAASProvisionerFacade interface {
 	CharmInfo(string) (*charmscommon.CharmInfo, error)
 	ApplicationCharmURL(string) (*charm.URL, error)
 	SetOperatorStatus(appName string, status status.Status, message string, data map[string]interface{}) error
-	Units(appName string) ([]names.Tag, error)
+	Units(appName string) ([]params.CAASUnit, error)
 	GarbageCollect(appName string, observedUnits []names.Tag, desiredReplicas int, activePodNames []string, force bool) error
 	ApplicationOCIResources(appName string) (map[string]resources.DockerImageDetails, error)
 	UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error)

--- a/worker/centralhub/manifold.go
+++ b/worker/centralhub/manifold.go
@@ -5,7 +5,7 @@ package centralhub
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"gopkg.in/tomb.v2"

--- a/worker/centralhub/manifold_test.go
+++ b/worker/centralhub/manifold_test.go
@@ -5,7 +5,7 @@ package centralhub_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/dependency"

--- a/worker/controllerport/manifold.go
+++ b/worker/controllerport/manifold.go
@@ -5,7 +5,7 @@ package controllerport
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/controllerport/manifold_test.go
+++ b/worker/controllerport/manifold_test.go
@@ -6,7 +6,7 @@ package controllerport_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/controllerport/worker.go
+++ b/worker/controllerport/worker.go
@@ -5,7 +5,7 @@ package controllerport
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"gopkg.in/tomb.v2"

--- a/worker/controllerport/worker_test.go
+++ b/worker/controllerport/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -82,7 +82,7 @@ func (s *WorkerSuite) TestNoChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-processed:
+	case <-pubsub.Wait(processed):
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for processed")
 	}
@@ -97,7 +97,7 @@ func (s *WorkerSuite) TestChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-processed:
+	case <-pubsub.Wait(processed):
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for processed")
 	}

--- a/worker/deployer/manifold.go
+++ b/worker/deployer/manifold.go
@@ -19,7 +19,7 @@ import (
 
 // Hub is a pubsub hub used for internal messaging.
 type Hub interface {
-	Publish(topic string, data interface{}) <-chan struct{}
+	Publish(topic string, data interface{}) func()
 	Subscribe(topic string, handler func(string, interface{})) func()
 }
 

--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -261,15 +261,15 @@ func (s *NestedContextSuite) TestStopStartUnits(c *gc.C) {
 		}
 	})
 
-	handled := s.hub.Publish(message.StopUnitTopic, message.Units{
+	done := s.hub.Publish(message.StopUnitTopic, message.Units{
 		Names: []string{"first/0", "second/0", "unknown/2"},
 	})
-	s.waitForEventHandled(c, handled)
+	s.waitForEventHandled(c, pubsub.Wait(done))
 	// Call the stop topic again, and the results are the same.
-	handled = s.hub.Publish(message.StopUnitTopic, message.Units{
+	done = s.hub.Publish(message.StopUnitTopic, message.Units{
 		Names: []string{"first/0", "second/0", "unknown/2"},
 	})
-	s.waitForEventHandled(c, handled)
+	s.waitForEventHandled(c, pubsub.Wait(done))
 	s.waitForEventHandled(c, handledBothCalls)
 	unsub()
 
@@ -290,15 +290,15 @@ func (s *NestedContextSuite) TestStopStartUnits(c *gc.C) {
 	})
 
 	// Start one back up again.
-	handled = s.hub.Publish(message.StartUnitTopic, message.Units{
+	done = s.hub.Publish(message.StartUnitTopic, message.Units{
 		Names: []string{"first/0", "unknown/2"},
 	})
-	s.waitForEventHandled(c, handled)
+	s.waitForEventHandled(c, pubsub.Wait(done))
 	// Called again gets the same results.
-	handled = s.hub.Publish(message.StartUnitTopic, message.Units{
+	done = s.hub.Publish(message.StartUnitTopic, message.Units{
 		Names: []string{"first/0", "unknown/2"},
 	})
-	s.waitForEventHandled(c, handled)
+	s.waitForEventHandled(c, pubsub.Wait(done))
 	s.waitForEventHandled(c, handledBothCalls)
 	unsub()
 
@@ -325,13 +325,13 @@ func (s *NestedContextSuite) TestUnitStatus(c *gc.C) {
 	ctx := s.newContext(c)
 	s.deployThreeUnits(c, ctx)
 	// And stop one.
-	handled := s.hub.Publish(message.StopUnitTopic, message.Units{
+	done := s.hub.Publish(message.StopUnitTopic, message.Units{
 		Names: []string{"second/0"},
 	})
-	s.waitForEventHandled(c, handled)
+	s.waitForEventHandled(c, pubsub.Wait(done))
 
-	handled = s.hub.Publish(message.UnitStatusTopic, nil)
-	s.waitForEventHandled(c, handled)
+	done = s.hub.Publish(message.UnitStatusTopic, nil)
+	s.waitForEventHandled(c, pubsub.Wait(done))
 	s.waitForEventHandled(c, responseHandled)
 }
 

--- a/worker/httpserver/manifold.go
+++ b/worker/httpserver/manifold.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/httpserver/manifold_test.go
+++ b/worker/httpserver/manifold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2/catacomb"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -413,7 +413,7 @@ func (s *WorkerControllerPortSuite) TestDualPortListenerWithDelay(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("the handler should have exited early and not be waiting")
 	}

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -50,14 +50,14 @@ type Clock interface {
 
 // SimpleHub is a pubsub hub used for internal messaging.
 type SimpleHub interface {
-	Publish(topic string, data interface{}) <-chan struct{}
+	Publish(topic string, data interface{}) func()
 	Subscribe(topic string, handler func(string, interface{})) func()
 }
 
 // StructuredHub is a pubsub hub used for messaging within the HA
 // controller applications.
 type StructuredHub interface {
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 	Subscribe(topic string, handler interface{}) (func(), error)
 }
 

--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/lease/manifold/manifold_test.go
+++ b/worker/lease/manifold/manifold_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/modelcache/manifold.go
+++ b/worker/modelcache/manifold.go
@@ -5,7 +5,7 @@ package modelcache
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/modelcache/manifold_test.go
+++ b/worker/modelcache/manifold_test.go
@@ -6,7 +6,7 @@ package modelcache_test
 import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jt "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -275,7 +275,7 @@ func (s *WorkerSuite) TestControllerConfigPubsubChange(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-handled:
+	case <-pubsub.Wait(handled):
 	case <-time.After(testing.LongWait):
 		c.Fatalf("config changed not handled")
 	}

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -107,7 +107,7 @@ var (
 // grouper uses.
 type Hub interface {
 	Subscribe(topic string, handler interface{}) (func(), error)
-	Publish(topic string, data interface{}) (<-chan struct{}, error)
+	Publish(topic string, data interface{}) (func(), error)
 }
 
 // pgWorker is a worker which watches the controller nodes in state

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/replicaset/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/voyeur"
@@ -1133,8 +1133,8 @@ func (nopAPIHostPortsSetter) SetAPIHostPorts(apiServers []network.SpaceHostPorts
 
 type nopHub struct{}
 
-func (nopHub) Publish(topic string, data interface{}) (<-chan struct{}, error) {
-	return nil, nil
+func (nopHub) Publish(topic string, data interface{}) (func(), error) {
+	return func() {}, nil
 }
 
 func (nopHub) Subscribe(topic string, handler interface{}) (func(), error) {

--- a/worker/presence/manifold.go
+++ b/worker/presence/manifold.go
@@ -5,7 +5,7 @@ package presence
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/presence/manifold_test.go
+++ b/worker/presence/manifold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/presence/presence.go
+++ b/worker/presence/presence.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"
 

--- a/worker/presence/presence_test.go
+++ b/worker/presence/presence_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -195,7 +195,7 @@ func (s *PresenceSuite) TestForwarderDisconnectConnectFromOther(c *gc.C) {
 		forwarder.DisconnectedTopic,
 		apiserver.OriginTarget{Origin: ourServer, Target: otherServer})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, alive(agent1), missing(agent2))
 }
 
@@ -209,7 +209,7 @@ func (s *PresenceSuite) TestForwarderDisconnectOthersIgnored(c *gc.C) {
 		forwarder.DisconnectedTopic,
 		apiserver.OriginTarget{Origin: "machine-7", Target: otherServer})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, alive(agent1), alive(agent2))
 }
 
@@ -228,7 +228,7 @@ func (s *PresenceSuite) TestConnectTopic(c *gc.C) {
 			UserData:        "test",
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, corepresence.Value{
 		Model:           "model-uuid",
 		Server:          "machine-5",
@@ -253,7 +253,7 @@ func (s *PresenceSuite) TestDisconnectTopic(c *gc.C) {
 			ConnectionID: agent2.ConnectionID,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 	s.AssertConnections(c, alive(agent1))
 }
 
@@ -323,7 +323,7 @@ func (s *PresenceSuite) TestPresenceResponse(c *gc.C) {
 			},
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.AssertDone(c, done)
+	s.AssertDone(c, pubsub.Wait(done))
 
 	s.AssertConnections(c, alive(agent1), alive(agent2), alive(agent3), alive(agent4))
 }

--- a/worker/pubsub/manifold.go
+++ b/worker/pubsub/manifold.go
@@ -6,7 +6,7 @@ package pubsub
 import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/pubsub/manifold_test.go
+++ b/worker/pubsub/manifold_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/pubsub/remoteserver.go
+++ b/worker/pubsub/remoteserver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/collections/deque"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/retry"
 	"github.com/juju/worker/v2"
 	"gopkg.in/tomb.v2"

--- a/worker/pubsub/remoteserver_test.go
+++ b/worker/pubsub/remoteserver_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2/workertest"
@@ -182,7 +182,7 @@ func (s *RemoteServerSuite) TestConnectRetryInterruptedOnTargetConnection(c *gc.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("worker didn't consume the event")
 	}

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -201,7 +201,7 @@ func (s *SubscriberSuite) enableHA(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("message handling not completed")
 	}
@@ -252,7 +252,7 @@ func (s *SubscriberSuite) TestEnableHAInternalAddress(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	select {
-	case <-done:
+	case <-pubsub.Wait(done):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("message handling not completed")
 	}
@@ -276,7 +276,7 @@ func (s *SubscriberSuite) TestSameMessagesForwardedForMachine(c *gc.C) {
 		expected = append(expected, message)
 		done, err := s.hub.Publish(message.Topic, nil)
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:
@@ -313,7 +313,7 @@ func (s *SubscriberSuite) TestSameMessagesForwardedForController(c *gc.C) {
 		expected = append(expected, message)
 		done, err := s.hub.Publish(message.Topic, nil)
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:
@@ -340,7 +340,7 @@ func (s *SubscriberSuite) TestLocalMessagesNotForwarded(c *gc.C) {
 			"local-only": true,
 		})
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:
@@ -367,7 +367,7 @@ func (s *SubscriberSuite) TestOtherOriginMessagesNotForwarded(c *gc.C) {
 			"origin": "other",
 		})
 		c.Assert(err, jc.ErrorIsNil)
-		last = done
+		last = pubsub.Wait(done)
 	}
 	select {
 	case <-last:

--- a/worker/raft/raftbackstop/manifold.go
+++ b/worker/raft/raftbackstop/manifold.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/raft/raftbackstop/manifold_test.go
+++ b/worker/raft/raftbackstop/manifold_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/raftbackstop/worker.go
+++ b/worker/raft/raftbackstop/worker.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 

--- a/worker/raft/raftbackstop/worker_test.go
+++ b/worker/raft/raftbackstop/worker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
@@ -348,7 +348,7 @@ func (s *WorkerSuite) publishDetails(c *gc.C, serverAddrs map[string]string) {
 	received, err := s.hub.Publish(apiserver.DetailsTopic, details)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-received:
+	case <-pubsub.Wait(received):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for details to be received")
 	}

--- a/worker/raft/raftclusterer/manifold.go
+++ b/worker/raft/raftclusterer/manifold.go
@@ -6,7 +6,7 @@ package raftclusterer
 import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 )

--- a/worker/raft/raftclusterer/manifold_test.go
+++ b/worker/raft/raftclusterer/manifold_test.go
@@ -6,7 +6,7 @@ package raftclusterer_test
 import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/workertest"
@@ -550,7 +550,7 @@ func (s *WorkerSuite) publishDetails(c *gc.C, serverAddrs map[string]string) {
 	received, err := s.hub.Publish(apiserver.DetailsTopic, details)
 	c.Assert(err, jc.ErrorIsNil)
 	select {
-	case <-received:
+	case <-pubsub.Wait(received):
 	case <-time.After(coretesting.LongWait):
 		c.Fatal("timed out waiting for details to be received")
 	}

--- a/worker/raft/raftforwarder/manifold.go
+++ b/worker/raft/raftforwarder/manifold.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/raft/raftforwarder/manifold_test.go
+++ b/worker/raft/raftforwarder/manifold_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 	"github.com/prometheus/client_golang/prometheus"

--- a/worker/raft/raftforwarder/worker_test.go
+++ b/worker/raft/raftforwarder/worker_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/rafttransport/manifold.go
+++ b/worker/raft/rafttransport/manifold.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/dependency"
 

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v2"

--- a/worker/raft/rafttransport/streamlayer.go
+++ b/worker/raft/rafttransport/streamlayer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/pubsub/apiserver"

--- a/worker/raft/rafttransport/worker.go
+++ b/worker/raft/rafttransport/worker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v2"
 	"github.com/juju/worker/v2/catacomb"
 


### PR DESCRIPTION
Merge 2.9 into develop.  Includes the following PRs:
- #13177
- #13180 
- #13186 
- #13188
- #13190 
- #13195 
- #13196
- #13197 

Fixed conflicts in:
- apiserver/facades/client/charms/client.go
- cmd/jujud/agent/machine.go 
- state/state.go 
- tests/suites/network/network_health.sh 
- worker/peergrouper/worker_test.go 
- worker/raft/rafttransport/worker.go
- go.mod
- go.sum