### PR TITLE
Updates to finding the correct juju-controller charm.

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -343,15 +343,14 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	})
 
 	curl := charm.MustParseURL(controllerCharmURL)
-	channel := corecharm.MakeRiskOnlyChannel("beta")
+	channel := corecharm.MustParseChannel("beta")
 	origin := corecharm.Origin{
 		Source:  corecharm.CharmHub,
-		Type:    "charm",
 		Channel: &channel,
 		Platform: corecharm.Platform{
 			Architecture: "amd64",
 			OS:           "ubuntu",
-			Series:       "NA",
+			Series:       "focal",
 		},
 	}
 
@@ -360,7 +359,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	storeCurl.Series = "focal"
 	storeCurl.Architecture = "amd64"
 	storeOrigin := origin
-	storeOrigin.Platform.Series = "focal"
+	storeOrigin.Type = "charm"
 	repo.EXPECT().ResolveWithPreferredChannel(curl, origin, nil).Return(&storeCurl, storeOrigin, nil, nil)
 
 	origin.Platform.Series = "focal"


### PR DESCRIPTION
As finding the correct revision of the juju-controller charm is done from the machine where the charm will be deployed, it's possible to skip the finding the correct base dance done when deploying a charm with the juju client.  Simply ask for the base which matches the controller machine.  

Otherwise we'd have to add a 2nd call to ResolveWithPreferredChannel once the series was determined from the supportedSeries list.  Lack of the 2nd call caused invalid data to be saved where the charm url and origin didn't match, which would cause issue when/if we tried to upgrade the charm at a future date.

The juju-controller charm will need to be updated before deploying on series other than focal, to add the series to the manifest.yaml, as well as remove the series from metadata.yaml.  You can bootstrap a different series right now, e.g. bionic, however you will get revision 1 of the charm.

## QA steps

```console
$ juju bootstrap localhost testme
$ juju status -m controller
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  testing     localhost/localhost  3.0-beta1.1  unsupported  16:30:42Z

App         Version  Status  Scale  Charm            Store     Channel  Rev  OS      Message
controller           active      1  juju-controller  charmhub  beta       3  ubuntu

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.74.147.77

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.74.147.77  juju-a9306e-0  focal       Running

```
