### PR TITLE
Show application data set by the remote app in show-unit output

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3166,13 +3166,6 @@ func (api *APIBase) relationData(app Application, myUnit Unit) ([]params.Endpoin
 			ApplicationData:  make(map[string]interface{}),
 			UnitRelationData: make(map[string]params.RelationData),
 		}
-		appSettings, err := rel.ApplicationSettings(app.Name())
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		for k, v := range appSettings {
-			erd.ApplicationData[k] = v
-		}
 		relatedEps, err := rel.RelatedEndpoints(app.Name())
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -3180,6 +3173,14 @@ func (api *APIBase) relationData(app Application, myUnit Unit) ([]params.Endpoin
 		// There is only one related endpoint.
 		related := relatedEps[0]
 		erd.RelatedEndpoint = related.Name
+
+		appSettings, err := rel.ApplicationSettings(related.ApplicationName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for k, v := range appSettings {
+			erd.ApplicationData[k] = v
+		}
 
 		otherApp, err := api.backend.Application(related.ApplicationName)
 		if errors.IsNotFound(err) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2324,7 +2324,7 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 			Endpoint:        "db",
 			CrossModel:      true,
 			RelatedEndpoint: "server",
-			ApplicationData: map[string]interface{}{"app-postgresql": "setting"},
+			ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
 			UnitRelationData: map[string]params.RelationData{
 				"gitlab/2": {
 					InScope:  true,


### PR DESCRIPTION
`juju show-unit foo` displays relation data as set by the app/unit foo is related to.
In the case of application relation data, we were showing the data that is set by the nominated unit, not the data that was set by the other side.

## QA steps

I used local copies of the controller and dashboard charms
juju deploy controller
juju deploy dashboard
juju relate controller dashboard
juju show-unit dashboard/0

App data would have been empty but is now
```
    application-data:
      controller-url: wss://10.160.126.204/api
      is-juju: "True"
      model-url-template: wss://10.160.126.204/model/${modelUUID}/api
```

