### PR TITLE
Only 1 origin in deployCommand stuct, remove the duplication.

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -47,7 +47,6 @@ type deployCharm struct {
 	flagSet          *gnuflag.FlagSet
 	model            ModelCommand
 	numUnits         int
-	origin           commoncharm.Origin
 	placement        []*instance.Placement
 	placementSpec    string
 	resources        map[string]string
@@ -237,7 +236,7 @@ func (d *deployCharm) deploy(
 	ctx.Infof(d.formatDeployingText())
 	args := applicationapi.DeployArgs{
 		CharmID:          id,
-		CharmOrigin:      d.origin,
+		CharmOrigin:      id.Origin,
 		Cons:             d.constraints,
 		ApplicationName:  applicationName,
 		Series:           d.series,
@@ -303,11 +302,12 @@ type predeployedLocalCharm struct {
 // String returns a string description of the deployer.
 func (d *predeployedLocalCharm) String() string {
 	str := fmt.Sprintf("deploy predeployed local charm: %s", d.userCharmURL.String())
-	if isEmptyOrigin(d.origin, commoncharm.OriginLocal) {
+	origin := d.id.Origin
+	if isEmptyOrigin(origin, commoncharm.OriginLocal) {
 		return str
 	}
 	var channel string
-	if ch := d.origin.CharmChannel().String(); ch != "" {
+	if ch := origin.CharmChannel().String(); ch != "" {
 		channel = fmt.Sprintf(" from channel %s", ch)
 	}
 	return fmt.Sprintf("%s%s", str, channel)
@@ -357,7 +357,6 @@ func (d *predeployedLocalCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI Dep
 		Origin: origin,
 	}
 	d.series = userCharmURL.Series
-	d.origin = origin
 	return d.deploy(ctx, deployAPI)
 }
 
@@ -401,7 +400,6 @@ func (l *localCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, _
 		// Local charms don't need a channel.
 	}
 	l.series = l.curl.Series
-	l.origin = origin
 	return l.deploy(ctx, deployAPI)
 }
 
@@ -414,11 +412,12 @@ type repositoryCharm struct {
 // String returns a string description of the deployer.
 func (c *repositoryCharm) String() string {
 	str := fmt.Sprintf("deploy charm: %s", c.userRequestedURL.String())
-	if isEmptyOrigin(c.origin, commoncharm.OriginCharmStore) {
+	origin := c.id.Origin
+	if isEmptyOrigin(origin, commoncharm.OriginCharmStore) {
 		return str
 	}
 	var channel string
-	if ch := c.origin.CharmChannel().String(); ch != "" {
+	if ch := origin.CharmChannel().String(); ch != "" {
 		channel = fmt.Sprintf(" from channel %s", ch)
 	}
 	return fmt.Sprintf("%s%s", str, channel)
@@ -452,7 +451,8 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	// Charm or bundle has been supplied as a URL so we resolve and
 	// deploy using the store but pass in the origin command line
 	// argument so users can target a specific origin.
-	storeCharmOrBundleURL, origin, supportedSeries, err := resolver.ResolveCharm(userRequestedURL, c.origin, false) // no --switch possible.
+	origin := c.id.Origin
+	storeCharmOrBundleURL, origin, supportedSeries, err := resolver.ResolveCharm(userRequestedURL, origin, false) // no --switch possible.
 	if charm.IsUnsupportedSeriesError(err) {
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	} else if err != nil {
@@ -492,18 +492,18 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// Ensure we save the origin.
-	c.origin = origin.WithSeries(series)
+	origin = origin.WithSeries(series)
 
 	// In-order for the url to represent the following updates to the the origin
 	// and machine, we need to ensure that the series is actually correct as
 	// well in the url.
 	deployableURL := storeCharmOrBundleURL
 	if charm.CharmHub.Matches(storeCharmOrBundleURL.Schema) {
-		deployableURL = storeCharmOrBundleURL.WithSeries(c.origin.Series)
+		deployableURL = storeCharmOrBundleURL.WithSeries(origin.Series)
 	}
 
 	// Store the charm in the controller
-	curl, csMac, csOrigin, err := store.AddCharmWithAuthorizationFromURL(deployAPI, macaroonGetter, deployableURL, c.origin, c.force)
+	curl, csMac, csOrigin, err := store.AddCharmWithAuthorizationFromURL(deployAPI, macaroonGetter, deployableURL, origin, c.force)
 	if err != nil {
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())
@@ -528,10 +528,9 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 
 	c.series = series
 	c.csMac = csMac
-	c.origin = csOrigin
 	c.id = application.CharmID{
 		URL:    curl,
-		Origin: c.origin,
+		Origin: csOrigin,
 	}
 	return c.deploy(ctx, deployAPI)
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/api/application"
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
@@ -491,7 +492,9 @@ func (d *factory) repositoryCharm() (Deployer, error) {
 	}
 
 	deployCharm := d.newDeployCharm()
-	deployCharm.origin = origin
+	deployCharm.id = application.CharmID{
+		Origin: origin,
+	}
 	return &repositoryCharm{
 		deployCharm:      deployCharm,
 		userRequestedURL: userRequestedURL,


### PR DESCRIPTION
deployCommand should have only 1 origin, not 2.  Remove the old one.

## QA steps

There should be no change to current charm deployment behavior.

```console 
$ juju deploy cs:ubuntu
$ juju deploy juju-qa-test --channel 2.0/stable
$ juju deploy ./testcharms/charm-repo/bionic/ubuntu-plus
```

