### PR TITLE
Use separate matching functions for block and filesystem volume devices

### DIFF
--- a/apiserver/common/storagecommon/blockdevices_test.go
+++ b/apiserver/common/storagecommon/blockdevices_test.go
@@ -32,7 +32,7 @@ func (s *BlockDeviceSuite) TestBlockDeviceMatchingSerialID(c *gc.C) {
 	}
 	atachmentInfo := state.VolumeAttachmentInfo{}
 	planBlockInfo := state.BlockDeviceInfo{}
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(blockDevices, volumeInfo, atachmentInfo, planBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(blockDevices, volumeInfo, atachmentInfo, planBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "sdb",
@@ -55,7 +55,7 @@ func (s *BlockDeviceSuite) TestBlockDeviceMatchingHardwareID(c *gc.C) {
 	}
 	atachmentInfo := state.VolumeAttachmentInfo{}
 	planBlockInfo := state.BlockDeviceInfo{}
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(blockDevices, volumeInfo, atachmentInfo, planBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(blockDevices, volumeInfo, atachmentInfo, planBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "sdb",
@@ -64,7 +64,7 @@ func (s *BlockDeviceSuite) TestBlockDeviceMatchingHardwareID(c *gc.C) {
 }
 
 func (s *BlockDeviceSuite) TestBlockDevicesAWS(c *gc.C) {
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(awsTestBlockDevices, awsTestVolumeInfo, awsTestAttachmentInfo, awsTestPlanBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(awsTestBlockDevices, awsTestVolumeInfo, awsTestAttachmentInfo, awsTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "nvme0n1",
@@ -87,7 +87,7 @@ var (
 )
 
 func (s *BlockDeviceSuite) TestBlockDevicesGCE(c *gc.C) {
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(gceTestBlockDevices, gceTestVolumeInfo, gceTestAttachmentInfo, gceTestPlanBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(gceTestBlockDevices, gceTestVolumeInfo, gceTestAttachmentInfo, gceTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "sdd",
@@ -104,7 +104,7 @@ func (s *BlockDeviceSuite) TestBlockDevicesGCE(c *gc.C) {
 }
 
 func (s *BlockDeviceSuite) TestBlockDevicesGCEPreferUUID(c *gc.C) {
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(gceTestBlockDevices, gceTestVolumeInfo, gceTestAttachmentInfoForUUID, gceTestPlanBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingFilesystemBlockDevice(gceTestBlockDevices, gceTestVolumeInfo, gceTestAttachmentInfoForUUID, gceTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "sda1",
@@ -137,7 +137,7 @@ var (
 )
 
 func (s *BlockDeviceSuite) TestBlockDevicesOpenStack(c *gc.C) {
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(osTestBlockDevices, osTestVolumeInfo, osTestAttachmentInfo, osTestPlanBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(osTestBlockDevices, osTestVolumeInfo, osTestAttachmentInfo, osTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "vdd",
@@ -159,7 +159,7 @@ var (
 )
 
 func (s *BlockDeviceSuite) TestBlockDevicesOCI(c *gc.C) {
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(ociTestBlockDevices, ociTestVolumeInfo, ociTestAttachmentInfo, ociTestPlanBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(ociTestBlockDevices, ociTestVolumeInfo, ociTestAttachmentInfo, ociTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "loop2",
@@ -175,7 +175,7 @@ var (
 )
 
 func (s *BlockDeviceSuite) TestBlockDevicesVSphere(c *gc.C) {
-	blockDeviceInfo, ok := storagecommon.MatchingBlockDevice(vsphereTestBlockDevices, vsphereTestVolumeInfo, vsphereTestAttachmentInfo, vsphereTestPlanBlockInfo)
+	blockDeviceInfo, ok := storagecommon.MatchingVolumeBlockDevice(vsphereTestBlockDevices, vsphereTestVolumeInfo, vsphereTestAttachmentInfo, vsphereTestPlanBlockInfo)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(blockDeviceInfo, jc.DeepEquals, &state.BlockDeviceInfo{
 		DeviceName: "loop0",

--- a/apiserver/common/storagecommon/storage.go
+++ b/apiserver/common/storagecommon/storage.go
@@ -147,7 +147,7 @@ func volumeStorageAttachmentInfo(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting block devices")
 	}
-	blockDevice, ok := MatchingBlockDevice(
+	blockDevice, ok := MatchingVolumeBlockDevice(
 		blockDevices,
 		volumeInfo,
 		volumeAttachmentInfo,

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -1261,7 +1261,7 @@ func (s *StorageProvisionerAPIv3) oneVolumeBlockDevice(
 	if err != nil {
 		return state.BlockDeviceInfo{}, err
 	}
-	blockDevice, ok := storagecommon.MatchingBlockDevice(
+	blockDevice, ok := storagecommon.MatchingFilesystemBlockDevice(
 		blockDevices,
 		volumeInfo,
 		volumeAttachmentInfo,

--- a/storage/path.go
+++ b/storage/path.go
@@ -27,12 +27,12 @@ func BlockDevicePath(device BlockDevice) (string, error) {
 	if device.HardwareId != "" {
 		return path.Join(diskByID, device.HardwareId), nil
 	}
-	if device.UUID != "" {
-		return path.Join(diskByUUID, device.UUID), nil
-	}
 	if len(device.DeviceLinks) > 0 {
 		// return the first device link in the list
 		return device.DeviceLinks[0], nil
+	}
+	if device.UUID != "" {
+		return path.Join(diskByUUID, device.UUID), nil
 	}
 	if device.DeviceName != "" {
 		return path.Join(diskByDeviceName, device.DeviceName), nil


### PR DESCRIPTION
There's a hard to reproduce issue deploying a charm with block storage on Azure - the incorrect device path is being given to the charm to use. It appears there might be an issue if, external to the charm, a partition is created on that block device; this could confuse the matching algorithm. There's 2 cases where we need to determine what block device represents a juju volume:
- some block storage is needed by the charm
- the charm requests filesystem storage and this is done by creating a volume and adding a filesystem on top

This PR separates the matching in the 2 cases, to avoid a potential incorrect match if there's a partition added to what Juju expects to be block storage. We also prefer to use the devicelink for the mount point instead of disk-by-uuid.

## QA steps

The issue in the bug could not be reproduced, but I deploy a charm with both block and filesystem storage to
- lxd
- azure
- google
- aws

And checked juju storage --format yaml and also the /etc/fstab on the unit's machine to ensure everything as set up as expected.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1936752
