### PR TITLE
Adds remaining authorization objects to ignore.

### DIFF
--- a/worker/caasadmission/filter.go
+++ b/worker/caasadmission/filter.go
@@ -21,6 +21,36 @@ var admissionObjectIgnores = []apis.GroupVersionKind{
 		Kind:    "SelfSubjectRulesReview",
 		Version: "v1",
 	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "SelfSubjectAccessReview",
+		Version: "v1beta1",
+	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "SelfSubjectRulesReview",
+		Version: "v1beta1",
+	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "SubjectAccessReview",
+		Version: "v1",
+	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "SubjectAccessReview",
+		Version: "v1beta1",
+	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "LocalSubjectAccessReview",
+		Version: "v1",
+	},
+	{
+		Group:   "authorization.k8s.io",
+		Kind:    "LocalSubjectAccessReview",
+		Version: "v1beta1",
+	},
 }
 
 // compareAPIGroupVersionKind compares two api GroupVersionKind objects for


### PR DESCRIPTION
It's important that the model admission operator ignores certain types
of Kubernetes objects that don't persist in the etcd state. This change
further adds remainder of objects that should be ignored.

## QA steps

Run Kubeflow locally on microk8s. Access the dashboard and add a volume from the Kubeflow dashboard.

Also confirmed from Dom that this fixes the issue.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1938955
