### PR TITLE
When there's an error connecting to mongo, ensure we restart it before trying again

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1026,6 +1026,10 @@ func (a *MachineAgent) initState(agentConfig agent.Config) (*state.StatePool, er
 		a.mongoTxnCollector.AfterRunTransaction,
 	)
 	if err != nil {
+		// On error, force a mongo refresh.
+		a.mongoInitMutex.Lock()
+		a.mongoInitialized = false
+		a.mongoInitMutex.Unlock()
 		return nil, err
 	}
 	logger.Infof("juju database opened")


### PR DESCRIPTION
If the juju-db snap is refreshed, it needs a restart before any client can connect to it. This includes the mongo CLI client as well as Juju.
The Juju state worker would exit with an error because the ping failed, and it would restart. But the reconnection to mongo failed because the agent uses a flag to prevent mongo from being initialised more than once. We need to reset the flag on error so the mongo service can be restarted if needed.

## QA steps

bootstrap to focal
ssh to controller
sudo snap refresh juju-db --channel=4.0/candidate

controller workers will exit with errors
workers will restart and controller comes alive again

## Bug reference

https://bugs.launchpad.net/juju/+bug/1905703
