### PR TITLE
Add impish to the ubuntu series list

### DIFF
--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -248,6 +248,7 @@ const (
 	Focal   SeriesName = "focal"
 	Groovy  SeriesName = "groovy"
 	Hirsute SeriesName = "hirsute"
+	Impish  SeriesName = "impish"
 )
 
 var ubuntuSeries = map[SeriesName]seriesVersion{
@@ -333,11 +334,14 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 	Groovy: {
 		WorkloadType: ControllerWorkloadType,
 		Version:      "20.10",
-		Supported:    true,
 	},
 	Hirsute: {
 		WorkloadType: ControllerWorkloadType,
 		Version:      "21.04",
+	},
+	Impish: {
+		WorkloadType: ControllerWorkloadType,
+		Version:      "21.10",
 	},
 }
 
@@ -345,7 +349,6 @@ const (
 	Centos7      SeriesName = "centos7"
 	Centos8      SeriesName = "centos8"
 	OpenSUSELeap SeriesName = "opensuseleap"
-	GenericLinux SeriesName = "genericlinux"
 	Kubernetes   SeriesName = "kubernetes"
 )
 

--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -79,7 +79,7 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	series, err := WorkloadSeries(time.Time{}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"bionic", "centos7", "centos8", "focal", "genericlinux", "groovy", "kubernetes", "opensuseleap",
+		"bionic", "centos7", "centos8", "focal", "genericlinux", "kubernetes", "opensuseleap",
 		"trusty", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2",
 		"win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81", "xenial"})
 }

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -37,10 +37,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -53,10 +53,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -69,10 +69,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -85,10 +85,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"groovy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 var getOSFromSeriesTests = []struct {


### PR DESCRIPTION
Add `impish` to the series list so that juju recognises it even it someone's distro-info is stale or they are using macos client.

## QA steps

`juju bootstrap lxd --bootstrap-series=impish --config image-stream=daily`

