### PR TITLE
close the edge case producing a nil origin

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -3589,6 +3589,8 @@ func (st *State) UploadedCharmOrigin(charmURL *charm.URL) (corecharm.Origin, err
 	}).One(&doc)
 	if err == mgo.ErrNotFound || doc.CharmOrigin == nil {
 		return corecharm.Origin{}, errors.NotFoundf("download origin for charm %q", charmURL)
+	} else if err != nil {
+		return corecharm.Origin{}, errors.Trace(err)
 	}
 
 	return doc.CharmOrigin.AsCoreCharmOrigin(), nil

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -182,6 +182,15 @@ func (s *ApplicationSuite) TestUploadedCharmOrigin(c *gc.C) {
 	c.Assert(obtainedOrigin, gc.DeepEquals, origin.AsCoreCharmOrigin())
 }
 
+func (s *ApplicationSuite) TestUploadedCharmOriginFail(c *gc.C) {
+	// Add a compatible charm.
+	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
+
+	// Search for the application-stored origin using the charm URL.
+	_, err := s.State.UploadedCharmOrigin(sch.URL())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func (s *ApplicationSuite) TestSetCharmCharmOriginNoChange(c *gc.C) {
 	// Add a compatible charm.
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)


### PR DESCRIPTION

If juju deploy of a charmhub charm with resources, failed after AddCharm was called, then subsequent deploy attempts of the same charm would fail in deployResource due to a nil origin.  The charm had already been downloaded, but no origin was available, and no error viewed when attempting to find the origin.

In the above case, down load the charm a 2nd time so we can have an application and origin.

## QA steps

```console
$ juju bootstrap localhost testme

# cause a charmhub charm with resources to fail after AddCharm during deploy.
$ juju deploy juju-qa-test --storage store=10G --to lxd
Located charm "juju-qa-test" in charm-hub, revision 13
ERROR adding storage to lxd container not supported

# deploy the charm again, without options which cause a failure.
$ juju deploy juju-qa-test
Located charm "juju-qa-test" in charm-hub, revision 13
Deploying "juju-qa-test" from charm-hub charm "juju-qa-test", revision 13 in channel stable
```

