### PR TITLE
Pubsub: centralhub metrics

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -98,7 +98,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, multiWatcherWorker) })
 
 	machineTag := names.NewMachineTag("0")
-	hub := centralhub.New(machineTag)
+	hub := centralhub.New(machineTag, centralhub.PubsubNoOpMetrics{})
 
 	initialized := gate.NewLock()
 	modelCache, err := modelcache.NewWorker(modelcache.Config{

--- a/apiserver/testserver/server.go
+++ b/apiserver/testserver/server.go
@@ -37,7 +37,7 @@ func DefaultServerConfig(c *gc.C, testclock clock.Clock) apiserver.ServerConfig 
 		testclock = clock.WallClock
 	}
 	fakeOrigin := names.NewMachineTag("0")
-	hub := centralhub.New(fakeOrigin)
+	hub := centralhub.New(fakeOrigin, centralhub.PubsubNoOpMetrics{})
 	return apiserver.ServerConfig{
 		Clock:               testclock,
 		Tag:                 names.NewMachineTag("0"),

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -347,6 +347,9 @@ func (a *MachineAgent) registerPrometheusCollectors() error {
 	if err := a.prometheusRegistry.Register(a.mongoDialCollector); err != nil {
 		return errors.Annotate(err, "registering mongo dial collector")
 	}
+	if err := a.prometheusRegistry.Register(a.pubsubMetrics); err != nil {
+		return errors.Annotate(err, "registering pubsub collector")
+	}
 	return nil
 }
 
@@ -385,7 +388,8 @@ type MachineAgent struct {
 
 	// Only API servers have hubs. This is temporary until the apiserver and
 	// peergrouper have manifolds.
-	centralHub *pubsub.StructuredHub
+	centralHub    *pubsub.StructuredHub
+	pubsubMetrics *centralhub.PubsubMetrics
 
 	isCaasAgent bool
 }
@@ -472,17 +476,19 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 
 	// When the API server and peergrouper have manifolds, they can
 	// have dependencies on a central hub worker.
-	a.centralHub = centralhub.New(a.Tag())
+	a.pubsubMetrics = centralhub.NewPubsubMetrics()
+	a.centralHub = centralhub.New(a.Tag(), a.pubsubMetrics)
 
-	// Before doing anything else, we need to make sure the certificate generated for
-	// use by mongo to validate controller connections is correct. This needs to be done
-	// before any possible restart of the mongo service.
+	// Before doing anything else, we need to make sure the certificate
+	// generated for use by mongo to validate controller connections is correct.
+	// This needs to be done before any possible restart of the mongo service.
 	// See bug http://pad.lv/1434680
 	if err := a.AgentConfigWriter.ChangeConfig(upgradeCertificateDNSNames); err != nil {
 		return errors.Annotate(err, "error upgrading server certificate")
 	}
 
-	// moved from NewMachineAgent here because the agent config could not be ready yet there.
+	// Moved from NewMachineAgent here because the agent config could not be
+	// ready yet there.
 	if err := a.registerPrometheusCollectors(); err != nil {
 		return errors.Trace(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
-	github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289
+	github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216

--- a/go.sum
+++ b/go.sum
@@ -486,6 +486,8 @@ github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4 h1:y2eoq0Uof/dWLAXRyKKG
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289 h1:JPKuGuO4eDWUstv4puLCAdikIiI4235jYUCiYILjgjI=
 github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289/go.mod h1:muz5gqZ/u1pTC84e9scTKhEtmvE02wbuK1kvyLzIwQc=
+github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b h1:EwjCZIeRDkUzIM7hFFmq339tBZA5NBXIzOUXM6KR3U8=
+github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b/go.mod h1:+fw+MJGVa006M85prHvwS9pQrCjkkaaH8Ds1wvEMpXQ=
 github.com/juju/qthttptest v0.0.1/go.mod h1://LCf/Ls22/rPw2u1yWukUJvYtfPY4nYpWUl2uZhryo=
 github.com/juju/qthttptest v0.1.1 h1:JPju5P5CDMCy8jmBJV2wGLjDItUsx2KKL514EfOYueM=
 github.com/juju/qthttptest v0.1.1/go.mod h1:aTlAv8TYaflIiTDIQYzxnl1QdPjAg8Q8qJMErpKy6A4=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -946,7 +946,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			machineTag := names.NewMachineTag("0")
 			estate.httpServer.StartTLS()
 			estate.presence = &fakePresence{make(map[string]presence.Status)}
-			estate.hub = centralhub.New(machineTag)
+			estate.hub = centralhub.New(machineTag, centralhub.PubsubNoOpMetrics{})
 
 			estate.leaseManager, err = leaseManager(
 				icfg.Controller.Config.ControllerUUID(),

--- a/pubsub/centralhub/centralhub.go
+++ b/pubsub/centralhub/centralhub.go
@@ -15,7 +15,7 @@ import (
 // New returns a new structured hub using yaml marshalling with an origin
 // specified. The post processing ensures that the maps all have string keys
 // so they messages can be marshalled between apiservers.
-func New(origin names.Tag) *pubsub.StructuredHub {
+func New(origin names.Tag, metrics pubsub.Metrics) *pubsub.StructuredHub {
 	return pubsub.NewStructuredHub(
 		&pubsub.StructuredHubConfig{
 			Logger:     loggo.GetLogger("juju.centralhub"),
@@ -23,6 +23,7 @@ func New(origin names.Tag) *pubsub.StructuredHub {
 			Annotations: map[string]interface{}{
 				"origin": origin.String(),
 			},
+			Metrics:     metrics,
 			PostProcess: ensureStringMaps,
 		})
 }

--- a/pubsub/centralhub/centralhub_test.go
+++ b/pubsub/centralhub/centralhub_test.go
@@ -28,7 +28,7 @@ func (*CentralHubSuite) waitForSubscribers(c *gc.C, done <-chan struct{}) {
 }
 
 func (s *CentralHubSuite) TestSetsOrigin(c *gc.C) {
-	hub := centralhub.New(names.NewControllerAgentTag("42"))
+	hub := centralhub.New(names.NewControllerAgentTag("42"), centralhub.PubsubNoOpMetrics{})
 	topic := "testing"
 	var called bool
 	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(t string, data map[string]interface{}) {
@@ -55,7 +55,7 @@ type IntStruct struct {
 }
 
 func (s *CentralHubSuite) TestYAMLMarshalling(c *gc.C) {
-	hub := centralhub.New(names.NewMachineTag("42"))
+	hub := centralhub.New(names.NewMachineTag("42"), centralhub.PubsubNoOpMetrics{})
 	topic := "testing"
 	var called bool
 	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(t string, data map[string]interface{}) {
@@ -87,7 +87,7 @@ func (s *CentralHubSuite) TestPostProcessingMaps(c *gc.C) {
 	// Due to the need to send the resulting maps over the API, nested structs
 	// need to be map[string]interface{} not map[interface{}]interface{},
 	// which is what the YAML marshaller will give us.
-	hub := centralhub.New(names.NewMachineTag("42"))
+	hub := centralhub.New(names.NewMachineTag("42"), centralhub.PubsubNoOpMetrics{})
 	topic := "testing"
 	var called bool
 	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(t string, data map[string]interface{}) {

--- a/pubsub/centralhub/metrics.go
+++ b/pubsub/centralhub/metrics.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package centralhub
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju_pubsub"
+)
+
+// PubsubMetrics implements pubsub.Metrics for gaining information about the
+// current work hub and it's subscribers are undertaking.
+type PubsubMetrics struct {
+	subscriptions prometheus.Gauge
+	published     *prometheus.GaugeVec
+	queue         *prometheus.GaugeVec
+	consumed      *prometheus.SummaryVec
+}
+
+// NewPubsubMetrics creates a new set of pubsub metrics for collecting
+// information about the ongoing work for a given central hub.
+func NewPubsubMetrics() *PubsubMetrics {
+	return &PubsubMetrics{
+		subscriptions: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "subscriptions",
+			Help:      "Number of subscriptions on a hub",
+		}),
+		published: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "published",
+			Help:      "Number of published message per topic",
+		}, []string{
+			"topic",
+		}),
+		queue: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "queue",
+			Help:      "Queue length for a given callback identifier",
+		}, []string{
+			"ident",
+		}),
+		consumed: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace: metricsNamespace,
+			Name:      "consumed",
+			Help:      "Consumed times for a pubsub message",
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		}, []string{
+			"ident",
+		}),
+	}
+}
+
+func (m *PubsubMetrics) Subscribed() {
+	m.subscriptions.Inc()
+}
+
+func (m *PubsubMetrics) Unsubscribed() {
+	m.subscriptions.Dec()
+}
+
+var leaseRequestRegex = regexp.MustCompile("lease.request.[0-9a-f]+.[0-9]+")
+
+func (m PubsubMetrics) Published(topic string) {
+	// Pubsub synchronous callback hack needs to be worked around, otherwise
+	// we explode the cardinality of the metrics.
+	if leaseRequestRegex.MatchString(topic) {
+		if index := strings.LastIndex(topic, "."); index > 0 {
+			topic = topic[:index]
+		}
+	}
+
+	m.published.With(prometheus.Labels{
+		"topic": topic,
+	}).Inc()
+}
+
+func (m PubsubMetrics) Enqueued(ident string) {
+	m.queue.With(prometheus.Labels{
+		"ident": ident,
+	}).Inc()
+}
+
+func (m PubsubMetrics) Dequeued(ident string) {
+	m.queue.With(prometheus.Labels{
+		"ident": ident,
+	}).Dec()
+}
+
+func (m PubsubMetrics) Consumed(ident string, duration time.Duration) {
+	elapsedMS := float64(duration) / float64(time.Millisecond)
+	m.consumed.With(prometheus.Labels{
+		"ident": ident,
+	}).Observe(elapsedMS)
+}
+
+// Describe is part of prometheus.Collector.
+func (m PubsubMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.subscriptions.Describe(ch)
+	m.published.Describe(ch)
+	m.queue.Describe(ch)
+	m.consumed.Describe(ch)
+}
+
+// Collect is part of prometheus.Collector.
+func (m PubsubMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.subscriptions.Collect(ch)
+	m.published.Collect(ch)
+	m.queue.Collect(ch)
+	m.consumed.Collect(ch)
+}
+
+type PubsubNoOpMetrics struct{}
+
+func (PubsubNoOpMetrics) Subscribed()                                   {}
+func (PubsubNoOpMetrics) Unsubscribed()                                 {}
+func (PubsubNoOpMetrics) Published(topic string)                        {}
+func (PubsubNoOpMetrics) Enqueued(ident string)                         {}
+func (PubsubNoOpMetrics) Dequeued(ident string)                         {}
+func (PubsubNoOpMetrics) Consumed(ident string, duration time.Duration) {}

--- a/worker/presence/presence_test.go
+++ b/worker/presence/presence_test.go
@@ -39,7 +39,7 @@ var _ = gc.Suite(&PresenceSuite{})
 
 func (s *PresenceSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.hub = centralhub.New(ourTag)
+	s.hub = centralhub.New(ourTag, centralhub.PubsubNoOpMetrics{})
 	s.clock = testclock.NewClock(time.Time{})
 	s.recorder = corepresence.New(s.clock)
 	s.recorder.Enable()

--- a/worker/pubsub/remoteserver_test.go
+++ b/worker/pubsub/remoteserver_test.go
@@ -44,7 +44,7 @@ func (s *RemoteServerSuite) SetUpTest(c *gc.C) {
 	s.connectionOpener = &fakeConnectionOpener{}
 	tag := names.NewMachineTag("42")
 	s.clock = testclock.NewClock(time.Now())
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.origin = tag.String()
 	s.config = psworker.RemoteServerConfig{
 		Hub:    s.hub,

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -137,7 +137,7 @@ func (s *SubscriberSuite) SetUpTest(c *gc.C) {
 	// loggo.GetLogger("pubsub").SetLogLevel(loggo.TRACE)
 	tag := names.NewMachineTag("42")
 	s.clock = testclock.NewClock(time.Now())
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.origin = tag.String()
 	s.remotes = &fakeRemoteTracker{
 		remotes: make(map[string]*fakeRemote),
@@ -296,7 +296,7 @@ func (s *SubscriberSuite) TestSameMessagesForwardedForMachine(c *gc.C) {
 func (s *SubscriberSuite) TestSameMessagesForwardedForController(c *gc.C) {
 	tag := names.NewControllerAgentTag("42")
 	s.origin = tag.String()
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.config.Origin = s.origin
 	s.config.Hub = s.hub
 	s.config.APIInfo.Tag = tag

--- a/worker/raft/raftbackstop/worker_test.go
+++ b/worker/raft/raftbackstop/worker_test.go
@@ -38,7 +38,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	tag := names.NewMachineTag("23")
 	s.raft = &mockRaft{}
 	s.logStore = &mockLogStore{}
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.config = raftbackstop.Config{
 		Raft:     s.raft,
 		LogStore: s.logStore,

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -31,7 +31,7 @@ type workerFixture struct {
 func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.FSM = &jujuraft.SimpleFSM{}
 	s.RaftFixture.SetUpTest(c)
-	s.hub = centralhub.New(names.NewMachineTag("0"))
+	s.hub = centralhub.New(names.NewMachineTag("0"), centralhub.PubsubNoOpMetrics{})
 	s.config = raftclusterer.Config{
 		Raft: s.Raft,
 		Hub:  s.hub,

--- a/worker/raft/raftforwarder/worker_test.go
+++ b/worker/raft/raftforwarder/worker_test.go
@@ -44,7 +44,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		response: s.response,
 	}}
 	s.target = &fakeTarget{}
-	s.hub = centralhub.New(names.NewMachineTag("17"))
+	s.hub = centralhub.New(names.NewMachineTag("17"), centralhub.PubsubNoOpMetrics{})
 	s.config = raftforwarder.Config{
 		Hub:                  s.hub,
 		Raft:                 s.raft,

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -58,7 +58,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.auth = &mockAuthenticator{}
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.mux = &apiserverhttp.Mux{}
 	s.stub.ResetCalls()
 	s.worker = &mockTransportWorker{

--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -52,7 +52,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 			Addrs:    []string{"testing.invalid:1234"},
 		},
 		DialConn:      rafttransport.DialConn,
-		Hub:           centralhub.New(tag),
+		Hub:           centralhub.New(tag, centralhub.PubsubNoOpMetrics{}),
 		Mux:           apiserverhttp.NewMux(),
 		Authenticator: &mockAuthenticator{auth: s.auth},
 		Path:          "/raft/path",


### PR DESCRIPTION
The centralhub is by the very definition central to Juju. So the
following adds metrics to see what's happening at runtime. We can use
these metrics to better understand if pubsub is being jammed up at any
point and if it is, we can then see if it also coincides with raft also
blowing up.

The implementation is really simple, just pass a new metrics type into
the central hub and provide ways to collect the metrics at the right
time.

## QA steps

### Setup

```sh
$ juju bootstrap lxd test
$ juju switch controller
$ juju add-user prom
$ juju change-user-password prom
# you need the password for later!
$ juju grant prom read controller
```

### Query

```sh
$ juju show-controller test --format=json | jq '.test.details."api-endpoints"[0]' | xargs -I % echo "https://%/introspection/metrics" | xargs curl -k -s -u user-prom:$PASSWORD | grep "juju_pubsub_"
```