### PR TITLE
Fix intermittent TestRBACMapperDeleteSync test failure

### DIFF
--- a/worker/caasrbacmapper/mapper.go
+++ b/worker/caasrbacmapper/mapper.go
@@ -54,7 +54,7 @@ func (d *DefaultMapper) AppNameForServiceAccount(id types.UID) (string, error) {
 	defer d.lock.RUnlock()
 	appName, found := d.saUIDAppMap[id]
 	if !found {
-		return "", errors.NotFoundf("service account for app found with id %v", id)
+		return "", errors.NotFoundf("service account for app with id %v", id)
 	}
 	return appName, nil
 }


### PR DESCRIPTION
The TestRBACMapperDeleteSync test was waiting for the informer event handler to be triggered but not for that handler to do the work needed.

## QA steps

go test --race


## Bug reference

https://bugs.launchpad.net/juju/+bug/1938136
