### PR TITLE
2.9 lease client abstraction

### DIFF
--- a/core/raftlease/client.go
+++ b/core/raftlease/client.go
@@ -1,0 +1,173 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/pubsub/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Client defines the methods for broadcasting a command.
+type Client interface {
+	Request(context.Context, *Command) error
+}
+
+// ClientMetrics represents the metrics during a client request.
+type ClientMetrics interface {
+	RecordOperation(string, string, time.Time)
+}
+
+type PubsubClient struct {
+	hub            *pubsub.StructuredHub
+	requestID      uint64
+	requestTopic   string
+	responseTopic  func(uint64) string
+	metrics        ClientMetrics
+	forwardTimeout time.Duration
+	clock          clock.Clock
+}
+
+// PubsubClientConfig holds resources and settings needed to run the
+// PubsubClient.
+type PubsubClientConfig struct {
+	Hub            *pubsub.StructuredHub
+	RequestTopic   string
+	ResponseTopic  func(requestID uint64) string
+	ClientMetrics  ClientMetrics
+	Clock          clock.Clock
+	ForwardTimeout time.Duration
+}
+
+// NewPubsubClient creates a PubSub raftlease client.
+func NewPubsubClient(config PubsubClientConfig) *PubsubClient {
+	return &PubsubClient{
+		hub:            config.Hub,
+		requestTopic:   config.RequestTopic,
+		responseTopic:  config.ResponseTopic,
+		metrics:        config.ClientMetrics,
+		forwardTimeout: config.ForwardTimeout,
+		clock:          config.Clock,
+	}
+}
+
+func (c *PubsubClient) Request(ctx context.Context, command *Command) error {
+	bytes, err := command.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	start := time.Now()
+
+	requestID := atomic.AddUint64(&c.requestID, 1)
+	responseTopic := c.responseTopic(requestID)
+
+	responseChan := make(chan ForwardResponse)
+	errChan := make(chan error)
+	unsubscribe, err := c.hub.Subscribe(
+		responseTopic,
+		func(_ string, resp ForwardResponse, err error) {
+			if err != nil {
+				errChan <- err
+			} else {
+				responseChan <- resp
+			}
+		},
+	)
+	if err != nil {
+		return errors.Annotatef(err, "running %s", command)
+	}
+	defer unsubscribe()
+
+	delivered, err := c.hub.Publish(c.requestTopic, ForwardRequest{
+		Command:       string(bytes),
+		ResponseTopic: responseTopic,
+	})
+	if err != nil {
+		c.record(command.Operation, "error", start)
+		return errors.Annotatef(err, "publishing %s", command)
+	}
+
+	// First block until subscribers are notified.
+	// In practice, this will be the Raft forwarder running on the leader node.
+	// This is an explicit step so that we can more accurately diagnose issues
+	// in-theatre.
+	select {
+	case <-pubsub.Wait(delivered):
+	case <-c.clock.After(c.forwardTimeout):
+		logger.Warningf("delivery timeout waiting for %s to be processed", command)
+		c.record(command.Operation, "delivery timeout", start)
+		return lease.ErrTimeout
+	}
+
+	// Now wait for the response.
+	// The timeout starts again here, which is deliberate.
+	// It is the same timeout that is used by the Raft forwarder
+	// when `Apply` is called on the FSM.
+	select {
+	case response := <-responseChan:
+		err := RecoverError(response.Error)
+		logger.Tracef("got response, err %v", err)
+		result := "success"
+		if err != nil {
+			logger.Warningf("command %s: %v", command, err)
+			result = "failure"
+		}
+		c.record(command.Operation, result, start)
+		return err
+	case err := <-errChan:
+		logger.Warningf("processing %s: %v", command, err)
+		c.record(command.Operation, "error", start)
+		return errors.Trace(err)
+	case <-ctx.Done():
+		return aborted(command)
+	case <-c.clock.After(c.forwardTimeout):
+		// TODO (thumper) 2019-12-20, bug 1857072
+		// Scale testing hit this a *lot*,
+		// perhaps we need to consider batching messages to run on the leader?
+		logger.Warningf("response timeout waiting for %s to be processed", command)
+		c.record(command.Operation, "response timeout", start)
+		return lease.ErrTimeout
+	}
+}
+
+func (c PubsubClient) record(operation, result string, start time.Time) {
+	c.metrics.RecordOperation(operation, result, start)
+}
+
+type OperationClientMetrics struct {
+	metrics *metricsCollector
+	clock   clock.Clock
+}
+
+func NewOperationClientMetrics(clock clock.Clock) *OperationClientMetrics {
+	return &OperationClientMetrics{
+		metrics: newMetricsCollector(),
+		clock:   clock,
+	}
+}
+
+func (m OperationClientMetrics) RecordOperation(operation, result string, start time.Time) {
+	elapsedMS := float64(m.clock.Now().Sub(start)) / float64(time.Millisecond)
+	m.metrics.requests.With(prometheus.Labels{
+		"operation": operation,
+		"result":    result,
+	}).Observe(elapsedMS)
+}
+
+// Describe is part of prometheus.Collector.
+func (c *OperationClientMetrics) Describe(ch chan<- *prometheus.Desc) {
+	c.metrics.Describe(ch)
+}
+
+// Collect is part of prometheus.Collector.
+func (c *OperationClientMetrics) Collect(ch chan<- prometheus.Metric) {
+	c.metrics.Collect(ch)
+}

--- a/core/raftlease/metrics.go
+++ b/core/raftlease/metrics.go
@@ -11,6 +11,14 @@ const (
 	metricsNamespace = "juju_raftlease"
 )
 
+type MetricsCollector interface {
+	// Describe is part of prometheus.Collector.
+	Describe(ch chan<- *prometheus.Desc)
+
+	// Collect is part of prometheus.Collector.
+	Collect(ch chan<- prometheus.Metric)
+}
+
 // metricsCollector is a prometheus.Collector that collects metrics
 // about lease store operations.
 type metricsCollector struct {

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -4,15 +4,13 @@
 package raftlease
 
 import (
+	"context"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/globalclock"
@@ -77,37 +75,29 @@ type ReadonlyFSM interface {
 
 // StoreConfig holds resources and settings needed to run the Store.
 type StoreConfig struct {
-	FSM           ReadonlyFSM
-	Hub           *pubsub.StructuredHub
-	Trapdoor      TrapdoorFunc
-	RequestTopic  string
-	ResponseTopic func(requestID uint64) string
+	FSM              ReadonlyFSM
+	Client           Client
+	Trapdoor         TrapdoorFunc
+	Clock            clock.Clock
+	MetricsCollector MetricsCollector
+}
 
-	Clock          clock.Clock
-	ForwardTimeout time.Duration
+// Store manages a raft FSM and forwards writes through a pubsub hub.
+type Store struct {
+	fsm     ReadonlyFSM
+	config  StoreConfig
+	metrics MetricsCollector
+	client  Client
 }
 
 // NewStore returns a core/lease.Store that manages leases in Raft.
 func NewStore(config StoreConfig) *Store {
 	return &Store{
-		fsm:      config.FSM,
-		hub:      config.Hub,
-		config:   config,
-		prevTime: config.FSM.GlobalTime(),
-		metrics:  newMetricsCollector(),
+		fsm:     config.FSM,
+		config:  config,
+		client:  config.Client,
+		metrics: config.MetricsCollector,
 	}
-}
-
-// Store manages a raft FSM and forwards writes through a pubsub hub.
-type Store struct {
-	fsm       ReadonlyFSM
-	hub       *pubsub.StructuredHub
-	requestID uint64
-	config    StoreConfig
-	metrics   *metricsCollector
-
-	prevTimeMu sync.Mutex
-	prevTime   time.Time
 }
 
 // ClaimLease is part of lease.Store.
@@ -196,94 +186,26 @@ func (s *Store) pinOp(operation string, key lease.Key, entity string, stop <-cha
 }
 
 func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
-	bytes, err := command.Marshal()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	requestID := atomic.AddUint64(&s.requestID, 1)
-	responseTopic := s.config.ResponseTopic(requestID)
-
-	responseChan := make(chan ForwardResponse)
-	errChan := make(chan error)
-	unsubscribe, err := s.hub.Subscribe(
-		responseTopic,
-		func(_ string, resp ForwardResponse, err error) {
-			if err != nil {
-				errChan <- err
-			} else {
-				responseChan <- resp
-			}
-		},
-	)
-	if err != nil {
-		return errors.Annotatef(err, "running %s", command)
-	}
-	defer unsubscribe()
-
-	start := time.Now()
+	start := s.config.Clock.Now()
 	defer func() {
-		elapsed := time.Since(start)
+		elapsed := s.config.Clock.Now().Sub(start)
 		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
 
-	delivered, err := s.hub.Publish(s.config.RequestTopic, ForwardRequest{
-		Command:       string(bytes),
-		ResponseTopic: responseTopic,
-	})
-	if err != nil {
-		s.record(command.Operation, "error", start)
-		return errors.Annotatef(err, "publishing %s", command)
-	}
+	ch := make(chan struct{})
+	defer close(ch)
 
-	// First block until subscribers are notified.
-	// In practice, this will be the Raft forwarder running on the leader node.
-	// This is an explicit step so that we can more accurately diagnose issues
-	// in-theatre.
-	select {
-	case <-pubsub.Wait(delivered):
-	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		logger.Warningf("delivery timeout waiting for %s to be processed", command)
-		s.record(command.Operation, "delivery timeout", start)
-		return lease.ErrTimeout
-	}
-
-	// Now wait for the response.
-	// The timeout starts again here, which is deliberate.
-	// It is the same timeout that is used by the Raft forwarder
-	// when `Apply` is called on the FSM.
-	select {
-	case response := <-responseChan:
-		err := RecoverError(response.Error)
-		logger.Tracef("got response, err %v", err)
-		result := "success"
-		if err != nil {
-			logger.Warningf("command %s: %v", command, err)
-			result = "failure"
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	go func() {
+		select {
+		case <-stop:
+			cancel()
+		case <-ch:
 		}
-		s.record(command.Operation, result, start)
-		return err
-	case err := <-errChan:
-		logger.Warningf("processing %s: %v", command, err)
-		s.record(command.Operation, "error", start)
-		return errors.Trace(err)
-	case <-stop:
-		return aborted(command)
-	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		// TODO (thumper) 2019-12-20, bug 1857072
-		// Scale testing hit this a *lot*,
-		// perhaps we need to consider batching messages to run on the leader?
-		logger.Warningf("response timeout waiting for %s to be processed", command)
-		s.record(command.Operation, "response timeout", start)
-		return lease.ErrTimeout
-	}
-}
+	}()
 
-func (s *Store) record(operation, result string, start time.Time) {
-	elapsedMS := float64(time.Now().Sub(start)) / float64(time.Millisecond)
-	s.metrics.requests.With(prometheus.Labels{
-		"operation": operation,
-		"result":    result,
-	}).Observe(elapsedMS)
+	return s.client.Request(ctx, command)
 }
 
 // ForwardRequest is a message sent over the hub to the raft forwarder

--- a/worker/lease/manifold/manifold_test.go
+++ b/worker/lease/manifold/manifold_test.go
@@ -149,16 +149,15 @@ func (s *manifoldSuite) TestStart(c *gc.C) {
 	c.Assert(args, gc.HasLen, 1)
 	c.Assert(args[0], gc.FitsTypeOf, raftlease.StoreConfig{})
 	storeConfig := args[0].(raftlease.StoreConfig)
-	c.Assert(storeConfig.ResponseTopic(1234), gc.Matches, "lease.manifold_test.[0-9a-f]{8}.1234")
-	storeConfig.ResponseTopic = nil
+
 	assertTrapdoorFuncsEqual(c, storeConfig.Trapdoor, s.stateTracker.pool.SystemState().LeaseTrapdoorFunc())
 	storeConfig.Trapdoor = nil
+	storeConfig.Client = nil
+	storeConfig.MetricsCollector = nil
+
 	c.Assert(storeConfig, gc.DeepEquals, raftlease.StoreConfig{
-		FSM:            s.fsm,
-		Hub:            s.hub,
-		RequestTopic:   "lease.manifold_test",
-		Clock:          s.clock,
-		ForwardTimeout: 5 * time.Second,
+		FSM:   s.fsm,
+		Clock: s.clock,
 	})
 
 	args = s.stub.Calls()[1].Args


### PR DESCRIPTION
### Overview

The following changes move out the pubsub callback async/sync setup
from the runOnLeader lease function into a new client. That way we can 
swap out the implementation for the lease store without knowing about 
the client implementation.

This should make the lease store much simpler because you don't have to
workout how the pubsub publish and subscribe setup works.
